### PR TITLE
[ty] Fix stack overflows when attempting to infer the truthiness of a TypeVar with an invalid recursive bound or constraints

### DIFF
--- a/crates/ty_python_semantic/resources/corpus/truthiness_test_on_recursive_bound_typevar.py
+++ b/crates/ty_python_semantic/resources/corpus/truthiness_test_on_recursive_bound_typevar.py
@@ -1,0 +1,4 @@
+class name_1[name_2: name_2[0]]:
+    def name_4(name_3: name_2, /):
+        if name_3:
+            pass

--- a/crates/ty_python_semantic/resources/corpus/truthiness_test_on_recursive_constrained_typevar.py
+++ b/crates/ty_python_semantic/resources/corpus/truthiness_test_on_recursive_constrained_typevar.py
@@ -1,0 +1,4 @@
+class name_1[name_2: (name_2[0], int)]:
+    def name_4(name_3: name_2, /):
+        if name_3:
+            pass

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_bool_conversion.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_bool_conversion.md
@@ -59,3 +59,39 @@ def get() -> NotBoolable1 | NotBoolable2 | NotBoolable3:
 # error: [unsupported-bool-conversion]
 10 and get() and True
 ```
+
+## Constrained TypeVar has >=1 constraint that doesn't support boolean conversion
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+class NotBoolable:
+    __bool__ = None
+
+def f[T: (int, NotBoolable)](x: T) -> T:
+    # error: [unsupported-bool-conversion]
+    if x:
+        pass
+    return x
+```
+
+## TypeVar has an upper bound that doesn't support boolean conversion
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+class NotBoolable:
+    __bool__ = None
+
+def f[T: NotBoolable](x: T) -> T:
+    # error: [unsupported-bool-conversion]
+    if x:
+        pass
+    return x
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Constrained_TypeVar_…_(d3fd18045d730775).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Constrained_TypeVar_…_(d3fd18045d730775).snap
@@ -1,0 +1,40 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: unsupported_bool_conversion.md - Different ways that `unsupported-bool-conversion` can occur - Constrained TypeVar has >=1 constraint that doesn't support boolean conversion
+mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_bool_conversion.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | class NotBoolable:
+2 |     __bool__ = None
+3 | 
+4 | def f[T: (int, NotBoolable)](x: T) -> T:
+5 |     # error: [unsupported-bool-conversion]
+6 |     if x:
+7 |         pass
+8 |     return x
+```
+
+# Diagnostics
+
+```
+error[unsupported-bool-conversion]: Boolean conversion is unsupported for type variable `T@f` because constraint `NotBoolable` doesn't implement `__bool__` correctly
+ --> src/mdtest_snippet.py:6:8
+  |
+4 | def f[T: (int, NotBoolable)](x: T) -> T:
+5 |     # error: [unsupported-bool-conversion]
+6 |     if x:
+  |        ^
+7 |         pass
+8 |     return x
+  |
+info: rule `unsupported-bool-conversion` is enabled by default
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_TypeVar_has_an_upper…_(c47b930ed7da5310).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_TypeVar_has_an_upper…_(c47b930ed7da5310).snap
@@ -1,0 +1,40 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: unsupported_bool_conversion.md - Different ways that `unsupported-bool-conversion` can occur - TypeVar has an upper bound that doesn't support boolean conversion
+mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_bool_conversion.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | class NotBoolable:
+2 |     __bool__ = None
+3 | 
+4 | def f[T: NotBoolable](x: T) -> T:
+5 |     # error: [unsupported-bool-conversion]
+6 |     if x:
+7 |         pass
+8 |     return x
+```
+
+# Diagnostics
+
+```
+error[unsupported-bool-conversion]: Boolean conversion is unsupported for type variable `T@f` because upper bound `NotBoolable` doesn't implement `__bool__` correctly
+ --> src/mdtest_snippet.py:6:8
+  |
+4 | def f[T: NotBoolable](x: T) -> T:
+5 |     # error: [unsupported-bool-conversion]
+6 |     if x:
+  |        ^
+7 |         pass
+8 |     return x
+  |
+info: rule `unsupported-bool-conversion` is enabled by default
+
+```


### PR DESCRIPTION
## Summary

This PR fixes the first stack overflow MRE given in https://github.com/astral-sh/ty/issues/1794.

## Test Plan

I added two corpus test cases that cause us to overflow our stack on `main`: one with a recursive upper bound, and a slightly trickier one with recursive constraints. I also added mdtests and snapshots.
