### PR TITLE
Implement goto-definition and find-references for global/nonlocal statements

### DIFF
--- a/crates/ty_ide/src/goto_references.rs
+++ b/crates/ty_ide/src/goto_references.rs
@@ -149,7 +149,6 @@ result = calculate_sum(value=42)
     }
 
     #[test]
-    #[ignore] // TODO: Enable when nonlocal support is fully implemented in goto.rs
     fn test_nonlocal_variable_references() {
         let test = cursor_test(
             "
@@ -183,7 +182,7 @@ def outer_function():
         2 | def outer_function():
         3 |     counter = 0
           |     ^^^^^^^
-        4 |     
+        4 |
         5 |     def increment():
           |
 
@@ -214,7 +213,7 @@ def outer_function():
          7 |         counter += 1
          8 |         return counter
            |                ^^^^^^^
-         9 |     
+         9 |
         10 |     def decrement():
            |
 
@@ -245,7 +244,7 @@ def outer_function():
         12 |         counter -= 1
         13 |         return counter
            |                ^^^^^^^
-        14 |     
+        14 |
         15 |     # Use counter in outer scope
            |
 
@@ -266,14 +265,13 @@ def outer_function():
         18 |     decrement()
         19 |     final = counter
            |             ^^^^^^^
-        20 |     
+        20 |
         21 |     return increment, decrement
            |
         ");
     }
 
     #[test]
-    #[ignore] // TODO: Enable when global support is fully implemented in goto.rs
     fn test_global_variable_references() {
         let test = cursor_test(
             "

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -2255,6 +2255,8 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 names,
             }) => {
                 for name in names {
+                    self.scopes_by_expression
+                        .record_expression(name, self.current_scope());
                     let symbol_id = self.add_symbol(name.id.clone());
                     let symbol = self.current_place_table().symbol(symbol_id);
                     // Check whether the variable has already been accessed in this scope.
@@ -2290,6 +2292,8 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 names,
             }) => {
                 for name in names {
+                    self.scopes_by_expression
+                        .record_expression(name, self.current_scope());
                     let symbol_id = self.add_symbol(name.id.clone());
                     let symbol = self.current_place_table().symbol(symbol_id);
                     // Check whether the variable has already been accessed in this scope.


### PR DESCRIPTION
## Summary

The implementation here is to just record the idents of these statements in `scopes_by_expression` (which already supported idents but only ones that happened to appear in expressions), so that `definitions_for_name` Just Works.

goto-type (and therefore hover) notably does not work on these statements because the typechecker does not record info for them. I am tempted to just introduce `type_for_name` which runs `definitions_for_name` to find other expressions and queries the inferred type... but that's a bit whack because it won't be the computed type at the right point in the code. It probably wouldn't be particularly expensive to just compute/record the type at those nodes, as if they were a load, because global/nonlocal is so scarce?

## Test Plan

Snapshot tests added/re-enabled.
