### PR TITLE
[ty] Classify `cls` as class parameter

### DIFF
--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -119,7 +119,7 @@ impl<'db> SubclassOfType<'db> {
         subclass_of.is_type_var()
     }
 
-    pub(crate) const fn into_type_var(self) -> Option<BoundTypeVarInstance<'db>> {
+    pub const fn into_type_var(self) -> Option<BoundTypeVarInstance<'db>> {
         self.subclass_of.into_type_var()
     }
 


### PR DESCRIPTION
## Summary

Classify usages of the `cls` parameter as `ClsParameter`.

## Test Plan

I updated the tests to have `cls` usages in the body and verified that they were incorrectly classified as `Parameter`. 

Now, with the changes in this PR, they're correctly classified as `ClsParameter`
