### PR TITLE
[ty] Attach salsa db when running ide tests for easier debugging

### DIFF
--- a/crates/ty_ide/src/goto_declaration.rs
+++ b/crates/ty_ide/src/goto_declaration.rs
@@ -2785,8 +2785,9 @@ def ab(a: int, *, c: int): ...
 
     impl CursorTest {
         fn goto_declaration(&self) -> String {
-            let Some(targets) = goto_declaration(&self.db, self.cursor.file, self.cursor.offset)
-            else {
+            let Some(targets) = salsa::attach(&self.db, || {
+                goto_declaration(&self.db, self.cursor.file, self.cursor.offset)
+            }) else {
                 return "No goto target found".to_string();
             };
 

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -1697,8 +1697,9 @@ Traceb<CURSOR>ackType
 
     impl CursorTest {
         fn goto_definition(&self) -> String {
-            let Some(targets) = goto_definition(&self.db, self.cursor.file, self.cursor.offset)
-            else {
+            let Some(targets) = salsa::attach(&self.db, || {
+                goto_definition(&self.db, self.cursor.file, self.cursor.offset)
+            }) else {
                 return "No goto target found".to_string();
             };
 

--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -1900,9 +1900,9 @@ def function():
 
     impl CursorTest {
         fn goto_type_definition(&self) -> String {
-            let Some(targets) =
+            let Some(targets) = salsa::attach(&self.db, || {
                 goto_type_definition(&self.db, self.cursor.file, self.cursor.offset)
-            else {
+            }) else {
                 return "No goto target found".to_string();
             };
 

--- a/crates/ty_ide/src/rename.rs
+++ b/crates/ty_ide/src/rename.rs
@@ -98,7 +98,9 @@ mod tests {
 
     impl CursorTest {
         fn prepare_rename(&self) -> String {
-            let Some(range) = can_rename(&self.db, self.cursor.file, self.cursor.offset) else {
+            let Some(range) = salsa::attach(&self.db, || {
+                can_rename(&self.db, self.cursor.file, self.cursor.offset)
+            }) else {
                 return "Cannot rename".to_string();
             };
 
@@ -106,13 +108,13 @@ mod tests {
         }
 
         fn rename(&self, new_name: &str) -> String {
-            let Some(_) = can_rename(&self.db, self.cursor.file, self.cursor.offset) else {
-                return "Cannot rename".to_string();
-            };
+            let rename_results = salsa::attach(&self.db, || {
+                can_rename(&self.db, self.cursor.file, self.cursor.offset)?;
 
-            let Some(rename_results) =
                 rename(&self.db, self.cursor.file, self.cursor.offset, new_name)
-            else {
+            });
+
+            let Some(rename_results) = rename_results else {
                 return "Cannot rename".to_string();
             };
 


### PR DESCRIPTION
## Summary

`dbg(salsa_struct)` only prints the salsa ID when called outside a query because 
the Salsa db isn't set for the current thread. 

This PR changes a few IDE tests to always attach the Salsa DB to the current thread
when calling the functions under tests so that debug printing salsa structs prints
the entire structs and not just the ID, making them much more useful.

