### PR TITLE
Print Python version and Python platform in the fuzzer output when fuzzing fails

### DIFF
--- a/python/py-fuzzer/fuzz.py
+++ b/python/py-fuzzer/fuzz.py
@@ -29,14 +29,12 @@ import concurrent.futures
 import enum
 import subprocess
 import tempfile
-import tomllib
 from collections.abc import Callable
 from dataclasses import KW_ONLY, dataclass
 from functools import partial
 from pathlib import Path
 from typing import Final, NewType, NoReturn, assert_never
 
-import packaging.specifiers
 from pysource_codegen import generate as generate_random_code
 from pysource_minimize import CouldNotMinimize, minimize as minimize_repro
 from rich_argparse import RawDescriptionRichHelpFormatter
@@ -48,15 +46,9 @@ ExitCode = NewType("ExitCode", int)
 
 TY_TARGET_PLATFORM: Final = "linux"
 
-with Path(__file__).parent.parent.parent.joinpath("pyproject.toml").open("rb") as f:
-    pyproject_toml = tomllib.load(f)
-
-pyproject_specifier = packaging.specifiers.Specifier(
-    pyproject_toml["project"]["requires-python"]
-)
-assert pyproject_specifier.operator == ">="
-
-OLDEST_SUPPORTED_PYTHON: Final = pyproject_specifier.version
+# ty supports `--python-version=3.8`, but typeshed only supports 3.9+,
+# so that's probably the oldest version we can usefully test with.
+OLDEST_SUPPORTED_PYTHON: Final = "3.9"
 
 
 def ty_contains_bug(code: str, *, ty_executable: Path) -> bool:

--- a/python/py-fuzzer/pyproject.toml
+++ b/python/py-fuzzer/pyproject.toml
@@ -4,7 +4,6 @@ version = "0.0.0"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "packaging",
     "pysource-codegen>=0.6.0",
     "pysource-minimize>=0.8.0",
     "rich-argparse>=1.7.0",
@@ -32,9 +31,6 @@ strict = true
 warn_unreachable = true
 local_partial_types = true
 enable_error_code = "ignore-without-code,redundant-expr,truthy-bool"
-
-[tool.ty.environment]
-python = "./.venv"
 
 [tool.ty.rules]
 possibly-unresolved-reference = "error"

--- a/python/py-fuzzer/uv.lock
+++ b/python/py-fuzzer/uv.lock
@@ -65,15 +65,6 @@ wheels = [
 ]
 
 [[package]]
-name = "packaging"
-version = "25.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
-]
-
-[[package]]
 name = "pathspec"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -87,7 +78,6 @@ name = "py-fuzzer"
 version = "0.0.0"
 source = { editable = "." }
 dependencies = [
-    { name = "packaging" },
     { name = "pysource-codegen" },
     { name = "pysource-minimize" },
     { name = "rich-argparse" },
@@ -104,7 +94,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "packaging" },
     { name = "pysource-codegen", specifier = ">=0.6.0" },
     { name = "pysource-minimize", specifier = ">=0.8.0" },
     { name = "rich-argparse", specifier = ">=1.7.0" },


### PR DESCRIPTION
## Summary

There was some confusion in https://github.com/astral-sh/ruff/pull/21839, because ty as executed by the fuzzer was picking up the `requires-python = ">=3.7"` setting in Ruff's pyproject.toml file. But that's different from ty's default behaviour (if executed in a directory that has no pyproject.toml file, and no pyproject.toml file in any of its ancestor directories), which is to assume Python 3.14.

I think running the fuzzer with `--python-version={OLDEST_SUPPORTED_PYTHON}` is actually a pretty good idea -- it caught a bug in #21839! But we should do that explicitly rather than having ty implicitly pick up the Python version from Ruff's pyproject.toml file. And we should print out the Python version and Python platform to the terminal when the fuzzer finds a bug.

<details>
<summary>Screenshot showing the new output when a bug is found</summary>

<img width="2642" height="1692" alt="image" src="https://github.com/user-attachments/assets/c748c7df-a7cc-49df-abd6-0a9ec939e626" />

</details> 

## Test Plan

- See above screenshot
- CI on this PR
