### PR TITLE
[ty] ensure `IntersectionBuilder` does not have multiple identical `InnerIntersectionBuilder`s

### DIFF
--- a/crates/ty_python_semantic/src/types/builder.rs
+++ b/crates/ty_python_semantic/src/types/builder.rs
@@ -689,6 +689,14 @@ impl<'db> IntersectionBuilder<'db> {
         }
     }
 
+    fn extend(&mut self, sub: Self) {
+        for inner in sub.intersections {
+            if !self.intersections.contains(&inner) {
+                self.intersections.push(inner);
+            }
+        }
+    }
+
     pub(crate) fn add_positive(self, ty: Type<'db>) -> Self {
         self.add_positive_impl(ty, &mut vec![])
     }
@@ -725,7 +733,7 @@ impl<'db> IntersectionBuilder<'db> {
                     .iter()
                     .map(|elem| self.clone().add_positive_impl(*elem, seen_aliases))
                     .fold(IntersectionBuilder::empty(self.db), |mut builder, sub| {
-                        builder.intersections.extend(sub.intersections);
+                        builder.extend(sub);
                         builder
                     })
             }
@@ -856,7 +864,7 @@ impl<'db> IntersectionBuilder<'db> {
                 positive_side.chain(negative_side).fold(
                     IntersectionBuilder::empty(self.db),
                     |mut builder, sub| {
-                        builder.intersections.extend(sub.intersections);
+                        builder.extend(sub);
                         builder
                     },
                 )
@@ -916,7 +924,7 @@ impl<'db> IntersectionBuilder<'db> {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct InnerIntersectionBuilder<'db> {
     positive: FxOrderSet<Type<'db>>,
     negative: FxOrderSet<Type<'db>>,


### PR DESCRIPTION
## Summary

From #17371

See [the comments in #17371](https://github.com/astral-sh/ruff/pull/17371#issuecomment-3671180138) for the motivation for this change.

## Test Plan

N/A
