### PR TITLE
Drop WSL1 special case in flake8-executable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1671,15 +1671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-docker"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "is-macro"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,16 +1691,6 @@ dependencies = [
  "hermit-abi",
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "is-wsl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
-dependencies = [
- "is-docker",
- "once_cell",
 ]
 
 [[package]]
@@ -3131,7 +3112,6 @@ dependencies = [
  "imperative",
  "insta",
  "is-macro",
- "is-wsl",
  "itertools 0.14.0",
  "jiff",
  "libcst",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,6 @@ indoc = { version = "2.0.4" }
 insta = { version = "1.35.1" }
 insta-cmd = { version = "0.6.0" }
 is-macro = { version = "0.3.5" }
-is-wsl = { version = "0.4.0" }
 itertools = { version = "0.14.0" }
 jiff = { version = "0.2.0" }
 js-sys = { version = "0.3.69" }

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -41,7 +41,6 @@ globset = { workspace = true }
 hashbrown = { workspace = true }
 imperative = { workspace = true }
 is-macro = { workspace = true }
-is-wsl = { workspace = true }
 itertools = { workspace = true }
 libcst = { workspace = true }
 jiff = { workspace = true }

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_executable_file.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_executable_file.rs
@@ -28,7 +28,11 @@ use crate::rules::flake8_executable::helpers::is_executable;
 ///
 /// A file is considered executable if it has the executable bit set (i.e., its
 /// permissions mode intersects with `0o111`). As such, _this rule is only
-/// available on Unix-like systems_, and is not enforced on Windows or WSL.
+/// available on Unix-like systems_.
+///
+/// If this rule produces a significant amount of false positives, it's likely
+/// your source is stored on a filesystem that does not implement Unix file
+/// permissions (e.g. FAT variants, NTFS, CIFS network mounts, VM/WSL shared folders, etc).
 ///
 /// ## References
 /// - [Python documentation: Executable Python Scripts](https://docs.python.org/3/tutorial/appendix.html#executable-python-scripts)
@@ -47,12 +51,6 @@ impl Violation for ShebangMissingExecutableFile {
 /// EXE002
 #[cfg(target_family = "unix")]
 pub(crate) fn shebang_missing_executable_file(filepath: &Path, context: &LintContext) {
-    // WSL supports Windows file systems, which do not have executable bits.
-    // Instead, everything is executable. Therefore, we skip this rule on WSL.
-
-    if is_wsl::is_wsl() {
-        return;
-    }
     if let Ok(true) = is_executable(filepath) {
         context.report_diagnostic_if_enabled(
             ShebangMissingExecutableFile,

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_executable.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_executable.rs
@@ -27,7 +27,11 @@ use crate::rules::flake8_executable::helpers::is_executable;
 ///
 /// A file is considered executable if it has the executable bit set (i.e., its
 /// permissions mode intersects with `0o111`). As such, _this rule is only
-/// available on Unix-like systems_, and is not enforced on Windows or WSL.
+/// available on Unix-like systems_.
+///
+/// If this rule produces a significant amount of false positives, it's likely
+/// your source is stored on a filesystem that does not implement Unix file
+/// permissions (e.g. FAT variants, NTFS, CIFS network mounts, VM/WSL shared folders, etc).
 ///
 /// ## Example
 /// ```python
@@ -51,13 +55,6 @@ impl Violation for ShebangNotExecutable {
 /// EXE001
 #[cfg(target_family = "unix")]
 pub(crate) fn shebang_not_executable(filepath: &Path, range: TextRange, context: &LintContext) {
-    // WSL supports Windows file systems, which do not have executable bits.
-    // Instead, everything is executable. Therefore, we skip this rule on WSL.
-
-    if is_wsl::is_wsl() {
-        return;
-    }
-
     if let Ok(false) = is_executable(filepath) {
         context.report_diagnostic_if_enabled(ShebangNotExecutable, range);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

WSL1 is very very dead, and WSL2 handles permissions properly. Fixes `cargo test` on Ruff itself failing on WSL2, and removes what's generally a high potential footgun.

Fixes #10084 in a simpler way than #17584.

## Test Plan

`cargo test` on a WSL2 system.