### PR TITLE
[`pylint`] Fix false negatives of `chained-comparison` (`PLR1716`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/boolean_chained_comparison.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/boolean_chained_comparison.py
@@ -134,7 +134,7 @@ a<b<c and c<d
 # more involved examples (all should error and fix)
 a < ( # sneaky comment
 	b
-  # more comments 
+  # more comments
 ) and b < c
 
 (
@@ -146,3 +146,42 @@ a < ( # sneaky comment
 )
 
 a < (b) and (((b)) < c)
+
+# ----------------------------------------------------------
+# examples where the expression could be simplified, but
+# only by changing the order of the expressions or replacing
+# '<' with '>' and vice-versa
+# ----------------------------------------------------------
+
+a = int(input())
+b = int(input())
+c = int(input())
+if b > a and c >= b:  # [boolean-chained-comparison]
+    pass
+
+a = int(input())
+b = int(input())
+c = int(input())
+if a < b and c >= b:  # [boolean-chained-comparison]
+    pass
+
+a = int(input())
+b = int(input())
+c = int(input())
+if b >= a and b <= c:  # [boolean-chained-comparison]
+    pass
+
+a = 1
+b = 2
+
+if a < b and a > b:  # [boolean-chained-comparison]
+    pass
+
+if a < b and c >= b:  # [boolean-chained-comparison]
+    pass
+
+if 5 > b and 2 < b:
+    pass
+
+if b < 5 and b > 2:
+    pass

--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -357,3 +357,8 @@ pub(crate) const fn is_collapsible_if_fix_safe_enabled(settings: &LinterSettings
 pub(crate) const fn is_ruff_ignore_enabled(settings: &LinterSettings) -> bool {
     settings.preview.is_enabled()
 }
+
+// https://github.com/astral-sh/ruff/pull/22206
+pub(crate) const fn is_chained_comparison_reorder_enabled(settings: &LinterSettings) -> bool {
+    settings.preview.is_enabled()
+}

--- a/crates/ruff_linter/src/rules/pylint/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/mod.rs
@@ -265,6 +265,10 @@ mod tests {
         Rule::UselessExceptionStatement,
         Path::new("useless_exception_statement.py")
     )]
+    #[test_case(
+        Rule::BooleanChainedComparison,
+        Path::new("boolean_chained_comparison.py")
+    )]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(
             "preview__{}_{}",

--- a/crates/ruff_linter/src/rules/pylint/rules/boolean_chained_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/boolean_chained_comparison.rs
@@ -1,13 +1,15 @@
+use std::fmt::Display;
+
 use itertools::Itertools;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::{
-    BoolOp, CmpOp, Expr, ExprBoolOp, ExprCompare,
+    BoolOp, CmpOp, Expr, ExprBoolOp,
     token::{parentheses_iterator, parenthesized_range},
 };
 use ruff_text_size::{Ranged, TextRange};
 
-use crate::checkers::ast::Checker;
-use crate::{AlwaysFixableViolation, Edit, Fix};
+use crate::{Edit, Fix, FixAvailability, preview::is_chained_comparison_reorder_enabled};
+use crate::{Violation, checkers::ast::Checker};
 
 /// ## What it does
 /// Check for chained boolean operations that can be simplified.
@@ -36,16 +38,68 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 /// ```
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "0.9.0")]
-pub(crate) struct BooleanChainedComparison;
+pub(crate) struct BooleanChainedComparison {
+    /// The position of the variable in the left hand side of the `and` or the `or` in the comparison.
+    lhs: ComparisonWithVariable,
+    /// The position of the variable in the right hand side of the `and` or the `or` in the comparison.
+    rhs: ComparisonWithVariable,
+}
 
-impl AlwaysFixableViolation for BooleanChainedComparison {
+/// The position of the reused variable in the comparison expression.
+///
+/// E.g., in `x > 5`, the position of the variable (`x`) is [LEFT].
+#[derive(Debug, PartialEq)]
+enum VariablePosition {
+    Left,
+    Right,
+}
+
+// Direction of a comparison (i.e. ascending for `<` and descending for `>`).
+#[derive(Debug, Eq, PartialEq)]
+enum ChainKind {
+    Ascending,
+    Descending,
+}
+
+/// Comparison that uses at least one variable, e.g. `x > 5`.
+#[derive(Debug, PartialEq)]
+struct ComparisonWithVariable {
+    variable_pos: VariablePosition,
+    chain_kind: ChainKind,
+}
+impl Display for ComparisonWithVariable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (&self.variable_pos, &self.chain_kind) {
+            (VariablePosition::Left, ChainKind::Ascending) => write!(f, "x < 7"),
+            (VariablePosition::Left, ChainKind::Descending) => write!(f, "x > 3"),
+            (VariablePosition::Right, ChainKind::Ascending) => write!(f, "3 < x"),
+            (VariablePosition::Right, ChainKind::Descending) => write!(f, "7 > x"),
+        }
+    }
+}
+
+impl Violation for BooleanChainedComparison {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         "Contains chained boolean comparison that can be simplified".to_string()
     }
 
-    fn fix_title(&self) -> String {
-        "Use a single compare expression".to_string()
+    fn fix_title(&self) -> Option<String> {
+        let Self { lhs, rhs } = self;
+
+        // quick-fix available, so no detailed explanation is needed
+        if lhs.variable_pos == VariablePosition::Right && rhs.variable_pos == VariablePosition::Left
+        {
+            return Some("Use a single compare expression".to_string());
+        }
+
+        // we try to re-build the same order of variables in the fix title,
+        // so that it's easier to understand how exactly this can be fixed manually.
+        Some(format!(
+            "Use a single compare expression. For example, '{lhs} and {rhs}' could be simplified to '3 < x < 7'."
+        ))
     }
 }
 
@@ -70,88 +124,183 @@ pub(crate) fn boolean_chained_comparison(checker: &Checker, expr_bool_op: &ExprB
         .iter()
         .map(|expr| expr.as_compare_expr().unwrap());
 
-    for (left_compare, right_compare) in
-        compare_expressions
-            .tuple_windows()
-            .filter(|(left_compare, right_compare)| {
-                are_compare_expr_simplifiable(left_compare, right_compare)
-            })
-    {
-        let Some(Expr::Name(left_compare_right)) = left_compare.comparators.last() else {
+    for (left_compare, right_compare) in compare_expressions.tuple_windows() {
+        let (Some(left_chain_direction), Some(right_chain_direction)) = (
+            comparison_chain_direction(&left_compare.ops),
+            comparison_chain_direction(&right_compare.ops),
+        ) else {
+            // at least one of the comparisons has operations with different directions, e.g. 5 > x < 7
             continue;
         };
 
-        let Expr::Name(right_compare_left) = &*right_compare.left else {
-            continue;
-        };
+        // first case: all comparison operations are pointing in the same direction
+        // e.g. <expr> <=? x and x <=? <expr>
+        if left_chain_direction == right_chain_direction {
+            if is_chained_comparison_reorder_enabled(checker.settings())
+                && let Expr::Name(left_compare_left) = &*left_compare.left
+                && let Some(Expr::Name(right_compare_right)) = right_compare.comparators.last()
+                && left_compare_left.id() == right_compare_right.id()
+            {
+                // could be simplified by swapping the condition parts
+                // e.g. x < 5 and 3 < x -> 3 < x < 5
+                // auto-fix would be possible but is not implemented yet
+                checker.report_diagnostic(
+                    BooleanChainedComparison {
+                        lhs: ComparisonWithVariable {
+                            variable_pos: VariablePosition::Left,
+                            chain_kind: left_chain_direction,
+                        },
+                        rhs: ComparisonWithVariable {
+                            variable_pos: VariablePosition::Right,
+                            chain_kind: right_chain_direction,
+                        },
+                    },
+                    TextRange::new(left_compare.start(), right_compare.end()),
+                );
+                continue;
+            }
 
-        if left_compare_right.id() != right_compare_left.id() {
-            continue;
+            let Some(Expr::Name(left_compare_right)) = left_compare.comparators.last() else {
+                continue;
+            };
+
+            let Expr::Name(right_compare_left) = &*right_compare.left else {
+                continue;
+            };
+
+            if left_compare_right.id() != right_compare_left.id() {
+                continue;
+            }
+
+            let left_paren_count =
+                parentheses_iterator(left_compare.into(), Some(expr_bool_op.into()), tokens)
+                    .count();
+
+            let right_paren_count =
+                parentheses_iterator(right_compare.into(), Some(expr_bool_op.into()), tokens)
+                    .count();
+
+            // Create the edit that removes the comparison operator
+
+            // In `a<(b) and ((b))<c`, we need to handle the
+            // parentheses when specifying the fix range.
+            let left_compare_right_range =
+                parenthesized_range(left_compare_right.into(), left_compare.into(), tokens)
+                    .unwrap_or(left_compare_right.range());
+            let right_compare_left_range =
+                parenthesized_range(right_compare_left.into(), right_compare.into(), tokens)
+                    .unwrap_or(right_compare_left.range());
+            let edit = Edit::range_replacement(
+                locator.slice(left_compare_right_range).to_string(),
+                TextRange::new(
+                    left_compare_right_range.start(),
+                    right_compare_left_range.end(),
+                ),
+            );
+
+            // Balance left and right parentheses
+            let fix = match left_paren_count.cmp(&right_paren_count) {
+                std::cmp::Ordering::Less => {
+                    let balance_parens_edit = Edit::insertion(
+                        "(".repeat(right_paren_count - left_paren_count),
+                        left_compare.start(),
+                    );
+                    Fix::safe_edits(edit, [balance_parens_edit])
+                }
+                std::cmp::Ordering::Equal => Fix::safe_edit(edit),
+                std::cmp::Ordering::Greater => {
+                    let balance_parens_edit = Edit::insertion(
+                        ")".repeat(left_paren_count - right_paren_count),
+                        right_compare.end(),
+                    );
+                    Fix::safe_edits(edit, [balance_parens_edit])
+                }
+            };
+
+            let mut diagnostic = checker.report_diagnostic(
+                BooleanChainedComparison {
+                    lhs: ComparisonWithVariable {
+                        variable_pos: VariablePosition::Right,
+                        chain_kind: left_chain_direction,
+                    },
+                    rhs: ComparisonWithVariable {
+                        variable_pos: VariablePosition::Left,
+                        chain_kind: right_chain_direction,
+                    },
+                },
+                TextRange::new(left_compare.start(), right_compare.end()),
+            );
+
+            diagnostic.set_fix(fix);
+        } else if is_chained_comparison_reorder_enabled(checker.settings()) {
+            // second case: comparison operators point in different directions
+            // that makes the fix ambiguous because it's unclear which comparison chain should be reversed (e.g. ">=" -> "<=")
+            // e.g. x > 4 and x < 7 -> 4 < x < 7
+
+            let are_left_vars_same_id = if let Expr::Name(left_compare_left) = &*left_compare.left
+                && let Expr::Name(right_compare_left) = &*right_compare.left
+                && left_compare_left.id() == right_compare_left.id()
+            {
+                true
+            } else {
+                false
+            };
+
+            if are_left_vars_same_id {
+                checker.report_diagnostic(
+                    BooleanChainedComparison {
+                        lhs: ComparisonWithVariable {
+                            variable_pos: VariablePosition::Left,
+                            chain_kind: left_chain_direction,
+                        },
+                        rhs: ComparisonWithVariable {
+                            variable_pos: VariablePosition::Left,
+                            chain_kind: right_chain_direction,
+                        },
+                    },
+                    TextRange::new(left_compare.start(), right_compare.end()),
+                );
+                continue;
+            }
+
+            let are_right_vars_same_id = if let Some(Expr::Name(left_compare_right)) =
+                left_compare.comparators.last()
+                && let Some(Expr::Name(right_compare_right)) = right_compare.comparators.last()
+                && left_compare_right.id() == right_compare_right.id()
+            {
+                true
+            } else {
+                false
+            };
+
+            if are_right_vars_same_id {
+                checker.report_diagnostic(
+                    BooleanChainedComparison {
+                        lhs: ComparisonWithVariable {
+                            variable_pos: VariablePosition::Right,
+                            chain_kind: left_chain_direction,
+                        },
+                        rhs: ComparisonWithVariable {
+                            variable_pos: VariablePosition::Right,
+                            chain_kind: right_chain_direction,
+                        },
+                    },
+                    TextRange::new(left_compare.start(), right_compare.end()),
+                );
+            }
         }
-
-        let left_paren_count =
-            parentheses_iterator(left_compare.into(), Some(expr_bool_op.into()), tokens).count();
-
-        let right_paren_count =
-            parentheses_iterator(right_compare.into(), Some(expr_bool_op.into()), tokens).count();
-
-        // Create the edit that removes the comparison operator
-
-        // In `a<(b) and ((b))<c`, we need to handle the
-        // parentheses when specifying the fix range.
-        let left_compare_right_range =
-            parenthesized_range(left_compare_right.into(), left_compare.into(), tokens)
-                .unwrap_or(left_compare_right.range());
-        let right_compare_left_range =
-            parenthesized_range(right_compare_left.into(), right_compare.into(), tokens)
-                .unwrap_or(right_compare_left.range());
-        let edit = Edit::range_replacement(
-            locator.slice(left_compare_right_range).to_string(),
-            TextRange::new(
-                left_compare_right_range.start(),
-                right_compare_left_range.end(),
-            ),
-        );
-
-        // Balance left and right parentheses
-        let fix = match left_paren_count.cmp(&right_paren_count) {
-            std::cmp::Ordering::Less => {
-                let balance_parens_edit = Edit::insertion(
-                    "(".repeat(right_paren_count - left_paren_count),
-                    left_compare.start(),
-                );
-                Fix::safe_edits(edit, [balance_parens_edit])
-            }
-            std::cmp::Ordering::Equal => Fix::safe_edit(edit),
-            std::cmp::Ordering::Greater => {
-                let balance_parens_edit = Edit::insertion(
-                    ")".repeat(left_paren_count - right_paren_count),
-                    right_compare.end(),
-                );
-                Fix::safe_edits(edit, [balance_parens_edit])
-            }
-        };
-
-        let mut diagnostic = checker.report_diagnostic(
-            BooleanChainedComparison,
-            TextRange::new(left_compare.start(), right_compare.end()),
-        );
-
-        diagnostic.set_fix(fix);
     }
 }
 
-/// Checks whether two compare expressions are simplifiable
-fn are_compare_expr_simplifiable(left: &ExprCompare, right: &ExprCompare) -> bool {
-    left.ops
-        .iter()
-        .chain(right.ops.iter())
-        .tuple_windows::<(_, _)>()
-        .all(|(left_operator, right_operator)| {
-            matches!(
-                (left_operator, right_operator),
-                (CmpOp::Lt | CmpOp::LtE, CmpOp::Lt | CmpOp::LtE)
-                    | (CmpOp::Gt | CmpOp::GtE, CmpOp::Gt | CmpOp::GtE)
-            )
-        })
+/// Checks whether all operations are comparisons and either all comparison operations in the iterator are ascending or all are descending.
+fn comparison_chain_direction(ops: &[CmpOp]) -> Option<ChainKind> {
+    if ops.iter().all(|op| matches!(op, CmpOp::Lt | CmpOp::LtE)) {
+        return Some(ChainKind::Ascending);
+    }
+
+    if ops.iter().all(|op| matches!(op, CmpOp::Gt | CmpOp::GtE)) {
+        return Some(ChainKind::Descending);
+    }
+
+    None
 }

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1716_boolean_chained_comparison.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1716_boolean_chained_comparison.py.snap
@@ -411,7 +411,7 @@ PLR1716 [*] Contains chained boolean comparison that can be simplified
 134 |   # more involved examples (all should error and fix)
 135 | / a < ( # sneaky comment
 136 | |     b
-137 | |   # more comments 
+137 | |   # more comments
 138 | | ) and b < c
     | |___________^
 139 |
@@ -420,7 +420,7 @@ PLR1716 [*] Contains chained boolean comparison that can be simplified
 help: Use a single compare expression
 135 | a < ( # sneaky comment
 136 | 	b
-137 |   # more comments 
+137 |   # more comments
     - ) and b < c
 138 + ) < c
 139 |
@@ -461,6 +461,8 @@ PLR1716 [*] Contains chained boolean comparison that can be simplified
 147 |
 148 | a < (b) and (((b)) < c)
     | ^^^^^^^^^^^^^^^^^^^^^^
+149 |
+150 | # ----------------------------------------------------------
     |
 help: Use a single compare expression
 145 |     and ((c<d))
@@ -468,3 +470,6 @@ help: Use a single compare expression
 147 |
     - a < (b) and (((b)) < c)
 148 + (a < (b) < c)
+149 |
+150 | # ----------------------------------------------------------
+151 | # examples where the expression could be simplified, but

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__preview__PLR1716_boolean_chained_comparison.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__preview__PLR1716_boolean_chained_comparison.py.snap
@@ -1,0 +1,94 @@
+---
+source: crates/ruff_linter/src/rules/pylint/mod.rs
+---
+--- Linter settings ---
+-linter.preview = disabled
++linter.preview = enabled
+
+--- Summary ---
+Removed: 0
+Added: 7
+
+--- Added ---
+PLR1716 Contains chained boolean comparison that can be simplified
+   --> boolean_chained_comparison.py:159:4
+    |
+157 | b = int(input())
+158 | c = int(input())
+159 | if b > a and c >= b:  # [boolean-chained-comparison]
+    |    ^^^^^^^^^^^^^^^^
+160 |     pass
+    |
+help: Use a single compare expression. For example, 'x > 3 and 7 > x' could be simplified to '3 < x < 7'.
+
+
+PLR1716 Contains chained boolean comparison that can be simplified
+   --> boolean_chained_comparison.py:165:4
+    |
+163 | b = int(input())
+164 | c = int(input())
+165 | if a < b and c >= b:  # [boolean-chained-comparison]
+    |    ^^^^^^^^^^^^^^^^
+166 |     pass
+    |
+help: Use a single compare expression. For example, '3 < x and 7 > x' could be simplified to '3 < x < 7'.
+
+
+PLR1716 Contains chained boolean comparison that can be simplified
+   --> boolean_chained_comparison.py:171:4
+    |
+169 | b = int(input())
+170 | c = int(input())
+171 | if b >= a and b <= c:  # [boolean-chained-comparison]
+    |    ^^^^^^^^^^^^^^^^^
+172 |     pass
+    |
+help: Use a single compare expression. For example, 'x > 3 and x < 7' could be simplified to '3 < x < 7'.
+
+
+PLR1716 Contains chained boolean comparison that can be simplified
+   --> boolean_chained_comparison.py:177:4
+    |
+175 | b = 2
+176 |
+177 | if a < b and a > b:  # [boolean-chained-comparison]
+    |    ^^^^^^^^^^^^^^^
+178 |     pass
+    |
+help: Use a single compare expression. For example, 'x < 7 and x > 3' could be simplified to '3 < x < 7'.
+
+
+PLR1716 Contains chained boolean comparison that can be simplified
+   --> boolean_chained_comparison.py:180:4
+    |
+178 |     pass
+179 |
+180 | if a < b and c >= b:  # [boolean-chained-comparison]
+    |    ^^^^^^^^^^^^^^^^
+181 |     pass
+    |
+help: Use a single compare expression. For example, '3 < x and 7 > x' could be simplified to '3 < x < 7'.
+
+
+PLR1716 Contains chained boolean comparison that can be simplified
+   --> boolean_chained_comparison.py:183:4
+    |
+181 |     pass
+182 |
+183 | if 5 > b and 2 < b:
+    |    ^^^^^^^^^^^^^^^
+184 |     pass
+    |
+help: Use a single compare expression. For example, '7 > x and 3 < x' could be simplified to '3 < x < 7'.
+
+
+PLR1716 Contains chained boolean comparison that can be simplified
+   --> boolean_chained_comparison.py:186:4
+    |
+184 |     pass
+185 |
+186 | if b < 5 and b > 2:
+    |    ^^^^^^^^^^^^^^^
+187 |     pass
+    |
+help: Use a single compare expression. For example, 'x < 7 and x > 3' could be simplified to '3 < x < 7'.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary
All the following if cases have the same semantic meaning:
```py
x = 5

if 4 < x and x < 7:
    ...

if x > 4 and x < 7:
    ...

if x > 4 and 7 > x:
    ...
```
However, the `boolean-chained-comparison` rule currently only spots the first case, even though all of them could be simplified by comparison chaining.

This PR implements a detection mechanism for the missing cases, however it does not implement quick fixes for them since this turned out to be quite difficult.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
I've added new test case snapshots and compared the behavior to `pylint`.