### PR TITLE
[ty] Revert "Do not infer types for invalid binary expressions in annotations"

### DIFF
--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -155,6 +155,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                     // anything else is an invalid annotation:
                     op => {
+                        // Avoid inferring the types of invalid binary expressions that have been
+                        // parsed from a string annotation, as they are not present in the semantic
+                        // index.
+                        if !self.deferred_state.in_string_annotation() {
+                            self.infer_binary_expression(binary, TypeContext::default());
+                        }
                         self.report_invalid_type_expression(
                             expression,
                             format_args!(


### PR DESCRIPTION
See discussion here: https://github.com/astral-sh/ruff/pull/21911#discussion_r2610155157