### PR TITLE
Fix iter example in usafe fixes doc

### DIFF
--- a/docs/linter.md
+++ b/docs/linter.md
@@ -188,7 +188,7 @@ IndexError: list index out of range
 ```
 
 ```console
-$ python -c 'next(iter(range(0)))[0]'
+$ python -c 'next(iter(range(0)))'
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
 StopIteration


### PR DESCRIPTION
## Summary

This appears to have been a copy/paste error from the list example, as the subscript is not present in the original next/iter example only in the case where the error case is shown. While in the specific example code the subscript actually has no effect, it does make the example slightly confusing.

Consider the following variations, first the example from the docs unchanged and second the same code but not hitting the intended error case (due to using a non-empty collection):
```console
$ python3 -c 'next(iter(range(0)))[0]'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
StopIteration

$ python3 -c 'next(iter(range(1)))[0]'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: 'int' object is not subscriptable
```

## Test Plan

Not directly tested, however see inline snippets above.