### PR TITLE
[ty] Avoid double-analyzing tuple in `Final` subscript

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -103,8 +103,9 @@ class C:
 
 ## Trailing comma creates a tuple
 
-A trailing comma in a subscript creates a single-element tuple. We need to handle this
-gracefully and emit a proper error rather than crashing (see [ty#1793](https://github.com/astral-sh/ty/issues/1793)).
+A trailing comma in a subscript creates a single-element tuple. We need to handle this gracefully
+and emit a proper error rather than crashing (see
+[ty#1793](https://github.com/astral-sh/ty/issues/1793)).
 
 ```py
 from typing import ClassVar
@@ -118,7 +119,8 @@ C().x = 42
 reveal_type(C.x)  # revealed: Unknown
 ```
 
-This also applies when the trailing comma is inside the brackets (see [ty#1768](https://github.com/astral-sh/ty/issues/1768)):
+This also applies when the trailing comma is inside the brackets (see
+[ty#1768](https://github.com/astral-sh/ty/issues/1768)):
 
 ```py
 from typing import ClassVar

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -342,8 +342,9 @@ class C:
 
 ### Trailing comma creates a tuple
 
-A trailing comma in a subscript creates a single-element tuple. We need to handle this
-gracefully and emit a proper error rather than crashing (see [ty#1793](https://github.com/astral-sh/ty/issues/1793)).
+A trailing comma in a subscript creates a single-element tuple. We need to handle this gracefully
+and emit a proper error rather than crashing (see
+[ty#1793](https://github.com/astral-sh/ty/issues/1793)).
 
 ```py
 from typing import Final

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/initvar.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/initvar.md
@@ -112,8 +112,9 @@ class Wrong:
     x: InitVar[int, str]  # error: [invalid-type-form] "Type qualifier `InitVar` expected exactly 1 argument, got 2"
 ```
 
-A trailing comma in a subscript creates a single-element tuple. We need to handle this
-gracefully and emit a proper error rather than crashing (see [ty#1793](https://github.com/astral-sh/ty/issues/1793)).
+A trailing comma in a subscript creates a single-element tuple. We need to handle this gracefully
+and emit a proper error rather than crashing (see
+[ty#1793](https://github.com/astral-sh/ty/issues/1793)).
 
 ```py
 from dataclasses import InitVar, dataclass

--- a/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
@@ -275,7 +275,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         };
                         let type_and_qualifiers = if let [argument] = arguments {
                             let mut type_and_qualifiers = self.infer_annotation_expression_impl(
-                                &argument,
+                                argument,
                                 PEP613Policy::Disallowed,
                             );
 


### PR DESCRIPTION
## Summary

As-is, a single-element tuple gets destructured via:

```rust
let arguments = if let ast::Expr::Tuple(tuple) = slice {
    &*tuple.elts
} else {
    std::slice::from_ref(slice)
};
```

But then, because it's a single element, we call `infer_annotation_expression_impl`, passing in the tuple, rather than the first element.

Closes https://github.com/astral-sh/ty/issues/1793.
Closes https://github.com/astral-sh/ty/issues/1768.
