### PR TITLE
[ty] Respect deferred values in keyword arguments et al for `.pyi` files

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/deferred.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/deferred.md
@@ -205,3 +205,93 @@ class B:
 class A(B): ...
 class B: ...
 ```
+
+## Default argument values
+
+### Not deferred in regular files
+
+```py
+# error: [unresolved-reference]
+def f(mode: int = ParseMode.test):
+    pass
+
+class ParseMode:
+    test = 1
+```
+
+### Deferred in stub files
+
+Forward references in default argument values are allowed in stub files.
+
+```pyi
+def f(mode: int = ParseMode.test): ...
+
+class ParseMode:
+    test: int
+```
+
+### Undefined names are still errors in stub files
+
+```pyi
+# error: [unresolved-reference]
+def f(mode: int = NeverDefined.test): ...
+```
+
+## Class keyword arguments
+
+### Not deferred in regular files
+
+```py
+# error: [unresolved-reference]
+class Foo(metaclass=SomeMeta):
+    pass
+
+class SomeMeta(type):
+    pass
+```
+
+### Deferred in stub files
+
+Forward references in class keyword arguments are allowed in stub files.
+
+```pyi
+class Foo(metaclass=SomeMeta): ...
+
+class SomeMeta(type): ...
+```
+
+### Undefined names are still errors in stub files
+
+```pyi
+# error: [unresolved-reference]
+class Foo(metaclass=NeverDefined): ...
+```
+
+## Lambda default argument values
+
+### Not deferred in regular files
+
+```py
+# error: [unresolved-reference]
+f = lambda x=Foo(): x
+
+class Foo:
+    pass
+```
+
+### Deferred in stub files
+
+Forward references in lambda default argument values are allowed in stub files.
+
+```pyi
+f = lambda x=Foo(): x
+
+class Foo: ...
+```
+
+### Undefined names are still errors in stub files
+
+```pyi
+# error: [unresolved-reference]
+f = lambda x=NeverDefined(): x
+```


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ty/issues/2019.
