### PR TITLE
[ty] Attach subdiagnostics to `unresolved-import` errors for relative imports as well as absolute imports

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_Using_`from`_with_an…_(6cff507dc64a1bff).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_Using_`from`_with_an…_(6cff507dc64a1bff).snap
@@ -28,6 +28,10 @@ error[unresolved-import]: Cannot resolve imported module `.does_not_exist.foo.ba
 2 |
 3 | stat = add(10, 15)
   |
+info: Searched in the following paths during module resolution:
+info:   1. /src (first-party code)
+info:   2. vendored://stdlib (stdlib typeshed stubs vendored by ty)
+info: make sure your Python environment is properly configured: https://docs.astral.sh/ty/modules/#python-environment
 info: rule `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_Using_`from`_with_an…_(9da56616d6332a83).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_Using_`from`_with_an…_(9da56616d6332a83).snap
@@ -28,6 +28,10 @@ error[unresolved-import]: Cannot resolve imported module `.does_not_exist`
 2 |
 3 | stat = add(10, 15)
   |
+info: Searched in the following paths during module resolution:
+info:   1. /src (first-party code)
+info:   2. vendored://stdlib (stdlib typeshed stubs vendored by ty)
+info: make sure your Python environment is properly configured: https://docs.astral.sh/ty/modules/#python-environment
 info: rule `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_Using_`from`_with_to…_(4b8ba6ee48180cdd).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_Using_`from`_with_to…_(4b8ba6ee48180cdd).snap
@@ -40,6 +40,10 @@ error[unresolved-import]: Cannot resolve imported module `....foo`
 2 |
 3 | stat = add(10, 15)
   |
+info: Searched in the following paths during module resolution:
+info:   1. /src (first-party code)
+info:   2. vendored://stdlib (stdlib typeshed stubs vendored by ty)
+info: make sure your Python environment is properly configured: https://docs.astral.sh/ty/modules/#python-environment
 info: rule `unresolved-import` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5803,6 +5803,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ".".repeat(level as usize),
             module.unwrap_or_default()
         ));
+
         if level == 0 {
             if let Some(module_name) = module.and_then(ModuleName::new) {
                 let program = Program::get(self.db());
@@ -5831,39 +5832,39 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                 }
             }
-
-            // Add search paths information to the diagnostic
-            // Use the same search paths function that is used in actual module resolution
-            let verbose = self.db().verbose();
-            let search_paths = search_paths(self.db(), ModuleResolveMode::StubsAllowed);
-
-            diagnostic.info(format_args!(
-                "Searched in the following paths during module resolution:"
-            ));
-
-            let mut search_paths = search_paths.enumerate();
-
-            while let Some((index, path)) = search_paths.next() {
-                if index > 4 && !verbose {
-                    let more = search_paths.count() + 1;
-                    diagnostic.info(format_args!(
-                        "  ... and {more} more paths. Run with `-v` to see all paths."
-                    ));
-                    break;
-                }
-                diagnostic.info(format_args!(
-                    "  {}. {} ({})",
-                    index + 1,
-                    path,
-                    path.describe_kind()
-                ));
-            }
-
-            diagnostic.info(
-                "make sure your Python environment is properly configured: \
-                https://docs.astral.sh/ty/modules/#python-environment",
-            );
         }
+
+        // Add search paths information to the diagnostic
+        // Use the same search paths function that is used in actual module resolution
+        let verbose = self.db().verbose();
+        let search_paths = search_paths(self.db(), ModuleResolveMode::StubsAllowed);
+
+        diagnostic.info(format_args!(
+            "Searched in the following paths during module resolution:"
+        ));
+
+        let mut search_paths = search_paths.enumerate();
+
+        while let Some((index, path)) = search_paths.next() {
+            if index > 4 && !verbose {
+                let more = search_paths.count() + 1;
+                diagnostic.info(format_args!(
+                    "  ... and {more} more paths. Run with `-v` to see all paths."
+                ));
+                break;
+            }
+            diagnostic.info(format_args!(
+                "  {}. {} ({})",
+                index + 1,
+                path,
+                path.describe_kind()
+            ));
+        }
+
+        diagnostic.info(
+            "make sure your Python environment is properly configured: \
+                https://docs.astral.sh/ty/modules/#python-environment",
+        );
     }
 
     fn infer_import_definition(


### PR DESCRIPTION
## Summary

If we're not able to resolve an import, we attach subdiagnostics to the error saying which search paths we looked for the import in, and linking to our settings page. However, we currently only attach these subdiagnostics if `level == 0` -- i.e., if it was an _absolute_ import that was unresolved. This doesn't make much sense; if anything, relative imports are more sensitive to the details of exactly which search paths the user has or hasn't got configured. It looks to me like this is just an accident; this PR changes things so that we attach the subdiagnostic to all `unresolved-import` diagnostics, not just absolute ones.

The diff here is easiest to review with GitHub's "hide whitespace changes" feature enabled 😄

## Test Plan

Snapshot updated
