### PR TITLE
[ty] Support implicit type of `cls` in signatures

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -607,7 +607,7 @@ class X:
     def __init__(self, val: int): ...
     def make_another(self) -> Self:
         reveal_type(self.__new__)  # revealed: def __new__(cls) -> Self@__new__
-        return self.__new__(X)
+        return self.__new__(type(self))
 ```
 
 ## Builtin functions and methods

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -271,8 +271,7 @@ reveal_type(Person._make)  # revealed: bound method <class 'Person'>._make(itera
 reveal_type(Person._asdict)  # revealed: def _asdict(self) -> dict[str, Any]
 reveal_type(Person._replace)  # revealed: def _replace(self, **kwargs: Any) -> Self@_replace
 
-# TODO: should be `Person` once we support implicit type of `self`
-reveal_type(Person._make(("Alice", 42)))  # revealed: Unknown
+reveal_type(Person._make(("Alice", 42)))  # revealed: Person
 
 person = Person("Alice", 42)
 


### PR DESCRIPTION
## Summary

Extends https://github.com/astral-sh/ruff/pull/20517 to support the implicit type of `cls` in `@classmethod` signatures. Part of https://github.com/astral-sh/ty/issues/159.

This PR is stacked on https://github.com/astral-sh/ruff/pull/21770.