### PR TITLE
[ty] Narrow types after NoReturn calls in if branches

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -49,3 +49,88 @@ def _(x: int | None):
 
     reveal_type(x)  # revealed: int
 ```
+
+## Narrowing after a NoReturn call in one branch
+
+When a branch calls a function that returns `NoReturn`/`Never`, we know that branch terminates and
+doesn't contribute to the type after the if statement.
+
+```py
+import sys
+
+def _(val: int | None):
+    if val is None:
+        sys.exit()
+    # After the if statement, val cannot be None because that case
+    # would have called sys.exit() and never reached here
+    reveal_type(val)  # revealed: int
+```
+
+This also works when the NoReturn function is called in the else branch:
+
+```py
+import sys
+
+def _(val: int | None):
+    if val is not None:
+        pass
+    else:
+        sys.exit()
+    reveal_type(val)  # revealed: int
+```
+
+And for elif branches:
+
+```py
+import sys
+
+def _(val: int | str | None):
+    if val is None:
+        sys.exit()
+    elif isinstance(val, int):
+        pass
+    else:
+        sys.exit()
+    # TODO: Should be `int`, but we don't yet fully support narrowing after NoReturn in elif chains
+    reveal_type(val)  # revealed: int | str
+```
+
+## Narrowing from assert should not affect reassigned variables
+
+When a variable is reassigned after an `assert`, the narrowing from the assert should not apply to
+the new value. The assert condition was about the old value, not the new one.
+
+```py
+def foo(arg: int) -> int | None:
+    return None
+
+def bar() -> None:
+    v = foo(1)
+    assert v is None
+
+    v = foo(2)
+    # v was reassigned, so the assert narrowing shouldn't apply
+    reveal_type(v)  # revealed: int | None
+```
+
+## Narrowing from NoReturn should not affect reassigned variables
+
+Similar to assert, when a variable is narrowed due to a NoReturn call in one branch and then
+reassigned, the narrowing should only apply before the reassignment, not after.
+
+```py
+import sys
+
+def foo() -> int | None:
+    return 3
+
+def bar():
+    v = foo()
+    if v is None:
+        sys.exit()
+    reveal_type(v)  # revealed: int
+
+    v = foo()
+    # v was reassigned, so the NoReturn narrowing shouldn't apply
+    reveal_type(v)  # revealed: int | None
+```

--- a/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
+++ b/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
@@ -618,9 +618,7 @@ def g(x: int | None):
     if x is None:
         sys.exit(1)
 
-    # TODO: should be just `int`, not `int | None`
-    # See https://github.com/astral-sh/ty/issues/685
-    reveal_type(x)  # revealed: int | None
+    reveal_type(x)  # revealed: int
 ```
 
 ### Possibly unresolved diagnostics

--- a/crates/ty_python_semantic/src/semantic_index/definition.rs
+++ b/crates/ty_python_semantic/src/semantic_index/definition.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use ruff_db::files::{File, FileRange};
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
-use ruff_python_ast as ast;
+use ruff_python_ast::{self as ast, NodeIndex};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::Db;
@@ -745,6 +745,37 @@ impl DefinitionKind<'_> {
 
     pub(crate) const fn is_function_def(&self) -> bool {
         matches!(self, DefinitionKind::Function(_))
+    }
+
+    /// Returns the [`NodeIndex`] of the definition target.
+    ///
+    /// This can be used to determine the relative ordering of definitions and expressions
+    /// in the AST without needing to access the parsed module.
+    pub(crate) fn target_node_index(&self) -> NodeIndex {
+        match self {
+            DefinitionKind::Import(import) => import.node.index(),
+            DefinitionKind::ImportFrom(import) => import.node.index(),
+            DefinitionKind::ImportFromSubmodule(import) => import.node.index(),
+            DefinitionKind::StarImport(import) => import.node.index(),
+            DefinitionKind::Function(function) => function.index(),
+            DefinitionKind::Class(class) => class.index(),
+            DefinitionKind::TypeAlias(type_alias) => type_alias.index(),
+            DefinitionKind::NamedExpression(named) => named.index(),
+            DefinitionKind::Assignment(assignment) => assignment.target.index(),
+            DefinitionKind::AnnotatedAssignment(assign) => assign.target.index(),
+            DefinitionKind::AugmentedAssignment(aug_assign) => aug_assign.index(),
+            DefinitionKind::For(for_stmt) => for_stmt.target.index(),
+            DefinitionKind::Comprehension(comp) => comp.target.index(),
+            DefinitionKind::VariadicPositionalParameter(parameter) => parameter.index(),
+            DefinitionKind::VariadicKeywordParameter(parameter) => parameter.index(),
+            DefinitionKind::Parameter(parameter) => parameter.index(),
+            DefinitionKind::WithItem(with_item) => with_item.target.index(),
+            DefinitionKind::MatchPattern(match_pattern) => match_pattern.identifier.index(),
+            DefinitionKind::ExceptHandler(handler) => handler.handler.index(),
+            DefinitionKind::TypeVar(type_var) => type_var.index(),
+            DefinitionKind::ParamSpec(param_spec) => param_spec.index(),
+            DefinitionKind::TypeVarTuple(type_var_tuple) => type_var_tuple.index(),
+        }
     }
 
     /// Returns the [`TextRange`] of the definition target.


### PR DESCRIPTION
When a branch calls a NoReturn function, use the negation of the condition to narrow types after the if statement. For example, after `if val is None: sys.exit()`, `val` is now correctly narrowed to `int` instead of `int | None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

References https://github.com/astral-sh/ty/issues/685(I don't consider this to complete it, since this PR doesn't handle `elif`-chains yet)