### PR TITLE
[ty] Fix panic where we would incorrectly consider overloads in another file as belonging to a function in the file being checked

### DIFF
--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -395,12 +395,12 @@ impl<'db> OverloadLiteral<'db> {
             return None;
         }
 
-        // These can both happen in edge cases involving not-yet-complete function definitions
-        // (invalid syntax).
+        // These can both happen in edge cases where a definition created with a `def`
+        // statement shadows a non-`def` symbol with the same name.
         if previous_overload.name(db) != self.name(db) {
             return None;
         }
-        if previous_overload.body_scope(db).file(db) != self.file(db) {
+        if previous_overload.definition(db).scope(db) != scope {
             return None;
         }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/1867. In certain cases where a function definition has not yet been completed, we can end up associating overloads from a totally different function (in a totally different file) with the unfinished function in the file being checked. That then leads us to panic in other places that assume (reasonably) that a function's overloads will all always be defined in a single file.

This PR fixes the panic by adding more sanity checks to `OverloadLiteral::previous_overload()`.

## Test Plan

Added a regression test that causes us to panic on `main`.
