### PR TITLE
[ty] Add hyperlinks to rule codes in CLI

### DIFF
--- a/crates/ruff_annotate_snippets/src/renderer/mod.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/mod.rs
@@ -76,6 +76,7 @@ impl Renderer {
                 }
                 .effects(Effects::BOLD),
                 none: Style::new(),
+                hyperlink: true,
             },
             ..Self::plain()
         }

--- a/crates/ruff_annotate_snippets/src/renderer/stylesheet.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/stylesheet.rs
@@ -10,6 +10,7 @@ pub(crate) struct Stylesheet {
     pub(crate) line_no: Style,
     pub(crate) emphasis: Style,
     pub(crate) none: Style,
+    pub(crate) hyperlink: bool,
 }
 
 impl Default for Stylesheet {
@@ -29,6 +30,7 @@ impl Stylesheet {
             line_no: Style::new(),
             emphasis: Style::new(),
             none: Style::new(),
+            hyperlink: false,
         }
     }
 }

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -65,6 +65,7 @@ impl Diagnostic {
             severity,
             message: message.into_diagnostic_message(),
             custom_concise_message: None,
+            documentation_url: None,
             annotations: vec![],
             subs: vec![],
             fix: None,
@@ -370,6 +371,14 @@ impl Diagnostic {
             .is_some_and(|fix| fix.applies(config.fix_applicability))
     }
 
+    pub fn documentation_url(&self) -> Option<&str> {
+        self.inner.documentation_url.as_deref()
+    }
+
+    pub fn set_documentation_url(&mut self, url: Option<String>) {
+        Arc::make_mut(&mut self.inner).documentation_url = url;
+    }
+
     /// Returns the offset of the parent statement for this diagnostic if it exists.
     ///
     /// This is primarily used for checking noqa/secondary code suppressions.
@@ -544,6 +553,7 @@ impl Diagnostic {
 #[derive(Debug, Clone, Eq, PartialEq, Hash, get_size2::GetSize)]
 struct DiagnosticInner {
     id: DiagnosticId,
+    documentation_url: Option<String>,
     severity: Severity,
     message: DiagnosticMessage,
     custom_concise_message: Option<DiagnosticMessage>,

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -9,27 +9,18 @@ use ruff_notebook::NotebookIndex;
 use ruff_source_file::OneIndexed;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
-use crate::diagnostic::render::{FileResolver, IdUrlResolver, Resolved};
+use crate::diagnostic::render::{FileResolver, Resolved};
 use crate::diagnostic::stylesheet::{DiagnosticStylesheet, fmt_styled};
 use crate::diagnostic::{Diagnostic, DiagnosticSource, DisplayDiagnosticConfig};
 
 pub(super) struct FullRenderer<'a> {
     resolver: &'a dyn FileResolver,
     config: &'a DisplayDiagnosticConfig,
-    url_resolver: Option<&'a IdUrlResolver>,
 }
 
 impl<'a> FullRenderer<'a> {
-    pub(super) fn new(
-        resolver: &'a dyn FileResolver,
-        config: &'a DisplayDiagnosticConfig,
-        url_resolver: Option<&'a IdUrlResolver>,
-    ) -> Self {
-        Self {
-            resolver,
-            config,
-            url_resolver,
-        }
+    pub(super) fn new(resolver: &'a dyn FileResolver, config: &'a DisplayDiagnosticConfig) -> Self {
+        Self { resolver, config }
     }
 
     pub(super) fn render(
@@ -61,7 +52,7 @@ impl<'a> FullRenderer<'a> {
             .none(stylesheet.none);
 
         for diag in diagnostics {
-            let resolved = Resolved::new(self.resolver, diag, self.config, self.url_resolver);
+            let resolved = Resolved::new(self.resolver, diag, self.config);
             let renderable = resolved.to_renderable(self.config.context);
             for diag in renderable.diagnostics.iter() {
                 writeln!(f, "{}", renderer.render(diag.to_annotate()))?;
@@ -738,7 +729,7 @@ print()
          ::: cell 2
         1 | # cell 2
           - import math
-        2 |
+        2 | 
         3 | print('hello world')
 
         error[unused-variable][*]: Local variable `x` is assigned to but never used
@@ -755,7 +746,7 @@ print()
         2 | def foo():
         3 |     print()
           -     x = 1
-        4 |
+        4 | 
         note: This is an unsafe fix and may change runtime behavior
         ");
     }
@@ -792,14 +783,14 @@ print()
          ::: cell 2
         1 | # cell 2
           - import math
-        2 |
+        2 | 
         3 | print('hello world')
          ::: cell 3
         1 | # cell 3
         2 | def foo():
         3 |     print()
           -     x = 1
-        4 |
+        4 | 
         note: This is an unsafe fix and may change runtime behavior
         ");
     }

--- a/crates/ruff_db/src/diagnostic/stylesheet.rs
+++ b/crates/ruff_db/src/diagnostic/stylesheet.rs
@@ -31,6 +31,43 @@ where
     FmtStyled { content, style }
 }
 
+pub(super) fn fmt_with_hyperlink<'a, T>(
+    content: T,
+    url: Option<&'a str>,
+    stylesheet: &DiagnosticStylesheet,
+) -> impl std::fmt::Display + 'a
+where
+    T: std::fmt::Display + 'a,
+{
+    struct FmtHyperlink<'a, T> {
+        content: T,
+        url: Option<&'a str>,
+    }
+
+    impl<T> std::fmt::Display for FmtHyperlink<'_, T>
+    where
+        T: std::fmt::Display,
+    {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            if let Some(url) = self.url {
+                write!(f, "\x1B]8;;{url}\x1B\\")?;
+            }
+
+            self.content.fmt(f)?;
+
+            if self.url.is_some() {
+                f.write_str("\x1B]8;;\x1B\\")?;
+            }
+
+            Ok(())
+        }
+    }
+
+    let url = if stylesheet.hyperlink { url } else { None };
+
+    FmtHyperlink { content, url }
+}
+
 #[derive(Clone, Debug)]
 pub struct DiagnosticStylesheet {
     pub(crate) error: Style,
@@ -47,6 +84,7 @@ pub struct DiagnosticStylesheet {
     pub(crate) deletion: Style,
     pub(crate) insertion_line_no: Style,
     pub(crate) deletion_line_no: Style,
+    pub(crate) hyperlink: bool,
 }
 
 impl Default for DiagnosticStylesheet {
@@ -74,6 +112,7 @@ impl DiagnosticStylesheet {
             deletion: AnsiColor::Red.on_default(),
             insertion_line_no: AnsiColor::Green.on_default().effects(Effects::BOLD),
             deletion_line_no: AnsiColor::Red.on_default().effects(Effects::BOLD),
+            hyperlink: true,
         }
     }
 
@@ -93,6 +132,7 @@ impl DiagnosticStylesheet {
             deletion: Style::new(),
             insertion_line_no: Style::new(),
             deletion_line_no: Style::new(),
+            hyperlink: false,
         }
     }
 }

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -21,9 +21,7 @@ use clap::{CommandFactory, Parser};
 use colored::Colorize;
 use crossbeam::channel as crossbeam_channel;
 use rayon::ThreadPoolBuilder;
-use ruff_db::diagnostic::{
-    Diagnostic, DiagnosticId, DisplayDiagnosticConfig, DisplayDiagnostics, Severity,
-};
+use ruff_db::diagnostic::{Diagnostic, DisplayDiagnosticConfig, DisplayDiagnostics, Severity};
 use ruff_db::files::File;
 use ruff_db::max_parallelism;
 use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf};
@@ -345,19 +343,10 @@ impl MainLoop {
                             // Only render diagnostics if they're going to be displayed, since doing
                             // so is expensive.
                             if stdout.is_enabled() {
-                                let url_resolver = |id: &DiagnosticId| {
-                                    let DiagnosticId::Lint(lint) = id else {
-                                        return None;
-                                    };
-
-                                    Some(format!("https://ty.dev/rules#{}", lint))
-                                };
-
                                 write!(
                                     stdout,
                                     "{}",
                                     DisplayDiagnostics::new(db, &display_config, &result)
-                                        .with_url_resolver(&url_resolver)
                                 )?;
                             }
 

--- a/crates/ty_python_semantic/src/diagnostic.rs
+++ b/crates/ty_python_semantic/src/diagnostic.rs
@@ -1,3 +1,7 @@
+use crate::{Db, Program, PythonVersionWithSource};
+use ruff_db::diagnostic::{Annotation, Diagnostic, SubDiagnostic, SubDiagnosticSeverity};
+use std::fmt::Write;
+
 /// Suggest a name from `existing_names` that is similar to `wrong_name`.
 pub(crate) fn did_you_mean<S: AsRef<str>, T: AsRef<str>>(
     existing_names: impl Iterator<Item = S>,
@@ -23,10 +27,6 @@ pub(crate) fn did_you_mean<S: AsRef<str>, T: AsRef<str>>(
         .filter(|(_, dist)| *dist <= 3)
         .map(|(id, _)| id)
 }
-
-use crate::{Db, Program, PythonVersionWithSource};
-use ruff_db::diagnostic::{Annotation, Diagnostic, SubDiagnostic, SubDiagnosticSeverity};
-use std::fmt::Write;
 
 /// Add a subdiagnostic to `diagnostic` that explains why a certain Python version was inferred.
 ///

--- a/crates/ty_python_semantic/src/lint.rs
+++ b/crates/ty_python_semantic/src/lint.rs
@@ -116,6 +116,10 @@ impl LintMetadata {
         self.documentation_lines().join("\n")
     }
 
+    pub fn documentation_url(&self) -> String {
+        lint_documentation_url(self.name())
+    }
+
     pub fn default_level(&self) -> Level {
         self.default_level
     }
@@ -131,6 +135,10 @@ impl LintMetadata {
     pub fn line(&self) -> u32 {
         self.line
     }
+}
+
+pub fn lint_documentation_url(lint_name: LintName) -> String {
+    format!("https://ty.dev/rules#{lint_name}")
 }
 
 #[doc(hidden)]

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -298,6 +298,7 @@ impl<'a> CheckSuppressionsContext<'a> {
 
         let id = DiagnosticId::Lint(lint.name());
         let mut diag = Diagnostic::new(id, severity, "");
+        diag.set_documentation_url(Some(lint.documentation_url()));
         let span = Span::from(self.file).with_range(range);
         diag.annotate(Annotation::primary(span).message(message));
         self.diagnostics.push(diag);

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -320,15 +320,11 @@ pub(super) fn to_lsp_diagnostic(
         })
         .filter(|mapped_tags| !mapped_tags.is_empty());
 
-    let code_description = diagnostic
-        .id()
-        .is_lint()
-        .then(|| {
-            Some(CodeDescription {
-                href: Url::parse(&format!("https://ty.dev/rules#{}", diagnostic.id())).ok()?,
-            })
-        })
-        .flatten();
+    let code_description = diagnostic.documentation_url().and_then(|url| {
+        let href = Url::parse(url).ok()?;
+
+        Some(CodeDescription { href })
+    });
 
     let mut related_information = Vec::new();
 


### PR DESCRIPTION
## Summary

This PR adds hyperlink rendering to our diagnostics so that users can jump to the rule documentation by clicking on the diagnostic id.

My first implementation added an optional `url_resolver: &dyn Fn(&DiagnosticId) -> Option<String>` argument to the full and concise rendering. The main idea was to avoid constructing the URLs unnecessarily when the output format doesn't need the URL. 

However, I then realised that the LSP always uses the URL and we have other output formats (ruff only for now) that construct the URL too, namely the JSON and rdjson output formats. The overhead also seems negligible compared to that we always construct the full diagnostic, even when only using the `concise` output format. That's why I opted to store the URL as an optional field on the diagnostic instead. Not only did it simplify the implementation, it also reduced some code duplication.

The main advantage of this approach is that it requires some amount of code duplication to set the URL on the diagnostic. 

It should be very easy to leverage this functionality in Ruff too (@ntBre if you're interested).


## Test Plan
https://github.com/user-attachments/assets/9855ca70-f92d-4299-b847-360be8ea1f89

