### PR TITLE
[ty] Avoid false positive for `not-iterable` with no-positive intersection types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -998,3 +998,17 @@ def g[T: tuple[int, ...] | list[str]](x: T):
             # so iterating gives `int`, NOT `int | str`.
             reveal_type(item)  # revealed: int
 ```
+
+## Iterating over a list with a negated type parameter
+
+When we have a list with a negated type parameter (e.g., `list[~str]`), we should still be able to
+iterate over it correctly. The negated type parameter represents all types except `str`, and
+`list[~str]` is still a valid list that can be iterated.
+
+```py
+from ty_extensions import Not
+
+def _(value: list[Not[str]]):
+    for x in value:
+        reveal_type(x)  # revealed: ~str
+```

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -704,6 +704,13 @@ impl<'db> Type<'db> {
                 ConstraintSet::from(false)
             }
 
+            // Fast path: `object` is only a subtype/assignable to a protocol if the protocol
+            // is equivalent to `object` (handled above). Otherwise, not all objects satisfy
+            // the protocol.
+            (Type::NominalInstance(source), Type::ProtocolInstance(_)) if source.is_object() => {
+                ConstraintSet::from(false)
+            }
+
             // Fast path: `object` is only a subtype/assignable to unions that contain a type
             // that can definitely accept `object`. If a union contains only types that cannot
             // accept `object`, we can short-circuit to false.

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -717,7 +717,7 @@ impl<'db> Type<'db> {
             (Type::NominalInstance(source), Type::Union(union)) if source.is_object() => {
                 let elements = union.elements(db);
                 let mut has_complex = false;
-                for &elem in elements.iter() {
+                for &elem in elements {
                     match elem {
                         _ if elem.is_object() => return ConstraintSet::from(true),
                         Type::Dynamic(_)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -695,59 +695,6 @@ impl<'db> Type<'db> {
                 ConstraintSet::from(true)
             }
 
-            // Fast path: `object` is only a subtype/assignable to unions that contain a type
-            // that can definitely accept `object`. If a union contains only types that cannot
-            // accept `object`, we can short-circuit to false.
-            (Type::NominalInstance(source), Type::Union(union)) if source.is_object() => {
-                let elements = union.elements(db);
-                let mut has_complex = false;
-                for &elem in elements {
-                    match elem {
-                        _ if elem.is_object() => return ConstraintSet::from(true),
-                        Type::Dynamic(_)
-                            if relation.is_assignability()
-                                || relation.is_constraint_set_assignability() =>
-                        {
-                            return ConstraintSet::from(true);
-                        }
-                        Type::TypeVar(typevar)
-                            if (relation.is_assignability()
-                                || relation.is_constraint_set_assignability())
-                                && typevar.is_inferable(db, inferable)
-                                && typevar
-                                    .typevar(db)
-                                    .upper_bound(db)
-                                    .is_none_or(|bound| bound.is_object()) =>
-                        {
-                            return ConstraintSet::from(true);
-                        }
-                        Type::TypeVar(_)
-                        | Type::ProtocolInstance(_)
-                        | Type::Intersection(_)
-                        | Type::Union(_)
-                        | Type::TypeAlias(_) => {
-                            has_complex = true;
-                        }
-                        _ => {}
-                    }
-                }
-
-                if has_complex {
-                    elements.iter().when_any(db, |&elem_ty| {
-                        self.has_relation_to_impl(
-                            db,
-                            elem_ty,
-                            inferable,
-                            relation,
-                            relation_visitor,
-                            disjointness_visitor,
-                        )
-                    })
-                } else {
-                    ConstraintSet::from(false)
-                }
-            }
-
             // `Never` is the bottom type, the empty set.
             (_, Type::Never) => ConstraintSet::from(false),
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -662,11 +662,106 @@ impl<'db> Type<'db> {
                 ConstraintSet::from(true)
             }
 
+            // Fast path: `object` is not a subtype of any nominal instance type other than itself.
+            // This is important for performance when checking intersections with no positive
+            // elements (pure negations like `~str`), which are treated as having `object` as
+            // the implicit positive element.
+            (Type::NominalInstance(source), Type::NominalInstance(_)) if source.is_object() => {
+                ConstraintSet::from(false)
+            }
+
+            // Fast path: `object` (an instance type) is not a subtype of any `type[X]` (a class type).
+            (Type::NominalInstance(source), Type::SubclassOf(_)) if source.is_object() => {
+                ConstraintSet::from(false)
+            }
+
+            // Fast path: `object` is not a subtype of any non-inferable type variable, since the
+            // type variable could be specialized to a type smaller than `object`.
+            (Type::NominalInstance(source), Type::TypeVar(typevar))
+                if source.is_object() && !typevar.is_inferable(db, inferable) =>
+            {
+                ConstraintSet::from(false)
+            }
+
+            // Fast path: `object` is assignable to any inferable type variable with no upper bound
+            // (or with `object` as its upper bound), which is the common case for generic
+            // type parameters like `_T` in `Iterator[_T]`.
+            (Type::NominalInstance(source), Type::TypeVar(typevar))
+                if source.is_object()
+                    && typevar.is_inferable(db, inferable)
+                    && relation.is_assignability()
+                    && typevar
+                        .typevar(db)
+                        .upper_bound(db)
+                        .is_none_or(|bound| bound.is_object()) =>
+            {
+                ConstraintSet::from(true)
+            }
+
+            // Fast path: `object` is not a subtype of any callable type, since not all objects
+            // are callable.
+            (Type::NominalInstance(source), Type::Callable(_)) if source.is_object() => {
+                ConstraintSet::from(false)
+            }
+
             // Fast path: `object` is only a subtype/assignable to a protocol if the protocol
             // is equivalent to `object` (handled above). Otherwise, not all objects satisfy
             // the protocol.
             (Type::NominalInstance(source), Type::ProtocolInstance(_)) if source.is_object() => {
                 ConstraintSet::from(false)
+            }
+
+            // Fast path: `object` is only a subtype/assignable to unions that contain a type
+            // that can definitely accept `object`. If a union contains only types that cannot
+            // accept `object`, we can short-circuit to false.
+            (Type::NominalInstance(source), Type::Union(union)) if source.is_object() => {
+                let elements = union.elements(db);
+                let mut has_complex = false;
+                for &elem in elements.iter() {
+                    match elem {
+                        _ if elem.is_object() => return ConstraintSet::from(true),
+                        Type::Dynamic(_)
+                            if relation.is_assignability()
+                                || relation.is_constraint_set_assignability() =>
+                        {
+                            return ConstraintSet::from(true);
+                        }
+                        Type::TypeVar(typevar)
+                            if (relation.is_assignability()
+                                || relation.is_constraint_set_assignability())
+                                && typevar.is_inferable(db, inferable)
+                                && typevar
+                                    .typevar(db)
+                                    .upper_bound(db)
+                                    .is_none_or(|bound| bound.is_object()) =>
+                        {
+                            return ConstraintSet::from(true);
+                        }
+                        Type::TypeVar(_)
+                        | Type::ProtocolInstance(_)
+                        | Type::Intersection(_)
+                        | Type::Union(_)
+                        | Type::TypeAlias(_) => {
+                            has_complex = true;
+                        }
+                        _ => {}
+                    }
+                }
+
+                if has_complex {
+                    elements.iter().when_any(db, |&elem_ty| {
+                        self.has_relation_to_impl(
+                            db,
+                            elem_ty,
+                            inferable,
+                            relation,
+                            relation_visitor,
+                            disjointness_visitor,
+                        )
+                    })
+                } else {
+                    ConstraintSet::from(false)
+                }
             }
 
             // `Never` is the bottom type, the empty set.
@@ -814,23 +909,47 @@ impl<'db> Type<'db> {
                     })
                 }),
 
+            // Fast path for pure negations (~X): these are semantically `object & ~X`, so they're
+            // only assignable to types that `object` is assignable to. Since `object` is only
+            // assignable to `object`, dynamic types, unions/protocols/intersections that might
+            // contain `object`, we can short-circuit most cases directly.
+            (Type::Intersection(intersection), _) if intersection.positive(db).is_empty() => {
+                match target {
+                    // `object` is a subtype of `object`
+                    _ if target.is_object() => ConstraintSet::from(true),
+                    // `object` is a subtype of dynamic types
+                    Type::Dynamic(_) => ConstraintSet::from(true),
+                    // These cases need more complex checking - delegate to full machinery
+                    // (TypeVar needs special handling for inference)
+                    Type::Union(_)
+                    | Type::ProtocolInstance(_)
+                    | Type::Intersection(_)
+                    | Type::TypeVar(_) => Type::object().has_relation_to_impl(
+                        db,
+                        target,
+                        inferable,
+                        relation,
+                        relation_visitor,
+                        disjointness_visitor,
+                    ),
+                    // `object` is not a subtype of any other type
+                    _ => ConstraintSet::from(false),
+                }
+            }
+
             (Type::Intersection(intersection), _) => {
                 // An intersection type is a subtype of another type if at least one of its
-                // positive elements is a subtype of that type. If there are no positive elements,
-                // we treat `object` as the implicit positive element (e.g., `~str` is semantically
-                // `object & ~str`).
-                intersection
-                    .positive_elements_or_object(db)
-                    .when_any(db, |elem_ty| {
-                        elem_ty.has_relation_to_impl(
-                            db,
-                            target,
-                            inferable,
-                            relation,
-                            relation_visitor,
-                            disjointness_visitor,
-                        )
-                    })
+                // positive elements is a subtype of that type.
+                intersection.positive(db).iter().when_any(db, |&elem_ty| {
+                    elem_ty.has_relation_to_impl(
+                        db,
+                        target,
+                        inferable,
+                        relation,
+                        relation_visitor,
+                        disjointness_visitor,
+                    )
+                })
             }
 
             // Other than the special cases checked above, no other types are a subtype of a

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -834,23 +834,47 @@ impl<'db> Type<'db> {
                     })
                 }),
 
+            // Fast path for pure negations (~X): these are semantically `object & ~X`, so they're
+            // only assignable to types that `object` is assignable to. Since `object` is only
+            // assignable to `object`, dynamic types, unions/protocols/intersections that might
+            // contain `object`, we can short-circuit most cases directly.
+            (Type::Intersection(intersection), _) if intersection.positive(db).is_empty() => {
+                match target {
+                    // `object` is a subtype of `object`
+                    _ if target.is_object() => ConstraintSet::from(true),
+                    // `object` is a subtype of dynamic types
+                    Type::Dynamic(_) => ConstraintSet::from(true),
+                    // These cases need more complex checking - delegate to full machinery
+                    // (TypeVar needs special handling for inference)
+                    Type::Union(_)
+                    | Type::ProtocolInstance(_)
+                    | Type::Intersection(_)
+                    | Type::TypeVar(_) => Type::object().has_relation_to_impl(
+                        db,
+                        target,
+                        inferable,
+                        relation,
+                        relation_visitor,
+                        disjointness_visitor,
+                    ),
+                    // `object` is not a subtype of any other type
+                    _ => ConstraintSet::from(false),
+                }
+            }
+
             (Type::Intersection(intersection), _) => {
                 // An intersection type is a subtype of another type if at least one of its
-                // positive elements is a subtype of that type. If there are no positive elements,
-                // we treat `object` as the implicit positive element (e.g., `~str` is semantically
-                // `object & ~str`).
-                intersection
-                    .positive_elements_or_object(db)
-                    .when_any(db, |elem_ty| {
-                        elem_ty.has_relation_to_impl(
-                            db,
-                            target,
-                            inferable,
-                            relation,
-                            relation_visitor,
-                            disjointness_visitor,
-                        )
-                    })
+                // positive elements is a subtype of that type.
+                intersection.positive(db).iter().when_any(db, |&elem_ty| {
+                    elem_ty.has_relation_to_impl(
+                        db,
+                        target,
+                        inferable,
+                        relation,
+                        relation_visitor,
+                        disjointness_visitor,
+                    )
+                })
             }
 
             // Other than the special cases checked above, no other types are a subtype of a

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -663,7 +663,8 @@ impl<'db> Type<'db> {
             }
 
             // Fast path for various types that we know `object` is never a subtype of
-            // (`object` can be a subtype of some protocols, but that case is handled above).
+            // (`object` can be a subtype of some protocols, or of itself, but those cases are
+            // handled above).
             (
                 Type::NominalInstance(source),
                 Type::NominalInstance(_)
@@ -678,21 +679,6 @@ impl<'db> Type<'db> {
                 if source.is_object() && !typevar.is_inferable(db, inferable) =>
             {
                 ConstraintSet::from(false)
-            }
-
-            // Fast path: `object` is assignable to any inferable type variable with no upper bound
-            // (or with `object` as its upper bound), which is the common case for generic
-            // type parameters like `_T` in `Iterator[_T]`.
-            (Type::NominalInstance(source), Type::TypeVar(typevar))
-                if source.is_object()
-                    && typevar.is_inferable(db, inferable)
-                    && relation.is_assignability()
-                    && typevar
-                        .typevar(db)
-                        .upper_bound(db)
-                        .is_none_or(|bound| bound.is_object()) =>
-            {
-                ConstraintSet::from(true)
             }
 
             // `Never` is the bottom type, the empty set.


### PR DESCRIPTION
## Summary

When checking if `list[~str]` is iterable, we end up looking for a positive element to satisfy assignability to `Iterable[~str]`. But when there are no positive elements, we return `false`, rather than falling back to `object`.

Closes https://github.com/astral-sh/ty/issues/1880.
