### PR TITLE
[ty] Only print dashed line for failing tests

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md
+++ b/crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md
@@ -22,7 +22,7 @@ def _(flag: bool):
 ```py
 def _(flag: bool):
     if (x := 1) or flag:
-        reveal_type(x)  # revealed: Literal[2]
+        reveal_type(x)  # revealed: Literal[1]
 
     if (x := 1) and flag:
         reveal_type(x)  # revealed: Literal[1]
@@ -36,7 +36,7 @@ if True or (x := 1):
     reveal_type(x)  # revealed: Unknown
 
 if True and (x := 1):
-    reveal_type(x)  # revealed: Literal[2]
+    reveal_type(x)  # revealed: Literal[1]
 ```
 
 ## Later expressions can always use variables from earlier expressions


### PR DESCRIPTION
## Summary

Don't print unnecessary dashed lines between passing tests. But keep the line between failing tests, as it improves readability if they're from the same mdtest file

## Test Plan

```
test mdtest::assignment/augmented.md                       ... ok
test mdtest::binary/booleans.md                            ... ok
test mdtest::binary/unions.md                              ... ok
test mdtest::binary/tuples.md                              ... ok

short_circuit.md - Short-Circuit Evalua… - First expression is … (80ce6787b0f38ead)

  crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md:25 unmatched assertion: revealed: Literal[2]
  crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md:25 unexpected error: 21 [revealed-type] "Revealed type: `Literal[1]`"

To rerun this specific test, set the environment variable: MDTEST_TEST_FILTER='short_circuit.md - Short-Circuit Evalua… - First expression is … (80ce6787b0f38ead)'
MDTEST_TEST_FILTER='short_circuit.md - Short-Circuit Evalua… - First expression is … (80ce6787b0f38ead)' cargo test -p ty_python_semantic --test mdtest -- boolean/short_circuit.md

--------------------------------------------------

test mdtest::binary/integers.md                            ... ok

short_circuit.md - Short-Circuit Evalua… - Statically known tru… (e71ec3b0aa226439)

  crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md:39 unmatched assertion: revealed: Literal[2]
  crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md:39 unexpected error: 17 [revealed-type] "Revealed type: `Literal[1]`"

To rerun this specific test, set the environment variable: MDTEST_TEST_FILTER='short_circuit.md - Short-Circuit Evalua… - Statically known tru… (e71ec3b0aa226439)'
MDTEST_TEST_FILTER='short_circuit.md - Short-Circuit Evalua… - Statically known tru… (e71ec3b0aa226439)' cargo test -p ty_python_semantic --test mdtest -- boolean/short_circuit.md

--------------------------------------------------


thread '<unnamed>' (6663782) panicked at crates/ty_test/src/lib.rs:157:5:
Some tests failed.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test mdtest::boolean/short_circuit.md                      ... FAILED
test mdtest::binary/custom.md                              ... ok
test mdtest::boundness_declaredness/public.md              ... ok
test mdtest::binary/instances.md                           ... ok
test mdtest::call/annotation.md                            ... ok
test mdtest::binary/classes.md                             ... ok
test mdtest::call/builtins.md                              ... ok

```
