### PR TITLE
[ty] Implicit type aliases: Instantiation and attribute access

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6045,6 +6045,10 @@ impl<'db> Type<'db> {
             )
             .into(),
 
+            Type::KnownInstance(KnownInstanceType::Annotated(ty)) => {
+                ty.inner(db).to_meta_type(db).bindings(db)
+            }
+
             Type::KnownInstance(known_instance) => {
                 known_instance.instance_fallback(db).bindings(db)
             }


### PR DESCRIPTION
## Summary

Allow `Annotated[MyClass, …]` instances to be instantiated.

## Test Plan

New Markdown tests.