### PR TITLE
Remove hack about unknown options warning

### DIFF
--- a/crates/ty_server/tests/e2e/initialize.rs
+++ b/crates/ty_server/tests/e2e/initialize.rs
@@ -402,7 +402,7 @@ fn unknown_initialization_options() -> Result<()> {
     insta::assert_json_snapshot!(show_message_params, @r#"
     {
       "type": 2,
-      "message": "Received unknown options during initialization: 'bar'. Refer to the logs for more details"
+      "message": "Received unknown options during initialization: {\n  /"bar/": null\n}"
     }
     "#);
 
@@ -427,7 +427,7 @@ fn unknown_options_in_workspace_configuration() -> Result<()> {
     insta::assert_json_snapshot!(show_message_params, @r#"
     {
       "type": 2,
-      "message": "Received unknown options for workspace `file://<temp_dir>/foo`: 'bar'. Refer to the logs for more details."
+      "message": "Received unknown options for workspace `file://<temp_dir>/foo`: {\n  /"bar/": null\n}"
     }
     "#);
 


### PR DESCRIPTION
This hack was introduced to reduce the amount of warnings that users would get while transitioning to the new settings format (https://github.com/astral-sh/ruff/pull/19787) but now that we're near the beta release, it would be good to remove this.