### PR TITLE
Update debug_assert which pointed at missing method

### DIFF
--- a/crates/ruff_diagnostics/src/edit.rs
+++ b/crates/ruff_diagnostics/src/edit.rs
@@ -39,7 +39,7 @@ impl Edit {
 
     /// Creates an edit that replaces the content in `range` with `content`.
     pub fn range_replacement(content: String, range: TextRange) -> Self {
-        debug_assert!(!content.is_empty(), "Prefer `Fix::deletion`");
+        debug_assert!(!content.is_empty(), "Prefer `Edit::deletion`");
 
         Self {
             content: Some(Box::from(content)),


### PR DESCRIPTION
## Summary

I assume that the class has been renamed or split since this assertion was created.

## Test Plan

Compiled locally, nothing more. Relying on CI given the triviality of this change.
