### PR TITLE
Add a `minimal-size` cargo build profile for users who want to build a smaller binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -272,6 +272,12 @@ large_stack_arrays = "allow"
 lto = "fat"
 codegen-units = 16
 
+# Profile to build a minimally sized binary for ruff/ty
+[profile.minimal-size]
+inherits = "release"
+opt-level = "z"
+codegen-units = 1
+
 # Some crates don't change as much but benefit more from
 # more expensive optimization passes, so we selectively
 # decrease codegen-units in some cases.


### PR DESCRIPTION
This PR adds the same `minimal-size` profile as `uv` repo workspace has

```toml
# Profile to build a minimally sized binary for uv-build
[profile.minimal-size]
inherits = "release"
opt-level = "z"
# This will still show a panic message, we only skip the unwind
panic = "abort"
codegen-units = 1
```
but removes its `panic = "abort"` setting

- As discussed in #21825

Compared to the ones pre-built via `uv tool install`, this builds 35% smaller ruff and 24% smaller ty binaries
(as measured [here](https://github.com/lmmx/just-pre-commit/blob/master/refresh_binaries.sh))