### PR TITLE
docs: Output file option with GitLab integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ An extremely fast Python linter and code formatter, written in Rust.
 - 🤝 Python 3.14 compatibility
 - ⚖️ Drop-in parity with [Flake8](https://docs.astral.sh/ruff/faq/#how-does-ruffs-linter-compare-to-flake8), isort, and [Black](https://docs.astral.sh/ruff/faq/#how-does-ruffs-formatter-compare-to-black)
 - 📦 Built-in caching, to avoid re-analyzing unchanged files
-- 🔧 Fix support, for automatic error correction (e.g. automatically remove unused imports)
+- 🔧 Fix support, for automatic error correction (e.g., automatically remove unused imports)
 - 📏 Over [800 built-in rules](https://docs.astral.sh/ruff/rules/), with native re-implementations
     of popular Flake8 plugins, like flake8-bugbear
 - ⌨️ First-party [editor integrations](https://docs.astral.sh/ruff/editors) for [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](https://docs.astral.sh/ruff/editors/setup)


### PR DESCRIPTION
## Summary

Document availability and usage of the `--output-file` option within the GitLab integration - over usage of `>`.

Interested whether there is rationale to retain the existing sample otherwise - in which case this issue can be closed.