### PR TITLE
[ty] Fix attribute lookup on `type[T]` where `T` has a union bound

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -71,8 +71,11 @@ reveal_type(constrained(str))  # revealed: str
 constrained(A)
 ```
 
-`type[T]` with a union upper bound `T: A | B` represents any subclass of `A` or `B`. Metaclass
-attributes like `__name__` and `__qualname__` should still be accessible:
+`type[T]` with a union upper bound `T: A | B` represents the metatype of a type variable `T` where
+`T` can be solved to any subtype of `A` or any subtype of `B`. It behaves similarly to a type
+variable that can be solved to any subclass of `A` or any subclass of `B`. Since all classes are
+instances of `type`, attributes on instances of `type` like `__name__` and `__qualname__` should
+still be accessible:
 
 ```py
 class Replace: ...

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7744,44 +7744,7 @@ impl<'db> Type<'db> {
             }
             Type::ClassLiteral(class) => class.metaclass(db),
             Type::GenericAlias(alias) => ClassType::from(alias).metaclass(db),
-            Type::SubclassOf(subclass_of_ty) => match subclass_of_ty.subclass_of() {
-                SubclassOfInner::Dynamic(dynamic) => {
-                    SubclassOfType::from(db, SubclassOfInner::Dynamic(dynamic))
-                }
-                SubclassOfInner::Class(class) => {
-                    SubclassOfType::try_from_type(db, class.metaclass(db))
-                        .unwrap_or(SubclassOfType::subclass_of_unknown())
-                }
-                SubclassOfInner::TypeVar(bound_typevar) => {
-                    // For `type[T]` where T is a TypeVar, compute the metatype by
-                    // getting the metatype of the bound. This correctly handles union
-                    // bounds like `T: A | B` by distributing: the metatype of
-                    // `type[T]` becomes `metatype(A) | metatype(B)`.
-                    match bound_typevar.typevar(db).bound_or_constraints(db) {
-                        None => {
-                            // Unbounded TypeVar: metatype is type[type] (metaclass of object)
-                            SubclassOfType::try_from_type(db, ClassType::object(db).metaclass(db))
-                                .unwrap_or(SubclassOfType::subclass_of_unknown())
-                        }
-                        Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                            // Get the metatype by converting the bound to type[bound] first,
-                            // then getting the metatype. For unions, this distributes:
-                            // type[A | B] = type[A] | type[B], and the metatype becomes
-                            // metatype(type[A]) | metatype(type[B]).
-                            SubclassOfType::try_from_instance(db, bound)
-                                .unwrap_or(SubclassOfType::subclass_of_unknown())
-                                .to_meta_type(db)
-                        }
-                        Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                            // For constraints like `T: (int, str)`, we need the metaclass of
-                            // each constraint class, not the metatype of the instance types.
-                            SubclassOfType::try_from_instance(db, constraints.as_type(db))
-                                .unwrap_or(SubclassOfType::subclass_of_unknown())
-                                .to_meta_type(db)
-                        }
-                    }
-                }
-            },
+            Type::SubclassOf(subclass_of_ty) => subclass_of_ty.to_meta_type(db),
             Type::StringLiteral(_) | Type::LiteralString => KnownClass::Str.to_class_literal(db),
             Type::Dynamic(dynamic) => SubclassOfType::from(db, SubclassOfInner::Dynamic(dynamic)),
             // TODO intersections


### PR DESCRIPTION
## Summary

For `type[T]` where `T: Replace | Multiply`, we now do the following:

- `try_from_instance(Replace | Multiply)` becomes `type[Replace] | type[Multiply]`
- `to_meta_type(type[Replace] | type[Multiply])` becomes `type[type] | type[type]` which becomes `type[type]`

See: https://github.com/astral-sh/ruff/pull/22115#issuecomment-3677977751
