### PR TITLE
Revert "Enable PEP 740 attestations when publishing to PyPI"

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -18,7 +18,8 @@ jobs:
     environment:
       name: release
     permissions:
-      id-token: write # For PyPI's trusted publishing + PEP 740 attestations
+      # For PyPI's trusted publishing.
+      id-token: write
     steps:
       - name: "Install uv"
         uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
@@ -27,8 +28,5 @@ jobs:
           pattern: wheels-*
           path: wheels
           merge-multiple: true
-      - uses: astral-sh/attest-action@2c727738cea36d6c97dd85eb133ea0e0e8fe754b # v0.0.4
-        with:
-          paths: wheels/*
       - name: Publish to PyPi
         run: uv publish -v wheels/*


### PR DESCRIPTION
Reverts astral-sh/ruff#21735

I'm preemptively reverting this based on https://github.com/astral-sh/uv/pull/16944, since it has the same reusable workflow pattern.