### PR TITLE
[ty] Fix flaky tests on macos

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1524,7 +1524,10 @@ impl<'db> InteriorNode<'db> {
                             .exists_one_inner(db, bound_typevar, map, path)
                     })
                     .unwrap_or(Node::AlwaysFalse);
-                Node::new(db, self_constraint, if_true, if_false)
+                // NB: We cannot use `Node::new` here, because the recursive calls might introduce new
+                // derived constraints into the result, and those constraints might appear before this
+                // one in the BDD ordering.
+                Node::new_constraint(db, self_constraint).ite(db, if_true, if_false)
             }
         }
     }


### PR DESCRIPTION
We're seeing flaky test failures on macos, which seems to be caused by different Salsa ID orderings on the different platforms. Constraint set BDDs order their internal nodes based on the Salsa IDs of the interned typevar structs, and we had some code that depended on variable ordering in an unexpected way.

This patch definitely fixes the macos test failure on #21414, and hopefully fixes it on #21436, too.