### PR TITLE
[`eradicate`] ignore ruff:disable and ruff:enable comments in `ERA001`

### DIFF
--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -22,6 +22,7 @@ static ALLOWLIST_REGEX: LazyLock<Regex> = LazyLock::new(|| {
             # Case-sensitive
             pyright
         |   pyrefly
+        |   ruff\s*:\s*(disable|enable)
         |   mypy:
         |   type:\s*ignore
         |   SPDX-License-Identifier:
@@ -148,6 +149,8 @@ mod tests {
         assert!(!comment_contains_code("# 123", &[]));
         assert!(!comment_contains_code("# 123.1", &[]));
         assert!(!comment_contains_code("# 1, 2, 3", &[]));
+        assert!(!comment_contains_code("# ruff: disable[E501]", &[]));
+        assert!(!comment_contains_code("#ruff:enable[E501, F84]", &[]));
         assert!(!comment_contains_code(
             "# pylint: disable=redefined-outer-name",
             &[]


### PR DESCRIPTION
## Summary

Don't flag `# ruff: disable` or `# ruff: enable` comments as commented-out code.

## Test Plan

New test cases.

Issue #3711
