### PR TITLE
[ty] Fix callout syntax in configuration mkdocs (#1875)

### DIFF
--- a/crates/ruff_dev/src/generate_ty_options.rs
+++ b/crates/ruff_dev/src/generate_ty_options.rs
@@ -144,8 +144,8 @@ fn emit_field(output: &mut String, name: &str, field: &OptionField, parents: &[S
     output.push('\n');
 
     if let Some(deprecated) = &field.deprecated {
-        output.push_str("> [!WARN] \"Deprecated\"\n");
-        output.push_str("> This option has been deprecated");
+        output.push_str("!!! warning \"Deprecated\"\n");
+        output.push_str("    This option has been deprecated");
 
         if let Some(since) = deprecated.since {
             write!(output, " in {since}").unwrap();

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -432,8 +432,8 @@ respect-ignore-files = false
 
 ### `root`
 
-> [!WARN] "Deprecated"
-> This option has been deprecated. Use `environment.root` instead.
+!!! warning "Deprecated"
+    This option has been deprecated. Use `environment.root` instead.
 
 The root of the project, used for finding first-party modules.
 


### PR DESCRIPTION
This is an alternative solution to https://github.com/astral-sh/ty/pull/1879 which does not add a new dependency.

## Before
<img width="1574" height="202" alt="image" src="https://github.com/user-attachments/assets/a98d23cf-d454-45f0-922f-38f5402ca998" />

## After
<img width="1548" height="312" alt="image" src="https://github.com/user-attachments/assets/dc76808c-20dc-4cd9-8c70-5b8b226dee04" />


Closes https://github.com/astral-sh/ty/issues/1875