### PR TITLE
[`pyflakes`] Treat function-scope bare annotations as locals per PEP 526 (`F821`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_34.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_34.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Callable
+
+
+def demonstrate_bare_local_annotation():
+    x: int
+    print(x)
+
+demonstrate_bare_local_annotation()
+
+
+def make_closure_pair() -> tuple[Callable[[], int], Callable[[int], None]]:
+    x: int
+
+    def get_value() -> int:
+        return x
+
+    def set_value(new_value: int) -> None:
+        nonlocal x
+        x = new_value
+
+    return get_value, set_value
+
+get_value, set_value = make_closure_pair()
+set_value(123)
+print(get_value())

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_34.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_34.py
@@ -3,13 +3,23 @@ from __future__ import annotations
 from typing import Callable
 
 
+# Error: bare annotation without assignment in same scope.
 def demonstrate_bare_local_annotation():
     x: int
     print(x)
 
-demonstrate_bare_local_annotation()
+
+# Error: bare annotation read from closure without nonlocal.
+def demonstrate_closure_without_nonlocal() -> Callable[[], int]:
+    x: int
+
+    def get_value() -> int:
+        return x
+
+    return get_value
 
 
+# OK: nonlocal declaration exists, so the annotation may be initialized.
 def make_closure_pair() -> tuple[Callable[[], int], Callable[[int], None]]:
     x: int
 
@@ -22,6 +32,14 @@ def make_closure_pair() -> tuple[Callable[[], int], Callable[[int], None]]:
 
     return get_value, set_value
 
-get_value, set_value = make_closure_pair()
-set_value(123)
-print(get_value())
+
+# OK: nonlocal declaration exists, outer scope reads after inner scope may assign.
+def demonstrate_nonlocal_rebinding_then_outer_read() -> int:
+    x: int
+
+    def set_value(new_value: int) -> None:
+        nonlocal x
+        x = new_value
+
+    set_value(1)
+    return x

--- a/crates/ruff_linter/src/checkers/ast/analyze/unresolved_references.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/unresolved_references.rs
@@ -39,6 +39,18 @@ pub(crate) fn unresolved_references(checker: &Checker) {
                     }
                 }
 
+                // Bare local annotations can be initialized through nested `nonlocal`
+                // rebindings. If such a rebinding exists, skip F821.
+                if let Some(annotation_binding_id) = reference.annotation_binding_id() {
+                    if checker
+                        .semantic
+                        .rebinding_scopes(annotation_binding_id)
+                        .is_some_and(|scopes| !scopes.is_empty())
+                    {
+                        continue;
+                    }
+                }
+
                 let symbol_name = reference.name(checker.source());
 
                 checker.report_diagnostic(

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -172,6 +172,7 @@ mod tests {
     #[test_case(Rule::UndefinedName, Path::new("F821_32.pyi"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_33.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_34.pyi"))]
+    #[test_case(Rule::UndefinedName, Path::new("F821_34.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.pyi"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_1.py"))]
@@ -3779,7 +3780,7 @@ lambda: fu
             name: str
             print(name)
         ",
-            &[Rule::UndefinedName],
+            &[],
         );
         flakes(
             r"

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -3780,7 +3780,7 @@ lambda: fu
             name: str
             print(name)
         ",
-            &[],
+            &[Rule::UndefinedName],
         );
         flakes(
             r"

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_34.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_34.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_34.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_34.py.snap
@@ -1,4 +1,21 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
+F821 Undefined name `x`
+ --> F821_34.py:9:11
+  |
+7 | def demonstrate_bare_local_annotation():
+8 |     x: int
+9 |     print(x)
+  |           ^
+  |
 
+F821 Undefined name `x`
+  --> F821_34.py:17:16
+   |
+16 |     def get_value() -> int:
+17 |         return x
+   |                ^
+18 |
+19 |     return get_value
+   |

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -476,9 +476,19 @@ impl<'a> SemanticModel<'a> {
                     // The `name` in `print(name)` should be treated as unresolved, but the `name` in
                     // `name: str` should be treated as used.
                     //
-                    // Stub files are an exception. In a stub file, it _is_ considered valid to
-                    // resolve to a type annotation.
-                    BindingKind::Annotation if !self.in_stub_file() => continue,
+                    // There are two exceptions to this rule:
+                    // 1. Stub files. In a stub file, it _is_ considered valid to resolve to a
+                    //    type annotation.
+                    // 2. Bare annotations inside functions. Per PEP 526, these create local
+                    //    variables.
+                    BindingKind::Annotation
+                        if !self.in_stub_file()
+                            && !self.scopes[self.bindings[binding_id].scope]
+                                .kind
+                                .is_function() =>
+                    {
+                        continue;
+                    }
 
                     // If it's a deletion, don't treat it as resolved, since the name is now
                     // unbound. For example, given:

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -363,6 +363,7 @@ impl<'a> SemanticModel<'a> {
             self.unresolved_references.push(
                 range,
                 self.exceptions(),
+                None,
                 UnresolvedReferenceFlags::empty(),
             );
         }
@@ -476,17 +477,27 @@ impl<'a> SemanticModel<'a> {
                     // The `name` in `print(name)` should be treated as unresolved, but the `name` in
                     // `name: str` should be treated as used.
                     //
-                    // There are two exceptions to this rule:
+                    // There is one exception to this rule:
                     // 1. Stub files. In a stub file, it _is_ considered valid to resolve to a
                     //    type annotation.
-                    // 2. Bare annotations inside functions. Per PEP 526, these create local
-                    //    variables.
-                    BindingKind::Annotation
-                        if !self.in_stub_file()
-                            && !self.scopes[self.bindings[binding_id].scope]
-                                .kind
-                                .is_function() =>
-                    {
+                    BindingKind::Annotation if !self.in_stub_file() => {
+                        if self.scopes[self.bindings[binding_id].scope]
+                            .kind
+                            .is_function()
+                        {
+                            // Treat bare function-scope annotations as unresolved. These can later be
+                            // suppressed if the binding is declared as `nonlocal` in a nested scope.
+                            self.unresolved_references.push(
+                                name.range,
+                                self.exceptions(),
+                                Some(binding_id),
+                                UnresolvedReferenceFlags::empty(),
+                            );
+                            if index == 0 {
+                                return ReadResult::UnboundLocal(binding_id);
+                            }
+                            return ReadResult::NotFound;
+                        }
                         continue;
                     }
 
@@ -548,6 +559,7 @@ impl<'a> SemanticModel<'a> {
                         self.unresolved_references.push(
                             name.range,
                             self.exceptions(),
+                            None,
                             UnresolvedReferenceFlags::empty(),
                         );
                         return ReadResult::UnboundLocal(binding_id);
@@ -557,6 +569,7 @@ impl<'a> SemanticModel<'a> {
                         self.unresolved_references.push(
                             name.range,
                             self.exceptions(),
+                            None,
                             UnresolvedReferenceFlags::empty(),
                         );
                         return ReadResult::UnboundLocal(binding_id);
@@ -659,6 +672,7 @@ impl<'a> SemanticModel<'a> {
             self.unresolved_references.push(
                 name.range,
                 self.exceptions(),
+                None,
                 UnresolvedReferenceFlags::WILDCARD_IMPORT,
             );
             ReadResult::WildcardImport
@@ -666,6 +680,7 @@ impl<'a> SemanticModel<'a> {
             self.unresolved_references.push(
                 name.range,
                 self.exceptions(),
+                None,
                 UnresolvedReferenceFlags::empty(),
             );
             ReadResult::NotFound

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -467,7 +467,7 @@ impl<'a> SemanticModel<'a> {
                 }
 
                 match self.bindings[binding_id].kind {
-                    // If it's a type annotation, don't treat it as resolved. For example, given:
+                    // Type annotations are generally not treated as resolved. For example, given:
                     //
                     // ```python
                     // name: str
@@ -477,16 +477,19 @@ impl<'a> SemanticModel<'a> {
                     // The `name` in `print(name)` should be treated as unresolved, but the `name` in
                     // `name: str` should be treated as used.
                     //
-                    // There is one exception to this rule:
+                    // There are two exceptions to this rule:
                     // 1. Stub files. In a stub file, it _is_ considered valid to resolve to a
                     //    type annotation.
+                    // 2. Bare annotations inside functions. Per PEP 526, these create local
+                    //    variables, so we stop searching outer scopes and resolve them as unbound
+                    //    locals (or not found, if accessed from a nested scope). The binding ID
+                    //    is recorded in the unresolved reference so the linter can suppress the
+                    //    error if a nested scope initializes the variable via `nonlocal`.
                     BindingKind::Annotation if !self.in_stub_file() => {
                         if self.scopes[self.bindings[binding_id].scope]
                             .kind
                             .is_function()
                         {
-                            // Treat bare function-scope annotations as unresolved. These can later be
-                            // suppressed if the binding is declared as `nonlocal` in a nested scope.
                             self.unresolved_references.push(
                                 name.range,
                                 self.exceptions(),

--- a/crates/ruff_python_semantic/src/reference.rs
+++ b/crates/ruff_python_semantic/src/reference.rs
@@ -6,6 +6,7 @@ use ruff_index::{IndexSlice, IndexVec, newtype_index};
 use ruff_python_ast::ExprContext;
 use ruff_text_size::{Ranged, TextRange};
 
+use crate::binding::BindingId;
 use crate::scope::ScopeId;
 use crate::{Exceptions, NodeId, SemanticModelFlags};
 
@@ -150,6 +151,8 @@ pub struct UnresolvedReference {
     range: TextRange,
     /// The set of exceptions that were handled when resolution was attempted.
     exceptions: Exceptions,
+    /// The annotation binding from which this unresolved reference originated, if any.
+    annotation_binding_id: Option<BindingId>,
     /// Flags indicating the context in which the reference occurs.
     flags: UnresolvedReferenceFlags,
 }
@@ -168,6 +171,11 @@ impl UnresolvedReference {
     /// The set of exceptions that were handled when resolution was attempted.
     pub const fn exceptions(&self) -> Exceptions {
         self.exceptions
+    }
+
+    /// The annotation binding from which this unresolved reference originated, if any.
+    pub const fn annotation_binding_id(&self) -> Option<BindingId> {
+        self.annotation_binding_id
     }
 
     /// Returns `true` if the unresolved reference may be resolved by a wildcard import.
@@ -202,11 +210,13 @@ impl UnresolvedReferences {
         &mut self,
         range: TextRange,
         exceptions: Exceptions,
+        annotation_binding_id: Option<BindingId>,
         flags: UnresolvedReferenceFlags,
     ) {
         self.0.push(UnresolvedReference {
             range,
             exceptions,
+            annotation_binding_id,
             flags,
         });
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Resolves #21494 

Treat function-scope annotated variables as locals per PEP 526 , preventing F821 false positives.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
<!-- How was it tested? -->
Added tests for these cases in `crates/ruff_linter/resources/test/fixtures/pyflakes/F821_34.py`