### PR TITLE
[ty] Run mypy_primer and typing-conformance workflows on fewer PRs

### DIFF
--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -9,7 +9,7 @@ on:
       - "!crates/ty_ide/**"
       - "!crates/ty_server/**"
       - "!crates/ty_test/**"
-      - "!crates/ty_server/**"
+      - "!crates/ty_completion_eval/**"
       - "!crates/ty_wasm/**"
       - "crates/ruff_db"
       - "crates/ruff_python_ast"

--- a/.github/workflows/typing_conformance.yaml
+++ b/.github/workflows/typing_conformance.yaml
@@ -9,7 +9,7 @@ on:
       - "!crates/ty_ide/**"
       - "!crates/ty_server/**"
       - "!crates/ty_test/**"
-      - "!crates/ty_server/**"
+      - "!crates/ty_completion_eval/**"
       - "!crates/ty_wasm/**"
       - "crates/ruff_db"
       - "crates/ruff_python_ast"


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/2090. Quoting my rationale from that issue:

> A PR that only touches code in [one of these crates] should never have any impact on memory usage or diagnostics produced. And the comments from the bot just lead to additional notifications which is annoying.

I _think_ I've got the syntax right here. The [docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax) say:

>  The order that you define paths patterns matters:
>
>  - A matching negative pattern (prefixed with !) after a positive match will exclude the path.
>  - A matching positive pattern after a negative match will include the path again.

## Test Plan

No idea? Merge it and see?