### PR TITLE
[ty] more precise inference for a failed specialization

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -223,7 +223,7 @@ static STATIC_FRAME: Benchmark = Benchmark::new(
         max_dep_date: "2025-08-09",
         python_version: PythonVersion::PY311,
     },
-    900,
+    950,
 );
 
 #[track_caller]

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -63,22 +63,6 @@ B = TypeVar("B", bound="Base")
 
 class Base(Generic[B]):
     pass
-
-T = TypeVar("T", bound="Foo[int]")
-
-class Foo(Generic[T]): ...
-```
-
-## Self-referential PEP-695 type variables
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-class Node[T: "Node[int]"]:
-    pass
 ```
 
 ## Parameter default values

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -146,7 +146,7 @@ The specialization must match the generic types:
 
 ```py
 # error: [invalid-type-arguments] "Too many type arguments to class `C`: expected 1, got 2"
-reveal_type(C[int, int]())  # revealed: Unknown
+reveal_type(C[int, int]())  # revealed: C[Unknown]
 ```
 
 If the type variable has an upper bound, the specialized type must satisfy that bound:
@@ -165,10 +165,10 @@ reveal_type(Bounded[int]())  # revealed: Bounded[int]
 reveal_type(Bounded[IntSubclass]())  # revealed: Bounded[IntSubclass]
 
 # error: [invalid-type-arguments] "Type `str` is not assignable to upper bound `int` of type variable `BoundedT@Bounded`"
-reveal_type(Bounded[str]())  # revealed: Unknown
+reveal_type(Bounded[str]())  # revealed: Bounded[Unknown]
 
 # error:  [invalid-type-arguments] "Type `int | str` is not assignable to upper bound `int` of type variable `BoundedT@Bounded`"
-reveal_type(Bounded[int | str]())  # revealed: Unknown
+reveal_type(Bounded[int | str]())  # revealed: Bounded[Unknown]
 
 reveal_type(BoundedByUnion[int]())  # revealed: BoundedByUnion[int]
 reveal_type(BoundedByUnion[IntSubclass]())  # revealed: BoundedByUnion[IntSubclass]
@@ -196,7 +196,7 @@ reveal_type(Constrained[str]())  # revealed: Constrained[str]
 reveal_type(Constrained[int | str]())  # revealed: Constrained[int | str]
 
 # error: [invalid-type-arguments] "Type `object` does not satisfy constraints `int`, `str` of type variable `ConstrainedT@Constrained`"
-reveal_type(Constrained[object]())  # revealed: Unknown
+reveal_type(Constrained[object]())  # revealed: Constrained[Unknown]
 ```
 
 If the type variable has a default, it can be omitted:

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
@@ -444,6 +444,22 @@ class G(Generic[T]):
 reveal_type(G[list[G]]().x)  # revealed: list[G[Unknown]]
 ```
 
+An invalid specialization in a recursive bound doesn't cause a panic:
+
+```py
+from typing import TypeVar, Generic
+
+# error: [invalid-type-arguments]
+T = TypeVar("T", bound="Node[int]")
+
+class Node(Generic[T]):
+    pass
+
+# error: [invalid-type-arguments]
+def _(n: Node[str]):
+    reveal_type(n)  # revealed: Node[Unknown]
+```
+
 ### Defaults
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -62,7 +62,7 @@ The specialization must match the generic types:
 
 ```py
 # error: [invalid-type-arguments] "Too many type arguments: expected 1, got 2"
-reveal_type(C[int, int])  # revealed: Unknown
+reveal_type(C[int, int])  # revealed: C[Unknown]
 ```
 
 And non-generic types cannot be specialized:
@@ -89,10 +89,10 @@ reveal_type(Bounded[int])  # revealed: Bounded[int]
 reveal_type(Bounded[IntSubclass])  # revealed: Bounded[IntSubclass]
 
 # error: [invalid-type-arguments] "Type `str` is not assignable to upper bound `int` of type variable `T@Bounded`"
-reveal_type(Bounded[str])  # revealed: Unknown
+reveal_type(Bounded[str])  # revealed: Bounded[Unknown]
 
 # error: [invalid-type-arguments] "Type `int | str` is not assignable to upper bound `int` of type variable `T@Bounded`"
-reveal_type(Bounded[int | str])  # revealed: Unknown
+reveal_type(Bounded[int | str])  # revealed: Bounded[Unknown]
 
 reveal_type(BoundedByUnion[int])  # revealed: BoundedByUnion[int]
 reveal_type(BoundedByUnion[IntSubclass])  # revealed: BoundedByUnion[IntSubclass]
@@ -118,7 +118,7 @@ reveal_type(Constrained[str])  # revealed: Constrained[str]
 reveal_type(Constrained[int | str])  # revealed: Constrained[int | str]
 
 # error: [invalid-type-arguments] "Type `object` does not satisfy constraints `int`, `str` of type variable `T@Constrained`"
-reveal_type(Constrained[object])  # revealed: Unknown
+reveal_type(Constrained[object])  # revealed: Constrained[Unknown]
 ```
 
 If the type variable has a default, it can be omitted:

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -136,7 +136,7 @@ The specialization must match the generic types:
 
 ```py
 # error: [invalid-type-arguments] "Too many type arguments to class `C`: expected 1, got 2"
-reveal_type(C[int, int]())  # revealed: Unknown
+reveal_type(C[int, int]())  # revealed: C[Unknown]
 ```
 
 If the type variable has an upper bound, the specialized type must satisfy that bound:
@@ -150,10 +150,10 @@ reveal_type(Bounded[int]())  # revealed: Bounded[int]
 reveal_type(Bounded[IntSubclass]())  # revealed: Bounded[IntSubclass]
 
 # error: [invalid-type-arguments] "Type `str` is not assignable to upper bound `int` of type variable `T@Bounded`"
-reveal_type(Bounded[str]())  # revealed: Unknown
+reveal_type(Bounded[str]())  # revealed: Bounded[Unknown]
 
 # error: [invalid-type-arguments] "Type `int | str` is not assignable to upper bound `int` of type variable `T@Bounded`"
-reveal_type(Bounded[int | str]())  # revealed: Unknown
+reveal_type(Bounded[int | str]())  # revealed: Bounded[Unknown]
 
 reveal_type(BoundedByUnion[int]())  # revealed: BoundedByUnion[int]
 reveal_type(BoundedByUnion[IntSubclass]())  # revealed: BoundedByUnion[IntSubclass]
@@ -179,7 +179,7 @@ reveal_type(Constrained[str]())  # revealed: Constrained[str]
 reveal_type(Constrained[int | str]())  # revealed: Constrained[int | str]
 
 # error: [invalid-type-arguments] "Type `object` does not satisfy constraints `int`, `str` of type variable `T@Constrained`"
-reveal_type(Constrained[object]())  # revealed: Unknown
+reveal_type(Constrained[object]())  # revealed: Constrained[Unknown]
 ```
 
 If the type variable has a default, it can be omitted:

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -834,6 +834,18 @@ class G[T: list[G]]:
 reveal_type(G[list[G]]().x)  # revealed: list[G[Unknown]]
 ```
 
+An invalid specialization in a recursive bound doesn't cause a panic:
+
+```py
+# error: [invalid-type-arguments]
+class Node[T: "Node[int]"]:
+    pass
+
+# error: [invalid-type-arguments]
+def _(n: Node[str]):
+    reveal_type(n)  # revealed: Node[Unknown]
+```
+
 ### Defaults
 
 Defaults can be generic, but can only refer to earlier typevars:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1397,7 +1397,7 @@ msg = Message(id=1, content="Hello")
 # No errors for yet-unsupported features (`closed`):
 OtherMessage = TypedDict("OtherMessage", {"id": int, "content": str}, closed=True)
 
-reveal_type(Message.__required_keys__)  # revealed: @Todo(Support for `TypedDict`)
+reveal_type(Message.__required_keys__)  # revealed: @Todo(Support for functional `TypedDict`)
 
 # TODO: this should be an error
 msg.content

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1118,6 +1118,11 @@ impl<'db> Bindings<'db> {
                             }
                         }
 
+                        Some(KnownFunction::NamedTuple) => {
+                            overload
+                                .set_return_type(todo_type!("Support for functional `namedtuple`"));
+                        }
+
                         _ => {
                             // Ideally, either the implementation, or exactly one of the overloads
                             // of the function can have the dataclass_transform decorator applied.
@@ -1350,7 +1355,7 @@ impl<'db> Bindings<'db> {
                     },
 
                     Type::SpecialForm(SpecialFormType::TypedDict) => {
-                        overload.set_return_type(todo_type!("Support for `TypedDict`"));
+                        overload.set_return_type(todo_type!("Support for functional `TypedDict`"));
                     }
 
                     // Not a special case

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1230,6 +1230,9 @@ pub enum KnownFunction {
     /// `builtins.__import__`, which returns the top-level module.
     #[strum(serialize = "__import__")]
     DunderImport,
+    /// `collections.namedtuple`
+    #[strum(serialize = "namedtuple")]
+    NamedTuple,
     /// `importlib.import_module`, which returns the submodule.
     ImportModule,
     /// `typing(_extensions).final`
@@ -1370,6 +1373,7 @@ impl KnownFunction {
             Self::ImportModule => module.is_importlib(),
 
             Self::TypeCheckOnly => matches!(module, KnownModule::Typing),
+            Self::NamedTuple => matches!(module, KnownModule::Collections),
         }
     }
 
@@ -1902,6 +1906,7 @@ pub(crate) mod tests {
                 | KnownFunction::AllMembers => KnownModule::TyExtensions,
 
                 KnownFunction::ImportModule => KnownModule::ImportLib,
+                KnownFunction::NamedTuple => KnownModule::Collections,
             };
 
             let function_definition = known_module_symbol(&db, module, function_name)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11384,7 +11384,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         if has_error {
-            return Type::unknown();
+            let unknowns = generic_context
+                .variables(self.db())
+                .map(|_| Some(Type::unknown()))
+                .collect::<Vec<_>>();
+            return specialize(&unknowns);
         }
 
         specialize(&specialization_types)


### PR DESCRIPTION
## Summary

Previously if an explicit specialization failed (e.g. wrong number of type arguments or violates an upper bound) we just inferred `Unknown` for the entire type. This actually caused us to panic on an a case of a recursive upper bound with invalid specialization; the upper bound would oscillate indefinitely in fixpoint iteration between `Unknown` and the given specialization. This could be fixed with a cycle recovery function, but in this case there's a simpler fix: if we infer `C[Unknown]` instead of `Unknown` for an invalid attempt to specialize `C`, that allows fixpoint iteration to quickly converge, as well as giving a more precise type inference.

Other type checkers actually just go with the attempted specialization even if it's invalid. So if `C` has a type parameter with upper bound `int`, and you say `C[str]`, they'll emit a diagnostic but just go with `C[str]`. Even weirder, if `C` has a single type parameter and you say `C[str, bytes]`, they'll just go with `C[str]` as the type. I'm not convinced by this approach; it seems odd to have specializations floating around that explicitly violate the declared upper bound, or in the latter case aren't even the specialization the annotation requested. I prefer `C[Unknown]` for this case.

Fixing this revealed an issue with `collections.namedtuple`, which returns `type[tuple[Any, ...]]`. Due to https://github.com/astral-sh/ty/issues/1649 we consider that to be an invalid specialization. So previously we returned `Unknown`; after this PR it would be `type[tuple[Unknown]]`, leading to more false positives from our lack of functional namedtuple support. To avoid that I added an explicit Todo type for functional namedtuples for now.

## Test Plan

Added and updated mdtests.

The conformance suite changes have to do with `ParamSpec`, so no meaningful signal there.

The ecosystem changes appear to be the expected effects of having more precise type information (including occurrences of known issues such as https://github.com/astral-sh/ty/issues/1495 ). Most effects are just changes to types in diagnostics.