### PR TITLE
[ty] Collect mdtest failures as part of the assertion message rather than printing them to the terminal immediately

### DIFF
--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -38,7 +38,6 @@ use ty_static::EnvVars;
 /// Run `path` as a markdown test suite with given `title`.
 ///
 /// Panic on test failure, and print failure details.
-#[expect(clippy::print_stdout)]
 pub fn run(
     absolute_fixture_path: &Utf8Path,
     relative_fixture_path: &Utf8Path,
@@ -55,6 +54,7 @@ pub fn run(
 
     let filter = std::env::var(EnvVars::MDTEST_TEST_FILTER).ok();
     let mut any_failures = false;
+    let mut assertion = String::new();
     for test in suite.tests() {
         if filter
             .as_ref()
@@ -79,7 +79,7 @@ pub fn run(
         any_failures = any_failures || this_test_failed;
 
         if this_test_failed && output_format.is_cli() {
-            println!("\n{}\n", test.name().bold().underline());
+            let _ = writeln!(assertion, "\n\n{}\n", test.name().bold().underline());
         }
 
         if let Err(failures) = result {
@@ -95,26 +95,29 @@ pub fn run(
                         OutputFormat::GitHub => absolute_fixture_path.as_str(),
                     };
 
-                    let absolute_line_number = match source_map
-                        .to_absolute_line_number(relative_line_number)
-                    {
-                        Ok(line_number) => line_number,
-                        Err(last_line_number) => {
-                            print!("{}",
-                                output_format.display_error(
-                                    file,
-                                    last_line_number,
-                                    "Found a trailing assertion comment (e.g., `# revealed:` or `# error:`) \
-                                    not followed by any statement."
-                                )
-                            );
+                    let absolute_line_number =
+                        match source_map.to_absolute_line_number(relative_line_number) {
+                            Ok(line_number) => line_number,
+                            Err(last_line_number) => {
+                                let _ = writeln!(
+                                    assertion,
+                                    "{}",
+                                    output_format.display_error(
+                                        file,
+                                        last_line_number,
+                                        "Found a trailing assertion comment \
+                                        (e.g., `# revealed:` or `# error:`) \
+                                        not followed by any statement."
+                                    )
+                                );
 
-                            continue;
-                        }
-                    };
+                                continue;
+                            }
+                        };
 
                     for failure in failures {
-                        print!(
+                        let _ = writeln!(
+                            assertion,
                             "{}",
                             output_format.display_error(file, absolute_line_number, failure)
                         );
@@ -128,10 +131,13 @@ pub fn run(
                 match output_format {
                     OutputFormat::Cli => {
                         let info = relative_fixture_path.to_string().cyan();
-                        println!("  {info} {inconsistency}");
+                        let _ = writeln!(assertion, "  {info} {inconsistency}");
                     }
                     OutputFormat::GitHub => {
-                        println!("::error file={absolute_fixture_path}::{inconsistency}");
+                        let _ = writeln!(
+                            assertion,
+                            "::error file={absolute_fixture_path}::{inconsistency}"
+                        );
                     }
                 }
             }
@@ -139,20 +145,24 @@ pub fn run(
 
         if this_test_failed && output_format.is_cli() {
             let escaped_test_name = test.name().replace('\'', "\\'");
-            println!(
-                "\nTo rerun this specific test, set the environment variable: {}='{escaped_test_name}'",
+            let _ = writeln!(
+                assertion,
+                "\nTo rerun this specific test, \
+                set the environment variable: {}='{escaped_test_name}'",
                 EnvVars::MDTEST_TEST_FILTER,
             );
-            println!(
-                "{}='{escaped_test_name}' cargo test -p ty_python_semantic --test mdtest -- {test_name}",
+            let _ = writeln!(
+                assertion,
+                "{}='{escaped_test_name}' cargo test -p ty_python_semantic \
+                --test mdtest -- {test_name}",
                 EnvVars::MDTEST_TEST_FILTER,
             );
 
-            println!("\n{}\n", "-".repeat(50));
+            let _ = writeln!(assertion, "\n{}", "-".repeat(50));
         }
     }
 
-    assert!(!any_failures, "Some tests failed.");
+    assert!(!any_failures, "{}", &assertion);
 
     Ok(())
 }
@@ -195,14 +205,14 @@ impl OutputFormat {
 
                 match format {
                     OutputFormat::Cli => {
-                        writeln!(
+                        write!(
                             f,
                             "  {file_line} {failure}",
                             file_line = format!("{file}:{line}").cyan()
                         )
                     }
                     OutputFormat::GitHub => {
-                        writeln!(f, "::error file={file},line={line}::{failure}")
+                        write!(f, "::error file={file},line={line}::{failure}")
                     }
                 }
             }


### PR DESCRIPTION
## Summary

This greatly improves the experience of running `mdtest.py` in a VSCode terminal now that we switched to using datatest rather than dirtest.

On `main`, with mdtest failures:

https://github.com/user-attachments/assets/e4aeb34d-264b-46e0-a5d7-a7d4235d00cf

With this PR, with the same mdtest failures:

https://github.com/user-attachments/assets/447d668e-7249-4f33-bbbf-b849a441ac42

I can now once again easily jump directly to the mdtest assertions that are failing from my in-editor terminal, because all the mdtest failing lines are collected at the bottom of the terminal after `mdtest.py` has finished runnning
