### PR TITLE
 Update T201 suggestion to not use root logger to satisfy LOG015

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
@@ -37,10 +37,11 @@ use crate::{Fix, FixAvailability, Violation};
 /// import logging
 ///
 /// logging.basicConfig(level=logging.INFO)
+/// logger = logging.getLogger(__name__)
 ///
 ///
 /// def sum_less_than_four(a, b):
-///     logging.debug("Calling sum_less_than_four")
+///     logger.debug("Calling sum_less_than_four")
 ///     return a + b < 4
 /// ```
 ///


### PR DESCRIPTION
## Summary

Currently, the proposed fix for https://docs.astral.sh/ruff/rules/print/ violates https://docs.astral.sh/ruff/rules/root-logger-call/. Thus, let's change the proposal to make LOG015 happy as well.

## Test Plan

Test manually in a project that has both T201 and LOG015 enabled and run them over the previous and proposed code. Is there continuous testing of the code snippets from the docs?
