### PR TITLE
[ty] uniformly weak imports

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/import/conflicts.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/conflicts.md
@@ -5,7 +5,7 @@
 ```py
 import a.b
 
-reveal_type(a.b)  # revealed: <module 'a.b'>
+reveal_type(a.b)  # revealed: int
 ```
 
 `a/__init__.py`:
@@ -44,8 +44,8 @@ b: int = 42
 import a.b
 from a import b
 
-reveal_type(b)  # revealed: <module 'a.b'>
-reveal_type(a.b)  # revealed: <module 'a.b'>
+reveal_type(b)  # revealed: int
+reveal_type(a.b)  # revealed: int
 ```
 
 `a/__init__.py`:
@@ -73,8 +73,8 @@ from a import b
 import a.b
 
 # Python would say `int` for `b`
-reveal_type(b)  # revealed: <module 'a.b'>
-reveal_type(a.b)  # revealed: <module 'a.b'>
+reveal_type(b)  # revealed: int
+reveal_type(a.b)  # revealed: int
 ```
 
 `a/__init__.py`:

--- a/crates/ty_python_semantic/resources/mdtest/import/tracking.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/tracking.md
@@ -89,8 +89,8 @@ import sub.b
 import attr.b
 
 # In the Python interpreter, `attr.b` is Literal[1]
-reveal_type(sub.b)  # revealed: <module 'sub.b'>
-reveal_type(attr.b)  # revealed: <module 'attr.b'>
+reveal_type(sub.b)  # revealed: Literal[1]
+reveal_type(attr.b)  # revealed: Literal[1]
 ```
 
 `sub/__init__.py`:

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -13301,19 +13301,6 @@ impl<'db> ModuleLiteralType<'db> {
             submodule_type = self.resolve_submodule(db, name);
         }
 
-        // if we're in a module `foo` and `foo` contains `import a.b`,
-        // and the package `a` has a submodule `b`, we assume that the
-        // attribute access `a.b` inside `foo` will resolve to the submodule
-        // `a.b` *even if* `a/__init__.py` also defines a symbol `b` (e.g. `b = 42`).
-        // This is a heuristic, but it's almost certainly what will actually happen
-        // at runtime. However, if `foo` only contains `from a.b import <something>,
-        // we prioritise the `b` attribute in `a/__init__.py` over the submodule `a.b`.
-        if available_submodule_kind == Some(ImportKind::Import)
-            && let Some(submodule) = submodule_type
-        {
-            return Place::bound(submodule).into();
-        }
-
         let place_and_qualifiers = self
             .module(db)
             .file(db)


### PR DESCRIPTION
Split out from #21583 to analyze the effect of this one change.

The code in the base PR gives `import a.b` highest priority, while `from a.b import ...` gets second-lowest priority (beating only `__getattr__`). This PR removes the special handling of `import a.b` so that they get the same priority as `from a.b import...`.