### PR TITLE
Add 7 day cooldown to Renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,8 @@
   extends: ["config:recommended"],
   labels: ["internal"],
   schedule: ["before 4am on Monday"],
+  "minimumReleaseAge": "7 days",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
   semanticCommits: "disabled",
   separateMajorMinor: false,
   prHourlyLimit: 10,


### PR DESCRIPTION
## Summary

Adds a 7 day cooldown to our automated Renovate bumps.

## Test Plan

No functional changes.