### PR TITLE
[ty] Improve concise diagnostics for invalid exceptions when a user catches a tuple of objects

### DIFF
--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -2436,6 +2436,7 @@ pub(super) fn report_possibly_missing_attribute(
 pub(super) fn report_invalid_exception_tuple_caught<'db, 'ast>(
     context: &InferContext<'db, 'ast>,
     node: &'ast ast::ExprTuple,
+    node_type: Type<'db>,
     invalid_tuple_nodes: impl IntoIterator<Item = (&'ast ast::Expr, Type<'db>)>,
 ) {
     let Some(builder) = context.report_lint(&INVALID_EXCEPTION_CAUGHT, node) else {
@@ -2443,6 +2444,10 @@ pub(super) fn report_invalid_exception_tuple_caught<'db, 'ast>(
     };
 
     let mut diagnostic = builder.into_diagnostic("Invalid tuple caught in an exception handler");
+    diagnostic.set_concise_message(format_args!(
+        "Cannot catch object of type `{}` in an exception handler",
+        node_type.display(context.db())
+    ));
 
     for (sub_node, ty) in invalid_tuple_nodes {
         let span = context.span(sub_node);

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3053,7 +3053,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .iter()
                         .map(|(index, ty)| (&tuple.elts[*index], **ty));
 
-                    report_invalid_exception_tuple_caught(&self.context, tuple, invalid_elements);
+                    report_invalid_exception_tuple_caught(
+                        &self.context,
+                        tuple,
+                        node_ty,
+                        invalid_elements,
+                    );
                 } else {
                     report_invalid_exception_caught(&self.context, node, node_ty);
                 }


### PR DESCRIPTION
## Summary

The concise diagnostic is currently just "Invalid tuple caught in an exception handler", which doesn't give the user sufficient information to debug the problem

## Test Plan

Manual testing, since we don't currently have any tests for concise diagnostics:

<img width="2532" height="102" alt="image" src="https://github.com/user-attachments/assets/a2cef445-102f-4499-b8b5-4155cbefce39" />

