### PR TITLE
[ty] Gracefully handle client requests that can't be deserialized

### DIFF
--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -116,25 +116,25 @@ pub(super) fn request(req: server::Request) -> Task {
             return Task::immediate(id, result);
         }
     }
-        .unwrap_or_else(|err| {
-            tracing::error!("Encountered error when routing request with ID {id}: {err}");
+    .unwrap_or_else(|err| {
+        tracing::error!("Encountered error when routing request with ID {id}: {err}");
 
-            Task::sync(move |_session, client| {
-                if matches!(err.code, ErrorCode::InternalError) {
-                    client.show_error_message("ty failed to handle a request from the editor. Check the logs for more details.");
-                }
+        Task::sync(move |_session, client| {
+            if matches!(err.code, ErrorCode::InternalError) {
+                client.show_error_message("ty failed to handle a request from the editor. Check the logs for more details.");
+            }
 
-                respond_silent_error(
-                    id,
-                    client,
-                    lsp_server::ResponseError {
-                        code: err.code as i32,
-                        message: err.to_string(),
-                        data: None,
-                    },
-                );
-            })
+            respond_silent_error(
+                id,
+                client,
+                lsp_server::ResponseError {
+                    code: err.code as i32,
+                    message: err.to_string(),
+                    data: None,
+                },
+            );
         })
+    })
 }
 
 pub(super) fn notification(notif: server::Notification) -> Task {


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/1328 by:

* Only showing users a pop-up if a request failed because of an internal error
* Use the RPC `InvalidParams` error code if deserializing the parameters failed (rather than internal error). This seems a better fit overall.


The thinking here is that users can't really do anything if their client sends an invalid request and
ty ignoring it is probably just fine.


## Test Plan

Not sure how to test this. I tried to reproduce https://github.com/astral-sh/ty/issues/1328 but I failed. 
I tried to add an E2E test but, obviously, our testing infrastructure doesn't allow to send malformed requests.... 


