### PR TITLE
Dogfood ty on the `scripts` directory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -284,6 +284,10 @@ jobs:
         run: cargo insta test --all-features --unreferenced reject --test-runner nextest
       - name: Dogfood ty on py-fuzzer
         run: uv run --project=./python/py-fuzzer cargo run -p ty check --project=./python/py-fuzzer
+      - name: Dogfood ty on the scripts directory
+        run: uv run --project=./scripts cargo run -p ty check --project=./scripts
+      - name: Dogfood ty on ty_benchmark
+        run: uv run --project=./scripts/ty_benchmark cargo run -p ty check --project=./scripts/ty_benchmark
       # Check for broken links in the documentation.
       - run: cargo doc --all --no-deps
         env:

--- a/scripts/add_rule.py
+++ b/scripts/add_rule.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import subprocess
+from pathlib import Path
 
 from _utils import ROOT_DIR, dir_name, get_indent, pascal_case, snake_case
 
@@ -153,7 +154,7 @@ pub(crate) fn {rule_name_snake}(checker: &mut Checker) {{}}
     _rustfmt(rules_mod)
 
 
-def _rustfmt(path: str) -> None:
+def _rustfmt(path: str | Path) -> None:
     subprocess.run(["rustfmt", path])
 
 

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -22,10 +22,11 @@ import re
 import tempfile
 import time
 from asyncio.subprocess import PIPE, create_subprocess_exec
+from collections.abc import Awaitable
 from contextlib import asynccontextmanager, nullcontext
 from pathlib import Path
 from signal import SIGINT, SIGTERM
-from typing import TYPE_CHECKING, NamedTuple, Self, TypeVar
+from typing import TYPE_CHECKING, Any, NamedTuple, Self, TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator, Sequence
@@ -342,7 +343,7 @@ DIFF_LINE_RE = re.compile(
     r"^(?P<pre>[+-]) (?P<inner>(?P<path>[^:]+):(?P<lnum>\d+):\d+:) (?P<post>.*)$",
 )
 
-T = TypeVar("T")
+T = TypeVar("T", bound=Awaitable[Any])
 
 
 async def main(

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "scripts"
 version = "0.0.1"
-dependencies = ["stdlibs"]
+dependencies = ["stdlibs", "tqdm", "mdformat", "pyyaml"]
 requires-python = ">=3.12"
 
 [tool.black]
@@ -9,3 +9,11 @@ line-length = 88
 
 [tool.ruff]
 extend = "../pyproject.toml"
+
+[tool.ty.src]
+# `ty_benchmark` is a standalone project with its own pyproject.toml files, search paths, etc.
+exclude = ["./ty_benchmark"]
+
+[tool.ty.rules]
+possibly-unresolved-reference = "error"
+division-by-zero = "error"

--- a/scripts/ty_benchmark/pyproject.toml
+++ b/scripts/ty_benchmark/pyproject.toml
@@ -19,3 +19,7 @@ packages = ["src/benchmark"]
 ignore = [
     "E501", # We use ruff format
 ]
+
+[tool.ty.rules]
+possibly-unresolved-reference = "error"
+division-by-zero = "error"

--- a/scripts/update_ambiguous_characters.py
+++ b/scripts/update_ambiguous_characters.py
@@ -43,7 +43,7 @@ def format_number(number: int) -> str:
     # underscore-delimited in the generated file, so we now preserve that property to
     # avoid unnecessary churn.
     if number > 100000:
-        number = str(number)
+        number: str = str(number)
         number = "_".join(number[i : i + 3] for i in range(0, len(number), 3))
         return f"{number}_u32"
 


### PR DESCRIPTION
## Summary

This PR sets up CI jobs to run ty from the `main` branch on the files and subdirectories in our `scripts` directory

## Test Plan

Both these commands pass for me locally:
- `uv run --project=./scripts cargo run -p ty check --project=./scripts`
- `uv run --project=./scripts/ty_benchmark cargo run -p ty check --project=./scripts/ty_benchmark`