### PR TITLE
Use our org-wide Renovate preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,7 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   dependencyDashboard: true,
   suppressNotifications: ["prEditedNotification"],
-  extends: ["config:recommended"],
+  extends: ["github>astral-sh/renovate-config"],
   labels: ["internal"],
   schedule: ["before 4am on Monday"],
   semanticCommits: "disabled",


### PR DESCRIPTION
## Summary

This switches the preset to https://github.com/astral-sh/renovate-config, which is a superset of the `config:recommended` preset (with cooldowns added).

## Test Plan

No functional changes.