### PR TITLE
[ty] Emit `invalid-named-tuple` on namedtuple classes that have field names starting with underscores

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -482,3 +482,21 @@ class F(NamedTuple):
 
 super(F, F(42))  # fine
 ```
+
+## NamedTuples cannot have field names starting with underscores
+
+<!-- snapshot-diagnostics -->
+
+```py
+from typing import NamedTuple
+
+class Foo(NamedTuple):
+    # error: [invalid-named-tuple] "NamedTuple field `_bar` cannot start with an underscore"
+    _bar: int
+
+class Bar(NamedTuple):
+    x: int
+
+class Baz(Bar):
+    _whatever: str  # `Baz` is not a NamedTuple class, so this is fine
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_NamedTuples_cannot_h…_(e2ed186fe2b2fc35).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_NamedTuples_cannot_h…_(e2ed186fe2b2fc35).snap
@@ -1,0 +1,43 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: named_tuple.md - `NamedTuple` - NamedTuples cannot have field names starting with underscores
+mdtest path: crates/ty_python_semantic/resources/mdtest/named_tuple.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | from typing import NamedTuple
+ 2 | 
+ 3 | class Foo(NamedTuple):
+ 4 |     # error: [invalid-named-tuple] "NamedTuple field `_bar` cannot start with an underscore"
+ 5 |     _bar: int
+ 6 | 
+ 7 | class Bar(NamedTuple):
+ 8 |     x: int
+ 9 | 
+10 | class Baz(Bar):
+11 |     _whatever: str  # `Baz` is not a NamedTuple class, so this is fine
+```
+
+# Diagnostics
+
+```
+error[invalid-named-tuple]: NamedTuple field name cannot start with an underscore
+ --> src/mdtest_snippet.py:5:5
+  |
+3 | class Foo(NamedTuple):
+4 |     # error: [invalid-named-tuple] "NamedTuple field `_bar` cannot start with an underscore"
+5 |     _bar: int
+  |     ^^^^^^^^^ Class definition will raise `TypeError` at runtime due to this field
+6 |
+7 | class Bar(NamedTuple):
+  |
+info: rule `invalid-named-tuple` is enabled by default
+
+```

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -76,7 +76,7 @@ use crate::types::diagnostic::{
     report_invalid_exception_raised, report_invalid_exception_tuple_caught,
     report_invalid_generator_function_return_type, report_invalid_key_on_typed_dict,
     report_invalid_or_unsupported_base, report_invalid_return_type,
-    report_invalid_type_checking_constant,
+    report_invalid_type_checking_constant, report_named_tuple_field_with_leading_underscore,
     report_namedtuple_field_without_default_after_field_with_default, report_non_subscriptable,
     report_possibly_missing_attribute, report_possibly_unresolved_reference,
     report_rebound_typevar, report_slice_step_size_zero,
@@ -628,6 +628,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 for (field_name, field) in
                     class.own_fields(self.db(), None, CodeGeneratorKind::NamedTuple)
                 {
+                    if field_name.starts_with('_') {
+                        report_named_tuple_field_with_leading_underscore(
+                            &self.context,
+                            class,
+                            &field_name,
+                            field.single_declaration,
+                        );
+                    }
+
                     if matches!(
                         field.kind,
                         FieldKind::NamedTuple {
@@ -641,7 +650,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         report_namedtuple_field_without_default_after_field_with_default(
                             &self.context,
                             class,
-                            &(field_name, field.single_declaration),
+                            (&field_name, field.single_declaration),
                             field_with_default,
                         );
                     }


### PR DESCRIPTION
## Summary

This raises `TypeError` at runtime and is caught by all other major type checkers

## Test Plan

snapshot/mdtest
