### PR TITLE
[ty] Fix benchmark assertion

### DIFF
--- a/scripts/ty_benchmark/src/benchmark/test_lsp_diagnostics.py
+++ b/scripts/ty_benchmark/src/benchmark/test_lsp_diagnostics.py
@@ -376,6 +376,10 @@ class IncrementalEditTest(LspTest):
             "The after edit diagnostics should be initialized if the test ran at least once. Did you forget to call `run`?"
         )
 
+        new_diagnostics = diff_diagnostics(
+            self.before_edit_diagnostics, self.after_edit_diagnostics
+        )
+
         before_edit_count = sum(
             len(diagnostics) for _, diagnostics in self.before_edit_diagnostics
         )
@@ -384,7 +388,7 @@ class IncrementalEditTest(LspTest):
             len(diagnostics) for _, diagnostics in self.after_edit_diagnostics
         )
 
-        assert after_edit_count > before_edit_count, (
+        assert len(new_diagnostics) > 0, (
             f"Expected more diagnostics after the change. "
             f"Initial: {before_edit_count}, After change: {after_edit_count}"
         )


### PR DESCRIPTION
The intention of the assertion is to catch cases where an edit didn't introduce any new diagnostics (or we failed to fetch them). However, simply asserting on the counts isn't sufficient because the assertion then also fails if the number of new and fixed diagnostics by an edit are equal.

This PR changes the assertion to diff the diagnostics first and assert if there are any new diagnostics.