### PR TITLE
[ty] remove the `visitor` parameter in the `recursive_type_normalized_impl` method

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -52,6 +52,10 @@ def f(x: A):
 
 JSONPrimitive = Union[str, int, float, bool, None]
 JSONValue = TypeAliasType("JSONValue", 'Union[JSONPrimitive, Sequence["JSONValue"], Mapping[str, "JSONValue"]]')
+
+def _(x: JSONValue):
+    # TODO: should be `JSONValue`
+    reveal_type(x)  # revealed: Divergent
 ```
 
 ## Self-referential legacy type variables

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -197,17 +197,16 @@ impl<'db> SuperOwnerKind<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         match self {
             SuperOwnerKind::Dynamic(dynamic) => {
                 Some(SuperOwnerKind::Dynamic(dynamic.recursive_type_normalized()))
             }
             SuperOwnerKind::Class(class) => Some(SuperOwnerKind::Class(
-                class.recursive_type_normalized_impl(db, div, nested, visitor)?,
+                class.recursive_type_normalized_impl(db, div, nested)?,
             )),
             SuperOwnerKind::Instance(instance) => Some(SuperOwnerKind::Instance(
-                instance.recursive_type_normalized_impl(db, div, nested, visitor)?,
+                instance.recursive_type_normalized_impl(db, div, nested)?,
             )),
         }
     }
@@ -620,14 +619,13 @@ impl<'db> BoundSuperType<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         Some(Self::new(
             db,
             self.pivot_class(db)
-                .recursive_type_normalized_impl(db, div, nested, visitor)?,
+                .recursive_type_normalized_impl(db, div, nested)?,
             self.owner(db)
-                .recursive_type_normalized_impl(db, div, nested, visitor)?,
+                .recursive_type_normalized_impl(db, div, nested)?,
         ))
     }
 }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -284,13 +284,12 @@ impl<'db> GenericAlias<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         Some(Self::new(
             db,
             self.origin(db),
             self.specialization(db)
-                .recursive_type_normalized_impl(db, div, nested, visitor)?,
+                .recursive_type_normalized_impl(db, div, nested)?,
         ))
     }
 
@@ -443,12 +442,11 @@ impl<'db> ClassType<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         match self {
             Self::NonGeneric(_) => Some(self),
             Self::Generic(generic) => Some(Self::Generic(
-                generic.recursive_type_normalized_impl(db, div, nested, visitor)?,
+                generic.recursive_type_normalized_impl(db, div, nested)?,
             )),
         }
     }

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -48,12 +48,11 @@ impl<'db> ClassBase<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         match self {
             Self::Dynamic(dynamic) => Some(Self::Dynamic(dynamic.recursive_type_normalized())),
             Self::Class(class) => Some(Self::Class(
-                class.recursive_type_normalized_impl(db, div, nested, visitor)?,
+                class.recursive_type_normalized_impl(db, div, nested)?,
             )),
             Self::Protocol | Self::Generic | Self::TypedDict => Some(self),
         }

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1112,19 +1112,14 @@ impl<'db> FunctionType<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         let literal = self.literal(db);
         let updated_signature = match self.updated_signature(db) {
-            Some(signature) => {
-                Some(signature.recursive_type_normalized_impl(db, div, nested, visitor)?)
-            }
+            Some(signature) => Some(signature.recursive_type_normalized_impl(db, div, nested)?),
             None => None,
         };
         let updated_last_definition_signature = match self.updated_last_definition_signature(db) {
-            Some(signature) => {
-                Some(signature.recursive_type_normalized_impl(db, div, nested, visitor)?)
-            }
+            Some(signature) => Some(signature.recursive_type_normalized_impl(db, div, nested)?),
             None => None,
         };
         Some(Self::new(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1045,24 +1045,23 @@ impl<'db> Specialization<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         let types = if nested {
             self.types(db)
                 .iter()
-                .map(|ty| ty.recursive_type_normalized_impl(db, div, true, visitor))
+                .map(|ty| ty.recursive_type_normalized_impl(db, div, true))
                 .collect::<Option<Box<[_]>>>()?
         } else {
             self.types(db)
                 .iter()
                 .map(|ty| {
-                    ty.recursive_type_normalized_impl(db, div, true, visitor)
+                    ty.recursive_type_normalized_impl(db, div, true)
                         .unwrap_or(div)
                 })
                 .collect::<Box<[_]>>()
         };
         let tuple_inner = match self.tuple_inner(db) {
-            Some(tuple) => Some(tuple.recursive_type_normalized_impl(db, div, nested, visitor)?),
+            Some(tuple) => Some(tuple.recursive_type_normalized_impl(db, div, nested)?),
             None => None,
         };
         let context = self.generic_context(db);

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -379,16 +379,15 @@ impl<'db> NominalInstanceType<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => {
                 Some(Self(NominalInstanceInner::ExactTuple(
-                    tuple.recursive_type_normalized_impl(db, div, nested, visitor)?,
+                    tuple.recursive_type_normalized_impl(db, div, nested)?,
                 )))
             }
             NominalInstanceInner::NonTuple(class) => Some(Self(NominalInstanceInner::NonTuple(
-                class.recursive_type_normalized_impl(db, div, nested, visitor)?,
+                class.recursive_type_normalized_impl(db, div, nested)?,
             ))),
             NominalInstanceInner::Object => Some(Self(NominalInstanceInner::Object)),
         }
@@ -750,12 +749,9 @@ impl<'db> ProtocolInstanceType<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         Some(Self {
-            inner: self
-                .inner
-                .recursive_type_normalized_impl(db, div, nested, visitor)?,
+            inner: self.inner.recursive_type_normalized_impl(db, div, nested)?,
             _phantom: PhantomData,
         })
     }
@@ -877,14 +873,13 @@ impl<'db> Protocol<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         match self {
             Self::FromClass(class) => Some(Self::FromClass(
-                class.recursive_type_normalized_impl(db, div, nested, visitor)?,
+                class.recursive_type_normalized_impl(db, div, nested)?,
             )),
             Self::Synthesized(synthesized) => Some(Self::Synthesized(
-                synthesized.recursive_type_normalized_impl(db, div, nested, visitor)?,
+                synthesized.recursive_type_normalized_impl(db, div, nested)?,
             )),
         }
     }
@@ -963,11 +958,9 @@ mod synthesized_protocol {
             db: &'db dyn Db,
             div: Type<'db>,
             nested: bool,
-            visitor: &NormalizedVisitor<'db>,
         ) -> Option<Self> {
             Some(Self(
-                self.0
-                    .recursive_type_normalized_impl(db, div, nested, visitor)?,
+                self.0.recursive_type_normalized_impl(db, div, nested)?,
             ))
         }
     }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -150,11 +150,9 @@ impl<'db> ProtocolClass<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         Some(Self(
-            self.0
-                .recursive_type_normalized_impl(db, div, nested, visitor)?,
+            self.0.recursive_type_normalized_impl(db, div, nested)?,
         ))
     }
 }
@@ -386,7 +384,6 @@ impl<'db> ProtocolInterface<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         Some(Self::new(
             db,
@@ -395,7 +392,7 @@ impl<'db> ProtocolInterface<'db> {
                 .map(|(name, data)| {
                     Some((
                         name.clone(),
-                        data.recursive_type_normalized_impl(db, div, nested, visitor)?,
+                        data.recursive_type_normalized_impl(db, div, nested)?,
                     ))
                 })
                 .collect::<Option<BTreeMap<_, _>>>()?,
@@ -498,21 +495,20 @@ impl<'db> ProtocolMemberData<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         Some(Self {
             kind: match &self.kind {
                 ProtocolMemberKind::Method(callable) => ProtocolMemberKind::Method(
-                    callable.recursive_type_normalized_impl(db, div, nested, visitor)?,
+                    callable.recursive_type_normalized_impl(db, div, nested)?,
                 ),
                 ProtocolMemberKind::Property(property) => ProtocolMemberKind::Property(
-                    property.recursive_type_normalized_impl(db, div, nested, visitor)?,
+                    property.recursive_type_normalized_impl(db, div, nested)?,
                 ),
-                ProtocolMemberKind::Other(ty) if nested => ProtocolMemberKind::Other(
-                    ty.recursive_type_normalized_impl(db, div, true, visitor)?,
-                ),
+                ProtocolMemberKind::Other(ty) if nested => {
+                    ProtocolMemberKind::Other(ty.recursive_type_normalized_impl(db, div, true)?)
+                }
                 ProtocolMemberKind::Other(ty) => ProtocolMemberKind::Other(
-                    ty.recursive_type_normalized_impl(db, div, true, visitor)
+                    ty.recursive_type_normalized_impl(db, div, true)
                         .unwrap_or(div),
                 ),
             },

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -179,13 +179,12 @@ impl<'db> CallableSignature<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         Some(Self {
             overloads: self
                 .overloads
                 .iter()
-                .map(|signature| signature.recursive_type_normalized_impl(db, div, nested, visitor))
+                .map(|signature| signature.recursive_type_normalized_impl(db, div, nested))
                 .collect::<Option<SmallVec<_>>>()?,
         })
     }
@@ -575,15 +574,14 @@ impl<'db> Signature<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         let return_ty = match self.return_ty {
             Some(return_ty) if nested => {
-                Some(return_ty.recursive_type_normalized_impl(db, div, true, visitor)?)
+                Some(return_ty.recursive_type_normalized_impl(db, div, true)?)
             }
             Some(return_ty) => Some(
                 return_ty
-                    .recursive_type_normalized_impl(db, div, true, visitor)
+                    .recursive_type_normalized_impl(db, div, true)
                     .unwrap_or(div),
             ),
             None => None,
@@ -591,7 +589,7 @@ impl<'db> Signature<'db> {
         let parameters = {
             let mut parameters = Vec::with_capacity(self.parameters.len());
             for param in &self.parameters {
-                parameters.push(param.recursive_type_normalized_impl(db, div, nested, visitor)?);
+                parameters.push(param.recursive_type_normalized_impl(db, div, nested)?);
             }
             Parameters::new(db, parameters)
         };
@@ -1906,7 +1904,6 @@ impl<'db> Parameter<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         let Parameter {
             annotated_type,
@@ -1916,9 +1913,9 @@ impl<'db> Parameter<'db> {
         } = self;
 
         let annotated_type = match annotated_type {
-            Some(ty) if nested => Some(ty.recursive_type_normalized_impl(db, div, true, visitor)?),
+            Some(ty) if nested => Some(ty.recursive_type_normalized_impl(db, div, true)?),
             Some(ty) => Some(
-                ty.recursive_type_normalized_impl(db, div, true, visitor)
+                ty.recursive_type_normalized_impl(db, div, true)
                     .unwrap_or(div),
             ),
             None => None,
@@ -1928,11 +1925,9 @@ impl<'db> Parameter<'db> {
             ParameterKind::PositionalOnly { name, default_type } => ParameterKind::PositionalOnly {
                 name: name.clone(),
                 default_type: match default_type {
-                    Some(ty) if nested => {
-                        Some(ty.recursive_type_normalized_impl(db, div, true, visitor)?)
-                    }
+                    Some(ty) if nested => Some(ty.recursive_type_normalized_impl(db, div, true)?),
                     Some(ty) => Some(
-                        ty.recursive_type_normalized_impl(db, div, true, visitor)
+                        ty.recursive_type_normalized_impl(db, div, true)
                             .unwrap_or(div),
                     ),
                     None => None,
@@ -1943,10 +1938,10 @@ impl<'db> Parameter<'db> {
                     name: name.clone(),
                     default_type: match default_type {
                         Some(ty) if nested => {
-                            Some(ty.recursive_type_normalized_impl(db, div, true, visitor)?)
+                            Some(ty.recursive_type_normalized_impl(db, div, true)?)
                         }
                         Some(ty) => Some(
-                            ty.recursive_type_normalized_impl(db, div, true, visitor)
+                            ty.recursive_type_normalized_impl(db, div, true)
                                 .unwrap_or(div),
                         ),
                         None => None,
@@ -1956,11 +1951,9 @@ impl<'db> Parameter<'db> {
             ParameterKind::KeywordOnly { name, default_type } => ParameterKind::KeywordOnly {
                 name: name.clone(),
                 default_type: match default_type {
-                    Some(ty) if nested => {
-                        Some(ty.recursive_type_normalized_impl(db, div, true, visitor)?)
-                    }
+                    Some(ty) if nested => Some(ty.recursive_type_normalized_impl(db, div, true)?),
                     Some(ty) => Some(
-                        ty.recursive_type_normalized_impl(db, div, true, visitor)
+                        ty.recursive_type_normalized_impl(db, div, true)
                             .unwrap_or(div),
                     ),
                     None => None,

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -272,12 +272,11 @@ impl<'db> SubclassOfType<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         Some(Self {
             subclass_of: self
                 .subclass_of
-                .recursive_type_normalized_impl(db, div, nested, visitor)?,
+                .recursive_type_normalized_impl(db, div, nested)?,
         })
     }
 
@@ -449,11 +448,10 @@ impl<'db> SubclassOfInner<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         match self {
             Self::Class(class) => Some(Self::Class(
-                class.recursive_type_normalized_impl(db, div, nested, visitor)?,
+                class.recursive_type_normalized_impl(db, div, nested)?,
             )),
             Self::Dynamic(dynamic) => Some(Self::Dynamic(dynamic.recursive_type_normalized())),
             Self::TypeVar(_) => Some(self),

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -234,12 +234,11 @@ impl<'db> TupleType<'db> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         Some(Self::new_internal(
             db,
             self.tuple(db)
-                .recursive_type_normalized_impl(db, div, nested, visitor)?,
+                .recursive_type_normalized_impl(db, div, nested)?,
         ))
     }
 
@@ -411,13 +410,12 @@ impl<'db> FixedLengthTuple<Type<'db>> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         if nested {
             Some(Self::from_elements(
                 self.0
                     .iter()
-                    .map(|ty| ty.recursive_type_normalized_impl(db, div, true, visitor))
+                    .map(|ty| ty.recursive_type_normalized_impl(db, div, true))
                     .collect::<Option<Box<[_]>>>()?,
             ))
         } else {
@@ -425,7 +423,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
                 self.0
                     .iter()
                     .map(|ty| {
-                        ty.recursive_type_normalized_impl(db, div, true, visitor)
+                        ty.recursive_type_normalized_impl(db, div, true)
                             .unwrap_or(div)
                     })
                     .collect::<Box<[_]>>(),
@@ -804,18 +802,17 @@ impl<'db> VariableLengthTuple<Type<'db>> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         let prefix = if nested {
             self.prefix
                 .iter()
-                .map(|ty| ty.recursive_type_normalized_impl(db, div, true, visitor))
+                .map(|ty| ty.recursive_type_normalized_impl(db, div, true))
                 .collect::<Option<Box<_>>>()?
         } else {
             self.prefix
                 .iter()
                 .map(|ty| {
-                    ty.recursive_type_normalized_impl(db, div, true, visitor)
+                    ty.recursive_type_normalized_impl(db, div, true)
                         .unwrap_or(div)
                 })
                 .collect::<Box<_>>()
@@ -823,23 +820,23 @@ impl<'db> VariableLengthTuple<Type<'db>> {
         let suffix = if nested {
             self.suffix
                 .iter()
-                .map(|ty| ty.recursive_type_normalized_impl(db, div, true, visitor))
+                .map(|ty| ty.recursive_type_normalized_impl(db, div, true))
                 .collect::<Option<Box<_>>>()?
         } else {
             self.suffix
                 .iter()
                 .map(|ty| {
-                    ty.recursive_type_normalized_impl(db, div, true, visitor)
+                    ty.recursive_type_normalized_impl(db, div, true)
                         .unwrap_or(div)
                 })
                 .collect::<Box<_>>()
         };
         let variable = if nested {
             self.variable
-                .recursive_type_normalized_impl(db, div, true, visitor)?
+                .recursive_type_normalized_impl(db, div, true)?
         } else {
             self.variable
-                .recursive_type_normalized_impl(db, div, true, visitor)
+                .recursive_type_normalized_impl(db, div, true)
                 .unwrap_or(div)
         };
         Some(Self {
@@ -1250,14 +1247,13 @@ impl<'db> Tuple<Type<'db>> {
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
-        visitor: &NormalizedVisitor<'db>,
     ) -> Option<Self> {
         match self {
             Tuple::Fixed(tuple) => Some(Tuple::Fixed(
-                tuple.recursive_type_normalized_impl(db, div, nested, visitor)?,
+                tuple.recursive_type_normalized_impl(db, div, nested)?,
             )),
             Tuple::Variable(tuple) => Some(Tuple::Variable(
-                tuple.recursive_type_normalized_impl(db, div, nested, visitor)?,
+                tuple.recursive_type_normalized_impl(db, div, nested)?,
             )),
         }
     }


### PR DESCRIPTION
## Summary

This is a follow-up to #20566.

I revisited the `recursive_type_normalized_impl` method and realized that the `visitor` parameter is no longer necessary (the method doesn't expand type aliases, so there's no risk of infinite recursion), so I removed it.
I also added some more comments to some parts.

## Test Plan

N/A