### PR TITLE
[ty] Fix playground inlay hint location

### DIFF
--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -454,10 +454,22 @@ class PlaygroundServer
     return {
       dispose: () => {},
       hints: inlayHints.map((hint) => ({
-        label: hint.label.map((part) => ({
-          label: part.label,
-          // As of 2025-09-23, location isn't supported by Monaco which is why we don't set it
-        })),
+        label: hint.label.map((part) => {
+          const locationLink = part.location
+            ? this.mapNavigationTarget(part.location)
+            : undefined;
+
+          return {
+            label: part.label,
+            // Range cannot be `undefined`.
+            location: locationLink?.targetSelectionRange
+              ? {
+                  uri: locationLink.uri,
+                  range: locationLink.targetSelectionRange,
+                }
+              : undefined,
+          };
+        }),
         position: {
           lineNumber: hint.position.line,
           column: hint.position.column,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Previously, we thought this didn't work.

It does, we were just using the wrong variable from `LocationLink`. Range for some reason points roughly to the current location, or the start of the inlay hint label part.

Now we use `targetSelectionRange`, which is what we always needed.

Mentioned in https://github.com/astral-sh/ty/issues/2204

## Test Plan
[Screencast_20251226_014911.webm](https://github.com/user-attachments/assets/1c0b8abb-aa4c-4038-83ee-5e5a90501613)

This does not work at all at [play.ty.dev](https://play.ty.dev/)