### PR TITLE
[ty] Respect debug text interpolation in f-strings

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/literal/f_string.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/f_string.md
@@ -24,6 +24,16 @@ string = "hello"
 reveal_type(f"{string!r}")  # revealed: str
 ```
 
+## Debug Specifier
+
+The `=` specifier causes the expression text and value to be included in the output:
+
+```py
+# f"{1=}" evaluates to "1=1", but we fall back to `str` for now
+reveal_type(f"{1=}")  # revealed: str
+reveal_type(f"value: {42=}")  # revealed: str
+```
+
 ## Format Specifiers
 
 ```py

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7594,7 +7594,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     range: _,
                                     node_index: _,
                                     expression,
-                                    debug_text: _,
+                                    debug_text,
                                     conversion,
                                     format_spec,
                                 } = expression;
@@ -7613,7 +7613,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 // (`Type::format`?) that handles the `__format__` method.
                                 // Conversion flags should be handled before calling `__format__`.
                                 // https://docs.python.org/3/library/string.html#format-string-syntax
-                                if !conversion.is_none() || format_spec.is_some() {
+                                if debug_text.is_some()
+                                    || !conversion.is_none()
+                                    || format_spec.is_some()
+                                {
                                     collector.add_expression();
                                 } else {
                                     if let Type::StringLiteral(literal) = ty.str(self.db()) {


### PR DESCRIPTION
## Summary

Per @carljm's comment, we just fall back to `str`.

Closes https://github.com/astral-sh/ty/issues/2151.
