### PR TITLE
[ty] Fix module resolution on network drives

### DIFF
--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -275,9 +275,9 @@ impl OsSystem {
     /// instead of at least one system call for each component between `path` and `prefix`.
     ///
     /// However, using `canonicalize` to resolve the path's casing doesn't work in two cases:
-    /// * if `path` is a symlink because `canonicalize` then returns the symlink's target and not the symlink's source path.
-    /// * on Windows: If `path` is a mapped network drive because `canonicalize` then returns the UNC path
-    ///   (e.g. `Z:\` is mapped to `\\server\share` and `canonicalize` then returns `\\?\UNC\server\share`).
+    /// * if `path` is a symlink, `canonicalize` returns the symlink's target and not the symlink's source path.
+    /// * on Windows: If `path` is a mapped network drive, `canonicalize` returns the UNC path
+    ///   (e.g. `Z:\` is mapped to `\\server\share` and `canonicalize` returns `\\?\UNC\server\share`).
     ///
     /// Symlinks and mapped network drives should be rare enough that this fast path is worth trying first,
     /// even if it comes at a cost for those rare use cases.


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/2062

This is a very silly bug (I'm allowed to say this because I wrote the code :)). The comment on `simplify_ignore_verbatim` explicitly states that the simplified path should only be used for comparision. And what did I do??? I use it as an argument to `canonicalize` which immediately fails because the simplified path isn't a valid path. 

The fix is trivial. Call canonicalize on the not-simplified path and only use the simplified path when comparing the two paths.

## Test plan

I verified that the imports in https://github.com/astral-sh/ty/issues/2062 now resovle successfully. 

I'm not sure how to write a test for a network drive...