### PR TITLE
[ty] Improve several "Did you mean?" suggestions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/literal_string.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/literal_string.md
@@ -35,6 +35,8 @@ bad_nesting: Literal[LiteralString]  # error: [invalid-type-form]
 
 `LiteralString` cannot be parameterized.
 
+<!-- snapshot-diagnostics -->
+
 ```py
 from typing_extensions import LiteralString
 
@@ -42,7 +44,6 @@ from typing_extensions import LiteralString
 a: LiteralString[str]
 
 # error: [invalid-type-form]
-# error: [unresolved-reference] "Name `foo` used when not defined"
 b: LiteralString["foo"]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_Module-literal_used_…_(652fec4fd4a6c63a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_Module-literal_used_…_(652fec4fd4a6c63a).snap
@@ -34,29 +34,27 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
 # Diagnostics
 
 ```
-error[invalid-type-form]: Variable of type `<module 'datetime'>` is not allowed in a type expression
+error[invalid-type-form]: Module `datetime` is not valid in a type expression
  --> src/foo.py:3:10
   |
 1 | import datetime
 2 |
 3 | def f(x: datetime): ...  # error: [invalid-type-form]
-  |          ^^^^^^^^
+  |          ^^^^^^^^ Did you mean to use the module's member `datetime.datetime`?
   |
-info: Did you mean to use the module's member `datetime.datetime` instead?
 info: rule `invalid-type-form` is enabled by default
 
 ```
 
 ```
-error[invalid-type-form]: Variable of type `<module 'PIL.Image'>` is not allowed in a type expression
+error[invalid-type-form]: Module `PIL.Image` is not valid in a type expression
  --> src/bar.py:3:10
   |
 1 | from PIL import Image
 2 |
 3 | def g(x: Image): ...  # error: [invalid-type-form]
-  |          ^^^^^
+  |          ^^^^^ Did you mean to use the module's member `Image.Image`?
   |
-info: Did you mean to use the module's member `Image.Image` instead?
 info: rule `invalid-type-form` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/literal_string.md_-_`LiteralString`_-_Usages_-_Parameterized_(ec84ce49ea235791).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/literal_string.md_-_`LiteralString`_-_Usages_-_Parameterized_(ec84ce49ea235791).snap
@@ -1,0 +1,52 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: literal_string.md - `LiteralString` - Usages - Parameterized
+mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/literal_string.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | from typing_extensions import LiteralString
+2 | 
+3 | # error: [invalid-type-form]
+4 | a: LiteralString[str]
+5 | 
+6 | # error: [invalid-type-form]
+7 | b: LiteralString["foo"]
+```
+
+# Diagnostics
+
+```
+error[invalid-type-form]: `LiteralString` expects no type parameter
+ --> src/mdtest_snippet.py:4:4
+  |
+3 | # error: [invalid-type-form]
+4 | a: LiteralString[str]
+  |    ^^^^^^^^^^^^^^^^^^
+5 |
+6 | # error: [invalid-type-form]
+  |
+info: rule `invalid-type-form` is enabled by default
+
+```
+
+```
+error[invalid-type-form]: `LiteralString` expects no type parameter
+ --> src/mdtest_snippet.py:7:4
+  |
+6 | # error: [invalid-type-form]
+7 | b: LiteralString["foo"]
+  |    -------------^^^^^^^
+  |    |
+  |    Did you mean `Literal`?
+  |
+info: rule `invalid-type-form` is enabled by default
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Error_cases_-_`typing.TypedDict`_i…_(9df67eb93e3df341).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Error_cases_-_`typing.TypedDict`_i…_(9df67eb93e3df341).snap
@@ -1,0 +1,34 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: typed_dict.md - `TypedDict` - Error cases - `typing.TypedDict` is not allowed in type expressions
+mdtest path: crates/ty_python_semantic/resources/mdtest/typed_dict.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | from typing import TypedDict
+2 | 
+3 | # error: [invalid-type-form] "The special form `typing.TypedDict` is not allowed in type expressions"
+4 | x: TypedDict = {"name": "Alice"}
+```
+
+# Diagnostics
+
+```
+error[invalid-type-form]: The special form `typing.TypedDict` is not allowed in type expressions
+ --> src/mdtest_snippet.py:4:4
+  |
+3 | # error: [invalid-type-form] "The special form `typing.TypedDict` is not allowed in type expressions"
+4 | x: TypedDict = {"name": "Alice"}
+  |    ^^^^^^^^^
+  |
+help: You might have meant to use a concrete TypedDict or `collections.abc.Mapping[str, object]`
+info: rule `invalid-type-form` is enabled by default
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1407,10 +1407,12 @@ msg.content
 
 ### `typing.TypedDict` is not allowed in type expressions
 
+<!-- snapshot-diagnostics -->
+
 ```py
 from typing import TypedDict
 
-# error: [invalid-type-form] "The special form `typing.TypedDict` is not allowed in type expressions."
+# error: [invalid-type-form] "The special form `typing.TypedDict` is not allowed in type expressions"
 x: TypedDict = {"name": "Alice"}
 ```
 

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -148,15 +148,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     // anything else is an invalid annotation:
                     op => {
                         self.infer_binary_expression(binary, TypeContext::default());
-                        if let Some(mut diag) = self.report_invalid_type_expression(
+                        self.report_invalid_type_expression(
                             expression,
                             format_args!(
                                 "Invalid binary operator `{}` in type annotation",
                                 op.as_str()
                             ),
-                        ) {
-                            diag.info("Did you mean to use `|`?");
-                        }
+                        );
                         Type::unknown()
                     }
                 }
@@ -1407,13 +1405,40 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 Type::unknown()
             }
             SpecialFormType::LiteralString => {
-                self.infer_type_expression(arguments_slice);
+                let arguments = self.infer_expression(arguments_slice, TypeContext::default());
 
                 if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
-                    let mut diag = builder.into_diagnostic(format_args!(
-                        "Type `{special_form}` expected no type parameter",
-                    ));
-                    diag.info("Did you mean to use `Literal[...]` instead?");
+                    let mut diag =
+                        builder.into_diagnostic("`LiteralString` expects no type parameter");
+
+                    let arguments_as_tuple = arguments.exact_tuple_instance_spec(db);
+
+                    let mut argument_elements = arguments_as_tuple
+                        .as_ref()
+                        .map(|tup| Either::Left(tup.all_elements().copied()))
+                        .unwrap_or(Either::Right(std::iter::once(arguments)));
+
+                    let probably_meant_literal = argument_elements.all(|ty| match ty {
+                        Type::StringLiteral(_)
+                        | Type::BytesLiteral(_)
+                        | Type::EnumLiteral(_)
+                        | Type::BooleanLiteral(_) => true,
+                        Type::NominalInstance(instance) => {
+                            instance.has_known_class(db, KnownClass::NoneType)
+                        }
+                        _ => false,
+                    });
+
+                    if probably_meant_literal {
+                        diag.annotate(
+                            self.context
+                                .secondary(&*subscript.value)
+                                .message("Did you mean `Literal`?"),
+                        );
+                        diag.set_concise_message(
+                            "`LiteralString` expects no type parameter - did you mean `Literal`?",
+                        );
+                    }
                 }
                 Type::unknown()
             }


### PR DESCRIPTION
## Summary

- Make some diagnostics more concise by moving suggestions from a subdiagnostic to a primary or secondary annotation message
- Make some diagnostic summary lines more concise by moving suggestions from the diagnostic summary line to subdiagnostics
- Consistently use the `help` severity for suggestions when they do appear as subdiagnostics, rather than the `info` severity

## Test Plan

Snapshots
