### PR TITLE
[ty] Reduce monomorphization

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -3774,10 +3774,7 @@ impl<'db> BoundTypeVarInstance<'db> {
     /// specifies the required specializations, and the iterator will be empty. For a constrained
     /// typevar, the primary result will include the fully static constraints, and the iterator
     /// will include an entry for each non-fully-static constraint.
-    fn required_specializations(
-        self,
-        db: &'db dyn Db,
-    ) -> (Node<'db>, impl IntoIterator<Item = Node<'db>>) {
+    fn required_specializations(self, db: &'db dyn Db) -> (Node<'db>, Vec<Node<'db>>) {
         // For upper bounds and constraints, we are free to choose any materialization that makes
         // the check succeed. In non-inferable positions, it is most helpful to choose a
         // materialization that is as restrictive as possible, since that minimizes the number of

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -514,7 +514,7 @@ pub fn call_signature_details<'db>(
         // Extract signature details from all callable bindings
         bindings
             .into_iter()
-            .flat_map(std::iter::IntoIterator::into_iter)
+            .flatten()
             .map(|binding| {
                 let argument_to_parameter_mapping = binding.argument_matches().to_vec();
                 let signature = binding.signature;
@@ -623,7 +623,7 @@ pub fn definitions_for_bin_op<'db>(
 
     let definitions: Vec<_> = bindings
         .into_iter()
-        .flat_map(std::iter::IntoIterator::into_iter)
+        .flatten()
         .filter_map(|binding| {
             Some(ResolvedDefinition::Definition(
                 binding.signature.definition?,
@@ -681,7 +681,7 @@ pub fn definitions_for_unary_op<'db>(
 
     let definitions = bindings
         .into_iter()
-        .flat_map(std::iter::IntoIterator::into_iter)
+        .flatten()
         .filter_map(|binding| {
             Some(ResolvedDefinition::Definition(
                 binding.signature.definition?,


### PR DESCRIPTION
## Summary

Avoid monomorphization by moving code that isn't generic into separate functions. This should help with build time and code size

## Test Plan

