### PR TITLE
[ty] Fix rendering of unused suppression diagnostic

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_lists_wi…_(ea7ebc83ec359b54).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_lists_wi…_(ea7ebc83ec359b54).snap
@@ -303,13 +303,13 @@ info: rule `duplicate-base` is enabled by default
 ```
 
 ```
-info[unused-ignore-comment]
+info[unused-ignore-comment]: Unused blanket `type: ignore` directive
   --> src/mdtest_snippet.py:72:9
    |
 70 |     A,
 71 |     # error: [unused-ignore-comment]
 72 |     A,  # type: ignore[duplicate-base]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unused blanket `type: ignore` directive
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 73 | ): ...
    |
 
@@ -346,13 +346,13 @@ info: rule `duplicate-base` is enabled by default
 ```
 
 ```
-info[unused-ignore-comment]
+info[unused-ignore-comment]: Unused blanket `type: ignore` directive
   --> src/mdtest_snippet.py:81:13
    |
 79 | ):
 80 |     # error: [unused-ignore-comment]
 81 |     x: int  # type: ignore[duplicate-base]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unused blanket `type: ignore` directive
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 82 |
 83 | # fmt: on
    |

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -297,10 +297,10 @@ impl<'a> CheckSuppressionsContext<'a> {
         };
 
         let id = DiagnosticId::Lint(lint.name());
-        let mut diag = Diagnostic::new(id, severity, "");
+        let mut diag = Diagnostic::new(id, severity, message);
         diag.set_documentation_url(Some(lint.documentation_url()));
         let span = Span::from(self.file).with_range(range);
-        diag.annotate(Annotation::primary(span).message(message));
+        diag.annotate(Annotation::primary(span));
         self.diagnostics.push(diag);
     }
 }


### PR DESCRIPTION
## Summary

Set the message passed to `context.report_unchecked` as the primary diagnostic message instead of using `""`. 

## Test plan

See changed snapshot