### PR TITLE
[ty] more detailed description of "Size limit on unions of literals" in mdtest

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/union.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/union.md
@@ -229,9 +229,8 @@ def _(literals_2: Literal[0, 1], b: bool, flag: bool):
     literals_128 = 2 * literals_64 + literals_2  # Literal[0, 1, .., 127]
     literals_256 = 2 * literals_128 + literals_2  # Literal[0, 1, .., 255]
 
-    # Going beyond the MAX_UNION_LITERALS limit (currently 512):
-    literals_512 = 2 * literals_256 + literals_2  # Literal[0, 1, .., 511]
-    reveal_type(literals_512 if flag else 512)  # revealed: int
+    # Going beyond the MAX_NON_RECURSIVE_UNION_LITERALS limit (currently 256):
+    reveal_type(literals_256 if flag else 256)  # revealed: int
 
     # Going beyond the limit when another type is already part of the union
     bool_and_literals_128 = b if flag else literals_128  # bool | Literal[0, 1, ..., 127]
@@ -243,6 +242,41 @@ def _(literals_2: Literal[0, 1], b: bool, flag: bool):
     # revealed: bool | Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255]
     reveal_type(two)
     reveal_type(two if flag else literals_256_shifted)  # revealed: int
+```
+
+Recursively defined literal union types are widened earlier than non-recursively defined types for
+faster convergence.
+
+```py
+class RecursiveAttr:
+    def __init__(self):
+        self.i = 0
+
+    def update(self):
+        self.i = self.i + 1
+
+reveal_type(RecursiveAttr().i)  # revealed: Unknown | int
+
+# Here are some recursive but saturating examples. Because it's difficult to statically determine whether literal unions saturate or diverge,
+# we widen them early, even though they may actually be convergent.
+class RecursiveAttr2:
+    def __init__(self):
+        self.i = 0
+
+    def update(self):
+        self.i = (self.i + 1) % 9
+
+reveal_type(RecursiveAttr2().i)  # revealed: Unknown | Literal[0, 1, 2, 3, 4, 5, 6, 7, 8]
+
+class RecursiveAttr3:
+    def __init__(self):
+        self.i = 0
+
+    def update(self):
+        self.i = (self.i + 1) % 10
+
+# Going beyond the MAX_RECURSIVE_UNION_LITERALS limit:
+reveal_type(RecursiveAttr3().i)  # revealed: Unknown | int
 ```
 
 ## Simplifying gradually-equivalent types


### PR DESCRIPTION
## Summary

This is a follow-up to #21683.

The description of "Size limit on union of literals" in `mdtest/call/union.md` has been revised, and a description of the behavior for recursively defined literal unions has been added.

## Test Plan

`mdtest/call/union.md` has been updated.
