### PR TITLE
[ty] Attach db to background request handler task

### DIFF
--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -299,7 +299,9 @@ where
             }
 
             if let Err(error) = ruff_db::panic::catch_unwind(|| {
-                R::handle_request(&id, &db, document, client, params);
+                salsa::attach(&db, || {
+                    R::handle_request(&id, &db, document, client, params);
+                });
             }) {
                 panic_response::<R>(&id, client, &error, retry);
             }


### PR DESCRIPTION
## Summary

Attach the salsa db before calling a background request handler so that `dbg!(salsa_struct)` prints more than just the salsa id.


