### PR TITLE
Upload full ecosystem report as a GitHub Actions artifact

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -131,6 +131,14 @@ jobs:
 
       # NOTE: astral-sh-bot uses this artifact to post comments on PRs.
       # Make sure to update the bot if you rename the artifact.
+      - name: "Upload full report"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: full-report
+          path: dist/
+
+      # NOTE: astral-sh-bot uses this artifact to post comments on PRs.
+      # Make sure to update the bot if you rename the artifact.
       - name: Upload comment
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:


### PR DESCRIPTION
## Summary

This is the first step towards removing the current in-action limitation with the report.

Once this is being consistently uploaded, I can begin to integrate it into astral-sh-bot, which'll then perform the appropriate Cloudflare Pages deployment directly.

## Test Plan

NFC. Intentionally running the ecosystem-analyzer to ensure this works 🙂 