### PR TITLE
[ty] Add a dedicated diagnostic for TypedDict deletions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/del.md
+++ b/crates/ty_python_semantic/resources/mdtest/del.md
@@ -242,6 +242,8 @@ Deleting a required key from a TypedDict is a type error because it would make t
 a valid instance of that TypedDict type. However, deleting `NotRequired` keys (or keys in
 `total=False` TypedDicts) is allowed.
 
+<!-- snapshot-diagnostics -->
+
 ```py
 from typing_extensions import TypedDict, NotRequired
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/del.md_-_`del`_statement_-_Delete_items_-_TypedDict_deletion_(1168a65357694229).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/del.md_-_`del`_statement_-_Delete_items_-_TypedDict_deletion_(1168a65357694229).snap
@@ -1,0 +1,113 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: del.md - `del` statement - Delete items - TypedDict deletion
+mdtest path: crates/ty_python_semantic/resources/mdtest/del.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | from typing_extensions import TypedDict, NotRequired
+ 2 | 
+ 3 | class Movie(TypedDict):
+ 4 |     name: str
+ 5 |     year: int
+ 6 | 
+ 7 | class PartialMovie(TypedDict, total=False):
+ 8 |     name: str
+ 9 |     year: int
+10 | 
+11 | class MixedMovie(TypedDict):
+12 |     name: str
+13 |     year: NotRequired[int]
+14 | 
+15 | m: Movie = {"name": "Blade Runner", "year": 1982}
+16 | p: PartialMovie = {"name": "Test"}
+17 | mixed: MixedMovie = {"name": "Test"}
+18 | 
+19 | # Required keys cannot be deleted.
+20 | # error: [invalid-argument-type]
+21 | del m["name"]
+22 | 
+23 | # In a partial TypedDict (`total=False`), all keys can be deleted.
+24 | del p["name"]
+25 | 
+26 | # `NotRequired` keys can always be deleted.
+27 | del mixed["year"]
+28 | 
+29 | # But required keys in mixed `TypedDict` still cannot be deleted.
+30 | # error: [invalid-argument-type]
+31 | del mixed["name"]
+32 | 
+33 | # And keys that don't exist cannot be deleted.
+34 | # error: [invalid-argument-type]
+35 | del mixed["non_existent"]
+```
+
+# Diagnostics
+
+```
+error[invalid-argument-type]: Cannot delete required key "name" from TypedDict `Movie`
+  --> src/mdtest_snippet.py:21:7
+   |
+19 | # Required keys cannot be deleted.
+20 | # error: [invalid-argument-type]
+21 | del m["name"]
+   |       ^^^^^^
+22 |
+23 | # In a partial TypedDict (`total=False`), all keys can be deleted.
+   |
+info: Field defined here
+ --> src/mdtest_snippet.py:4:5
+  |
+3 | class Movie(TypedDict):
+4 |     name: str
+  |     --------- `name` declared as required here; consider making it `NotRequired`
+5 |     year: int
+  |
+info: Only keys marked as `NotRequired` (or in a TypedDict with `total=False`) can be deleted
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Cannot delete required key "name" from TypedDict `MixedMovie`
+  --> src/mdtest_snippet.py:31:11
+   |
+29 | # But required keys in mixed `TypedDict` still cannot be deleted.
+30 | # error: [invalid-argument-type]
+31 | del mixed["name"]
+   |           ^^^^^^
+32 |
+33 | # And keys that don't exist cannot be deleted.
+   |
+info: Field defined here
+  --> src/mdtest_snippet.py:12:5
+   |
+11 | class MixedMovie(TypedDict):
+12 |     name: str
+   |     --------- `name` declared as required here; consider making it `NotRequired`
+13 |     year: NotRequired[int]
+   |
+info: Only keys marked as `NotRequired` (or in a TypedDict with `total=False`) can be deleted
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Cannot delete unknown key "non_existent" from TypedDict `MixedMovie`
+  --> src/mdtest_snippet.py:35:11
+   |
+33 | # And keys that don't exist cannot be deleted.
+34 | # error: [invalid-argument-type]
+35 | del mixed["non_existent"]
+   |           ^^^^^^^^^^^^^^
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -612,7 +612,7 @@ pub(super) fn validate_typed_dict_key_assignment<'db, 'ast>(
         };
 
     let add_item_definition_subdiagnostic = |diagnostic: &mut Diagnostic, message| {
-        if let Some(declaration) = item.first_declaration {
+        if let Some(declaration) = item.first_declaration() {
             let file = declaration.file(db);
             let module = parsed_module(db, file).load(db);
 
@@ -970,6 +970,10 @@ impl<'db> TypedDictField<'db> {
 
     pub(crate) const fn is_read_only(&self) -> bool {
         self.flags.contains(TypedDictFieldFlags::READ_ONLY)
+    }
+
+    pub(crate) const fn first_declaration(&self) -> Option<Definition<'db>> {
+        self.first_declaration
     }
 
     pub(crate) fn apply_type_mapping_impl<'a>(


### PR DESCRIPTION
## Summary

Provides a message like:

```
  error[invalid-argument-type]: Cannot delete required key "name" from TypedDict `Movie`
    --> test.py:15:7
     |
  15 | del m["name"]
     |       ^^^^^^
     |
  info: Field defined here
   --> test.py:4:5
    |
  4 |     name: str
    |     --------- `name` declared as required here; consider making it `NotRequired`
    |
  info: Only keys marked as `NotRequired` (or in a TypedDict with `total=False`) can be deleted
```
