### PR TITLE
[ty] Don't show hover for expressions with no inferred type

### DIFF
--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -295,7 +295,7 @@ impl<'db> Definitions<'db> {
 
 impl GotoTarget<'_> {
     pub(crate) fn inferred_type<'db>(&self, model: &SemanticModel<'db>) -> Option<Type<'db>> {
-        let ty = match self {
+        match self {
             GotoTarget::Expression(expression) => expression.inferred_type(model),
             GotoTarget::FunctionDef(function) => function.inferred_type(model),
             GotoTarget::ClassDef(class) => class.inferred_type(model),
@@ -317,7 +317,7 @@ impl GotoTarget<'_> {
             } => {
                 // We don't currently support hovering the bare `.` so there is always a name
                 let module = import_name(module_name, *component_index);
-                model.resolve_module_type(Some(module), *level)?
+                model.resolve_module_type(Some(module), *level)
             }
             GotoTarget::StringAnnotationSubexpr {
                 string_expr,
@@ -334,16 +334,16 @@ impl GotoTarget<'_> {
                 } else {
                     // TODO: force the typechecker to tell us its secrets
                     // (it computes but then immediately discards these types)
-                    return None;
+                    None
                 }
             }
             GotoTarget::BinOp { expression, .. } => {
                 let (_, ty) = ty_python_semantic::definitions_for_bin_op(model, expression)?;
-                ty
+                Some(ty)
             }
             GotoTarget::UnaryOp { expression, .. } => {
                 let (_, ty) = ty_python_semantic::definitions_for_unary_op(model, expression)?;
-                ty
+                Some(ty)
             }
             // TODO: Support identifier targets
             GotoTarget::PatternMatchRest(_)
@@ -353,10 +353,8 @@ impl GotoTarget<'_> {
             | GotoTarget::TypeParamParamSpecName(_)
             | GotoTarget::TypeParamTypeVarTupleName(_)
             | GotoTarget::NonLocal { .. }
-            | GotoTarget::Globals { .. } => return None,
-        };
-
-        Some(ty)
+            | GotoTarget::Globals { .. } => None,
+        }
     }
 
     /// Try to get a simplified display of this callable type by resolving overloads

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -3610,6 +3610,20 @@ def function():
         ");
     }
 
+    #[test]
+    fn hover_tuple_assignment_target() {
+        let test = CursorTest::builder()
+            .source(
+                "test.py",
+                r#"
+                (x, y)<CURSOR> = "test", 10
+                "#,
+            )
+            .build();
+
+        assert_snapshot!(test.hover(), @"Hover provided no content");
+    }
+
     impl CursorTest {
         fn hover(&self) -> String {
             use std::fmt::Write;

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -362,8 +362,9 @@ impl<'a> SourceOrderVisitor<'a> for InlayHintVisitor<'a, '_> {
             Expr::Name(name) => {
                 if let Some(rhs) = self.assignment_rhs {
                     if name.ctx.is_store() {
-                        let ty = expr.inferred_type(&self.model);
-                        self.add_type_hint(expr, rhs, ty, !self.in_no_edits_allowed);
+                        if let Some(ty) = expr.inferred_type(&self.model) {
+                            self.add_type_hint(expr, rhs, ty, !self.in_no_edits_allowed);
+                        }
                     }
                 }
                 source_order::walk_expr(self, expr);
@@ -371,8 +372,9 @@ impl<'a> SourceOrderVisitor<'a> for InlayHintVisitor<'a, '_> {
             Expr::Attribute(attribute) => {
                 if let Some(rhs) = self.assignment_rhs {
                     if attribute.ctx.is_store() {
-                        let ty = expr.inferred_type(&self.model);
-                        self.add_type_hint(expr, rhs, ty, !self.in_no_edits_allowed);
+                        if let Some(ty) = expr.inferred_type(&self.model) {
+                            self.add_type_hint(expr, rhs, ty, !self.in_no_edits_allowed);
+                        }
                     }
                 }
                 source_order::walk_expr(self, expr);

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -878,7 +878,7 @@ impl<'db> Type<'db> {
         Self::Dynamic(DynamicType::Any)
     }
 
-    pub(crate) const fn unknown() -> Self {
+    pub const fn unknown() -> Self {
         Self::Dynamic(DynamicType::Unknown)
     }
 


### PR DESCRIPTION
## Summary

ty doesn't infer types for every expression. This PR ensures we don't show Unknown when hovering such an expression 
but, instead, don't show a hover at all.

Whether we want to show a different hover in this case is something I'll suggest leaving for another PR.

## Test Plan

Added test
