### PR TITLE
Add Ability to Output to Multiple Files/Formats

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -604,9 +604,11 @@ Options:
           format is "full" [env: RUFF_OUTPUT_FORMAT=] [possible values:
           concise, full, json, json-lines, junit, grouped, github, gitlab,
           pylint, rdjson, azure, sarif]
-  -o, --output-file <OUTPUT_FILE>
-          Specify file to write the linter output to (default: stdout) [env:
-          RUFF_OUTPUT_FILE=]
+  -o, --output-file <FORMAT:TARGET>
+          Specify output destination(s) using format:target syntax. Can be
+          specified multiple times for multiple outputs. Also supports
+          comma-separated values: --output-file gitlab:file.json,full:stdout
+          [env: RUFF_OUTPUT_FILE=]
       --target-version <TARGET_VERSION>
           The minimum Python version that should be supported [possible values:
           py37, py38, py39, py310, py311, py312, py313, py314]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
I have written many CI jobs where Ruff outputs in the GitLab format to a file, but this suppresses outputting to `stdout`/`stderr`. If Ruff finds an issue this will fail the CI job and it won't be immediately obvious to the developer what the lint finding was -- they'd have to go and crack open the GitLab JSON artifact, or view it in GitLab's merge request view.

This change allows us to write both a machine-readable artifact (e.g. GitLab JSON format) as well as output Ruff's findings in a human-readable format without needing to run it twice.

This PR should resolve #2388.

## Test Plan

<!-- How was it tested? -->
Tested locally, and hopefully tests will also be run in a CI pipeline.
