### PR TITLE
[ty] Fix outdated version in publish diagnostics after `didChange`

### DIFF
--- a/crates/ty_server/src/server/api/notifications/did_change.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change.rs
@@ -26,7 +26,7 @@ impl SyncNotificationHandler for DidChangeTextDocumentHandler {
             content_changes,
         } = params;
 
-        let document = session
+        let mut document = session
             .document_handle(&uri)
             .with_failure_code(ErrorCode::InternalError)?;
 

--- a/crates/ty_server/src/server/api/notifications/did_change_notebook.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_notebook.rs
@@ -24,7 +24,7 @@ impl SyncNotificationHandler for DidChangeNotebookHandler {
             change: types::NotebookDocumentChangeEvent { cells, metadata },
         }: types::DidChangeNotebookDocumentParams,
     ) -> Result<()> {
-        let document = session
+        let mut document = session
             .document_handle(&uri)
             .with_failure_code(ErrorCode::InternalError)?;
 

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_change.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_change.snap
@@ -1,0 +1,21 @@
+---
+source: crates/ty_server/tests/e2e/publish_diagnostics.rs
+expression: diagnostics
+---
+PublishDiagnosticsParams {
+    uri: Url {
+        scheme: "file",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: None,
+        port: None,
+        path: "<temp_dir>/src/foo.py",
+        query: None,
+        fragment: None,
+    },
+    diagnostics: [],
+    version: Some(
+        2,
+    ),
+}


### PR DESCRIPTION
## Summary

Fixes the bug reported in https://github.com/astral-sh/ty/issues/1652#issuecomment-3645976277

`publish_diagnostics` used the version of `DocumentHandle::version`. However, we didn't update
that version in the `didChange` handler, resulting in ty publishing diagnostics for the previous
version rather than the most recent version (making clients ignore the diagnostics).

This PR fixes this by updating the version on `DocumentHandle` when updating the document.

## Test Plan

Added E2E test
