### PR TITLE
Use `npm ci --ignore-scripts` everywhere

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -918,7 +918,7 @@ jobs:
           cache-dependency-path: playground/package-lock.json
       - uses: jetli/wasm-bindgen-action@20b33e20595891ab1a0ed73145d8a21fc96e7c29 # v0.2.0
       - name: "Install Node dependencies"
-        run: npm ci
+        run: npm ci --ignore-scripts
         working-directory: playground
       - name: "Build playgrounds"
         run: npm run dev:wasm

--- a/.github/workflows/publish-playground.yml
+++ b/.github/workflows/publish-playground.yml
@@ -37,7 +37,7 @@ jobs:
           package-manager-cache: false
       - uses: jetli/wasm-bindgen-action@20b33e20595891ab1a0ed73145d8a21fc96e7c29 # v0.2.0
       - name: "Install Node dependencies"
-        run: npm ci
+        run: npm ci --ignore-scripts
         working-directory: playground
       - name: "Run TypeScript checks"
         run: npm run check

--- a/.github/workflows/publish-ty-playground.yml
+++ b/.github/workflows/publish-ty-playground.yml
@@ -41,7 +41,7 @@ jobs:
           package-manager-cache: false
       - uses: jetli/wasm-bindgen-action@20b33e20595891ab1a0ed73145d8a21fc96e7c29 # v0.2.0
       - name: "Install Node dependencies"
-        run: npm ci
+        run: npm ci --ignore-scripts
         working-directory: playground
       - name: "Run TypeScript checks"
         run: npm run check

--- a/crates/ruff_python_formatter/CONTRIBUTING.md
+++ b/crates/ruff_python_formatter/CONTRIBUTING.md
@@ -74,7 +74,7 @@ def f():  # a
 The other option is to use the playground (also check the playground README):
 
 ```shell
-cd playground && npm install && npm run dev:wasm && npm run dev
+cd playground && npm ci --ignore-scripts && npm run dev:wasm && npm run dev
 ```
 
 Run`npm run dev:wasm` and reload the page in the browser to refresh.

--- a/playground/README.md
+++ b/playground/README.md
@@ -4,7 +4,7 @@ In-browser playground for Ruff. Available [https://play.ruff.rs/](https://play.r
 
 ## Getting started
 
-Install the NPM dependencies with `npm install`, and run the development server with
+Install the NPM dependencies with `npm ci --ignore-scripts`, and run the development server with
 `npm start --workspace ruff-playground` or `npm start --workspace ty-playground`.
 You may need to restart the server after making changes to Ruff or ty to re-build the WASM
 module.

--- a/scripts/ty_benchmark/README.md
+++ b/scripts/ty_benchmark/README.md
@@ -7,7 +7,7 @@
 
 1. Build ty: `cargo build --bin ty --release`
 1. `cd` into the benchmark directory: `cd scripts/ty_benchmark`
-1. Install Pyright: `npm install`
+1. Install Pyright: `npm ci --ignore-scripts`
 1. Run benchmarks: `uv run benchmark`
 
 Requires hyperfine 1.20 or newer.

--- a/scripts/ty_benchmark/src/benchmark/tool.py
+++ b/scripts/ty_benchmark/src/benchmark/tool.py
@@ -185,7 +185,7 @@ class Pyright(Tool):
 
             if not self.path.exists():
                 print(
-                    "Pyright executable not found. Did you ran `npm install` in the `ty_benchmark` directory?"
+                    "Pyright executable not found. Did you run `npm ci` in the `ty_benchmark` directory?"
                 )
 
     @override

--- a/scripts/update_schemastore.py
+++ b/scripts/update_schemastore.py
@@ -87,9 +87,9 @@ def update_schemastore(
         cwd=schemastore_path,
     )
 
-    # Run npm install
+    # Run npm ci
     src = schemastore_path / "src"
-    check_call(["npm", "install"], cwd=schemastore_path)
+    check_call(["npm", "ci", "--ignore-scripts"], cwd=schemastore_path)
 
     # Update the schema and format appropriately
     schema = json.loads(RUFF_SCHEMA.read_text())


### PR DESCRIPTION
## Summary

This is more reproducible, and avoids unnecessary build-time script execution.

## Test Plan

See what happens in CI. I've confirmed that the SchemaStore change in particular works by making the same change to uv: https://github.com/astral-sh/uv/pull/16915