### PR TITLE
[ty] Add method resolution order to info diagnostic `unsupported-base`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_includes…_(d2532518c44112c8).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_includes…_(d2532518c44112c8).snap
@@ -53,7 +53,7 @@ warning[unsupported-base]: Unsupported class base
 18 |
 19 | reveal_mro(Foo)  # revealed: (<class 'Foo'>, Unknown, <class 'object'>)
    |
-info: ty cannot resolve a consistent MRO for class `Foo` due to this base
+info: ty cannot resolve a consistent method resolution order (MRO) for class `Foo` due to this base
 info: Only class objects or `Any` are supported as class bases
 info: rule `unsupported-base` is enabled by default
 
@@ -68,7 +68,7 @@ warning[unsupported-base]: Unsupported class base
 27 |     class D(C): ...  # error: [unsupported-base]
    |             ^ Has type `<class 'mdtest_snippet.<locals of function 'f'>.C @ src/mdtest_snippet.py:23'> | <class 'mdtest_snippet.<locals of function 'f'>.C @ src/mdtest_snippet.py:25'>`
    |
-info: ty cannot resolve a consistent MRO for class `D` due to this base
+info: ty cannot resolve a consistent method resolution order (MRO) for class `D` due to this base
 info: Only class objects or `Any` are supported as class bases
 info: rule `unsupported-base` is enabled by default
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_lists_th…_(6f8d0bf648c4b305).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_lists_th…_(6f8d0bf648c4b305).snap
@@ -57,7 +57,7 @@ warning[unsupported-base]: Unsupported class base
 7 | class Bad1:
 8 |     def __mro_entries__(self, bases, extra_arg):
   |
-info: ty cannot resolve a consistent MRO for class `Bar` due to this base
+info: ty cannot resolve a consistent method resolution order (MRO) for class `Bar` due to this base
 info: Only class objects or `Any` are supported as class bases
 info: rule `unsupported-base` is enabled by default
 

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3532,7 +3532,7 @@ fn report_unsupported_base(
         base_type.display(db)
     ));
     diagnostic.info(format_args!(
-        "ty cannot resolve a consistent MRO for class `{}` due to this base",
+        "ty cannot resolve a consistent method resolution order (MRO) for class `{}` due to this base",
         class.name(db)
     ));
     diagnostic.info("Only class objects or `Any` are supported as class bases");


### PR DESCRIPTION
## Summary

Added method resolution order to the message. The other similar diagnostics do the same. 
It's already called out in the documentation the same way. 

Fixes https://github.com/astral-sh/ty/issues/2212. If there are no other suggestions for this issue, I guess it can be closed. 
## Test Plan

Existing tests
