### PR TITLE
[ty] Don't suggest keyword statements when only expressions are valid

### DIFF
--- a/crates/ty_completion_eval/completion-evaluation-tasks.csv
+++ b/crates/ty_completion_eval/completion-evaluation-tasks.csv
@@ -15,7 +15,7 @@ import-deprioritizes-type_check_only,main.py,3,2
 import-deprioritizes-type_check_only,main.py,4,3
 import-keyword-completion,main.py,0,1
 internal-typeshed-hidden,main.py,0,2
-none-completion,main.py,0,2
+none-completion,main.py,0,1
 numpy-array,main.py,0,159
 numpy-array,main.py,1,1
 object-attr-instance-methods,main.py,0,1


### PR DESCRIPTION
There are cases where the python grammar enforces expressions after certain statements. In such cases we want to suppress irrelevant keywords from the auto-complete suggestions.

E.g. `with a<CURSOR>`, suggesting `raise` here never makes sense because it is not valid by the grammar.

## Summary
This tries to detect all cases where the python grammar disallows anything but expressions and eliminates
statements keywords in those cases as we know those are invalid.

## Test Plan
New test cases and testing in the playground.

