### PR TITLE
[ty] Add test case for fixed panic

### DIFF
--- a/crates/ty_python_semantic/resources/corpus/future_annotations_recursive_annotation.py
+++ b/crates/ty_python_semantic/resources/corpus/future_annotations_recursive_annotation.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+class MyClass:
+    type: type = str


### PR DESCRIPTION
## Summary

We used to panic on this snippet, but we no longer do. The only thing left to do is to add a test case ensuring that we never do so again!

Closes https://github.com/astral-sh/ty/issues/899

## Test Plan

I ran `cargo run -p ty check --python-version=3.14` and `cargo run -p ty check --python-version=3.9` on this snippet. Neither panics anymore.
