### PR TITLE
[ty] Fix sync-typeshed workflow timeouts

### DIFF
--- a/.github/workflows/daily_fuzz.yaml
+++ b/.github/workflows/daily_fuzz.yaml
@@ -62,7 +62,7 @@ jobs:
     name: Create an issue if the daily fuzz surfaced any bugs
     runs-on: ubuntu-latest
     needs: fuzz
-    if: ${{ github.repository == 'astral-sh/ruff' && always() && github.event_name == 'schedule' && needs.fuzz.result == 'failure' }}
+    if: ${{ github.repository == 'astral-sh/ruff' && always() && github.event_name == 'schedule' && needs.fuzz.result != 'success' }}
     permissions:
       issues: write
     steps:

--- a/.github/workflows/sync_typeshed.yaml
+++ b/.github/workflows/sync_typeshed.yaml
@@ -198,42 +198,6 @@ jobs:
         run: |
           rm "${VENDORED_TYPESHED}/pyproject.toml"
           git commit -am "Remove pyproject.toml file"
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-      - name: "Install Rust toolchain"
-        if: ${{ success() }}
-        run: rustup show
-      - name: "Install mold"
-        if: ${{ success() }}
-        uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-      - name: "Install cargo nextest"
-        if: ${{ success() }}
-        uses: taiki-e/install-action@3575e532701a5fc614b0c842e4119af4cc5fd16d # v2.62.60
-        with:
-          tool: cargo-nextest
-      - name: "Install cargo insta"
-        if: ${{ success() }}
-        uses: taiki-e/install-action@3575e532701a5fc614b0c842e4119af4cc5fd16d # v2.62.60
-        with:
-          tool: cargo-insta
-      - name: Update snapshots
-        if: ${{ success() }}
-        run: |
-          cargo r \
-          --profile=profiling \
-          -p ty_completion_eval \
-          -- all --tasks ./crates/ty_completion_eval/completion-evaluation-tasks.csv
-
-          # The `cargo insta` docs indicate that `--unreferenced=delete` might be a good option,
-          # but from local testing it appears to just revert all changes made by `cargo insta test --accept`.
-          #
-          # If there were only snapshot-related failures, `cargo insta test --accept` will have exit code 0,
-          # but if there were also other mdtest failures (for example), it will return a nonzero exit code.
-          # We don't care about other tests failing here, we just want snapshots updated where possible,
-          # so we use `|| true` here to ignore the exit code.
-          cargo insta test --accept --color=always --all-features --test-runner=nextest || true
-      - name: Commit snapshot changes
-        if: ${{ success() }}
-        run: git commit -am "Update snapshots" || echo "No snapshot changes to commit"
       - name: Push changes upstream and create a PR
         if: ${{ success() }}
         run: |
@@ -245,7 +209,7 @@ jobs:
     name: Create an issue if the typeshed sync failed
     runs-on: ubuntu-latest
     needs: [sync, docstrings-windows, docstrings-macos-and-pr]
-    if: ${{ github.repository == 'astral-sh/ruff' && always() && github.event_name == 'schedule' && (needs.sync.result == 'failure' || needs.docstrings-windows.result == 'failure' || needs.docstrings-macos-and-pr.result == 'failure') }}
+    if: ${{ github.repository == 'astral-sh/ruff' && always() && github.event_name == 'schedule' && (needs.sync.result != 'success' || needs.docstrings-windows.result != 'success' || needs.docstrings-macos-and-pr.result != 'success') }}
     permissions:
       issues: write
     steps:


### PR DESCRIPTION
## Summary

Our most recent typeshed-sync workflow failed, and failed again when I re-ran it: https://github.com/astral-sh/ruff/actions/runs/20216754532. The cause of the failure was that it took too long to build ty in the last stage, so the job timed out. Because the job timed out rather than an error occurring, there also wasn't an issue created telling us that the typeshed sync failed.

This PR fixes the timeout by removing the part where we try to run ty's tests from the workflow. This part was added in https://github.com/astral-sh/ruff/pull/20892, but it's never worked as intended: https://github.com/astral-sh/ruff/pull/20892#issuecomment-3536537553. So we may as well remove it.

I also fixed the issue-creation logic so that an issue will be created whenever the outcome `!= 'success'`, instead of an issue only being created when the outcome `== 'failure'`. According to https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#needs-context, `needs.<job_id>.result` could be `success`, `failure`, `cancelled`, or `skipped`.

Fixes https://github.com/astral-sh/ty/issues/1996

## Test Plan

I'll run the sync-typeshed workflow on this branch to test it: https://github.com/astral-sh/ruff/actions/runs/20378210302
