### PR TITLE
[ty] Handle `Definition`s in `SemanticModel::scope`

### DIFF
--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -241,6 +241,8 @@ impl<'db> SemanticModel<'db> {
         let index = semantic_index(self.db, self.file);
         match self.node_in_ast(node) {
             ast::AnyNodeRef::Identifier(identifier) => index.try_expression_scope_id(identifier),
+
+            // Nodes implementing `HasDefinition`
             ast::AnyNodeRef::StmtFunctionDef(function) => Some(
                 function
                     .definition(self)
@@ -271,6 +273,8 @@ impl<'db> SemanticModel<'db> {
             ast::AnyNodeRef::TypeParamTypeVar(var) => {
                 Some(var.definition(self).scope(self.db).file_scope_id(self.db))
             }
+
+            // Fallback
             node => match node.as_expr_ref() {
                 // If we couldn't identify a specific
                 // expression that we're in, then just


### PR DESCRIPTION
## Summary

I called `definitions_for_name`, where the node was a function definition, and I was really 
surprised that it returned no results, ever... 

The issue was that `SemanticModel::scope` currently only handles expressions and identifiers.

This PR adds the necessary handling to lookup the scope in which the function, class, ... is defined.

## Test Plan

I don't think this is used anywhere today. But seems a footgun not to have from an API standpoint.
