### PR TITLE
Document `*.pyw` is included by default in preview

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -351,7 +351,8 @@ For example, without `force-exclude` enabled, `ruff check /path/to/excluded/file
 
 ### Default inclusions
 
-By default, Ruff will discover files matching `*.py`, `*.pyi`, `*.pyw`, `*.ipynb`, or `pyproject.toml`.
+By default, Ruff will discover files matching `*.py`, `*.pyi`, `*.ipynb`, or `pyproject.toml`.
+In [preview](preview.md) mode, Ruff will also discover `*.pyw` by default.
 
 To lint or format files with additional file extensions, use the [`extend-include`](settings.md#extend-include) setting.
 You can also change the default selection using the [`include`](settings.md#include) setting.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Document `*.pyw` is included by default.
Originally requested in https://github.com/astral-sh/ruff/issues/13246 and added in https://github.com/astral-sh/ruff/pull/20458

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
