### PR TITLE
[ty] Fix workspace symbols to return members too

### DIFF
--- a/crates/ty_ide/src/workspace_symbols.rs
+++ b/crates/ty_ide/src/workspace_symbols.rs
@@ -148,28 +148,6 @@ class Test:
           |
         info: Method from_path
         ");
-
-        assert_snapshot!(test.workspace_symbols("data"), @r"
-        info[workspace-symbols]: WorkspaceSymbolInfo
-         --> models.py:2:7
-          |
-        2 | class DataModel:
-          |       ^^^^^^^^^
-        3 |     '''A data model class'''
-        4 |     def __init__(self):
-          |
-        info: Class DataModel
-        ");
-
-        assert_snapshot!(test.workspace_symbols("apibase"), @r"
-        info[workspace-symbols]: WorkspaceSymbolInfo
-         --> constants.py:2:1
-          |
-        2 | API_BASE_URL = 'https://api.example.com'
-          | ^^^^^^^^^^^^
-          |
-        info: Constant API_BASE_URL
-        ");
     }
 
     impl CursorTest {


### PR DESCRIPTION
## Summary

I think it was an accidental change in https://github.com/astral-sh/ruff/pull/20030 to use `symbols_for_files_global_only` in the workspace symbol request.
The result of it is that you can only find global symbols but not method members.

This PR changes workspace symbols back to use `symbols_for_file`.

Fixes the missing members reported in https://github.com/astral-sh/ty/issues/1856 but not the caching issue

## Test Plan


https://github.com/user-attachments/assets/2a86d850-4c6a-4a70-b483-6955a8090fb1

