### PR TITLE
[ty] Add `KnownUnion::to_type()`

### DIFF
--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -7,8 +7,9 @@ use crate::semantic_index::definition::DefinitionKind;
 use crate::semantic_index::{attribute_scopes, global_scope, semantic_index, use_def_map};
 use crate::types::call::{CallArguments, MatchedArgument};
 use crate::types::signatures::{ParameterKind, Signature};
-use crate::types::{CallDunderError, UnionType};
-use crate::types::{CallableTypes, ClassBase, KnownClass, Type, TypeContext};
+use crate::types::{
+    CallDunderError, CallableTypes, ClassBase, KnownUnion, Type, TypeContext, UnionType,
+};
 use crate::{Db, DisplaySettings, HasType, SemanticModel};
 use ruff_db::files::FileRange;
 use ruff_db::parsed::parsed_module;
@@ -193,21 +194,8 @@ pub fn definitions_for_name<'db>(
 
 fn is_float_or_complex_annotation(db: &dyn Db, ty: UnionType, name: &str) -> bool {
     let float_or_complex_ty = match name {
-        "float" => UnionType::from_elements(
-            db,
-            [
-                KnownClass::Int.to_instance(db),
-                KnownClass::Float.to_instance(db),
-            ],
-        ),
-        "complex" => UnionType::from_elements(
-            db,
-            [
-                KnownClass::Int.to_instance(db),
-                KnownClass::Float.to_instance(db),
-                KnownClass::Complex.to_instance(db),
-            ],
-        ),
+        "float" => KnownUnion::Float.to_type(db),
+        "complex" => KnownUnion::Complex.to_type(db),
         _ => return false,
     }
     .expect_union();

--- a/crates/ty_python_semantic/src/types/newtype.rs
+++ b/crates/ty_python_semantic/src/types/newtype.rs
@@ -3,9 +3,7 @@ use std::collections::BTreeSet;
 use crate::Db;
 use crate::semantic_index::definition::{Definition, DefinitionKind};
 use crate::types::constraints::ConstraintSet;
-use crate::types::{
-    ClassType, KnownClass, KnownUnion, Type, UnionType, definition_expression_type, visitor,
-};
+use crate::types::{ClassType, KnownUnion, Type, definition_expression_type, visitor};
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
 
@@ -236,21 +234,8 @@ impl<'db> NewTypeBase<'db> {
         match self {
             NewTypeBase::ClassType(class_type) => Type::instance(db, class_type),
             NewTypeBase::NewType(newtype) => Type::NewTypeInstance(newtype),
-            NewTypeBase::Float => UnionType::from_elements(
-                db,
-                [
-                    KnownClass::Int.to_instance(db),
-                    KnownClass::Float.to_instance(db),
-                ],
-            ),
-            NewTypeBase::Complex => UnionType::from_elements(
-                db,
-                [
-                    KnownClass::Int.to_instance(db),
-                    KnownClass::Float.to_instance(db),
-                    KnownClass::Complex.to_instance(db),
-                ],
-            ),
+            NewTypeBase::Float => KnownUnion::Float.to_type(db),
+            NewTypeBase::Complex => KnownUnion::Complex.to_type(db),
         }
     }
 }


### PR DESCRIPTION
## Summary

A small refactor followup to https://github.com/astral-sh/ruff/pull/21886. Now that we have a `KnownUnion` enum, we can use it in more places to make our code a bit more DRY

## Test Plan

pure refactor; no added tests
