### PR TITLE
[ty] Reduce verbosity of `ty_ide` snapshots

### DIFF
--- a/crates/ty_ide/src/find_references.rs
+++ b/crates/ty_ide/src/find_references.rs
@@ -35,8 +35,6 @@ mod tests {
     use crate::tests::{CursorTest, IntoDiagnostic, cursor_test};
     use insta::assert_snapshot;
     use ruff_db::diagnostic::{Annotation, Diagnostic, DiagnosticId, LintName, Severity, Span};
-    use ruff_db::files::FileRange;
-    use ruff_text_size::Ranged;
 
     impl CursorTest {
         fn references(&self) -> String {
@@ -52,20 +50,14 @@ mod tests {
 
             reference_results.sort_by_key(ReferenceTarget::file);
 
-            self.render_diagnostics(reference_results.into_iter().enumerate().map(
-                |(i, ref_item)| -> ReferenceResult {
-                    ReferenceResult {
-                        index: i,
-                        file_range: FileRange::new(ref_item.file(), ref_item.range()),
-                    }
-                },
-            ))
+            self.render_diagnostics([ReferenceResult {
+                references: reference_results,
+            }])
         }
     }
 
     struct ReferenceResult {
-        index: usize,
-        file_range: FileRange,
+        references: Vec<ReferenceTarget>,
     }
 
     impl IntoDiagnostic for ReferenceResult {
@@ -73,11 +65,14 @@ mod tests {
             let mut main = Diagnostic::new(
                 DiagnosticId::Lint(LintName::of("references")),
                 Severity::Info,
-                format!("Reference {}", self.index + 1),
+                format!("Found {} references", self.references.len()),
             );
-            main.annotate(Annotation::primary(
-                Span::from(self.file_range.file()).with_range(self.file_range.range()),
-            ));
+
+            for reference in self.references {
+                main.annotate(Annotation::secondary(
+                    Span::from(reference.file()).with_range(reference.range()),
+                ));
+            }
 
             main
         }
@@ -97,55 +92,24 @@ result = calculate_sum(value=42)
 ",
         );
 
-        assert_snapshot!(test.references(), @r###"
-        info[references]: Reference 1
+        assert_snapshot!(test.references(), @r"
+        info[references]: Found 5 references
          --> main.py:2:19
           |
         2 | def calculate_sum(value: int) -> int:
-          |                   ^^^^^
+          |                   -----
         3 |     doubled = value * 2
+          |               -----
         4 |     result = value + doubled
-          |
-
-        info[references]: Reference 2
-         --> main.py:3:15
-          |
-        2 | def calculate_sum(value: int) -> int:
-        3 |     doubled = value * 2
-          |               ^^^^^
-        4 |     result = value + doubled
+          |              -----
         5 |     return value
-          |
-
-        info[references]: Reference 3
-         --> main.py:4:14
-          |
-        2 | def calculate_sum(value: int) -> int:
-        3 |     doubled = value * 2
-        4 |     result = value + doubled
-          |              ^^^^^
-        5 |     return value
-          |
-
-        info[references]: Reference 4
-         --> main.py:5:12
-          |
-        3 |     doubled = value * 2
-        4 |     result = value + doubled
-        5 |     return value
-          |            ^^^^^
+          |            -----
         6 |
         7 | # Call with keyword argument
-          |
-
-        info[references]: Reference 5
-         --> main.py:8:24
-          |
-        7 | # Call with keyword argument
         8 | result = calculate_sum(value=42)
-          |                        ^^^^^
+          |                        -----
           |
-        "###);
+        ");
     }
 
     #[test]
@@ -176,95 +140,36 @@ def outer_function():
         );
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
-         --> main.py:3:5
-          |
-        2 | def outer_function():
-        3 |     counter = 0
-          |     ^^^^^^^
-        4 |
-        5 |     def increment():
-          |
-
-        info[references]: Reference 2
-         --> main.py:6:18
-          |
-        5 |     def increment():
-        6 |         nonlocal counter
-          |                  ^^^^^^^
-        7 |         counter += 1
-        8 |         return counter
-          |
-
-        info[references]: Reference 3
-         --> main.py:7:9
-          |
-        5 |     def increment():
-        6 |         nonlocal counter
-        7 |         counter += 1
-          |         ^^^^^^^
-        8 |         return counter
-          |
-
-        info[references]: Reference 4
-          --> main.py:8:16
+        info[references]: Found 9 references
+          --> main.py:3:5
            |
+         2 | def outer_function():
+         3 |     counter = 0
+           |     -------
+         4 |
+         5 |     def increment():
          6 |         nonlocal counter
+           |                  -------
          7 |         counter += 1
+           |         -------
          8 |         return counter
-           |                ^^^^^^^
+           |                -------
          9 |
         10 |     def decrement():
-           |
-
-        info[references]: Reference 5
-          --> main.py:11:18
-           |
-        10 |     def decrement():
         11 |         nonlocal counter
-           |                  ^^^^^^^
+           |                  -------
         12 |         counter -= 1
+           |         -------
         13 |         return counter
-           |
-
-        info[references]: Reference 6
-          --> main.py:12:9
-           |
-        10 |     def decrement():
-        11 |         nonlocal counter
-        12 |         counter -= 1
-           |         ^^^^^^^
-        13 |         return counter
-           |
-
-        info[references]: Reference 7
-          --> main.py:13:16
-           |
-        11 |         nonlocal counter
-        12 |         counter -= 1
-        13 |         return counter
-           |                ^^^^^^^
+           |                -------
         14 |
         15 |     # Use counter in outer scope
-           |
-
-        info[references]: Reference 8
-          --> main.py:16:15
-           |
-        15 |     # Use counter in outer scope
         16 |     initial = counter
-           |               ^^^^^^^
-        17 |     increment()
-        18 |     decrement()
-           |
-
-        info[references]: Reference 9
-          --> main.py:19:13
-           |
+           |               -------
         17 |     increment()
         18 |     decrement()
         19 |     final = counter
-           |             ^^^^^^^
+           |             -------
         20 |
         21 |     return increment, decrement
            |
@@ -296,94 +201,35 @@ final_value = global_counter
         );
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
-         --> main.py:2:1
-          |
-        2 | global_counter = 0
-          | ^^^^^^^^^^^^^^
-        3 |
-        4 | def increment_global():
-          |
-
-        info[references]: Reference 2
-         --> main.py:5:12
-          |
-        4 | def increment_global():
-        5 |     global global_counter
-          |            ^^^^^^^^^^^^^^
-        6 |     global_counter += 1
-        7 |     return global_counter
-          |
-
-        info[references]: Reference 3
-         --> main.py:6:5
-          |
-        4 | def increment_global():
-        5 |     global global_counter
-        6 |     global_counter += 1
-          |     ^^^^^^^^^^^^^^
-        7 |     return global_counter
-          |
-
-        info[references]: Reference 4
-         --> main.py:7:12
-          |
-        5 |     global global_counter
-        6 |     global_counter += 1
-        7 |     return global_counter
-          |            ^^^^^^^^^^^^^^
-        8 |
-        9 | def decrement_global():
-          |
-
-        info[references]: Reference 5
-          --> main.py:10:12
+        info[references]: Found 9 references
+          --> main.py:2:1
            |
+         2 | global_counter = 0
+           | --------------
+         3 |
+         4 | def increment_global():
+         5 |     global global_counter
+           |            --------------
+         6 |     global_counter += 1
+           |     --------------
+         7 |     return global_counter
+           |            --------------
+         8 |
          9 | def decrement_global():
         10 |     global global_counter
-           |            ^^^^^^^^^^^^^^
+           |            --------------
         11 |     global_counter -= 1
+           |     --------------
         12 |     return global_counter
-           |
-
-        info[references]: Reference 6
-          --> main.py:11:5
-           |
-         9 | def decrement_global():
-        10 |     global global_counter
-        11 |     global_counter -= 1
-           |     ^^^^^^^^^^^^^^
-        12 |     return global_counter
-           |
-
-        info[references]: Reference 7
-          --> main.py:12:12
-           |
-        10 |     global global_counter
-        11 |     global_counter -= 1
-        12 |     return global_counter
-           |            ^^^^^^^^^^^^^^
+           |            --------------
         13 |
         14 | # Use global_counter at module level
-           |
-
-        info[references]: Reference 8
-          --> main.py:15:17
-           |
-        14 | # Use global_counter at module level
         15 | initial_value = global_counter
-           |                 ^^^^^^^^^^^^^^
-        16 | increment_global()
-        17 | decrement_global()
-           |
-
-        info[references]: Reference 9
-          --> main.py:18:15
-           |
+           |                 --------------
         16 | increment_global()
         17 | decrement_global()
         18 | final_value = global_counter
-           |               ^^^^^^^^^^^^^^
+           |               --------------
            |
         ");
     }
@@ -406,45 +252,23 @@ except ValueError as err:
         );
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
-         --> main.py:4:29
-          |
-        2 | try:
-        3 |     x = 1 / 0
-        4 | except ZeroDivisionError as err:
-          |                             ^^^
-        5 |     print(f'Error: {err}')
-        6 |     return err
-          |
-
-        info[references]: Reference 2
-         --> main.py:5:21
-          |
-        3 |     x = 1 / 0
-        4 | except ZeroDivisionError as err:
-        5 |     print(f'Error: {err}')
-          |                     ^^^
-        6 |     return err
-          |
-
-        info[references]: Reference 3
-         --> main.py:6:12
-          |
-        4 | except ZeroDivisionError as err:
-        5 |     print(f'Error: {err}')
-        6 |     return err
-          |            ^^^
-        7 |
-        8 | try:
-          |
-
-        info[references]: Reference 4
-          --> main.py:11:31
+        info[references]: Found 4 references
+          --> main.py:4:29
            |
+         2 | try:
+         3 |     x = 1 / 0
+         4 | except ZeroDivisionError as err:
+           |                             ---
+         5 |     print(f'Error: {err}')
+           |                     ---
+         6 |     return err
+           |            ---
+         7 |
+         8 | try:
          9 |     y = 2 / 0
         10 | except ValueError as err:
         11 |     print(f'Different error: {err}')
-           |                               ^^^
+           |                               ---
            |
         ");
     }
@@ -462,39 +286,21 @@ match x:
 ",
         );
 
-        assert_snapshot!(test.references(), @r###"
-        info[references]: Reference 1
+        assert_snapshot!(test.references(), @r"
+        info[references]: Found 3 references
          --> main.py:3:20
           |
         2 | match x:
         3 |     case [a, b] as pattern:
-          |                    ^^^^^^^
+          |                    -------
         4 |         print(f'Matched: {pattern}')
+          |                           -------
         5 |         return pattern
-          |
-
-        info[references]: Reference 2
-         --> main.py:4:27
-          |
-        2 | match x:
-        3 |     case [a, b] as pattern:
-        4 |         print(f'Matched: {pattern}')
-          |                           ^^^^^^^
-        5 |         return pattern
-        6 |     case _:
-          |
-
-        info[references]: Reference 3
-         --> main.py:5:16
-          |
-        3 |     case [a, b] as pattern:
-        4 |         print(f'Matched: {pattern}')
-        5 |         return pattern
-          |                ^^^^^^^
+          |                -------
         6 |     case _:
         7 |         pass
           |
-        "###);
+        ");
     }
 
     #[test]
@@ -509,47 +315,21 @@ match data:
 ",
         );
 
-        assert_snapshot!(test.references(), @r###"
-        info[references]: Reference 1
+        assert_snapshot!(test.references(), @r"
+        info[references]: Found 4 references
          --> main.py:3:29
           |
         2 | match data:
         3 |     case {'a': a, 'b': b, **rest}:
-          |                             ^^^^
+          |                             ----
         4 |         print(f'Rest data: {rest}')
+          |                             ----
         5 |         process(rest)
-          |
-
-        info[references]: Reference 2
-         --> main.py:4:29
-          |
-        2 | match data:
-        3 |     case {'a': a, 'b': b, **rest}:
-        4 |         print(f'Rest data: {rest}')
-          |                             ^^^^
-        5 |         process(rest)
+          |                 ----
         6 |         return rest
+          |                ----
           |
-
-        info[references]: Reference 3
-         --> main.py:5:17
-          |
-        3 |     case {'a': a, 'b': b, **rest}:
-        4 |         print(f'Rest data: {rest}')
-        5 |         process(rest)
-          |                 ^^^^
-        6 |         return rest
-          |
-
-        info[references]: Reference 4
-         --> main.py:6:16
-          |
-        4 |         print(f'Rest data: {rest}')
-        5 |         process(rest)
-        6 |         return rest
-          |                ^^^^
-          |
-        "###);
+        ");
     }
 
     #[test]
@@ -573,60 +353,30 @@ value = my_function
         );
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
-         --> main.py:2:5
-          |
-        2 | def my_function():
-          |     ^^^^^^^^^^^
-        3 |     return 42
-          |
-
-        info[references]: Reference 2
-         --> main.py:6:11
-          |
-        5 | # Call the function multiple times
-        6 | result1 = my_function()
-          |           ^^^^^^^^^^^
-        7 | result2 = my_function()
-          |
-
-        info[references]: Reference 3
-         --> main.py:7:11
-          |
-        5 | # Call the function multiple times
-        6 | result1 = my_function()
-        7 | result2 = my_function()
-          |           ^^^^^^^^^^^
-        8 |
-        9 | # Function passed as an argument
-          |
-
-        info[references]: Reference 4
-          --> main.py:10:12
+        info[references]: Found 6 references
+          --> main.py:2:5
            |
+         2 | def my_function():
+           |     -----------
+         3 |     return 42
+           |
+          ::: main.py:6:11
+           |
+         5 | # Call the function multiple times
+         6 | result1 = my_function()
+           |           -----------
+         7 | result2 = my_function()
+           |           -----------
+         8 |
          9 | # Function passed as an argument
         10 | callback = my_function
-           |            ^^^^^^^^^^^
+           |            -----------
         11 |
         12 | # Function used in different contexts
-           |
-
-        info[references]: Reference 5
-          --> main.py:13:7
-           |
-        12 | # Function used in different contexts
         13 | print(my_function())
-           |       ^^^^^^^^^^^
+           |       -----------
         14 | value = my_function
-           |
-
-        info[references]: Reference 6
-          --> main.py:14:9
-           |
-        12 | # Function used in different contexts
-        13 | print(my_function())
-        14 | value = my_function
-           |         ^^^^^^^^^^^
+           |         -----------
            |
         ");
     }
@@ -653,59 +403,32 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
-         --> main.py:2:7
-          |
-        2 | class MyClass:
-          |       ^^^^^^^
-        3 |     def __init__(self):
-        4 |         pass
-          |
-
-        info[references]: Reference 2
-         --> main.py:7:8
-          |
-        6 | # Create instances
-        7 | obj1 = MyClass()
-          |        ^^^^^^^
-        8 | obj2 = MyClass()
-          |
-
-        info[references]: Reference 3
-          --> main.py:8:8
+        info[references]: Found 6 references
+          --> main.py:2:7
+           |
+         2 | class MyClass:
+           |       -------
+         3 |     def __init__(self):
+         4 |         pass
+           |
+          ::: main.py:7:8
            |
          6 | # Create instances
          7 | obj1 = MyClass()
+           |        -------
          8 | obj2 = MyClass()
-           |        ^^^^^^^
+           |        -------
          9 |
         10 | # Use in type annotations
-           |
-
-        info[references]: Reference 4
-          --> main.py:11:23
-           |
-        10 | # Use in type annotations
         11 | def process(instance: MyClass) -> MyClass:
-           |                       ^^^^^^^
+           |                       -------     -------
         12 |     return instance
            |
-
-        info[references]: Reference 5
-          --> main.py:11:35
-           |
-        10 | # Use in type annotations
-        11 | def process(instance: MyClass) -> MyClass:
-           |                                   ^^^^^^^
-        12 |     return instance
-           |
-
-        info[references]: Reference 6
-          --> main.py:15:7
+          ::: main.py:15:7
            |
         14 | # Reference the class itself
         15 | cls = MyClass
-           |       ^^^^^^^
+           |       -------
            |
         ");
     }
@@ -722,22 +445,14 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r#"
-        info[references]: Reference 1
+        info[references]: Found 2 references
          --> main.py:2:5
           |
         2 | a: "MyClass" = 1
-          |     ^^^^^^^
+          |     -------
         3 |
         4 | class MyClass:
-          |
-
-        info[references]: Reference 2
-         --> main.py:4:7
-          |
-        2 | a: "MyClass" = 1
-        3 |
-        4 | class MyClass:
-          |       ^^^^^^^
+          |       -------
         5 |     """some docs"""
           |
         "#);
@@ -755,22 +470,14 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r#"
-        info[references]: Reference 1
+        info[references]: Found 2 references
          --> main.py:2:12
           |
         2 | a: "None | MyClass" = 1
-          |            ^^^^^^^
+          |            -------
         3 |
         4 | class MyClass:
-          |
-
-        info[references]: Reference 2
-         --> main.py:4:7
-          |
-        2 | a: "None | MyClass" = 1
-        3 |
-        4 | class MyClass:
-          |       ^^^^^^^
+          |       -------
         5 |     """some docs"""
           |
         "#);
@@ -802,22 +509,14 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r#"
-        info[references]: Reference 1
+        info[references]: Found 2 references
          --> main.py:2:12
           |
         2 | a: "None | MyClass" = 1
-          |            ^^^^^^^
+          |            -------
         3 |
         4 | class MyClass:
-          |
-
-        info[references]: Reference 2
-         --> main.py:4:7
-          |
-        2 | a: "None | MyClass" = 1
-        3 |
-        4 | class MyClass:
-          |       ^^^^^^^
+          |       -------
         5 |     """some docs"""
           |
         "#);
@@ -863,22 +562,14 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r#"
-        info[references]: Reference 1
+        info[references]: Found 2 references
          --> main.py:2:5
           |
         2 | a: "MyClass | No" = 1
-          |     ^^^^^^^
+          |     -------
         3 |
         4 | class MyClass:
-          |
-
-        info[references]: Reference 2
-         --> main.py:4:7
-          |
-        2 | a: "MyClass | No" = 1
-        3 |
-        4 | class MyClass:
-          |       ^^^^^^^
+          |       -------
         5 |     """some docs"""
           |
         "#);
@@ -907,18 +598,11 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r#"
-        info[references]: Reference 1
+        info[references]: Found 2 references
          --> main.py:2:1
           |
         2 | ab: "ab"
-          | ^^
-          |
-
-        info[references]: Reference 2
-         --> main.py:2:6
-          |
-        2 | ab: "ab"
-          |      ^^
+          | --   --
           |
         "#);
     }
@@ -946,23 +630,15 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r#"
-        info[references]: Reference 1
+        info[references]: Found 2 references
          --> main.py:4:22
           |
         2 | def my_func(command: str):
         3 |     match command.split():
         4 |         case ["get", ab]:
-          |                      ^^
+          |                      --
         5 |             x = ab
-          |
-
-        info[references]: Reference 2
-         --> main.py:5:17
-          |
-        3 |     match command.split():
-        4 |         case ["get", ab]:
-        5 |             x = ab
-          |                 ^^
+          |                 --
           |
         "#);
     }
@@ -979,23 +655,15 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r#"
-        info[references]: Reference 1
+        info[references]: Found 2 references
          --> main.py:4:22
           |
         2 | def my_func(command: str):
         3 |     match command.split():
         4 |         case ["get", ab]:
-          |                      ^^
+          |                      --
         5 |             x = ab
-          |
-
-        info[references]: Reference 2
-         --> main.py:5:17
-          |
-        3 |     match command.split():
-        4 |         case ["get", ab]:
-        5 |             x = ab
-          |                 ^^
+          |                 --
           |
         "#);
     }
@@ -1012,23 +680,15 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r#"
-        info[references]: Reference 1
+        info[references]: Found 2 references
          --> main.py:4:23
           |
         2 | def my_func(command: str):
         3 |     match command.split():
         4 |         case ["get", *ab]:
-          |                       ^^
+          |                       --
         5 |             x = ab
-          |
-
-        info[references]: Reference 2
-         --> main.py:5:17
-          |
-        3 |     match command.split():
-        4 |         case ["get", *ab]:
-        5 |             x = ab
-          |                 ^^
+          |                 --
           |
         "#);
     }
@@ -1045,23 +705,15 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r#"
-        info[references]: Reference 1
+        info[references]: Found 2 references
          --> main.py:4:23
           |
         2 | def my_func(command: str):
         3 |     match command.split():
         4 |         case ["get", *ab]:
-          |                       ^^
+          |                       --
         5 |             x = ab
-          |
-
-        info[references]: Reference 2
-         --> main.py:5:17
-          |
-        3 |     match command.split():
-        4 |         case ["get", *ab]:
-        5 |             x = ab
-          |                 ^^
+          |                 --
           |
         "#);
     }
@@ -1078,23 +730,15 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r#"
-        info[references]: Reference 1
+        info[references]: Found 2 references
          --> main.py:4:37
           |
         2 | def my_func(command: str):
         3 |     match command.split():
         4 |         case ["get", ("a" | "b") as ab]:
-          |                                     ^^
+          |                                     --
         5 |             x = ab
-          |
-
-        info[references]: Reference 2
-         --> main.py:5:17
-          |
-        3 |     match command.split():
-        4 |         case ["get", ("a" | "b") as ab]:
-        5 |             x = ab
-          |                 ^^
+          |                 --
           |
         "#);
     }
@@ -1111,23 +755,15 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r#"
-        info[references]: Reference 1
+        info[references]: Found 2 references
          --> main.py:4:37
           |
         2 | def my_func(command: str):
         3 |     match command.split():
         4 |         case ["get", ("a" | "b") as ab]:
-          |                                     ^^
+          |                                     --
         5 |             x = ab
-          |
-
-        info[references]: Reference 2
-         --> main.py:5:17
-          |
-        3 |     match command.split():
-        4 |         case ["get", ("a" | "b") as ab]:
-        5 |             x = ab
-          |                 ^^
+          |                 --
           |
         "#);
     }
@@ -1150,23 +786,15 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
+        info[references]: Found 2 references
           --> main.py:10:30
            |
          8 | def my_func(event: Click):
          9 |     match event:
         10 |         case Click(x, button=ab):
-           |                              ^^
+           |                              --
         11 |             x = ab
-           |
-
-        info[references]: Reference 2
-          --> main.py:11:17
-           |
-         9 |     match event:
-        10 |         case Click(x, button=ab):
-        11 |             x = ab
-           |                 ^^
+           |                 --
            |
         ");
     }
@@ -1189,23 +817,15 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
+        info[references]: Found 2 references
           --> main.py:10:30
            |
          8 | def my_func(event: Click):
          9 |     match event:
         10 |         case Click(x, button=ab):
-           |                              ^^
+           |                              --
         11 |             x = ab
-           |
-
-        info[references]: Reference 2
-          --> main.py:11:17
-           |
-         9 |     match event:
-        10 |         case Click(x, button=ab):
-        11 |             x = ab
-           |                 ^^
+           |                 --
            |
         ");
     }
@@ -1228,33 +848,23 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r#"
-        info[references]: Reference 1
-         --> main.py:2:7
-          |
-        2 | class Click:
-          |       ^^^^^
-        3 |     __match_args__ = ("position", "button")
-        4 |     def __init__(self, pos, btn):
-          |
-
-        info[references]: Reference 2
-          --> main.py:8:20
+        info[references]: Found 3 references
+          --> main.py:2:7
+           |
+         2 | class Click:
+           |       -----
+         3 |     __match_args__ = ("position", "button")
+         4 |     def __init__(self, pos, btn):
+           |
+          ::: main.py:8:20
            |
          6 |         self.button: str = btn
          7 |
          8 | def my_func(event: Click):
-           |                    ^^^^^
+           |                    -----
          9 |     match event:
         10 |         case Click(x, button=ab):
-           |
-
-        info[references]: Reference 3
-          --> main.py:10:14
-           |
-         8 | def my_func(event: Click):
-         9 |     match event:
-        10 |         case Click(x, button=ab):
-           |              ^^^^^
+           |              -----
         11 |             x = ab
            |
         "#);
@@ -1289,25 +899,11 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
+        info[references]: Found 3 references
          --> main.py:2:13
           |
         2 | type Alias1[AB: int = bool] = tuple[AB, list[AB]]
-          |             ^^
-          |
-
-        info[references]: Reference 2
-         --> main.py:2:37
-          |
-        2 | type Alias1[AB: int = bool] = tuple[AB, list[AB]]
-          |                                     ^^
-          |
-
-        info[references]: Reference 3
-         --> main.py:2:46
-          |
-        2 | type Alias1[AB: int = bool] = tuple[AB, list[AB]]
-          |                                              ^^
+          |             --                      --       --
           |
         ");
     }
@@ -1321,25 +917,11 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
+        info[references]: Found 3 references
          --> main.py:2:13
           |
         2 | type Alias1[AB: int = bool] = tuple[AB, list[AB]]
-          |             ^^
-          |
-
-        info[references]: Reference 2
-         --> main.py:2:37
-          |
-        2 | type Alias1[AB: int = bool] = tuple[AB, list[AB]]
-          |                                     ^^
-          |
-
-        info[references]: Reference 3
-         --> main.py:2:46
-          |
-        2 | type Alias1[AB: int = bool] = tuple[AB, list[AB]]
-          |                                              ^^
+          |             --                      --       --
           |
         ");
     }
@@ -1354,28 +936,12 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
+        info[references]: Found 3 references
          --> main.py:3:15
           |
         2 | from typing import Callable
         3 | type Alias2[**AB = [int, str]] = Callable[AB, tuple[AB]]
-          |               ^^
-          |
-
-        info[references]: Reference 2
-         --> main.py:3:43
-          |
-        2 | from typing import Callable
-        3 | type Alias2[**AB = [int, str]] = Callable[AB, tuple[AB]]
-          |                                           ^^
-          |
-
-        info[references]: Reference 3
-         --> main.py:3:53
-          |
-        2 | from typing import Callable
-        3 | type Alias2[**AB = [int, str]] = Callable[AB, tuple[AB]]
-          |                                                     ^^
+          |               --                          --        --
           |
         ");
     }
@@ -1390,28 +956,12 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
+        info[references]: Found 3 references
          --> main.py:3:15
           |
         2 | from typing import Callable
         3 | type Alias2[**AB = [int, str]] = Callable[AB, tuple[AB]]
-          |               ^^
-          |
-
-        info[references]: Reference 2
-         --> main.py:3:43
-          |
-        2 | from typing import Callable
-        3 | type Alias2[**AB = [int, str]] = Callable[AB, tuple[AB]]
-          |                                           ^^
-          |
-
-        info[references]: Reference 3
-         --> main.py:3:53
-          |
-        2 | from typing import Callable
-        3 | type Alias2[**AB = [int, str]] = Callable[AB, tuple[AB]]
-          |                                                     ^^
+          |               --                          --        --
           |
         ");
     }
@@ -1425,25 +975,11 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
+        info[references]: Found 3 references
          --> main.py:2:14
           |
         2 | type Alias3[*AB = ()] = tuple[tuple[*AB], tuple[*AB]]
-          |              ^^
-          |
-
-        info[references]: Reference 2
-         --> main.py:2:38
-          |
-        2 | type Alias3[*AB = ()] = tuple[tuple[*AB], tuple[*AB]]
-          |                                      ^^
-          |
-
-        info[references]: Reference 3
-         --> main.py:2:50
-          |
-        2 | type Alias3[*AB = ()] = tuple[tuple[*AB], tuple[*AB]]
-          |                                                  ^^
+          |              --                      --          --
           |
         ");
     }
@@ -1457,25 +993,11 @@ cls = MyClass
         );
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
+        info[references]: Found 3 references
          --> main.py:2:14
           |
         2 | type Alias3[*AB = ()] = tuple[tuple[*AB], tuple[*AB]]
-          |              ^^
-          |
-
-        info[references]: Reference 2
-         --> main.py:2:38
-          |
-        2 | type Alias3[*AB = ()] = tuple[tuple[*AB], tuple[*AB]]
-          |                                      ^^
-          |
-
-        info[references]: Reference 3
-         --> main.py:2:50
-          |
-        2 | type Alias3[*AB = ()] = tuple[tuple[*AB], tuple[*AB]]
-          |                                                  ^^
+          |              --                      --          --
           |
         ");
     }
@@ -1515,57 +1037,35 @@ class DataProcessor:
             .build();
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
-         --> utils.py:2:5
-          |
-        2 | def func(x):
-          |     ^^^^
-        3 |     return x * 2
-          |
-
-        info[references]: Reference 2
-         --> module.py:2:19
-          |
-        2 | from utils import func
-          |                   ^^^^
-        3 |
-        4 | def process_data(data):
-          |
-
-        info[references]: Reference 3
-         --> module.py:5:12
-          |
-        4 | def process_data(data):
-        5 |     return func(data)
-          |            ^^^^
-          |
-
-        info[references]: Reference 4
+        info[references]: Found 6 references
          --> app.py:2:19
           |
         2 | from utils import func
-          |                   ^^^^
+          |                   ----
         3 |
-        4 | class DataProcessor:
-          |
-
-        info[references]: Reference 5
-         --> app.py:6:27
-          |
         4 | class DataProcessor:
         5 |     def __init__(self):
         6 |         self.multiplier = func
-          |                           ^^^^
+          |                           ----
         7 |
         8 |     def process(self, value):
-          |
-
-        info[references]: Reference 6
-         --> app.py:9:16
-          |
-        8 |     def process(self, value):
         9 |         return func(value)
-          |                ^^^^
+          |                ----
+          |
+         ::: module.py:2:19
+          |
+        2 | from utils import func
+          |                   ----
+        3 |
+        4 | def process_data(data):
+        5 |     return func(data)
+          |            ----
+          |
+         ::: utils.py:2:5
+          |
+        2 | def func(x):
+          |     ----
+        3 |     return x * 2
           |
         ");
     }
@@ -1598,52 +1098,27 @@ def process_model():
             .build();
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
-         --> models.py:3:5
-          |
-        2 | class MyModel:
-        3 |     attr = 42
-          |     ^^^^
-        4 |
-        5 |     def get_attribute(self):
-          |
-
-        info[references]: Reference 2
-         --> models.py:6:24
-          |
-        5 |     def get_attribute(self):
-        6 |         return MyModel.attr
-          |                        ^^^^
-          |
-
-        info[references]: Reference 3
+        info[references]: Found 5 references
          --> main.py:6:19
           |
         4 | def process_model():
         5 |     model = MyModel()
         6 |     value = model.attr
-          |                   ^^^^
+          |                   ----
         7 |     model.attr = 100
+          |           ----
         8 |     return model.attr
+          |                  ----
           |
-
-        info[references]: Reference 4
-         --> main.py:7:11
+         ::: models.py:3:5
           |
-        5 |     model = MyModel()
-        6 |     value = model.attr
-        7 |     model.attr = 100
-          |           ^^^^
-        8 |     return model.attr
-          |
-
-        info[references]: Reference 5
-         --> main.py:8:18
-          |
-        6 |     value = model.attr
-        7 |     model.attr = 100
-        8 |     return model.attr
-          |                  ^^^^
+        2 | class MyModel:
+        3 |     attr = 42
+          |     ----
+        4 |
+        5 |     def get_attribute(self):
+        6 |         return MyModel.attr
+          |                        ----
           |
         ");
     }
@@ -1673,22 +1148,14 @@ func<CURSOR>_alias()
         // When finding references to the alias, we should NOT find references
         // to the original function in the original module
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
+        info[references]: Found 2 references
          --> importer.py:2:30
           |
         2 | from original import func as func_alias
-          |                              ^^^^^^^^^^
+          |                              ----------
         3 |
         4 | func_alias()
-          |
-
-        info[references]: Reference 2
-         --> importer.py:4:1
-          |
-        2 | from original import func as func_alias
-        3 |
-        4 | func_alias()
-          | ^^^^^^^^^^
+          | ----------
           |
         ");
     }
@@ -1721,42 +1188,23 @@ func<CURSOR>_alias()
             )
             .build();
 
-        assert_snapshot!(test.references(), @r###"
-        info[references]: Reference 1
-         --> path.pyi:2:7
-          |
-        2 | class Path:
-          |       ^^^^
-        3 |     def __init__(self, path: str): ...
-          |
-
-        info[references]: Reference 2
+        assert_snapshot!(test.references(), @r#"
+        info[references]: Found 4 references
          --> importer.py:2:18
           |
         2 | from path import Path
-          |                  ^^^^
+          |                  ----
         3 |
         4 | a: Path = Path("test")
+          |    ----   ----
           |
-
-        info[references]: Reference 3
-         --> importer.py:4:4
+         ::: path.pyi:2:7
           |
-        2 | from path import Path
-        3 |
-        4 | a: Path = Path("test")
-          |    ^^^^
+        2 | class Path:
+          |       ----
+        3 |     def __init__(self, path: str): ...
           |
-
-        info[references]: Reference 4
-         --> importer.py:4:11
-          |
-        2 | from path import Path
-        3 |
-        4 | a: Path = Path("test")
-          |           ^^^^
-          |
-        "###);
+        "#);
     }
 
     #[test]
@@ -1775,23 +1223,15 @@ func<CURSOR>_alias()
             .build();
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
+        info[references]: Found 2 references
          --> main.py:3:20
           |
         2 | import warnings
         3 | import warnings as abc
-          |                    ^^^
+          |                    ---
         4 |
         5 | x = abc
-          |
-
-        info[references]: Reference 2
-         --> main.py:5:5
-          |
-        3 | import warnings as abc
-        4 |
-        5 | x = abc
-          |     ^^^
+          |     ---
         6 | y = warnings
           |
         ");
@@ -1813,23 +1253,15 @@ func<CURSOR>_alias()
             .build();
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
+        info[references]: Found 2 references
          --> main.py:3:20
           |
         2 | import warnings
         3 | import warnings as abc
-          |                    ^^^
+          |                    ---
         4 |
         5 | x = abc
-          |
-
-        info[references]: Reference 2
-         --> main.py:5:5
-          |
-        3 | import warnings as abc
-        4 |
-        5 | x = abc
-          |     ^^^
+          |     ---
         6 | y = warnings
           |
         ");
@@ -1851,21 +1283,15 @@ func<CURSOR>_alias()
             .build();
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
+        info[references]: Found 2 references
          --> main.py:2:36
           |
         2 | from warnings import deprecated as xyz
-          |                                    ^^^
-        3 | from warnings import deprecated
-          |
-
-        info[references]: Reference 2
-         --> main.py:5:5
-          |
+          |                                    ---
         3 | from warnings import deprecated
         4 |
         5 | y = xyz
-          |     ^^^
+          |     ---
         6 | z = deprecated
           |
         ");
@@ -1887,21 +1313,15 @@ func<CURSOR>_alias()
             .build();
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
+        info[references]: Found 2 references
          --> main.py:2:36
           |
         2 | from warnings import deprecated as xyz
-          |                                    ^^^
-        3 | from warnings import deprecated
-          |
-
-        info[references]: Reference 2
-         --> main.py:5:5
-          |
+          |                                    ---
         3 | from warnings import deprecated
         4 |
         5 | y = xyz
-          |     ^^^
+          |     ---
         6 | z = deprecated
           |
         ");
@@ -1929,13 +1349,13 @@ func<CURSOR>_alias()
 
         // TODO(submodule-imports): this should light up both instances of `subpkg`
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
+        info[references]: Found 1 references
          --> mypackage/__init__.py:4:5
           |
         2 | from .subpkg.submod import val
         3 |
         4 | x = subpkg
-          |     ^^^^^^
+          |     ------
           |
         ");
     }
@@ -2055,29 +1475,19 @@ func<CURSOR>_alias()
             .build();
 
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
+        info[references]: Found 3 references
          --> mypackage/__init__.py:2:21
           |
         2 | from .subpkg import subpkg
-          |                     ^^^^^^
+          |                     ------
         3 |
         4 | x = subpkg
+          |     ------
           |
-
-        info[references]: Reference 2
-         --> mypackage/__init__.py:4:5
-          |
-        2 | from .subpkg import subpkg
-        3 |
-        4 | x = subpkg
-          |     ^^^^^^
-          |
-
-        info[references]: Reference 3
-         --> mypackage/subpkg/__init__.py:2:1
+         ::: mypackage/subpkg/__init__.py:2:1
           |
         2 | subpkg: int = 10
-          | ^^^^^^
+          | ------
           |
         ");
     }
@@ -2103,13 +1513,13 @@ func<CURSOR>_alias()
 
         // TODO: this should also highlight the RHS subpkg in the import
         assert_snapshot!(test.references(), @r"
-        info[references]: Reference 1
+        info[references]: Found 1 references
          --> mypackage/__init__.py:4:5
           |
         2 | from .subpkg import subpkg
         3 |
         4 | x = subpkg
-          |     ^^^^^^
+          |     ------
           |
         ");
     }
@@ -2131,33 +1541,17 @@ func<CURSOR>_alias()
             .build();
 
         assert_snapshot!(test.references(), @r#"
-        info[references]: Reference 1
+        info[references]: Found 3 references
          --> main.py:2:1
           |
         2 | a: str = "test"
-          | ^
+          | -
         3 |
         4 | a: int = 10
-          |
-
-        info[references]: Reference 2
-         --> main.py:4:1
-          |
-        2 | a: str = "test"
-        3 |
-        4 | a: int = 10
-          | ^
+          | -
         5 |
         6 | print(a)
-          |
-
-        info[references]: Reference 3
-         --> main.py:6:7
-          |
-        4 | a: int = 10
-        5 |
-        6 | print(a)
-          |       ^
+          |       -
           |
         "#);
     }

--- a/crates/ty_ide/src/goto_declaration.rs
+++ b/crates/ty_ide/src/goto_declaration.rs
@@ -31,15 +31,9 @@ pub fn goto_declaration(
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::{CursorTest, IntoDiagnostic, cursor_test};
-    use crate::{NavigationTarget, goto_declaration};
+    use crate::goto_declaration;
+    use crate::tests::{CursorTest, cursor_test};
     use insta::assert_snapshot;
-    use ruff_db::diagnostic::{
-        Annotation, Diagnostic, DiagnosticId, LintName, Severity, Span, SubDiagnostic,
-        SubDiagnosticSeverity,
-    };
-    use ruff_db::files::FileRange;
-    use ruff_text_size::Ranged;
 
     #[test]
     fn goto_declaration_function_call_to_definition() {
@@ -53,20 +47,20 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> main.py:2:5
-          |
-        2 | def my_function(x, y):
-          |     ^^^^^^^^^^^
-        3 |     return x + y
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:5:10
           |
         3 |     return x + y
         4 |
         5 | result = my_function(1, 2)
-          |          ^^^^^^^^^^^
+          |          ^^^^^^^^^^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> main.py:2:5
+          |
+        2 | def my_function(x, y):
+          |     -----------
+        3 |     return x + y
           |
         ");
     }
@@ -81,19 +75,19 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> main.py:2:1
-          |
-        2 | x = 42
-          | ^
-        3 | y = x
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:3:5
           |
         2 | x = 42
         3 | y = x
-          |     ^
+          |     ^ Clicking here
+          |
+        info: Found 1 declaration
+         --> main.py:2:1
+          |
+        2 | x = 42
+          | -
+        3 | y = x
           |
         ");
     }
@@ -111,38 +105,22 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
+         --> main.py:6:12
+          |
+        4 |         pass
+        5 |
+        6 | instance = MyClass()
+          |            ^^^^^^^ Clicking here
+          |
+        info: Found 2 declarations
          --> main.py:2:7
           |
         2 | class MyClass:
-          |       ^^^^^^^
+          |       -------
         3 |     def __init__(self):
+          |         --------
         4 |         pass
-          |
-        info: Source
-         --> main.py:6:12
-          |
-        4 |         pass
-        5 |
-        6 | instance = MyClass()
-          |            ^^^^^^^
-          |
-
-        info[goto-declaration]: Declaration
-         --> main.py:3:9
-          |
-        2 | class MyClass:
-        3 |     def __init__(self):
-          |         ^^^^^^^^
-        4 |         pass
-          |
-        info: Source
-         --> main.py:6:12
-          |
-        4 |         pass
-        5 |
-        6 | instance = MyClass()
-          |            ^^^^^^^
           |
         ");
     }
@@ -157,19 +135,19 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> main.py:2:9
-          |
-        2 | def foo(param):
-          |         ^^^^^
-        3 |     return param * 2
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:3:12
           |
         2 | def foo(param):
         3 |     return param * 2
-          |            ^^^^^
+          |            ^^^^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> main.py:2:9
+          |
+        2 | def foo(param):
+          |         -----
+        3 |     return param * 2
           |
         ");
     }
@@ -185,20 +163,20 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> main.py:2:18
-          |
-        2 | def generic_func[T](value: T) -> T:
-          |                  ^
-        3 |     v: T = value
-        4 |     return v
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:3:8
           |
         2 | def generic_func[T](value: T) -> T:
         3 |     v: T = value
-          |        ^
+          |        ^ Clicking here
+        4 |     return v
+          |
+        info: Found 1 declaration
+         --> main.py:2:18
+          |
+        2 | def generic_func[T](value: T) -> T:
+          |                  -
+        3 |     v: T = value
         4 |     return v
           |
         ");
@@ -215,20 +193,20 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> main.py:2:20
-          |
-        2 | class GenericClass[T]:
-          |                    ^
-        3 |     def __init__(self, value: T):
-        4 |         self.value = value
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:3:31
           |
         2 | class GenericClass[T]:
         3 |     def __init__(self, value: T):
-          |                               ^
+          |                               ^ Clicking here
+        4 |         self.value = value
+          |
+        info: Found 1 declaration
+         --> main.py:2:20
+          |
+        2 | class GenericClass[T]:
+          |                    -
+        3 |     def __init__(self, value: T):
         4 |         self.value = value
           |
         ");
@@ -247,22 +225,22 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> main.py:2:1
-          |
-        2 | x = "outer"
-          | ^
-        3 | def outer_func():
-        4 |     def inner_func():
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:5:16
           |
         3 | def outer_func():
         4 |     def inner_func():
         5 |         return x  # Should find outer x
-          |                ^
+          |                ^ Clicking here
         6 |     return inner_func
+          |
+        info: Found 1 declaration
+         --> main.py:2:1
+          |
+        2 | x = "outer"
+          | -
+        3 | def outer_func():
+        4 |     def inner_func():
           |
         "#);
     }
@@ -307,20 +285,20 @@ variable = 42
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> mymodule.py:1:1
-          |
-        1 |
-          | ^
-        2 | def function():
-        3 |     return "hello from mymodule"
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:3:7
           |
         2 | import mymodule
         3 | print(mymodule.function())
-          |       ^^^^^^^^
+          |       ^^^^^^^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> mymodule.py:1:1
+          |
+        1 |
+          | -
+        2 | def function():
+        3 |     return "hello from mymodule"
           |
         "#);
     }
@@ -348,19 +326,19 @@ def other_function():
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> mymodule.py:2:5
-          |
-        2 | def my_function():
-          |     ^^^^^^^^^^^
-        3 |     return "hello"
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:3:7
           |
         2 | from mymodule import my_function
         3 | print(my_function())
-          |       ^^^^^^^^^^^
+          |       ^^^^^^^^^^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> mymodule.py:2:5
+          |
+        2 | def my_function():
+          |     -----------
+        3 |     return "hello"
           |
         "#);
     }
@@ -390,22 +368,22 @@ FOO = 0
             .build();
 
         // Should find the submodule file itself
-        assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> mymodule/submodule.py:1:1
-          |
-        1 |
-          | ^
-        2 | FOO = 0
-          |
-        info: Source
+        assert_snapshot!(test.goto_declaration(), @r"
+        info[goto-declaration]: Go to declaration
          --> main.py:3:7
           |
         2 | import mymodule.submodule as sub
         3 | print(sub.helper())
-          |       ^^^
+          |       ^^^ Clicking here
           |
-        "#);
+        info: Found 1 declaration
+         --> mymodule/submodule.py:1:1
+          |
+        1 |
+          | -
+        2 | FOO = 0
+          |
+        ");
     }
 
     #[test]
@@ -429,19 +407,19 @@ def func(arg):
 
         // Should resolve to the actual function definition, not the import statement
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> utils.py:2:5
-          |
-        2 | def func(arg):
-          |     ^^^^
-        3 |     return f"Processed: {arg}"
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:3:7
           |
         2 | from utils import func as h
         3 | print(h("test"))
-          |       ^
+          |       ^ Clicking here
+          |
+        info: Found 1 declaration
+         --> utils.py:2:5
+          |
+        2 | def func(arg):
+          |     ----
+        3 |     return f"Processed: {arg}"
           |
         "#);
     }
@@ -473,19 +451,19 @@ def shared_function():
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> original.py:2:5
-          |
-        2 | def shared_function():
-          |     ^^^^^^^^^^^^^^^
-        3 |     return "from original"
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:3:7
           |
         2 | from intermediate import shared_function
         3 | print(shared_function())
-          |       ^^^^^^^^^^^^^^^
+          |       ^^^^^^^^^^^^^^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> original.py:2:5
+          |
+        2 | def shared_function():
+          |     ---------------
+        3 |     return "from original"
           |
         "#);
     }
@@ -515,20 +493,20 @@ def multiply_numbers(a, b):
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> math_utils.py:2:5
-          |
-        2 | def add_numbers(a, b):
-          |     ^^^^^^^^^^^
-        3 |     """Add two numbers together."""
-        4 |     return a + b
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:3:10
           |
         2 | from math_utils import *
         3 | result = add_numbers(5, 3)
-          |          ^^^^^^^^^^^
+          |          ^^^^^^^^^^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> math_utils.py:2:5
+          |
+        2 | def add_numbers(a, b):
+          |     -----------
+        3 |     """Add two numbers together."""
+        4 |     return a + b
           |
         "#);
     }
@@ -565,20 +543,20 @@ def another_helper():
 
         // Should resolve the relative import to find the actual function definition
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> package/utils.py:2:5
-          |
-        2 | def helper_function(arg):
-          |     ^^^^^^^^^^^^^^^
-        3 |     """A helper function in utils module."""
-        4 |     return f"Processed: {arg}"
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> package/main.py:3:10
           |
         2 | from .utils import helper_function
         3 | result = helper_function("test")
-          |          ^^^^^^^^^^^^^^^
+          |          ^^^^^^^^^^^^^^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> package/utils.py:2:5
+          |
+        2 | def helper_function(arg):
+          |     ---------------
+        3 |     """A helper function in utils module."""
+        4 |     return f"Processed: {arg}"
           |
         "#);
     }
@@ -614,20 +592,20 @@ def another_helper():
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> package/utils.py:2:5
-          |
-        2 | def helper_function(arg):
-          |     ^^^^^^^^^^^^^^^
-        3 |     """A helper function in utils module."""
-        4 |     return f"Processed: {arg}"
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> package/main.py:3:10
           |
         2 | from .utils import *
         3 | result = helper_function("test")
-          |          ^^^^^^^^^^^^^^^
+          |          ^^^^^^^^^^^^^^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> package/utils.py:2:5
+          |
+        2 | def helper_function(arg):
+          |     ---------------
+        3 |     """A helper function in utils module."""
+        4 |     return f"Processed: {arg}"
           |
         "#);
     }
@@ -657,19 +635,19 @@ FOO = 0
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> mymodule/submodule.py:1:1
-          |
-        1 |
-          | ^
-        2 | FOO = 0
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:2:30
           |
         2 | import mymodule.submodule as sub
-          |                              ^^^
+          |                              ^^^ Clicking here
         3 | print(sub.helper())
+          |
+        info: Found 1 declaration
+         --> mymodule/submodule.py:1:1
+          |
+        1 |
+          | -
+        2 | FOO = 0
           |
         ");
     }
@@ -699,19 +677,19 @@ FOO = 0
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> mymodule/submodule.py:1:1
-          |
-        1 |
-          | ^
-        2 | FOO = 0
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:2:17
           |
         2 | import mymodule.submodule as sub
-          |                 ^^^^^^^^^
+          |                 ^^^^^^^^^ Clicking here
         3 | print(sub.helper())
+          |
+        info: Found 1 declaration
+         --> mymodule/submodule.py:1:1
+          |
+        1 |
+          | -
+        2 | FOO = 0
           |
         ");
     }
@@ -745,19 +723,19 @@ def another_helper(path):
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> mypackage/utils.py:2:5
-          |
-        2 | def helper(a, b):
-          |     ^^^^^^
-        3 |     return a + "/" + b
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:2:29
           |
         2 | from mypackage.utils import helper as h
-          |                             ^^^^^^
+          |                             ^^^^^^ Clicking here
         3 | result = h("/a", "/b")
+          |
+        info: Found 1 declaration
+         --> mypackage/utils.py:2:5
+          |
+        2 | def helper(a, b):
+          |     ------
+        3 |     return a + "/" + b
           |
         "#);
     }
@@ -791,19 +769,19 @@ def another_helper(path):
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> mypackage/utils.py:2:5
-          |
-        2 | def helper(a, b):
-          |     ^^^^^^
-        3 |     return a + "/" + b
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:2:39
           |
         2 | from mypackage.utils import helper as h
-          |                                       ^
+          |                                       ^ Clicking here
         3 | result = h("/a", "/b")
+          |
+        info: Found 1 declaration
+         --> mypackage/utils.py:2:5
+          |
+        2 | def helper(a, b):
+          |     ------
+        3 |     return a + "/" + b
           |
         "#);
     }
@@ -837,20 +815,20 @@ def another_helper(path):
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> mypackage/utils.py:1:1
-          |
-        1 |
-          | ^
-        2 | def helper(a, b):
-        3 |     return a + "/" + b
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:2:16
           |
         2 | from mypackage.utils import helper as h
-          |                ^^^^^
+          |                ^^^^^ Clicking here
         3 | result = h("/a", "/b")
+          |
+        info: Found 1 declaration
+         --> mypackage/utils.py:1:1
+          |
+        1 |
+          | -
+        2 | def helper(a, b):
+        3 |     return a + "/" + b
           |
         "#);
     }
@@ -869,22 +847,22 @@ def another_helper(path):
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
+         --> main.py:7:7
+          |
+        6 | c = C()
+        7 | y = c.x
+          |       ^ Clicking here
+          |
+        info: Found 1 declaration
          --> main.py:4:9
           |
         2 | class C:
         3 |     def __init__(self):
         4 |         self.x: int = 1
-          |         ^^^^^^
+          |         ------
         5 |
         6 | c = C()
-          |
-        info: Source
-         --> main.py:7:7
-          |
-        6 | c = C()
-        7 | y = c.x
-          |       ^
           |
         ");
     }
@@ -901,22 +879,22 @@ def another_helper(path):
         );
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
+         --> main.py:2:5
+          |
+        2 | a: "MyClass" = 1
+          |     ^^^^^^^ Clicking here
+        3 |
+        4 | class MyClass:
+          |
+        info: Found 1 declaration
          --> main.py:4:7
           |
         2 | a: "MyClass" = 1
         3 |
         4 | class MyClass:
-          |       ^^^^^^^
+          |       -------
         5 |     """some docs"""
-          |
-        info: Source
-         --> main.py:2:5
-          |
-        2 | a: "MyClass" = 1
-          |     ^^^^^^^
-        3 |
-        4 | class MyClass:
           |
         "#);
     }
@@ -933,22 +911,22 @@ def another_helper(path):
         );
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
+         --> main.py:2:12
+          |
+        2 | a: "None | MyClass" = 1
+          |            ^^^^^^^ Clicking here
+        3 |
+        4 | class MyClass:
+          |
+        info: Found 1 declaration
          --> main.py:4:7
           |
         2 | a: "None | MyClass" = 1
         3 |
         4 | class MyClass:
-          |       ^^^^^^^
+          |       -------
         5 |     """some docs"""
-          |
-        info: Source
-         --> main.py:2:12
-          |
-        2 | a: "None | MyClass" = 1
-          |            ^^^^^^^
-        3 |
-        4 | class MyClass:
           |
         "#);
     }
@@ -979,22 +957,22 @@ def another_helper(path):
         );
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
+         --> main.py:2:12
+          |
+        2 | a: "None | MyClass" = 1
+          |            ^^^^^^^ Clicking here
+        3 |
+        4 | class MyClass:
+          |
+        info: Found 1 declaration
          --> main.py:4:7
           |
         2 | a: "None | MyClass" = 1
         3 |
         4 | class MyClass:
-          |       ^^^^^^^
+          |       -------
         5 |     """some docs"""
-          |
-        info: Source
-         --> main.py:2:12
-          |
-        2 | a: "None | MyClass" = 1
-          |            ^^^^^^^
-        3 |
-        4 | class MyClass:
           |
         "#);
     }
@@ -1039,22 +1017,22 @@ def another_helper(path):
         );
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
+         --> main.py:2:5
+          |
+        2 | a: "MyClass | No" = 1
+          |     ^^^^^^^ Clicking here
+        3 |
+        4 | class MyClass:
+          |
+        info: Found 1 declaration
          --> main.py:4:7
           |
         2 | a: "MyClass | No" = 1
         3 |
         4 | class MyClass:
-          |       ^^^^^^^
+          |       -------
         5 |     """some docs"""
-          |
-        info: Source
-         --> main.py:2:5
-          |
-        2 | a: "MyClass | No" = 1
-          |     ^^^^^^^
-        3 |
-        4 | class MyClass:
           |
         "#);
     }
@@ -1082,17 +1060,17 @@ def another_helper(path):
         );
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> main.py:2:1
-          |
-        2 | ab: "ab"
-          | ^^
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:2:6
           |
         2 | ab: "ab"
-          |      ^^
+          |      ^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> main.py:2:1
+          |
+        2 | ab: "ab"
+          | --
           |
         "#);
     }
@@ -1126,23 +1104,23 @@ def another_helper(path):
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
+          --> main.py:11:9
+           |
+        10 | d = D()
+        11 | y = d.y.x
+           |         ^ Clicking here
+           |
+        info: Found 1 declaration
          --> main.py:4:9
           |
         2 | class C:
         3 |     def __init__(self):
         4 |         self.x: int = 1
-          |         ^^^^^^
+          |         ------
         5 |
         6 | class D:
           |
-        info: Source
-          --> main.py:11:9
-           |
-        10 | d = D()
-        11 | y = d.y.x
-           |         ^
-           |
         ");
     }
 
@@ -1160,22 +1138,22 @@ def another_helper(path):
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
+         --> main.py:7:7
+          |
+        6 | c = C()
+        7 | y = c.x
+          |       ^ Clicking here
+          |
+        info: Found 1 declaration
          --> main.py:4:9
           |
         2 | class C:
         3 |     def __init__(self):
         4 |         self.x = 1
-          |         ^^^^^^
+          |         ------
         5 |
         6 | c = C()
-          |
-        info: Source
-         --> main.py:7:7
-          |
-        6 | c = C()
-        7 | y = c.x
-          |       ^
           |
         ");
     }
@@ -1194,20 +1172,20 @@ def another_helper(path):
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> main.py:3:9
-          |
-        2 | class C:
-        3 |     def foo(self):
-          |         ^^^
-        4 |         return 42
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:7:9
           |
         6 | c = C()
         7 | res = c.foo()
-          |         ^^^
+          |         ^^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> main.py:3:9
+          |
+        2 | class C:
+        3 |     def foo(self):
+          |         ---
+        4 |         return 42
           |
         ");
     }
@@ -1244,7 +1222,7 @@ x: i<CURSOR>nt = 42
             "Should find the int class definition"
         );
         assert!(
-            result.contains("info[goto-declaration]: Declaration"),
+            result.contains("info[goto-declaration]: Go to declaration"),
             "Should be a goto-declaration result"
         );
     }
@@ -1267,25 +1245,25 @@ def outer():
 
         // Should find the variable declaration in the outer scope, not the nonlocal statement
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> main.py:3:5
-          |
-        2 | def outer():
-        3 |     x = "outer_value"
-          |     ^
-        4 |
-        5 |     def inner():
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
           --> main.py:8:16
            |
          6 |         nonlocal x
          7 |         x = "modified"
          8 |         return x  # Should find the nonlocal x declaration in outer scope
-           |                ^
+           |                ^ Clicking here
          9 |
         10 |     return inner
            |
+        info: Found 1 declaration
+         --> main.py:3:5
+          |
+        2 | def outer():
+        3 |     x = "outer_value"
+          |     -
+        4 |
+        5 |     def inner():
+          |
         "#);
     }
 
@@ -1307,23 +1285,23 @@ def outer():
 
         // Should find the variable declaration in the outer scope, not the nonlocal statement
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> main.py:3:5
-          |
-        2 | def outer():
-        3 |     xy = "outer_value"
-          |     ^^
-        4 |
-        5 |     def inner():
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:6:18
           |
         5 |     def inner():
         6 |         nonlocal xy
-          |                  ^^
+          |                  ^^ Clicking here
         7 |         xy = "modified"
         8 |         return x  # Should find the nonlocal x declaration in outer scope
+          |
+        info: Found 1 declaration
+         --> main.py:3:5
+          |
+        2 | def outer():
+        3 |     xy = "outer_value"
+          |     --
+        4 |
+        5 |     def inner():
           |
         "#);
     }
@@ -1343,21 +1321,21 @@ def function():
 
         // Should find the global variable declaration, not the global statement
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> main.py:2:1
-          |
-        2 | global_var = "global_value"
-          | ^^^^^^^^^^
-        3 |
-        4 | def function():
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:7:12
           |
         5 |     global global_var
         6 |     global_var = "modified"
         7 |     return global_var  # Should find the global variable declaration
-          |            ^^^^^^^^^^
+          |            ^^^^^^^^^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> main.py:2:1
+          |
+        2 | global_var = "global_value"
+          | ----------
+        3 |
+        4 | def function():
           |
         "#);
     }
@@ -1377,22 +1355,22 @@ def function():
 
         // Should find the global variable declaration, not the global statement
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> main.py:2:1
-          |
-        2 | global_var = "global_value"
-          | ^^^^^^^^^^
-        3 |
-        4 | def function():
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:5:12
           |
         4 | def function():
         5 |     global global_var
-          |            ^^^^^^^^^^
+          |            ^^^^^^^^^^ Clicking here
         6 |     global_var = "modified"
         7 |     return global_var  # Should find the global variable declaration
+          |
+        info: Found 1 declaration
+         --> main.py:2:1
+          |
+        2 | global_var = "global_value"
+          | ----------
+        3 |
+        4 | def function():
           |
         "#);
     }
@@ -1413,21 +1391,21 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> main.py:3:5
-          |
-        2 | class A:
-        3 |     x = 10
-          |     ^
-        4 |
-        5 | class B(A):
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:9:7
           |
         8 | b = B()
         9 | y = b.x
-          |       ^
+          |       ^ Clicking here
+          |
+        info: Found 1 declaration
+         --> main.py:3:5
+          |
+        2 | class A:
+        3 |     x = 10
+          |     -
+        4 |
+        5 | class B(A):
           |
         ");
     }
@@ -1444,22 +1422,22 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
          --> main.py:4:22
           |
         2 | def my_func(command: str):
         3 |     match command.split():
         4 |         case ["get", ab]:
-          |                      ^^
+          |                      ^^ Clicking here
         5 |             x = ab
           |
-        info: Source
+        info: Found 1 declaration
          --> main.py:4:22
           |
         2 | def my_func(command: str):
         3 |     match command.split():
         4 |         case ["get", ab]:
-          |                      ^^
+          |                      --
         5 |             x = ab
           |
         "#);
@@ -1477,22 +1455,22 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> main.py:4:22
-          |
-        2 | def my_func(command: str):
-        3 |     match command.split():
-        4 |         case ["get", ab]:
-          |                      ^^
-        5 |             x = ab
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:5:17
           |
         3 |     match command.split():
         4 |         case ["get", ab]:
         5 |             x = ab
-          |                 ^^
+          |                 ^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> main.py:4:22
+          |
+        2 | def my_func(command: str):
+        3 |     match command.split():
+        4 |         case ["get", ab]:
+          |                      --
+        5 |             x = ab
           |
         "#);
     }
@@ -1509,22 +1487,22 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
          --> main.py:4:23
           |
         2 | def my_func(command: str):
         3 |     match command.split():
         4 |         case ["get", *ab]:
-          |                       ^^
+          |                       ^^ Clicking here
         5 |             x = ab
           |
-        info: Source
+        info: Found 1 declaration
          --> main.py:4:23
           |
         2 | def my_func(command: str):
         3 |     match command.split():
         4 |         case ["get", *ab]:
-          |                       ^^
+          |                       --
         5 |             x = ab
           |
         "#);
@@ -1542,22 +1520,22 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> main.py:4:23
-          |
-        2 | def my_func(command: str):
-        3 |     match command.split():
-        4 |         case ["get", *ab]:
-          |                       ^^
-        5 |             x = ab
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:5:17
           |
         3 |     match command.split():
         4 |         case ["get", *ab]:
         5 |             x = ab
-          |                 ^^
+          |                 ^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> main.py:4:23
+          |
+        2 | def my_func(command: str):
+        3 |     match command.split():
+        4 |         case ["get", *ab]:
+          |                       --
+        5 |             x = ab
           |
         "#);
     }
@@ -1574,22 +1552,22 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
          --> main.py:4:37
           |
         2 | def my_func(command: str):
         3 |     match command.split():
         4 |         case ["get", ("a" | "b") as ab]:
-          |                                     ^^
+          |                                     ^^ Clicking here
         5 |             x = ab
           |
-        info: Source
+        info: Found 1 declaration
          --> main.py:4:37
           |
         2 | def my_func(command: str):
         3 |     match command.split():
         4 |         case ["get", ("a" | "b") as ab]:
-          |                                     ^^
+          |                                     --
         5 |             x = ab
           |
         "#);
@@ -1607,22 +1585,22 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> main.py:4:37
-          |
-        2 | def my_func(command: str):
-        3 |     match command.split():
-        4 |         case ["get", ("a" | "b") as ab]:
-          |                                     ^^
-        5 |             x = ab
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:5:17
           |
         3 |     match command.split():
         4 |         case ["get", ("a" | "b") as ab]:
         5 |             x = ab
-          |                 ^^
+          |                 ^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> main.py:4:37
+          |
+        2 | def my_func(command: str):
+        3 |     match command.split():
+        4 |         case ["get", ("a" | "b") as ab]:
+          |                                     --
+        5 |             x = ab
           |
         "#);
     }
@@ -1645,22 +1623,22 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
           --> main.py:10:30
            |
          8 | def my_func(event: Click):
          9 |     match event:
         10 |         case Click(x, button=ab):
-           |                              ^^
+           |                              ^^ Clicking here
         11 |             x = ab
            |
-        info: Source
+        info: Found 1 declaration
           --> main.py:10:30
            |
          8 | def my_func(event: Click):
          9 |     match event:
         10 |         case Click(x, button=ab):
-           |                              ^^
+           |                              --
         11 |             x = ab
            |
         ");
@@ -1684,22 +1662,22 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-          --> main.py:10:30
-           |
-         8 | def my_func(event: Click):
-         9 |     match event:
-        10 |         case Click(x, button=ab):
-           |                              ^^
-        11 |             x = ab
-           |
-        info: Source
+        info[goto-declaration]: Go to declaration
           --> main.py:11:17
            |
          9 |     match event:
         10 |         case Click(x, button=ab):
         11 |             x = ab
-           |                 ^^
+           |                 ^^ Clicking here
+           |
+        info: Found 1 declaration
+          --> main.py:10:30
+           |
+         8 | def my_func(event: Click):
+         9 |     match event:
+        10 |         case Click(x, button=ab):
+           |                              --
+        11 |             x = ab
            |
         ");
     }
@@ -1722,23 +1700,23 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> main.py:2:7
-          |
-        2 | class Click:
-          |       ^^^^^
-        3 |     __match_args__ = ("position", "button")
-        4 |     def __init__(self, pos, btn):
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
           --> main.py:10:14
            |
          8 | def my_func(event: Click):
          9 |     match event:
         10 |         case Click(x, button=ab):
-           |              ^^^^^
+           |              ^^^^^ Clicking here
         11 |             x = ab
            |
+        info: Found 1 declaration
+         --> main.py:2:7
+          |
+        2 | class Click:
+          |       -----
+        3 |     __match_args__ = ("position", "button")
+        4 |     def __init__(self, pos, btn):
+          |
         "#);
     }
 
@@ -1771,17 +1749,17 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
          --> main.py:2:13
           |
         2 | type Alias1[AB: int = bool] = tuple[AB, list[AB]]
-          |             ^^
+          |             ^^ Clicking here
           |
-        info: Source
+        info: Found 1 declaration
          --> main.py:2:13
           |
         2 | type Alias1[AB: int = bool] = tuple[AB, list[AB]]
-          |             ^^
+          |             --
           |
         ");
     }
@@ -1795,17 +1773,17 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> main.py:2:13
-          |
-        2 | type Alias1[AB: int = bool] = tuple[AB, list[AB]]
-          |             ^^
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:2:37
           |
         2 | type Alias1[AB: int = bool] = tuple[AB, list[AB]]
-          |                                     ^^
+          |                                     ^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> main.py:2:13
+          |
+        2 | type Alias1[AB: int = bool] = tuple[AB, list[AB]]
+          |             --
           |
         ");
     }
@@ -1820,19 +1798,19 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
          --> main.py:3:15
           |
         2 | from typing import Callable
         3 | type Alias2[**AB = [int, str]] = Callable[AB, tuple[AB]]
-          |               ^^
+          |               ^^ Clicking here
           |
-        info: Source
+        info: Found 1 declaration
          --> main.py:3:15
           |
         2 | from typing import Callable
         3 | type Alias2[**AB = [int, str]] = Callable[AB, tuple[AB]]
-          |               ^^
+          |               --
           |
         ");
     }
@@ -1847,19 +1825,19 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> main.py:3:15
-          |
-        2 | from typing import Callable
-        3 | type Alias2[**AB = [int, str]] = Callable[AB, tuple[AB]]
-          |               ^^
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:3:43
           |
         2 | from typing import Callable
         3 | type Alias2[**AB = [int, str]] = Callable[AB, tuple[AB]]
-          |                                           ^^
+          |                                           ^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> main.py:3:15
+          |
+        2 | from typing import Callable
+        3 | type Alias2[**AB = [int, str]] = Callable[AB, tuple[AB]]
+          |               --
           |
         ");
     }
@@ -1873,17 +1851,17 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
          --> main.py:2:14
           |
         2 | type Alias3[*AB = ()] = tuple[tuple[*AB], tuple[*AB]]
-          |              ^^
+          |              ^^ Clicking here
           |
-        info: Source
+        info: Found 1 declaration
          --> main.py:2:14
           |
         2 | type Alias3[*AB = ()] = tuple[tuple[*AB], tuple[*AB]]
-          |              ^^
+          |              --
           |
         ");
     }
@@ -1897,17 +1875,17 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> main.py:2:14
-          |
-        2 | type Alias3[*AB = ()] = tuple[tuple[*AB], tuple[*AB]]
-          |              ^^
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:2:38
           |
         2 | type Alias3[*AB = ()] = tuple[tuple[*AB], tuple[*AB]]
-          |                                      ^^
+          |                                      ^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> main.py:2:14
+          |
+        2 | type Alias3[*AB = ()] = tuple[tuple[*AB], tuple[*AB]]
+          |              --
           |
         ");
     }
@@ -1930,21 +1908,21 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> main.py:7:9
-          |
-        6 |     @property
-        7 |     def value(self):
-          |         ^^^^^
-        8 |         return self._value
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
           --> main.py:11:3
            |
         10 | c = C()
         11 | c.value = 42
-           |   ^^^^^
+           |   ^^^^^ Clicking here
            |
+        info: Found 1 declaration
+         --> main.py:7:9
+          |
+        6 |     @property
+        7 |     def value(self):
+          |         -----
+        8 |         return self._value
+          |
         ");
     }
 
@@ -1982,7 +1960,7 @@ def function():
             "Should find the __doc__ attribute definition"
         );
         assert!(
-            result.contains("info[goto-declaration]: Declaration"),
+            result.contains("info[goto-declaration]: Go to declaration"),
             "Should be a goto-declaration result"
         );
     }
@@ -2003,22 +1981,22 @@ def function():
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
+         --> main.py:9:9
+          |
+        8 | def use_drawable(obj: Drawable):
+        9 |     obj.name
+          |         ^^^^ Clicking here
+          |
+        info: Found 1 declaration
          --> main.py:6:5
           |
         4 | class Drawable(Protocol):
         5 |     def draw(self) -> None: ...
         6 |     name: str
-          |     ^^^^
+          |     ----
         7 |
         8 | def use_drawable(obj: Drawable):
-          |
-        info: Source
-         --> main.py:9:9
-          |
-        8 | def use_drawable(obj: Drawable):
-        9 |     obj.name
-          |         ^^^^
           |
         ");
     }
@@ -2037,23 +2015,23 @@ class MyClass:
 
         // Should find the ClassType defined in the class body, not fail to resolve
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> main.py:3:5
-          |
-        2 | class MyClass:
-        3 |     ClassType = int
-          |     ^^^^^^^^^
-        4 |
-        5 |     def generic_method[T](self, value: ClassType) -> T:
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:5:40
           |
         3 |     ClassType = int
         4 |
         5 |     def generic_method[T](self, value: ClassType) -> T:
-          |                                        ^^^^^^^^^
+          |                                        ^^^^^^^^^ Clicking here
         6 |         return value
+          |
+        info: Found 1 declaration
+         --> main.py:3:5
+          |
+        2 | class MyClass:
+        3 |     ClassType = int
+          |     ---------
+        4 |
+        5 |     def generic_method[T](self, value: ClassType) -> T:
           |
         ");
     }
@@ -2070,20 +2048,20 @@ class MyClass:
         );
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> main.py:2:20
-          |
-        2 | def my_function(x, y, z=10):
-          |                    ^
-        3 |     return x + y + z
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:5:25
           |
         3 |     return x + y + z
         4 |
         5 | result = my_function(1, y=2, z=3)
-          |                         ^
+          |                         ^ Clicking here
+          |
+        info: Found 1 declaration
+         --> main.py:2:20
+          |
+        2 | def my_function(x, y, z=10):
+          |                    -
+        3 |     return x + y + z
           |
         ");
     }
@@ -2110,38 +2088,25 @@ class MyClass:
 
         // Should navigate to the parameter in both matching overloads
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
-         --> main.py:5:24
-          |
-        4 | @overload
-        5 | def process(data: str, format: str) -> str: ...
-          |                        ^^^^^^
-        6 |
-        7 | @overload
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
           --> main.py:14:27
            |
         13 | # Call the overloaded function
         14 | result = process("hello", format="json")
-           |                           ^^^^^^
+           |                           ^^^^^^ Clicking here
            |
-
-        info[goto-declaration]: Declaration
-          --> main.py:8:24
+        info: Found 2 declarations
+          --> main.py:5:24
            |
+         4 | @overload
+         5 | def process(data: str, format: str) -> str: ...
+           |                        ------
+         6 |
          7 | @overload
          8 | def process(data: int, format: int) -> int: ...
-           |                        ^^^^^^
+           |                        ------
          9 |
         10 | def process(data, format):
-           |
-        info: Source
-          --> main.py:14:27
-           |
-        13 | # Call the overloaded function
-        14 | result = process("hello", format="json")
-           |                           ^^^^^^
            |
         "#);
     }
@@ -2179,38 +2144,24 @@ def ab(a: str): ...
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
+         --> main.py:4:1
+          |
+        2 | from mymodule import ab
+        3 |
+        4 | ab(1)
+          | ^^ Clicking here
+          |
+        info: Found 2 declarations
          --> mymodule.pyi:5:5
           |
         4 | @overload
         5 | def ab(a: int): ...
-          |     ^^
+          |     --
         6 |
         7 | @overload
-          |
-        info: Source
-         --> main.py:4:1
-          |
-        2 | from mymodule import ab
-        3 |
-        4 | ab(1)
-          | ^^
-          |
-
-        info[goto-declaration]: Declaration
-         --> mymodule.pyi:8:5
-          |
-        7 | @overload
         8 | def ab(a: str): ...
-          |     ^^
-          |
-        info: Source
-         --> main.py:4:1
-          |
-        2 | from mymodule import ab
-        3 |
-        4 | ab(1)
-          | ^^
+          |     --
           |
         ");
     }
@@ -2248,38 +2199,24 @@ def ab(a: str): ...
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
+         --> main.py:4:1
+          |
+        2 | from mymodule import ab
+        3 |
+        4 | ab("hello")
+          | ^^ Clicking here
+          |
+        info: Found 2 declarations
          --> mymodule.pyi:5:5
           |
         4 | @overload
         5 | def ab(a: int): ...
-          |     ^^
+          |     --
         6 |
         7 | @overload
-          |
-        info: Source
-         --> main.py:4:1
-          |
-        2 | from mymodule import ab
-        3 |
-        4 | ab("hello")
-          | ^^
-          |
-
-        info[goto-declaration]: Declaration
-         --> mymodule.pyi:8:5
-          |
-        7 | @overload
         8 | def ab(a: str): ...
-          |     ^^
-          |
-        info: Source
-         --> main.py:4:1
-          |
-        2 | from mymodule import ab
-        3 |
-        4 | ab("hello")
-          | ^^
+          |     --
           |
         "#);
     }
@@ -2317,38 +2254,24 @@ def ab(a: int): ...
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
+         --> main.py:4:1
+          |
+        2 | from mymodule import ab
+        3 |
+        4 | ab(1, 2)
+          | ^^ Clicking here
+          |
+        info: Found 2 declarations
          --> mymodule.pyi:5:5
           |
         4 | @overload
         5 | def ab(a: int, b: int): ...
-          |     ^^
+          |     --
         6 |
         7 | @overload
-          |
-        info: Source
-         --> main.py:4:1
-          |
-        2 | from mymodule import ab
-        3 |
-        4 | ab(1, 2)
-          | ^^
-          |
-
-        info[goto-declaration]: Declaration
-         --> mymodule.pyi:8:5
-          |
-        7 | @overload
         8 | def ab(a: int): ...
-          |     ^^
-          |
-        info: Source
-         --> main.py:4:1
-          |
-        2 | from mymodule import ab
-        3 |
-        4 | ab(1, 2)
-          | ^^
+          |     --
           |
         ");
     }
@@ -2386,38 +2309,24 @@ def ab(a: int): ...
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
+         --> main.py:4:1
+          |
+        2 | from mymodule import ab
+        3 |
+        4 | ab(1)
+          | ^^ Clicking here
+          |
+        info: Found 2 declarations
          --> mymodule.pyi:5:5
           |
         4 | @overload
         5 | def ab(a: int, b: int): ...
-          |     ^^
+          |     --
         6 |
         7 | @overload
-          |
-        info: Source
-         --> main.py:4:1
-          |
-        2 | from mymodule import ab
-        3 |
-        4 | ab(1)
-          | ^^
-          |
-
-        info[goto-declaration]: Declaration
-         --> mymodule.pyi:8:5
-          |
-        7 | @overload
         8 | def ab(a: int): ...
-          |     ^^
-          |
-        info: Source
-         --> main.py:4:1
-          |
-        2 | from mymodule import ab
-        3 |
-        4 | ab(1)
-          | ^^
+          |     --
           |
         ");
     }
@@ -2458,57 +2367,29 @@ def ab(a: int, *, c: int): ...
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> mymodule.pyi:5:5
-          |
-        4 | @overload
-        5 | def ab(a: int): ...
-          |     ^^
-        6 |
-        7 | @overload
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:4:1
           |
         2 | from mymodule import ab
         3 |
         4 | ab(1, b=2)
-          | ^^
+          | ^^ Clicking here
           |
-
-        info[goto-declaration]: Declaration
-          --> mymodule.pyi:8:5
+        info: Found 3 declarations
+          --> mymodule.pyi:5:5
            |
+         4 | @overload
+         5 | def ab(a: int): ...
+           |     --
+         6 |
          7 | @overload
          8 | def ab(a: int, *, b: int): ...
-           |     ^^
+           |     --
          9 |
         10 | @overload
-           |
-        info: Source
-         --> main.py:4:1
-          |
-        2 | from mymodule import ab
-        3 |
-        4 | ab(1, b=2)
-          | ^^
-          |
-
-        info[goto-declaration]: Declaration
-          --> mymodule.pyi:11:5
-           |
-        10 | @overload
         11 | def ab(a: int, *, c: int): ...
-           |     ^^
+           |     --
            |
-        info: Source
-         --> main.py:4:1
-          |
-        2 | from mymodule import ab
-        3 |
-        4 | ab(1, b=2)
-          | ^^
-          |
         ");
     }
 
@@ -2548,57 +2429,29 @@ def ab(a: int, *, c: int): ...
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> mymodule.pyi:5:5
-          |
-        4 | @overload
-        5 | def ab(a: int): ...
-          |     ^^
-        6 |
-        7 | @overload
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> main.py:4:1
           |
         2 | from mymodule import ab
         3 |
         4 | ab(1, c=2)
-          | ^^
+          | ^^ Clicking here
           |
-
-        info[goto-declaration]: Declaration
-          --> mymodule.pyi:8:5
+        info: Found 3 declarations
+          --> mymodule.pyi:5:5
            |
+         4 | @overload
+         5 | def ab(a: int): ...
+           |     --
+         6 |
          7 | @overload
          8 | def ab(a: int, *, b: int): ...
-           |     ^^
+           |     --
          9 |
         10 | @overload
-           |
-        info: Source
-         --> main.py:4:1
-          |
-        2 | from mymodule import ab
-        3 |
-        4 | ab(1, c=2)
-          | ^^
-          |
-
-        info[goto-declaration]: Declaration
-          --> mymodule.pyi:11:5
-           |
-        10 | @overload
         11 | def ab(a: int, *, c: int): ...
-           |     ^^
+           |     --
            |
-        info: Source
-         --> main.py:4:1
-          |
-        2 | from mymodule import ab
-        3 |
-        4 | ab(1, c=2)
-          | ^^
-          |
         ");
     }
 
@@ -2627,21 +2480,21 @@ def ab(a: int, *, c: int): ...
         // which is correct but unhelpful. Unfortunately even if it only claimed the LHS identifier it
         // would highlight `subpkg.submod` which is strictly better but still isn't what we want.
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> mypackage/__init__.py:2:1
-          |
-        2 | from .subpkg.submod import val
-          | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        3 |
-        4 | x = subpkg
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> mypackage/__init__.py:4:5
           |
         2 | from .subpkg.submod import val
         3 |
         4 | x = subpkg
-          |     ^^^^^^
+          |     ^^^^^^ Clicking here
+          |
+        info: Found 1 declaration
+         --> mypackage/__init__.py:2:1
+          |
+        2 | from .subpkg.submod import val
+          | ------------------------------
+        3 |
+        4 | x = subpkg
           |
         ");
     }
@@ -2671,18 +2524,18 @@ def ab(a: int, *, c: int): ...
         // `subpkg = mypackage.subpkg`. As in, it's both defining a local `subpkg` and
         // loading the module `mypackage.subpkg`, so, it's understandable to get confused!
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-        --> mypackage/subpkg/__init__.py:1:1
-         |
-         |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> mypackage/__init__.py:2:7
           |
         2 | from .subpkg.submod import val
-          |       ^^^^^^
+          |       ^^^^^^ Clicking here
         3 |
         4 | x = subpkg
           |
+        info: Found 1 declaration
+        --> mypackage/subpkg/__init__.py:1:1
+         |
+         |
         ");
     }
 
@@ -2732,20 +2585,20 @@ def ab(a: int, *, c: int): ...
 
         // Going to the submod module is correct!
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> mypackage/subpkg/submod.py:1:1
-          |
-        1 |
-          | ^
-        2 | val: int = 0
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> mypackage/__init__.py:2:14
           |
         2 | from .subpkg.submod import val
-          |              ^^^^^^
+          |              ^^^^^^ Clicking here
         3 |
         4 | x = submod
+          |
+        info: Found 1 declaration
+         --> mypackage/subpkg/submod.py:1:1
+          |
+        1 |
+          | -
+        2 | val: int = 0
           |
         ");
     }
@@ -2771,20 +2624,20 @@ def ab(a: int, *, c: int): ...
 
         // Going to the subpkg module is correct!
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> mypackage/subpkg/__init__.py:1:1
-          |
-        1 |
-          | ^
-        2 | subpkg: int = 10
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> mypackage/__init__.py:2:7
           |
         2 | from .subpkg import subpkg
-          |       ^^^^^^
+          |       ^^^^^^ Clicking here
         3 |
         4 | x = subpkg
+          |
+        info: Found 1 declaration
+         --> mypackage/subpkg/__init__.py:1:1
+          |
+        1 |
+          | -
+        2 | subpkg: int = 10
           |
         ");
     }
@@ -2810,19 +2663,19 @@ def ab(a: int, *, c: int): ...
 
         // Going to the subpkg `int` is correct!
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
-         --> mypackage/subpkg/__init__.py:2:1
-          |
-        2 | subpkg: int = 10
-          | ^^^^^^
-          |
-        info: Source
+        info[goto-declaration]: Go to declaration
          --> mypackage/__init__.py:2:21
           |
         2 | from .subpkg import subpkg
-          |                     ^^^^^^
+          |                     ^^^^^^ Clicking here
         3 |
         4 | x = subpkg
+          |
+        info: Found 1 declaration
+         --> mypackage/subpkg/__init__.py:2:1
+          |
+        2 | subpkg: int = 10
+          | ------
           |
         ");
     }
@@ -2860,36 +2713,26 @@ def ab(a: int, *, c: int): ...
         //    that *immediately* overwrites the `ImportFromSubmodule`'s definition
         //    This span seemingly doesn't appear at all!? Is it getting hidden by the LHS span?
         assert_snapshot!(test.goto_declaration(), @r"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
+         --> mypackage/__init__.py:4:5
+          |
+        2 | from .subpkg import subpkg
+        3 |
+        4 | x = subpkg
+          |     ^^^^^^ Clicking here
+          |
+        info: Found 2 declarations
          --> mypackage/__init__.py:2:1
           |
         2 | from .subpkg import subpkg
-          | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+          | --------------------------
         3 |
         4 | x = subpkg
           |
-        info: Source
-         --> mypackage/__init__.py:4:5
-          |
-        2 | from .subpkg import subpkg
-        3 |
-        4 | x = subpkg
-          |     ^^^^^^
-          |
-
-        info[goto-declaration]: Declaration
-         --> mypackage/subpkg/__init__.py:2:1
+         ::: mypackage/subpkg/__init__.py:2:1
           |
         2 | subpkg: int = 10
-          | ^^^^^^
-          |
-        info: Source
-         --> mypackage/__init__.py:4:5
-          |
-        2 | from .subpkg import subpkg
-        3 |
-        4 | x = subpkg
-          |     ^^^^^^
+          | ------
           |
         ");
     }
@@ -2913,63 +2756,29 @@ def ab(a: int, *, c: int): ...
             .build();
 
         assert_snapshot!(test.goto_declaration(), @r#"
-        info[goto-declaration]: Declaration
+        info[goto-declaration]: Go to declaration
+         --> main.py:6:7
+          |
+        4 | a: int = 10
+        5 |
+        6 | print(a)
+          |       ^ Clicking here
+        7 |
+        8 | a: bool = True
+          |
+        info: Found 3 declarations
          --> main.py:2:1
           |
         2 | a: str = "test"
-          | ^
+          | -
         3 |
         4 | a: int = 10
-          |
-        info: Source
-         --> main.py:6:7
-          |
-        4 | a: int = 10
+          | -
         5 |
-        6 | print(a)
-          |       ^
-        7 |
-        8 | a: bool = True
-          |
-
-        info[goto-declaration]: Declaration
-         --> main.py:4:1
-          |
-        2 | a: str = "test"
-        3 |
-        4 | a: int = 10
-          | ^
-        5 |
-        6 | print(a)
-          |
-        info: Source
-         --> main.py:6:7
-          |
-        4 | a: int = 10
-        5 |
-        6 | print(a)
-          |       ^
-        7 |
-        8 | a: bool = True
-          |
-
-        info[goto-declaration]: Declaration
-         --> main.py:8:1
-          |
         6 | print(a)
         7 |
         8 | a: bool = True
-          | ^
-          |
-        info: Source
-         --> main.py:6:7
-          |
-        4 | a: int = 10
-        5 |
-        6 | print(a)
-          |       ^
-        7 |
-        8 | a: bool = True
+          | -
           |
         "#);
     }
@@ -2985,47 +2794,10 @@ def ab(a: int, *, c: int): ...
                 return "No declarations found".to_string();
             }
 
-            let source = targets.range;
-            self.render_diagnostics(
-                targets
-                    .into_iter()
-                    .map(|target| GotoDeclarationDiagnostic::new(source, &target)),
-            )
-        }
-    }
-
-    struct GotoDeclarationDiagnostic {
-        source: FileRange,
-        target: FileRange,
-    }
-
-    impl GotoDeclarationDiagnostic {
-        fn new(source: FileRange, target: &NavigationTarget) -> Self {
-            Self {
-                source,
-                target: FileRange::new(target.file(), target.focus_range()),
-            }
-        }
-    }
-
-    impl IntoDiagnostic for GotoDeclarationDiagnostic {
-        fn into_diagnostic(self) -> Diagnostic {
-            let mut source = SubDiagnostic::new(SubDiagnosticSeverity::Info, "Source");
-            source.annotate(Annotation::primary(
-                Span::from(self.source.file()).with_range(self.source.range()),
-            ));
-
-            let mut main = Diagnostic::new(
-                DiagnosticId::Lint(LintName::of("goto-declaration")),
-                Severity::Info,
-                "Declaration".to_string(),
-            );
-            main.annotate(Annotation::primary(
-                Span::from(self.target.file()).with_range(self.target.range()),
-            ));
-            main.sub(source);
-
-            main
+            self.render_diagnostics([crate::goto_definition::test::GotoDiagnostic::new(
+                crate::goto_definition::test::GotoAction::Declaration,
+                targets,
+            )])
         }
     }
 }

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -30,15 +30,15 @@ pub fn goto_definition(
 }
 
 #[cfg(test)]
-mod test {
+pub(super) mod test {
+
     use crate::tests::{CursorTest, IntoDiagnostic};
-    use crate::{NavigationTarget, goto_definition};
+    use crate::{NavigationTargets, RangedValue, goto_definition};
     use insta::assert_snapshot;
     use ruff_db::diagnostic::{
         Annotation, Diagnostic, DiagnosticId, LintName, Severity, Span, SubDiagnostic,
         SubDiagnosticSeverity,
     };
-    use ruff_db::files::FileRange;
     use ruff_text_size::Ranged;
 
     /// goto-definition on a module should go to the .py not the .pyi
@@ -70,19 +70,19 @@ def my_function(): ...
             .build();
 
         assert_snapshot!(test.goto_definition(), @r#"
-        info[goto-definition]: Definition
-         --> mymodule.py:1:1
-          |
-        1 |
-          | ^
-        2 | def my_function():
-        3 |     return "hello"
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:2:6
           |
         2 | from mymodule import my_function
-          |      ^^^^^^^^
+          |      ^^^^^^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> mymodule.py:1:1
+          |
+        1 |
+          | -
+        2 | def my_function():
+        3 |     return "hello"
           |
         "#);
     }
@@ -114,20 +114,20 @@ def my_function(): ...
             .build();
 
         assert_snapshot!(test.goto_definition(), @r#"
-        info[goto-definition]: Definition
-         --> mymodule.py:1:1
-          |
-        1 |
-          | ^
-        2 | def my_function():
-        3 |     return "hello"
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:3:5
           |
         2 | import mymodule
         3 | x = mymodule
-          |     ^^^^^^^^
+          |     ^^^^^^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> mymodule.py:1:1
+          |
+        1 |
+          | -
+        2 | def my_function():
+        3 |     return "hello"
           |
         "#);
     }
@@ -164,19 +164,19 @@ def other_function(): ...
             .build();
 
         assert_snapshot!(test.goto_definition(), @r#"
-        info[goto-definition]: Definition
-         --> mymodule.py:2:5
-          |
-        2 | def my_function():
-          |     ^^^^^^^^^^^
-        3 |     return "hello"
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:3:7
           |
         2 | from mymodule import my_function
         3 | print(my_function())
-          |       ^^^^^^^^^^^
+          |       ^^^^^^^^^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> mymodule.py:2:5
+          |
+        2 | def my_function():
+          |     -----------
+        3 |     return "hello"
           |
         "#);
     }
@@ -206,20 +206,20 @@ def other_function(): ...
             .build();
 
         assert_snapshot!(test.goto_definition(), @r#"
-        info[goto-definition]: Definition
-         --> mymodule.py:2:5
-          |
-        2 | def my_function():
-          |     ^^^^^^^^^^^
-        3 |     return "hello"
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> mymodule.pyi:2:5
           |
         2 | def my_function(): ...
-          |     ^^^^^^^^^^^
+          |     ^^^^^^^^^^^ Clicking here
         3 |
         4 | def other_function(): ...
+          |
+        info: Found 1 definition
+         --> mymodule.py:2:5
+          |
+        2 | def my_function():
+          |     -----------
+        3 |     return "hello"
           |
         "#);
     }
@@ -266,53 +266,27 @@ def other_function(): ...
             .build();
 
         assert_snapshot!(test.goto_definition(), @r#"
-        info[goto-definition]: Definition
+        info[goto-definition]: Go to definition
+         --> main.py:3:7
+          |
+        2 | from mymodule import my_function
+        3 | print(my_function())
+          |       ^^^^^^^^^^^ Clicking here
+          |
+        info: Found 3 definitions
          --> mymodule.py:2:5
           |
         2 | def my_function():
-          |     ^^^^^^^^^^^
-        3 |     return "hello"
-          |
-        info: Source
-         --> main.py:3:7
-          |
-        2 | from mymodule import my_function
-        3 | print(my_function())
-          |       ^^^^^^^^^^^
-          |
-
-        info[goto-definition]: Definition
-         --> mymodule.py:5:5
-          |
+          |     -----------
         3 |     return "hello"
         4 |
         5 | def my_function():
-          |     ^^^^^^^^^^^
-        6 |     return "hello again"
-          |
-        info: Source
-         --> main.py:3:7
-          |
-        2 | from mymodule import my_function
-        3 | print(my_function())
-          |       ^^^^^^^^^^^
-          |
-
-        info[goto-definition]: Definition
-         --> mymodule.py:8:5
-          |
+          |     -----------
         6 |     return "hello again"
         7 |
         8 | def my_function():
-          |     ^^^^^^^^^^^
+          |     -----------
         9 |     return "we can't keep doing this"
-          |
-        info: Source
-         --> main.py:3:7
-          |
-        2 | from mymodule import my_function
-        3 | print(my_function())
-          |       ^^^^^^^^^^^
           |
         "#);
     }
@@ -353,20 +327,20 @@ class MyOtherClass:
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> mymodule.py:2:7
-          |
-        2 | class MyClass:
-          |       ^^^^^^^
-        3 |     def __init__(self, val):
-        4 |         self.val = val
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:3:5
           |
         2 | from mymodule import MyClass
         3 | x = MyClass
-          |     ^^^^^^^
+          |     ^^^^^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> mymodule.py:2:7
+          |
+        2 | class MyClass:
+          |       -------
+        3 |     def __init__(self, val):
+        4 |         self.val = val
           |
         ");
     }
@@ -400,20 +374,20 @@ class MyOtherClass:
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> mymodule.py:2:7
-          |
-        2 | class MyClass:
-          |       ^^^^^^^
-        3 |     def __init__(self, val):
-        4 |         self.val = val
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> mymodule.pyi:2:7
           |
         2 | class MyClass:
-          |       ^^^^^^^
+          |       ^^^^^^^ Clicking here
         3 |     def __init__(self, val: bool): ...
+          |
+        info: Found 1 definition
+         --> mymodule.py:2:7
+          |
+        2 | class MyClass:
+          |       -------
+        3 |     def __init__(self, val):
+        4 |         self.val = val
           |
         ");
     }
@@ -454,36 +428,21 @@ class MyOtherClass:
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
+        info[goto-definition]: Go to definition
+         --> main.py:3:5
+          |
+        2 | from mymodule import MyClass
+        3 | x = MyClass(0)
+          |     ^^^^^^^ Clicking here
+          |
+        info: Found 2 definitions
          --> mymodule.py:2:7
           |
         2 | class MyClass:
-          |       ^^^^^^^
+          |       -------
         3 |     def __init__(self, val):
+          |         --------
         4 |         self.val = val
-          |
-        info: Source
-         --> main.py:3:5
-          |
-        2 | from mymodule import MyClass
-        3 | x = MyClass(0)
-          |     ^^^^^^^
-          |
-
-        info[goto-definition]: Definition
-         --> mymodule.py:3:9
-          |
-        2 | class MyClass:
-        3 |     def __init__(self, val):
-          |         ^^^^^^^^
-        4 |         self.val = val
-          |
-        info: Source
-         --> main.py:3:5
-          |
-        2 | from mymodule import MyClass
-        3 | x = MyClass(0)
-          |     ^^^^^^^
           |
         ");
     }
@@ -528,22 +487,22 @@ class MyOtherClass:
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> mymodule.py:5:9
-          |
-        3 |     def __init__(self, val):
-        4 |         self.val = val
-        5 |     def action(self):
-          |         ^^^^^^
-        6 |         print(self.val)
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:4:3
           |
         2 | from mymodule import MyClass
         3 | x = MyClass(0)
         4 | x.action()
-          |   ^^^^^^
+          |   ^^^^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> mymodule.py:5:9
+          |
+        3 |     def __init__(self, val):
+        4 |         self.val = val
+        5 |     def action(self):
+          |         ------
+        6 |         print(self.val)
           |
         ");
     }
@@ -587,21 +546,21 @@ class MyOtherClass:
             .build();
 
         assert_snapshot!(test.goto_definition(), @r#"
-        info[goto-definition]: Definition
+        info[goto-definition]: Go to definition
+         --> main.py:3:13
+          |
+        2 | from mymodule import MyClass
+        3 | x = MyClass.action()
+          |             ^^^^^^ Clicking here
+          |
+        info: Found 1 definition
          --> mymodule.py:5:9
           |
         3 |     def __init__(self, val):
         4 |         self.val = val
         5 |     def action():
-          |         ^^^^^^
+          |         ------
         6 |         print("hi!")
-          |
-        info: Source
-         --> main.py:3:13
-          |
-        2 | from mymodule import MyClass
-        3 | x = MyClass.action()
-          |             ^^^^^^
           |
         "#);
     }
@@ -631,17 +590,17 @@ class MyClass: ...
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> mymodule.py:2:7
-          |
-        2 | class MyClass: ...
-          |       ^^^^^^^
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:2:22
           |
         2 | from mymodule import MyClass
-          |                      ^^^^^^^
+          |                      ^^^^^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> mymodule.py:2:7
+          |
+        2 | class MyClass: ...
+          |       -------
           |
         ");
     }
@@ -665,21 +624,21 @@ my_func(my_other_func(ab=5, y=2), 0)
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> main.py:2:13
-          |
-        2 | def my_func(ab, y, z = None): ...
-          |             ^^
-        3 | def my_other_func(ab, y): ...
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:5:23
           |
         3 | def my_other_func(ab, y): ...
         4 |
         5 | my_other_func(my_func(ab=5, y=2), 0)
-          |                       ^^
+          |                       ^^ Clicking here
         6 | my_func(my_other_func(ab=5, y=2), 0)
+          |
+        info: Found 1 definition
+         --> main.py:2:13
+          |
+        2 | def my_func(ab, y, z = None): ...
+          |             --
+        3 | def my_other_func(ab, y): ...
           |
         ");
     }
@@ -703,21 +662,21 @@ my_func(my_other_func(a<CURSOR>b=5, y=2), 0)
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> main.py:3:19
-          |
-        2 | def my_func(ab, y, z = None): ...
-        3 | def my_other_func(ab, y): ...
-          |                   ^^
-        4 |
-        5 | my_other_func(my_func(ab=5, y=2), 0)
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:6:23
           |
         5 | my_other_func(my_func(ab=5, y=2), 0)
         6 | my_func(my_other_func(ab=5, y=2), 0)
-          |                       ^^
+          |                       ^^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:3:19
+          |
+        2 | def my_func(ab, y, z = None): ...
+        3 | def my_other_func(ab, y): ...
+          |                   --
+        4 |
+        5 | my_other_func(my_func(ab=5, y=2), 0)
           |
         ");
     }
@@ -741,21 +700,21 @@ my_func(my_other_func(ab=5, y=2), 0)
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> main.py:2:13
-          |
-        2 | def my_func(ab, y): ...
-          |             ^^
-        3 | def my_other_func(ab, y): ...
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:5:23
           |
         3 | def my_other_func(ab, y): ...
         4 |
         5 | my_other_func(my_func(ab=5, y=2), 0)
-          |                       ^^
+          |                       ^^ Clicking here
         6 | my_func(my_other_func(ab=5, y=2), 0)
+          |
+        info: Found 1 definition
+         --> main.py:2:13
+          |
+        2 | def my_func(ab, y): ...
+          |             --
+        3 | def my_other_func(ab, y): ...
           |
         ");
     }
@@ -779,21 +738,21 @@ my_func(my_other_func(a<CURSOR>b=5, y=2), 0)
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> main.py:3:19
-          |
-        2 | def my_func(ab, y): ...
-        3 | def my_other_func(ab, y): ...
-          |                   ^^
-        4 |
-        5 | my_other_func(my_func(ab=5, y=2), 0)
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:6:23
           |
         5 | my_other_func(my_func(ab=5, y=2), 0)
         6 | my_func(my_other_func(ab=5, y=2), 0)
-          |                       ^^
+          |                       ^^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:3:19
+          |
+        2 | def my_func(ab, y): ...
+        3 | def my_other_func(ab, y): ...
+          |                   --
+        4 |
+        5 | my_other_func(my_func(ab=5, y=2), 0)
           |
         ");
     }
@@ -831,20 +790,20 @@ def ab(a: str): ...
             .build();
 
         assert_snapshot!(test.goto_definition(), @r#"
-        info[goto-definition]: Definition
-         --> mymodule.py:2:5
-          |
-        2 | def ab(a):
-          |     ^^
-        3 |     """the real implementation!"""
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:4:1
           |
         2 | from mymodule import ab
         3 |
         4 | ab(1)
-          | ^^
+          | ^^ Clicking here
+          |
+        info: Found 1 definition
+         --> mymodule.py:2:5
+          |
+        2 | def ab(a):
+          |     --
+        3 |     """the real implementation!"""
           |
         "#);
     }
@@ -882,20 +841,20 @@ def ab(a: str): ...
             .build();
 
         assert_snapshot!(test.goto_definition(), @r#"
-        info[goto-definition]: Definition
-         --> mymodule.py:2:5
-          |
-        2 | def ab(a):
-          |     ^^
-        3 |     """the real implementation!"""
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:4:1
           |
         2 | from mymodule import ab
         3 |
         4 | ab("hello")
-          | ^^
+          | ^^ Clicking here
+          |
+        info: Found 1 definition
+         --> mymodule.py:2:5
+          |
+        2 | def ab(a):
+          |     --
+        3 |     """the real implementation!"""
           |
         "#);
     }
@@ -933,20 +892,20 @@ def ab(a: int): ...
             .build();
 
         assert_snapshot!(test.goto_definition(), @r#"
-        info[goto-definition]: Definition
-         --> mymodule.py:2:5
-          |
-        2 | def ab(a, b = None):
-          |     ^^
-        3 |     """the real implementation!"""
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:4:1
           |
         2 | from mymodule import ab
         3 |
         4 | ab(1, 2)
-          | ^^
+          | ^^ Clicking here
+          |
+        info: Found 1 definition
+         --> mymodule.py:2:5
+          |
+        2 | def ab(a, b = None):
+          |     --
+        3 |     """the real implementation!"""
           |
         "#);
     }
@@ -984,20 +943,20 @@ def ab(a: int): ...
             .build();
 
         assert_snapshot!(test.goto_definition(), @r#"
-        info[goto-definition]: Definition
-         --> mymodule.py:2:5
-          |
-        2 | def ab(a, b = None):
-          |     ^^
-        3 |     """the real implementation!"""
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:4:1
           |
         2 | from mymodule import ab
         3 |
         4 | ab(1)
-          | ^^
+          | ^^ Clicking here
+          |
+        info: Found 1 definition
+         --> mymodule.py:2:5
+          |
+        2 | def ab(a, b = None):
+          |     --
+        3 |     """the real implementation!"""
           |
         "#);
     }
@@ -1038,20 +997,20 @@ def ab(a: int, *, c: int): ...
             .build();
 
         assert_snapshot!(test.goto_definition(), @r#"
-        info[goto-definition]: Definition
-         --> mymodule.py:2:5
-          |
-        2 | def ab(a, *, b = None, c = None):
-          |     ^^
-        3 |     """the real implementation!"""
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:4:1
           |
         2 | from mymodule import ab
         3 |
         4 | ab(1, b=2)
-          | ^^
+          | ^^ Clicking here
+          |
+        info: Found 1 definition
+         --> mymodule.py:2:5
+          |
+        2 | def ab(a, *, b = None, c = None):
+          |     --
+        3 |     """the real implementation!"""
           |
         "#);
     }
@@ -1092,20 +1051,20 @@ def ab(a: int, *, c: int): ...
             .build();
 
         assert_snapshot!(test.goto_definition(), @r#"
-        info[goto-definition]: Definition
-         --> mymodule.py:2:5
-          |
-        2 | def ab(a, *, b = None, c = None):
-          |     ^^
-        3 |     """the real implementation!"""
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:4:1
           |
         2 | from mymodule import ab
         3 |
         4 | ab(1, c=2)
-          | ^^
+          | ^^ Clicking here
+          |
+        info: Found 1 definition
+         --> mymodule.py:2:5
+          |
+        2 | def ab(a, *, b = None, c = None):
+          |     --
+        3 |     """the real implementation!"""
           |
         "#);
     }
@@ -1130,22 +1089,22 @@ a <CURSOR>+ b
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> main.py:3:9
-          |
-        2 | class Test:
-        3 |     def __add__(self, other):
-          |         ^^^^^^^
-        4 |         return Test()
-          |
-        info: Source
+        info[goto-definition]: Go to definition
           --> main.py:10:3
            |
          8 | b = Test()
          9 |
         10 | a + b
-           |   ^
+           |   ^ Clicking here
            |
+        info: Found 1 definition
+         --> main.py:3:9
+          |
+        2 | class Test:
+        3 |     def __add__(self, other):
+          |         -------
+        4 |         return Test()
+          |
         ");
     }
 
@@ -1167,21 +1126,21 @@ B() <CURSOR>+ A()
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> main.py:3:9
-          |
-        2 | class A:
-        3 |     def __radd__(self, other) -> A:
-          |         ^^^^^^^^
-        4 |         return self
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:8:5
           |
         6 | class B: ...
         7 |
         8 | B() + A()
-          |     ^
+          |     ^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:3:9
+          |
+        2 | class A:
+        3 |     def __radd__(self, other) -> A:
+          |         --------
+        4 |         return self
           |
         ");
     }
@@ -1206,22 +1165,22 @@ a<CURSOR>+b
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> main.py:3:9
-          |
-        2 | class Test:
-        3 |     def __add__(self, other):
-          |         ^^^^^^^
-        4 |         return Test()
-          |
-        info: Source
+        info[goto-definition]: Go to definition
           --> main.py:10:2
            |
          8 | b = Test()
          9 |
         10 | a+b
-           |  ^
+           |  ^ Clicking here
            |
+        info: Found 1 definition
+         --> main.py:3:9
+          |
+        2 | class Test:
+        3 |     def __add__(self, other):
+          |         -------
+        4 |         return Test()
+          |
         ");
     }
 
@@ -1245,22 +1204,22 @@ a+<CURSOR>b
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-          --> main.py:8:1
-           |
-         7 | a = Test()
-         8 | b = Test()
-           | ^
-         9 |
-        10 | a+b
-           |
-        info: Source
+        info[goto-definition]: Go to definition
           --> main.py:10:3
            |
          8 | b = Test()
          9 |
         10 | a+b
-           |   ^
+           |   ^ Clicking here
+           |
+        info: Found 1 definition
+          --> main.py:8:1
+           |
+         7 | a = Test()
+         8 | b = Test()
+           | -
+         9 |
+        10 | a+b
            |
         ");
     }
@@ -1304,22 +1263,22 @@ a = Test()
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> main.py:3:9
-          |
-        2 | class Test:
-        3 |     def __invert__(self) -> 'Test': ...
-          |         ^^^^^^^^^^
-        4 |
-        5 | a = Test()
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:7:1
           |
         5 | a = Test()
         6 |
         7 | ~a
-          | ^
+          | ^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:3:9
+          |
+        2 | class Test:
+        3 |     def __invert__(self) -> 'Test': ...
+          |         ----------
+        4 |
+        5 | a = Test()
           |
         ");
     }
@@ -1342,22 +1301,22 @@ a = Test()
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> main.py:3:9
-          |
-        2 | class Test:
-        3 |     def __invert__(self, extra_arg) -> 'Test': ...
-          |         ^^^^^^^^^^
-        4 |
-        5 | a = Test()
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:7:1
           |
         5 | a = Test()
         6 |
         7 | ~a
-          | ^
+          | ^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:3:9
+          |
+        2 | class Test:
+        3 |     def __invert__(self, extra_arg) -> 'Test': ...
+          |         ----------
+        4 |
+        5 | a = Test()
           |
         ");
     }
@@ -1379,22 +1338,22 @@ a = Test()
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> main.py:3:9
-          |
-        2 | class Test:
-        3 |     def __invert__(self) -> 'Test': ...
-          |         ^^^^^^^^^^
-        4 |
-        5 | a = Test()
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:7:1
           |
         5 | a = Test()
         6 |
         7 | ~ a
-          | ^
+          | ^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:3:9
+          |
+        2 | class Test:
+        3 |     def __invert__(self) -> 'Test': ...
+          |         ----------
+        4 |
+        5 | a = Test()
           |
         ");
     }
@@ -1416,23 +1375,23 @@ a = Test()
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> main.py:5:1
-          |
-        3 |     def __invert__(self) -> 'Test': ...
-        4 |
-        5 | a = Test()
-          | ^
-        6 |
-        7 | -a
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:7:2
           |
         5 | a = Test()
         6 |
         7 | -a
-          |  ^
+          |  ^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:5:1
+          |
+        3 |     def __invert__(self) -> 'Test': ...
+        4 |
+        5 | a = Test()
+          | -
+        6 |
+        7 | -a
           |
         ");
     }
@@ -1454,22 +1413,22 @@ a = Test()
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> main.py:3:9
-          |
-        2 | class Test:
-        3 |     def __bool__(self) -> bool: ...
-          |         ^^^^^^^^
-        4 |
-        5 | a = Test()
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:7:1
           |
         5 | a = Test()
         6 |
         7 | not a
-          | ^^^
+          | ^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:3:9
+          |
+        2 | class Test:
+        3 |     def __bool__(self) -> bool: ...
+          |         --------
+        4 |
+        5 | a = Test()
           |
         ");
     }
@@ -1491,22 +1450,22 @@ a = Test()
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> main.py:3:9
-          |
-        2 | class Test:
-        3 |     def __len__(self) -> 42: ...
-          |         ^^^^^^^
-        4 |
-        5 | a = Test()
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:7:1
           |
         5 | a = Test()
         6 |
         7 | not a
-          | ^^^
+          | ^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:3:9
+          |
+        2 | class Test:
+        3 |     def __len__(self) -> 42: ...
+          |         -------
+        4 |
+        5 | a = Test()
           |
         ");
     }
@@ -1532,21 +1491,21 @@ a = Test()
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> main.py:3:9
-          |
-        2 | class Test:
-        3 |     def __bool__(self, extra_arg) -> bool: ...
-          |         ^^^^^^^^
-        4 |     def __len__(self) -> 42: ...
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:8:1
           |
         6 | a = Test()
         7 |
         8 | not a
-          | ^^^
+          | ^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:3:9
+          |
+        2 | class Test:
+        3 |     def __bool__(self, extra_arg) -> bool: ...
+          |         --------
+        4 |     def __len__(self) -> 42: ...
           |
         ");
     }
@@ -1572,22 +1531,22 @@ a = Test()
             .build();
 
         assert_snapshot!(test.goto_definition(), @r"
-        info[goto-definition]: Definition
-         --> main.py:3:9
-          |
-        2 | class Test:
-        3 |     def __len__(self, extra_arg) -> 42: ...
-          |         ^^^^^^^
-        4 |
-        5 | a = Test()
-          |
-        info: Source
+        info[goto-definition]: Go to definition
          --> main.py:7:1
           |
         5 | a = Test()
         6 |
         7 | not a
-          | ^^^
+          | ^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:3:9
+          |
+        2 | class Test:
+        3 |     def __len__(self, extra_arg) -> 42: ...
+          |         -------
+        4 |
+        5 | a = Test()
           |
         ");
     }
@@ -1604,36 +1563,28 @@ a: float<CURSOR> = 3.14
             .build();
 
         assert_snapshot!(test.goto_definition(), @r#"
-        info[goto-definition]: Definition
+        info[goto-definition]: Go to definition
+         --> main.py:2:4
+          |
+        2 | a: float = 3.14
+          |    ^^^^^ Clicking here
+          |
+        info: Found 2 definitions
            --> stdlib/builtins.pyi:348:7
             |
         347 | @disjoint_base
         348 | class int:
-            |       ^^^
+            |       ---
         349 |     """int([x]) -> integer
         350 |     int(x, base=10) -> integer
             |
-        info: Source
-         --> main.py:2:4
-          |
-        2 | a: float = 3.14
-          |    ^^^^^
-          |
-
-        info[goto-definition]: Definition
-           --> stdlib/builtins.pyi:661:7
+           ::: stdlib/builtins.pyi:661:7
             |
         660 | @disjoint_base
         661 | class float:
-            |       ^^^^^
+            |       -----
         662 |     """Convert a string or number to a floating-point number, if possible."""
             |
-        info: Source
-         --> main.py:2:4
-          |
-        2 | a: float = 3.14
-          |    ^^^^^
-          |
         "#);
     }
 
@@ -1649,51 +1600,35 @@ a: complex<CURSOR> = 3.14
             .build();
 
         assert_snapshot!(test.goto_definition(), @r#"
-        info[goto-definition]: Definition
+        info[goto-definition]: Go to definition
+         --> main.py:2:4
+          |
+        2 | a: complex = 3.14
+          |    ^^^^^^^ Clicking here
+          |
+        info: Found 3 definitions
            --> stdlib/builtins.pyi:348:7
             |
         347 | @disjoint_base
         348 | class int:
-            |       ^^^
+            |       ---
         349 |     """int([x]) -> integer
         350 |     int(x, base=10) -> integer
             |
-        info: Source
-         --> main.py:2:4
-          |
-        2 | a: complex = 3.14
-          |    ^^^^^^^
-          |
-
-        info[goto-definition]: Definition
-           --> stdlib/builtins.pyi:661:7
+           ::: stdlib/builtins.pyi:661:7
             |
         660 | @disjoint_base
         661 | class float:
-            |       ^^^^^
+            |       -----
         662 |     """Convert a string or number to a floating-point number, if possible."""
             |
-        info: Source
-         --> main.py:2:4
-          |
-        2 | a: complex = 3.14
-          |    ^^^^^^^
-          |
-
-        info[goto-definition]: Definition
-           --> stdlib/builtins.pyi:822:7
+           ::: stdlib/builtins.pyi:822:7
             |
         821 | @disjoint_base
         822 | class complex:
-            |       ^^^^^^^
+            |       -------
         823 |     """Create a complex number from a string or numbers.
             |
-        info: Source
-         --> main.py:2:4
-          |
-        2 | a: complex = 3.14
-          |    ^^^^^^^
-          |
         "#);
     }
 
@@ -1733,63 +1668,29 @@ Traceb<CURSOR>ackType
             .build();
 
         assert_snapshot!(test.goto_definition(), @r#"
-        info[goto-definition]: Definition
+        info[goto-definition]: Go to definition
+         --> main.py:6:7
+          |
+        4 | a: int = 10
+        5 |
+        6 | print(a)
+          |       ^ Clicking here
+        7 |
+        8 | a: bool = True
+          |
+        info: Found 3 definitions
          --> main.py:2:1
           |
         2 | a: str = "test"
-          | ^
+          | -
         3 |
         4 | a: int = 10
-          |
-        info: Source
-         --> main.py:6:7
-          |
-        4 | a: int = 10
+          | -
         5 |
-        6 | print(a)
-          |       ^
-        7 |
-        8 | a: bool = True
-          |
-
-        info[goto-definition]: Definition
-         --> main.py:4:1
-          |
-        2 | a: str = "test"
-        3 |
-        4 | a: int = 10
-          | ^
-        5 |
-        6 | print(a)
-          |
-        info: Source
-         --> main.py:6:7
-          |
-        4 | a: int = 10
-        5 |
-        6 | print(a)
-          |       ^
-        7 |
-        8 | a: bool = True
-          |
-
-        info[goto-definition]: Definition
-         --> main.py:8:1
-          |
         6 | print(a)
         7 |
         8 | a: bool = True
-          | ^
-          |
-        info: Source
-         --> main.py:6:7
-          |
-        4 | a: int = 10
-        5 |
-        6 | print(a)
-          |       ^
-        7 |
-        8 | a: bool = True
+          | -
           |
         "#);
     }
@@ -1805,47 +1706,86 @@ Traceb<CURSOR>ackType
                 return "No definitions found".to_string();
             }
 
-            let source = targets.range;
-            self.render_diagnostics(
-                targets
-                    .into_iter()
-                    .map(|target| GotoDefinitionDiagnostic::new(source, &target)),
-            )
+            self.render_diagnostics([GotoDiagnostic::new(GotoAction::Definition, targets)])
         }
     }
 
-    struct GotoDefinitionDiagnostic {
-        source: FileRange,
-        target: FileRange,
+    pub(crate) struct GotoDiagnostic {
+        action: GotoAction,
+        targets: RangedValue<NavigationTargets>,
     }
 
-    impl GotoDefinitionDiagnostic {
-        fn new(source: FileRange, target: &NavigationTarget) -> Self {
-            Self {
-                source,
-                target: FileRange::new(target.file(), target.focus_range()),
-            }
+    impl GotoDiagnostic {
+        pub(crate) fn new(action: GotoAction, targets: RangedValue<NavigationTargets>) -> Self {
+            Self { action, targets }
         }
     }
 
-    impl IntoDiagnostic for GotoDefinitionDiagnostic {
+    impl IntoDiagnostic for GotoDiagnostic {
         fn into_diagnostic(self) -> Diagnostic {
-            let mut source = SubDiagnostic::new(SubDiagnosticSeverity::Info, "Source");
-            source.annotate(Annotation::primary(
-                Span::from(self.source.file()).with_range(self.source.range()),
-            ));
-
+            let source = self.targets.range;
             let mut main = Diagnostic::new(
-                DiagnosticId::Lint(LintName::of("goto-definition")),
+                DiagnosticId::Lint(LintName::of(self.action.name())),
                 Severity::Info,
-                "Definition".to_string(),
+                self.action.label().to_string(),
             );
-            main.annotate(Annotation::primary(
-                Span::from(self.target.file()).with_range(self.target.range()),
-            ));
-            main.sub(source);
+
+            main.annotate(
+                Annotation::primary(Span::from(source.file()).with_range(source.range()))
+                    .message("Clicking here"),
+            );
+
+            let mut sub = SubDiagnostic::new(
+                SubDiagnosticSeverity::Info,
+                format_args!(
+                    "Found {} {}{}",
+                    self.targets.len(),
+                    self.action.item_label(),
+                    if self.targets.len() == 1 { "" } else { "s" }
+                ),
+            );
+
+            for target in self.targets {
+                sub.annotate(Annotation::secondary(
+                    Span::from(target.file()).with_range(target.focus_range()),
+                ));
+            }
+
+            main.sub(sub);
 
             main
+        }
+    }
+
+    pub(crate) enum GotoAction {
+        Definition,
+        Declaration,
+        TypeDefinition,
+    }
+
+    impl GotoAction {
+        fn name(&self) -> &'static str {
+            match self {
+                GotoAction::Definition => "goto-definition",
+                GotoAction::Declaration => "goto-declaration",
+                GotoAction::TypeDefinition => "goto-type definition",
+            }
+        }
+
+        fn label(&self) -> &'static str {
+            match self {
+                GotoAction::Definition => "Go to definition",
+                GotoAction::Declaration => "Go to declaration",
+                GotoAction::TypeDefinition => "Go to type definition",
+            }
+        }
+
+        fn item_label(&self) -> &'static str {
+            match self {
+                GotoAction::Definition => "definition",
+                GotoAction::Declaration => "declaration",
+                GotoAction::TypeDefinition => "type definition",
+            }
         }
     }
 }

--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -28,15 +28,9 @@ pub fn goto_type_definition(
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::{CursorTest, IntoDiagnostic, cursor_test};
-    use crate::{NavigationTarget, goto_type_definition};
+    use crate::goto_type_definition;
+    use crate::tests::{CursorTest, cursor_test};
     use insta::assert_snapshot;
-    use ruff_db::diagnostic::{
-        Annotation, Diagnostic, DiagnosticId, LintName, Severity, Span, SubDiagnostic,
-        SubDiagnosticSeverity,
-    };
-    use ruff_db::files::FileRange;
-    use ruff_text_size::Ranged;
 
     #[test]
     fn goto_type_of_expression_with_class_type() {
@@ -49,21 +43,21 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> main.py:2:7
-          |
-        2 | class Test: ...
-          |       ^^^^
-        3 |
-        4 | ab = Test()
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:4:1
           |
         2 | class Test: ...
         3 |
         4 | ab = Test()
-          | ^^
+          | ^^ Clicking here
+          |
+        info: Found 1 type definition
+         --> main.py:2:7
+          |
+        2 | class Test: ...
+          |       ----
+        3 |
+        4 | ab = Test()
           |
         ");
     }
@@ -79,23 +73,23 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-           --> stdlib/typing.pyi:351:1
-            |
-        349 | Final: _SpecialForm
-        350 |
-        351 | Literal: _SpecialForm
-            | ^^^^^^^
-        352 | TypedDict: _SpecialForm
-            |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:4:1
           |
         2 | from typing import Literal
         3 |
         4 | ab = Literal
-          | ^^
+          | ^^ Clicking here
           |
+        info: Found 1 type definition
+           --> stdlib/typing.pyi:351:1
+            |
+        349 | Final: _SpecialForm
+        350 |
+        351 | Literal: _SpecialForm
+            | -------
+        352 | TypedDict: _SpecialForm
+            |
         ");
     }
 
@@ -112,23 +106,23 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
-           --> stdlib/typing.pyi:166:7
-            |
-        164 | # from _typeshed import AnnotationForm
-        165 |
-        166 | class Any:
-            |       ^^^
-        167 |     """Special type indicating an unconstrained type.
-            |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:4:1
           |
         2 | from typing import Any
         3 |
         4 | ab = Any
-          | ^^
+          | ^^ Clicking here
           |
+        info: Found 1 type definition
+           --> stdlib/typing.pyi:166:7
+            |
+        164 | # from _typeshed import AnnotationForm
+        165 |
+        166 | class Any:
+            |       ---
+        167 |     """Special type indicating an unconstrained type.
+            |
         "#);
     }
 
@@ -144,24 +138,24 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-           --> stdlib/typing.pyi:781:1
-            |
-        779 |         def __class_getitem__(cls, args: TypeVar | tuple[TypeVar, ...]) -> _Final: ...
-        780 |
-        781 | Generic: type[_Generic]
-            | ^^^^^^^
-        782 |
-        783 | class _ProtocolMeta(ABCMeta):
-            |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:4:1
           |
         2 | from typing import Generic
         3 |
         4 | ab = Generic
-          | ^^
+          | ^^ Clicking here
           |
+        info: Found 1 type definition
+           --> stdlib/typing.pyi:781:1
+            |
+        779 |         def __class_getitem__(cls, args: TypeVar | tuple[TypeVar, ...]) -> _Final: ...
+        780 |
+        781 | Generic: type[_Generic]
+            | -------
+        782 |
+        783 | class _ProtocolMeta(ABCMeta):
+            |
         ");
     }
 
@@ -176,23 +170,23 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-          --> stdlib/ty_extensions.pyi:21:1
-           |
-        19 | # Types
-        20 | Unknown = object()
-        21 | AlwaysTruthy = object()
-           | ^^^^^^^^^^^^
-        22 | AlwaysFalsy = object()
-           |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:4:1
           |
         2 | from ty_extensions import AlwaysTruthy
         3 |
         4 | ab = AlwaysTruthy
-          | ^^
+          | ^^ Clicking here
           |
+        info: Found 1 type definition
+          --> stdlib/ty_extensions.pyi:21:1
+           |
+        19 | # Types
+        20 | Unknown = object()
+        21 | AlwaysTruthy = object()
+           | ------------
+        22 | AlwaysFalsy = object()
+           |
         ");
     }
 
@@ -209,21 +203,21 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> main.py:2:5
-          |
-        2 | def foo(a, b): ...
-          |     ^^^
-        3 |
-        4 | ab = foo
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:6:1
           |
         4 | ab = foo
         5 |
         6 | ab
-          | ^^
+          | ^^ Clicking here
+          |
+        info: Found 1 type definition
+         --> main.py:2:5
+          |
+        2 | def foo(a, b): ...
+          |     ---
+        3 |
+        4 | ab = foo
           |
         ");
     }
@@ -247,41 +241,25 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
+        info[goto-type definition]: Go to type definition
+          --> main.py:12:1
+           |
+        10 |     a = bar
+        11 |
+        12 | a
+           | ^ Clicking here
+           |
+        info: Found 2 type definitions
          --> main.py:3:5
           |
         3 | def foo(a, b): ...
-          |     ^^^
+          |     ---
         4 |
         5 | def bar(a, b): ...
-          |
-        info: Source
-          --> main.py:12:1
-           |
-        10 |     a = bar
-        11 |
-        12 | a
-           | ^
-           |
-
-        info[goto-type-definition]: Type definition
-         --> main.py:5:5
-          |
-        3 | def foo(a, b): ...
-        4 |
-        5 | def bar(a, b): ...
-          |     ^^^
+          |     ---
         6 |
         7 | if random.choice():
           |
-        info: Source
-          --> main.py:12:1
-           |
-        10 |     a = bar
-        11 |
-        12 | a
-           | ^
-           |
         ");
     }
 
@@ -296,17 +274,17 @@ mod tests {
         test.write_file("lib.py", "a = 10").unwrap();
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> lib.py:1:1
-          |
-        1 | a = 10
-          | ^^^^^^
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:2:8
           |
         2 | import lib
-          |        ^^^
+          |        ^^^ Clicking here
+          |
+        info: Found 1 type definition
+         --> lib.py:1:1
+          |
+        1 | a = 10
+          | ------
           |
         ");
     }
@@ -323,17 +301,17 @@ mod tests {
         test.write_file("lib/submod.py", "a = 10").unwrap();
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> lib/__init__.py:1:1
-          |
-        1 | b = 7
-          | ^^^^^
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:2:8
           |
         2 | import lib.submod
-          |        ^^^
+          |        ^^^ Clicking here
+          |
+        info: Found 1 type definition
+         --> lib/__init__.py:1:1
+          |
+        1 | b = 7
+          | -----
           |
         ");
     }
@@ -350,17 +328,17 @@ mod tests {
         test.write_file("lib/submod.py", "a = 10").unwrap();
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> lib/submod.py:1:1
-          |
-        1 | a = 10
-          | ^^^^^^
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:2:12
           |
         2 | import lib.submod
-          |            ^^^^^^
+          |            ^^^^^^ Clicking here
+          |
+        info: Found 1 type definition
+         --> lib/submod.py:1:1
+          |
+        1 | a = 10
+          | ------
           |
         ");
     }
@@ -376,17 +354,17 @@ mod tests {
         test.write_file("lib.py", "a = 10").unwrap();
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> lib.py:1:1
-          |
-        1 | a = 10
-          | ^^^^^^
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:2:6
           |
         2 | from lib import a
-          |      ^^^
+          |      ^^^ Clicking here
+          |
+        info: Found 1 type definition
+         --> lib.py:1:1
+          |
+        1 | a = 10
+          | ------
           |
         ");
     }
@@ -403,17 +381,17 @@ mod tests {
         test.write_file("lib/submod.py", "a = 10").unwrap();
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> lib/__init__.py:1:1
-          |
-        1 | b = 7
-          | ^^^^^
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:2:6
           |
         2 | from lib.submod import a
-          |      ^^^
+          |      ^^^ Clicking here
+          |
+        info: Found 1 type definition
+         --> lib/__init__.py:1:1
+          |
+        1 | b = 7
+          | -----
           |
         ");
     }
@@ -430,17 +408,17 @@ mod tests {
         test.write_file("lib/submod.py", "a = 10").unwrap();
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> lib/submod.py:1:1
-          |
-        1 | a = 10
-          | ^^^^^^
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:2:10
           |
         2 | from lib.submod import a
-          |          ^^^^^^
+          |          ^^^^^^ Clicking here
+          |
+        info: Found 1 type definition
+         --> lib/submod.py:1:1
+          |
+        1 | a = 10
+          | ------
           |
         ");
     }
@@ -466,18 +444,18 @@ mod tests {
             .unwrap();
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> lib/sub/bot/botmod.py:1:1
-          |
-        1 | botmod = 31
-          | ^^^^^^^^^^^
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> lib/sub/__init__.py:2:11
           |
         2 | from .bot.botmod import *
-          |           ^^^^^^
+          |           ^^^^^^ Clicking here
         3 | sub = 2
+          |
+        info: Found 1 type definition
+         --> lib/sub/bot/botmod.py:1:1
+          |
+        1 | botmod = 31
+          | -----------
           |
         ");
     }
@@ -503,18 +481,18 @@ mod tests {
             .unwrap();
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> lib/sub/bot/__init__.py:1:1
-          |
-        1 | bot = 3
-          | ^^^^^^^
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> lib/sub/__init__.py:2:7
           |
         2 | from .bot.botmod import *
-          |       ^^^
+          |       ^^^ Clicking here
         3 | sub = 2
+          |
+        info: Found 1 type definition
+         --> lib/sub/bot/__init__.py:1:1
+          |
+        1 | bot = 3
+          | -------
           |
         ");
     }
@@ -540,18 +518,18 @@ mod tests {
             .unwrap();
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> lib/sub/bot/__init__.py:1:1
-          |
-        1 | bot = 3
-          | ^^^^^^^
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> lib/sub/__init__.py:2:7
           |
         2 | from .bot.botmod import *
-          |       ^^^
+          |       ^^^ Clicking here
         3 | sub = 2
+          |
+        info: Found 1 type definition
+         --> lib/sub/bot/__init__.py:1:1
+          |
+        1 | bot = 3
+          | -------
           |
         ");
     }
@@ -592,19 +570,19 @@ mod tests {
         test.write_file("lib.py", "a = 10").unwrap();
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> lib.py:1:1
-          |
-        1 | a = 10
-          | ^^^^^^
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:4:1
           |
         2 | import lib
         3 |
         4 | lib
-          | ^^^
+          | ^^^ Clicking here
+          |
+        info: Found 1 type definition
+         --> lib.py:1:1
+          |
+        1 | a = 10
+          | ------
           |
         ");
     }
@@ -620,23 +598,23 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
-           --> stdlib/builtins.pyi:915:7
-            |
-        914 | @disjoint_base
-        915 | class str(Sequence[str]):
-            |       ^^^
-        916 |     """str(object='') -> str
-        917 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
-            |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:4:1
           |
         2 | a: str = "test"
         3 |
         4 | a
-          | ^
+          | ^ Clicking here
           |
+        info: Found 1 type definition
+           --> stdlib/builtins.pyi:915:7
+            |
+        914 | @disjoint_base
+        915 | class str(Sequence[str]):
+            |       ---
+        916 |     """str(object='') -> str
+        917 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
+            |
         "#);
     }
     #[test]
@@ -648,21 +626,21 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
+        info[goto-type definition]: Go to type definition
+         --> main.py:2:10
+          |
+        2 | a: str = "test"
+          |          ^^^^^^ Clicking here
+          |
+        info: Found 1 type definition
            --> stdlib/builtins.pyi:915:7
             |
         914 | @disjoint_base
         915 | class str(Sequence[str]):
-            |       ^^^
+            |       ---
         916 |     """str(object='') -> str
         917 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
             |
-        info: Source
-         --> main.py:2:10
-          |
-        2 | a: str = "test"
-          |          ^^^^^^
-          |
         "#);
     }
 
@@ -675,17 +653,17 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> main.py:2:12
-          |
-        2 | type Alias[T: int = bool] = list[T]
-          |            ^
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:2:34
           |
         2 | type Alias[T: int = bool] = list[T]
-          |                                  ^
+          |                                  ^ Clicking here
+          |
+        info: Found 1 type definition
+         --> main.py:2:12
+          |
+        2 | type Alias[T: int = bool] = list[T]
+          |            -
           |
         ");
     }
@@ -699,17 +677,17 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> main.py:2:14
-          |
-        2 | type Alias[**P = [int, str]] = Callable[P, int]
-          |              ^
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:2:41
           |
         2 | type Alias[**P = [int, str]] = Callable[P, int]
-          |                                         ^
+          |                                         ^ Clicking here
+          |
+        info: Found 1 type definition
+         --> main.py:2:14
+          |
+        2 | type Alias[**P = [int, str]] = Callable[P, int]
+          |              -
           |
         ");
     }
@@ -756,22 +734,22 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
+        info[goto-type definition]: Go to type definition
+         --> main.py:2:5
+          |
+        2 | a: "MyClass" = 1
+          |     ^^^^^^^ Clicking here
+        3 |
+        4 | class MyClass:
+          |
+        info: Found 1 type definition
          --> main.py:4:7
           |
         2 | a: "MyClass" = 1
         3 |
         4 | class MyClass:
-          |       ^^^^^^^
+          |       -------
         5 |     """some docs"""
-          |
-        info: Source
-         --> main.py:2:5
-          |
-        2 | a: "MyClass" = 1
-          |     ^^^^^^^
-        3 |
-        4 | class MyClass:
           |
         "#);
     }
@@ -802,41 +780,31 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
-         --> main.py:4:7
-          |
-        2 | a: "None | MyClass" = 1
-        3 |
-        4 | class MyClass:
-          |       ^^^^^^^
-        5 |     """some docs"""
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:2:4
           |
         2 | a: "None | MyClass" = 1
-          |    ^^^^^^^^^^^^^^^^
+          |    ^^^^^^^^^^^^^^^^ Clicking here
         3 |
         4 | class MyClass:
           |
-
-        info[goto-type-definition]: Type definition
-           --> stdlib/types.pyi:950:11
+        info: Found 2 type definitions
+           --> main.py:4:7
+            |
+          2 | a: "None | MyClass" = 1
+          3 |
+          4 | class MyClass:
+            |       -------
+          5 |     """some docs"""
+            |
+           ::: stdlib/types.pyi:950:11
             |
         948 | if sys.version_info >= (3, 10):
         949 |     @final
         950 |     class NoneType:
-            |           ^^^^^^^^
+            |           --------
         951 |         """The type of the None singleton."""
             |
-        info: Source
-         --> main.py:2:4
-          |
-        2 | a: "None | MyClass" = 1
-          |    ^^^^^^^^^^^^^^^^
-        3 |
-        4 | class MyClass:
-          |
         "#);
     }
 
@@ -866,41 +834,31 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
-         --> main.py:4:7
-          |
-        2 | a: "None | MyClass" = 1
-        3 |
-        4 | class MyClass:
-          |       ^^^^^^^
-        5 |     """some docs"""
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:2:4
           |
         2 | a: "None | MyClass" = 1
-          |    ^^^^^^^^^^^^^^^^
+          |    ^^^^^^^^^^^^^^^^ Clicking here
         3 |
         4 | class MyClass:
           |
-
-        info[goto-type-definition]: Type definition
-           --> stdlib/types.pyi:950:11
+        info: Found 2 type definitions
+           --> main.py:4:7
+            |
+          2 | a: "None | MyClass" = 1
+          3 |
+          4 | class MyClass:
+            |       -------
+          5 |     """some docs"""
+            |
+           ::: stdlib/types.pyi:950:11
             |
         948 | if sys.version_info >= (3, 10):
         949 |     @final
         950 |     class NoneType:
-            |           ^^^^^^^^
+            |           --------
         951 |         """The type of the None singleton."""
             |
-        info: Source
-         --> main.py:2:4
-          |
-        2 | a: "None | MyClass" = 1
-          |    ^^^^^^^^^^^^^^^^
-        3 |
-        4 | class MyClass:
-          |
         "#);
     }
 
@@ -916,23 +874,23 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
+        info[goto-type definition]: Go to type definition
+         --> main.py:2:4
+          |
+        2 | a: "MyClass |" = 1
+          |    ^^^^^^^^^^^ Clicking here
+        3 |
+        4 | class MyClass:
+          |
+        info: Found 1 type definition
           --> stdlib/ty_extensions.pyi:20:1
            |
         19 | # Types
         20 | Unknown = object()
-           | ^^^^^^^
+           | -------
         21 | AlwaysTruthy = object()
         22 | AlwaysFalsy = object()
            |
-        info: Source
-         --> main.py:2:4
-          |
-        2 | a: "MyClass |" = 1
-          |    ^^^^^^^^^^^
-        3 |
-        4 | class MyClass:
-          |
         "#);
     }
 
@@ -973,21 +931,21 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
+        info[goto-type definition]: Go to type definition
+         --> main.py:2:6
+          |
+        2 | ab: "ab"
+          |      ^^ Clicking here
+          |
+        info: Found 1 type definition
           --> stdlib/ty_extensions.pyi:20:1
            |
         19 | # Types
         20 | Unknown = object()
-           | ^^^^^^^
+           | -------
         21 | AlwaysTruthy = object()
         22 | AlwaysFalsy = object()
            |
-        info: Source
-         --> main.py:2:6
-          |
-        2 | ab: "ab"
-          |      ^^
-          |
         "#);
     }
 
@@ -1000,21 +958,21 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
+        info[goto-type definition]: Go to type definition
+         --> main.py:2:5
+          |
+        2 | x: "foobar"
+          |     ^^^^^^ Clicking here
+          |
+        info: Found 1 type definition
           --> stdlib/ty_extensions.pyi:20:1
            |
         19 | # Types
         20 | Unknown = object()
-           | ^^^^^^^
+           | -------
         21 | AlwaysTruthy = object()
         22 | AlwaysFalsy = object()
            |
-        info: Source
-         --> main.py:2:5
-          |
-        2 | x: "foobar"
-          |     ^^^^^^
-          |
         "#);
     }
 
@@ -1160,23 +1118,23 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
-         --> main.py:2:7
-          |
-        2 | class Click:
-          |       ^^^^^
-        3 |     __match_args__ = ("position", "button")
-        4 |     def __init__(self, pos, btn):
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
           --> main.py:10:14
            |
          8 | def my_func(event: Click):
          9 |     match event:
         10 |         case Click(x, button=ab):
-           |              ^^^^^
+           |              ^^^^^ Clicking here
         11 |             x = ab
            |
+        info: Found 1 type definition
+         --> main.py:2:7
+          |
+        2 | class Click:
+          |       -----
+        3 |     __match_args__ = ("position", "button")
+        4 |     def __init__(self, pos, btn):
+          |
         "#);
     }
 
@@ -1209,17 +1167,17 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
+        info[goto-type definition]: Go to type definition
          --> main.py:2:13
           |
         2 | type Alias1[AB: int = bool] = tuple[AB, list[AB]]
-          |             ^^
+          |             ^^ Clicking here
           |
-        info: Source
+        info: Found 1 type definition
          --> main.py:2:13
           |
         2 | type Alias1[AB: int = bool] = tuple[AB, list[AB]]
-          |             ^^
+          |             --
           |
         ");
     }
@@ -1233,17 +1191,17 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> main.py:2:13
-          |
-        2 | type Alias1[AB: int = bool] = tuple[AB, list[AB]]
-          |             ^^
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:2:37
           |
         2 | type Alias1[AB: int = bool] = tuple[AB, list[AB]]
-          |                                     ^^
+          |                                     ^^ Clicking here
+          |
+        info: Found 1 type definition
+         --> main.py:2:13
+          |
+        2 | type Alias1[AB: int = bool] = tuple[AB, list[AB]]
+          |             --
           |
         ");
     }
@@ -1305,23 +1263,23 @@ mod tests {
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
-           --> stdlib/builtins.pyi:915:7
-            |
-        914 | @disjoint_base
-        915 | class str(Sequence[str]):
-            |       ^^^
-        916 |     """str(object='') -> str
-        917 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
-            |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:4:6
           |
         2 | def test(a: str): ...
         3 |
         4 | test(a= "123")
-          |      ^
+          |      ^ Clicking here
           |
+        info: Found 1 type definition
+           --> stdlib/builtins.pyi:915:7
+            |
+        914 | @disjoint_base
+        915 | class str(Sequence[str]):
+            |       ---
+        916 |     """str(object='') -> str
+        917 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
+            |
         "#);
     }
 
@@ -1339,23 +1297,23 @@ mod tests {
         //   the keyword is typed as a string. It's only the passed argument that
         //   is an int. Navigating to `str` would match pyright's behavior.
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
-           --> stdlib/builtins.pyi:348:7
-            |
-        347 | @disjoint_base
-        348 | class int:
-            |       ^^^
-        349 |     """int([x]) -> integer
-        350 |     int(x, base=10) -> integer
-            |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:4:6
           |
         2 | def test(a: str): ...
         3 |
         4 | test(a= 123)
-          |      ^
+          |      ^ Clicking here
           |
+        info: Found 1 type definition
+           --> stdlib/builtins.pyi:348:7
+            |
+        347 | @disjoint_base
+        348 | class int:
+            |       ---
+        349 |     """int([x]) -> integer
+        350 |     int(x, base=10) -> integer
+            |
         "#);
     }
 
@@ -1372,23 +1330,23 @@ f(**kwargs<CURSOR>)
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
-            --> stdlib/builtins.pyi:2920:7
-             |
-        2919 | @disjoint_base
-        2920 | class dict(MutableMapping[_KT, _VT]):
-             |       ^^^^
-        2921 |     """dict() -> new empty dictionary
-        2922 |     dict(mapping) -> new dictionary initialized from a mapping object's
-             |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:6:5
           |
         4 | kwargs = { "name": "test"}
         5 |
         6 | f(**kwargs)
-          |     ^^^^^^
+          |     ^^^^^^ Clicking here
           |
+        info: Found 1 type definition
+            --> stdlib/builtins.pyi:2920:7
+             |
+        2919 | @disjoint_base
+        2920 | class dict(MutableMapping[_KT, _VT]):
+             |       ----
+        2921 |     """dict() -> new empty dictionary
+        2922 |     dict(mapping) -> new dictionary initialized from a mapping object's
+             |
         "#);
     }
 
@@ -1410,25 +1368,25 @@ def outer():
 
         // Should find the variable declaration in the outer scope, not the nonlocal statement
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
-           --> stdlib/builtins.pyi:915:7
-            |
-        914 | @disjoint_base
-        915 | class str(Sequence[str]):
-            |       ^^^
-        916 |     """str(object='') -> str
-        917 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
-            |
-        info: Source
+        info[goto-type definition]: Go to type definition
           --> main.py:8:16
            |
          6 |         nonlocal x
          7 |         x = "modified"
          8 |         return x  # Should find the nonlocal x declaration in outer scope
-           |                ^
+           |                ^ Clicking here
          9 |
         10 |     return inner
            |
+        info: Found 1 type definition
+           --> stdlib/builtins.pyi:915:7
+            |
+        914 | @disjoint_base
+        915 | class str(Sequence[str]):
+            |       ---
+        916 |     """str(object='') -> str
+        917 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
+            |
         "#);
     }
 
@@ -1467,23 +1425,23 @@ def function():
 
         // Should find the global variable declaration, not the global statement
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
-           --> stdlib/builtins.pyi:915:7
-            |
-        914 | @disjoint_base
-        915 | class str(Sequence[str]):
-            |       ^^^
-        916 |     """str(object='') -> str
-        917 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
-            |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:7:12
           |
         5 |     global global_var
         6 |     global_var = "modified"
         7 |     return global_var  # Should find the global variable declaration
-          |            ^^^^^^^^^^
+          |            ^^^^^^^^^^ Clicking here
           |
+        info: Found 1 type definition
+           --> stdlib/builtins.pyi:915:7
+            |
+        914 | @disjoint_base
+        915 | class str(Sequence[str]):
+            |       ---
+        916 |     """str(object='') -> str
+        917 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
+            |
         "#);
     }
 
@@ -1514,22 +1472,22 @@ def function():
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
-           --> stdlib/builtins.pyi:915:7
-            |
-        914 | @disjoint_base
-        915 | class str(Sequence[str]):
-            |       ^^^
-        916 |     """str(object='') -> str
-        917 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
-            |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:3:5
           |
         2 | def foo(a: str):
         3 |     a
-          |     ^
+          |     ^ Clicking here
           |
+        info: Found 1 type definition
+           --> stdlib/builtins.pyi:915:7
+            |
+        914 | @disjoint_base
+        915 | class str(Sequence[str]):
+            |       ---
+        916 |     """str(object='') -> str
+        917 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
+            |
         "#);
     }
 
@@ -1547,20 +1505,20 @@ def function():
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> main.py:2:7
-          |
-        2 | class X:
-          |       ^
-        3 |     def foo(a, b): ...
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:7:1
           |
         5 | x = X()
         6 |
         7 | x.foo()
-          | ^
+          | ^ Clicking here
+          |
+        info: Found 1 type definition
+         --> main.py:2:7
+          |
+        2 | class X:
+          |       -
+        3 |     def foo(a, b): ...
           |
         ");
     }
@@ -1576,21 +1534,21 @@ def function():
         );
 
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-         --> main.py:2:5
-          |
-        2 | def foo(a, b): ...
-          |     ^^^
-        3 |
-        4 | foo()
-          |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:4:1
           |
         2 | def foo(a, b): ...
         3 |
         4 | foo()
-          | ^^^
+          | ^^^ Clicking here
+          |
+        info: Found 1 type definition
+         --> main.py:2:5
+          |
+        2 | def foo(a, b): ...
+          |     ---
+        3 |
+        4 | foo()
           |
         ");
     }
@@ -1606,23 +1564,23 @@ def function():
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
-           --> stdlib/builtins.pyi:915:7
-            |
-        914 | @disjoint_base
-        915 | class str(Sequence[str]):
-            |       ^^^
-        916 |     """str(object='') -> str
-        917 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
-            |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:4:15
           |
         2 | def foo(a: str | None, b):
         3 |     if a is not None:
         4 |         print(a)
-          |               ^
+          |               ^ Clicking here
           |
+        info: Found 1 type definition
+           --> stdlib/builtins.pyi:915:7
+            |
+        914 | @disjoint_base
+        915 | class str(Sequence[str]):
+            |       ---
+        916 |     """str(object='') -> str
+        917 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
+            |
         "#);
     }
 
@@ -1636,39 +1594,30 @@ def function():
         );
 
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
-           --> stdlib/types.pyi:950:11
-            |
-        948 | if sys.version_info >= (3, 10):
-        949 |     @final
-        950 |     class NoneType:
-            |           ^^^^^^^^
-        951 |         """The type of the None singleton."""
-            |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> main.py:3:5
           |
         2 | def foo(a: str | None, b):
         3 |     a
-          |     ^
+          |     ^ Clicking here
           |
-
-        info[goto-type-definition]: Type definition
+        info: Found 2 type definitions
            --> stdlib/builtins.pyi:915:7
             |
         914 | @disjoint_base
         915 | class str(Sequence[str]):
-            |       ^^^
+            |       ---
         916 |     """str(object='') -> str
         917 |     str(bytes_or_buffer[, encoding[, errors]]) -> str
             |
-        info: Source
-         --> main.py:3:5
-          |
-        2 | def foo(a: str | None, b):
-        3 |     a
-          |     ^
-          |
+           ::: stdlib/types.pyi:950:11
+            |
+        948 | if sys.version_info >= (3, 10):
+        949 |     @final
+        950 |     class NoneType:
+            |           --------
+        951 |         """The type of the None singleton."""
+            |
         "#);
     }
 
@@ -1694,18 +1643,18 @@ def function():
 
         // The module is the correct type definition
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-        --> mypackage/subpkg/__init__.py:1:1
-         |
-         |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> mypackage/__init__.py:4:5
           |
         2 | from .subpkg.submod import val
         3 |
         4 | x = subpkg
-          |     ^^^^^^
+          |     ^^^^^^ Clicking here
           |
+        info: Found 1 type definition
+        --> mypackage/subpkg/__init__.py:1:1
+         |
+         |
         ");
     }
 
@@ -1731,18 +1680,18 @@ def function():
 
         // The module is the correct type definition
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-        --> mypackage/subpkg/__init__.py:1:1
-         |
-         |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> mypackage/__init__.py:2:7
           |
         2 | from .subpkg.submod import val
-          |       ^^^^^^
+          |       ^^^^^^ Clicking here
         3 |
         4 | x = subpkg
           |
+        info: Found 1 type definition
+        --> mypackage/subpkg/__init__.py:1:1
+         |
+         |
         ");
     }
 
@@ -1768,23 +1717,23 @@ def function():
 
         // Unknown is correct, `submod` is not in scope
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
-          --> stdlib/ty_extensions.pyi:20:1
-           |
-        19 | # Types
-        20 | Unknown = object()
-           | ^^^^^^^
-        21 | AlwaysTruthy = object()
-        22 | AlwaysFalsy = object()
-           |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> mypackage/__init__.py:4:5
           |
         2 | from .subpkg.submod import val
         3 |
         4 | x = submod
-          |     ^^^^^^
+          |     ^^^^^^ Clicking here
           |
+        info: Found 1 type definition
+          --> stdlib/ty_extensions.pyi:20:1
+           |
+        19 | # Types
+        20 | Unknown = object()
+           | -------
+        21 | AlwaysTruthy = object()
+        22 | AlwaysFalsy = object()
+           |
         ");
     }
 
@@ -1810,20 +1759,20 @@ def function():
 
         // The module is correct
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
+        info[goto-type definition]: Go to type definition
+         --> mypackage/__init__.py:2:14
+          |
+        2 | from .subpkg.submod import val
+          |              ^^^^^^ Clicking here
+        3 |
+        4 | x = submod
+          |
+        info: Found 1 type definition
          --> mypackage/subpkg/submod.py:1:1
           |
         1 | /
         2 | | val: int = 0
-          | |_____________^
-          |
-        info: Source
-         --> mypackage/__init__.py:2:14
-          |
-        2 | from .subpkg.submod import val
-          |              ^^^^^^
-        3 |
-        4 | x = submod
+          | |_____________-
           |
         ");
     }
@@ -1849,20 +1798,20 @@ def function():
 
         // The module is correct
         assert_snapshot!(test.goto_type_definition(), @r"
-        info[goto-type-definition]: Type definition
+        info[goto-type definition]: Go to type definition
+         --> mypackage/__init__.py:2:7
+          |
+        2 | from .subpkg import subpkg
+          |       ^^^^^^ Clicking here
+        3 |
+        4 | x = subpkg
+          |
+        info: Found 1 type definition
          --> mypackage/subpkg/__init__.py:1:1
           |
         1 | /
         2 | | subpkg: int = 10
-          | |_________________^
-          |
-        info: Source
-         --> mypackage/__init__.py:2:7
-          |
-        2 | from .subpkg import subpkg
-          |       ^^^^^^
-        3 |
-        4 | x = subpkg
+          | |_________________-
           |
         ");
     }
@@ -1888,23 +1837,23 @@ def function():
 
         // `int` is correct
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
+        info[goto-type definition]: Go to type definition
+         --> mypackage/__init__.py:2:21
+          |
+        2 | from .subpkg import subpkg
+          |                     ^^^^^^ Clicking here
+        3 |
+        4 | x = subpkg
+          |
+        info: Found 1 type definition
            --> stdlib/builtins.pyi:348:7
             |
         347 | @disjoint_base
         348 | class int:
-            |       ^^^
+            |       ---
         349 |     """int([x]) -> integer
         350 |     int(x, base=10) -> integer
             |
-        info: Source
-         --> mypackage/__init__.py:2:21
-          |
-        2 | from .subpkg import subpkg
-          |                     ^^^^^^
-        3 |
-        4 | x = subpkg
-          |
         "#);
     }
 
@@ -1929,23 +1878,23 @@ def function():
 
         // `int` is correct
         assert_snapshot!(test.goto_type_definition(), @r#"
-        info[goto-type-definition]: Type definition
-           --> stdlib/builtins.pyi:348:7
-            |
-        347 | @disjoint_base
-        348 | class int:
-            |       ^^^
-        349 |     """int([x]) -> integer
-        350 |     int(x, base=10) -> integer
-            |
-        info: Source
+        info[goto-type definition]: Go to type definition
          --> mypackage/__init__.py:4:5
           |
         2 | from .subpkg import subpkg
         3 |
         4 | x = subpkg
-          |     ^^^^^^
+          |     ^^^^^^ Clicking here
           |
+        info: Found 1 type definition
+           --> stdlib/builtins.pyi:348:7
+            |
+        347 | @disjoint_base
+        348 | class int:
+            |       ---
+        349 |     """int([x]) -> integer
+        350 |     int(x, base=10) -> integer
+            |
         "#);
     }
 
@@ -1961,47 +1910,10 @@ def function():
                 return "No type definitions found".to_string();
             }
 
-            let source = targets.range;
-            self.render_diagnostics(
-                targets
-                    .into_iter()
-                    .map(|target| GotoTypeDefinitionDiagnostic::new(source, &target)),
-            )
-        }
-    }
-
-    struct GotoTypeDefinitionDiagnostic {
-        source: FileRange,
-        target: FileRange,
-    }
-
-    impl GotoTypeDefinitionDiagnostic {
-        fn new(source: FileRange, target: &NavigationTarget) -> Self {
-            Self {
-                source,
-                target: FileRange::new(target.file(), target.focus_range()),
-            }
-        }
-    }
-
-    impl IntoDiagnostic for GotoTypeDefinitionDiagnostic {
-        fn into_diagnostic(self) -> Diagnostic {
-            let mut source = SubDiagnostic::new(SubDiagnosticSeverity::Info, "Source");
-            source.annotate(Annotation::primary(
-                Span::from(self.source.file()).with_range(self.source.range()),
-            ));
-
-            let mut main = Diagnostic::new(
-                DiagnosticId::Lint(LintName::of("goto-type-definition")),
-                Severity::Info,
-                "Type definition".to_string(),
-            );
-            main.annotate(Annotation::primary(
-                Span::from(self.target.file()).with_range(self.target.range()),
-            ));
-            main.sub(source);
-
-            main
+            self.render_diagnostics([crate::goto_definition::test::GotoDiagnostic::new(
+                crate::goto_definition::test::GotoAction::TypeDefinition,
+                targets,
+            )])
         }
     }
 }

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -230,6 +230,11 @@ impl NavigationTargets {
     fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
 }
 
 impl IntoIterator for NavigationTargets {


### PR DESCRIPTION
## Summary

This PR makes our ty_ide snapshot tests for find references, go to definition, go to declaration, and go to type definition more succingt by:

* Don't repeat the source for every found go to definition target. They're all the same! 
* Use a single diagnostic for all results with secondary annotations, allowing multiple results to be rendered into the same code frame.

## Test Plan

Updated snapshots, no code change
