### PR TITLE
[ty] Add missing projects to `good.txt`

### DIFF
--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -14,6 +14,7 @@ altair
 antidote
 anyio
 apprise
+archinstall
 artigraph
 arviz
 async-utils
@@ -25,7 +26,9 @@ bidict
 black
 bokeh
 boostedblob
+build
 check-jsonschema
+cibuildwheel
 cki-lib
 cloud-init
 colour
@@ -104,6 +107,7 @@ pylox
 pyodide
 pyp
 pyppeteer
+pyproject-metadata
 pytest
 pytest-robotframework
 python-chess
@@ -118,6 +122,7 @@ schemathesis
 scikit-build-core
 scikit-learn
 scipy
+scipy-stubs
 scrapy
 setuptools
 sockeye


### PR DESCRIPTION
## Summary

These projects from `mypy_primer` were missing from both `good.txt` and `bad.txt` for some reason. I thought about writing a script that would verify that `good.txt` + `bad.txt` = `mypy_primer.projects`, but that's not completely trivial since there are projects like `cpython` only appear once in `good.txt`. Given that we can hopefully soon get rid of both of these files (and always run on all projects), it's probably not worth the effort. We are usually notified of all `mypy_primer` changes.

## Test Plan

CI on this PR