### PR TITLE
[ty] Switch the error code from `unresolved-attribute` to `possibly-missing-attribute` for submodules that may not be available

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2711,9 +2711,9 @@ We give special diagnostics for this common case too:
 import foo
 import baz
 
-# error: [unresolved-attribute]
+# error: [possibly-missing-attribute]
 reveal_type(foo.bar)  # revealed: Unknown
-# error: [unresolved-attribute]
+# error: [possibly-missing-attribute]
 reveal_type(baz.bar)  # revealed: Unknown
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/import/nonstandard_conventions.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/nonstandard_conventions.md
@@ -60,7 +60,7 @@ Y: int = 47
 import mypackage
 
 reveal_type(mypackage.imported.X)  # revealed: int
-# error: [unresolved-attribute] "Submodule `fails` may not be available"
+# error: [possibly-missing-attribute] "Submodule `fails` may not be available"
 reveal_type(mypackage.fails.Y)  # revealed: Unknown
 ```
 
@@ -90,7 +90,7 @@ Y: int = 47
 import mypackage
 
 reveal_type(mypackage.imported.X)  # revealed: int
-# error: [unresolved-attribute] "Submodule `fails` may not be available"
+# error: [possibly-missing-attribute] "Submodule `fails` may not be available"
 reveal_type(mypackage.fails.Y)  # revealed: Unknown
 ```
 
@@ -125,7 +125,7 @@ Y: int = 47
 import mypackage
 
 reveal_type(mypackage.imported.X)  # revealed: int
-# error: [unresolved-attribute] "Submodule `fails` may not be available"
+# error: [possibly-missing-attribute] "Submodule `fails` may not be available"
 reveal_type(mypackage.fails.Y)  # revealed: Unknown
 ```
 
@@ -155,7 +155,7 @@ Y: int = 47
 import mypackage
 
 reveal_type(mypackage.imported.X)  # revealed: int
-# error: [unresolved-attribute] "Submodule `fails` may not be available"
+# error: [possibly-missing-attribute] "Submodule `fails` may not be available"
 reveal_type(mypackage.fails.Y)  # revealed: Unknown
 ```
 
@@ -184,7 +184,7 @@ X: int = 42
 import mypackage
 
 # TODO: this could work and would be nice to have?
-# error: [unresolved-attribute] "Submodule `imported` may not be available"
+# error: [possibly-missing-attribute] "Submodule `imported` may not be available"
 reveal_type(mypackage.imported.X)  # revealed: Unknown
 ```
 
@@ -208,7 +208,7 @@ X: int = 42
 import mypackage
 
 # TODO: this could work and would be nice to have
-# error: [unresolved-attribute] "Submodule `imported` may not be available"
+# error: [possibly-missing-attribute] "Submodule `imported` may not be available"
 reveal_type(mypackage.imported.X)  # revealed: Unknown
 ```
 
@@ -242,9 +242,9 @@ X: int = 42
 import mypackage
 
 reveal_type(mypackage.submodule)  # revealed: <module 'mypackage.submodule'>
-# error: [unresolved-attribute] "Submodule `nested` may not be available"
+# error: [possibly-missing-attribute] "Submodule `nested` may not be available"
 reveal_type(mypackage.submodule.nested)  # revealed: Unknown
-# error: [unresolved-attribute] "Submodule `nested` may not be available"
+# error: [possibly-missing-attribute] "Submodule `nested` may not be available"
 reveal_type(mypackage.submodule.nested.X)  # revealed: Unknown
 # error: [unresolved-attribute] "has no member `nested`"
 reveal_type(mypackage.nested)  # revealed: Unknown
@@ -280,9 +280,9 @@ import mypackage
 
 reveal_type(mypackage.submodule)  # revealed: <module 'mypackage.submodule'>
 # TODO: this would be nice to support
-# error: [unresolved-attribute] "Submodule `nested` may not be available"
+# error: [possibly-missing-attribute] "Submodule `nested` may not be available"
 reveal_type(mypackage.submodule.nested)  # revealed: Unknown
-# error: [unresolved-attribute] "Submodule `nested` may not be available"
+# error: [possibly-missing-attribute] "Submodule `nested` may not be available"
 reveal_type(mypackage.submodule.nested.X)  # revealed: Unknown
 reveal_type(mypackage.nested)  # revealed: <module 'mypackage.submodule.nested'>
 reveal_type(mypackage.nested.X)  # revealed: int
@@ -318,9 +318,9 @@ X: int = 42
 import mypackage
 
 reveal_type(mypackage.submodule)  # revealed: <module 'mypackage.submodule'>
-# error: [unresolved-attribute] "Submodule `nested` may not be available"
+# error: [possibly-missing-attribute] "Submodule `nested` may not be available"
 reveal_type(mypackage.submodule.nested)  # revealed: Unknown
-# error: [unresolved-attribute] "Submodule `nested` may not be available"
+# error: [possibly-missing-attribute] "Submodule `nested` may not be available"
 reveal_type(mypackage.submodule.nested.X)  # revealed: Unknown
 # error: [unresolved-attribute] "has no member `nested`"
 reveal_type(mypackage.nested)  # revealed: Unknown
@@ -356,9 +356,9 @@ import mypackage
 
 reveal_type(mypackage.submodule)  # revealed: <module 'mypackage.submodule'>
 # TODO: this would be nice to support
-# error: [unresolved-attribute] "Submodule `nested` may not be available"
+# error: [possibly-missing-attribute] "Submodule `nested` may not be available"
 reveal_type(mypackage.submodule.nested)  # revealed: Unknown
-# error: [unresolved-attribute] "Submodule `nested` may not be available"
+# error: [possibly-missing-attribute] "Submodule `nested` may not be available"
 reveal_type(mypackage.submodule.nested.X)  # revealed: Unknown
 reveal_type(mypackage.nested)  # revealed: <module 'mypackage.submodule.nested'>
 reveal_type(mypackage.nested.X)  # revealed: int
@@ -393,11 +393,11 @@ X: int = 42
 ```py
 import mypackage
 
-# error: [unresolved-attribute] "Submodule `submodule` may not be available"
+# error: [possibly-missing-attribute] "Submodule `submodule` may not be available"
 reveal_type(mypackage.submodule)  # revealed: Unknown
-# error: [unresolved-attribute] "Submodule `submodule` may not be available"
+# error: [possibly-missing-attribute] "Submodule `submodule` may not be available"
 reveal_type(mypackage.submodule.nested)  # revealed: Unknown
-# error: [unresolved-attribute] "Submodule `submodule` may not be available"
+# error: [possibly-missing-attribute] "Submodule `submodule` may not be available"
 reveal_type(mypackage.submodule.nested.X)  # revealed: Unknown
 ```
 
@@ -429,11 +429,11 @@ X: int = 42
 import mypackage
 
 # TODO: this would be nice to support
-# error: [unresolved-attribute] "Submodule `submodule` may not be available"
+# error: [possibly-missing-attribute] "Submodule `submodule` may not be available"
 reveal_type(mypackage.submodule)  # revealed: Unknown
-# error: [unresolved-attribute] "Submodule `submodule` may not be available"
+# error: [possibly-missing-attribute] "Submodule `submodule` may not be available"
 reveal_type(mypackage.submodule.nested)  # revealed: Unknown
-# error: [unresolved-attribute] "Submodule `submodule` may not be available"
+# error: [possibly-missing-attribute] "Submodule `submodule` may not be available"
 reveal_type(mypackage.submodule.nested.X)  # revealed: Unknown
 ```
 
@@ -460,7 +460,7 @@ X: int = 42
 ```py
 import mypackage
 
-# error: [unresolved-attribute] "Submodule `imported` may not be available"
+# error: [possibly-missing-attribute] "Submodule `imported` may not be available"
 reveal_type(mypackage.imported.X)  # revealed: Unknown
 # error: [unresolved-attribute] "has no member `imported_m`"
 reveal_type(mypackage.imported_m.X)  # revealed: Unknown
@@ -486,7 +486,7 @@ X: int = 42
 import mypackage
 
 # TODO: this would be nice to support, as it works at runtime
-# error: [unresolved-attribute] "Submodule `imported` may not be available"
+# error: [possibly-missing-attribute] "Submodule `imported` may not be available"
 reveal_type(mypackage.imported.X)  # revealed: Unknown
 reveal_type(mypackage.imported_m.X)  # revealed: int
 ```
@@ -673,7 +673,7 @@ reveal_type(imported.X)  # revealed: int
 
 # TODO: this would be nice to support, but it's dangerous with available_submodule_attributes
 # for details, see: https://github.com/astral-sh/ty/issues/1488
-# error: [unresolved-attribute] "Submodule `imported` may not be available"
+# error: [possibly-missing-attribute] "Submodule `imported` may not be available"
 reveal_type(mypackage.imported.X)  # revealed: Unknown
 ```
 
@@ -699,7 +699,7 @@ from mypackage import imported
 reveal_type(imported.X)  # revealed: int
 
 # TODO: this would be nice to support, as it works at runtime
-# error: [unresolved-attribute] "Submodule `imported` may not be available"
+# error: [possibly-missing-attribute] "Submodule `imported` may not be available"
 reveal_type(mypackage.imported.X)  # revealed: Unknown
 ```
 
@@ -737,7 +737,7 @@ from mypackage import imported
 reveal_type(imported.X)  # revealed: int
 # error: [unresolved-attribute] "has no member `fails`"
 reveal_type(imported.fails.Y)  # revealed: Unknown
-# error: [unresolved-attribute] "Submodule `fails` may not be available"
+# error: [possibly-missing-attribute] "Submodule `fails` may not be available"
 reveal_type(mypackage.fails.Y)  # revealed: Unknown
 ```
 
@@ -770,7 +770,7 @@ from mypackage import imported
 
 reveal_type(imported.X)  # revealed: int
 reveal_type(imported.fails.Y)  # revealed: int
-# error: [unresolved-attribute] "Submodule `fails`"
+# error: [possibly-missing-attribute] "Submodule `fails`"
 reveal_type(mypackage.fails.Y)  # revealed: Unknown
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/import/relative.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/relative.md
@@ -247,7 +247,7 @@ X: int = 42
 from . import foo
 import package
 
-# error: [unresolved-attribute]
+# error: [possibly-missing-attribute]
 reveal_type(package.foo.X)  # revealed: Unknown
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attributes.md_-_Attributes_-_Unimported_submodule…_(2b6da09ed380b2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attributes.md_-_Attributes_-_Unimported_submodule…_(2b6da09ed380b2).snap
@@ -30,39 +30,39 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/attributes.md
 1 | import foo
 2 | import baz
 3 | 
-4 | # error: [unresolved-attribute]
+4 | # error: [possibly-missing-attribute]
 5 | reveal_type(foo.bar)  # revealed: Unknown
-6 | # error: [unresolved-attribute]
+6 | # error: [possibly-missing-attribute]
 7 | reveal_type(baz.bar)  # revealed: Unknown
 ```
 
 # Diagnostics
 
 ```
-error[unresolved-attribute]: Submodule `bar` may not be available as an attribute on module `foo`
+warning[possibly-missing-attribute]: Submodule `bar` may not be available as an attribute on module `foo`
  --> src/main.py:5:13
   |
-4 | # error: [unresolved-attribute]
+4 | # error: [possibly-missing-attribute]
 5 | reveal_type(foo.bar)  # revealed: Unknown
   |             ^^^^^^^
-6 | # error: [unresolved-attribute]
+6 | # error: [possibly-missing-attribute]
 7 | reveal_type(baz.bar)  # revealed: Unknown
   |
 help: Consider explicitly importing `foo.bar`
-info: rule `unresolved-attribute` is enabled by default
+info: rule `possibly-missing-attribute` is enabled by default
 
 ```
 
 ```
-error[unresolved-attribute]: Submodule `bar` may not be available as an attribute on module `baz`
+warning[possibly-missing-attribute]: Submodule `bar` may not be available as an attribute on module `baz`
  --> src/main.py:7:13
   |
 5 | reveal_type(foo.bar)  # revealed: Unknown
-6 | # error: [unresolved-attribute]
+6 | # error: [possibly-missing-attribute]
 7 | reveal_type(baz.bar)  # revealed: Unknown
   |             ^^^^^^^
   |
 help: Consider explicitly importing `baz.bar`
-info: rule `unresolved-attribute` is enabled by default
+info: rule `possibly-missing-attribute` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -628,7 +628,7 @@ import imported
 from module2 import imported as other_imported
 from ty_extensions import TypeOf, static_assert, is_equivalent_to
 
-# error: [unresolved-attribute]
+# error: [possibly-missing-attribute]
 reveal_type(imported.abc)  # revealed: Unknown
 
 reveal_type(other_imported.abc)  # revealed: <module 'imported.abc'>


### PR DESCRIPTION
## Summary

This is one of the two suggestions in https://github.com/astral-sh/ty/issues/1623. Empirically, these attributes often _are_ available even when they "morally" shouldn't be, and it's confusing to users when we report diagnostics on things that "work fine" at runtime. `possibly-missing-attribute` therefore seems a better fit than `unresolved-attribute`, since it better conveys that this diagnostic isn't one we're certain about, and since that error code has `"warn"` level by default rather than `"error"` level by default.

## Test Plan

mdtests updated
