### PR TITLE
[ty] Fix edge cases for autocomplete suppressions in variable bindings

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -1407,6 +1407,24 @@ fn is_in_variable_binding(parsed: &ParsedModuleRef, offset: TextSize, typed: Opt
             type_param.name.range.contains_range(range)
         }
         ast::AnyNodeRef::StmtFor(stmt_for) => stmt_for.target.range().contains_range(range),
+        // The AST does not produce `ast::AnyNodeRef::Parameter` nodes for keywords
+        // or otherwise invalid syntax. Rather they are captured in a
+        // `ast::AnyNodeRef::Parameters` node as "empty space". To ensure
+        // we still suppress suggestions even when the syntax is technically
+        // invalid we extract the token under the cursor and check if it makes
+        // up that "empty space" inside the Parameters Node. If it does, we know
+        // that we are still binding variables, just that the current state is
+        // syntatically invalid. Hence we suppress autocomplete suggestons
+        // also in those cases.
+        ast::AnyNodeRef::Parameters(params) => {
+            if !params.range.contains_range(range) {
+                return false;
+            }
+            params
+                .iter()
+                .map(|param| param.range())
+                .all(|r| !r.contains_range(range))
+        }
         _ => false,
     })
 }
@@ -5355,6 +5373,45 @@ for foo, bar<CURSOR>
         let builder = completion_test_builder(
             "\
 def foo(p<CURSOR>
+",
+        );
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"<No completions found>",
+        );
+    }
+
+    #[test]
+    fn no_completions_in_function_param_keyword() {
+        let builder = completion_test_builder(
+            "\
+def foo(in<CURSOR>
+",
+        );
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"<No completions found>",
+        );
+    }
+
+    #[test]
+    fn no_completions_in_function_param_multi_keyword() {
+        let builder = completion_test_builder(
+            "\
+def foo(param, in<CURSOR>
+",
+        );
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"<No completions found>",
+        );
+    }
+
+    #[test]
+    fn no_completions_in_function_param_multi_keyword_middle() {
+        let builder = completion_test_builder(
+            "\
+def foo(param, in<CURSOR>, param_two
 ",
         );
         assert_snapshot!(


### PR DESCRIPTION
## Summary
This handles a few edge cases related to https://github.com/astral-sh/ty/issues/1563  that was not fully handled in https://github.com/astral-sh/ruff/pull/21549

Only using the individual `Parameter` nodes in the AST to determine parameter bindings is not enough when you're in a state where the syntax is invalid. For example when the name of the parameter clashes with a keyword. In those scenarios we now go up a level and inspect the `Parameters` node to determine if we're still binding variables.


## Test Plan

New tests and ty-playground sanity-check.
