### PR TITLE
Add python 3.14 as a supported version for PyPi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Rust",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
## Summary

Update pypi metadata

## Test Plan

Not applicable
