### PR TITLE
Set severity for non-rule diagnostics

### DIFF
--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -283,24 +283,27 @@ fn to_lsp_diagnostic(
         range = diagnostic_range.to_range(source_kind.source_code(), index, encoding);
     }
 
-    let (severity, tags, code) = if let Some(code) = code {
-        let code = code.to_string();
-        (
-            Some(severity(&code)),
-            tags(diagnostic),
-            Some(lsp_types::NumberOrString::String(code)),
-        )
+    let (severity, code) = if let Some(code) = code {
+        (severity(code), code.to_string())
     } else {
-        (None, None, None)
+        (
+            match diagnostic.severity() {
+                ruff_db::diagnostic::Severity::Info => lsp_types::DiagnosticSeverity::INFORMATION,
+                ruff_db::diagnostic::Severity::Warning => lsp_types::DiagnosticSeverity::WARNING,
+                ruff_db::diagnostic::Severity::Error => lsp_types::DiagnosticSeverity::ERROR,
+                ruff_db::diagnostic::Severity::Fatal => lsp_types::DiagnosticSeverity::ERROR,
+            },
+            diagnostic.id().to_string(),
+        )
     };
 
     (
         cell,
         lsp_types::Diagnostic {
             range,
-            severity,
-            tags,
-            code,
+            severity: Some(severity),
+            tags: tags(diagnostic),
+            code: Some(lsp_types::NumberOrString::String(code)),
             code_description: diagnostic.documentation_url().and_then(|url| {
                 Some(lsp_types::CodeDescription {
                     href: lsp_types::Url::parse(url).ok()?,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

This change makes ruff server emit LSP diagnostics with severity level in more situations. Specifically, if the diagnostic didn't have a "secondary code" (I'm not super familiar what that is.) ruff server would previously emit _no_ severity.

This isn't good, because we always have an internal severity, so the information is right there. Editor experience is degraded without the severity information. For example, I use Helix. Themes typically don't consider the case of diagnostics without severity, and the fallback style is very ugly on most themes. Another functional problem is that Helix has a "diagnostics picker", which can filter by severity. This allows users to focus on errors before warnings. It doesn't work without the severity information.

I also added `tags(diagnostic)` to the same code path, because the information also doesn't seem to depend on the "secondary code". However, I haven't noticed this information missing in my own use of ruff, so I didn't confirm the difference in my own testing.

## Test Plan

I saw diagnostics without severity in my editor (Helix), made the fix, installed ruff, restarted LSP in Helix, confirmed that diagnostics now have severity.

A very simple file to confirm this just contains `if`, which will emit a "Expected an expression" diagnostic. With this PR, it has the severity "error", without it it has none.