### PR TITLE
[ty] Visit class arguments in source order for semantic tokens

### DIFF
--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -38,12 +38,11 @@ use itertools::Itertools;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::visitor::source_order::{
-    SourceOrderVisitor, TraversalSignal, walk_expr, walk_stmt,
+    SourceOrderVisitor, TraversalSignal, walk_arguments, walk_expr, walk_stmt,
 };
-use ruff_python_ast::{self as ast, ArgOrKeyword};
 use ruff_python_ast::{
-    AnyNodeRef, BytesLiteral, Expr, FString, InterpolatedStringElement, Stmt, StringLiteral,
-    TypeParam,
+    self as ast, AnyNodeRef, BytesLiteral, Expr, FString, InterpolatedStringElement, Stmt,
+    StringLiteral, TypeParam,
 };
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use std::ops::Deref;
@@ -668,12 +667,7 @@ impl SourceOrderVisitor<'_> for SemanticTokenVisitor<'_> {
 
                 // Handle base classes and type annotations in inheritance
                 if let Some(arguments) = &class.arguments {
-                    for arg_or_keyword in arguments.arguments_source_order() {
-                        match arg_or_keyword {
-                            ArgOrKeyword::Arg(arg) => self.visit_expr(arg),
-                            ArgOrKeyword::Keyword(keyword) => self.visit_expr(&keyword.value),
-                        }
-                    }
+                    walk_arguments(self, arguments);
                 }
 
                 let prev_in_class = self.in_class_scope;


### PR DESCRIPTION
## Summary

Before we would hit a debug assertion that tokens
were inserted out-of-order for statements like
`class Foo(m=x, m)`. This was because arguments
were always inserted before the keyword arguments
in class definitions. This changes the ordering
to use source order.


## Test Plan
Added a small test and validated in the playground that this no longer panics.
