### PR TITLE
[ty] Use `ParamSpec` without the attr for inferable check

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -711,6 +711,9 @@ class Child2(Parent):
 
 ### One `ParamSpec` not inferable
 
+Here, `P` is in a non-inferable position while `Q` is inferable. So, they are not considered
+assignable.
+
 ```py
 from typing import Callable
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2174,23 +2174,6 @@ impl<'db> Type<'db> {
                 ConstraintSet::from(true)
             }
 
-            // Two ParamSpec attributes (P.args/P.kwargs and Q.args/Q.kwargs) are assignable to
-            // each other if they have the same attribute kind and both underlying ParamSpecs are
-            // inferable.
-            (Type::TypeVar(lhs_bound_typevar), Type::TypeVar(rhs_bound_typevar))
-                if lhs_bound_typevar.paramspec_attr(db).is_some()
-                    && lhs_bound_typevar.paramspec_attr(db)
-                        == rhs_bound_typevar.paramspec_attr(db)
-                    && lhs_bound_typevar
-                        .without_paramspec_attr(db)
-                        .is_inferable(db, inferable)
-                    && rhs_bound_typevar
-                        .without_paramspec_attr(db)
-                        .is_inferable(db, inferable) =>
-            {
-                ConstraintSet::from(true)
-            }
-
             // `type[T]` is a subtype of the class object `A` if every instance of `T` is a subtype of an instance
             // of `A`, and vice versa.
             (Type::SubclassOf(subclass_of), _)


### PR DESCRIPTION
## Summary

fixes: https://github.com/astral-sh/ty/issues/1820

## Test Plan

Add new mdtests.

Ecosystem changes removes all false positives.
