### PR TITLE
[ty] Suppress false positives when `dataclasses.dataclass(...)(cls)` is called imperatively

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -1483,7 +1483,7 @@ def sequence(cls: type[U]) -> type[U]:
         match_args=False,
         kw_only=True,
     )(cls)
-    reveal_type(d)  # revealed: type[U@sequence]
+    reveal_type(d)  # revealed: type[U@sequence] & Any
     return d
 
 @dataclass_transform(kw_only_default=True)
@@ -1494,7 +1494,7 @@ def sequence2(cls: type) -> type:
         match_args=False,
         kw_only=True,
     )(cls)
-    reveal_type(d)  # revealed: type
+    reveal_type(d)  # revealed: type & Any
     return d
 
 @dataclass_transform(kw_only_default=True)
@@ -1506,4 +1506,13 @@ def sequence3(cls: type[U]) -> type[U]:
 def sequence4(cls: type) -> type:
     # TODO: should reveal `type`
     return reveal_type(dataclass(cls))  # revealed: Unknown
+
+class Foo: ...
+
+ordered_foo = dataclass(order=True)(Foo)
+reveal_type(ordered_foo)  # revealed: type[Foo] & Any
+# TODO: should be `Foo & Any`
+reveal_type(ordered_foo())  # revealed: @Todo(Type::Intersection.call)
+# TODO: should be `Any`
+reveal_type(ordered_foo() < ordered_foo())  # revealed: @Todo(Type::Intersection.call)
 ```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6195,7 +6195,7 @@ impl<'db> Type<'db> {
             ),
 
             Type::Intersection(_) => {
-                Binding::single(self, Signature::todo("Type::Intersection.call()")).into()
+                Binding::single(self, Signature::todo("Type::Intersection.call")).into()
             }
 
             Type::DataclassDecorator(_) => {
@@ -6204,10 +6204,13 @@ impl<'db> Type<'db> {
                 let context = GenericContext::from_typevar_instances(db, [typevar]);
                 let parameters = [Parameter::positional_only(Some(Name::new_static("cls")))
                     .with_annotated_type(typevar_meta)];
+                // Intersect with `Any` for the return type to reflect the fact that the `dataclass()`
+                // decorator adds methods to the class
+                let returns = IntersectionType::from_elements(db, [typevar_meta, Type::any()]);
                 let signature = Signature::new_generic(
                     Some(context),
                     Parameters::new(db, parameters),
-                    Some(typevar_meta),
+                    Some(returns),
                 );
                 Binding::single(self, signature).into()
             }


### PR DESCRIPTION
Fixes https://github.com/astral-sh/ty/issues/1705