### PR TITLE
[ty] Only add `import`ed modules to `imported_modules` if the `import` statement is in the global scope

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/import/tracking.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/tracking.md
@@ -1,6 +1,6 @@
 # Tracking imported modules
 
-These tests depend on how we track which modules have been imported. There are currently two
+These tests depend on how we track which modules have been imported. There are several
 characteristics of our module tracking that can lead to inaccuracies:
 
 - Imports are tracked on a per-file basis. At runtime, importing a submodule in one file makes that
@@ -13,10 +13,10 @@ characteristics of our module tracking that can lead to inaccuracies:
     typing spec and that are visible to our file-scoped import tracking.
 
 - Imports are tracked flow-insensitively: submodule accesses are allowed and resolved if that
-    submodule is imported _anywhere in the file_. This handles the common case where all imports are
-    grouped at the top of the file, and is easiest to implement. We might revisit this decision and
-    track submodule imports flow-sensitively, in which case we will have to update the assertions in
-    some of these tests.
+    submodule is imported _anywhere in the global scope of the file_. This handles the common case
+    where all imports are grouped at the top of the file, and is easiest to implement. We might
+    revisit this decision and track submodule imports flow-sensitively, in which case we will have
+    to update the assertions in some of these tests.
 
 ## Import submodule later in file
 
@@ -115,4 +115,29 @@ b = 1
 `attr/b.py`:
 
 ```py
+```
+
+## Submodule is loaded in a non-global scope
+
+We do not recognise a submodule as being available as an attribute if it is only loaded in a
+function scope. The function might never be executed, which would mean that the submodule would
+never be loaded:
+
+`a/b.py`:
+
+```py
+```
+
+`main.py`:
+
+```py
+import a
+
+def f():
+    import a.b
+
+f()
+
+# error: [unresolved-attribute]
+reveal_type(a.b)  # revealed: Unknown
 ```

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -1469,9 +1469,11 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                     .record_node_reachability(NodeKey::from_node(node));
 
                 for (alias_index, alias) in node.names.iter().enumerate() {
-                    // Mark the imported module, and all of its parents, as being imported in this
-                    // file.
-                    if let Some(module_name) = ModuleName::new(&alias.name) {
+                    // If we're in the global scope, mark the imported module,
+                    // and all of its parents, as being imported in this file.
+                    if self.current_scope().is_global()
+                        && let Some(module_name) = ModuleName::new(&alias.name)
+                    {
                         self.imported_modules.extend(module_name.ancestors());
                     }
 


### PR DESCRIPTION
## Summary

@Gankra pointed out in https://github.com/astral-sh/ruff/pull/21583#discussion_r2554196826 that we're currently inconsistent here between how we treat `import` statements and `from ... import ...` statements. We should probably be consistent!

## Test Plan

Added an mdtest
