### PR TITLE
[ty] Exclude `typing_extensions` from completions unless it's really available

### DIFF
--- a/crates/ty_completion_eval/completion-evaluation-tasks.csv
+++ b/crates/ty_completion_eval/completion-evaluation-tasks.csv
@@ -25,4 +25,4 @@ scope-simple-long-identifier,main.py,0,1
 tstring-completions,main.py,0,1
 ty-extensions-lower-stdlib,main.py,0,8
 type-var-typing-over-ast,main.py,0,3
-type-var-typing-over-ast,main.py,1,278
+type-var-typing-over-ast,main.py,1,275

--- a/crates/ty_ide/src/all_symbols.rs
+++ b/crates/ty_ide/src/all_symbols.rs
@@ -1,6 +1,6 @@
 use ruff_db::files::File;
 use ty_project::Db;
-use ty_python_semantic::{Module, all_modules};
+use ty_python_semantic::{Module, ModuleName, all_modules, resolve_real_shadowable_module};
 
 use crate::symbols::{QueryPattern, SymbolInfo, symbols_for_file_global_only};
 
@@ -8,11 +8,19 @@ use crate::symbols::{QueryPattern, SymbolInfo, symbols_for_file_global_only};
 ///
 /// Returns symbols from all files in the workspace and dependencies, filtered
 /// by the query.
-pub fn all_symbols<'db>(db: &'db dyn Db, query: &QueryPattern) -> Vec<AllSymbolInfo<'db>> {
+pub fn all_symbols<'db>(
+    db: &'db dyn Db,
+    importing_from: File,
+    query: &QueryPattern,
+) -> Vec<AllSymbolInfo<'db>> {
     // If the query is empty, return immediately to avoid expensive file scanning
     if query.will_match_everything() {
         return Vec::new();
     }
+
+    let typing_extensions = ModuleName::new("typing_extensions").unwrap();
+    let is_typing_extensions_available = importing_from.is_stub(db)
+        || resolve_real_shadowable_module(db, &typing_extensions).is_some();
 
     let results = std::sync::Mutex::new(Vec::new());
     {
@@ -28,6 +36,11 @@ pub fn all_symbols<'db>(db: &'db dyn Db, query: &QueryPattern) -> Vec<AllSymbolI
                 let Some(file) = module.file(&*db) else {
                     continue;
                 };
+                // TODO: also make it available in `TYPE_CHECKING` blocks
+                // (we'd need https://github.com/astral-sh/ty/issues/1553 to do this well)
+                if !is_typing_extensions_available && module.name(&*db) == &typing_extensions {
+                    continue;
+                }
                 s.spawn(move |_| {
                     for (_, symbol) in symbols_for_file_global_only(&*db, file).search(query) {
                         // It seems like we could do better here than
@@ -143,7 +156,7 @@ ABCDEFGHIJKLMNOP = 'https://api.example.com'
 
     impl CursorTest {
         fn all_symbols(&self, query: &str) -> String {
-            let symbols = all_symbols(&self.db, &QueryPattern::fuzzy(query));
+            let symbols = all_symbols(&self.db, self.cursor.file, &QueryPattern::fuzzy(query));
 
             if symbols.is_empty() {
                 return "No symbols found".to_string();

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -13,7 +13,8 @@ pub use diagnostic::add_inferred_python_version_hint_to_diagnostic;
 pub use module_name::{ModuleName, ModuleNameResolutionError};
 pub use module_resolver::{
     KnownModule, Module, SearchPath, SearchPathValidationError, SearchPaths, all_modules,
-    list_modules, resolve_module, resolve_real_module, system_module_search_paths,
+    list_modules, resolve_module, resolve_real_module, resolve_real_shadowable_module,
+    system_module_search_paths,
 };
 pub use program::{
     Program, ProgramSettings, PythonVersionFileSource, PythonVersionSource,

--- a/crates/ty_python_semantic/src/module_resolver/list.rs
+++ b/crates/ty_python_semantic/src/module_resolver/list.rs
@@ -8,9 +8,7 @@ use crate::program::Program;
 
 use super::module::{Module, ModuleKind};
 use super::path::{ModulePath, SearchPath, SystemOrVendoredPathRef};
-use super::resolver::{
-    ModuleResolveMode, ResolverContext, is_non_shadowable, resolve_file_module, search_paths,
-};
+use super::resolver::{ModuleResolveMode, ResolverContext, resolve_file_module, search_paths};
 
 /// List all available modules, including all sub-modules, sorted in lexicographic order.
 pub fn all_modules(db: &dyn Db) -> Vec<Module<'_>> {
@@ -309,7 +307,8 @@ impl<'db> Lister<'db> {
 
     /// Returns true if the given module name cannot be shadowable.
     fn is_non_shadowable(&self, name: &ModuleName) -> bool {
-        is_non_shadowable(self.python_version().minor, name.as_str())
+        ModuleResolveMode::StubsAllowed
+            .is_non_shadowable(self.python_version().minor, name.as_str())
     }
 
     /// Returns the Python version we want to perform module resolution

--- a/crates/ty_python_semantic/src/module_resolver/mod.rs
+++ b/crates/ty_python_semantic/src/module_resolver/mod.rs
@@ -6,7 +6,7 @@ pub use module::Module;
 pub use path::{SearchPath, SearchPathValidationError};
 pub use resolver::SearchPaths;
 pub(crate) use resolver::file_to_module;
-pub use resolver::{resolve_module, resolve_real_module};
+pub use resolver::{resolve_module, resolve_real_module, resolve_real_shadowable_module};
 use ruff_db::system::SystemPath;
 
 use crate::Db;

--- a/crates/ty_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/ty_python_semantic/src/module_resolver/resolver.rs
@@ -47,8 +47,33 @@ pub fn resolve_real_module<'db>(db: &'db dyn Db, module_name: &ModuleName) -> Op
     resolve_module_query(db, interned_name)
 }
 
+/// Resolves a module name to a module (stubs not allowed, some shadowing is
+/// allowed).
+///
+/// In particular, this allows `typing_extensions` to be shadowed by a
+/// non-standard library module. This is useful in the context of the LSP
+/// where we don't want to pretend as if these modules are always available at
+/// runtime.
+///
+/// This should generally only be used within the context of the LSP. Using it
+/// within ty proper risks being unable to resolve builtin modules since they
+/// are involved in an import cycle with `builtins`.
+pub fn resolve_real_shadowable_module<'db>(
+    db: &'db dyn Db,
+    module_name: &ModuleName,
+) -> Option<Module<'db>> {
+    let interned_name = ModuleNameIngredient::new(
+        db,
+        module_name,
+        ModuleResolveMode::StubsNotAllowedSomeShadowingAllowed,
+    );
+
+    resolve_module_query(db, interned_name)
+}
+
 /// Which files should be visible when doing a module query
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, get_size2::GetSize)]
+#[allow(clippy::enum_variant_names)]
 pub(crate) enum ModuleResolveMode {
     /// Stubs are allowed to appear.
     ///
@@ -61,6 +86,13 @@ pub(crate) enum ModuleResolveMode {
     /// implementations. When querying searchpaths this also notably replaces typeshed with
     /// the "real" stdlib.
     StubsNotAllowed,
+    /// Like `StubsNotAllowed`, but permits some modules to be shadowed.
+    ///
+    /// In particular, this allows `typing_extensions` to be shadowed by a
+    /// non-standard library module. This is useful in the context of the LSP
+    /// where we don't want to pretend as if these modules are always available
+    /// at runtime.
+    StubsNotAllowedSomeShadowingAllowed,
 }
 
 #[salsa::interned(heap_size=ruff_memory_usage::heap_size)]
@@ -72,6 +104,39 @@ pub(crate) struct ModuleResolveModeIngredient<'db> {
 impl ModuleResolveMode {
     fn stubs_allowed(self) -> bool {
         matches!(self, Self::StubsAllowed)
+    }
+
+    /// Returns `true` if the module name refers to a standard library module
+    /// which can't be shadowed by a first-party module.
+    ///
+    /// This includes "builtin" modules, which can never be shadowed at runtime
+    /// either. Additionally, certain other modules that are involved in an
+    /// import cycle with `builtins` (`types`, `typing_extensions`, etc.) are
+    /// also considered non-shadowable, unless the module resolution mode
+    /// specifically opts into allowing some of them to be shadowed. This
+    /// latter set of modules cannot be allowed to be shadowed by first-party
+    /// or "extra-path" modules in ty proper, or we risk panics in unexpected
+    /// places due to being unable to resolve builtin symbols. This is similar
+    /// behaviour to other type checkers such as mypy:
+    /// <https://github.com/python/mypy/blob/3807423e9d98e678bf16b13ec8b4f909fe181908/mypy/build.py#L104-L117>
+    pub(super) fn is_non_shadowable(self, minor_version: u8, module_name: &str) -> bool {
+        // Builtin modules are never shadowable, no matter what.
+        if ruff_python_stdlib::sys::is_builtin_module(minor_version, module_name) {
+            return true;
+        }
+        // Similarly for `types`, which is always available at runtime.
+        if module_name == "types" {
+            return true;
+        }
+
+        // Otherwise, some modules should only be conditionally allowed
+        // to be shadowed, depending on the module resolution mode.
+        match self {
+            ModuleResolveMode::StubsAllowed | ModuleResolveMode::StubsNotAllowed => {
+                module_name == "typing_extensions"
+            }
+            ModuleResolveMode::StubsNotAllowedSomeShadowingAllowed => false,
+        }
     }
 }
 
@@ -386,7 +451,10 @@ impl SearchPaths {
     pub(crate) fn stdlib(&self, mode: ModuleResolveMode) -> Option<&SearchPath> {
         match mode {
             ModuleResolveMode::StubsAllowed => self.stdlib_path.as_ref(),
-            ModuleResolveMode::StubsNotAllowed => self.real_stdlib_path.as_ref(),
+            ModuleResolveMode::StubsNotAllowed
+            | ModuleResolveMode::StubsNotAllowedSomeShadowingAllowed => {
+                self.real_stdlib_path.as_ref()
+            }
         }
     }
 
@@ -439,7 +507,8 @@ pub(crate) fn dynamic_resolution_paths<'db>(
     // Use the `ModuleResolveMode` to determine which stdlib (if any) to mark as existing
     let stdlib = match mode.mode(db) {
         ModuleResolveMode::StubsAllowed => stdlib_path,
-        ModuleResolveMode::StubsNotAllowed => real_stdlib_path,
+        ModuleResolveMode::StubsNotAllowed
+        | ModuleResolveMode::StubsNotAllowedSomeShadowingAllowed => real_stdlib_path,
     };
     if let Some(path) = stdlib.as_ref().and_then(SearchPath::as_system_path) {
         existing_paths.insert(Cow::Borrowed(path));
@@ -684,27 +753,13 @@ struct ModuleNameIngredient<'db> {
     pub(super) mode: ModuleResolveMode,
 }
 
-/// Returns `true` if the module name refers to a standard library module which can't be shadowed
-/// by a first-party module.
-///
-/// This includes "builtin" modules, which can never be shadowed at runtime either, as well as
-/// certain other modules that are involved in an import cycle with `builtins` (`types`,
-/// `typing_extensions`, etc.). This latter set of modules cannot be allowed to be shadowed by
-/// first-party or "extra-path" modules, or we risk panics in unexpected places due to being
-/// unable to resolve builtin symbols. This is similar behaviour to other type checkers such
-/// as mypy: <https://github.com/python/mypy/blob/3807423e9d98e678bf16b13ec8b4f909fe181908/mypy/build.py#L104-L117>
-pub(super) fn is_non_shadowable(minor_version: u8, module_name: &str) -> bool {
-    matches!(module_name, "types" | "typing_extensions")
-        || ruff_python_stdlib::sys::is_builtin_module(minor_version, module_name)
-}
-
 /// Given a module name and a list of search paths in which to lookup modules,
 /// attempt to resolve the module name
 fn resolve_name(db: &dyn Db, name: &ModuleName, mode: ModuleResolveMode) -> Option<ResolvedName> {
     let program = Program::get(db);
     let python_version = program.python_version(db);
     let resolver_state = ResolverContext::new(db, python_version, mode);
-    let is_non_shadowable = is_non_shadowable(python_version.minor, name.as_str());
+    let is_non_shadowable = mode.is_non_shadowable(python_version.minor, name.as_str());
 
     let name = RelaxedModuleName::new(name);
     let stub_name = name.to_stub_package();

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_undefined_decorator.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_undefined_decorator.snap
@@ -4,52 +4,6 @@ expression: code_actions
 ---
 [
   {
-    "title": "import typing_extensions.deprecated",
-    "kind": "quickfix",
-    "diagnostics": [
-      {
-        "range": {
-          "start": {
-            "line": 1,
-            "character": 1
-          },
-          "end": {
-            "line": 1,
-            "character": 11
-          }
-        },
-        "severity": 1,
-        "code": "unresolved-reference",
-        "codeDescription": {
-          "href": "https://ty.dev/rules#unresolved-reference"
-        },
-        "source": "ty",
-        "message": "Name `deprecated` used when not defined",
-        "relatedInformation": []
-      }
-    ],
-    "edit": {
-      "changes": {
-        "file://<temp_dir>/src/foo.py": [
-          {
-            "range": {
-              "start": {
-                "line": 0,
-                "character": 0
-              },
-              "end": {
-                "line": 0,
-                "character": 0
-              }
-            },
-            "newText": "from typing_extensions import deprecated\n"
-          }
-        ]
-      }
-    },
-    "isPreferred": true
-  },
-  {
     "title": "import warnings.deprecated",
     "kind": "quickfix",
     "diagnostics": [

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_undefined_reference_multi.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_undefined_reference_multi.snap
@@ -50,52 +50,6 @@ expression: code_actions
     "isPreferred": true
   },
   {
-    "title": "import typing_extensions.Literal",
-    "kind": "quickfix",
-    "diagnostics": [
-      {
-        "range": {
-          "start": {
-            "line": 0,
-            "character": 3
-          },
-          "end": {
-            "line": 0,
-            "character": 10
-          }
-        },
-        "severity": 1,
-        "code": "unresolved-reference",
-        "codeDescription": {
-          "href": "https://ty.dev/rules#unresolved-reference"
-        },
-        "source": "ty",
-        "message": "Name `Literal` used when not defined",
-        "relatedInformation": []
-      }
-    ],
-    "edit": {
-      "changes": {
-        "file://<temp_dir>/src/foo.py": [
-          {
-            "range": {
-              "start": {
-                "line": 0,
-                "character": 0
-              },
-              "end": {
-                "line": 0,
-                "character": 0
-              }
-            },
-            "newText": "from typing_extensions import Literal\n"
-          }
-        ]
-      }
-    },
-    "isPreferred": true
-  },
-  {
     "title": "Ignore 'unresolved-reference' for this line",
     "kind": "quickfix",
     "diagnostics": [

--- a/crates/ty_server/tests/e2e/snapshots/e2e__notebook__auto_import.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__notebook__auto_import.snap
@@ -25,30 +25,9 @@ expression: completions
     ]
   },
   {
-    "label": "Literal (import typing_extensions)",
-    "kind": 6,
-    "sortText": " 51",
-    "insertText": "Literal",
-    "additionalTextEdits": [
-      {
-        "range": {
-          "start": {
-            "line": 1,
-            "character": 0
-          },
-          "end": {
-            "line": 1,
-            "character": 0
-          }
-        },
-        "newText": "from typing_extensions import Literal\n"
-      }
-    ]
-  },
-  {
     "label": "LiteralString (import typing)",
     "kind": 6,
-    "sortText": " 52",
+    "sortText": " 51",
     "insertText": "LiteralString",
     "additionalTextEdits": [
       {
@@ -63,27 +42,6 @@ expression: completions
           }
         },
         "newText": "from typing import LiteralString\n"
-      }
-    ]
-  },
-  {
-    "label": "LiteralString (import typing_extensions)",
-    "kind": 6,
-    "sortText": " 53",
-    "insertText": "LiteralString",
-    "additionalTextEdits": [
-      {
-        "range": {
-          "start": {
-            "line": 1,
-            "character": 0
-          },
-          "end": {
-            "line": 1,
-            "character": 0
-          }
-        },
-        "newText": "from typing_extensions import LiteralString\n"
       }
     ]
   }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__notebook__auto_import_docstring.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__notebook__auto_import_docstring.snap
@@ -25,30 +25,9 @@ expression: completions
     ]
   },
   {
-    "label": "Literal (import typing_extensions)",
-    "kind": 6,
-    "sortText": " 51",
-    "insertText": "Literal",
-    "additionalTextEdits": [
-      {
-        "range": {
-          "start": {
-            "line": 1,
-            "character": 0
-          },
-          "end": {
-            "line": 1,
-            "character": 0
-          }
-        },
-        "newText": "from typing_extensions import Literal\n"
-      }
-    ]
-  },
-  {
     "label": "LiteralString (import typing)",
     "kind": 6,
-    "sortText": " 52",
+    "sortText": " 51",
     "insertText": "LiteralString",
     "additionalTextEdits": [
       {
@@ -63,27 +42,6 @@ expression: completions
           }
         },
         "newText": "from typing import LiteralString\n"
-      }
-    ]
-  },
-  {
-    "label": "LiteralString (import typing_extensions)",
-    "kind": 6,
-    "sortText": " 53",
-    "insertText": "LiteralString",
-    "additionalTextEdits": [
-      {
-        "range": {
-          "start": {
-            "line": 1,
-            "character": 0
-          },
-          "end": {
-            "line": 1,
-            "character": 0
-          }
-        },
-        "newText": "from typing_extensions import LiteralString\n"
       }
     ]
   }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__notebook__auto_import_from_future.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__notebook__auto_import_from_future.snap
@@ -25,30 +25,9 @@ expression: completions
     ]
   },
   {
-    "label": "Literal (import typing_extensions)",
-    "kind": 6,
-    "sortText": " 51",
-    "insertText": "Literal",
-    "additionalTextEdits": [
-      {
-        "range": {
-          "start": {
-            "line": 1,
-            "character": 0
-          },
-          "end": {
-            "line": 1,
-            "character": 0
-          }
-        },
-        "newText": "from typing_extensions import Literal\n"
-      }
-    ]
-  },
-  {
     "label": "LiteralString (import typing)",
     "kind": 6,
-    "sortText": " 52",
+    "sortText": " 51",
     "insertText": "LiteralString",
     "additionalTextEdits": [
       {
@@ -63,27 +42,6 @@ expression: completions
           }
         },
         "newText": "from typing import LiteralString\n"
-      }
-    ]
-  },
-  {
-    "label": "LiteralString (import typing_extensions)",
-    "kind": 6,
-    "sortText": " 53",
-    "insertText": "LiteralString",
-    "additionalTextEdits": [
-      {
-        "range": {
-          "start": {
-            "line": 1,
-            "character": 0
-          },
-          "end": {
-            "line": 1,
-            "character": 0
-          }
-        },
-        "newText": "from typing_extensions import LiteralString\n"
       }
     ]
   }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__notebook__auto_import_same_cell.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__notebook__auto_import_same_cell.snap
@@ -25,30 +25,9 @@ expression: completions
     ]
   },
   {
-    "label": "Literal (import typing_extensions)",
-    "kind": 6,
-    "sortText": " 51",
-    "insertText": "Literal",
-    "additionalTextEdits": [
-      {
-        "range": {
-          "start": {
-            "line": 0,
-            "character": 0
-          },
-          "end": {
-            "line": 0,
-            "character": 0
-          }
-        },
-        "newText": "from typing_extensions import Literal\n"
-      }
-    ]
-  },
-  {
     "label": "LiteralString (import typing)",
     "kind": 6,
-    "sortText": " 52",
+    "sortText": " 51",
     "insertText": "LiteralString",
     "additionalTextEdits": [
       {
@@ -63,27 +42,6 @@ expression: completions
           }
         },
         "newText": ", LiteralString"
-      }
-    ]
-  },
-  {
-    "label": "LiteralString (import typing_extensions)",
-    "kind": 6,
-    "sortText": " 53",
-    "insertText": "LiteralString",
-    "additionalTextEdits": [
-      {
-        "range": {
-          "start": {
-            "line": 0,
-            "character": 0
-          },
-          "end": {
-            "line": 0,
-            "character": 0
-          }
-        },
-        "newText": "from typing_extensions import LiteralString\n"
       }
     ]
   }


### PR DESCRIPTION
This works by adding a third module resolution mode that lets the caller
opt into _some_ shadowing of modules that is otherwise not allowed (for
`typing` and `typing_extensions`).

Fixes astral-sh/ty#1658
