### PR TITLE
[ty] Add support for descriptor checks with unions

### DIFF
--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5100,15 +5100,36 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                         let assignable_to_meta_attr = if let Place::Defined(DefinedPlace {
                             ty: meta_dunder_set,
+                            definedness: dunder_set_boundness,
                             ..
                         }) =
                             meta_attr_ty.class_member(db, "__set__".into()).place
                         {
+                            // When `__set__` is only possibly defined (some union elements have it, some don't),
+                            // we need to check the `__set__` call only for elements that actually have `__set__`.
+                            // Otherwise, we'd be passing a union containing non-descriptor types as `self` to
+                            // `__set__`, which would fail. We also need to check normal assignment for non-descriptor
+                            // elements.
+                            let (descriptor_ty, non_descriptor_ty) = if dunder_set_boundness
+                                == Definedness::PossiblyUndefined
+                                && let Type::Union(union) = meta_attr_ty
+                            {
+                                let with_set = union.filter(db, |elem| {
+                                    !elem.class_member(db, "__set__".into()).place.is_undefined()
+                                });
+                                let without_set = union.filter(db, |elem| {
+                                    elem.class_member(db, "__set__".into()).place.is_undefined()
+                                });
+                                (with_set, Some(without_set))
+                            } else {
+                                (meta_attr_ty, None)
+                            };
+
                             // TODO: We could use the annotated parameter type of `__set__` as
                             // type context here.
                             let dunder_set_result = meta_dunder_set.try_call(
                                 db,
-                                &CallArguments::positional([meta_attr_ty, object_ty, value_ty]),
+                                &CallArguments::positional([descriptor_ty, object_ty, value_ty]),
                             );
 
                             if emit_diagnostics
@@ -5123,7 +5144,40 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 );
                             }
 
-                            dunder_set_result.is_ok()
+                            let descriptor_ok = dunder_set_result.is_ok();
+
+                            // For union elements without `__set__`, the value
+                            // shadows the class attribute in the instance dict.
+                            // Check against instance member type if declared.
+                            let non_descriptor_ok =
+                                if non_descriptor_ty.is_some_and(|ty| !ty.is_never()) {
+                                    if let PlaceAndQualifiers {
+                                        place:
+                                            Place::Defined(DefinedPlace {
+                                                ty: instance_attr_ty,
+                                                ..
+                                            }),
+                                        qualifiers,
+                                    } = object_ty.instance_member(db, attribute)
+                                    {
+                                        let value_ty = infer_value_ty(
+                                            self,
+                                            TypeContext::new(Some(instance_attr_ty)),
+                                        );
+                                        if invalid_assignment_to_final(self, qualifiers) {
+                                            return false;
+                                        }
+                                        ensure_assignable_to(self, value_ty, instance_attr_ty)
+                                    } else {
+                                        // No instance member declared; value shadows
+                                        // the class attribute
+                                        true
+                                    }
+                                } else {
+                                    true
+                                };
+
+                            descriptor_ok && non_descriptor_ok
                         } else {
                             let value_ty =
                                 infer_value_ty(self, TypeContext::new(Some(meta_attr_ty)));
@@ -5267,15 +5321,36 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                         let assignable_to_meta_attr = if let Place::Defined(DefinedPlace {
                             ty: meta_dunder_set,
+                            definedness: dunder_set_boundness,
                             ..
                         }) =
                             meta_attr_ty.class_member(db, "__set__".into()).place
                         {
+                            // When `__set__` is only possibly defined (some union elements have it, some don't),
+                            // we need to check the `__set__` call only for elements that actually have `__set__`.
+                            // Otherwise, we'd be passing a union containing non-descriptor types as `self` to
+                            // `__set__`, which would fail. We also need to check normal assignment for non-descriptor
+                            // elements.
+                            let (descriptor_ty, non_descriptor_ty) = if dunder_set_boundness
+                                == Definedness::PossiblyUndefined
+                                && let Type::Union(union) = meta_attr_ty
+                            {
+                                let with_set = union.filter(db, |elem| {
+                                    !elem.class_member(db, "__set__".into()).place.is_undefined()
+                                });
+                                let without_set = union.filter(db, |elem| {
+                                    elem.class_member(db, "__set__".into()).place.is_undefined()
+                                });
+                                (with_set, Some(without_set))
+                            } else {
+                                (meta_attr_ty, None)
+                            };
+
                             // TODO: We could use the annotated parameter type of `__set__` as
                             // type context here.
                             let dunder_set_result = meta_dunder_set.try_call(
                                 db,
-                                &CallArguments::positional([meta_attr_ty, object_ty, value_ty]),
+                                &CallArguments::positional([descriptor_ty, object_ty, value_ty]),
                             );
 
                             if emit_diagnostics
@@ -5290,7 +5365,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 );
                             }
 
-                            dunder_set_result.is_ok()
+                            let descriptor_ok = dunder_set_result.is_ok();
+
+                            // For union elements without `__set__`, the value
+                            // is written directly to the class dict. Check that
+                            // the value is assignable to the type of those elements.
+                            let non_descriptor_ok = if let Some(non_desc_ty) = non_descriptor_ty {
+                                if non_desc_ty.is_never() {
+                                    true
+                                } else {
+                                    let value_ty =
+                                        infer_value_ty(self, TypeContext::new(Some(non_desc_ty)));
+                                    ensure_assignable_to(self, value_ty, non_desc_ty)
+                                }
+                            } else {
+                                true
+                            };
+
+                            descriptor_ok && non_descriptor_ok
                         } else {
                             let value_ty =
                                 infer_value_ty(self, TypeContext::new(Some(meta_attr_ty)));


### PR DESCRIPTION
## Summary

This PR attempts to support cases like the following ([playground](https://play.ty.dev/cf79b56e-4350-49e2-ad3f-795e68613401)):

```python
from typing import Any

class DescriptorWithSet:
    def __set__(self, instance: object, value: Any) -> None: ...

class NoSet:
    pass

class MyModel:
    state: DescriptorWithSet | NoSet

m = MyModel()
m.state = 1
```

At present, `m.state = 1` fails with `Invalid assignment to data descriptor attribute state on type MyModel with custom __set__ method (invalid-assignment)`, because we attempt to reconcile the `DescriptorWithSet | NoSet` against the `__set__` call. With this change, we instead partition the union into those members that implement `__set__` and those that don't.
