### PR TITLE
[ty] Add support for dict(...) calls in typed dict contexts

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -55,10 +55,13 @@ class TD(TypedDict):
 d1 = {"x": 1}
 d2: TD = {"x": 1}
 d3: dict[str, int] = {"x": 1}
+d4: TD = dict(x=1)
+d5: TD = dict(x="1")  # error: [invalid-argument-type]
 
 reveal_type(d1)  # revealed: dict[Unknown | str, Unknown | int]
 reveal_type(d2)  # revealed: TD
 reveal_type(d3)  # revealed: dict[str, int]
+reveal_type(d4)  # revealed: TD
 
 def _() -> TD:
     return {"x": 1}


### PR DESCRIPTION
## Summary

fixes https://github.com/astral-sh/ty/issues/2127
- handle `dict(...)` calls in TypedDict context with bidirectional inference
- validate keys/values using the existing TypedDict constructor implem
- mdtest: add 1 positive test, 1 negative test for invalid coverage

## Test Plan

```sh
cargo clippy --workspace --all-targets --all-features -- -D warnings  # Rust linting
cargo test  # Rust testing
uvx pre-commit run --all-files --show-diff-on-failure  # Rust and Python formatting, Markdown and Python linting, etc.
```
fully green