### PR TITLE
[ty] Fix iteration over intersections with TypeVars whose bounds contain non-iterable types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -951,3 +951,24 @@ for x in Bar:
     # TODO: should reveal `Any`
     reveal_type(x)  # revealed: Unknown
 ```
+
+## Iterating over an intersection with a TypeVar whose bound is a union
+
+When a TypeVar has a union bound where some elements are iterable and some are not, and the TypeVar
+is intersected with an iterable type (e.g., via `isinstance`), the iteration should use the iterable
+parts of the TypeVar's bound.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+def f[T: tuple[int, ...] | int](x: T):
+    if isinstance(x, tuple):
+        reveal_type(x)  # revealed: T@f & tuple[object, ...]
+        for item in x:
+            # The TypeVar T is constrained to tuple[int, ...] by the isinstance check,
+            # so iterating should give `int`, not `object`.
+            reveal_type(item)  # revealed: int
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4731,44 +4731,52 @@ impl<'db> Type<'db> {
                     // We only fail if all elements fail to iterate; as long as at least one
                     // element can be iterated over, we can produce a result.
                     //
-                    // For TypeVars with union bounds where some union elements are not iterable,
-                    // we iterate the iterable parts of the bound. This is sound because the
-                    // intersection constrains the TypeVar to only the iterable parts.
+                    // For TypeVars, we replace them with their upper bound for iteration
+                    // purposes. Once we are iterating, the fact that it's a TypeVar no
+                    // longer matters: all that matters is the upper bound.
+                    //
+                    // For unions in an intersection context, if some elements are not
+                    // iterable, we iterate only the iterable parts. This is sound because
+                    // the intersection constrains the type to the iterable parts.
                     // For example, for `T & tuple[object, ...]` where `T: tuple[int, ...] | int`,
                     // iterating should give `int` (from the `tuple[int, ...]` part of T's bound),
                     // not `object` (from ignoring T entirely).
                     let try_iterate_element =
                         |element: Type<'db>| -> Option<Cow<'db, TupleSpec<'db>>> {
-                            // First try normal iteration
+                            // Replace TypeVar with its upper bound for iteration purposes.
+                            let element = if let Type::TypeVar(tvar) = element {
+                                match tvar.typevar(db).bound_or_constraints(db) {
+                                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound,
+                                    Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                                        constraints.as_type(db)
+                                    }
+                                    None => return None,
+                                }
+                            } else {
+                                element
+                            };
+
+                            // Try normal iteration.
                             if let Ok(spec) =
                                 element.try_iterate_with_mode(db, EvaluationMode::Sync)
                             {
                                 return Some(spec);
                             }
 
-                            // If that fails and the element is a TypeVar with a union bound,
-                            // try to iterate the iterable parts of the union.
-                            if let Type::TypeVar(tvar) = element {
-                                if let Some(TypeVarBoundOrConstraints::UpperBound(Type::Union(
-                                    union,
-                                ))) = tvar.typevar(db).bound_or_constraints(db)
-                                {
-                                    // Collect iteration specs for all iterable union elements.
-                                    let mut iterable_specs = union.elements(db).iter().filter_map(
-                                        |elem| {
-                                            elem.try_iterate_with_mode(db, EvaluationMode::Sync)
-                                                .ok()
-                                        },
-                                    );
+                            // For unions, try iterating only the iterable parts.
+                            if let Type::Union(union) = element {
+                                let mut iterable_specs = union.elements(db).iter().filter_map(
+                                    |elem| {
+                                        elem.try_iterate_with_mode(db, EvaluationMode::Sync).ok()
+                                    },
+                                );
 
-                                    // If any union elements are iterable, union their specs.
-                                    if let Some(first) = iterable_specs.next() {
-                                        let mut builder = TupleSpecBuilder::from(&*first);
-                                        for spec in iterable_specs {
-                                            builder = builder.union(db, &spec);
-                                        }
-                                        return Some(Cow::Owned(builder.build()));
+                                if let Some(first) = iterable_specs.next() {
+                                    let mut builder = TupleSpecBuilder::from(&*first);
+                                    for spec in iterable_specs {
+                                        builder = builder.union(db, &spec);
                                     }
+                                    return Some(Cow::Owned(builder.build()));
                                 }
                             }
 


### PR DESCRIPTION
## Summary

When iterating over an intersection like `T & tuple[object, ...]` where `T` is a `TypeVar` bounded by `tuple[int, ...] | int`, the iteration was returning `object` instead of `int`. Now, when a `TypeVar` fails to iterate normally, we check if it has a union bound, then extract the iterable parts and use those for the result.

See: https://github.com/astral-sh/ruff/pull/22115#issuecomment-3677967837
