### PR TITLE
Use OIDC instead of codspeed token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1014,7 +1014,6 @@ jobs:
         with:
           mode: simulation
           run: cargo codspeed run
-          token: ${{ secrets.CODSPEED_TOKEN }}
 
   benchmarks-walltime:
     name: "benchmarks walltime (${{ matrix.benchmarks }})"


### PR DESCRIPTION
Don't use a persistent token, instead use OIDC to generate a token on the fly, as recommended by codspeed.

I also updated the `mode` from `instrumentation` to `simulation` because codspeed logged a deprecation warning