### PR TITLE
[ty] proof of concept: clickable types in hover

### DIFF
--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -399,7 +399,7 @@ impl Workspace {
 
         Ok(Some(Hover {
             markdown: range_info
-                .display(&self.db, MarkupKind::Markdown)
+                .display(&self.db, MarkupKind::Markdown, &|_| None)
                 .to_string(),
             range: source_range,
         }))


### PR DESCRIPTION
## Summary

This is a proof of concept for rendering types as a series of hyperlinks in hovers:

<img width="485" height="72" alt="Screenshot 2025-12-15 at 2 19 20 PM" src="https://github.com/user-attachments/assets/91cfd72e-0351-4cdc-9a37-574c60c993c9" />

<img width="204" height="75" alt="Screenshot 2025-12-15 at 2 19 09 PM" src="https://github.com/user-attachments/assets/71b1bb45-901e-481b-a8df-ca40396ca24c" />

* A silly solution to https://github.com/astral-sh/ty/issues/1575

## Test Plan

Messing around in IDE.
