### PR TITLE
[ty] Set flag to avoid `type[T@f]` being inserted when you double-click on the inlay

### DIFF
--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -6614,13 +6614,6 @@ mod tests {
         3 |     y[: type[T@f]] = x
           |              ^^^
           |
-
-        ---------------------------------------------
-        info[inlay-hint-edit]: File after edits
-        info: Source
-
-        def f[T](x: type[T]):
-            y: type[T@f] = x
         "#);
     }
 

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -711,6 +711,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     f.write_char(']')
                 }
                 SubclassOfInner::TypeVar(bound_typevar) => {
+                    f.set_invalid_syntax();
                     f.with_type(KnownClass::Type.to_class_literal(self.db))
                         .write_str("type")?;
                     f.write_char('[')?;


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

I believe we should not be able to add this edit.

## Test Plan

Update ide test.
