### PR TITLE
[`flake8_print`] better suggestion for basicConfig in `T201` docs

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
@@ -44,7 +44,7 @@ use crate::{Fix, FixAvailability, Violation};
 ///     return a + b < 4
 ///
 ///
-/// def main():
+/// if __name__ == "__main__":
 ///     logging.basicConfig(level=logging.INFO)
 /// ```
 ///


### PR DESCRIPTION

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

`logging.basicConfig` should not be called at a global module scope,
as that produces a race condition to configure logging based on which
module gets imported first.  Logging should instead be initialized
in an entrypoint to the program, either in a `main()` or in the
typical `if __name__ == "__main__"` block.

## Test Plan

tbd
