### PR TITLE
[ty] Collapse `never` paths in constraint set BDDs

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -3449,9 +3449,7 @@ mod tests {
                 │   └─₀ (U = bool)
                 │       ┡━₁ always
                 │       └─₀ never
-                └─₀ (U = str)
-                    ┡━₁ never
-                    └─₀ never
+                └─₀ never
         "#}
         .trim_end();
 


### PR DESCRIPTION
#21744 fixed some non-determinism in our constraint set implementation by switching our BDD representation from being "fully reduced" to being "quasi-reduced". We still deduplicate identical nodes (via salsa interning), but we removed the logic to prune redundant nodes (one with identical outgoing true and false edges). This ensures that the BDD "remembers" all of the individual constraints that it was created with.

However, that comes at the cost of creating larger BDDs, and on #21551 that was causing performance issues. `scikit-learn` was producing a function signature with dozens of overloads, and we were trying to create a constraint set that would map a return type typevar to any of those overload's return types. This created a combinatorial explosion in the BDD, with by far most of the BDD paths leading to the `never` terminal.

This change updates the quasi-reduction logic to prune nodes that are redundant _because both edges lead to the `never` terminal_. In this case, we don't need to "remember" that constraint, since no assignment to it can lead to a valid specialization. So we keep the "memory" of our quasi-reduced structure, while still pruning large unneeded portions of the BDD structure.

Pulling this out of https://github.com/astral-sh/ruff/pull/21551 for separate review.