### PR TITLE
[ty] Add basic support for overloads in `ParamSpec`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -694,6 +694,7 @@ def foo(int_or_str: int | str):
     reveal_type(with_parameters(int_int, int_or_str))  # revealed: Overload[(x: int) -> str, (x: str) -> str]
 
 # Keyword argument matching should also work
+# TODO: This should reveal the matching overload instead
 reveal_type(with_parameters(int_int, x=1))  # revealed: Overload[(x: int) -> str, (x: str) -> str]
 reveal_type(with_parameters(int_int, x="a"))  # revealed: Overload[(x: int) -> str, (x: str) -> str]
 
@@ -731,6 +732,7 @@ reveal_type(run(multi, 1, 2))  # revealed: int | str
 reveal_type(run(multi, "a", "b"))  # revealed: int | str
 
 # Mixed positional and keyword
+# TODO: both should reveal `int`
 reveal_type(run(multi, 1, y=2))  # revealed: int | str
 reveal_type(run(multi, x=1, y=2))  # revealed: int | str
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3451,9 +3451,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         };
 
         // SAFETY: `bindings` was created from a single `CallableBinding` above.
-        let Some(callable_binding) = bindings.single_element() else {
-            unreachable!("ParamSpec sub-call should only contain a single CallableBinding");
-        };
+        let callable_binding = bindings
+            .single_element()
+            .expect("ParamSpec sub-call should only contain a single CallableBinding");
 
         match callable_binding.matching_overload_index() {
             MatchingOverloadIndex::None => {


### PR DESCRIPTION
## Summary

fixes: https://github.com/astral-sh/ty/issues/1838

This PR adds basic support for overloaded function when used to specialize a `ParamSpec` type variable.

Following cases are still remaining:
1. Updating the specialization with the matching overload after the paramspec sub-call logic
2. Updating the specialization with the matching overload using the return type

Both of these cases are present in the mdtest file.

## Test Plan

Update mdtest with new cases.
