### PR TITLE
[ty] Make Python-version subdiagnostics less verbose

### DIFF
--- a/crates/ty/tests/cli/python_environment.rs
+++ b/crates/ty/tests/cli/python_environment.rs
@@ -43,7 +43,7 @@ fn config_override_python_version() -> anyhow::Result<()> {
       |
     2 | [tool.ty.environment]
     3 | python-version = "3.11"
-      |                  ^^^^^^ Python 3.11 assumed due to this configuration setting
+      |                  ^^^^^^ Python version configuration
       |
     info: rule `unresolved-attribute` is enabled by default
 
@@ -143,7 +143,7 @@ fn config_file_annotation_showing_where_python_version_set_typing_error() -> any
         ),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r###"
+    assert_cmd_snapshot!(case.command(), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -159,14 +159,14 @@ fn config_file_annotation_showing_where_python_version_set_typing_error() -> any
       |
     2 | [tool.ty.environment]
     3 | python-version = "3.8"
-      |                  ^^^^^ Python 3.8 assumed due to this configuration setting
+      |                  ^^^^^ Python version configuration
       |
     info: rule `unresolved-reference` is enabled by default
 
     Found 1 diagnostic
 
     ----- stderr -----
-    "###);
+    "#);
 
     assert_cmd_snapshot!(case.command().arg("--python-version=3.9"), @r###"
     success: false
@@ -772,7 +772,7 @@ fn pyvenv_cfg_file_annotation_showing_where_python_version_set() -> anyhow::Resu
         ("test.py", "aiter"),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r###"
+    assert_cmd_snapshot!(case.command(), @r"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -787,7 +787,7 @@ fn pyvenv_cfg_file_annotation_showing_where_python_version_set() -> anyhow::Resu
      --> venv/pyvenv.cfg:2:11
       |
     2 | version = 3.8
-      |           ^^^ Python version inferred from virtual environment metadata file
+      |           ^^^ Virtual environment metadata
     3 | home = foo/bar/bin
       |
     info: No Python version was specified on the command line or in a configuration file
@@ -796,7 +796,7 @@ fn pyvenv_cfg_file_annotation_showing_where_python_version_set() -> anyhow::Resu
     Found 1 diagnostic
 
     ----- stderr -----
-    "###);
+    ");
 
     Ok(())
 }
@@ -831,7 +831,7 @@ fn pyvenv_cfg_file_annotation_no_trailing_newline() -> anyhow::Result<()> {
         ("test.py", "aiter"),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r###"
+    assert_cmd_snapshot!(case.command(), @r"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -846,7 +846,7 @@ fn pyvenv_cfg_file_annotation_no_trailing_newline() -> anyhow::Result<()> {
      --> venv/pyvenv.cfg:4:23
       |
     4 |             version = 3.8
-      |                       ^^^ Python version inferred from virtual environment metadata file
+      |                       ^^^ Virtual environment metadata
       |
     info: No Python version was specified on the command line or in a configuration file
     info: rule `unresolved-reference` is enabled by default
@@ -854,7 +854,7 @@ fn pyvenv_cfg_file_annotation_no_trailing_newline() -> anyhow::Result<()> {
     Found 1 diagnostic
 
     ----- stderr -----
-    "###);
+    ");
 
     Ok(())
 }
@@ -898,7 +898,7 @@ fn config_file_annotation_showing_where_python_version_set_syntax_error() -> any
       |
     2 | [project]
     3 | requires-python = ">=3.8"
-      |                   ^^^^^^^ Python 3.8 assumed due to this configuration setting
+      |                   ^^^^^^^ Python version configuration
       |
 
     Found 1 diagnostic
@@ -1206,7 +1206,7 @@ fn defaults_to_a_new_python_version() -> anyhow::Result<()> {
       |
     2 | [environment]
     3 | python-version = "3.10"
-      |                  ^^^^^^ Python 3.10 assumed due to this configuration setting
+      |                  ^^^^^^ Python version configuration
     4 | python-platform = "linux"
       |
     info: rule `unresolved-attribute` is enabled by default
@@ -1225,7 +1225,7 @@ fn defaults_to_a_new_python_version() -> anyhow::Result<()> {
       |
     2 | [environment]
     3 | python-version = "3.10"
-      |                  ^^^^^^ Python 3.10 assumed due to this configuration setting
+      |                  ^^^^^^ Python version configuration
     4 | python-platform = "linux"
       |
     info: rule `unresolved-import` is enabled by default

--- a/crates/ty_python_semantic/src/diagnostic.rs
+++ b/crates/ty_python_semantic/src/diagnostic.rs
@@ -58,9 +58,8 @@ pub fn add_inferred_python_version_hint_to_diagnostic(
                     SubDiagnosticSeverity::Info,
                     format_args!("Python {version} was assumed when {action}"),
                 );
-                sub_diagnostic.annotate(Annotation::primary(span).message(format_args!(
-                    "Python {version} assumed due to this configuration setting"
-                )));
+                sub_diagnostic
+                    .annotate(Annotation::primary(span).message("Python version configuration"));
                 diagnostic.sub(sub_diagnostic);
             } else {
                 diagnostic.info(format_args!(
@@ -76,10 +75,8 @@ pub fn add_inferred_python_version_hint_to_diagnostic(
                         "Python {version} was assumed when {action} because of your virtual environment"
                     ),
                 );
-                sub_diagnostic.annotate(
-                    Annotation::primary(span)
-                        .message("Python version inferred from virtual environment metadata file"),
-                );
+                sub_diagnostic
+                    .annotate(Annotation::primary(span).message("Virtual environment metadata"));
                 // TODO: it would also be nice to tell them how we resolved their virtual environment...
                 diagnostic.sub(sub_diagnostic);
             } else {


### PR DESCRIPTION
## Summary

@MichaReiser mentioned in https://github.com/astral-sh/ty/issues/1582#issuecomment-3626991908 that these subdiagnostics currently repeat some information from the primary diagnostic, which feels unnecessary. I agree.

Before:

<details>
<summary>Before</summary>

<img width="1644" height="876" alt="image" src="https://github.com/user-attachments/assets/fb9dd3ed-ba0e-420c-9aab-5cbd1c04837d" />

</details>

<details>
<summary>After</summary>

<img width="1492" height="900" alt="image" src="https://github.com/user-attachments/assets/798ebe13-ece2-4d09-a4de-857f3650902d" />

</details>

## Test Plan

Snapshots updated
