### PR TITLE
[ty] Invert dependencies of `ty_combine` and `ty_python_semantic`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4391,7 +4391,6 @@ dependencies = [
  "ordermap",
  "ruff_db",
  "ruff_python_ast",
- "ty_python_semantic",
 ]
 
 [[package]]
@@ -4559,6 +4558,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.17",
  "tracing",
+ "ty_combine",
  "ty_module_resolver",
  "ty_static",
  "ty_test",

--- a/crates/ty_combine/Cargo.toml
+++ b/crates/ty_combine/Cargo.toml
@@ -12,7 +12,6 @@ license.workspace = true
 [dependencies]
 ruff_db = { workspace = true }
 ruff_python_ast = { workspace = true }
-ty_python_semantic = { workspace = true }
 
 ordermap = { workspace = true }
 

--- a/crates/ty_combine/src/lib.rs
+++ b/crates/ty_combine/src/lib.rs
@@ -8,7 +8,6 @@ use std::{collections::HashMap, hash::BuildHasher};
 use ordermap::OrderMap;
 use ruff_db::system::SystemPathBuf;
 use ruff_python_ast::PythonVersion;
-use ty_python_semantic::PythonPlatform;
 
 /// Combine two values, preferring the values in `self`.
 ///
@@ -145,7 +144,6 @@ macro_rules! impl_noop_combine {
 }
 
 impl_noop_combine!(SystemPathBuf);
-impl_noop_combine!(PythonPlatform);
 impl_noop_combine!(PythonVersion);
 
 // std types

--- a/crates/ty_python_semantic/Cargo.toml
+++ b/crates/ty_python_semantic/Cargo.toml
@@ -25,6 +25,7 @@ ruff_text_size = { workspace = true }
 ruff_python_literal = { workspace = true }
 ruff_python_trivia = { workspace = true }
 ty_module_resolver = { workspace = true }
+ty_combine = { workspace = true }
 ty_static = { workspace = true }
 
 anyhow = { workspace = true }

--- a/crates/ty_python_semantic/src/python_platform.rs
+++ b/crates/ty_python_semantic/src/python_platform.rs
@@ -1,4 +1,5 @@
 use std::fmt::{Display, Formatter};
+use ty_combine::Combine;
 
 /// The target platform to assume when resolving types.
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
@@ -52,6 +53,10 @@ impl Default for PythonPlatform {
             PythonPlatform::Identifier("linux".to_string())
         }
     }
+}
+
+impl Combine for PythonPlatform {
+    fn combine_with(&mut self, _other: Self) {}
 }
 
 #[cfg(feature = "schemars")]


### PR DESCRIPTION
## Summary

`ty_combine` is an utility crate. Make `ty_python_semantic` depend on it instead of the other way round
(we don't want crates depending on `ty_combine` to block on building `ty_python_semantic` first.

## Test Plan

`cargo test`
