### PR TITLE
[ty] Support rendering `__doc__` on hover

### DIFF
--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -2740,6 +2740,86 @@ def function():
     }
 
     #[test]
+    fn hover_dunder_doc() {
+        let test = cursor_test(
+            r#"
+            class My<CURSOR>Class:
+                __doc__ = "hello there"
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @r#"
+        <class 'MyClass'>
+        ---------------------------------------------
+        hello there
+
+        ---------------------------------------------
+        ```xml
+        <class 'MyClass'>
+        ```
+        ---
+        hello there
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:2:7
+          |
+        2 | class MyClass:
+          |       ^^-^^^^
+          |       | |
+          |       | Cursor offset
+          |       source
+        3 |     __doc__ = "hello there"
+          |
+        "#);
+    }
+
+    #[test]
+    fn hover_dunder_doc_complex() {
+        let test = cursor_test(
+            r#"
+            class My<CURSOR>Class:
+                __doc__ = (
+                    r"""This is some extremely complex docstring
+
+                Designed to make
+                """
+                    + r"""
+
+                A typechecker
+            """
+                    """
+                Fall to its knees and sob
+            """
+                    r"""
+                Witness my works and 
+                weep before them
+                """
+                )
+        "#,
+        );
+
+        assert_snapshot!(test.hover(), @r#"
+        <class 'MyClass'>
+        ---------------------------------------------
+        ```xml
+        <class 'MyClass'>
+        ```
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:2:7
+          |
+        2 | class MyClass:
+          |       ^^-^^^^
+          |       | |
+          |       | Cursor offset
+          |       source
+        3 |     __doc__ = (
+        4 |         r"""This is some extremely complex docstring
+          |
+        "#);
+    }
+
+    #[test]
     fn hover_class_typevar_variance() {
         let test = cursor_test(
             r#"


### PR DESCRIPTION
## Summary

I got this far before I realized how nightmarish the pytorch `__doc__` uses are. Not even asking the type checker what the string's value is would help here (the version I have checked in here is actually way way easier than what pytorch actually has).

I don't really think this is worth landing if all the actual usecases of `__doc__` are still impossible for us to handle.

* Fixes https://github.com/astral-sh/ty/issues/2051

## Test Plan

Snapshots
