### PR TITLE
[ty] Avoid including `property` in subclasses properties

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -525,6 +525,42 @@ c.name = None
 c.name = 42
 ```
 
+### Overriding properties in subclasses
+
+When a subclass overrides a property, accessing other inherited properties from within the
+overriding property methods should still work correctly.
+
+```py
+class Base:
+    _value: float = 0.0
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+    @value.setter
+    def value(self, v: float) -> None:
+        self._value = v
+
+    @property
+    def other(self) -> float:
+        return self.value
+
+    @other.setter
+    def other(self, v: float) -> None:
+        self.value = v
+
+class Derived(Base):
+    @property
+    def other(self) -> float:
+        return self.value
+
+    @other.setter
+    def other(self, v: float) -> None:
+        reveal_type(self.value)  # revealed: int | float
+        self.value = v
+```
+
 ### Properties with no setters
 
 <!-- snapshot-diagnostics -->


### PR DESCRIPTION
## Summary

As-is, the following rejects `return self.value` in `def other` in the subclass ([link](https://play.ty.dev/f55b47b2-313e-45d1-ba45-fde410bed32e)) because `self.value` is resolving to `Unknown | int | float | property`:

```python
class Base:
    _value: float = 0.0

    @property
    def value(self) -> float:
        return self._value

    @value.setter
    def value(self, v: float) -> None:
        self._value = v

    @property
    def other(self) -> float:
        return self.value

    @other.setter
    def other(self, v: float) -> None:
        self.value = v

class Derived(Base):
    @property
    def other(self) -> float:
        return self.value

    @other.setter
    def other(self, v: float) -> None:
        reveal_type(self.value)  # revealed: int | float
        self.value = v
```

I believe the root cause is that we're not excluding properties when searching for class methods, so we're treating the `other` setter as a classmethod. I don't fully understand how that ends up materializing as `| property` on the union though.
