### PR TITLE
Ecosystem report: publish site via astral-sh-bot

### DIFF
--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -14,7 +14,6 @@ env:
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
   RUST_BACKTRACE: 1
-  CF_API_TOKEN_EXISTS: ${{ secrets.CF_API_TOKEN != '' }}
 
 jobs:
   ty-ecosystem-report:


### PR DESCRIPTION
## Summary

Moves the periodic ecosystem report's publication to astral-sh-bot, rather than publishing it directly via the workflow.

Similar vein as #22098.

## Test Plan

Manually by yours truly. ~~WIP while I dispatch events manually.~~