### PR TITLE
[ty] improve "Did you mean?" suggestion selection algorithm

### DIFF
--- a/crates/ty_python_semantic/src/diagnostic.rs
+++ b/crates/ty_python_semantic/src/diagnostic.rs
@@ -1,5 +1,7 @@
 use crate::{
-    Db, Program, PythonVersionWithSource, lint::lint_documentation_url, types::TypeCheckDiagnostics,
+    Db, Program, PythonVersionWithSource,
+    lint::lint_documentation_url,
+    types::{Type, TypeCheckDiagnostics, list_members::all_members},
 };
 use ruff_db::{
     diagnostic::{Annotation, Diagnostic, DiagnosticId, SubDiagnostic, SubDiagnosticSeverity},
@@ -7,6 +9,19 @@ use ruff_db::{
 };
 use std::cell::RefCell;
 use std::fmt::Write;
+
+pub(crate) fn did_you_mean_for_unresolved_member<'db>(
+    db: &'db dyn Db,
+    obj: Type<'db>,
+    unresolved_member: &str,
+) -> Option<String> {
+    did_you_mean(
+        all_members(db, obj)
+            .iter()
+            .map(|member| member.name.as_str()),
+        unresolved_member,
+    )
+}
 
 /// Suggest a name from `existing_names` that is similar to `wrong_name`.
 /// The suggestion algorithm is inspired by [rustc](https://doc.rust-lang.org/beta/nightly-rustc/src/rustc_span/edit_distance.rs.html).

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4218,7 +4218,7 @@ pub(super) fn hint_if_stdlib_submodule_exists_on_other_versions(
 /// misconfigured their Python version.
 pub(super) fn hint_if_stdlib_attribute_exists_on_other_versions(
     db: &dyn Db,
-    mut diagnostic: LintDiagnosticGuard,
+    diagnostic: &mut LintDiagnosticGuard,
     value_type: Type,
     attr: &str,
     action: &str,
@@ -4258,5 +4258,5 @@ pub(super) fn hint_if_stdlib_attribute_exists_on_other_versions(
     // TODO: determine what version they need to be on
     // TODO: also mention the platform we're assuming
     // TODO: determine what platform they need to be on
-    add_inferred_python_version_hint_to_diagnostic(db, &mut diagnostic, action);
+    add_inferred_python_version_hint_to_diagnostic(db, diagnostic, action);
 }


### PR DESCRIPTION
## Summary

This is a revival of #21780. After seeing #21780, I thought that perhaps we could reduce the number of incorrect hits by improving the edit distance calculation and candidate filtering.

I improved `did_you_mean` by referring to rustc's suggestion selection algorithm[^1].

[^1]: https://doc.rust-lang.org/beta/nightly-rustc/src/rustc_span/edit_distance.rs.html

## Test Plan

new snapshots