### PR TITLE
[ty] Ecosystem analyzer: support custom `ty_cmd`s

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -67,7 +67,7 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@e5c5f5b2d762af91b28490537fe0077334165693"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@e26ebfb78d372b8b091e1cb1d6fc522e135474c1"
 
           ecosystem-analyzer \
             --repository ruff \

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -52,7 +52,7 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@e5c5f5b2d762af91b28490537fe0077334165693"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@e26ebfb78d372b8b091e1cb1d6fc522e135474c1"
 
           ecosystem-analyzer \
             --verbose \


### PR DESCRIPTION
## Summary

Pulls in https://github.com/astral-sh/ecosystem-analyzer/commit/e26ebfb78d372b8b091e1cb1d6fc522e135474c1 in order to support some projects that now require a custom `ty_cmd`.

## Test Plan

CI on this PR
