### PR TITLE
[ty] Show the user where the type variable was defined in `invalid-type-arguments` diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -210,6 +210,37 @@ reveal_type(WithDefault[str, str]())  # revealed: WithDefault[str, str]
 reveal_type(WithDefault[str]())  # revealed: WithDefault[str, int]
 ```
 
+## Diagnostics for bad specializations
+
+We show the user where the type variable was defined if a specialization is given that doesn't
+satisfy the type variable's upper bound or constraints:
+
+<!-- snapshot-diagnostics -->
+
+`library.py`:
+
+```py
+from typing import TypeVar, Generic
+
+T = TypeVar("T", bound=str)
+U = TypeVar("U", int, bytes)
+
+class Bounded(Generic[T]):
+    x: T
+
+class Constrained(Generic[U]):
+    x: U
+```
+
+`main.py`:
+
+```py
+from library import Bounded, Constrained
+
+x: Bounded[int]  # error: [invalid-type-arguments]
+y: Constrained[str]  # error: [invalid-type-arguments]
+```
+
 ## Inferring generic class parameters
 
 We can infer the type parameter from a type context:

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -191,6 +191,32 @@ reveal_type(WithDefault[str, str]())  # revealed: WithDefault[str, str]
 reveal_type(WithDefault[str]())  # revealed: WithDefault[str, int]
 ```
 
+## Diagnostics for bad specializations
+
+We show the user where the type variable was defined if a specialization is given that doesn't
+satisfy the type variable's upper bound or constraints:
+
+<!-- snapshot-diagnostics -->
+
+`library.py`:
+
+```py
+class Bounded[T: str]:
+    x: T
+
+class Constrained[U: (int, bytes)]:
+    x: U
+```
+
+`main.py`:
+
+```py
+from library import Bounded, Constrained
+
+x: Bounded[int]  # error: [invalid-type-arguments]
+y: Constrained[str]  # error: [invalid-type-arguments]
+```
+
 ## Inferring generic class parameters
 
 We can infer the type parameter from a type context:

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___Leg…_-_Diagnostics_for_bad_…_(2ceba7b720e21b8b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___Leg…_-_Diagnostics_for_bad_…_(2ceba7b720e21b8b).snap
@@ -1,0 +1,78 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: classes.md - Generic classes: Legacy syntax - Diagnostics for bad specializations
+mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+---
+
+# Python source files
+
+## library.py
+
+```
+ 1 | from typing import TypeVar, Generic
+ 2 | 
+ 3 | T = TypeVar("T", bound=str)
+ 4 | U = TypeVar("U", int, bytes)
+ 5 | 
+ 6 | class Bounded(Generic[T]):
+ 7 |     x: T
+ 8 | 
+ 9 | class Constrained(Generic[U]):
+10 |     x: U
+```
+
+## main.py
+
+```
+1 | from library import Bounded, Constrained
+2 | 
+3 | x: Bounded[int]  # error: [invalid-type-arguments]
+4 | y: Constrained[str]  # error: [invalid-type-arguments]
+```
+
+# Diagnostics
+
+```
+error[invalid-type-arguments]: Type `int` is not assignable to upper bound `str` of type variable `T@Bounded`
+ --> src/main.py:3:12
+  |
+1 | from library import Bounded, Constrained
+2 |
+3 | x: Bounded[int]  # error: [invalid-type-arguments]
+  |            ^^^
+4 | y: Constrained[str]  # error: [invalid-type-arguments]
+  |
+ ::: src/library.py:3:1
+  |
+1 | from typing import TypeVar, Generic
+2 |
+3 | T = TypeVar("T", bound=str)
+  | - Type variable defined here
+4 | U = TypeVar("U", int, bytes)
+  |
+info: rule `invalid-type-arguments` is enabled by default
+
+```
+
+```
+error[invalid-type-arguments]: Type `str` does not satisfy constraints `int`, `bytes` of type variable `U@Constrained`
+ --> src/main.py:4:16
+  |
+3 | x: Bounded[int]  # error: [invalid-type-arguments]
+4 | y: Constrained[str]  # error: [invalid-type-arguments]
+  |                ^^^
+  |
+ ::: src/library.py:4:1
+  |
+3 | T = TypeVar("T", bound=str)
+4 | U = TypeVar("U", int, bytes)
+  | - Type variable defined here
+5 |
+6 | class Bounded(Generic[T]):
+  |
+info: rule `invalid-type-arguments` is enabled by default
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___PEP…_-_Diagnostics_for_bad_…_(cf706b07cf0ec31f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___PEP…_-_Diagnostics_for_bad_…_(cf706b07cf0ec31f).snap
@@ -1,0 +1,71 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: classes.md - Generic classes: PEP 695 syntax - Diagnostics for bad specializations
+mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+---
+
+# Python source files
+
+## library.py
+
+```
+1 | class Bounded[T: str]:
+2 |     x: T
+3 | 
+4 | class Constrained[U: (int, bytes)]:
+5 |     x: U
+```
+
+## main.py
+
+```
+1 | from library import Bounded, Constrained
+2 | 
+3 | x: Bounded[int]  # error: [invalid-type-arguments]
+4 | y: Constrained[str]  # error: [invalid-type-arguments]
+```
+
+# Diagnostics
+
+```
+error[invalid-type-arguments]: Type `int` is not assignable to upper bound `str` of type variable `T@Bounded`
+ --> src/main.py:3:12
+  |
+1 | from library import Bounded, Constrained
+2 |
+3 | x: Bounded[int]  # error: [invalid-type-arguments]
+  |            ^^^
+4 | y: Constrained[str]  # error: [invalid-type-arguments]
+  |
+ ::: src/library.py:1:15
+  |
+1 | class Bounded[T: str]:
+  |               - Type variable defined here
+2 |     x: T
+  |
+info: rule `invalid-type-arguments` is enabled by default
+
+```
+
+```
+error[invalid-type-arguments]: Type `str` does not satisfy constraints `int`, `bytes` of type variable `U@Constrained`
+ --> src/main.py:4:16
+  |
+3 | x: Bounded[int]  # error: [invalid-type-arguments]
+4 | y: Constrained[str]  # error: [invalid-type-arguments]
+  |                ^^^
+  |
+ ::: src/library.py:4:19
+  |
+2 |     x: T
+3 |
+4 | class Constrained[U: (int, bytes)]:
+  |                   - Type variable defined here
+5 |     x: U
+  |
+info: rule `invalid-type-arguments` is enabled by default
+
+```


### PR DESCRIPTION
## Summary

It's hard to debug the false-positive diagnostics in https://github.com/astral-sh/ty/issues/1685 because the diagnostics complain that the argument type is invalid for a certain type variable, but doesn't show you where the type variable is defined. This PR adds secondary annotations so the user can jump straight there and debug the diagnostic more easily.

## Test Plan

added snapshots.
