### PR TITLE
[ty] Rename benchmarks, update iteration counts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1034,7 +1034,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: benchmarks-walltime-binary
-          path: target/codspeed/walltime/ty_walltime
+          path: target/codspeed/walltime/ruff_benchmark
           retention-days: 1
 
   benchmarks-walltime-run:
@@ -1069,7 +1069,7 @@ jobs:
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: benchmarks-walltime-binary
-          path: target/codspeed/walltime/ty_walltime
+          path: target/codspeed/walltime/ruff_benchmark
 
       - name: "Restore binary permissions"
         run: chmod +x target/codspeed/walltime/ruff_benchmark/ty_walltime


### PR DESCRIPTION
## Summary

Remove the `small`, `medium` and `large` groups because projects that used to be very fast
to type check now take longer and would have to be moved into another group so that we can update the iteration counts.

This PR also updates the iteration counts for `colour_science` and `pandas` (from 3 to 2, equal to moving them to large) and
pydantic (from 1 to 3, moving it from large to medium).

The downside of this is that we lose our historical data but this is a better long-term setup.


| Benchmark | Time per iter | Iterations | Total |
|-----------|---------------|------------|-------|
| colour_science | 1.5 min | 2 | ~3 min |
| pandas | 1 min | 2 | ~2 min |
| sympy | 52s | 2 | ~1.7 min |
| static_frame | 20s | 3 | ~1 min |
| pydantic | 11s | 3 | ~33s |
| freqtrade | 8s | 6 | ~48s |
| altair | 5s | 6 | ~30s |
| tanjun | 2.5s | 6 | ~15s |
| multithreaded | 1.4s | 24 | ~34s |


## Test Plan

CI
