### PR TITLE
[`flake8-bugbear`] Allow `B901` in pytest hook wrappers

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B901.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B901.py
@@ -1,8 +1,7 @@
 """
 Should emit:
-B901 - on lines 9, 36, 56, 60, 72, 83, 88, 112, 119, 126
+B901 - on lines 9, 36
 """
-import pytest
 
 
 def broken():
@@ -89,6 +88,9 @@ async def broken7():
     return [1, 2, 3]
 
 
+import pytest
+
+
 @pytest.hookimpl(wrapper=True)
 def pytest_runtest_makereport():
     result = yield
@@ -99,6 +101,12 @@ def pytest_runtest_makereport():
 def pytest_fixture_setup():
     result = yield
     result.some_attr = "modified"
+    return result
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call():
+    result = yield
     return result
 
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/return_in_generator.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/return_in_generator.rs
@@ -5,7 +5,7 @@ use ruff_text_size::TextRange;
 
 use crate::Violation;
 use crate::checkers::ast::Checker;
-use crate::rules::flake8_pytest_style::is_pytest_hookimpl_wrapper;
+use crate::rules::flake8_pytest_style::helpers::is_pytest_hookimpl_wrapper;
 
 /// ## What it does
 /// Checks for `return {value}` statements in functions that also contain `yield`

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B901_B901.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B901_B901.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
-assertion_line: 82
 ---
 B901 Using `yield` and `return {value}` in a generator function can lead to confusing behavior
   --> B901.py:9:9
@@ -67,28 +66,28 @@ B901 Using `yield` and `return {value}` in a generator function can lead to conf
    |
 
 B901 Using `yield` and `return {value}` in a generator function can lead to confusing behavior
-   --> B901.py:112:5
+   --> B901.py:116:5
     |
-110 | def pytest_configure():
-111 |     yield
-112 |     return "should error"
+114 | def pytest_configure():
+115 |     yield
+116 |     return "should error"
     |     ^^^^^^^^^^^^^^^^^^^^^
     |
 
 B901 Using `yield` and `return {value}` in a generator function can lead to confusing behavior
-   --> B901.py:119:5
+   --> B901.py:122:5
     |
-117 | def pytest_unconfigure():
-118 |     yield
-119 |     return "should error"
+120 | def pytest_unconfigure():
+121 |     yield
+122 |     return "should error"
     |     ^^^^^^^^^^^^^^^^^^^^^
     |
 
 B901 Using `yield` and `return {value}` in a generator function can lead to confusing behavior
-   --> B901.py:126:5
+   --> B901.py:128:5
     |
-124 | def my_fixture():
-125 |     yield
-126 |     return "should error"
+126 | def my_fixture():
+127 |     yield
+128 |     return "should error"
     |     ^^^^^^^^^^^^^^^^^^^^^
     |

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
@@ -1,10 +1,8 @@
 //! Rules from [flake8-pytest-style](https://pypi.org/project/flake8-pytest-style/).
-mod helpers;
+pub(crate) mod helpers;
 pub(crate) mod rules;
 pub mod settings;
 pub mod types;
-
-pub(crate) use helpers::is_pytest_hookimpl_wrapper;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION

## Summary
Stop raising return-in-generator with pytest hook wrappers (@hookimpl(wrapper=True)). They are specifically designed to use this pattern: https://docs.pytest.org/en/stable/how-to/writing_hook_functions.html#hook-wrappers-executing-around-other-hooks

Before: return-in-generator reports would surface with pytest hook wrappers

After: specifically check for pytest hook wrappers before reporting return-in-generator 

Testing:
Wrote some tests to cover different cases