### PR TITLE
[ty] Exclude parameterized tuple types from narrowing when disjoint from comparison values

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -238,3 +238,21 @@ def _(s: LiteralString | None, t: LiteralString | Any):
         # TODO could be `Literal["foo"] | Any`
         reveal_type(t)  # revealed: LiteralString | Any
 ```
+
+## Narrowing with tuple types
+
+Parameterized tuple types like `tuple[A, B]` have a known structure and use standard tuple `__eq__`
+which only returns True for other tuples. So they are excluded from the narrowed type when comparing
+to non-tuple values.
+
+```py
+from typing import Literal
+
+def _(x: Literal["a", "b"] | tuple[int, int]):
+    if x == "a":
+        # tuple type is excluded because it's disjoint from the string literal
+        reveal_type(x)  # revealed: Literal["a"]
+    else:
+        # tuple type remains in the else branch
+        reveal_type(x)  # revealed: Literal["b"] | tuple[int, int]
+```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -241,9 +241,8 @@ def _(s: LiteralString | None, t: LiteralString | Any):
 
 ## Narrowing with tuple types
 
-Parameterized tuple types like `tuple[A, B]` have a known structure and use standard tuple `__eq__`
-which only returns True for other tuples. So they are excluded from the narrowed type when comparing
-to non-tuple values.
+We assume that tuple subclasses don't override `tuple.__eq__`, which only returns True for other
+tuples. So they are excluded from the narrowed type when comparing to non-tuple values.
 
 ```py
 from typing import Literal

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -194,9 +194,8 @@ def test(x: Status | int):
 
 ## Union with tuple and `Literal`
 
-Parameterized tuple types like `tuple[A, B]` have a known structure and use standard tuple `__eq__`
-which only returns True for other tuples. So they are excluded from the narrowed type when disjoint
-from the RHS values.
+We assume that tuple subclasses don't override `tuple.__eq__`, which only returns True for other
+tuples. So they are excluded from the narrowed type when disjoint from the RHS values.
 
 ```py
 from typing import Literal

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -191,3 +191,21 @@ def test(x: Status | int):
     else:
         reveal_type(x)  # revealed: Literal[Status.REJECTED] | int
 ```
+
+## Union with tuple and `Literal`
+
+Parameterized tuple types like `tuple[A, B]` have a known structure and use standard tuple `__eq__`
+which only returns True for other tuples. So they are excluded from the narrowed type when disjoint
+from the RHS values.
+
+```py
+from typing import Literal
+
+def test(x: Literal["none", "auto", "required"] | tuple[list[str], Literal["auto", "required"]]):
+    if x in ("auto", "required"):
+        # tuple type is excluded because it's disjoint from the string literals
+        reveal_type(x)  # revealed: Literal["auto", "required"]
+    else:
+        # tuple type remains in the else branch
+        reveal_type(x)  # revealed: Literal["none"] | tuple[list[str], Literal["auto", "required"]]
+```

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -347,7 +347,7 @@ fn could_compare_equal<'db>(db: &'db dyn Db, left_ty: Type<'db>, right_ty: Type<
         // `True == 1` and `False == 0`.
         (Type::BooleanLiteral(b), Type::IntLiteral(i))
         | (Type::IntLiteral(i), Type::BooleanLiteral(b)) => i64::from(b) == i,
-        // Tuples with known structure use standard `__eq__` which only returns True
+        // We assume that tuples use `tuple.__eq__` which only returns True
         // for other tuples, so they cannot compare equal to non-tuple types.
         (Type::NominalInstance(instance), _) if instance.tuple_spec(db).is_some() => false,
         (_, Type::NominalInstance(instance)) if instance.tuple_spec(db).is_some() => false,


### PR DESCRIPTION
## Summary

IIUC, tuples with a known structure (`tuple_spec`) use the standard tuple `__eq__` which only returns `True` for other tuples, so they can be safely excluded when disjoint from string literals or other non-tuple types.

Closes https://github.com/astral-sh/ty/issues/2140.
