### PR TITLE
[ty] Exclude `@Todo` types from `assert_{type,never}` checks

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/directives/assert_never.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/assert_never.md
@@ -124,10 +124,6 @@ def match_singletons_error(obj: Literal[1, "a"] | None):
         case None:
             pass
         case _ as obj:
-            # TODO: We should emit an error here, but the message should
-            # show the type `Literal["a"]` instead of `@Todo(…)`. We only
-            # assert on the first part of the message because the `@Todo`
-            # message is not available in release mode builds.
-            # error: [type-assertion-failure] "Type `@Todo"
+            # TODO: We should emit an error here: `Literal["a"]` is not `Never`.
             assert_never(obj)
 ```

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1358,6 +1358,8 @@ impl KnownFunction {
         let db = context.db();
         let parameter_types = overload.parameter_types();
 
+        let is_todo_type = |ty: Type<'db>| ty.is_todo();
+
         match self {
             KnownFunction::RevealType => {
                 let revealed_type = overload
@@ -1391,7 +1393,10 @@ impl KnownFunction {
                 let [Some(actual_ty), Some(asserted_ty)] = parameter_types else {
                     return;
                 };
-                if actual_ty.is_equivalent_to(db, *asserted_ty) {
+                if actual_ty.is_equivalent_to(db, *asserted_ty)
+                    || any_over_type(db, *actual_ty, &is_todo_type, true)
+                    || any_over_type(db, *asserted_ty, &is_todo_type, true)
+                {
                     return;
                 }
                 if let Some(builder) = context.report_lint(&TYPE_ASSERTION_FAILURE, call_expression)
@@ -1427,7 +1432,9 @@ impl KnownFunction {
                 let [Some(actual_ty)] = parameter_types else {
                     return;
                 };
-                if actual_ty.is_equivalent_to(db, Type::Never) {
+                if actual_ty.is_equivalent_to(db, Type::Never)
+                    || any_over_type(db, *actual_ty, &is_todo_type, true)
+                {
                     return;
                 }
                 if let Some(builder) = context.report_lint(&TYPE_ASSERTION_FAILURE, call_expression)


### PR DESCRIPTION
## Summary

Not sure if this a good idea, I can see arguments either way. This was prompted by a wave of type-assertion failures involving `@Todo` types in https://github.com/astral-sh/ruff/pull/21553.