### PR TITLE
[ty] Remove brittle constraint set reveal tests

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -137,84 +137,26 @@ class Sub(Base): ...
 class Unrelated: ...
 
 def unbounded_unconstrained[T, U](t: T, u: U) -> None:
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, T))
     static_assert(is_assignable_to(T, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, object))
     static_assert(is_assignable_to(T, object))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(T, Super))
     static_assert(not is_assignable_to(T, Super))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, Any))
     static_assert(is_assignable_to(T, Any))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(Any, T))
     static_assert(is_assignable_to(Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(U, U))
     static_assert(is_assignable_to(U, U))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(U, object))
     static_assert(is_assignable_to(U, object))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(U, Super))
     static_assert(not is_assignable_to(U, Super))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(T, U))
     static_assert(not is_assignable_to(T, U))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(U, T))
     static_assert(not is_assignable_to(U, T))
 
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_subtype_of(T, T))
     static_assert(is_subtype_of(T, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_subtype_of(T, object))
     static_assert(is_subtype_of(T, object))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Super))
     static_assert(not is_subtype_of(T, Super))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Any))
     static_assert(not is_subtype_of(T, Any))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Any, T))
     static_assert(not is_subtype_of(Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_subtype_of(U, U))
     static_assert(is_subtype_of(U, U))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_subtype_of(U, object))
     static_assert(is_subtype_of(U, object))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(U, Super))
     static_assert(not is_subtype_of(U, Super))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, U))
     static_assert(not is_subtype_of(T, U))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(U, T))
     static_assert(not is_subtype_of(U, T))
 ```
 
@@ -229,137 +171,47 @@ from typing import Any
 from typing_extensions import final
 
 def bounded[T: Super](t: T) -> None:
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, Any))
     static_assert(is_assignable_to(T, Any))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(Any, T))
     static_assert(is_assignable_to(Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, Super))
     static_assert(is_assignable_to(T, Super))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(T, Sub))
     static_assert(not is_assignable_to(T, Sub))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(Super, T))
     static_assert(not is_assignable_to(Super, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(Sub, T))
     static_assert(not is_assignable_to(Sub, T))
 
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Any))
     static_assert(not is_subtype_of(T, Any))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Any, T))
     static_assert(not is_subtype_of(Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_subtype_of(T, Super))
     static_assert(is_subtype_of(T, Super))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Sub))
     static_assert(not is_subtype_of(T, Sub))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Super, T))
     static_assert(not is_subtype_of(Super, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Sub, T))
     static_assert(not is_subtype_of(Sub, T))
 
 def bounded_by_gradual[T: Any](t: T) -> None:
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, Any))
     static_assert(is_assignable_to(T, Any))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(Any, T))
     static_assert(is_assignable_to(Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, Super))
     static_assert(is_assignable_to(T, Super))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(Super, T))
     static_assert(not is_assignable_to(Super, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, Sub))
     static_assert(is_assignable_to(T, Sub))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(Sub, T))
     static_assert(not is_assignable_to(Sub, T))
 
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Any))
     static_assert(not is_subtype_of(T, Any))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Any, T))
     static_assert(not is_subtype_of(Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Super))
     static_assert(not is_subtype_of(T, Super))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Super, T))
     static_assert(not is_subtype_of(Super, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Sub))
     static_assert(not is_subtype_of(T, Sub))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Sub, T))
     static_assert(not is_subtype_of(Sub, T))
 
 @final
 class FinalClass: ...
 
 def bounded_final[T: FinalClass](t: T) -> None:
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, Any))
     static_assert(is_assignable_to(T, Any))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(Any, T))
     static_assert(is_assignable_to(Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, FinalClass))
     static_assert(is_assignable_to(T, FinalClass))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(FinalClass, T))
     static_assert(not is_assignable_to(FinalClass, T))
 
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Any))
     static_assert(not is_subtype_of(T, Any))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Any, T))
     static_assert(not is_subtype_of(Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_subtype_of(T, FinalClass))
     static_assert(is_subtype_of(T, FinalClass))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(FinalClass, T))
     static_assert(not is_subtype_of(FinalClass, T))
 ```
 
@@ -370,37 +222,17 @@ typevars to `Never` in addition to that final class.
 
 ```py
 def two_bounded[T: Super, U: Super](t: T, u: U) -> None:
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(T, U))
     static_assert(not is_assignable_to(T, U))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(U, T))
     static_assert(not is_assignable_to(U, T))
 
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, U))
     static_assert(not is_subtype_of(T, U))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(U, T))
     static_assert(not is_subtype_of(U, T))
 
 def two_final_bounded[T: FinalClass, U: FinalClass](t: T, u: U) -> None:
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(T, U))
     static_assert(not is_assignable_to(T, U))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(U, T))
     static_assert(not is_assignable_to(U, T))
 
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, U))
     static_assert(not is_subtype_of(T, U))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(U, T))
     static_assert(not is_subtype_of(U, T))
 ```
 
@@ -412,237 +244,67 @@ intersection of all of its constraints is a subtype of the typevar.
 from ty_extensions import Intersection
 
 def constrained[T: (Base, Unrelated)](t: T) -> None:
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(T, Super))
     static_assert(not is_assignable_to(T, Super))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(T, Base))
     static_assert(not is_assignable_to(T, Base))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(T, Sub))
     static_assert(not is_assignable_to(T, Sub))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(T, Unrelated))
     static_assert(not is_assignable_to(T, Unrelated))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, Any))
     static_assert(is_assignable_to(T, Any))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, Super | Unrelated))
     static_assert(is_assignable_to(T, Super | Unrelated))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, Base | Unrelated))
     static_assert(is_assignable_to(T, Base | Unrelated))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(T, Sub | Unrelated))
     static_assert(not is_assignable_to(T, Sub | Unrelated))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(Any, T))
     static_assert(is_assignable_to(Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(Super, T))
     static_assert(not is_assignable_to(Super, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(Unrelated, T))
     static_assert(not is_assignable_to(Unrelated, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(Super | Unrelated, T))
     static_assert(not is_assignable_to(Super | Unrelated, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(Intersection[Base, Unrelated], T))
     static_assert(is_assignable_to(Intersection[Base, Unrelated], T))
 
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Super))
     static_assert(not is_subtype_of(T, Super))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Base))
     static_assert(not is_subtype_of(T, Base))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Sub))
     static_assert(not is_subtype_of(T, Sub))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Unrelated))
     static_assert(not is_subtype_of(T, Unrelated))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Any))
     static_assert(not is_subtype_of(T, Any))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_subtype_of(T, Super | Unrelated))
     static_assert(is_subtype_of(T, Super | Unrelated))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_subtype_of(T, Base | Unrelated))
     static_assert(is_subtype_of(T, Base | Unrelated))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Sub | Unrelated))
     static_assert(not is_subtype_of(T, Sub | Unrelated))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Any, T))
     static_assert(not is_subtype_of(Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Super, T))
     static_assert(not is_subtype_of(Super, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Unrelated, T))
     static_assert(not is_subtype_of(Unrelated, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Super | Unrelated, T))
     static_assert(not is_subtype_of(Super | Unrelated, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_subtype_of(Intersection[Base, Unrelated], T))
     static_assert(is_subtype_of(Intersection[Base, Unrelated], T))
 
 def constrained_by_gradual[T: (Base, Any)](t: T) -> None:
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, Super))
     static_assert(is_assignable_to(T, Super))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, Base))
     static_assert(is_assignable_to(T, Base))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(T, Sub))
     static_assert(not is_assignable_to(T, Sub))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(T, Unrelated))
     static_assert(not is_assignable_to(T, Unrelated))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, Any))
     static_assert(is_assignable_to(T, Any))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, Super | Any))
     static_assert(is_assignable_to(T, Super | Any))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, Super | Unrelated))
     static_assert(is_assignable_to(T, Super | Unrelated))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(Super, T))
     static_assert(not is_assignable_to(Super, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(Base, T))
     static_assert(is_assignable_to(Base, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(Unrelated, T))
     static_assert(not is_assignable_to(Unrelated, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(Any, T))
     static_assert(is_assignable_to(Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(Super | Any, T))
     static_assert(not is_assignable_to(Super | Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(Base | Any, T))
     static_assert(is_assignable_to(Base | Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(Super | Unrelated, T))
     static_assert(not is_assignable_to(Super | Unrelated, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(Intersection[Base, Unrelated], T))
     static_assert(is_assignable_to(Intersection[Base, Unrelated], T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(Intersection[Base, Any], T))
     static_assert(is_assignable_to(Intersection[Base, Any], T))
 
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Super))
     static_assert(not is_subtype_of(T, Super))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Base))
     static_assert(not is_subtype_of(T, Base))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Sub))
     static_assert(not is_subtype_of(T, Sub))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Unrelated))
     static_assert(not is_subtype_of(T, Unrelated))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Any))
     static_assert(not is_subtype_of(T, Any))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Super | Any))
     static_assert(not is_subtype_of(T, Super | Any))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, Super | Unrelated))
     static_assert(not is_subtype_of(T, Super | Unrelated))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Super, T))
     static_assert(not is_subtype_of(Super, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Base, T))
     static_assert(not is_subtype_of(Base, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Unrelated, T))
     static_assert(not is_subtype_of(Unrelated, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Any, T))
     static_assert(not is_subtype_of(Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Super | Any, T))
     static_assert(not is_subtype_of(Super | Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Base | Any, T))
     static_assert(not is_subtype_of(Base | Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Super | Unrelated, T))
     static_assert(not is_subtype_of(Super | Unrelated, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Intersection[Base, Unrelated], T))
     static_assert(not is_subtype_of(Intersection[Base, Unrelated], T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(Intersection[Base, Any], T))
     static_assert(not is_subtype_of(Intersection[Base, Any], T))
 ```
 
@@ -653,40 +315,20 @@ the same type.
 
 ```py
 def two_constrained[T: (int, str), U: (int, str)](t: T, u: U) -> None:
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(T, U))
     static_assert(not is_assignable_to(T, U))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(U, T))
     static_assert(not is_assignable_to(U, T))
 
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, U))
     static_assert(not is_subtype_of(T, U))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(U, T))
     static_assert(not is_subtype_of(U, T))
 
 @final
 class AnotherFinalClass: ...
 
 def two_final_constrained[T: (FinalClass, AnotherFinalClass), U: (FinalClass, AnotherFinalClass)](t: T, u: U) -> None:
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(T, U))
     static_assert(not is_assignable_to(T, U))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_assignable_to(U, T))
     static_assert(not is_assignable_to(U, T))
 
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T, U))
     static_assert(not is_subtype_of(T, U))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(U, T))
     static_assert(not is_subtype_of(U, T))
 ```
 
@@ -694,20 +336,10 @@ A bound or constrained typevar is a subtype of itself in a union:
 
 ```py
 def union[T: Base, U: (Base, Unrelated)](t: T, u: U) -> None:
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T, T | None))
     static_assert(is_assignable_to(T, T | None))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(U, U | None))
     static_assert(is_assignable_to(U, U | None))
 
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_subtype_of(T, T | None))
     static_assert(is_subtype_of(T, T | None))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_subtype_of(U, U | None))
     static_assert(is_subtype_of(U, U | None))
 ```
 
@@ -715,20 +347,10 @@ A bound or constrained typevar in a union with a dynamic type is assignable to t
 
 ```py
 def union_with_dynamic[T: Base, U: (Base, Unrelated)](t: T, u: U) -> None:
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(T | Any, T))
     static_assert(is_assignable_to(T | Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(U | Any, U))
     static_assert(is_assignable_to(U | Any, U))
 
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(T | Any, T))
     static_assert(not is_subtype_of(T | Any, T))
-
-    # revealed: ty_extensions.ConstraintSet[never]
-    reveal_type(is_subtype_of(U | Any, U))
     static_assert(not is_subtype_of(U | Any, U))
 ```
 
@@ -740,20 +362,9 @@ from ty_extensions import Intersection, Not, is_disjoint_from
 class A: ...
 
 def inter[T: Base, U: (Base, Unrelated)](t: T, u: U) -> None:
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(Intersection[T, Unrelated], T))
     static_assert(is_assignable_to(Intersection[T, Unrelated], T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_subtype_of(Intersection[T, Unrelated], T))
     static_assert(is_subtype_of(Intersection[T, Unrelated], T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(Intersection[U, A], U))
     static_assert(is_assignable_to(Intersection[U, A], U))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_subtype_of(Intersection[U, A], U))
     static_assert(is_subtype_of(Intersection[U, A], U))
 
     static_assert(is_disjoint_from(Not[T], T))
@@ -1054,20 +665,10 @@ of) itself.
 from ty_extensions import is_assignable_to, is_subtype_of, Not, static_assert
 
 def intersection_is_assignable[T](t: T) -> None:
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(Intersection[T, None], T))
     static_assert(is_assignable_to(Intersection[T, None], T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_assignable_to(Intersection[T, Not[None]], T))
     static_assert(is_assignable_to(Intersection[T, Not[None]], T))
 
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_subtype_of(Intersection[T, None], T))
     static_assert(is_subtype_of(Intersection[T, None], T))
-
-    # revealed: ty_extensions.ConstraintSet[always]
-    reveal_type(is_subtype_of(Intersection[T, Not[None]], T))
     static_assert(is_subtype_of(Intersection[T, Not[None]], T))
 ```
 


### PR DESCRIPTION
These were added to try to make it clearer that assignability checks will eventually return more detailed answers than true or false. However, the constraint set display rendering is still more brittle than I'd like it to be, and it's more trouble than it's worth to keep them updated with semantically identically but textually different edits. The `static_assert`s are sufficient to check correctness, and we can always add `reveal_type` when needed for further debugging.