### PR TITLE
[ty] Fix `@staticmethod` combined with other decorators incorrectly binding `self`

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -194,7 +194,7 @@ static SYMPY: Benchmark = Benchmark::new(
         max_dep_date: "2025-06-17",
         python_version: PythonVersion::PY312,
     },
-    13100,
+    13106,
 );
 
 static TANJUN: Benchmark = Benchmark::new(

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -588,6 +588,31 @@ reveal_type(C.f2(1))  # revealed: str
 reveal_type(C().f2(1))  # revealed: str
 ```
 
+When a `@staticmethod` is decorated with `@contextmanager`, accessing it from an instance should not
+bind `self`:
+
+```py
+from contextlib import contextmanager
+from collections.abc import Iterator
+
+class D:
+    @staticmethod
+    @contextmanager
+    def ctx(num: int) -> Iterator[int]:
+        yield num
+
+    def use_ctx(self) -> None:
+        # Accessing via self should not bind self
+        with self.ctx(10) as x:
+            reveal_type(x)  # revealed: int
+
+# Accessing via class works
+reveal_type(D.ctx(5))  # revealed: _GeneratorContextManager[int, None, None]
+
+# Accessing via instance should also work (no self-binding)
+reveal_type(D().ctx(5))  # revealed: _GeneratorContextManager[int, None, None]
+```
+
 ### `__new__`
 
 `__new__` is an implicit `@staticmethod`; accessing it on an instance does not bind the `cls`

--- a/crates/ty_python_semantic/resources/mdtest/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/final.md
@@ -119,8 +119,8 @@ class OtherChild(Parent): ...
 
 class Grandchild(OtherChild):
     @staticmethod
-    # TODO: we should emit a Liskov violation here too
     # error: [override-of-final-method]
+    # error: [invalid-method-override]
     def foo(): ...
     @property
     # TODO: we should emit a Liskov violation here too

--- a/crates/ty_python_semantic/resources/mdtest/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/final.md
@@ -118,6 +118,10 @@ class Child(Parent):
 class OtherChild(Parent): ...
 
 class Grandchild(OtherChild):
+    # TODO: The Liskov violation here maybe shouldn't be emitted? Whether called on the
+    # type or on an instance, it will behave the same from the caller's perspective. The only
+    # difference is whether the method body gets access to `self`, which is not a
+    # concern of Liskov.
     @staticmethod
     # error: [override-of-final-method]
     # error: [invalid-method-override]
@@ -267,6 +271,7 @@ class ChildOfGood(Good):
     def f(self, x: str) -> str: ...
     @overload
     def f(self, x: int) -> int: ...
+
     # error: [override-of-final-method]
     def f(self, x: int | str) -> int | str:
         return x
@@ -277,6 +282,7 @@ class Bad:
     def f(self, x: str) -> str: ...
     @overload
     def f(self, x: int) -> int: ...
+
     # error: [invalid-overload]
     def f(self, x: int | str) -> int | str:
         return x
@@ -286,6 +292,7 @@ class Bad:
     def g(self, x: str) -> str: ...
     @overload
     def g(self, x: int) -> int: ...
+
     # error: [invalid-overload]
     def g(self, x: int | str) -> int | str:
         return x
@@ -295,6 +302,7 @@ class Bad:
     @overload
     @final
     def h(self, x: int) -> int: ...
+
     # error: [invalid-overload]
     def h(self, x: int | str) -> int | str:
         return x
@@ -304,6 +312,7 @@ class Bad:
     @final
     @overload
     def i(self, x: int) -> int: ...
+
     # error: [invalid-overload]
     def i(self, x: int | str) -> int | str:
         return x
@@ -478,7 +487,8 @@ class B(A):
     #
     # TODO: we should emit a Liskov violation here too
     # error: [override-of-final-method]
-    method4 = 42; unrelated = 56  # fmt: skip
+    method4 = 42
+    unrelated = 56  # fmt: skip
 
 # Possible overrides of possibly `@final` methods...
 class C(A):
@@ -542,6 +552,7 @@ class Child(Parent):
     else:
         # Fine because this doesn't override any reachable definitions
         def foooo(self) -> None: ...
+
         # There are `@final` definitions being overridden here,
         # but the definitions that override them are unreachable
         def spam(self) -> None: ...

--- a/crates/ty_python_semantic/resources/mdtest/override.md
+++ b/crates/ty_python_semantic/resources/mdtest/override.md
@@ -185,7 +185,7 @@ class LiskovViolatingButNotOverrideViolating(Parent):
 
     @staticmethod
     @override
-    def class_method1() -> int: ...
+    def class_method1() -> int: ...  # error: [invalid-method-override]
 
     @classmethod
     @override

--- a/crates/ty_python_semantic/resources/mdtest/override.md
+++ b/crates/ty_python_semantic/resources/mdtest/override.md
@@ -183,6 +183,9 @@ class LiskovViolatingButNotOverrideViolating(Parent):
     @override
     def my_property1(self) -> int: ...
 
+    # TODO: This maybe shouldn't be a Liskov violation? Whether called on the type or
+    # on an instance, it will behave the same from the caller's perspective. The only difference
+    # is whether the method body gets access to `cls`, which is not a concern of Liskov.
     @staticmethod
     @override
     def class_method1() -> int: ...  # error: [invalid-method-override]
@@ -428,6 +431,7 @@ class Spam:
     def baz(self, x: str) -> str: ...
     @overload
     def baz(self, x: int) -> int: ...
+
     # error: [invalid-overload] "`@override` decorator should be applied only to the overload implementation"
     # error: [invalid-explicit-override]
     def baz(self, x: str | int) -> str | int:

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_possibly-undefined…_(fc7b496fd1986deb).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_possibly-undefined…_(fc7b496fd1986deb).snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ty_test/src/lib.rs
+assertion_line: 623
 expression: snapshot
 ---
 ---
@@ -55,28 +56,29 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 41 |     #
 42 |     # TODO: we should emit a Liskov violation here too
 43 |     # error: [override-of-final-method]
-44 |     method4 = 42; unrelated = 56  # fmt: skip
-45 | 
-46 | # Possible overrides of possibly `@final` methods...
-47 | class C(A):
-48 |     if coinflip():
-49 |         def method1(self) -> None: ...  # error: [override-of-final-method]
-50 |     else:
-51 |         pass
-52 | 
-53 |     if coinflip():
-54 |         def method2(self) -> None: ...  # error: [override-of-final-method]
-55 |     else:
-56 |         def method2(self) -> None: ...
-57 | 
-58 |     if coinflip():
-59 |         def method3(self) -> None: ...  # error: [override-of-final-method]
-60 | 
-61 |     # TODO: we should emit Liskov violations here too:
-62 |     if coinflip():
-63 |         method4 = 42  # error: [override-of-final-method]
-64 |     else:
-65 |         method4 = 56
+44 |     method4 = 42
+45 |     unrelated = 56  # fmt: skip
+46 | 
+47 | # Possible overrides of possibly `@final` methods...
+48 | class C(A):
+49 |     if coinflip():
+50 |         def method1(self) -> None: ...  # error: [override-of-final-method]
+51 |     else:
+52 |         pass
+53 | 
+54 |     if coinflip():
+55 |         def method2(self) -> None: ...  # error: [override-of-final-method]
+56 |     else:
+57 |         def method2(self) -> None: ...
+58 | 
+59 |     if coinflip():
+60 |         def method3(self) -> None: ...  # error: [override-of-final-method]
+61 | 
+62 |     # TODO: we should emit Liskov violations here too:
+63 |     if coinflip():
+64 |         method4 = 42  # error: [override-of-final-method]
+65 |     else:
+66 |         method4 = 56
 ```
 
 # Diagnostics
@@ -195,10 +197,9 @@ error[override-of-final-method]: Cannot override `A.method4`
    |
 42 |     # TODO: we should emit a Liskov violation here too
 43 |     # error: [override-of-final-method]
-44 |     method4 = 42; unrelated = 56  # fmt: skip
+44 |     method4 = 42
    |     ^^^^^^^ Overrides a definition from superclass `A`
-45 |
-46 | # Possible overrides of possibly `@final` methods...
+45 |     unrelated = 56  # fmt: skip
    |
 info: `A.method4` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.py:29:9
@@ -219,14 +220,14 @@ info: rule `override-of-final-method` is enabled by default
 
 ```
 error[override-of-final-method]: Cannot override `A.method1`
-  --> src/mdtest_snippet.py:49:13
+  --> src/mdtest_snippet.py:50:13
    |
-47 | class C(A):
-48 |     if coinflip():
-49 |         def method1(self) -> None: ...  # error: [override-of-final-method]
+48 | class C(A):
+49 |     if coinflip():
+50 |         def method1(self) -> None: ...  # error: [override-of-final-method]
    |             ^^^^^^^ Overrides a definition from superclass `A`
-50 |     else:
-51 |         pass
+51 |     else:
+52 |         pass
    |
 info: `A.method1` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.py:8:9
@@ -247,13 +248,13 @@ info: rule `override-of-final-method` is enabled by default
 
 ```
 error[override-of-final-method]: Cannot override `A.method2`
-  --> src/mdtest_snippet.py:54:13
+  --> src/mdtest_snippet.py:55:13
    |
-53 |     if coinflip():
-54 |         def method2(self) -> None: ...  # error: [override-of-final-method]
+54 |     if coinflip():
+55 |         def method2(self) -> None: ...  # error: [override-of-final-method]
    |             ^^^^^^^ Overrides a definition from superclass `A`
-55 |     else:
-56 |         def method2(self) -> None: ...
+56 |     else:
+57 |         def method2(self) -> None: ...
    |
 info: `A.method2` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.py:16:9
@@ -274,13 +275,13 @@ info: rule `override-of-final-method` is enabled by default
 
 ```
 error[override-of-final-method]: Cannot override `A.method3`
-  --> src/mdtest_snippet.py:59:13
+  --> src/mdtest_snippet.py:60:13
    |
-58 |     if coinflip():
-59 |         def method3(self) -> None: ...  # error: [override-of-final-method]
+59 |     if coinflip():
+60 |         def method3(self) -> None: ...  # error: [override-of-final-method]
    |             ^^^^^^^ Overrides a definition from superclass `A`
-60 |
-61 |     # TODO: we should emit Liskov violations here too:
+61 |
+62 |     # TODO: we should emit Liskov violations here too:
    |
 info: `A.method3` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.py:20:9
@@ -300,14 +301,14 @@ info: rule `override-of-final-method` is enabled by default
 
 ```
 error[override-of-final-method]: Cannot override `A.method4`
-  --> src/mdtest_snippet.py:63:9
+  --> src/mdtest_snippet.py:64:9
    |
-61 |     # TODO: we should emit Liskov violations here too:
-62 |     if coinflip():
-63 |         method4 = 42  # error: [override-of-final-method]
+62 |     # TODO: we should emit Liskov violations here too:
+63 |     if coinflip():
+64 |         method4 = 42  # error: [override-of-final-method]
    |         ^^^^^^^ Overrides a definition from superclass `A`
-64 |     else:
-65 |         method4 = 56
+65 |     else:
+66 |         method4 = 56
    |
 info: `A.method4` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.py:29:9

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Cannot_override_a_me…_(338615109711a91b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Cannot_override_a_me…_(338615109711a91b).snap
@@ -96,8 +96,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
  82 | 
  83 | class Grandchild(OtherChild):
  84 |     @staticmethod
- 85 |     # TODO: we should emit a Liskov violation here too
- 86 |     # error: [override-of-final-method]
+ 85 |     # error: [override-of-final-method]
+ 86 |     # error: [invalid-method-override]
  87 |     def foo(): ...
  88 |     @property
  89 |     # TODO: we should emit a Liskov violation here too
@@ -407,11 +407,37 @@ note: This is an unsafe fix and may change runtime behavior
 ```
 
 ```
+error[invalid-method-override]: Invalid override of method `foo`
+  --> src/mdtest_snippet.pyi:87:9
+   |
+85 |     # error: [override-of-final-method]
+86 |     # error: [invalid-method-override]
+87 |     def foo(): ...
+   |         ^^^^^ Definition is incompatible with `Parent.foo`
+88 |     @property
+89 |     # TODO: we should emit a Liskov violation here too
+   |
+  ::: src/mdtest_snippet.pyi:7:9
+   |
+ 5 | class Parent:
+ 6 |     @final
+ 7 |     def foo(self): ...
+   |         --------- `Parent.foo` defined here
+ 8 |
+ 9 |     @final
+   |
+info: `Grandchild.foo` is a staticmethod but `Parent.foo` is an instance method
+info: This violates the Liskov Substitution Principle
+info: rule `invalid-method-override` is enabled by default
+
+```
+
+```
 error[override-of-final-method]: Cannot override `Parent.foo`
   --> src/mdtest_snippet.pyi:87:9
    |
-85 |     # TODO: we should emit a Liskov violation here too
-86 |     # error: [override-of-final-method]
+85 |     # error: [override-of-final-method]
+86 |     # error: [invalid-method-override]
 87 |     def foo(): ...
    |         ^^^ Overrides a definition from superclass `Parent`
 88 |     @property
@@ -434,8 +460,8 @@ info: rule `override-of-final-method` is enabled by default
 82 | 
 83 | class Grandchild(OtherChild):
    -     @staticmethod
-   -     # TODO: we should emit a Liskov violation here too
    -     # error: [override-of-final-method]
+   -     # error: [invalid-method-override]
    -     def foo(): ...
 84 +     
 85 |     @property

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Cannot_override_a_me…_(338615109711a91b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Cannot_override_a_me…_(338615109711a91b).snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ty_test/src/lib.rs
+assertion_line: 623
 expression: snapshot
 ---
 ---
@@ -95,30 +96,30 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
  81 | class OtherChild(Parent): ...
  82 | 
  83 | class Grandchild(OtherChild):
- 84 |     @staticmethod
- 85 |     # error: [override-of-final-method]
- 86 |     # error: [invalid-method-override]
- 87 |     def foo(): ...
- 88 |     @property
- 89 |     # TODO: we should emit a Liskov violation here too
- 90 |     # error: [override-of-final-method]
- 91 |     def my_property1(self) -> str: ...
- 92 |     # TODO: we should emit a Liskov violation here too
- 93 |     # error: [override-of-final-method]
- 94 |     class_method1 = None
- 95 | 
- 96 | # Diagnostic edge case: `final` is very far away from the method definition in the source code:
- 97 | 
- 98 | T = TypeVar("T")
+ 84 |     # TODO: The Liskov violation here maybe shouldn't be emitted? Whether called on the
+ 85 |     # type or on an instance, it will behave the same from the caller's perspective. The only
+ 86 |     # difference is whether the method body gets access to `self`, which is not a
+ 87 |     # concern of Liskov.
+ 88 |     @staticmethod
+ 89 |     # error: [override-of-final-method]
+ 90 |     # error: [invalid-method-override]
+ 91 |     def foo(): ...
+ 92 |     @property
+ 93 |     # TODO: we should emit a Liskov violation here too
+ 94 |     # error: [override-of-final-method]
+ 95 |     def my_property1(self) -> str: ...
+ 96 |     # TODO: we should emit a Liskov violation here too
+ 97 |     # error: [override-of-final-method]
+ 98 |     class_method1 = None
  99 | 
-100 | def identity(x: T) -> T: ...
+100 | # Diagnostic edge case: `final` is very far away from the method definition in the source code:
 101 | 
-102 | class Foo:
-103 |     @final
-104 |     @identity
-105 |     @identity
-106 |     @identity
-107 |     @identity
+102 | T = TypeVar("T")
+103 | 
+104 | def identity(x: T) -> T: ...
+105 | 
+106 | class Foo:
+107 |     @final
 108 |     @identity
 109 |     @identity
 110 |     @identity
@@ -133,10 +134,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 119 |     @identity
 120 |     @identity
 121 |     @identity
-122 |     def bar(self): ...
-123 | 
-124 | class Baz(Foo):
-125 |     def bar(self): ...  # error: [override-of-final-method]
+122 |     @identity
+123 |     @identity
+124 |     @identity
+125 |     @identity
+126 |     def bar(self): ...
+127 | 
+128 | class Baz(Foo):
+129 |     def bar(self): ...  # error: [override-of-final-method]
 ```
 
 # Diagnostics
@@ -408,14 +413,14 @@ note: This is an unsafe fix and may change runtime behavior
 
 ```
 error[invalid-method-override]: Invalid override of method `foo`
-  --> src/mdtest_snippet.pyi:87:9
+  --> src/mdtest_snippet.pyi:91:9
    |
-85 |     # error: [override-of-final-method]
-86 |     # error: [invalid-method-override]
-87 |     def foo(): ...
+89 |     # error: [override-of-final-method]
+90 |     # error: [invalid-method-override]
+91 |     def foo(): ...
    |         ^^^^^ Definition is incompatible with `Parent.foo`
-88 |     @property
-89 |     # TODO: we should emit a Liskov violation here too
+92 |     @property
+93 |     # TODO: we should emit a Liskov violation here too
    |
   ::: src/mdtest_snippet.pyi:7:9
    |
@@ -434,14 +439,14 @@ info: rule `invalid-method-override` is enabled by default
 
 ```
 error[override-of-final-method]: Cannot override `Parent.foo`
-  --> src/mdtest_snippet.pyi:87:9
+  --> src/mdtest_snippet.pyi:91:9
    |
-85 |     # error: [override-of-final-method]
-86 |     # error: [invalid-method-override]
-87 |     def foo(): ...
+89 |     # error: [override-of-final-method]
+90 |     # error: [invalid-method-override]
+91 |     def foo(): ...
    |         ^^^ Overrides a definition from superclass `Parent`
-88 |     @property
-89 |     # TODO: we should emit a Liskov violation here too
+92 |     @property
+93 |     # TODO: we should emit a Liskov violation here too
    |
 info: `Parent.foo` is decorated with `@final`, forbidding overrides
  --> src/mdtest_snippet.pyi:6:5
@@ -456,31 +461,31 @@ info: `Parent.foo` is decorated with `@final`, forbidding overrides
   |
 help: Remove the override of `foo`
 info: rule `override-of-final-method` is enabled by default
-81 | class OtherChild(Parent): ...
-82 | 
-83 | class Grandchild(OtherChild):
+85 |     # type or on an instance, it will behave the same from the caller's perspective. The only
+86 |     # difference is whether the method body gets access to `self`, which is not a
+87 |     # concern of Liskov.
    -     @staticmethod
    -     # error: [override-of-final-method]
    -     # error: [invalid-method-override]
    -     def foo(): ...
-84 +     
-85 |     @property
-86 |     # TODO: we should emit a Liskov violation here too
-87 |     # error: [override-of-final-method]
+88 +     
+89 |     @property
+90 |     # TODO: we should emit a Liskov violation here too
+91 |     # error: [override-of-final-method]
 note: This is an unsafe fix and may change runtime behavior
 
 ```
 
 ```
 error[override-of-final-method]: Cannot override `Parent.my_property1`
-  --> src/mdtest_snippet.pyi:91:9
+  --> src/mdtest_snippet.pyi:95:9
    |
-89 |     # TODO: we should emit a Liskov violation here too
-90 |     # error: [override-of-final-method]
-91 |     def my_property1(self) -> str: ...
+93 |     # TODO: we should emit a Liskov violation here too
+94 |     # error: [override-of-final-method]
+95 |     def my_property1(self) -> str: ...
    |         ^^^^^^^^^^^^ Overrides a definition from superclass `Parent`
-92 |     # TODO: we should emit a Liskov violation here too
-93 |     # error: [override-of-final-method]
+96 |     # TODO: we should emit a Liskov violation here too
+97 |     # error: [override-of-final-method]
    |
 info: `Parent.my_property1` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.pyi:9:5
@@ -502,15 +507,15 @@ info: rule `override-of-final-method` is enabled by default
 
 ```
 error[override-of-final-method]: Cannot override `Parent.class_method1`
-  --> src/mdtest_snippet.pyi:94:5
-   |
-92 |     # TODO: we should emit a Liskov violation here too
-93 |     # error: [override-of-final-method]
-94 |     class_method1 = None
-   |     ^^^^^^^^^^^^^ Overrides a definition from superclass `Parent`
-95 |
-96 | # Diagnostic edge case: `final` is very far away from the method definition in the source code:
-   |
+   --> src/mdtest_snippet.pyi:98:5
+    |
+ 96 |     # TODO: we should emit a Liskov violation here too
+ 97 |     # error: [override-of-final-method]
+ 98 |     class_method1 = None
+    |     ^^^^^^^^^^^^^ Overrides a definition from superclass `Parent`
+ 99 |
+100 | # Diagnostic edge case: `final` is very far away from the method definition in the source code:
+    |
 info: `Parent.class_method1` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.pyi:21:5
    |
@@ -531,37 +536,37 @@ info: rule `override-of-final-method` is enabled by default
 
 ```
 error[override-of-final-method]: Cannot override `Foo.bar`
-   --> src/mdtest_snippet.pyi:125:9
+   --> src/mdtest_snippet.pyi:129:9
     |
-124 | class Baz(Foo):
-125 |     def bar(self): ...  # error: [override-of-final-method]
+128 | class Baz(Foo):
+129 |     def bar(self): ...  # error: [override-of-final-method]
     |         ^^^ Overrides a definition from superclass `Foo`
     |
 info: `Foo.bar` is decorated with `@final`, forbidding overrides
-   --> src/mdtest_snippet.pyi:103:5
+   --> src/mdtest_snippet.pyi:107:5
     |
-102 | class Foo:
-103 |     @final
+106 | class Foo:
+107 |     @final
     |     ------
-104 |     @identity
-105 |     @identity
+108 |     @identity
+109 |     @identity
     |
-   ::: src/mdtest_snippet.pyi:122:9
+   ::: src/mdtest_snippet.pyi:126:9
     |
-120 |     @identity
-121 |     @identity
-122 |     def bar(self): ...
+124 |     @identity
+125 |     @identity
+126 |     def bar(self): ...
     |         --- `Foo.bar` defined here
-123 |
-124 | class Baz(Foo):
+127 |
+128 | class Baz(Foo):
     |
 help: Remove the override of `bar`
 info: rule `override-of-final-method` is enabled by default
-122 |     def bar(self): ...
-123 | 
-124 | class Baz(Foo):
+126 |     def bar(self): ...
+127 | 
+128 | class Baz(Foo):
     -     def bar(self): ...  # error: [override-of-final-method]
-125 +     pass  # error: [override-of-final-method]
+129 +     pass  # error: [override-of-final-method]
 note: This is an unsafe fix and may change runtime behavior
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overloaded_methods_d…_(861757f48340ed92).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overloaded_methods_d…_(861757f48340ed92).snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ty_test/src/lib.rs
+assertion_line: 623
 expression: snapshot
 ---
 ---
@@ -84,53 +85,58 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 14 |     def f(self, x: str) -> str: ...
 15 |     @overload
 16 |     def f(self, x: int) -> int: ...
-17 |     # error: [override-of-final-method]
-18 |     def f(self, x: int | str) -> int | str:
-19 |         return x
-20 | 
-21 | class Bad:
-22 |     @overload
-23 |     @final
-24 |     def f(self, x: str) -> str: ...
-25 |     @overload
-26 |     def f(self, x: int) -> int: ...
-27 |     # error: [invalid-overload]
-28 |     def f(self, x: int | str) -> int | str:
-29 |         return x
-30 | 
-31 |     @final
-32 |     @overload
-33 |     def g(self, x: str) -> str: ...
+17 | 
+18 |     # error: [override-of-final-method]
+19 |     def f(self, x: int | str) -> int | str:
+20 |         return x
+21 | 
+22 | class Bad:
+23 |     @overload
+24 |     @final
+25 |     def f(self, x: str) -> str: ...
+26 |     @overload
+27 |     def f(self, x: int) -> int: ...
+28 | 
+29 |     # error: [invalid-overload]
+30 |     def f(self, x: int | str) -> int | str:
+31 |         return x
+32 | 
+33 |     @final
 34 |     @overload
-35 |     def g(self, x: int) -> int: ...
-36 |     # error: [invalid-overload]
-37 |     def g(self, x: int | str) -> int | str:
-38 |         return x
-39 | 
-40 |     @overload
-41 |     def h(self, x: str) -> str: ...
-42 |     @overload
-43 |     @final
-44 |     def h(self, x: int) -> int: ...
-45 |     # error: [invalid-overload]
-46 |     def h(self, x: int | str) -> int | str:
-47 |         return x
+35 |     def g(self, x: str) -> str: ...
+36 |     @overload
+37 |     def g(self, x: int) -> int: ...
+38 | 
+39 |     # error: [invalid-overload]
+40 |     def g(self, x: int | str) -> int | str:
+41 |         return x
+42 | 
+43 |     @overload
+44 |     def h(self, x: str) -> str: ...
+45 |     @overload
+46 |     @final
+47 |     def h(self, x: int) -> int: ...
 48 | 
-49 |     @overload
-50 |     def i(self, x: str) -> str: ...
-51 |     @final
-52 |     @overload
-53 |     def i(self, x: int) -> int: ...
-54 |     # error: [invalid-overload]
-55 |     def i(self, x: int | str) -> int | str:
-56 |         return x
-57 | 
-58 | class ChildOfBad(Bad):
-59 |     # TODO: these should all cause us to emit Liskov violations as well
-60 |     f = None  # error: [override-of-final-method]
-61 |     g = None  # error: [override-of-final-method]
-62 |     h = None  # error: [override-of-final-method]
-63 |     i = None  # error: [override-of-final-method]
+49 |     # error: [invalid-overload]
+50 |     def h(self, x: int | str) -> int | str:
+51 |         return x
+52 | 
+53 |     @overload
+54 |     def i(self, x: str) -> str: ...
+55 |     @final
+56 |     @overload
+57 |     def i(self, x: int) -> int: ...
+58 | 
+59 |     # error: [invalid-overload]
+60 |     def i(self, x: int | str) -> int | str:
+61 |         return x
+62 | 
+63 | class ChildOfBad(Bad):
+64 |     # TODO: these should all cause us to emit Liskov violations as well
+65 |     f = None  # error: [override-of-final-method]
+66 |     g = None  # error: [override-of-final-method]
+67 |     h = None  # error: [override-of-final-method]
+68 |     i = None  # error: [override-of-final-method]
 ```
 
 # Diagnostics
@@ -331,13 +337,12 @@ note: This is an unsafe fix and may change runtime behavior
 
 ```
 error[override-of-final-method]: Cannot override `Good.f`
-  --> src/main.py:18:9
+  --> src/main.py:19:9
    |
-16 |     def f(self, x: int) -> int: ...
-17 |     # error: [override-of-final-method]
-18 |     def f(self, x: int | str) -> int | str:
+18 |     # error: [override-of-final-method]
+19 |     def f(self, x: int | str) -> int | str:
    |         ^ Overrides a definition from superclass `Good`
-19 |         return x
+20 |         return x
    |
 info: `Good.f` is decorated with `@final`, forbidding overrides
   --> src/main.py:8:5
@@ -361,28 +366,28 @@ info: rule `override-of-final-method` is enabled by default
    -     def f(self, x: int) -> int: ...
 13 +     pass
 14 +     pass
-15 |     # error: [override-of-final-method]
+15 | 
+16 |     # error: [override-of-final-method]
    -     def f(self, x: int | str) -> int | str:
    -         return x
-16 +     pass
-17 | 
-18 | class Bad:
-19 |     @overload
+17 +     pass
+18 | 
+19 | class Bad:
+20 |     @overload
 note: This is an unsafe fix and may change runtime behavior
 
 ```
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/main.py:28:9
+  --> src/main.py:30:9
    |
-26 |     def f(self, x: int) -> int: ...
-27 |     # error: [invalid-overload]
-28 |     def f(self, x: int | str) -> int | str:
+29 |     # error: [invalid-overload]
+30 |     def f(self, x: int | str) -> int | str:
    |         -
    |         |
    |         Implementation defined here
-29 |         return x
+31 |         return x
    |
 info: rule `invalid-overload` is enabled by default
 
@@ -390,15 +395,14 @@ info: rule `invalid-overload` is enabled by default
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/main.py:37:9
+  --> src/main.py:40:9
    |
-35 |     def g(self, x: int) -> int: ...
-36 |     # error: [invalid-overload]
-37 |     def g(self, x: int | str) -> int | str:
+39 |     # error: [invalid-overload]
+40 |     def g(self, x: int | str) -> int | str:
    |         -
    |         |
    |         Implementation defined here
-38 |         return x
+41 |         return x
    |
 info: rule `invalid-overload` is enabled by default
 
@@ -406,15 +410,14 @@ info: rule `invalid-overload` is enabled by default
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/main.py:46:9
+  --> src/main.py:50:9
    |
-44 |     def h(self, x: int) -> int: ...
-45 |     # error: [invalid-overload]
-46 |     def h(self, x: int | str) -> int | str:
+49 |     # error: [invalid-overload]
+50 |     def h(self, x: int | str) -> int | str:
    |         -
    |         |
    |         Implementation defined here
-47 |         return x
+51 |         return x
    |
 info: rule `invalid-overload` is enabled by default
 
@@ -422,15 +425,14 @@ info: rule `invalid-overload` is enabled by default
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/main.py:55:9
+  --> src/main.py:60:9
    |
-53 |     def i(self, x: int) -> int: ...
-54 |     # error: [invalid-overload]
-55 |     def i(self, x: int | str) -> int | str:
+59 |     # error: [invalid-overload]
+60 |     def i(self, x: int | str) -> int | str:
    |         -
    |         |
    |         Implementation defined here
-56 |         return x
+61 |         return x
    |
 info: rule `invalid-overload` is enabled by default
 
@@ -438,23 +440,22 @@ info: rule `invalid-overload` is enabled by default
 
 ```
 error[override-of-final-method]: Cannot override `Bad.f`
-  --> src/main.py:60:5
+  --> src/main.py:65:5
    |
-58 | class ChildOfBad(Bad):
-59 |     # TODO: these should all cause us to emit Liskov violations as well
-60 |     f = None  # error: [override-of-final-method]
+63 | class ChildOfBad(Bad):
+64 |     # TODO: these should all cause us to emit Liskov violations as well
+65 |     f = None  # error: [override-of-final-method]
    |     ^ Overrides a definition from superclass `Bad`
-61 |     g = None  # error: [override-of-final-method]
-62 |     h = None  # error: [override-of-final-method]
+66 |     g = None  # error: [override-of-final-method]
+67 |     h = None  # error: [override-of-final-method]
    |
 info: `Bad.f` is decorated with `@final`, forbidding overrides
-  --> src/main.py:28:9
+  --> src/main.py:30:9
    |
-26 |     def f(self, x: int) -> int: ...
-27 |     # error: [invalid-overload]
-28 |     def f(self, x: int | str) -> int | str:
+29 |     # error: [invalid-overload]
+30 |     def f(self, x: int | str) -> int | str:
    |         - `Bad.f` defined here
-29 |         return x
+31 |         return x
    |
 help: Remove the override of `f`
 info: rule `override-of-final-method` is enabled by default
@@ -463,23 +464,22 @@ info: rule `override-of-final-method` is enabled by default
 
 ```
 error[override-of-final-method]: Cannot override `Bad.g`
-  --> src/main.py:61:5
+  --> src/main.py:66:5
    |
-59 |     # TODO: these should all cause us to emit Liskov violations as well
-60 |     f = None  # error: [override-of-final-method]
-61 |     g = None  # error: [override-of-final-method]
+64 |     # TODO: these should all cause us to emit Liskov violations as well
+65 |     f = None  # error: [override-of-final-method]
+66 |     g = None  # error: [override-of-final-method]
    |     ^ Overrides a definition from superclass `Bad`
-62 |     h = None  # error: [override-of-final-method]
-63 |     i = None  # error: [override-of-final-method]
+67 |     h = None  # error: [override-of-final-method]
+68 |     i = None  # error: [override-of-final-method]
    |
 info: `Bad.g` is decorated with `@final`, forbidding overrides
-  --> src/main.py:37:9
+  --> src/main.py:40:9
    |
-35 |     def g(self, x: int) -> int: ...
-36 |     # error: [invalid-overload]
-37 |     def g(self, x: int | str) -> int | str:
+39 |     # error: [invalid-overload]
+40 |     def g(self, x: int | str) -> int | str:
    |         - `Bad.g` defined here
-38 |         return x
+41 |         return x
    |
 help: Remove the override of `g`
 info: rule `override-of-final-method` is enabled by default
@@ -488,22 +488,21 @@ info: rule `override-of-final-method` is enabled by default
 
 ```
 error[override-of-final-method]: Cannot override `Bad.h`
-  --> src/main.py:62:5
+  --> src/main.py:67:5
    |
-60 |     f = None  # error: [override-of-final-method]
-61 |     g = None  # error: [override-of-final-method]
-62 |     h = None  # error: [override-of-final-method]
+65 |     f = None  # error: [override-of-final-method]
+66 |     g = None  # error: [override-of-final-method]
+67 |     h = None  # error: [override-of-final-method]
    |     ^ Overrides a definition from superclass `Bad`
-63 |     i = None  # error: [override-of-final-method]
+68 |     i = None  # error: [override-of-final-method]
    |
 info: `Bad.h` is decorated with `@final`, forbidding overrides
-  --> src/main.py:46:9
+  --> src/main.py:50:9
    |
-44 |     def h(self, x: int) -> int: ...
-45 |     # error: [invalid-overload]
-46 |     def h(self, x: int | str) -> int | str:
+49 |     # error: [invalid-overload]
+50 |     def h(self, x: int | str) -> int | str:
    |         - `Bad.h` defined here
-47 |         return x
+51 |         return x
    |
 help: Remove the override of `h`
 info: rule `override-of-final-method` is enabled by default
@@ -512,21 +511,20 @@ info: rule `override-of-final-method` is enabled by default
 
 ```
 error[override-of-final-method]: Cannot override `Bad.i`
-  --> src/main.py:63:5
+  --> src/main.py:68:5
    |
-61 |     g = None  # error: [override-of-final-method]
-62 |     h = None  # error: [override-of-final-method]
-63 |     i = None  # error: [override-of-final-method]
+66 |     g = None  # error: [override-of-final-method]
+67 |     h = None  # error: [override-of-final-method]
+68 |     i = None  # error: [override-of-final-method]
    |     ^ Overrides a definition from superclass `Bad`
    |
 info: `Bad.i` is decorated with `@final`, forbidding overrides
-  --> src/main.py:55:9
+  --> src/main.py:60:9
    |
-53 |     def i(self, x: int) -> int: ...
-54 |     # error: [invalid-overload]
-55 |     def i(self, x: int | str) -> int | str:
+59 |     # error: [invalid-overload]
+60 |     def i(self, x: int | str) -> int | str:
    |         - `Bad.i` defined here
-56 |         return x
+61 |         return x
    |
 help: Remove the override of `i`
 info: rule `override-of-final-method` is enabled by default

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/override.md_-_`typing.override`_-_Basics_(b7c220f8171f11f0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/override.md_-_`typing.override`_-_Basics_(b7c220f8171f11f0).snap
@@ -188,7 +188,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/override.md
 174 | 
 175 |     @staticmethod
 176 |     @override
-177 |     def class_method1() -> int: ...
+177 |     def class_method1() -> int: ...  # error: [invalid-method-override]
 178 | 
 179 |     @classmethod
 180 |     @override
@@ -364,6 +364,31 @@ error[invalid-explicit-override]: Method `bad_settable_property` is decorated wi
     |
 info: No `bad_settable_property` definitions were found on any superclasses of `Invalid`
 info: rule `invalid-explicit-override` is enabled by default
+
+```
+
+```
+error[invalid-method-override]: Invalid override of method `class_method1`
+   --> src/mdtest_snippet.pyi:177:9
+    |
+175 |     @staticmethod
+176 |     @override
+177 |     def class_method1() -> int: ...  # error: [invalid-method-override]
+    |         ^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.class_method1`
+178 |
+179 |     @classmethod
+    |
+   ::: src/mdtest_snippet.pyi:21:9
+    |
+ 20 |     @classmethod
+ 21 |     def class_method1(cls) -> int: ...
+    |         ------------------------- `Parent.class_method1` defined here
+ 22 |
+ 23 |     @staticmethod
+    |
+info: `LiskovViolatingButNotOverrideViolating.class_method1` is a staticmethod but `Parent.class_method1` is a classmethod
+info: This violates the Liskov Substitution Principle
+info: rule `invalid-method-override` is enabled by default
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/override.md_-_`typing.override`_-_Basics_(b7c220f8171f11f0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/override.md_-_`typing.override`_-_Basics_(b7c220f8171f11f0).snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ty_test/src/lib.rs
+assertion_line: 623
 expression: snapshot
 ---
 ---
@@ -186,25 +187,25 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/override.md
 172 |     @override
 173 |     def my_property1(self) -> int: ...
 174 | 
-175 |     @staticmethod
-176 |     @override
-177 |     def class_method1() -> int: ...  # error: [invalid-method-override]
-178 | 
-179 |     @classmethod
-180 |     @override
-181 |     def static_method1(cls) -> int: ...
-182 | 
-183 | # Diagnostic edge case: `override` is very far away from the method definition in the source code:
-184 | 
-185 | T = TypeVar("T")
-186 | 
-187 | def identity(x: T) -> T: ...
-188 | 
-189 | class Foo:
-190 |     @override
-191 |     @identity
-192 |     @identity
-193 |     @identity
+175 |     # TODO: This maybe shouldn't be a Liskov violation? Whether called on the type or
+176 |     # on an instance, it will behave the same from the caller's perspective. The only difference
+177 |     # is whether the method body gets access to `cls`, which is not a concern of Liskov.
+178 |     @staticmethod
+179 |     @override
+180 |     def class_method1() -> int: ...  # error: [invalid-method-override]
+181 | 
+182 |     @classmethod
+183 |     @override
+184 |     def static_method1(cls) -> int: ...
+185 | 
+186 | # Diagnostic edge case: `override` is very far away from the method definition in the source code:
+187 | 
+188 | T = TypeVar("T")
+189 | 
+190 | def identity(x: T) -> T: ...
+191 | 
+192 | class Foo:
+193 |     @override
 194 |     @identity
 195 |     @identity
 196 |     @identity
@@ -220,7 +221,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/override.md
 206 |     @identity
 207 |     @identity
 208 |     @identity
-209 |     def bar(self): ...  # error: [invalid-explicit-override]
+209 |     @identity
+210 |     @identity
+211 |     @identity
+212 |     def bar(self): ...  # error: [invalid-explicit-override]
 ```
 
 # Diagnostics
@@ -369,14 +373,14 @@ info: rule `invalid-explicit-override` is enabled by default
 
 ```
 error[invalid-method-override]: Invalid override of method `class_method1`
-   --> src/mdtest_snippet.pyi:177:9
+   --> src/mdtest_snippet.pyi:180:9
     |
-175 |     @staticmethod
-176 |     @override
-177 |     def class_method1() -> int: ...  # error: [invalid-method-override]
+178 |     @staticmethod
+179 |     @override
+180 |     def class_method1() -> int: ...  # error: [invalid-method-override]
     |         ^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.class_method1`
-178 |
-179 |     @classmethod
+181 |
+182 |     @classmethod
     |
    ::: src/mdtest_snippet.pyi:21:9
     |
@@ -394,20 +398,20 @@ info: rule `invalid-method-override` is enabled by default
 
 ```
 error[invalid-explicit-override]: Method `bar` is decorated with `@override` but does not override anything
-   --> src/mdtest_snippet.pyi:209:9
+   --> src/mdtest_snippet.pyi:212:9
     |
-207 |     @identity
-208 |     @identity
-209 |     def bar(self): ...  # error: [invalid-explicit-override]
+210 |     @identity
+211 |     @identity
+212 |     def bar(self): ...  # error: [invalid-explicit-override]
     |         ^^^
     |
-   ::: src/mdtest_snippet.pyi:190:5
+   ::: src/mdtest_snippet.pyi:193:5
     |
-189 | class Foo:
-190 |     @override
+192 | class Foo:
+193 |     @override
     |     ---------
-191 |     @identity
-192 |     @identity
+194 |     @identity
+195 |     @identity
     |
 info: No `bar` definitions were found on any superclasses of `Foo`
 info: rule `invalid-explicit-override` is enabled by default

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4687,6 +4687,11 @@ impl<'db> Type<'db> {
             owner.display(db)
         );
         match self {
+            Type::Callable(callable) if callable.is_staticmethod_like(db) => {
+                // For "staticmethod-like" callables, model the behavior of `staticmethod.__get__`.
+                // The underlying function is returned as-is, without binding self.
+                return Some((self, AttributeKind::NormalOrNonDataDescriptor));
+            }
             Type::Callable(callable)
                 if callable.is_function_like(db) || callable.is_classmethod_like(db) =>
             {
@@ -12387,6 +12392,10 @@ pub enum CallableTypeKind {
     /// instances, i.e. they bind `self`.
     FunctionLike,
 
+    /// A callable type that represents a staticmethod. These callables do not bind `self`
+    /// when accessed as attributes on instances - they return the underlying function as-is.
+    StaticMethodLike,
+
     /// A callable type that we believe represents a classmethod (i.e. it will unconditionally bind
     /// the first argument on `__get__`).
     ClassMethodLike,
@@ -12489,6 +12498,10 @@ impl<'db> CallableType<'db> {
 
     pub(crate) fn is_classmethod_like(self, db: &'db dyn Db) -> bool {
         matches!(self.kind(db), CallableTypeKind::ClassMethodLike)
+    }
+
+    pub(crate) fn is_staticmethod_like(self, db: &'db dyn Db) -> bool {
+        matches!(self.kind(db), CallableTypeKind::StaticMethodLike)
     }
 
     pub(crate) fn bind_self(

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1089,6 +1089,8 @@ impl<'db> FunctionType<'db> {
     pub(crate) fn into_callable_type(self, db: &'db dyn Db) -> CallableType<'db> {
         let kind = if self.is_classmethod(db) {
             CallableTypeKind::ClassMethodLike
+        } else if self.is_staticmethod(db) {
+            CallableTypeKind::StaticMethodLike
         } else {
             CallableTypeKind::FunctionLike
         };

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2436,6 +2436,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .and_then(CallableTypes::exactly_one)
                         .and_then(|callable| match callable.kind(self.db()) {
                             kind @ (CallableTypeKind::FunctionLike
+                            | CallableTypeKind::StaticMethodLike
                             | CallableTypeKind::ClassMethodLike) => Some(kind),
                             _ => None,
                         });
@@ -2445,9 +2446,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     {
                         // When a method on a class is decorated with a function that returns a
                         // `Callable`, assume that the returned callable is also function-like (or
-                        // classmethod-like). See "Decorating a method with a `Callable`-typed
-                        // decorator" in `callables_as_descriptors.md` for the extended
-                        // explanation.
+                        // classmethod-like or staticmethod-like). See "Decorating a method with
+                        // a `Callable`-typed decorator" in `callables_as_descriptors.md` for the
+                        // extended explanation.
                         return_ty_modified
                     } else {
                         return_ty


### PR DESCRIPTION
## Summary

We already had `CallableTypeKind::ClassMethodLike` to track callables that behave like `classmethods` (always bind the first argument). This PR adds the symmetric `CallableTypeKind::StaticMethodLike` for callables that behave like `staticmethods` (never bind `self`).

Closes https://github.com/astral-sh/ty/issues/2114.
