### PR TITLE
[ty] Fix panic introduced in #22076

### DIFF
--- a/crates/ty/src/args.rs
+++ b/crates/ty/src/args.rs
@@ -190,7 +190,7 @@ pub(crate) struct CheckCommand {
 
 impl CheckCommand {
     pub(crate) fn force_exclude(&self) -> bool {
-        resolve_bool_arg(self.force_exclude, self.no_progress).unwrap_or_default()
+        resolve_bool_arg(self.force_exclude, self.no_force_exclude).unwrap_or_default()
     }
 
     pub(crate) fn into_options(self) -> Options {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Was looking over that PR and this looked wrong.

panic introduced in #22076 

## Test Plan

Before running:

```bash
cargo run -p ty check test.py --force-exclude --no-progress 
```

would result in a panic

```text
thread 'main' (162713) panicked at crates/ty/src/args.rs:459:17:
internal error: entered unreachable code: Clap should make this impossible
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Now it does not.
