### PR TITLE
[ty] fix panic when attempting to infer the variance of a PEP-695 class that depends on a recursive type aliases and also somehow protocols

### DIFF
--- a/crates/ty_python_semantic/resources/corpus/cyclic_pep695_variance.py
+++ b/crates/ty_python_semantic/resources/corpus/cyclic_pep695_variance.py
@@ -1,0 +1,14 @@
+from typing import Protocol
+
+class A(Protocol):
+    @property
+    def f(self): ...
+
+type Recursive = int | tuple[Recursive, ...]
+
+class B[T: A]: ...
+
+class C[T: A](A):
+    x: tuple[Recursive, ...]
+
+class D(B[C]): ...

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -340,9 +340,18 @@ impl<'db> From<GenericAlias<'db>> for Type<'db> {
     }
 }
 
+fn variance_of_cycle_initial<'db>(
+    _db: &'db dyn Db,
+    _id: salsa::Id,
+    _self: GenericAlias<'db>,
+    _typevar: BoundTypeVarInstance<'db>,
+) -> TypeVarVariance {
+    TypeVarVariance::Bivariant
+}
+
 #[salsa::tracked]
 impl<'db> VarianceInferable<'db> for GenericAlias<'db> {
-    #[salsa::tracked(heap_size=ruff_memory_usage::heap_size)]
+    #[salsa::tracked(heap_size=ruff_memory_usage::heap_size, cycle_initial=variance_of_cycle_initial)]
     fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarVariance {
         let origin = self.origin(db);
 


### PR DESCRIPTION
Fixes https://github.com/astral-sh/ty/issues/1716.

## Test plan

I added a corpus snippet that causes us to panic on `main` (I tested by running `cargo run -p ty_python_semantic --test=corpus` without the fix applied).