### PR TITLE
[ty] Show types of non-trivial string annotations in hovers

### DIFF
--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -8,7 +8,7 @@
 Default level: <a href="../rules.md#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20byte-string-type-annotation" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L36" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L37" target="_blank">View source</a>
 </small>
 
 
@@ -283,7 +283,7 @@ class A:  # Crash at runtime
 Default level: <a href="../rules.md#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20escape-character-in-forward-annotation" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L120" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L121" target="_blank">View source</a>
 </small>
 
 
@@ -295,7 +295,7 @@ TODO #14889
 Default level: <a href="../rules.md#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20fstring-type-annotation" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L11" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L12" target="_blank">View source</a>
 </small>
 
 
@@ -326,7 +326,7 @@ def test(): -> "int":
 Default level: <a href="../rules.md#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20implicit-concatenated-string-type-annotation" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L86" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L87" target="_blank">View source</a>
 </small>
 
 
@@ -1386,7 +1386,7 @@ super(B, A)  # error: `A` does not satisfy `issubclass(A, B)`
 Default level: <a href="../rules.md#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-syntax-in-forward-annotation" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L111" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L112" target="_blank">View source</a>
 </small>
 
 
@@ -1859,7 +1859,7 @@ f(x=1)  # Error raised here
 Default level: <a href="../rules.md#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20raw-string-type-annotation" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L61" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L62" target="_blank">View source</a>
 </small>
 
 

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -313,18 +313,11 @@ impl GotoTarget<'_> {
                 subrange,
                 ..
             } => {
-                let (subast, _submodel) = model.enter_string_annotation(string_expr)?;
-                let submod = subast.syntax();
-                let subnode = covering_node(submod.into(), *subrange).node();
-
-                // The type checker knows the type of the full annotation but nothing else
-                if AnyNodeRef::from(&*submod.body) == subnode {
-                    string_expr.inferred_type(model)
-                } else {
-                    // TODO: force the typechecker to tell us its secrets
-                    // (it computes but then immediately discards these types)
-                    return None;
-                }
+                let (subast, submodel) = model.enter_string_annotation(string_expr)?;
+                let subexpr = covering_node(subast.syntax().into(), *subrange)
+                    .node()
+                    .as_expr_ref()?;
+                subexpr.inferred_type(&submodel)
             }
             GotoTarget::BinOp { expression, .. } => {
                 let (_, ty) = ty_python_semantic::definitions_for_bin_op(model, expression)?;

--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -787,7 +787,25 @@ mod tests {
         "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @"No goto target found");
+        assert_snapshot!(test.goto_type_definition(), @r#"
+        info[goto-type-definition]: Type definition
+         --> main.py:4:7
+          |
+        2 | a: "None | MyClass" = 1
+        3 |
+        4 | class MyClass:
+          |       ^^^^^^^
+        5 |     """some docs"""
+          |
+        info: Source
+         --> main.py:2:12
+          |
+        2 | a: "None | MyClass" = 1
+          |            ^^^^^^^
+        3 |
+        4 | class MyClass:
+          |
+        "#);
     }
 
     #[test]
@@ -851,7 +869,25 @@ mod tests {
         "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @"No goto target found");
+        assert_snapshot!(test.goto_type_definition(), @r#"
+        info[goto-type-definition]: Type definition
+         --> main.py:4:7
+          |
+        2 | a: "None | MyClass" = 1
+        3 |
+        4 | class MyClass:
+          |       ^^^^^^^
+        5 |     """some docs"""
+          |
+        info: Source
+         --> main.py:2:12
+          |
+        2 | a: "None | MyClass" = 1
+          |            ^^^^^^^
+        3 |
+        4 | class MyClass:
+          |
+        "#);
     }
 
     #[test]
@@ -947,7 +983,25 @@ mod tests {
         "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @"No goto target found");
+        assert_snapshot!(test.goto_type_definition(), @r#"
+        info[goto-type-definition]: Type definition
+         --> main.py:4:7
+          |
+        2 | a: "MyClass | No" = 1
+        3 |
+        4 | class MyClass:
+          |       ^^^^^^^
+        5 |     """some docs"""
+          |
+        info: Source
+         --> main.py:2:5
+          |
+        2 | a: "MyClass | No" = 1
+          |     ^^^^^^^
+        3 |
+        4 | class MyClass:
+          |
+        "#);
     }
 
     #[test]
@@ -961,7 +1015,25 @@ mod tests {
         "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @"No goto target found");
+        assert_snapshot!(test.goto_type_definition(), @r#"
+        info[goto-type-definition]: Type definition
+          --> stdlib/ty_extensions.pyi:20:1
+           |
+        19 | # Types
+        20 | Unknown = object()
+           | ^^^^^^^
+        21 | AlwaysTruthy = object()
+        22 | AlwaysFalsy = object()
+           |
+        info: Source
+         --> main.py:2:15
+          |
+        2 | a: "MyClass | No" = 1
+          |               ^^
+        3 |
+        4 | class MyClass:
+          |
+        "#);
     }
 
     #[test]

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -953,9 +953,15 @@ mod tests {
         );
 
         assert_snapshot!(test.hover(), @r#"
+        MyClass
+        ---------------------------------------------
         some docs
 
         ---------------------------------------------
+        ```python
+        MyClass
+        ```
+        ---
         some docs
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -998,9 +1004,15 @@ mod tests {
         );
 
         assert_snapshot!(test.hover(), @r#"
+        MyClass
+        ---------------------------------------------
         some docs
 
         ---------------------------------------------
+        ```python
+        MyClass
+        ```
+        ---
         some docs
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -1056,9 +1068,15 @@ mod tests {
         );
 
         assert_snapshot!(test.hover(), @r#"
+        MyClass
+        ---------------------------------------------
         some docs
 
         ---------------------------------------------
+        ```python
+        MyClass
+        ```
+        ---
         some docs
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -1086,7 +1104,25 @@ mod tests {
         "#,
         );
 
-        assert_snapshot!(test.hover(), @"Hover provided no content");
+        assert_snapshot!(test.hover(), @r#"
+        Unknown
+        ---------------------------------------------
+        ```python
+        Unknown
+        ```
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:2:15
+          |
+        2 | a: "MyClass | No" = 1
+          |               ^-
+          |               ||
+          |               |Cursor offset
+          |               source
+        3 |
+        4 | class MyClass:
+          |
+        "#);
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/semantic_index/ast_ids.rs
+++ b/crates/ty_python_semantic/src/semantic_index/ast_ids.rs
@@ -116,29 +116,44 @@ pub(crate) mod node_key {
     use crate::node_key::NodeKey;
 
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, salsa::Update, get_size2::GetSize)]
-    pub(crate) struct ExpressionNodeKey(NodeKey);
+    pub(crate) struct ExpressionNodeKey(NodeKey, Option<NodeKey>);
+
+    impl From<(NodeKey, &ast::Expr)> for ExpressionNodeKey {
+        fn from(value: (NodeKey, &ast::Expr)) -> Self {
+            Self(value.0, Some(NodeKey::from_node(value.1)))
+        }
+    }
+
+    impl From<(ast::ExprRef<'_>, ast::ExprRef<'_>)> for ExpressionNodeKey {
+        fn from(value: (ast::ExprRef<'_>, ast::ExprRef<'_>)) -> Self {
+            Self(
+                NodeKey::from_node(value.0),
+                Some(NodeKey::from_node(value.1)),
+            )
+        }
+    }
 
     impl From<ast::ExprRef<'_>> for ExpressionNodeKey {
         fn from(value: ast::ExprRef<'_>) -> Self {
-            Self(NodeKey::from_node(value))
+            Self(NodeKey::from_node(value), None)
         }
     }
 
     impl From<&ast::Expr> for ExpressionNodeKey {
         fn from(value: &ast::Expr) -> Self {
-            Self(NodeKey::from_node(value))
+            Self(NodeKey::from_node(value), None)
         }
     }
 
     impl From<&ast::ExprCall> for ExpressionNodeKey {
         fn from(value: &ast::ExprCall) -> Self {
-            Self(NodeKey::from_node(value))
+            Self(NodeKey::from_node(value), None)
         }
     }
 
     impl From<&ast::Identifier> for ExpressionNodeKey {
         fn from(value: &ast::Identifier) -> Self {
-            Self(NodeKey::from_node(value))
+            Self(NodeKey::from_node(value), None)
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/string_annotation.rs
+++ b/crates/ty_python_semantic/src/types/string_annotation.rs
@@ -1,3 +1,4 @@
+use ruff_db::parsed::parsed_string_annotation;
 use ruff_db::source::source_text;
 use ruff_python_ast::{self as ast, ModExpression};
 use ruff_python_parser::Parsed;
@@ -149,7 +150,7 @@ pub(crate) fn parse_string_annotation(
         // Compare the raw contents (without quotes) of the expression with the parsed contents
         // contained in the string literal.
         } else if &source[string_literal.content_range()] == string_literal.as_str() {
-            match ruff_python_parser::parse_string_annotation(source.as_str(), string_literal) {
+            match parsed_string_annotation(source.as_str(), string_literal) {
                 Ok(parsed) => return Some(parsed),
                 Err(parse_error) => {
                     if let Some(builder) =


### PR DESCRIPTION
## Summary

The basic implementation here is instead of only being able to lookup types by `&Expr` we can now look them up by `(&Expr, &Expr)` as well, where the second expression is a sub-expression in the sub-AST of a string annotation. This is a bit of a naive implementation that will probably cause an enormous amount of additional memory usage. A less naive implementation should probably shove this in `extras`.

This also requires some adjustment to ensure the sub-expression has properly indexed AST nodes.

* Fixes https://github.com/astral-sh/ty/issues/1640
* Fixes https://github.com/astral-sh/ty/issues/2028

## Test Plan

Existing tests cover the behaviour (snapshots updated).
