### PR TITLE
Disable ty workspace diagnostics for VSCode users

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "rust-analyzer.check.command": "clippy",
     "search.exclude": {
         "**/*.snap": true
-    }
+    },
+    "ty.diagnosticMode": "openFilesOnly"
 }


### PR DESCRIPTION
## Summary

It's currently pretty painful to have ty's workspace diagnostics enabled in the Ruff repo, because ty will proceed to type-check every single fixture in the `ruff_linter` crate, resulting in >10,000 diagnostics. This PR disables ty workspace diagnostics if you're browsing this repo inside VSCode.

## Test Plan

On this branch, I no longer have >10,000 diagnostics reported in the `problems` tab in VSCode, despite having the ty-vscode plugin installed and despite having this setting in my VSCode user settings:

```json
    "ty.diagnosticMode": "workspace"
```