### PR TITLE
[ty] Unwrap `enum.nonmember` values

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -455,19 +455,6 @@ reveal_type(enum_members(Answer))
 # `nonmember` attributes are unwrapped to the inner value type when accessed.
 # revealed: int
 reveal_type(Answer.OTHER)
-
-def coinflip() -> bool:
-    return True
-
-class WithConditionalNonmember(Enum):
-    A = 1
-    # Union of nonmember types: the nonmember is still unwrapped.
-    # This tests that `try_unwrap_nonmember_value` correctly handles
-    # unions containing nonmember instances.
-    B = nonmember("foo") if coinflip() else nonmember("bar")
-
-# revealed: str
-reveal_type(WithConditionalNonmember.B)
 ```
 
 `member` can also be used as a decorator:

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -455,6 +455,19 @@ reveal_type(enum_members(Answer))
 # `nonmember` attributes are unwrapped to the inner value type when accessed.
 # revealed: int
 reveal_type(Answer.OTHER)
+
+def coinflip() -> bool:
+    return True
+
+class WithConditionalNonmember(Enum):
+    A = 1
+    # Union of nonmember types: the nonmember is still unwrapped.
+    # This tests that `try_unwrap_nonmember_value` correctly handles
+    # unions containing nonmember instances.
+    B = nonmember("foo") if coinflip() else nonmember("bar")
+
+# revealed: str
+reveal_type(WithConditionalNonmember.B)
 ```
 
 `member` can also be used as a decorator:

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -453,7 +453,7 @@ class Answer(Enum):
 reveal_type(enum_members(Answer))
 
 # `nonmember` attributes are unwrapped to the inner value type when accessed.
-# revealed: Unknown | int
+# revealed: int
 reveal_type(Answer.OTHER)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -451,6 +451,10 @@ class Answer(Enum):
 
 # revealed: tuple[Literal["YES"], Literal["NO"]]
 reveal_type(enum_members(Answer))
+
+# `nonmember` attributes are unwrapped to the inner value type when accessed.
+# revealed: Unknown | int
+reveal_type(Answer.OTHER)
 ```
 
 `member` can also be used as a decorator:

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -912,18 +912,6 @@ impl<'db> Type<'db> {
         matches!(self, Type::Callable(..))
     }
 
-    /// Returns `true` if this type is or contains an `enum.nonmember` instance.
-    pub(crate) fn contains_nonmember(&self, db: &'db dyn Db) -> bool {
-        match self {
-            Type::NominalInstance(instance) => instance.has_known_class(db, KnownClass::Nonmember),
-            Type::Union(union) => union
-                .elements(db)
-                .iter()
-                .any(|elem| elem.contains_nonmember(db)),
-            _ => false,
-        }
-    }
-
     pub(crate) fn cycle_normalized(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -912,6 +912,18 @@ impl<'db> Type<'db> {
         matches!(self, Type::Callable(..))
     }
 
+    /// Returns `true` if this type is or contains an `enum.nonmember` instance.
+    pub(crate) fn contains_nonmember(&self, db: &'db dyn Db) -> bool {
+        match self {
+            Type::NominalInstance(instance) => instance.has_known_class(db, KnownClass::Nonmember),
+            Type::Union(union) => union
+                .elements(db)
+                .iter()
+                .any(|elem| elem.contains_nonmember(db)),
+            _ => false,
+        }
+    }
+
     pub(crate) fn cycle_normalized(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2361,18 +2361,10 @@ impl<'db> ClassLiteral<'db> {
         // For enum classes, `nonmember(value)` creates a non-member attribute.
         // At runtime, the enum metaclass unwraps the value, so accessing the attribute
         // returns the inner value, not the `nonmember` wrapper.
-        //
-        // We check bindings directly (not combined with declarations) to match the
-        // behavior in `enum_metadata`, which also uses only bindings.
-        if is_enum_class_by_inheritance(db, self) {
-            if let Some(symbol_id) = place_table(db, body_scope).symbol_id(name) {
-                let use_def = use_def_map(db, body_scope);
-                let bindings = use_def.end_of_scope_symbol_bindings(symbol_id);
-                let inferred = place_from_bindings(db, bindings).place;
-                if let Place::Defined(ty, _, _) = inferred {
-                    if let Some(value_ty) = try_unwrap_nonmember_value(db, ty) {
-                        return Member::definitely_declared(value_ty);
-                    }
+        if let Some(ty) = member.inner.place.ignore_possibly_undefined() {
+            if let Some(value_ty) = try_unwrap_nonmember_value(db, ty) {
+                if is_enum_class_by_inheritance(db, self) {
+                    return Member::definitely_declared(value_ty);
                 }
             }
         }

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -60,11 +60,7 @@ pub(crate) fn enum_metadata<'db>(
         return None;
     }
 
-    if !Type::ClassLiteral(class).is_subtype_of(db, KnownClass::Enum.to_subclass_of(db))
-        && !class
-            .metaclass(db)
-            .is_subtype_of(db, KnownClass::EnumType.to_subclass_of(db))
-    {
+    if !is_enum_class_by_inheritance(db, class) {
         return None;
     }
 
@@ -292,5 +288,57 @@ pub(crate) fn is_enum_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     match ty {
         Type::ClassLiteral(class_literal) => enum_metadata(db, class_literal).is_some(),
         _ => false,
+    }
+}
+
+/// Checks if a class is an enum class by inheritance (either a subtype of `Enum`
+/// or has a metaclass that is a subtype of `EnumType`).
+///
+/// This is a lighter-weight check than `enum_metadata`, which additionally
+/// verifies that the class has members.
+pub(crate) fn is_enum_class_by_inheritance<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> bool {
+    Type::ClassLiteral(class).is_subtype_of(db, KnownClass::Enum.to_subclass_of(db))
+        || class
+            .metaclass(db)
+            .is_subtype_of(db, KnownClass::EnumType.to_subclass_of(db))
+}
+
+/// Extracts the inner value type from an `enum.nonmember()` wrapper.
+///
+/// At runtime, the enum metaclass unwraps `nonmember(value)`, so accessing the attribute
+/// returns the inner value, not the `nonmember` wrapper.
+///
+/// If the type is a union containing a `nonmember[T]`, the nonmember is unwrapped and
+/// the other union elements (like `Unknown` from declarations) are filtered out.
+///
+/// Returns `Some(value_type)` if the type is or contains a `nonmember[T]`, otherwise `None`.
+pub(crate) fn try_unwrap_nonmember_value<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
+    match ty {
+        Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Nonmember) => {
+            Some(
+                ty.member(db, "value")
+                    .place
+                    .ignore_possibly_undefined()
+                    .unwrap_or(Type::unknown()),
+            )
+        }
+        Type::Union(union) => {
+            // If the union contains a nonmember, extract its value.
+            // Filter out other elements (like Unknown from declarations).
+            for elem in union.elements(db) {
+                if let Type::NominalInstance(instance) = elem {
+                    if instance.has_known_class(db, KnownClass::Nonmember) {
+                        return Some(
+                            elem.member(db, "value")
+                                .place
+                                .ignore_possibly_undefined()
+                                .unwrap_or(Type::unknown()),
+                        );
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
     }
 }

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -325,10 +325,7 @@ pub(crate) fn try_unwrap_nonmember_value<'db>(db: &'db dyn Db, ty: Type<'db>) ->
             //
             // For now, we filter out Unknown and expect exactly one nonmember type
             // to remain. If there are other non-Unknown types mixed in, we bail out.
-            let mut non_unknown = union
-                .elements(db)
-                .iter()
-                .filter(|elem| !elem.is_unknown());
+            let mut non_unknown = union.elements(db).iter().filter(|elem| !elem.is_unknown());
 
             let first = non_unknown.next()?;
 

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -319,6 +319,37 @@ pub(crate) fn try_unwrap_nonmember_value<'db>(db: &'db dyn Db, ty: Type<'db>) ->
                     .unwrap_or(Type::unknown()),
             )
         }
+        Type::Union(union) => {
+            // TODO: This is a hack. The proper fix is to avoid unioning Unknown from
+            // declarations into Place when we have concrete bindings.
+            //
+            // For now, we filter out Unknown and expect exactly one nonmember type
+            // to remain. If there are other non-Unknown types mixed in, we bail out.
+            let mut non_unknown = union
+                .elements(db)
+                .iter()
+                .filter(|elem| !elem.is_unknown());
+
+            let first = non_unknown.next()?;
+
+            // Ensure there's exactly one non-Unknown element.
+            if non_unknown.next().is_some() {
+                return None;
+            }
+
+            if let Type::NominalInstance(instance) = first {
+                if instance.has_known_class(db, KnownClass::Nonmember) {
+                    return Some(
+                        first
+                            .member(db, "value")
+                            .place
+                            .ignore_possibly_undefined()
+                            .unwrap_or(Type::unknown()),
+                    );
+                }
+            }
+            None
+        }
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary

This PR unwraps the `enum.nonmember` type to match runtime behavior.

Closes https://github.com/astral-sh/ty/issues/1974.
