### PR TITLE
[ty] Make a server snapshot less painful to update

### DIFF
--- a/crates/ty_server/tests/e2e/commands.rs
+++ b/crates/ty_server/tests/e2e/commands.rs
@@ -44,10 +44,10 @@ return 42
 
     insta::with_settings!({
         filters => vec![
-            (r"\b[0-9]+.[0-9]+MB\b","[X.XXMB]"),
-            (r"Workspace .+\)","Workspace XXX"),
-            (r"Project at .+","Project at XXX"),
-            (r"rules: \{(.|\n)+?\}\,","rules: {<RULES>},"),
+            (r"\b[0-9]+.[0-9]+MB\b", "[X.XXMB]"),
+            (r"Workspace .+\)", "Workspace XXX"),
+            (r"Project at .+", "Project at XXX"),
+            (r"rules: \{(.|\n)+?\}\,", "rules: <RULES>,"),
     ]}, {
         insta::assert_snapshot!(response);
     });

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -27,7 +27,7 @@ Settings: WorkspaceSettings {
 
 Project at XXX
 Settings: Settings {
-    rules: {<RULES>},
+    rules: <RULES>,
     terminal: TerminalSettings {
         output_format: Full,
         error_on_warning: false,


### PR DESCRIPTION
## Summary

Currently this snapshot feels like it causes quite a lot of development pain (at least for me), because I never think to run the `ty_server` tests if all I'm doing is adding a new diagnostic to the `ty_python_semantic` crate. So I always push my PR and only remember that there's this snapshot that also needs to be updated when CI starts failing on my PR.

This PR adds a new filter to the snapshot so that the snapshot no longer lists every rule that ty has, meaning that the snapshot no longer needs to be updated every time we add a new diagnostic to `ty_python_semantic`.

## Test Plan

`cargo test -p ty_server`
