### PR TITLE
[ty] Fixed benchmark markdown auto-linenumbers

### DIFF
--- a/scripts/ty_benchmark/README.md
+++ b/scripts/ty_benchmark/README.md
@@ -1,10 +1,8 @@
 ## Getting started
 
 1. [Install `uv`](https://docs.astral.sh/uv/getting-started/installation/)
-
-- Unix: `curl -LsSf https://astral.sh/uv/install.sh | sh`
-- Windows: `powershell -c "irm https://astral.sh/uv/install.ps1 | iex"`
-
+    - Unix: `curl -LsSf https://astral.sh/uv/install.sh | sh`
+    - Windows: `powershell -c "irm https://astral.sh/uv/install.ps1 | iex"`
 1. Build ty: `cargo build --bin ty --release`
 1. `cd` into the benchmark directory: `cd scripts/ty_benchmark`
 1. Install Pyright: `npm ci --ignore-scripts`


### PR DESCRIPTION
## Summary

Small nitpick I noticed when looking to leverage the benchmark script on a codebase we are considering what next-gen typechecker to adopt.

The auto linenumbering of the markdown list is broken due to sublist not being indented enough

<img width="666" height="495" alt="image" src="https://github.com/user-attachments/assets/7f54a9f6-5075-44cc-8f57-21d6bacebad9" />


## Test Plan

Rendered Github preview: https://github.com/sinon/ruff/blob/893556f460cd88623aa19cafb9680f324e598a5e/scripts/ty_benchmark/README.md

<!-- How was it tested? -->
