### PR TITLE
[ty] Don't create a related diagnostic for the primary annotation of sub-diagnostics

### DIFF
--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -888,6 +888,10 @@ impl Annotation {
     pub fn hide_snippet(&mut self, yes: bool) {
         self.hide_snippet = yes;
     }
+
+    pub fn is_primary(&self) -> bool {
+        self.is_primary
+    }
 }
 
 /// Tags that can be associated with an annotation.

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -349,6 +349,7 @@ pub(super) fn to_lsp_diagnostic(
             sub_diagnostic
                 .annotations()
                 .iter()
+                .filter(|annotation| !annotation.is_primary())
                 .filter_map(|annotation| {
                     annotation_to_related_information(db, annotation, encoding)
                 }),


### PR DESCRIPTION
## Summary

Addresses the 'too many "Python 3.7 was assumed" diagnostics issue raised in [this comment](https://github.com/astral-sh/ty/issues/1582#issuecomment-3626555051)

We already skip the primary annotation when creating related diagnostics for the main diagnostic, but we failed to do so for sub-diagnostics, which results in duplicated related information diagnostics.

We need to skip the primary annotation because we already use that range when generating related information for the subdiagnostic.


## Test Plan

<img width="970" height="305" alt="Screenshot 2025-12-08 at 14 48 57" src="https://github.com/user-attachments/assets/af23f771-5176-4152-a357-0a9b25869609" />

