### PR TITLE
docs: update reference to the pre-commit hook

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -372,7 +372,7 @@ This tutorial has focused on Ruff's command-line interface, but Ruff can also be
   rev: v0.14.6
   hooks:
     # Run the linter.
-    - id: ruff
+    - id: ruff-check
     # Run the formatter.
     - id: ruff-format
 ```


### PR DESCRIPTION
## Summary

The reference to the pre-commit hook inside the tutorial was to the legacy alias `ruff` instead of the current `ruff-check`.

Ref: https://github.com/astral-sh/ruff-pre-commit/pull/124

## Test Plan

Not applicable.
