### PR TITLE
Sync interpolated lexer state within `re_lex_logical_token`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3349,6 +3349,7 @@ dependencies = [
  "compact_str",
  "get-size2",
  "insta",
+ "itertools 0.14.0",
  "memchr",
  "ruff_annotate_snippets",
  "ruff_python_ast",

--- a/crates/ruff_python_ast/src/token.rs
+++ b/crates/ruff_python_ast/src/token.rs
@@ -841,7 +841,7 @@ impl TokenFlags {
         self.intersects(TokenFlags::T_STRING.union(TokenFlags::F_STRING))
     }
 
-    /// Returns `true` if the token is a triple-quoted t-string.
+    /// Returns `true` if the token is a triple-quoted interpolated-string.
     pub fn is_triple_quoted_interpolated_string(self) -> bool {
         self.intersects(TokenFlags::TRIPLE_QUOTED_STRING) && self.is_interpolated_string()
     }

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -35,6 +35,7 @@ ruff_source_file = { workspace = true }
 
 anyhow = { workspace = true }
 insta = { workspace = true, features = ["glob"] }
+itertools = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/ruff_python_parser/resources/invalid/re_lexing/ty_1828.py
+++ b/crates/ruff_python_parser/resources/invalid/re_lexing/ty_1828.py
@@ -1,0 +1,5 @@
+# Regression test for https://github.com/astral-sh/ty/issues/1828
+(c: int = 1,f"""{d=[
+def a(
+class A:
+    pass

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1543,8 +1543,6 @@ impl<'src> Lexer<'src> {
             }
         }
 
-        dbg!("Handle unclosed string");
-
         if self.errors.last().is_some_and(|error| {
             error.location() == self.current_range
                 && matches!(error.error(), LexicalErrorType::UnclosedStringError)

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -67,26 +67,59 @@ impl<'src> TokenSource<'src> {
     ///
     /// [`re_lex_logical_token`]: Lexer::re_lex_logical_token
     pub(crate) fn re_lex_logical_token(&mut self) {
-        let mut non_logical_newline_start = None;
-        for token in self.tokens.iter().rev() {
+        let mut non_logical_line = None;
+
+        #[cfg(debug_assertions)]
+        let last_non_trivia_end_before = {
+            self.tokens
+                .iter()
+                .rev()
+                .find(|tok| !tok.kind().is_trivia())
+                .map(ruff_text_size::Ranged::end)
+        };
+
+        for (index, token) in self.tokens.iter().enumerate().rev() {
             match token.kind() {
                 TokenKind::NonLogicalNewline => {
-                    non_logical_newline_start = Some(token.start());
+                    non_logical_line = Some((index, token.start()));
                 }
                 TokenKind::Comment => continue,
                 _ => break,
             }
         }
 
-        if self.lexer.re_lex_logical_token(non_logical_newline_start) {
-            let current_start = self.current_range().start();
-            while self
-                .tokens
-                .last()
-                .is_some_and(|last| last.start() >= current_start)
-            {
-                self.tokens.pop();
-            }
+        if !self
+            .lexer
+            .re_lex_logical_token(non_logical_line.map(|(_, start)| start))
+        {
+            return;
+        }
+
+        let non_logical_line_index = non_logical_line
+            .expect(
+                "`re_lex_logical_token` should only return `true` if `non_logical_line` is `Some`",
+            )
+            .0;
+
+        // Trim the already bumped logical line token (and comments coming after it) as it might now have become a logical line token
+        self.tokens.truncate(non_logical_line_index);
+
+        #[cfg(debug_assertions)]
+        {
+            let last_non_trivia_end_now = {
+                self.tokens
+                    .iter()
+                    .rev()
+                    .find(|tok| !tok.kind().is_trivia())
+                    .map(ruff_text_size::Ranged::end)
+            };
+
+            assert_eq!(last_non_trivia_end_before, last_non_trivia_end_now);
+        }
+
+        // Ensure `current` is positioned at a non-trivia token.
+        if self.current_kind().is_trivia() {
+            self.bump(self.current_kind());
         }
     }
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lex_logical_token.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lex_logical_token.py.snap
@@ -296,7 +296,7 @@ Module(
                     test: Call(
                         ExprCall {
                             node_index: NodeIndex(None),
-                            range: 456..472,
+                            range: 456..471,
                             func: Name(
                                 ExprName {
                                     node_index: NodeIndex(None),
@@ -306,7 +306,7 @@ Module(
                                 },
                             ),
                             arguments: Arguments {
-                                range: 460..472,
+                                range: 460..471,
                                 node_index: NodeIndex(None),
                                 args: [
                                     Name(
@@ -581,7 +581,7 @@ Module(
                     test: Call(
                         ExprCall {
                             node_index: NodeIndex(None),
-                            range: 890..906,
+                            range: 890..905,
                             func: Name(
                                 ExprName {
                                     node_index: NodeIndex(None),
@@ -591,7 +591,7 @@ Module(
                                 },
                             ),
                             arguments: Arguments {
-                                range: 894..906,
+                                range: 894..905,
                                 node_index: NodeIndex(None),
                                 args: [
                                     FString(
@@ -832,7 +832,16 @@ Module(
    |
 28 | # The lexer is nested with multiple levels of parentheses
 29 | if call(foo, [a, b
-   |                   ^ Syntax Error: Expected `]`, found NonLogicalNewline
+30 |     def bar():
+   |     ^^^ Syntax Error: Expected `]`, found `def`
+31 |         pass
+   |
+
+
+   |
+28 | # The lexer is nested with multiple levels of parentheses
+29 | if call(foo, [a, b
+   |                   ^ Syntax Error: Expected `)`, found newline
 30 |     def bar():
 31 |         pass
    |
@@ -857,11 +866,10 @@ Module(
 
 
    |
-41 | # test is to make sure it emits a `NonLogicalNewline` token after `b`.
 42 | if call(foo, [a,
 43 |     b
-   |      ^ Syntax Error: Expected `]`, found NonLogicalNewline
 44 | )
+   | ^ Syntax Error: Expected `]`, found `)`
 45 |     def bar():
 46 |         pass
    |
@@ -898,7 +906,7 @@ Module(
    |
 49 | # F-strings uses normal list parsing, so test those as well
 50 | if call(f"hello {x
-   |                   ^ Syntax Error: Expected FStringEnd, found NonLogicalNewline
+   |                   ^ Syntax Error: Expected `)`, found newline
 51 |     def bar():
 52 |         pass
    |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lex_logical_token_mac_eol.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lex_logical_token_mac_eol.py.snap
@@ -17,7 +17,7 @@ Module(
                     test: Call(
                         ExprCall {
                             node_index: NodeIndex(None),
-                            range: 3..19,
+                            range: 3..18,
                             func: Name(
                                 ExprName {
                                     node_index: NodeIndex(None),
@@ -27,7 +27,7 @@ Module(
                                 },
                             ),
                             arguments: Arguments {
-                                range: 7..19,
+                                range: 7..18,
                                 node_index: NodeIndex(None),
                                 args: [
                                     Name(
@@ -113,5 +113,11 @@ Module(
 
   |
 1 | if call(foo, [a, b    def bar():        pass
-  |                   ^ Syntax Error: Expected `]`, found NonLogicalNewline
+  |                       ^^^ Syntax Error: Expected `]`, found `def`
+  |
+
+
+  |
+1 | if call(foo, [a, b    def bar():        pass
+  |                   ^ Syntax Error: Expected `)`, found newline
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lex_logical_token_windows_eol.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lex_logical_token_windows_eol.py.snap
@@ -17,7 +17,7 @@ Module(
                     test: Call(
                         ExprCall {
                             node_index: NodeIndex(None),
-                            range: 3..20,
+                            range: 3..18,
                             func: Name(
                                 ExprName {
                                     node_index: NodeIndex(None),
@@ -27,7 +27,7 @@ Module(
                                 },
                             ),
                             arguments: Arguments {
-                                range: 7..20,
+                                range: 7..18,
                                 node_index: NodeIndex(None),
                                 args: [
                                     Name(
@@ -113,7 +113,15 @@ Module(
 
   |
 1 | if call(foo, [a, b
-  |                   ^ Syntax Error: Expected `]`, found NonLogicalNewline
+2 |     def bar():
+  |     ^^^ Syntax Error: Expected `]`, found `def`
+3 |         pass
+  |
+
+
+  |
+1 | if call(foo, [a, b
+  |                   ^ Syntax Error: Expected `)`, found newline
 2 |     def bar():
 3 |         pass
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__ty_1828.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__ty_1828.py.snap
@@ -1,0 +1,227 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/re_lexing/ty_1828.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        node_index: NodeIndex(None),
+        range: 0..112,
+        body: [
+            AnnAssign(
+                StmtAnnAssign {
+                    node_index: NodeIndex(None),
+                    range: 66..93,
+                    target: Name(
+                        ExprName {
+                            node_index: NodeIndex(None),
+                            range: 67..68,
+                            id: Name("c"),
+                            ctx: Store,
+                        },
+                    ),
+                    annotation: Name(
+                        ExprName {
+                            node_index: NodeIndex(None),
+                            range: 70..73,
+                            id: Name("int"),
+                            ctx: Load,
+                        },
+                    ),
+                    value: Some(
+                        Tuple(
+                            ExprTuple {
+                                node_index: NodeIndex(None),
+                                range: 76..93,
+                                elts: [
+                                    NumberLiteral(
+                                        ExprNumberLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 76..77,
+                                            value: Int(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                    Subscript(
+                                        ExprSubscript {
+                                            node_index: NodeIndex(None),
+                                            range: 78..90,
+                                            value: FString(
+                                                ExprFString {
+                                                    node_index: NodeIndex(None),
+                                                    range: 78..85,
+                                                    value: FStringValue {
+                                                        inner: Single(
+                                                            FString(
+                                                                FString {
+                                                                    range: 78..85,
+                                                                    node_index: NodeIndex(None),
+                                                                    elements: [
+                                                                        Interpolation(
+                                                                            InterpolatedElement {
+                                                                                range: 82..85,
+                                                                                node_index: NodeIndex(None),
+                                                                                expression: Name(
+                                                                                    ExprName {
+                                                                                        node_index: NodeIndex(None),
+                                                                                        range: 83..84,
+                                                                                        id: Name("d"),
+                                                                                        ctx: Load,
+                                                                                    },
+                                                                                ),
+                                                                                debug_text: Some(
+                                                                                    DebugText {
+                                                                                        leading: "",
+                                                                                        trailing: "=",
+                                                                                    },
+                                                                                ),
+                                                                                conversion: None,
+                                                                                format_spec: None,
+                                                                            },
+                                                                        ),
+                                                                    ],
+                                                                    flags: FStringFlags {
+                                                                        quote_style: Double,
+                                                                        prefix: Regular,
+                                                                        triple_quoted: true,
+                                                                        unclosed: true,
+                                                                    },
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                },
+                                            ),
+                                            slice: Slice(
+                                                ExprSlice {
+                                                    node_index: NodeIndex(None),
+                                                    range: 87..90,
+                                                    lower: None,
+                                                    upper: Some(
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 87..90,
+                                                                id: Name("def"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    step: None,
+                                                },
+                                            ),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    Call(
+                                        ExprCall {
+                                            node_index: NodeIndex(None),
+                                            range: 91..93,
+                                            func: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 91..92,
+                                                    id: Name("a"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            arguments: Arguments {
+                                                range: 92..93,
+                                                node_index: NodeIndex(None),
+                                                args: [],
+                                                keywords: [],
+                                            },
+                                        },
+                                    ),
+                                ],
+                                ctx: Load,
+                                parenthesized: false,
+                            },
+                        ),
+                    ),
+                    simple: false,
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | # Regression test for https://github.com/astral-sh/ty/issues/1828
+2 | (c: int = 1,f"""{d=[
+  |   ^ Syntax Error: Expected `)`, found `:`
+3 | def a(
+4 | class A:
+  |
+
+
+  |
+1 | # Regression test for https://github.com/astral-sh/ty/issues/1828
+2 | (c: int = 1,f"""{d=[
+  |                    ^ Syntax Error: f-string: expecting `}`
+3 | def a(
+4 | class A:
+  |
+
+
+  |
+1 | # Regression test for https://github.com/astral-sh/ty/issues/1828
+2 | (c: int = 1,f"""{d=[
+3 | def a(
+  | ^^^ Syntax Error: Expected `:`, found `def`
+4 | class A:
+5 |     pass
+  |
+
+
+  |
+1 | # Regression test for https://github.com/astral-sh/ty/issues/1828
+2 | (c: int = 1,f"""{d=[
+3 | def a(
+  |     ^ Syntax Error: Expected `]`, found name
+4 | class A:
+5 |     pass
+  |
+
+
+  |
+1 |   # Regression test for https://github.com/astral-sh/ty/issues/1828
+2 |   (c: int = 1,f"""{d=[
+3 |   def a(
+  |  _______^
+4 | | class A:
+5 | |     pass
+  | |_________^ Syntax Error: f-string: unterminated triple-quoted string
+  |
+
+
+  |
+2 | (c: int = 1,f"""{d=[
+3 | def a(
+4 | class A:
+  | ^^^^^ Syntax Error: Expected `)`, found `class`
+5 |     pass
+  |
+
+
+  |
+1 |   # Regression test for https://github.com/astral-sh/ty/issues/1828
+2 |   (c: int = 1,f"""{d=[
+3 |   def a(
+  |  _______^
+4 | | class A:
+5 | |     pass
+  | |_________^ Syntax Error: Expected a statement
+  |
+
+
+  |
+4 | class A:
+5 |     pass
+  |         ^ Syntax Error: unexpected EOF while parsing
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__ty_1828.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__ty_1828.py.snap
@@ -145,6 +145,28 @@ Module(
                     simple: false,
                 },
             ),
+            ClassDef(
+                StmtClassDef {
+                    node_index: NodeIndex(None),
+                    range: 94..111,
+                    decorator_list: [],
+                    name: Identifier {
+                        id: Name("A"),
+                        range: 100..101,
+                        node_index: NodeIndex(None),
+                    },
+                    type_params: None,
+                    arguments: None,
+                    body: [
+                        Pass(
+                            StmtPass {
+                                node_index: NodeIndex(None),
+                                range: 107..111,
+                            },
+                        ),
+                    ],
+                },
+            ),
         ],
     },
 )
@@ -190,33 +212,11 @@ Module(
 
 
   |
-1 |   # Regression test for https://github.com/astral-sh/ty/issues/1828
-2 |   (c: int = 1,f"""{d=[
-3 |   def a(
-  |  _______^
-4 | | class A:
-5 | |     pass
-  | |_________^ Syntax Error: f-string: unterminated triple-quoted string
-  |
-
-
-  |
 2 | (c: int = 1,f"""{d=[
 3 | def a(
 4 | class A:
   | ^^^^^ Syntax Error: Expected `)`, found `class`
 5 |     pass
-  |
-
-
-  |
-1 |   # Regression test for https://github.com/astral-sh/ty/issues/1828
-2 |   (c: int = 1,f"""{d=[
-3 |   def a(
-  |  _______^
-4 | | class A:
-5 | |     pass
-  | |_________^ Syntax Error: Expected a statement
   |
 
 


### PR DESCRIPTION
## Summary

I don't think this is the proper fix but it seems more correct than what we have today? 

This PR ensures that we also update the interpolated string state when decrementing the nesting level
to avoid that it has pending interpolations that are more deeply nested than the lexer itself.

I'm pretty neutral on whether we should land this change.

I wrote up a more detailed summary here https://github.com/astral-sh/ruff/issues/21896


## Test Plan

Updated test
