### PR TITLE
parser: add `is_stub` to `ParseOptions` to fix false positive syntax error for stub files

### DIFF
--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -444,6 +444,9 @@ impl<'src> Parser<'src> {
     /// Add an [`UnsupportedSyntaxError`] with the given [`UnsupportedSyntaxErrorKind`] and
     /// [`TextRange`] if its minimum version is less than [`Parser::target_version`].
     fn add_unsupported_syntax_error(&mut self, kind: UnsupportedSyntaxErrorKind, range: TextRange) {
+        if self.options.is_stub {
+            return;
+        }
         if kind.is_unsupported(self.options.target_version) {
             self.unsupported_syntax_errors.push(UnsupportedSyntaxError {
                 kind,

--- a/crates/ruff_python_parser/src/parser/options.rs
+++ b/crates/ruff_python_parser/src/parser/options.rs
@@ -26,6 +26,8 @@ pub struct ParseOptions {
     pub(crate) mode: Mode,
     /// Target version for detecting version-related syntax errors.
     pub(crate) target_version: PythonVersion,
+    /// Whether the source file is a stub file.
+    pub(crate) is_stub: bool,
 }
 
 impl ParseOptions {
@@ -38,6 +40,16 @@ impl ParseOptions {
     pub fn target_version(&self) -> PythonVersion {
         self.target_version
     }
+
+    #[must_use]
+    pub fn with_is_stub(mut self, is_stub: bool) -> Self {
+        self.is_stub = is_stub;
+        self
+    }
+
+    pub fn is_stub(&self) -> bool {
+        self.is_stub
+    }
 }
 
 impl From<Mode> for ParseOptions {
@@ -45,6 +57,7 @@ impl From<Mode> for ParseOptions {
         Self {
             mode,
             target_version: PythonVersion::default(),
+            is_stub: false,
         }
     }
 }
@@ -54,6 +67,7 @@ impl From<PySourceType> for ParseOptions {
         Self {
             mode: source_type.as_mode(),
             target_version: PythonVersion::default(),
+            is_stub: source_type.is_stub(),
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This PR fixes #21677 

## Test Plan

<!-- How was it tested? -->
I have locally tested the working for main.pyi:
```
def foo[T](): ...

type Foo = int
```
<img width="733" height="56" alt="image" src="https://github.com/user-attachments/assets/f96e1772-e823-4841-b64e-c30f92e5e847" />

