### PR TITLE
[ty] Only clear output between two successful checks

### DIFF
--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -273,9 +273,6 @@ impl MainLoop {
         let mut revision = 0u64;
 
         while let Ok(message) = self.receiver.recv() {
-            if self.watcher.is_some() {
-                Printer::clear_screen()?;
-            }
             match message {
                 MainLoopMessage::CheckWorkspace => {
                     let db = db.clone();
@@ -384,12 +381,15 @@ impl MainLoop {
                 }
 
                 MainLoopMessage::ApplyChanges(changes) => {
+                    Printer::clear_screen()?;
+
                     revision += 1;
                     // Automatically cancels any pending queries and waits for them to complete.
                     db.apply_changes(changes, Some(&self.project_options_overrides));
                     if let Some(watcher) = self.watcher.as_mut() {
                         watcher.update(db);
                     }
+
                     self.sender.send(MainLoopMessage::CheckWorkspace).unwrap();
                 }
                 MainLoopMessage::Exit => {


### PR DESCRIPTION
## Summary

It's difficult to narrow down https://github.com/astral-sh/ty/issues/1973 because `--watch` always clears the output. 

E.g. it clears the output right when it receives the check results, removing all the very helpful verbose output. 

This PR only calls `clear_screen` between two successful `CheckWorkspace` calls. 
This ensures that we preserve the verbose output for the current run

## Test Plan


https://github.com/user-attachments/assets/4a72206e-dcd8-47f1-99ab-b951d07248a8

