### PR TITLE
[`flake8-bandit`] Fix broken link (`S704`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/unsafe_markup_use.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/unsafe_markup_use.rs
@@ -12,7 +12,7 @@ use crate::{checkers::ast::Checker, settings::LinterSettings};
 /// Checks for non-literal strings being passed to [`markupsafe.Markup`][markupsafe-markup].
 ///
 /// ## Why is this bad?
-/// [`markupsafe.Markup`] does not perform any escaping, so passing dynamic
+/// [`markupsafe.Markup`][markupsafe-markup] does not perform any escaping, so passing dynamic
 /// content, like f-strings, variables or interpolated strings will potentially
 /// lead to XSS vulnerabilities.
 ///


### PR DESCRIPTION
Summary
--

While going through all the rules I noticed a broken link in the S704 docs. (I then got really confused because it appeared to be correct in the _other_ `unsafe_markup_use.rs` file for the removed RUF version of the rule).

Test Plan
--

[Before](https://docs.astral.sh/ruff/rules/unsafe-markup-use/):

<img width="537" height="171" alt="image" src="https://github.com/user-attachments/assets/01007cab-6673-48e5-b3a5-6006bc78a027" />


After:

<img width="451" height="189" alt="image" src="https://github.com/user-attachments/assets/4e5d0e0d-76be-4f66-b747-e209f11ab11a" />

I also did at least a cursory grep for other cases with escaped link brackets (`\[`) and only turned up this rule on main.
