### PR TITLE
[ty] Improve diagnostic when `callable` is used in a type expression instead of `collections.abc.Callable` or `typing.Callable`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
@@ -266,3 +266,12 @@ def _(
 ) -> (int, str):  # error: [invalid-type-form]
     return x
 ```
+
+### Special-cased diagnostic for `callable` used in a type expression
+
+```py
+# error: [invalid-type-form]
+# error: [invalid-type-form]
+def decorator(fn: callable) -> callable:
+    return fn
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_Special-cased_diagno…_(a4b698196d337a3f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_Special-cased_diagno…_(a4b698196d337a3f).snap
@@ -1,0 +1,49 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: invalid.md - Tests for invalid types in type expressions - Diagnostics for common errors - Special-cased diagnostic for `callable` used in a type expression
+mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | # error: [invalid-type-form]
+2 | # error: [invalid-type-form]
+3 | def decorator(fn: callable) -> callable:
+4 |     return fn
+```
+
+# Diagnostics
+
+```
+error[invalid-type-form]: Function `callable` is not valid in a type expression
+ --> src/mdtest_snippet.py:3:19
+  |
+1 | # error: [invalid-type-form]
+2 | # error: [invalid-type-form]
+3 | def decorator(fn: callable) -> callable:
+  |                   ^^^^^^^^ Did you mean `collections.abc.Callable`?
+4 |     return fn
+  |
+info: rule `invalid-type-form` is enabled by default
+
+```
+
+```
+error[invalid-type-form]: Function `callable` is not valid in a type expression
+ --> src/mdtest_snippet.py:3:32
+  |
+1 | # error: [invalid-type-form]
+2 | # error: [invalid-type-form]
+3 | def decorator(fn: callable) -> callable:
+  |                                ^^^^^^^^ Did you mean `collections.abc.Callable`?
+4 |     return fn
+  |
+info: rule `invalid-type-form` is enabled by default
+
+```


### PR DESCRIPTION
## Summary

I noticed when reviewing the ecosystem report for https://github.com/astral-sh/ruff/pull/22145 that ibis makes this mistake. Mypy [has a special-cased diagnostic for this](https://mypy-play.net/?mypy=latest&python=3.12&gist=6071f0cae0d7a46532070e819bb94a2b), and there's no reason we can't too.

## Test Plan

snapshot added
