### PR TITLE
[ty] Always register rename provider if client doesn't support dynamic registration

### DIFF
--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -72,15 +72,8 @@ impl Server {
         tracing::debug!("Resolved client capabilities: {resolved_client_capabilities}");
 
         let position_encoding = Self::find_best_position_encoding(&client_capabilities);
-        let server_capabilities = server_capabilities(
-            position_encoding,
-            resolved_client_capabilities,
-            &initialization_options
-                .options
-                .global
-                .clone()
-                .into_settings(),
-        );
+        let server_capabilities =
+            server_capabilities(position_encoding, resolved_client_capabilities);
 
         let version = ruff_db::program_version().unwrap_or("Unknown");
         tracing::info!("Version: {version}");

--- a/crates/ty_server/src/server/api/requests/prepare_rename.rs
+++ b/crates/ty_server/src/server/api/requests/prepare_rename.rs
@@ -32,6 +32,7 @@ impl BackgroundDocumentRequestHandler for PrepareRenameRequestHandler {
         if snapshot
             .workspace_settings()
             .is_language_services_disabled()
+            || !snapshot.global_settings().is_rename_enabled()
         {
             return Ok(None);
         }

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -564,7 +564,7 @@ impl Session {
             publish_settings_diagnostics(self, client, root);
         }
 
-        if let Some(global_options) = combined_global_options.take() {
+        if let Some(global_options) = combined_global_options {
             let global_settings = global_options.into_settings();
             if global_settings.diagnostic_mode().is_workspace() {
                 for project in self.projects.values_mut() {

--- a/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization.snap
@@ -48,6 +48,9 @@ expression: initialization_result
         "quickfix"
       ]
     },
+    "renameProvider": {
+      "prepareProvider": true
+    },
     "declarationProvider": true,
     "executeCommandProvider": {
       "commands": [

--- a/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization_with_workspace.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization_with_workspace.snap
@@ -48,6 +48,9 @@ expression: initialization_result
         "quickfix"
       ]
     },
+    "renameProvider": {
+      "prepareProvider": true
+    },
     "declarationProvider": true,
     "executeCommandProvider": {
       "commands": [


### PR DESCRIPTION
## Summary

Always register the rename provider if the client doesn't support dynamic registrations so that users don't need to know that renaming support can only be configured using `initialize_options`.

Fixes https://github.com/astral-sh/ty/issues/1745


## Test Plan

I removed the dynamic registration check in `server_capabilities` and tested that symbol renaming isn't
working in VS Code when disabling `rename` but is working when enabled. I also verified
that VS Code uses the rename functionality of any other available LSP (it doesn't block renaming if one LSP returns `None` and an other returns `Some`).
