### PR TITLE
[ty] Uniformly use "not supported" in diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/assignment/augmented.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/augmented.md
@@ -44,7 +44,7 @@ class C:
         return 42
 
 x = C()
-# error: [unsupported-operator] "Operator `-=` is unsupported between objects of type `C` and `Literal[1]`"
+# error: [unsupported-operator] "Operator `-=` is not supported between objects of type `C` and `Literal[1]`"
 x -= 1
 
 reveal_type(x)  # revealed: int
@@ -79,7 +79,7 @@ def _(flag: bool):
 
     f = Foo()
 
-    # error: [unsupported-operator] "Operator `+=` is unsupported between objects of type `Foo` and `Literal["Hello, world!"]`"
+    # error: [unsupported-operator] "Operator `+=` is not supported between objects of type `Foo` and `Literal["Hello, world!"]`"
     f += "Hello, world!"
 
     reveal_type(f)  # revealed: int | Unknown

--- a/crates/ty_python_semantic/resources/mdtest/binary/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/classes.md
@@ -27,7 +27,7 @@ python-version = "3.9"
 class A: ...
 class B: ...
 
-# error: "Operator `|` is unsupported between objects of type `<class 'A'>` and `<class 'B'>`"
+# error: "Operator `|` is not supported between objects of type `<class 'A'>` and `<class 'B'>`"
 reveal_type(A | B)  # revealed: Unknown
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/binary/custom.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/custom.md
@@ -79,59 +79,59 @@ reveal_type(Sub() & Sub())  # revealed: Literal["&"]
 reveal_type(Sub() // Sub())  # revealed: Literal["//"]
 
 # No does not implement any of the dunder methods.
-# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `No` and `No`"
+# error: [unsupported-operator] "Operator `+` is not supported between objects of type `No` and `No`"
 reveal_type(No() + No())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `-` is unsupported between objects of type `No` and `No`"
+# error: [unsupported-operator] "Operator `-` is not supported between objects of type `No` and `No`"
 reveal_type(No() - No())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `*` is unsupported between objects of type `No` and `No`"
+# error: [unsupported-operator] "Operator `*` is not supported between objects of type `No` and `No`"
 reveal_type(No() * No())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `@` is unsupported between objects of type `No` and `No`"
+# error: [unsupported-operator] "Operator `@` is not supported between objects of type `No` and `No`"
 reveal_type(No() @ No())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `/` is unsupported between objects of type `No` and `No`"
+# error: [unsupported-operator] "Operator `/` is not supported between objects of type `No` and `No`"
 reveal_type(No() / No())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `%` is unsupported between objects of type `No` and `No`"
+# error: [unsupported-operator] "Operator `%` is not supported between objects of type `No` and `No`"
 reveal_type(No() % No())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `**` is unsupported between objects of type `No` and `No`"
+# error: [unsupported-operator] "Operator `**` is not supported between objects of type `No` and `No`"
 reveal_type(No() ** No())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `<<` is unsupported between objects of type `No` and `No`"
+# error: [unsupported-operator] "Operator `<<` is not supported between objects of type `No` and `No`"
 reveal_type(No() << No())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `>>` is unsupported between objects of type `No` and `No`"
+# error: [unsupported-operator] "Operator `>>` is not supported between objects of type `No` and `No`"
 reveal_type(No() >> No())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `|` is unsupported between objects of type `No` and `No`"
+# error: [unsupported-operator] "Operator `|` is not supported between objects of type `No` and `No`"
 reveal_type(No() | No())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `^` is unsupported between objects of type `No` and `No`"
+# error: [unsupported-operator] "Operator `^` is not supported between objects of type `No` and `No`"
 reveal_type(No() ^ No())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `&` is unsupported between objects of type `No` and `No`"
+# error: [unsupported-operator] "Operator `&` is not supported between objects of type `No` and `No`"
 reveal_type(No() & No())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `//` is unsupported between objects of type `No` and `No`"
+# error: [unsupported-operator] "Operator `//` is not supported between objects of type `No` and `No`"
 reveal_type(No() // No())  # revealed: Unknown
 
 # Yes does not implement any of the reflected dunder methods.
-# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `No` and `Yes`"
+# error: [unsupported-operator] "Operator `+` is not supported between objects of type `No` and `Yes`"
 reveal_type(No() + Yes())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `-` is unsupported between objects of type `No` and `Yes`"
+# error: [unsupported-operator] "Operator `-` is not supported between objects of type `No` and `Yes`"
 reveal_type(No() - Yes())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `*` is unsupported between objects of type `No` and `Yes`"
+# error: [unsupported-operator] "Operator `*` is not supported between objects of type `No` and `Yes`"
 reveal_type(No() * Yes())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `@` is unsupported between objects of type `No` and `Yes`"
+# error: [unsupported-operator] "Operator `@` is not supported between objects of type `No` and `Yes`"
 reveal_type(No() @ Yes())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `/` is unsupported between objects of type `No` and `Yes`"
+# error: [unsupported-operator] "Operator `/` is not supported between objects of type `No` and `Yes`"
 reveal_type(No() / Yes())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `%` is unsupported between objects of type `No` and `Yes`"
+# error: [unsupported-operator] "Operator `%` is not supported between objects of type `No` and `Yes`"
 reveal_type(No() % Yes())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `**` is unsupported between objects of type `No` and `Yes`"
+# error: [unsupported-operator] "Operator `**` is not supported between objects of type `No` and `Yes`"
 reveal_type(No() ** Yes())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `<<` is unsupported between objects of type `No` and `Yes`"
+# error: [unsupported-operator] "Operator `<<` is not supported between objects of type `No` and `Yes`"
 reveal_type(No() << Yes())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `>>` is unsupported between objects of type `No` and `Yes`"
+# error: [unsupported-operator] "Operator `>>` is not supported between objects of type `No` and `Yes`"
 reveal_type(No() >> Yes())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `|` is unsupported between objects of type `No` and `Yes`"
+# error: [unsupported-operator] "Operator `|` is not supported between objects of type `No` and `Yes`"
 reveal_type(No() | Yes())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `^` is unsupported between objects of type `No` and `Yes`"
+# error: [unsupported-operator] "Operator `^` is not supported between objects of type `No` and `Yes`"
 reveal_type(No() ^ Yes())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `&` is unsupported between objects of type `No` and `Yes`"
+# error: [unsupported-operator] "Operator `&` is not supported between objects of type `No` and `Yes`"
 reveal_type(No() & Yes())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `//` is unsupported between objects of type `No` and `Yes`"
+# error: [unsupported-operator] "Operator `//` is not supported between objects of type `No` and `Yes`"
 reveal_type(No() // Yes())  # revealed: Unknown
 ```
 
@@ -307,11 +307,11 @@ class Yes:
 class Sub(Yes): ...
 class No: ...
 
-# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `<class 'Yes'>` and `<class 'Yes'>`"
+# error: [unsupported-operator] "Operator `+` is not supported between objects of type `<class 'Yes'>` and `<class 'Yes'>`"
 reveal_type(Yes + Yes)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `<class 'Sub'>` and `<class 'Sub'>`"
+# error: [unsupported-operator] "Operator `+` is not supported between objects of type `<class 'Sub'>` and `<class 'Sub'>`"
 reveal_type(Sub + Sub)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `<class 'No'>` and `<class 'No'>`"
+# error: [unsupported-operator] "Operator `+` is not supported between objects of type `<class 'No'>` and `<class 'No'>`"
 reveal_type(No + No)  # revealed: Unknown
 ```
 
@@ -336,11 +336,11 @@ def sub() -> type[Sub]:
 def no() -> type[No]:
     return No
 
-# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `type[Yes]` and `type[Yes]`"
+# error: [unsupported-operator] "Operator `+` is not supported between objects of type `type[Yes]` and `type[Yes]`"
 reveal_type(yes() + yes())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `type[Sub]` and `type[Sub]`"
+# error: [unsupported-operator] "Operator `+` is not supported between objects of type `type[Sub]` and `type[Sub]`"
 reveal_type(sub() + sub())  # revealed: Unknown
-# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `type[No]` and `type[No]`"
+# error: [unsupported-operator] "Operator `+` is not supported between objects of type `type[No]` and `type[No]`"
 reveal_type(no() + no())  # revealed: Unknown
 ```
 
@@ -350,30 +350,30 @@ reveal_type(no() + no())  # revealed: Unknown
 def f():
     pass
 
-# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
+# error: [unsupported-operator] "Operator `+` is not supported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
 reveal_type(f + f)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `-` is unsupported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
+# error: [unsupported-operator] "Operator `-` is not supported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
 reveal_type(f - f)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `*` is unsupported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
+# error: [unsupported-operator] "Operator `*` is not supported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
 reveal_type(f * f)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `@` is unsupported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
+# error: [unsupported-operator] "Operator `@` is not supported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
 reveal_type(f @ f)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `/` is unsupported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
+# error: [unsupported-operator] "Operator `/` is not supported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
 reveal_type(f / f)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `%` is unsupported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
+# error: [unsupported-operator] "Operator `%` is not supported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
 reveal_type(f % f)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `**` is unsupported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
+# error: [unsupported-operator] "Operator `**` is not supported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
 reveal_type(f**f)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `<<` is unsupported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
+# error: [unsupported-operator] "Operator `<<` is not supported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
 reveal_type(f << f)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `>>` is unsupported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
+# error: [unsupported-operator] "Operator `>>` is not supported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
 reveal_type(f >> f)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `|` is unsupported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
+# error: [unsupported-operator] "Operator `|` is not supported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
 reveal_type(f | f)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `^` is unsupported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
+# error: [unsupported-operator] "Operator `^` is not supported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
 reveal_type(f ^ f)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `&` is unsupported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
+# error: [unsupported-operator] "Operator `&` is not supported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
 reveal_type(f & f)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `//` is unsupported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
+# error: [unsupported-operator] "Operator `//` is not supported between objects of type `def f() -> Unknown` and `def f() -> Unknown`"
 reveal_type(f // f)  # revealed: Unknown
 ```

--- a/crates/ty_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/instances.md
@@ -386,7 +386,7 @@ class A(metaclass=Meta): ...
 class B(metaclass=Meta): ...
 
 reveal_type(A + B)  # revealed: int
-# error: [unsupported-operator] "Operator `-` is unsupported between objects of type `<class 'A'>` and `<class 'B'>`"
+# error: [unsupported-operator] "Operator `-` is not supported between objects of type `<class 'A'>` and `<class 'B'>`"
 reveal_type(A - B)  # revealed: Unknown
 
 reveal_type(A < B)  # revealed: bool
@@ -412,7 +412,7 @@ class A:
     def __init__(self):
         self.__add__ = add_impl
 
-# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `A` and `A`"
+# error: [unsupported-operator] "Operator `+` is not supported between objects of type `A` and `A`"
 # revealed: Unknown
 reveal_type(A() + A())
 ```

--- a/crates/ty_python_semantic/resources/mdtest/binary/integers.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/integers.md
@@ -13,7 +13,7 @@ reveal_type(3 | 4)  # revealed: Literal[7]
 reveal_type(5 & 6)  # revealed: Literal[4]
 reveal_type(7 ^ 2)  # revealed: Literal[5]
 
-# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `Literal[2]` and `Literal["f"]`"
+# error: [unsupported-operator] "Operator `+` is not supported between objects of type `Literal[2]` and `Literal["f"]`"
 reveal_type(2 + "f")  # revealed: Unknown
 
 def lhs(x: int):

--- a/crates/ty_python_semantic/resources/mdtest/binary/unions.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/unions.md
@@ -5,9 +5,9 @@ combinations of types:
 
 ```py
 def f1(i: int, u: int | None):
-    # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `int` and `int | None`"
+    # error: [unsupported-operator] "Operator `+` is not supported between objects of type `int` and `int | None`"
     reveal_type(i + u)  # revealed: Unknown
-    # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `int | None` and `int`"
+    # error: [unsupported-operator] "Operator `+` is not supported between objects of type `int | None` and `int`"
     reveal_type(u + i)  # revealed: Unknown
 ```
 
@@ -18,7 +18,7 @@ cannot be added, because that would require addition of `int` and `str` or vice 
 def f2(i: int, s: str, int_or_str: int | str):
     i + i
     s + s
-    # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `int | str` and `int | str`"
+    # error: [unsupported-operator] "Operator `+` is not supported between objects of type `int | str` and `int | str`"
     reveal_type(int_or_str + int_or_str)  # revealed: Unknown
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/conditional/if_expression.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/if_expression.md
@@ -42,6 +42,6 @@ def _(flag: bool):
 class NotBoolable:
     __bool__: int = 3
 
-# error: [unsupported-bool-conversion] "Boolean conversion is unsupported for type `NotBoolable`"
+# error: [unsupported-bool-conversion] "Boolean conversion is not supported for type `NotBoolable`"
 3 if NotBoolable() else 4
 ```

--- a/crates/ty_python_semantic/resources/mdtest/conditional/if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/if_statement.md
@@ -154,10 +154,10 @@ def _(flag: bool):
 class NotBoolable:
     __bool__: int = 3
 
-# error: [unsupported-bool-conversion] "Boolean conversion is unsupported for type `NotBoolable`"
+# error: [unsupported-bool-conversion] "Boolean conversion is not supported for type `NotBoolable`"
 if NotBoolable():
     ...
-# error: [unsupported-bool-conversion] "Boolean conversion is unsupported for type `NotBoolable`"
+# error: [unsupported-bool-conversion] "Boolean conversion is not supported for type `NotBoolable`"
 elif NotBoolable():
     ...
 ```

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -378,7 +378,7 @@ class NotBoolable:
 def _(target: int, flag: NotBoolable):
     y = 1
     match target:
-        # error: [unsupported-bool-conversion] "Boolean conversion is unsupported for type `NotBoolable`"
+        # error: [unsupported-bool-conversion] "Boolean conversion is not supported for type `NotBoolable`"
         case 1 if flag:
             y = 2
         case 2:

--- a/crates/ty_python_semantic/resources/mdtest/expression/assert.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/assert.md
@@ -4,6 +4,6 @@
 class NotBoolable:
     __bool__: int = 3
 
-# error: [unsupported-bool-conversion] "Boolean conversion is unsupported for type `NotBoolable`"
+# error: [unsupported-bool-conversion] "Boolean conversion is not supported for type `NotBoolable`"
 assert NotBoolable()
 ```

--- a/crates/ty_python_semantic/resources/mdtest/expression/boolean.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/boolean.md
@@ -232,7 +232,7 @@ if NotBoolable():
 class NotBoolable:
     __bool__: None = None
 
-# error: [unsupported-bool-conversion] "Boolean conversion is unsupported for type `NotBoolable`"
+# error: [unsupported-bool-conversion] "Boolean conversion is not supported for type `NotBoolable`"
 if NotBoolable():
     ...
 ```
@@ -244,7 +244,7 @@ def test(cond: bool):
     class NotBoolable:
         __bool__: int | None = None if cond else 3
 
-    # error: [unsupported-bool-conversion] "Boolean conversion is unsupported for type `NotBoolable`"
+    # error: [unsupported-bool-conversion] "Boolean conversion is not supported for type `NotBoolable`"
     if NotBoolable():
         ...
 ```
@@ -258,7 +258,7 @@ def test(cond: bool):
 
     a = 10 if cond else NotBoolable()
 
-    # error: [unsupported-bool-conversion] "Boolean conversion is unsupported for type `Literal[10] | NotBoolable`"
+    # error: [unsupported-bool-conversion] "Boolean conversion is not supported for type `Literal[10] | NotBoolable`"
     if a:
         ...
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -277,7 +277,7 @@ T = TypeVar("T", int, str)
 
 def same_constrained_types(t1: T, t2: T) -> T:
     # TODO: no error
-    # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `T@same_constrained_types` and `T@same_constrained_types`"
+    # error: [unsupported-operator] "Operator `+` is not supported between objects of type `T@same_constrained_types` and `T@same_constrained_types`"
     return t1 + t2
 ```
 
@@ -287,7 +287,7 @@ and an `int` and a `str` cannot be added together:
 
 ```py
 def unions_are_different(t1: int | str, t2: int | str) -> int | str:
-    # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `int | str` and `int | str`"
+    # error: [unsupported-operator] "Operator `+` is not supported between objects of type `int | str` and `int | str`"
     return t1 + t2
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -246,7 +246,7 @@ methods that are compatible with the return type, so the `return` expression is 
 ```py
 def same_constrained_types[T: (int, str)](t1: T, t2: T) -> T:
     # TODO: no error
-    # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `T@same_constrained_types` and `T@same_constrained_types`"
+    # error: [unsupported-operator] "Operator `+` is not supported between objects of type `T@same_constrained_types` and `T@same_constrained_types`"
     return t1 + t2
 ```
 
@@ -256,7 +256,7 @@ and an `int` and a `str` cannot be added together:
 
 ```py
 def unions_are_different(t1: int | str, t2: int | str) -> int | str:
-    # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `int | str` and `int | str`"
+    # error: [unsupported-operator] "Operator `+` is not supported between objects of type `int | str` and `int | str`"
     return t1 + t2
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -214,7 +214,7 @@ def _(int_or_int: IntOrInt, list_of_int_or_list_of_int: ListOfIntOrListOfInt):
 `NoneType` has no special or-operator behavior, so this is an error:
 
 ```py
-None | None  # error: [unsupported-operator] "Operator `|` is unsupported between objects of type `None` and `None`"
+None | None  # error: [unsupported-operator] "Operator `|` is not supported between objects of type `None` and `None`"
 ```
 
 When constructing something nonsensical like `int | 1`, we emit a diagnostic for the expression

--- a/crates/ty_python_semantic/resources/mdtest/loops/while_loop.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/while_loop.md
@@ -123,7 +123,7 @@ def _(flag: bool, flag2: bool):
 class NotBoolable:
     __bool__: int = 3
 
-# error: [unsupported-bool-conversion] "Boolean conversion is unsupported for type `NotBoolable`"
+# error: [unsupported-bool-conversion] "Boolean conversion is not supported for type `NotBoolable`"
 while NotBoolable():
     ...
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -270,7 +270,7 @@ def _(
     if af:
         reveal_type(af)  # revealed: type[AmbiguousClass] & ~AlwaysFalsy
 
-    # error: [unsupported-bool-conversion] "Boolean conversion is unsupported for type `MetaDeferred`"
+    # error: [unsupported-bool-conversion] "Boolean conversion is not supported for type `MetaDeferred`"
     if d:
         # TODO: Should be `Unknown`
         reveal_type(d)  # revealed: type[DeferredClass] & ~AlwaysFalsy

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/annotations.md_-_Assignment_with_anno…_-_PEP-604_in_non-type-…_-_Earlier_versions_(f2859c9800f37c7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/annotations.md_-_Assignment_with_anno…_-_PEP-604_in_non-type-…_-_Earlier_versions_(f2859c9800f37c7).snap
@@ -19,7 +19,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/assignment/annotations.m
 # Diagnostics
 
 ```
-error[unsupported-operator]: Operator `|` is unsupported between objects of type `<class 'int'>` and `<class 'str'>`
+error[unsupported-operator]: Operator `|` is not supported between objects of type `<class 'int'>` and `<class 'str'>`
  --> src/mdtest_snippet.py:2:12
   |
 1 | # error: [unsupported-operator]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on…_-_Operations_involving…_(492b1163b8163c05).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on…_-_Operations_involving…_(492b1163b8163c05).snap
@@ -24,7 +24,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/binary/instances.md
 # Diagnostics
 
 ```
-error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
  --> src/mdtest_snippet.py:7:8
   |
 6 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membersh…_-_Return_type_that_doe…_(feccf6b9da1e7cd3).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membersh…_-_Return_type_that_doe…_(feccf6b9da1e7cd3).snap
@@ -28,7 +28,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/instances/mem
 # Diagnostics
 
 ```
-error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
   --> src/mdtest_snippet.py:9:1
    |
  8 | # error: [unsupported-bool-conversion]
@@ -43,7 +43,7 @@ info: rule `unsupported-bool-conversion` is enabled by default
 ```
 
 ```
-error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
   --> src/mdtest_snippet.py:11:1
    |
  9 | 10 in WithContains()

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implemen…_(ab3f546bf004e24d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implemen…_(ab3f546bf004e24d).snap
@@ -22,7 +22,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/unary/not.md
 # Diagnostics
 
 ```
-error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
  --> src/mdtest_snippet.py:5:1
   |
 4 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Com…_-_Chained_comparisons_…_(c391c13e2abc18a0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Com…_-_Chained_comparisons_…_(c391c13e2abc18a0).snap
@@ -33,7 +33,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/instances/ric
 # Diagnostics
 
 ```
-error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
   --> src/mdtest_snippet.py:12:1
    |
 11 | # error: [unsupported-bool-conversion]
@@ -48,7 +48,7 @@ info: rule `unsupported-bool-conversion` is enabled by default
 ```
 
 ```
-error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
   --> src/mdtest_snippet.py:14:1
    |
 12 | 10 < Comparable() < 20

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_…_(f45f1da2f8ca693d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_…_(f45f1da2f8ca693d).snap
@@ -34,7 +34,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
 # Diagnostics
 
 ```
-error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable | Literal[False]`
+error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable | Literal[False]`
   --> src/mdtest_snippet.py:15:1
    |
 14 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elemen…_(39b614d4707c0661).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elemen…_(39b614d4707c0661).snap
@@ -58,7 +58,7 @@ info: rule `invalid-method-override` is enabled by default
 ```
 
 ```
-error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
   --> src/mdtest_snippet.py:10:1
    |
  9 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Has_a_`__bool__`_att…_(2721d40bf12fe8b7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Has_a_`__bool__`_att…_(2721d40bf12fe8b7).snap
@@ -24,7 +24,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 # Diagnostics
 
 ```
-error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
  --> src/mdtest_snippet.py:7:8
   |
 6 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Has_a_`__bool__`_met…_(15636dc4074e5335).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Has_a_`__bool__`_met…_(15636dc4074e5335).snap
@@ -25,7 +25,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 # Diagnostics
 
 ```
-error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
  --> src/mdtest_snippet.py:8:8
   |
 7 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Has_a_`__bool__`_met…_(ce8b8da49eaf4cda).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Has_a_`__bool__`_met…_(ce8b8da49eaf4cda).snap
@@ -25,7 +25,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 # Diagnostics
 
 ```
-error[unsupported-bool-conversion]: Boolean conversion is unsupported for type `NotBoolable`
+error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
  --> src/mdtest_snippet.py:8:8
   |
 7 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Part_of_a_union_wher…_(7cca8063ea43c1a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Part_of_a_union_wher…_(7cca8063ea43c1a).snap
@@ -32,7 +32,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 # Diagnostics
 
 ```
-error[unsupported-bool-conversion]: Boolean conversion is unsupported for union `NotBoolable1 | NotBoolable2 | NotBoolable3` because `NotBoolable1` doesn't implement `__bool__` correctly
+error[unsupported-bool-conversion]: Boolean conversion is not supported for union `NotBoolable1 | NotBoolable2 | NotBoolable3` because `NotBoolable1` doesn't implement `__bool__` correctly
   --> src/mdtest_snippet.py:15:8
    |
 14 | # error: [unsupported-bool-conversion]

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -237,7 +237,7 @@ class InvalidBoolDunder:
     def __bool__(self) -> int:
         return 1
 
-# error: [unsupported-bool-conversion]  "Boolean conversion is unsupported for type `InvalidBoolDunder`"
+# error: [unsupported-bool-conversion]  "Boolean conversion is not supported for type `InvalidBoolDunder`"
 static_assert(InvalidBoolDunder())
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/unary/custom.md
+++ b/crates/ty_python_semantic/resources/mdtest/unary/custom.md
@@ -24,11 +24,11 @@ reveal_type(+Sub())  # revealed: bool
 reveal_type(-Sub())  # revealed: str
 reveal_type(~Sub())  # revealed: int
 
-# error: [unsupported-operator] "Unary operator `+` is unsupported for type `No`"
+# error: [unsupported-operator] "Unary operator `+` is not supported for type `No`"
 reveal_type(+No())  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `-` is unsupported for type `No`"
+# error: [unsupported-operator] "Unary operator `-` is not supported for type `No`"
 reveal_type(-No())  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `~` is unsupported for type `No`"
+# error: [unsupported-operator] "Unary operator `~` is not supported for type `No`"
 reveal_type(~No())  # revealed: Unknown
 ```
 
@@ -52,25 +52,25 @@ class Yes:
 class Sub(Yes): ...
 class No: ...
 
-# error: [unsupported-operator] "Unary operator `+` is unsupported for type `<class 'Yes'>`"
+# error: [unsupported-operator] "Unary operator `+` is not supported for type `<class 'Yes'>`"
 reveal_type(+Yes)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `-` is unsupported for type `<class 'Yes'>`"
+# error: [unsupported-operator] "Unary operator `-` is not supported for type `<class 'Yes'>`"
 reveal_type(-Yes)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `~` is unsupported for type `<class 'Yes'>`"
+# error: [unsupported-operator] "Unary operator `~` is not supported for type `<class 'Yes'>`"
 reveal_type(~Yes)  # revealed: Unknown
 
-# error: [unsupported-operator] "Unary operator `+` is unsupported for type `<class 'Sub'>`"
+# error: [unsupported-operator] "Unary operator `+` is not supported for type `<class 'Sub'>`"
 reveal_type(+Sub)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `-` is unsupported for type `<class 'Sub'>`"
+# error: [unsupported-operator] "Unary operator `-` is not supported for type `<class 'Sub'>`"
 reveal_type(-Sub)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `~` is unsupported for type `<class 'Sub'>`"
+# error: [unsupported-operator] "Unary operator `~` is not supported for type `<class 'Sub'>`"
 reveal_type(~Sub)  # revealed: Unknown
 
-# error: [unsupported-operator] "Unary operator `+` is unsupported for type `<class 'No'>`"
+# error: [unsupported-operator] "Unary operator `+` is not supported for type `<class 'No'>`"
 reveal_type(+No)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `-` is unsupported for type `<class 'No'>`"
+# error: [unsupported-operator] "Unary operator `-` is not supported for type `<class 'No'>`"
 reveal_type(-No)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `~` is unsupported for type `<class 'No'>`"
+# error: [unsupported-operator] "Unary operator `~` is not supported for type `<class 'No'>`"
 reveal_type(~No)  # revealed: Unknown
 ```
 
@@ -80,11 +80,11 @@ reveal_type(~No)  # revealed: Unknown
 def f():
     pass
 
-# error: [unsupported-operator] "Unary operator `+` is unsupported for type `def f() -> Unknown`"
+# error: [unsupported-operator] "Unary operator `+` is not supported for type `def f() -> Unknown`"
 reveal_type(+f)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `-` is unsupported for type `def f() -> Unknown`"
+# error: [unsupported-operator] "Unary operator `-` is not supported for type `def f() -> Unknown`"
 reveal_type(-f)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `~` is unsupported for type `def f() -> Unknown`"
+# error: [unsupported-operator] "Unary operator `~` is not supported for type `def f() -> Unknown`"
 reveal_type(~f)  # revealed: Unknown
 ```
 
@@ -113,25 +113,25 @@ def sub() -> type[Sub]:
 def no() -> type[No]:
     return No
 
-# error: [unsupported-operator] "Unary operator `+` is unsupported for type `type[Yes]`"
+# error: [unsupported-operator] "Unary operator `+` is not supported for type `type[Yes]`"
 reveal_type(+yes())  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `-` is unsupported for type `type[Yes]`"
+# error: [unsupported-operator] "Unary operator `-` is not supported for type `type[Yes]`"
 reveal_type(-yes())  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `~` is unsupported for type `type[Yes]`"
+# error: [unsupported-operator] "Unary operator `~` is not supported for type `type[Yes]`"
 reveal_type(~yes())  # revealed: Unknown
 
-# error: [unsupported-operator] "Unary operator `+` is unsupported for type `type[Sub]`"
+# error: [unsupported-operator] "Unary operator `+` is not supported for type `type[Sub]`"
 reveal_type(+sub())  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `-` is unsupported for type `type[Sub]`"
+# error: [unsupported-operator] "Unary operator `-` is not supported for type `type[Sub]`"
 reveal_type(-sub())  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `~` is unsupported for type `type[Sub]`"
+# error: [unsupported-operator] "Unary operator `~` is not supported for type `type[Sub]`"
 reveal_type(~sub())  # revealed: Unknown
 
-# error: [unsupported-operator] "Unary operator `+` is unsupported for type `type[No]`"
+# error: [unsupported-operator] "Unary operator `+` is not supported for type `type[No]`"
 reveal_type(+no())  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `-` is unsupported for type `type[No]`"
+# error: [unsupported-operator] "Unary operator `-` is not supported for type `type[No]`"
 reveal_type(-no())  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `~` is unsupported for type `type[No]`"
+# error: [unsupported-operator] "Unary operator `~` is not supported for type `type[No]`"
 reveal_type(~no())  # revealed: Unknown
 ```
 
@@ -160,10 +160,10 @@ reveal_type(+Sub)  # revealed: bool
 reveal_type(-Sub)  # revealed: str
 reveal_type(~Sub)  # revealed: int
 
-# error: [unsupported-operator] "Unary operator `+` is unsupported for type `<class 'No'>`"
+# error: [unsupported-operator] "Unary operator `+` is not supported for type `<class 'No'>`"
 reveal_type(+No)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `-` is unsupported for type `<class 'No'>`"
+# error: [unsupported-operator] "Unary operator `-` is not supported for type `<class 'No'>`"
 reveal_type(-No)  # revealed: Unknown
-# error: [unsupported-operator] "Unary operator `~` is unsupported for type `<class 'No'>`"
+# error: [unsupported-operator] "Unary operator `~` is not supported for type `<class 'No'>`"
 reveal_type(~No)  # revealed: Unknown
 ```

--- a/crates/ty_python_semantic/resources/mdtest/unary/invert_add_usub.md
+++ b/crates/ty_python_semantic/resources/mdtest/unary/invert_add_usub.md
@@ -27,7 +27,7 @@ reveal_type(~a)  # revealed: Literal[True]
 class NoDunder: ...
 
 b = NoDunder()
-+b  # error: [unsupported-operator] "Unary operator `+` is unsupported for type `NoDunder`"
--b  # error: [unsupported-operator] "Unary operator `-` is unsupported for type `NoDunder`"
-~b  # error: [unsupported-operator] "Unary operator `~` is unsupported for type `NoDunder`"
++b  # error: [unsupported-operator] "Unary operator `+` is not supported for type `NoDunder`"
+-b  # error: [unsupported-operator] "Unary operator `-` is not supported for type `NoDunder`"
+~b  # error: [unsupported-operator] "Unary operator `~` is not supported for type `NoDunder`"
 ```

--- a/crates/ty_python_semantic/resources/mdtest/unary/not.md
+++ b/crates/ty_python_semantic/resources/mdtest/unary/not.md
@@ -187,7 +187,7 @@ class MethodBoolInvalid:
     def __bool__(self) -> int:
         return 0
 
-# error: [unsupported-bool-conversion] "Boolean conversion is unsupported for type `MethodBoolInvalid`"
+# error: [unsupported-bool-conversion] "Boolean conversion is not supported for type `MethodBoolInvalid`"
 # revealed: bool
 reveal_type(not MethodBoolInvalid())
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -11574,7 +11574,7 @@ impl<'db> BoolError<'db> {
                 not_boolable_type, ..
             } => {
                 let mut diag = builder.into_diagnostic(format_args!(
-                    "Boolean conversion is unsupported for type `{}`",
+                    "Boolean conversion is not supported for type `{}`",
                     not_boolable_type.display(context.db())
                 ));
                 let mut sub = SubDiagnostic::new(
@@ -11599,7 +11599,7 @@ impl<'db> BoolError<'db> {
                 return_type,
             } => {
                 let mut diag = builder.into_diagnostic(format_args!(
-                    "Boolean conversion is unsupported for type `{not_boolable}`",
+                    "Boolean conversion is not supported for type `{not_boolable}`",
                     not_boolable = not_boolable_type.display(context.db()),
                 ));
                 let mut sub = SubDiagnostic::new(
@@ -11625,7 +11625,7 @@ impl<'db> BoolError<'db> {
             }
             Self::NotCallable { not_boolable_type } => {
                 let mut diag = builder.into_diagnostic(format_args!(
-                    "Boolean conversion is unsupported for type `{}`",
+                    "Boolean conversion is not supported for type `{}`",
                     not_boolable_type.display(context.db())
                 ));
                 let sub = SubDiagnostic::new(
@@ -11648,7 +11648,7 @@ impl<'db> BoolError<'db> {
                     .unwrap();
 
                 builder.into_diagnostic(format_args!(
-                    "Boolean conversion is unsupported for union `{}` \
+                    "Boolean conversion is not supported for union `{}` \
                      because `{}` doesn't implement `__bool__` correctly",
                     Type::Union(*union).display(context.db()),
                     first_error.not_boolable_type().display(context.db()),
@@ -11657,7 +11657,7 @@ impl<'db> BoolError<'db> {
 
             Self::Other { not_boolable_type } => {
                 builder.into_diagnostic(format_args!(
-                    "Boolean conversion is unsupported for type `{}`; \
+                    "Boolean conversion is not supported for type `{}`; \
                      it incorrectly implements `__bool__`",
                     not_boolable_type.display(context.db())
                 ));

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5910,7 +5910,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 return;
             };
             builder.into_diagnostic(format_args!(
-                "Operator `{op}=` is unsupported between objects of type `{}` and `{}`",
+                "Operator `{op}=` is not supported between objects of type `{}` and `{}`",
                 target_type.display(db),
                 value_type.display(db)
             ));
@@ -9679,7 +9679,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             self.context.report_lint(&UNSUPPORTED_OPERATOR, unary)
                         {
                             builder.into_diagnostic(format_args!(
-                                "Unary operator `{op}` is unsupported for type `{}`",
+                                "Unary operator `{op}` is not supported for type `{}`",
                                 operand_type.display(self.db()),
                             ));
                         }
@@ -9716,7 +9716,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 if let Some(builder) = self.context.report_lint(&UNSUPPORTED_OPERATOR, binary) {
                     let mut diag = builder.into_diagnostic(format_args!(
-                        "Operator `{op}` is unsupported between objects of type `{}` and `{}`",
+                        "Operator `{op}` is not supported between objects of type `{}` and `{}`",
                         left_ty.display(db),
                         right_ty.display(db)
                     ));


### PR DESCRIPTION
## Summary

Some (most?) diagnostic messages already use the form "Operator <op> not supported", but others use "Operator <op> unsupported":

https://play.ty.dev/ae13cd3d-531b-4ed3-adea-eba9b0cafb6c
```py
0 + ""
0 < ""
```
> Operator `+` is unsupported between objects of type `Literal[0]` and `Literal[""]` (unsupported-operator) [Ln 1, Col 1]
> Operator `<` is not supported between objects of type `Literal[0]` and `Literal[""]` (unsupported-operator) [Ln 2, Col 1]

This commit uniforms the diagnostic messages, favoring "not supported". While it is two characters longer, this:
- matches pyright/pyrefly's messages,
- is slightly less redundant given that "unsupported" already appears in the diagnostic's type (e.g., unsupported-operator), 
- makes the "not" stand out.

(This commit does not remove all occurrences of "unsupported" in diagnostic messages: there are still some that e.g. start with "Unsupported X". I think those are acceptable as they are.)


## Test Plan

Updated existing tests, and checked the new diagnostics messages with those produced by pyright/pyrefly.