### PR TITLE
[ty] Improve disambiguation of types in many cases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1208,7 +1208,7 @@ def _(flag: bool):
     reveal_type(C1.y)  # revealed: int | str
 
     C1.y = 100
-    # error: [invalid-assignment] "Object of type `Literal["problematic"]` is not assignable to attribute `y` on type `<class 'C1'> | <class 'C1'>`"
+    # error: [invalid-assignment] "Object of type `Literal["problematic"]` is not assignable to attribute `y` on type `<class 'mdtest_snippet.<locals of function '_'>.C1 @ src/mdtest_snippet.py:3'> | <class 'mdtest_snippet.<locals of function '_'>.C1 @ src/mdtest_snippet.py:8'>`"
     C1.y = "problematic"
 
     class C2:

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
@@ -195,3 +195,52 @@ class C:
 c = C()
 c.square("hello")  # error: [invalid-argument-type]
 ```
+
+## Types with the same name but from different files
+
+`module.py`:
+
+```py
+class Foo: ...
+
+def needs_a_foo(x: Foo): ...
+```
+
+`main.py`:
+
+```py
+from module import needs_a_foo
+
+class Foo: ...
+
+needs_a_foo(Foo())  # error: [invalid-argument-type]
+```
+
+## TypeVars with bounds that have the same name but are from different files
+
+In this case, using fully qualified names is *not* necessary.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+`module.py`:
+
+```py
+class Foo: ...
+
+def needs_a_foo(x: Foo): ...
+```
+
+`main.py`:
+
+```py
+from module import needs_a_foo
+
+class Foo: ...
+
+def f[T: Foo](x: T) -> T:
+    needs_a_foo(x)  # error: [invalid-argument-type]
+    return x
+```

--- a/crates/ty_python_semantic/resources/mdtest/mro.md
+++ b/crates/ty_python_semantic/resources/mdtest/mro.md
@@ -393,7 +393,7 @@ else:
 # revealed: (<class 'B'>, <class 'X'>, <class 'Y'>, <class 'O'>, <class 'object'>) | (<class 'B'>, <class 'Y'>, <class 'X'>, <class 'O'>, <class 'object'>)
 reveal_mro(B)
 
-# error: 12 [unsupported-base] "Unsupported class base with type `<class 'B'> | <class 'B'>`"
+# error: 12 [unsupported-base] "Unsupported class base with type `<class 'mdtest_snippet.B @ src/mdtest_snippet.py:25'> | <class 'mdtest_snippet.B @ src/mdtest_snippet.py:28'>`"
 class Z(A, B): ...
 
 reveal_mro(Z)  # revealed: (<class 'Z'>, Unknown, <class 'object'>)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Setting_attributes_o…_(467e26496f4c0c13).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Setting_attributes_o…_(467e26496f4c0c13).snap
@@ -37,7 +37,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 # Diagnostics
 
 ```
-error[invalid-assignment]: Object of type `Literal[1]` is not assignable to attribute `attr` on type `<class 'C1'> | <class 'C1'>`
+error[invalid-assignment]: Object of type `Literal[1]` is not assignable to attribute `attr` on type `<class 'mdtest_snippet.<locals of function '_'>.C1 @ src/mdtest_snippet.py:3'> | <class 'mdtest_snippet.<locals of function '_'>.C1 @ src/mdtest_snippet.py:7'>`
   --> src/mdtest_snippet.py:11:5
    |
 10 |     # TODO: The error message here could be improved to explain why the assignment fails.

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_TypeVars_with_bounds…_(25b61918ea9f5644).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_TypeVars_with_bounds…_(25b61918ea9f5644).snap
@@ -1,0 +1,53 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - TypeVars with bounds that have the same name but are from different files
+mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## module.py
+
+```
+1 | class Foo: ...
+2 | 
+3 | def needs_a_foo(x: Foo): ...
+```
+
+## main.py
+
+```
+1 | from module import needs_a_foo
+2 | 
+3 | class Foo: ...
+4 | 
+5 | def f[T: Foo](x: T) -> T:
+6 |     needs_a_foo(x)  # error: [invalid-argument-type]
+7 |     return x
+```
+
+# Diagnostics
+
+```
+error[invalid-argument-type]: Argument to function `needs_a_foo` is incorrect
+ --> src/main.py:6:17
+  |
+5 | def f[T: Foo](x: T) -> T:
+6 |     needs_a_foo(x)  # error: [invalid-argument-type]
+  |                 ^ Expected `Foo`, found `T@f`
+7 |     return x
+  |
+info: Function defined here
+ --> src/module.py:3:5
+  |
+1 | class Foo: ...
+2 |
+3 | def needs_a_foo(x: Foo): ...
+  |     ^^^^^^^^^^^ ------ Parameter declared here
+  |
+info: rule `invalid-argument-type` is enabled by default
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Types_with_the_same_…_(34531e82322f6f21).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Types_with_the_same_…_(34531e82322f6f21).snap
@@ -1,0 +1,51 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid_argument_type.md - Invalid argument type diagnostics - Types with the same name but from different files
+mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+---
+
+# Python source files
+
+## module.py
+
+```
+1 | class Foo: ...
+2 | 
+3 | def needs_a_foo(x: Foo): ...
+```
+
+## main.py
+
+```
+1 | from module import needs_a_foo
+2 | 
+3 | class Foo: ...
+4 | 
+5 | needs_a_foo(Foo())  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error[invalid-argument-type]: Argument to function `needs_a_foo` is incorrect
+ --> src/main.py:5:13
+  |
+3 | class Foo: ...
+4 |
+5 | needs_a_foo(Foo())  # error: [invalid-argument-type]
+  |             ^^^^^ Expected `module.Foo`, found `main.Foo`
+  |
+info: Function defined here
+ --> src/module.py:3:5
+  |
+1 | class Foo: ...
+2 |
+3 | def needs_a_foo(x: Foo): ...
+  |     ^^^^^^^^^^^ ------ Parameter declared here
+  |
+info: rule `invalid-argument-type` is enabled by default
+
+```

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -21,7 +21,6 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::{SmallVec, smallvec, smallvec_inline};
 
 use super::{Argument, CallArguments, CallError, CallErrorKind, InferContext, Signature, Type};
-use crate::Program;
 use crate::db::Db;
 use crate::dunder_all::dunder_all_names;
 use crate::module_resolver::KnownModule;
@@ -52,6 +51,7 @@ use crate::types::{
     enums, list_members, todo_type,
 };
 use crate::unpack::EvaluationMode;
+use crate::{DisplaySettings, Program};
 use ruff_db::diagnostic::{Annotation, Diagnostic, SubDiagnostic, SubDiagnosticSeverity};
 use ruff_python_ast::{self as ast, ArgOrKeyword, PythonVersion};
 
@@ -4156,8 +4156,13 @@ impl<'db> BindingError<'db> {
                     return;
                 };
 
-                let provided_ty_display = provided_ty.display(context.db());
-                let expected_ty_display = expected_ty.display(context.db());
+                let display_settings = DisplaySettings::from_possibly_ambiguous_types(
+                    context.db(),
+                    [provided_ty, expected_ty],
+                );
+                let provided_ty_display =
+                    provided_ty.display_with(context.db(), display_settings.clone());
+                let expected_ty_display = expected_ty.display_with(context.db(), display_settings);
 
                 let mut diag = builder.into_diagnostic(format_args!(
                     "Argument{} is incorrect",


### PR DESCRIPTION
## Summary

### The "display disambiguator"

For many diagnostics, we run the "display disambiguator" on all types that will appear in that diagnostic. This is to avoid confusing diagnostic messages in situations where two files have types that are distinct but share the same name -- e.g. without the "display disambiguator", we'd end up with messages like this:

```
error [invalid-return-type] Expected type `Foo`, got type `Foo`
```

whereas with it, we get

```
error [invalid-return-type] Expected type `module.Foo`, got type `main.Foo`
```

(The "display disambiguator" means that we only use the fully qualified name for _actually ambiguous_ cases. Types that are not ambiguous still use the unqualified names in diagnostic messages.)

### This PR

This PR extends our usage of the display disambiguator in two ways:
- We now run it by default in all calls to `Type::display()`. Even if there is only one type that needs to be rendered in a diagnostic message, that type might _contain_ lots of other types and therefore require disambiguation. A common example that we've seen in the ecosystem is `numpy.bool[builtins.bool]` being rendered confusingly as `bool[bool]`.
- I added calls to the display disambiguator to our `invalid-argument-type` diagnostic -- this is a specific diagnostic that involves a pair of types, where we weren't running it previously.

## Test Plan

Mdtests/snapshots added and updated.
