### PR TITLE
Document known lambda formatting deviations from Black

### DIFF
--- a/docs/formatter/black.md
+++ b/docs/formatter/black.md
@@ -745,7 +745,7 @@ items = {(123)}
 
 ### Long lambda expressions
 
-In [preview](preview.md), Ruff will keep lambda parameters on a single line,
+In [preview](../preview.md), Ruff will keep lambda parameters on a single line,
 just like Black:
 
 ```python


### PR DESCRIPTION
Summary
--

Following #8179, we now format long lambda expressions a bit more like Black, preferring to keep long parameter lists on a single line, but we go one step further to break the body itself across multiple lines and parenthesize it if it's still too long. This PR documents both the stable deviation that breaks parameters across multiple lines, and the new preview deviation that breaks the body instead.

I also fixed a couple of typos in the section immediately above my addition.

Test Plan
--

I tested all of the snippets here against `main` for the preview behavior, our playground for the stable behavior, and Black's playground for their behavior
