### PR TITLE
[ty] Cache `KnownClass::to_class_literal`

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -4261,7 +4261,6 @@ pub enum KnownClass {
     Specialization,
 }
 
-#[salsa::tracked]
 impl KnownClass {
     pub(crate) const fn is_bool(self) -> bool {
         matches!(self, Self::Bool)


### PR DESCRIPTION
This PR adds salsa caching to `KnownClass::to_class_literal`. 

I noticed that we spend about 4.5% of discord.py's entire check time in `KnownClass::to_class_literal` which seemed high. That's why I added salsa caching to the lookup and the results are much better than I thought because:

* `KnownClass::Module::to_class_literal` ends up in a cycle. Adding cycle handling to `to_class_literal` reduces the size of the cycle. `imported_symbol` (which `KnownClass::to_class_literal` uses resolves `KnownClass::Module.to_instance`). It might be worth trying if we can resolve this cycle somehow
* We tracked the dependencies of `KnownClass::to_class_literal` on the calling query, adding many dependencies to every query that uses a `KnownClass`. Making `KnownClass::to_class_literal` a query ensures that we store the dependencies only once, and dependent query only have to depend on `KnownClass::to_class_literal`. This helps reduce the memo metadata.
* We avoid recomputing the same value which is obviously great