### PR TITLE
[ty] fix typo in HasDefinition trait docstring

### DIFF
--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -397,7 +397,7 @@ pub trait HasType {
 }
 
 pub trait HasDefinition {
-    /// Returns the inferred type of `self`.
+    /// Returns the definition of `self`.
     ///
     /// ## Panics
     /// May panic if `self` is from another file than `model`.


### PR DESCRIPTION
## Summary
Fixes a typo in the docstring for the definition method in the HasDefinition trait