### PR TITLE
[ty] Fix `super()` with TypeVar-annotated `self` and `cls` parameter

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -375,17 +375,15 @@ class Parent:
 
 class Child(Parent):
     def copy(self) -> Self:
-        # super().copy() should return Self@copy, not Child
         result = super().copy()
         reveal_type(result)  # revealed: Self@copy
         return result
 
-# When called on concrete types, Self is substituted correctly
+# When called on concrete types, Self is substituted correctly.
 reveal_type(Child().copy())  # revealed: Child
 ```
 
-TODO: The same should apply to classmethods with `Self` return types, but this isn't fully working yet.
-The call to `super().create()` incorrectly fails with a type variable constraint error.
+The same applies to classmethods with `Self` return types:
 
 ```py
 from typing import Self
@@ -398,13 +396,11 @@ class Parent:
 class Child(Parent):
     @classmethod
     def create(cls) -> Self:
-        # TODO: super().create() should return Self@create, not error
-        # error: [invalid-argument-type]
         result = super().create()
-        reveal_type(result)  # revealed: Unknown
+        reveal_type(result)  # revealed: Self@create
         return result
 
-# When called on concrete types, Self is substituted correctly
+# When called on concrete types, Self is substituted correctly.
 reveal_type(Child.create())  # revealed: Child
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -384,6 +384,30 @@ class Child(Parent):
 reveal_type(Child().copy())  # revealed: Child
 ```
 
+TODO: The same should apply to classmethods with `Self` return types, but this isn't fully working yet.
+The call to `super().create()` incorrectly fails with a type variable constraint error.
+
+```py
+from typing import Self
+
+class Parent:
+    @classmethod
+    def create(cls) -> Self:
+        return cls()
+
+class Child(Parent):
+    @classmethod
+    def create(cls) -> Self:
+        # TODO: super().create() should return Self@create, not error
+        # error: [invalid-argument-type]
+        result = super().create()
+        reveal_type(result)  # revealed: Unknown
+        return result
+
+# When called on concrete types, Self is substituted correctly
+reveal_type(Child.create())  # revealed: Child
+```
+
 ## Attributes
 
 TODO: The use of `Self` to annotate the `next_node` attribute should be

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -359,6 +359,31 @@ reveal_type(GenericCircle[int].bar())  # revealed: GenericCircle[int]
 reveal_type(GenericCircle.baz(1))  # revealed: GenericShape[Literal[1]]
 ```
 
+### Calling `super()` in overridden methods with `Self` return type
+
+This is a regression test for <https://github.com/astral-sh/ty/issues/2122>.
+
+When a child class overrides a parent method with a `Self` return type and calls `super().method()`,
+the return type should be the child's `Self` type variable, not the concrete child class type.
+
+```py
+from typing import Self
+
+class Parent:
+    def copy(self) -> Self:
+        return self
+
+class Child(Parent):
+    def copy(self) -> Self:
+        # super().copy() should return Self@copy, not Child
+        result = super().copy()
+        reveal_type(result)  # revealed: Self@copy
+        return result
+
+# When called on concrete types, Self is substituted correctly
+reveal_type(Child().copy())  # revealed: Child
+```
+
 ## Attributes
 
 TODO: The use of `Self` to annotate the `next_node` attribute should be

--- a/crates/ty_python_semantic/resources/mdtest/class/super.md
+++ b/crates/ty_python_semantic/resources/mdtest/class/super.md
@@ -733,9 +733,8 @@ _T_co = TypeVar("_T_co", covariant=True)
 class MyProtocol(Protocol, Generic[_T_co]):
     def __class_getitem__(cls, item):
         # Accessing parent's __class_getitem__ through super()
-        # TODO: This should work - Protocol-inheriting classes can use super()
-        # error: [invalid-super-argument]
+        reveal_type(super())  # revealed: <super: <class 'MyProtocol'>, type[Self@__class_getitem__]>
         parent_method = super().__class_getitem__
-        reveal_type(parent_method)  # revealed: Unknown
+        reveal_type(parent_method)  # revealed: @Todo(super in generic class)
         return parent_method(item)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/class/super.md
+++ b/crates/ty_python_semantic/resources/mdtest/class/super.md
@@ -262,7 +262,8 @@ class Foo[T]:
         return self
 
     def method10[S: Callable[..., str]](self: S, other: S) -> S:
-        # revealed: <super: <class 'Foo'>, S@method10>
+        # error: [invalid-super-argument]
+        # revealed: Unknown
         reveal_type(super())
         return self
 

--- a/crates/ty_python_semantic/resources/mdtest/class/super.md
+++ b/crates/ty_python_semantic/resources/mdtest/class/super.md
@@ -168,13 +168,14 @@ class A:
 
 class B(A):
     def __init__(self, a: int):
-        reveal_type(super())  # revealed: <super: <class 'B'>, B>
+        reveal_type(super())  # revealed: <super: <class 'B'>, Self@__init__>
         reveal_type(super(object, super()))  # revealed: <super: <class 'object'>, super>
         super().__init__(a)
 
     @classmethod
     def f(cls):
-        reveal_type(super())  # revealed: <super: <class 'B'>, <class 'B'>>
+        reveal_type(super())  # revealed: <super: <class 'B'>, Self@f>
+        # error: [invalid-argument-type]
         super().f()
 
 super(B, B(42)).__init__(42)
@@ -229,16 +230,17 @@ class Foo[T]:
         reveal_type(super())
 
     def method4(self: Self):
-        # revealed: <super: <class 'Foo'>, Foo[T@Foo]>
+        # revealed: <super: <class 'Foo'>, Self@method4>
         reveal_type(super())
 
     def method5[S: Foo[int]](self: S, other: S) -> S:
-        # revealed: <super: <class 'Foo'>, Foo[int]>
+        # revealed: <super: <class 'Foo'>, S@method5>
         reveal_type(super())
         return self
 
     def method6[S: (Foo[int], Foo[str])](self: S, other: S) -> S:
-        # revealed: <super: <class 'Foo'>, Foo[int]> | <super: <class 'Foo'>, Foo[str]>
+        # error: [invalid-super-argument]
+        # revealed: Unknown
         reveal_type(super())
         return self
 
@@ -261,8 +263,7 @@ class Foo[T]:
         return self
 
     def method10[S: Callable[..., str]](self: S, other: S) -> S:
-        # error: [invalid-super-argument]
-        # revealed: Unknown
+        # revealed: <super: <class 'Foo'>, S@method10>
         reveal_type(super())
         return self
 
@@ -359,15 +360,15 @@ from __future__ import annotations
 
 class A:
     def test(self):
-        reveal_type(super())  # revealed: <super: <class 'A'>, A>
+        reveal_type(super())  # revealed: <super: <class 'A'>, Self@test>
 
     class B:
         def test(self):
-            reveal_type(super())  # revealed: <super: <class 'B'>, B>
+            reveal_type(super())  # revealed: <super: <class 'B'>, Self@test>
 
             class C(A.B):
                 def test(self):
-                    reveal_type(super())  # revealed: <super: <class 'C'>, C>
+                    reveal_type(super())  # revealed: <super: <class 'C'>, Self@test>
 
             def inner(t: C):
                 reveal_type(super())  # revealed: <super: <class 'B'>, C>
@@ -645,7 +646,7 @@ class A:
 class B(A):
     def __init__(self, a: int):
         super().__init__(a)
-        # error: [unresolved-attribute] "Object of type `<super: <class 'B'>, B>` has no attribute `a`"
+        # error: [unresolved-attribute] "Object of type `<super: <class 'B'>, Self@__init__>` has no attribute `a`"
         super().a
 
 # error: [unresolved-attribute] "Object of type `<super: <class 'B'>, B>` has no attribute `a`"

--- a/crates/ty_python_semantic/resources/mdtest/class/super.md
+++ b/crates/ty_python_semantic/resources/mdtest/class/super.md
@@ -238,8 +238,7 @@ class Foo[T]:
         return self
 
     def method6[S: (Foo[int], Foo[str])](self: S, other: S) -> S:
-        # error: [invalid-super-argument]
-        # revealed: Unknown
+        # revealed: <super: <class 'Foo'>, S@method6> | <super: <class 'Foo'>, S@method6>
         reveal_type(super())
         return self
 

--- a/crates/ty_python_semantic/resources/mdtest/class/super.md
+++ b/crates/ty_python_semantic/resources/mdtest/class/super.md
@@ -174,8 +174,7 @@ class B(A):
 
     @classmethod
     def f(cls):
-        reveal_type(super())  # revealed: <super: <class 'B'>, Self@f>
-        # error: [invalid-argument-type]
+        reveal_type(super())  # revealed: <super: <class 'B'>, type[Self@f]>
         super().f()
 
 super(B, B(42)).__init__(42)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Implicit_Super_Objec…_(f9e5e48e3a4a4c12).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Implicit_Super_Objec…_(f9e5e48e3a4a4c12).snap
@@ -28,160 +28,134 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/class/super.md
  13 | 
  14 |     @classmethod
  15 |     def f(cls):
- 16 |         reveal_type(super())  # revealed: <super: <class 'B'>, Self@f>
- 17 |         # error: [invalid-argument-type]
- 18 |         super().f()
- 19 | 
- 20 | super(B, B(42)).__init__(42)
- 21 | super(B, B).f()
- 22 | import enum
- 23 | from typing import Any, Self, Never, Protocol, Callable
- 24 | from ty_extensions import Intersection
- 25 | 
- 26 | class BuilderMeta(type):
- 27 |     def __new__(
- 28 |         cls: type[Any],
- 29 |         name: str,
- 30 |         bases: tuple[type, ...],
- 31 |         dct: dict[str, Any],
- 32 |     ) -> BuilderMeta:
- 33 |         # revealed: <super: <class 'BuilderMeta'>, Any>
- 34 |         s = reveal_type(super())
- 35 |         # revealed: Any
- 36 |         return reveal_type(s.__new__(cls, name, bases, dct))
- 37 | 
- 38 | class BuilderMeta2(type):
- 39 |     def __new__(
- 40 |         cls: type[BuilderMeta2],
- 41 |         name: str,
- 42 |         bases: tuple[type, ...],
- 43 |         dct: dict[str, Any],
- 44 |     ) -> BuilderMeta2:
- 45 |         # revealed: <super: <class 'BuilderMeta2'>, <class 'BuilderMeta2'>>
- 46 |         s = reveal_type(super())
- 47 |         return reveal_type(s.__new__(cls, name, bases, dct))  # revealed: BuilderMeta2
- 48 | 
- 49 | class Foo[T]:
- 50 |     x: T
- 51 | 
- 52 |     def method(self: Any):
- 53 |         reveal_type(super())  # revealed: <super: <class 'Foo'>, Any>
- 54 | 
- 55 |         if isinstance(self, Foo):
- 56 |             reveal_type(super())  # revealed: <super: <class 'Foo'>, Any>
- 57 | 
- 58 |     def method2(self: Foo[T]):
- 59 |         # revealed: <super: <class 'Foo'>, Foo[T@Foo]>
- 60 |         reveal_type(super())
- 61 | 
- 62 |     def method3(self: Foo):
- 63 |         # revealed: <super: <class 'Foo'>, Foo[Unknown]>
- 64 |         reveal_type(super())
- 65 | 
- 66 |     def method4(self: Self):
- 67 |         # revealed: <super: <class 'Foo'>, Self@method4>
- 68 |         reveal_type(super())
- 69 | 
- 70 |     def method5[S: Foo[int]](self: S, other: S) -> S:
- 71 |         # revealed: <super: <class 'Foo'>, S@method5>
- 72 |         reveal_type(super())
- 73 |         return self
- 74 | 
- 75 |     def method6[S: (Foo[int], Foo[str])](self: S, other: S) -> S:
- 76 |         # error: [invalid-super-argument]
- 77 |         # revealed: Unknown
- 78 |         reveal_type(super())
- 79 |         return self
- 80 | 
- 81 |     def method7[S](self: S, other: S) -> S:
- 82 |         # error: [invalid-super-argument]
- 83 |         # revealed: Unknown
- 84 |         reveal_type(super())
- 85 |         return self
- 86 | 
- 87 |     def method8[S: int](self: S, other: S) -> S:
- 88 |         # error: [invalid-super-argument]
- 89 |         # revealed: Unknown
- 90 |         reveal_type(super())
- 91 |         return self
- 92 | 
- 93 |     def method9[S: (int, str)](self: S, other: S) -> S:
- 94 |         # error: [invalid-super-argument]
- 95 |         # revealed: Unknown
- 96 |         reveal_type(super())
- 97 |         return self
- 98 | 
- 99 |     def method10[S: Callable[..., str]](self: S, other: S) -> S:
-100 |         # revealed: <super: <class 'Foo'>, S@method10>
-101 |         reveal_type(super())
-102 |         return self
-103 | 
-104 | type Alias = Bar
-105 | 
-106 | class Bar:
-107 |     def method(self: Alias):
-108 |         # revealed: <super: <class 'Bar'>, Bar>
-109 |         reveal_type(super())
-110 | 
-111 |     def pls_dont_call_me(self: Never):
-112 |         # revealed: <super: <class 'Bar'>, Unknown>
-113 |         reveal_type(super())
-114 | 
-115 |     def only_call_me_on_callable_subclasses(self: Intersection[Bar, Callable[..., object]]):
-116 |         # revealed: <super: <class 'Bar'>, Bar>
-117 |         reveal_type(super())
-118 | 
-119 | class P(Protocol):
-120 |     def method(self: P):
-121 |         # revealed: <super: <class 'P'>, P>
-122 |         reveal_type(super())
-123 | 
-124 | class E(enum.Enum):
-125 |     X = 1
-126 | 
-127 |     def method(self: E):
-128 |         match self:
-129 |             case E.X:
-130 |                 # revealed: <super: <class 'E'>, E>
-131 |                 reveal_type(super())
+ 16 |         reveal_type(super())  # revealed: <super: <class 'B'>, type[Self@f]>
+ 17 |         super().f()
+ 18 | 
+ 19 | super(B, B(42)).__init__(42)
+ 20 | super(B, B).f()
+ 21 | import enum
+ 22 | from typing import Any, Self, Never, Protocol, Callable
+ 23 | from ty_extensions import Intersection
+ 24 | 
+ 25 | class BuilderMeta(type):
+ 26 |     def __new__(
+ 27 |         cls: type[Any],
+ 28 |         name: str,
+ 29 |         bases: tuple[type, ...],
+ 30 |         dct: dict[str, Any],
+ 31 |     ) -> BuilderMeta:
+ 32 |         # revealed: <super: <class 'BuilderMeta'>, Any>
+ 33 |         s = reveal_type(super())
+ 34 |         # revealed: Any
+ 35 |         return reveal_type(s.__new__(cls, name, bases, dct))
+ 36 | 
+ 37 | class BuilderMeta2(type):
+ 38 |     def __new__(
+ 39 |         cls: type[BuilderMeta2],
+ 40 |         name: str,
+ 41 |         bases: tuple[type, ...],
+ 42 |         dct: dict[str, Any],
+ 43 |     ) -> BuilderMeta2:
+ 44 |         # revealed: <super: <class 'BuilderMeta2'>, <class 'BuilderMeta2'>>
+ 45 |         s = reveal_type(super())
+ 46 |         return reveal_type(s.__new__(cls, name, bases, dct))  # revealed: BuilderMeta2
+ 47 | 
+ 48 | class Foo[T]:
+ 49 |     x: T
+ 50 | 
+ 51 |     def method(self: Any):
+ 52 |         reveal_type(super())  # revealed: <super: <class 'Foo'>, Any>
+ 53 | 
+ 54 |         if isinstance(self, Foo):
+ 55 |             reveal_type(super())  # revealed: <super: <class 'Foo'>, Any>
+ 56 | 
+ 57 |     def method2(self: Foo[T]):
+ 58 |         # revealed: <super: <class 'Foo'>, Foo[T@Foo]>
+ 59 |         reveal_type(super())
+ 60 | 
+ 61 |     def method3(self: Foo):
+ 62 |         # revealed: <super: <class 'Foo'>, Foo[Unknown]>
+ 63 |         reveal_type(super())
+ 64 | 
+ 65 |     def method4(self: Self):
+ 66 |         # revealed: <super: <class 'Foo'>, Self@method4>
+ 67 |         reveal_type(super())
+ 68 | 
+ 69 |     def method5[S: Foo[int]](self: S, other: S) -> S:
+ 70 |         # revealed: <super: <class 'Foo'>, S@method5>
+ 71 |         reveal_type(super())
+ 72 |         return self
+ 73 | 
+ 74 |     def method6[S: (Foo[int], Foo[str])](self: S, other: S) -> S:
+ 75 |         # error: [invalid-super-argument]
+ 76 |         # revealed: Unknown
+ 77 |         reveal_type(super())
+ 78 |         return self
+ 79 | 
+ 80 |     def method7[S](self: S, other: S) -> S:
+ 81 |         # error: [invalid-super-argument]
+ 82 |         # revealed: Unknown
+ 83 |         reveal_type(super())
+ 84 |         return self
+ 85 | 
+ 86 |     def method8[S: int](self: S, other: S) -> S:
+ 87 |         # error: [invalid-super-argument]
+ 88 |         # revealed: Unknown
+ 89 |         reveal_type(super())
+ 90 |         return self
+ 91 | 
+ 92 |     def method9[S: (int, str)](self: S, other: S) -> S:
+ 93 |         # error: [invalid-super-argument]
+ 94 |         # revealed: Unknown
+ 95 |         reveal_type(super())
+ 96 |         return self
+ 97 | 
+ 98 |     def method10[S: Callable[..., str]](self: S, other: S) -> S:
+ 99 |         # revealed: <super: <class 'Foo'>, S@method10>
+100 |         reveal_type(super())
+101 |         return self
+102 | 
+103 | type Alias = Bar
+104 | 
+105 | class Bar:
+106 |     def method(self: Alias):
+107 |         # revealed: <super: <class 'Bar'>, Bar>
+108 |         reveal_type(super())
+109 | 
+110 |     def pls_dont_call_me(self: Never):
+111 |         # revealed: <super: <class 'Bar'>, Unknown>
+112 |         reveal_type(super())
+113 | 
+114 |     def only_call_me_on_callable_subclasses(self: Intersection[Bar, Callable[..., object]]):
+115 |         # revealed: <super: <class 'Bar'>, Bar>
+116 |         reveal_type(super())
+117 | 
+118 | class P(Protocol):
+119 |     def method(self: P):
+120 |         # revealed: <super: <class 'P'>, P>
+121 |         reveal_type(super())
+122 | 
+123 | class E(enum.Enum):
+124 |     X = 1
+125 | 
+126 |     def method(self: E):
+127 |         match self:
+128 |             case E.X:
+129 |                 # revealed: <super: <class 'E'>, E>
+130 |                 reveal_type(super())
 ```
 
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to bound method `f` is incorrect
-  --> src/mdtest_snippet.py:18:9
-   |
-16 |         reveal_type(super())  # revealed: <super: <class 'B'>, Self@f>
-17 |         # error: [invalid-argument-type]
-18 |         super().f()
-   |         ^^^^^^^^^^^ Expected `type[A]`, found `type[Self@f]`
-19 |
-20 | super(B, B(42)).__init__(42)
-   |
-info: Method defined here
- --> src/mdtest_snippet.py:6:9
-  |
-4 |     def __init__(self, a: int): ...
-5 |     @classmethod
-6 |     def f(cls): ...
-  |         ^ --- Parameter declared here
-7 |
-8 | class B(A):
-  |
-info: rule `invalid-argument-type` is enabled by default
-
-```
-
-```
 error[invalid-super-argument]: `S@method6` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method6)` call
-  --> src/mdtest_snippet.py:78:21
+  --> src/mdtest_snippet.py:77:21
    |
-76 |         # error: [invalid-super-argument]
-77 |         # revealed: Unknown
-78 |         reveal_type(super())
+75 |         # error: [invalid-super-argument]
+76 |         # revealed: Unknown
+77 |         reveal_type(super())
    |                     ^^^^^^^
-79 |         return self
+78 |         return self
    |
 info: rule `invalid-super-argument` is enabled by default
 
@@ -189,13 +163,13 @@ info: rule `invalid-super-argument` is enabled by default
 
 ```
 error[invalid-super-argument]: `S@method7` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method7)` call
-  --> src/mdtest_snippet.py:84:21
+  --> src/mdtest_snippet.py:83:21
    |
-82 |         # error: [invalid-super-argument]
-83 |         # revealed: Unknown
-84 |         reveal_type(super())
+81 |         # error: [invalid-super-argument]
+82 |         # revealed: Unknown
+83 |         reveal_type(super())
    |                     ^^^^^^^
-85 |         return self
+84 |         return self
    |
 info: rule `invalid-super-argument` is enabled by default
 
@@ -203,13 +177,13 @@ info: rule `invalid-super-argument` is enabled by default
 
 ```
 error[invalid-super-argument]: `S@method8` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method8)` call
-  --> src/mdtest_snippet.py:90:21
+  --> src/mdtest_snippet.py:89:21
    |
-88 |         # error: [invalid-super-argument]
-89 |         # revealed: Unknown
-90 |         reveal_type(super())
+87 |         # error: [invalid-super-argument]
+88 |         # revealed: Unknown
+89 |         reveal_type(super())
    |                     ^^^^^^^
-91 |         return self
+90 |         return self
    |
 info: rule `invalid-super-argument` is enabled by default
 
@@ -217,13 +191,13 @@ info: rule `invalid-super-argument` is enabled by default
 
 ```
 error[invalid-super-argument]: `S@method9` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method9)` call
-  --> src/mdtest_snippet.py:96:21
+  --> src/mdtest_snippet.py:95:21
    |
-94 |         # error: [invalid-super-argument]
-95 |         # revealed: Unknown
-96 |         reveal_type(super())
+93 |         # error: [invalid-super-argument]
+94 |         # revealed: Unknown
+95 |         reveal_type(super())
    |                     ^^^^^^^
-97 |         return self
+96 |         return self
    |
 info: rule `invalid-super-argument` is enabled by default
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Implicit_Super_Objec…_(f9e5e48e3a4a4c12).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Implicit_Super_Objec…_(f9e5e48e3a4a4c12).snap
@@ -2,6 +2,7 @@
 source: crates/ty_test/src/lib.rs
 expression: snapshot
 ---
+
 ---
 mdtest name: super.md - Super - Basic Usage - Implicit Super Object
 mdtest path: crates/ty_python_semantic/resources/mdtest/class/super.md
@@ -86,91 +87,75 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/class/super.md
  72 |         return self
  73 | 
  74 |     def method6[S: (Foo[int], Foo[str])](self: S, other: S) -> S:
- 75 |         # error: [invalid-super-argument]
- 76 |         # revealed: Unknown
- 77 |         reveal_type(super())
- 78 |         return self
- 79 | 
- 80 |     def method7[S](self: S, other: S) -> S:
- 81 |         # error: [invalid-super-argument]
- 82 |         # revealed: Unknown
- 83 |         reveal_type(super())
- 84 |         return self
- 85 | 
- 86 |     def method8[S: int](self: S, other: S) -> S:
- 87 |         # error: [invalid-super-argument]
- 88 |         # revealed: Unknown
- 89 |         reveal_type(super())
- 90 |         return self
- 91 | 
- 92 |     def method9[S: (int, str)](self: S, other: S) -> S:
- 93 |         # error: [invalid-super-argument]
- 94 |         # revealed: Unknown
- 95 |         reveal_type(super())
- 96 |         return self
- 97 | 
- 98 |     def method10[S: Callable[..., str]](self: S, other: S) -> S:
- 99 |         # error: [invalid-super-argument]
-100 |         # revealed: Unknown
-101 |         reveal_type(super())
-102 |         return self
-103 | 
-104 | type Alias = Bar
-105 | 
-106 | class Bar:
-107 |     def method(self: Alias):
-108 |         # revealed: <super: <class 'Bar'>, Bar>
-109 |         reveal_type(super())
-110 | 
-111 |     def pls_dont_call_me(self: Never):
-112 |         # revealed: <super: <class 'Bar'>, Unknown>
-113 |         reveal_type(super())
-114 | 
-115 |     def only_call_me_on_callable_subclasses(self: Intersection[Bar, Callable[..., object]]):
-116 |         # revealed: <super: <class 'Bar'>, Bar>
-117 |         reveal_type(super())
-118 | 
-119 | class P(Protocol):
-120 |     def method(self: P):
-121 |         # revealed: <super: <class 'P'>, P>
-122 |         reveal_type(super())
-123 | 
-124 | class E(enum.Enum):
-125 |     X = 1
-126 | 
-127 |     def method(self: E):
-128 |         match self:
-129 |             case E.X:
-130 |                 # revealed: <super: <class 'E'>, E>
-131 |                 reveal_type(super())
+ 75 |         # revealed: <super: <class 'Foo'>, S@method6> | <super: <class 'Foo'>, S@method6>
+ 76 |         reveal_type(super())
+ 77 |         return self
+ 78 | 
+ 79 |     def method7[S](self: S, other: S) -> S:
+ 80 |         # error: [invalid-super-argument]
+ 81 |         # revealed: Unknown
+ 82 |         reveal_type(super())
+ 83 |         return self
+ 84 | 
+ 85 |     def method8[S: int](self: S, other: S) -> S:
+ 86 |         # error: [invalid-super-argument]
+ 87 |         # revealed: Unknown
+ 88 |         reveal_type(super())
+ 89 |         return self
+ 90 | 
+ 91 |     def method9[S: (int, str)](self: S, other: S) -> S:
+ 92 |         # error: [invalid-super-argument]
+ 93 |         # revealed: Unknown
+ 94 |         reveal_type(super())
+ 95 |         return self
+ 96 | 
+ 97 |     def method10[S: Callable[..., str]](self: S, other: S) -> S:
+ 98 |         # error: [invalid-super-argument]
+ 99 |         # revealed: Unknown
+100 |         reveal_type(super())
+101 |         return self
+102 | 
+103 | type Alias = Bar
+104 | 
+105 | class Bar:
+106 |     def method(self: Alias):
+107 |         # revealed: <super: <class 'Bar'>, Bar>
+108 |         reveal_type(super())
+109 | 
+110 |     def pls_dont_call_me(self: Never):
+111 |         # revealed: <super: <class 'Bar'>, Unknown>
+112 |         reveal_type(super())
+113 | 
+114 |     def only_call_me_on_callable_subclasses(self: Intersection[Bar, Callable[..., object]]):
+115 |         # revealed: <super: <class 'Bar'>, Bar>
+116 |         reveal_type(super())
+117 | 
+118 | class P(Protocol):
+119 |     def method(self: P):
+120 |         # revealed: <super: <class 'P'>, P>
+121 |         reveal_type(super())
+122 | 
+123 | class E(enum.Enum):
+124 |     X = 1
+125 | 
+126 |     def method(self: E):
+127 |         match self:
+128 |             case E.X:
+129 |                 # revealed: <super: <class 'E'>, E>
+130 |                 reveal_type(super())
 ```
 
 # Diagnostics
 
 ```
-error[invalid-super-argument]: `S@method6` is a type variable with an abstract/structural type as its bounds or constraints, in `super(<class 'Foo'>, S@method6)` call
-  --> src/mdtest_snippet.py:77:21
-   |
-75 |         # error: [invalid-super-argument]
-76 |         # revealed: Unknown
-77 |         reveal_type(super())
-   |                     ^^^^^^^
-78 |         return self
-   |
-info: Type variable `S` has constraints `Foo[int], Foo[str]`
-info: rule `invalid-super-argument` is enabled by default
-
-```
-
-```
 error[invalid-super-argument]: `S@method7` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method7)` call
-  --> src/mdtest_snippet.py:83:21
+  --> src/mdtest_snippet.py:82:21
    |
-81 |         # error: [invalid-super-argument]
-82 |         # revealed: Unknown
-83 |         reveal_type(super())
+80 |         # error: [invalid-super-argument]
+81 |         # revealed: Unknown
+82 |         reveal_type(super())
    |                     ^^^^^^^
-84 |         return self
+83 |         return self
    |
 info: Type variable `S` has `object` as its implicit upper bound
 info: `object` is not an instance or subclass of `<class 'Foo'>`
@@ -181,13 +166,13 @@ info: rule `invalid-super-argument` is enabled by default
 
 ```
 error[invalid-super-argument]: `S@method8` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method8)` call
-  --> src/mdtest_snippet.py:89:21
+  --> src/mdtest_snippet.py:88:21
    |
-87 |         # error: [invalid-super-argument]
-88 |         # revealed: Unknown
-89 |         reveal_type(super())
+86 |         # error: [invalid-super-argument]
+87 |         # revealed: Unknown
+88 |         reveal_type(super())
    |                     ^^^^^^^
-90 |         return self
+89 |         return self
    |
 info: Type variable `S` has upper bound `int`
 info: `int` is not an instance or subclass of `<class 'Foo'>`
@@ -196,29 +181,30 @@ info: rule `invalid-super-argument` is enabled by default
 ```
 
 ```
-error[invalid-super-argument]: `S@method9` is a type variable with an abstract/structural type as its bounds or constraints, in `super(<class 'Foo'>, S@method9)` call
-  --> src/mdtest_snippet.py:95:21
+error[invalid-super-argument]: `S@method9` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method9)` call
+  --> src/mdtest_snippet.py:94:21
    |
-93 |         # error: [invalid-super-argument]
-94 |         # revealed: Unknown
-95 |         reveal_type(super())
+92 |         # error: [invalid-super-argument]
+93 |         # revealed: Unknown
+94 |         reveal_type(super())
    |                     ^^^^^^^
-96 |         return self
+95 |         return self
    |
 info: Type variable `S` has constraints `int, str`
+info: `int | str` is not an instance or subclass of `<class 'Foo'>`
 info: rule `invalid-super-argument` is enabled by default
 
 ```
 
 ```
 error[invalid-super-argument]: `S@method10` is a type variable with an abstract/structural type as its bounds or constraints, in `super(<class 'Foo'>, S@method10)` call
-   --> src/mdtest_snippet.py:101:21
+   --> src/mdtest_snippet.py:100:21
     |
- 99 |         # error: [invalid-super-argument]
-100 |         # revealed: Unknown
-101 |         reveal_type(super())
+ 98 |         # error: [invalid-super-argument]
+ 99 |         # revealed: Unknown
+100 |         reveal_type(super())
     |                     ^^^^^^^
-102 |         return self
+101 |         return self
     |
 info: Type variable `S` has upper bound `(...) -> str`
 info: rule `invalid-super-argument` is enabled by default

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Implicit_Super_Objec…_(f9e5e48e3a4a4c12).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Implicit_Super_Objec…_(f9e5e48e3a4a4c12).snap
@@ -22,191 +22,209 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/class/super.md
   7 | 
   8 | class B(A):
   9 |     def __init__(self, a: int):
- 10 |         reveal_type(super())  # revealed: <super: <class 'B'>, B>
+ 10 |         reveal_type(super())  # revealed: <super: <class 'B'>, Self@__init__>
  11 |         reveal_type(super(object, super()))  # revealed: <super: <class 'object'>, super>
  12 |         super().__init__(a)
  13 | 
  14 |     @classmethod
  15 |     def f(cls):
- 16 |         reveal_type(super())  # revealed: <super: <class 'B'>, <class 'B'>>
- 17 |         super().f()
- 18 | 
- 19 | super(B, B(42)).__init__(42)
- 20 | super(B, B).f()
- 21 | import enum
- 22 | from typing import Any, Self, Never, Protocol, Callable
- 23 | from ty_extensions import Intersection
- 24 | 
- 25 | class BuilderMeta(type):
- 26 |     def __new__(
- 27 |         cls: type[Any],
- 28 |         name: str,
- 29 |         bases: tuple[type, ...],
- 30 |         dct: dict[str, Any],
- 31 |     ) -> BuilderMeta:
- 32 |         # revealed: <super: <class 'BuilderMeta'>, Any>
- 33 |         s = reveal_type(super())
- 34 |         # revealed: Any
- 35 |         return reveal_type(s.__new__(cls, name, bases, dct))
- 36 | 
- 37 | class BuilderMeta2(type):
- 38 |     def __new__(
- 39 |         cls: type[BuilderMeta2],
- 40 |         name: str,
- 41 |         bases: tuple[type, ...],
- 42 |         dct: dict[str, Any],
- 43 |     ) -> BuilderMeta2:
- 44 |         # revealed: <super: <class 'BuilderMeta2'>, <class 'BuilderMeta2'>>
- 45 |         s = reveal_type(super())
- 46 |         return reveal_type(s.__new__(cls, name, bases, dct))  # revealed: BuilderMeta2
- 47 | 
- 48 | class Foo[T]:
- 49 |     x: T
- 50 | 
- 51 |     def method(self: Any):
- 52 |         reveal_type(super())  # revealed: <super: <class 'Foo'>, Any>
- 53 | 
- 54 |         if isinstance(self, Foo):
- 55 |             reveal_type(super())  # revealed: <super: <class 'Foo'>, Any>
- 56 | 
- 57 |     def method2(self: Foo[T]):
- 58 |         # revealed: <super: <class 'Foo'>, Foo[T@Foo]>
- 59 |         reveal_type(super())
- 60 | 
- 61 |     def method3(self: Foo):
- 62 |         # revealed: <super: <class 'Foo'>, Foo[Unknown]>
- 63 |         reveal_type(super())
- 64 | 
- 65 |     def method4(self: Self):
- 66 |         # revealed: <super: <class 'Foo'>, Foo[T@Foo]>
- 67 |         reveal_type(super())
- 68 | 
- 69 |     def method5[S: Foo[int]](self: S, other: S) -> S:
- 70 |         # revealed: <super: <class 'Foo'>, Foo[int]>
- 71 |         reveal_type(super())
- 72 |         return self
- 73 | 
- 74 |     def method6[S: (Foo[int], Foo[str])](self: S, other: S) -> S:
- 75 |         # revealed: <super: <class 'Foo'>, Foo[int]> | <super: <class 'Foo'>, Foo[str]>
- 76 |         reveal_type(super())
- 77 |         return self
- 78 | 
- 79 |     def method7[S](self: S, other: S) -> S:
- 80 |         # error: [invalid-super-argument]
- 81 |         # revealed: Unknown
- 82 |         reveal_type(super())
- 83 |         return self
- 84 | 
- 85 |     def method8[S: int](self: S, other: S) -> S:
- 86 |         # error: [invalid-super-argument]
- 87 |         # revealed: Unknown
- 88 |         reveal_type(super())
- 89 |         return self
- 90 | 
- 91 |     def method9[S: (int, str)](self: S, other: S) -> S:
- 92 |         # error: [invalid-super-argument]
- 93 |         # revealed: Unknown
- 94 |         reveal_type(super())
- 95 |         return self
- 96 | 
- 97 |     def method10[S: Callable[..., str]](self: S, other: S) -> S:
- 98 |         # error: [invalid-super-argument]
- 99 |         # revealed: Unknown
-100 |         reveal_type(super())
-101 |         return self
-102 | 
-103 | type Alias = Bar
-104 | 
-105 | class Bar:
-106 |     def method(self: Alias):
-107 |         # revealed: <super: <class 'Bar'>, Bar>
-108 |         reveal_type(super())
-109 | 
-110 |     def pls_dont_call_me(self: Never):
-111 |         # revealed: <super: <class 'Bar'>, Unknown>
-112 |         reveal_type(super())
-113 | 
-114 |     def only_call_me_on_callable_subclasses(self: Intersection[Bar, Callable[..., object]]):
-115 |         # revealed: <super: <class 'Bar'>, Bar>
-116 |         reveal_type(super())
-117 | 
-118 | class P(Protocol):
-119 |     def method(self: P):
-120 |         # revealed: <super: <class 'P'>, P>
-121 |         reveal_type(super())
-122 | 
-123 | class E(enum.Enum):
-124 |     X = 1
-125 | 
-126 |     def method(self: E):
-127 |         match self:
-128 |             case E.X:
-129 |                 # revealed: <super: <class 'E'>, E>
-130 |                 reveal_type(super())
+ 16 |         reveal_type(super())  # revealed: <super: <class 'B'>, Self@f>
+ 17 |         # error: [invalid-argument-type]
+ 18 |         super().f()
+ 19 | 
+ 20 | super(B, B(42)).__init__(42)
+ 21 | super(B, B).f()
+ 22 | import enum
+ 23 | from typing import Any, Self, Never, Protocol, Callable
+ 24 | from ty_extensions import Intersection
+ 25 | 
+ 26 | class BuilderMeta(type):
+ 27 |     def __new__(
+ 28 |         cls: type[Any],
+ 29 |         name: str,
+ 30 |         bases: tuple[type, ...],
+ 31 |         dct: dict[str, Any],
+ 32 |     ) -> BuilderMeta:
+ 33 |         # revealed: <super: <class 'BuilderMeta'>, Any>
+ 34 |         s = reveal_type(super())
+ 35 |         # revealed: Any
+ 36 |         return reveal_type(s.__new__(cls, name, bases, dct))
+ 37 | 
+ 38 | class BuilderMeta2(type):
+ 39 |     def __new__(
+ 40 |         cls: type[BuilderMeta2],
+ 41 |         name: str,
+ 42 |         bases: tuple[type, ...],
+ 43 |         dct: dict[str, Any],
+ 44 |     ) -> BuilderMeta2:
+ 45 |         # revealed: <super: <class 'BuilderMeta2'>, <class 'BuilderMeta2'>>
+ 46 |         s = reveal_type(super())
+ 47 |         return reveal_type(s.__new__(cls, name, bases, dct))  # revealed: BuilderMeta2
+ 48 | 
+ 49 | class Foo[T]:
+ 50 |     x: T
+ 51 | 
+ 52 |     def method(self: Any):
+ 53 |         reveal_type(super())  # revealed: <super: <class 'Foo'>, Any>
+ 54 | 
+ 55 |         if isinstance(self, Foo):
+ 56 |             reveal_type(super())  # revealed: <super: <class 'Foo'>, Any>
+ 57 | 
+ 58 |     def method2(self: Foo[T]):
+ 59 |         # revealed: <super: <class 'Foo'>, Foo[T@Foo]>
+ 60 |         reveal_type(super())
+ 61 | 
+ 62 |     def method3(self: Foo):
+ 63 |         # revealed: <super: <class 'Foo'>, Foo[Unknown]>
+ 64 |         reveal_type(super())
+ 65 | 
+ 66 |     def method4(self: Self):
+ 67 |         # revealed: <super: <class 'Foo'>, Self@method4>
+ 68 |         reveal_type(super())
+ 69 | 
+ 70 |     def method5[S: Foo[int]](self: S, other: S) -> S:
+ 71 |         # revealed: <super: <class 'Foo'>, S@method5>
+ 72 |         reveal_type(super())
+ 73 |         return self
+ 74 | 
+ 75 |     def method6[S: (Foo[int], Foo[str])](self: S, other: S) -> S:
+ 76 |         # error: [invalid-super-argument]
+ 77 |         # revealed: Unknown
+ 78 |         reveal_type(super())
+ 79 |         return self
+ 80 | 
+ 81 |     def method7[S](self: S, other: S) -> S:
+ 82 |         # error: [invalid-super-argument]
+ 83 |         # revealed: Unknown
+ 84 |         reveal_type(super())
+ 85 |         return self
+ 86 | 
+ 87 |     def method8[S: int](self: S, other: S) -> S:
+ 88 |         # error: [invalid-super-argument]
+ 89 |         # revealed: Unknown
+ 90 |         reveal_type(super())
+ 91 |         return self
+ 92 | 
+ 93 |     def method9[S: (int, str)](self: S, other: S) -> S:
+ 94 |         # error: [invalid-super-argument]
+ 95 |         # revealed: Unknown
+ 96 |         reveal_type(super())
+ 97 |         return self
+ 98 | 
+ 99 |     def method10[S: Callable[..., str]](self: S, other: S) -> S:
+100 |         # revealed: <super: <class 'Foo'>, S@method10>
+101 |         reveal_type(super())
+102 |         return self
+103 | 
+104 | type Alias = Bar
+105 | 
+106 | class Bar:
+107 |     def method(self: Alias):
+108 |         # revealed: <super: <class 'Bar'>, Bar>
+109 |         reveal_type(super())
+110 | 
+111 |     def pls_dont_call_me(self: Never):
+112 |         # revealed: <super: <class 'Bar'>, Unknown>
+113 |         reveal_type(super())
+114 | 
+115 |     def only_call_me_on_callable_subclasses(self: Intersection[Bar, Callable[..., object]]):
+116 |         # revealed: <super: <class 'Bar'>, Bar>
+117 |         reveal_type(super())
+118 | 
+119 | class P(Protocol):
+120 |     def method(self: P):
+121 |         # revealed: <super: <class 'P'>, P>
+122 |         reveal_type(super())
+123 | 
+124 | class E(enum.Enum):
+125 |     X = 1
+126 | 
+127 |     def method(self: E):
+128 |         match self:
+129 |             case E.X:
+130 |                 # revealed: <super: <class 'E'>, E>
+131 |                 reveal_type(super())
 ```
 
 # Diagnostics
 
 ```
-error[invalid-super-argument]: `S@method7` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method7)` call
-  --> src/mdtest_snippet.py:82:21
+error[invalid-argument-type]: Argument to bound method `f` is incorrect
+  --> src/mdtest_snippet.py:18:9
    |
-80 |         # error: [invalid-super-argument]
-81 |         # revealed: Unknown
-82 |         reveal_type(super())
+16 |         reveal_type(super())  # revealed: <super: <class 'B'>, Self@f>
+17 |         # error: [invalid-argument-type]
+18 |         super().f()
+   |         ^^^^^^^^^^^ Expected `type[A]`, found `type[Self@f]`
+19 |
+20 | super(B, B(42)).__init__(42)
+   |
+info: Method defined here
+ --> src/mdtest_snippet.py:6:9
+  |
+4 |     def __init__(self, a: int): ...
+5 |     @classmethod
+6 |     def f(cls): ...
+  |         ^ --- Parameter declared here
+7 |
+8 | class B(A):
+  |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-super-argument]: `S@method6` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method6)` call
+  --> src/mdtest_snippet.py:78:21
+   |
+76 |         # error: [invalid-super-argument]
+77 |         # revealed: Unknown
+78 |         reveal_type(super())
    |                     ^^^^^^^
-83 |         return self
+79 |         return self
    |
-info: Type variable `S` has `object` as its implicit upper bound
-info: `object` is not an instance or subclass of `<class 'Foo'>`
-help: Consider adding an upper bound to type variable `S`
+info: rule `invalid-super-argument` is enabled by default
+
+```
+
+```
+error[invalid-super-argument]: `S@method7` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method7)` call
+  --> src/mdtest_snippet.py:84:21
+   |
+82 |         # error: [invalid-super-argument]
+83 |         # revealed: Unknown
+84 |         reveal_type(super())
+   |                     ^^^^^^^
+85 |         return self
+   |
 info: rule `invalid-super-argument` is enabled by default
 
 ```
 
 ```
 error[invalid-super-argument]: `S@method8` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method8)` call
-  --> src/mdtest_snippet.py:88:21
+  --> src/mdtest_snippet.py:90:21
    |
-86 |         # error: [invalid-super-argument]
-87 |         # revealed: Unknown
-88 |         reveal_type(super())
+88 |         # error: [invalid-super-argument]
+89 |         # revealed: Unknown
+90 |         reveal_type(super())
    |                     ^^^^^^^
-89 |         return self
+91 |         return self
    |
-info: Type variable `S` has upper bound `int`
-info: `int` is not an instance or subclass of `<class 'Foo'>`
 info: rule `invalid-super-argument` is enabled by default
 
 ```
 
 ```
 error[invalid-super-argument]: `S@method9` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method9)` call
-  --> src/mdtest_snippet.py:94:21
+  --> src/mdtest_snippet.py:96:21
    |
-92 |         # error: [invalid-super-argument]
-93 |         # revealed: Unknown
-94 |         reveal_type(super())
+94 |         # error: [invalid-super-argument]
+95 |         # revealed: Unknown
+96 |         reveal_type(super())
    |                     ^^^^^^^
-95 |         return self
+97 |         return self
    |
-info: Type variable `S` has constraints `int, str`
-info: `int | str` is not an instance or subclass of `<class 'Foo'>`
-info: rule `invalid-super-argument` is enabled by default
-
-```
-
-```
-error[invalid-super-argument]: `S@method10` is a type variable with an abstract/structural type as its bounds or constraints, in `super(<class 'Foo'>, S@method10)` call
-   --> src/mdtest_snippet.py:100:21
-    |
- 98 |         # error: [invalid-super-argument]
- 99 |         # revealed: Unknown
-100 |         reveal_type(super())
-    |                     ^^^^^^^
-101 |         return self
-    |
-info: Type variable `S` has upper bound `(...) -> str`
 info: rule `invalid-super-argument` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Implicit_Super_Objec…_(f9e5e48e3a4a4c12).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Implicit_Super_Objec…_(f9e5e48e3a4a4c12).snap
@@ -115,17 +115,17 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/class/super.md
 100 |         reveal_type(super())
 101 |         return self
 102 |     # TypeVar bounded by `type[Foo]` rather than `Foo`
-103 |     def method11[S: type[Foo[int]]](self: S, other: S) -> S:
-104 |         # error: [invalid-super-argument]
-105 |         # revealed: Unknown
-106 |         reveal_type(super())
+103 |     # TODO: Should error on signature - `self` is annotated as a class type, not an instance type
+104 |     def method11[S: type[Foo[int]]](self: S, other: S) -> S:
+105 |         # Delegates to the bound to resolve the super type
+106 |         reveal_type(super())  # revealed: <super: <class 'Foo'>, <class 'Foo[int]'>>
 107 |         return self
 108 |     # TypeVar bounded by `type[Foo]`, used in `type[T]` position
-109 |     @classmethod
-110 |     def method12[S: type[Foo[int]]](cls: type[S]) -> S:
-111 |         # error: [invalid-super-argument]
-112 |         # revealed: Unknown
-113 |         reveal_type(super())
+109 |     # TODO: Should error on signature - `cls` would be `type[type[Foo[int]]]`, a metaclass
+110 |     # Delegates to `type[Unknown]` since `type[type[Foo[int]]]` can't be constructed
+111 |     @classmethod
+112 |     def method12[S: type[Foo[int]]](cls: type[S]) -> S:
+113 |         reveal_type(super())  # revealed: <super: <class 'Foo'>, Unknown>
 114 |         raise NotImplementedError
 115 | 
 116 | type Alias = Bar
@@ -221,37 +221,6 @@ error[invalid-super-argument]: `S@method10` is a type variable with an abstract/
 102 |     # TypeVar bounded by `type[Foo]` rather than `Foo`
     |
 info: Type variable `S` has upper bound `(...) -> str`
-info: rule `invalid-super-argument` is enabled by default
-
-```
-
-```
-error[invalid-super-argument]: `S@method11` is a type variable with an abstract/structural type as its bounds or constraints, in `super(<class 'Foo'>, S@method11)` call
-   --> src/mdtest_snippet.py:106:21
-    |
-104 |         # error: [invalid-super-argument]
-105 |         # revealed: Unknown
-106 |         reveal_type(super())
-    |                     ^^^^^^^
-107 |         return self
-108 |     # TypeVar bounded by `type[Foo]`, used in `type[T]` position
-    |
-info: Type variable `S` has upper bound `type[Foo[int]]`
-info: rule `invalid-super-argument` is enabled by default
-
-```
-
-```
-error[invalid-super-argument]: `type[S@method12]` is a type variable with an abstract/structural type as its bounds or constraints, in `super(<class 'Foo'>, type[S@method12])` call
-   --> src/mdtest_snippet.py:113:21
-    |
-111 |         # error: [invalid-super-argument]
-112 |         # revealed: Unknown
-113 |         reveal_type(super())
-    |                     ^^^^^^^
-114 |         raise NotImplementedError
-    |
-info: Type variable `S` has upper bound `type[Foo[int]]`
 info: rule `invalid-super-argument` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Implicit_Super_Objec…_(f9e5e48e3a4a4c12).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Implicit_Super_Objec…_(f9e5e48e3a4a4c12).snap
@@ -114,35 +114,48 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/class/super.md
  99 |         # revealed: Unknown
 100 |         reveal_type(super())
 101 |         return self
-102 | 
-103 | type Alias = Bar
-104 | 
-105 | class Bar:
-106 |     def method(self: Alias):
-107 |         # revealed: <super: <class 'Bar'>, Bar>
-108 |         reveal_type(super())
-109 | 
-110 |     def pls_dont_call_me(self: Never):
-111 |         # revealed: <super: <class 'Bar'>, Unknown>
-112 |         reveal_type(super())
-113 | 
-114 |     def only_call_me_on_callable_subclasses(self: Intersection[Bar, Callable[..., object]]):
-115 |         # revealed: <super: <class 'Bar'>, Bar>
-116 |         reveal_type(super())
+102 |     # TypeVar bounded by `type[Foo]` rather than `Foo`
+103 |     def method11[S: type[Foo[int]]](self: S, other: S) -> S:
+104 |         # error: [invalid-super-argument]
+105 |         # revealed: Unknown
+106 |         reveal_type(super())
+107 |         return self
+108 |     # TypeVar bounded by `type[Foo]`, used in `type[T]` position
+109 |     @classmethod
+110 |     def method12[S: type[Foo[int]]](cls: type[S]) -> S:
+111 |         # error: [invalid-super-argument]
+112 |         # revealed: Unknown
+113 |         reveal_type(super())
+114 |         raise NotImplementedError
+115 | 
+116 | type Alias = Bar
 117 | 
-118 | class P(Protocol):
-119 |     def method(self: P):
-120 |         # revealed: <super: <class 'P'>, P>
+118 | class Bar:
+119 |     def method(self: Alias):
+120 |         # revealed: <super: <class 'Bar'>, Bar>
 121 |         reveal_type(super())
 122 | 
-123 | class E(enum.Enum):
-124 |     X = 1
-125 | 
-126 |     def method(self: E):
-127 |         match self:
-128 |             case E.X:
-129 |                 # revealed: <super: <class 'E'>, E>
-130 |                 reveal_type(super())
+123 |     def pls_dont_call_me(self: Never):
+124 |         # revealed: <super: <class 'Bar'>, Unknown>
+125 |         reveal_type(super())
+126 | 
+127 |     def only_call_me_on_callable_subclasses(self: Intersection[Bar, Callable[..., object]]):
+128 |         # revealed: <super: <class 'Bar'>, Bar>
+129 |         reveal_type(super())
+130 | 
+131 | class P(Protocol):
+132 |     def method(self: P):
+133 |         # revealed: <super: <class 'P'>, P>
+134 |         reveal_type(super())
+135 | 
+136 | class E(enum.Enum):
+137 |     X = 1
+138 | 
+139 |     def method(self: E):
+140 |         match self:
+141 |             case E.X:
+142 |                 # revealed: <super: <class 'E'>, E>
+143 |                 reveal_type(super())
 ```
 
 # Diagnostics
@@ -205,8 +218,40 @@ error[invalid-super-argument]: `S@method10` is a type variable with an abstract/
 100 |         reveal_type(super())
     |                     ^^^^^^^
 101 |         return self
+102 |     # TypeVar bounded by `type[Foo]` rather than `Foo`
     |
 info: Type variable `S` has upper bound `(...) -> str`
+info: rule `invalid-super-argument` is enabled by default
+
+```
+
+```
+error[invalid-super-argument]: `S@method11` is a type variable with an abstract/structural type as its bounds or constraints, in `super(<class 'Foo'>, S@method11)` call
+   --> src/mdtest_snippet.py:106:21
+    |
+104 |         # error: [invalid-super-argument]
+105 |         # revealed: Unknown
+106 |         reveal_type(super())
+    |                     ^^^^^^^
+107 |         return self
+108 |     # TypeVar bounded by `type[Foo]`, used in `type[T]` position
+    |
+info: Type variable `S` has upper bound `type[Foo[int]]`
+info: rule `invalid-super-argument` is enabled by default
+
+```
+
+```
+error[invalid-super-argument]: `type[S@method12]` is a type variable with an abstract/structural type as its bounds or constraints, in `super(<class 'Foo'>, type[S@method12])` call
+   --> src/mdtest_snippet.py:113:21
+    |
+111 |         # error: [invalid-super-argument]
+112 |         # revealed: Unknown
+113 |         reveal_type(super())
+    |                     ^^^^^^^
+114 |         raise NotImplementedError
+    |
+info: Type variable `S` has upper bound `type[Foo[int]]`
 info: rule `invalid-super-argument` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Implicit_Super_Objec…_(f9e5e48e3a4a4c12).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Implicit_Super_Objec…_(f9e5e48e3a4a4c12).snap
@@ -2,7 +2,6 @@
 source: crates/ty_test/src/lib.rs
 expression: snapshot
 ---
-
 ---
 mdtest name: super.md - Super - Basic Usage - Implicit Super Object
 mdtest path: crates/ty_python_semantic/resources/mdtest/class/super.md
@@ -111,44 +110,45 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/class/super.md
  96 |         return self
  97 | 
  98 |     def method10[S: Callable[..., str]](self: S, other: S) -> S:
- 99 |         # revealed: <super: <class 'Foo'>, S@method10>
-100 |         reveal_type(super())
-101 |         return self
-102 | 
-103 | type Alias = Bar
-104 | 
-105 | class Bar:
-106 |     def method(self: Alias):
-107 |         # revealed: <super: <class 'Bar'>, Bar>
-108 |         reveal_type(super())
-109 | 
-110 |     def pls_dont_call_me(self: Never):
-111 |         # revealed: <super: <class 'Bar'>, Unknown>
-112 |         reveal_type(super())
-113 | 
-114 |     def only_call_me_on_callable_subclasses(self: Intersection[Bar, Callable[..., object]]):
-115 |         # revealed: <super: <class 'Bar'>, Bar>
-116 |         reveal_type(super())
-117 | 
-118 | class P(Protocol):
-119 |     def method(self: P):
-120 |         # revealed: <super: <class 'P'>, P>
-121 |         reveal_type(super())
-122 | 
-123 | class E(enum.Enum):
-124 |     X = 1
-125 | 
-126 |     def method(self: E):
-127 |         match self:
-128 |             case E.X:
-129 |                 # revealed: <super: <class 'E'>, E>
-130 |                 reveal_type(super())
+ 99 |         # error: [invalid-super-argument]
+100 |         # revealed: Unknown
+101 |         reveal_type(super())
+102 |         return self
+103 | 
+104 | type Alias = Bar
+105 | 
+106 | class Bar:
+107 |     def method(self: Alias):
+108 |         # revealed: <super: <class 'Bar'>, Bar>
+109 |         reveal_type(super())
+110 | 
+111 |     def pls_dont_call_me(self: Never):
+112 |         # revealed: <super: <class 'Bar'>, Unknown>
+113 |         reveal_type(super())
+114 | 
+115 |     def only_call_me_on_callable_subclasses(self: Intersection[Bar, Callable[..., object]]):
+116 |         # revealed: <super: <class 'Bar'>, Bar>
+117 |         reveal_type(super())
+118 | 
+119 | class P(Protocol):
+120 |     def method(self: P):
+121 |         # revealed: <super: <class 'P'>, P>
+122 |         reveal_type(super())
+123 | 
+124 | class E(enum.Enum):
+125 |     X = 1
+126 | 
+127 |     def method(self: E):
+128 |         match self:
+129 |             case E.X:
+130 |                 # revealed: <super: <class 'E'>, E>
+131 |                 reveal_type(super())
 ```
 
 # Diagnostics
 
 ```
-error[invalid-super-argument]: `S@method6` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method6)` call
+error[invalid-super-argument]: `S@method6` is a type variable with an abstract/structural type as its bounds or constraints, in `super(<class 'Foo'>, S@method6)` call
   --> src/mdtest_snippet.py:77:21
    |
 75 |         # error: [invalid-super-argument]
@@ -157,6 +157,7 @@ error[invalid-super-argument]: `S@method6` is not an instance or subclass of `<c
    |                     ^^^^^^^
 78 |         return self
    |
+info: Type variable `S` has constraints `Foo[int], Foo[str]`
 info: rule `invalid-super-argument` is enabled by default
 
 ```
@@ -171,6 +172,9 @@ error[invalid-super-argument]: `S@method7` is not an instance or subclass of `<c
    |                     ^^^^^^^
 84 |         return self
    |
+info: Type variable `S` has `object` as its implicit upper bound
+info: `object` is not an instance or subclass of `<class 'Foo'>`
+help: Consider adding an upper bound to type variable `S`
 info: rule `invalid-super-argument` is enabled by default
 
 ```
@@ -185,12 +189,14 @@ error[invalid-super-argument]: `S@method8` is not an instance or subclass of `<c
    |                     ^^^^^^^
 90 |         return self
    |
+info: Type variable `S` has upper bound `int`
+info: `int` is not an instance or subclass of `<class 'Foo'>`
 info: rule `invalid-super-argument` is enabled by default
 
 ```
 
 ```
-error[invalid-super-argument]: `S@method9` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method9)` call
+error[invalid-super-argument]: `S@method9` is a type variable with an abstract/structural type as its bounds or constraints, in `super(<class 'Foo'>, S@method9)` call
   --> src/mdtest_snippet.py:95:21
    |
 93 |         # error: [invalid-super-argument]
@@ -199,6 +205,22 @@ error[invalid-super-argument]: `S@method9` is not an instance or subclass of `<c
    |                     ^^^^^^^
 96 |         return self
    |
+info: Type variable `S` has constraints `int, str`
+info: rule `invalid-super-argument` is enabled by default
+
+```
+
+```
+error[invalid-super-argument]: `S@method10` is a type variable with an abstract/structural type as its bounds or constraints, in `super(<class 'Foo'>, S@method10)` call
+   --> src/mdtest_snippet.py:101:21
+    |
+ 99 |         # error: [invalid-super-argument]
+100 |         # revealed: Unknown
+101 |         reveal_type(super())
+    |                     ^^^^^^^
+102 |         return self
+    |
+info: Type variable `S` has upper bound `(...) -> str`
 info: rule `invalid-super-argument` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -417,8 +417,15 @@ impl<'db> BoundSuperType<'db> {
                     let typevar = bound_typevar.typevar(db);
                     match typevar.bound_or_constraints(db) {
                         Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                            if let Type::NominalInstance(instance) = bound {
-                                SuperOwnerKind::ClassTypeVar(bound_typevar, instance.class(db))
+                            let class = match bound {
+                                Type::NominalInstance(instance) => Some(instance.class(db)),
+                                Type::ProtocolInstance(protocol) => protocol
+                                    .to_nominal_instance()
+                                    .map(|instance| instance.class(db)),
+                                _ => None,
+                            };
+                            if let Some(class) = class {
+                                SuperOwnerKind::ClassTypeVar(bound_typevar, class)
                             } else {
                                 return Err(BoundSuperError::AbstractOwnerType {
                                     owner_type,
@@ -495,8 +502,15 @@ impl<'db> BoundSuperType<'db> {
                 let typevar = bound_typevar.typevar(db);
                 match typevar.bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                        if let Type::NominalInstance(instance) = bound {
-                            SuperOwnerKind::InstanceTypeVar(bound_typevar, instance.class(db))
+                        let class = match bound {
+                            Type::NominalInstance(instance) => Some(instance.class(db)),
+                            Type::ProtocolInstance(protocol) => protocol
+                                .to_nominal_instance()
+                                .map(|instance| instance.class(db)),
+                            _ => None,
+                        };
+                        if let Some(class) = class {
+                            SuperOwnerKind::InstanceTypeVar(bound_typevar, class)
                         } else {
                             return Err(BoundSuperError::AbstractOwnerType {
                                 owner_type,

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -417,20 +417,14 @@ impl<'db> BoundSuperType<'db> {
                     let typevar = bound_typevar.typevar(db);
                     match typevar.bound_or_constraints(db) {
                         Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                            // For ClassTypeVar, extract the class from the bound.
-                            let class = match bound {
-                                Type::NominalInstance(instance) => Some(instance.class(db)),
-                                _ => bound.to_class_type(db),
-                            };
-                            match class {
-                                Some(class) => SuperOwnerKind::ClassTypeVar(bound_typevar, class),
-                                None => {
-                                    return Err(BoundSuperError::AbstractOwnerType {
-                                        owner_type,
-                                        pivot_class: pivot_class_type,
-                                        typevar_context: Some(typevar),
-                                    });
-                                }
+                            if let Type::NominalInstance(instance) = bound {
+                                SuperOwnerKind::ClassTypeVar(bound_typevar, instance.class(db))
+                            } else {
+                                return Err(BoundSuperError::AbstractOwnerType {
+                                    owner_type,
+                                    pivot_class: pivot_class_type,
+                                    typevar_context: Some(typevar),
+                                });
                             }
                         }
                         Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
@@ -443,8 +437,7 @@ impl<'db> BoundSuperType<'db> {
                         }
                         None => {
                             // No bound means the implicit upper bound is `object`.
-                            let class = ClassType::object(db);
-                            SuperOwnerKind::ClassTypeVar(bound_typevar, class)
+                            SuperOwnerKind::ClassTypeVar(bound_typevar, ClassType::object(db))
                         }
                     }
                 }
@@ -502,20 +495,14 @@ impl<'db> BoundSuperType<'db> {
                 let typevar = bound_typevar.typevar(db);
                 match typevar.bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                        // For InstanceTypeVar, extract the class from the bound.
-                        let class = match bound {
-                            Type::NominalInstance(instance) => Some(instance.class(db)),
-                            _ => bound.to_class_type(db),
-                        };
-                        match class {
-                            Some(class) => SuperOwnerKind::InstanceTypeVar(bound_typevar, class),
-                            None => {
-                                return Err(BoundSuperError::AbstractOwnerType {
-                                    owner_type,
-                                    pivot_class: pivot_class_type,
-                                    typevar_context: Some(typevar),
-                                });
-                            }
+                        if let Type::NominalInstance(instance) = bound {
+                            SuperOwnerKind::InstanceTypeVar(bound_typevar, instance.class(db))
+                        } else {
+                            return Err(BoundSuperError::AbstractOwnerType {
+                                owner_type,
+                                pivot_class: pivot_class_type,
+                                typevar_context: Some(typevar),
+                            });
                         }
                     }
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
@@ -528,8 +515,7 @@ impl<'db> BoundSuperType<'db> {
                     }
                     None => {
                         // No bound means the implicit upper bound is `object`.
-                        let class = ClassType::object(db);
-                        SuperOwnerKind::InstanceTypeVar(bound_typevar, class)
+                        SuperOwnerKind::InstanceTypeVar(bound_typevar, ClassType::object(db))
                     }
                 }
             }

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -236,6 +236,7 @@ impl<'db> SuperOwnerKind<'db> {
                 instance.recursive_type_normalized_impl(db, div, nested)?,
             )),
             SuperOwnerKind::InstanceTypeVar(_, _) | SuperOwnerKind::ClassTypeVar(_, _) => {
+                // TODO: we might need to normalize the nested class here?
                 Some(self)
             }
         }

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -988,7 +988,9 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .display_with(self.db, self.settings.singleline())
                     .fmt_detailed(f)?;
                 f.write_str(", ")?;
-                Type::from(bound_super.owner(self.db))
+                bound_super
+                    .owner(self.db)
+                    .binding_type(self.db)
                     .display_with(self.db, self.settings.singleline())
                     .fmt_detailed(f)?;
                 f.write_str(">")

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -990,7 +990,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                 f.write_str(", ")?;
                 bound_super
                     .owner(self.db)
-                    .binding_type(self.db)
+                    .owner_type(self.db)
                     .display_with(self.db, self.settings.singleline())
                     .fmt_detailed(f)?;
                 f.write_str(">")

--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -190,17 +190,16 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
                 (SuperOwnerKind::Instance(_), _) => Ordering::Less,
                 (_, SuperOwnerKind::Instance(_)) => Ordering::Greater,
                 (
-                    SuperOwnerKind::InstanceTypeVar(left, _)
-                    | SuperOwnerKind::ClassTypeVar(left, _),
-                    SuperOwnerKind::InstanceTypeVar(right, _)
-                    | SuperOwnerKind::ClassTypeVar(right, _),
+                    SuperOwnerKind::InstanceTypeVar(left, _),
+                    SuperOwnerKind::InstanceTypeVar(right, _),
                 ) => left.cmp(&right),
-                (SuperOwnerKind::InstanceTypeVar(..) | SuperOwnerKind::ClassTypeVar(..), _) => {
-                    Ordering::Less
+                (SuperOwnerKind::InstanceTypeVar(..), _) => Ordering::Less,
+                (_, SuperOwnerKind::InstanceTypeVar(..)) => Ordering::Greater,
+                (SuperOwnerKind::ClassTypeVar(left, _), SuperOwnerKind::ClassTypeVar(right, _)) => {
+                    left.cmp(&right)
                 }
-                (_, SuperOwnerKind::InstanceTypeVar(..) | SuperOwnerKind::ClassTypeVar(..)) => {
-                    Ordering::Greater
-                }
+                (SuperOwnerKind::ClassTypeVar(..), _) => Ordering::Less,
+                (_, SuperOwnerKind::ClassTypeVar(..)) => Ordering::Greater,
                 (SuperOwnerKind::Dynamic(left), SuperOwnerKind::Dynamic(right)) => {
                     dynamic_elements_ordering(left, right)
                 }

--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -189,6 +189,18 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
                 }
                 (SuperOwnerKind::Instance(_), _) => Ordering::Less,
                 (_, SuperOwnerKind::Instance(_)) => Ordering::Greater,
+                (
+                    SuperOwnerKind::TypeVar {
+                        bound_typevar: left,
+                        ..
+                    },
+                    SuperOwnerKind::TypeVar {
+                        bound_typevar: right,
+                        ..
+                    },
+                ) => left.cmp(&right),
+                (SuperOwnerKind::TypeVar { .. }, _) => Ordering::Less,
+                (_, SuperOwnerKind::TypeVar { .. }) => Ordering::Greater,
                 (SuperOwnerKind::Dynamic(left), SuperOwnerKind::Dynamic(right)) => {
                     dynamic_elements_ordering(left, right)
                 }

--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -190,13 +190,15 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
                 (SuperOwnerKind::Instance(_), _) => Ordering::Less,
                 (_, SuperOwnerKind::Instance(_)) => Ordering::Greater,
                 (
-                    SuperOwnerKind::InstanceTypeVar(left) | SuperOwnerKind::ClassTypeVar(left),
-                    SuperOwnerKind::InstanceTypeVar(right) | SuperOwnerKind::ClassTypeVar(right),
+                    SuperOwnerKind::InstanceTypeVar(left, _)
+                    | SuperOwnerKind::ClassTypeVar(left, _),
+                    SuperOwnerKind::InstanceTypeVar(right, _)
+                    | SuperOwnerKind::ClassTypeVar(right, _),
                 ) => left.cmp(&right),
-                (SuperOwnerKind::InstanceTypeVar(_) | SuperOwnerKind::ClassTypeVar(_), _) => {
+                (SuperOwnerKind::InstanceTypeVar(..) | SuperOwnerKind::ClassTypeVar(..), _) => {
                     Ordering::Less
                 }
-                (_, SuperOwnerKind::InstanceTypeVar(_) | SuperOwnerKind::ClassTypeVar(_)) => {
+                (_, SuperOwnerKind::InstanceTypeVar(..) | SuperOwnerKind::ClassTypeVar(..)) => {
                     Ordering::Greater
                 }
                 (SuperOwnerKind::Dynamic(left), SuperOwnerKind::Dynamic(right)) => {

--- a/crates/ty_python_semantic/src/types/type_ordering.rs
+++ b/crates/ty_python_semantic/src/types/type_ordering.rs
@@ -190,17 +190,15 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
                 (SuperOwnerKind::Instance(_), _) => Ordering::Less,
                 (_, SuperOwnerKind::Instance(_)) => Ordering::Greater,
                 (
-                    SuperOwnerKind::TypeVar {
-                        bound_typevar: left,
-                        ..
-                    },
-                    SuperOwnerKind::TypeVar {
-                        bound_typevar: right,
-                        ..
-                    },
+                    SuperOwnerKind::InstanceTypeVar(left) | SuperOwnerKind::ClassTypeVar(left),
+                    SuperOwnerKind::InstanceTypeVar(right) | SuperOwnerKind::ClassTypeVar(right),
                 ) => left.cmp(&right),
-                (SuperOwnerKind::TypeVar { .. }, _) => Ordering::Less,
-                (_, SuperOwnerKind::TypeVar { .. }) => Ordering::Greater,
+                (SuperOwnerKind::InstanceTypeVar(_) | SuperOwnerKind::ClassTypeVar(_), _) => {
+                    Ordering::Less
+                }
+                (_, SuperOwnerKind::InstanceTypeVar(_) | SuperOwnerKind::ClassTypeVar(_)) => {
+                    Ordering::Greater
+                }
                 (SuperOwnerKind::Dynamic(left), SuperOwnerKind::Dynamic(right)) => {
                     dynamic_elements_ordering(left, right)
                 }


### PR DESCRIPTION
## Summary

This PR fixes `super()` handling when the first parameter (`self` or `cls`) is annotated with a TypeVar, like `Self`. 

Previously, `super()` would incorrectly resolve TypeVars to their bounds before creating the `BoundSuperType`. So if you had `self: Self` where `Self` is bounded by `Parent`, we'd process `Parent` as a `NominalInstance` and end up with `SuperOwnerKind::Instance(Parent)`.

As a result:

```python
class Parent:
    @classmethod
    def create(cls) -> Self:
        return cls()

class Child(Parent):
    @classmethod
    def create(cls) -> Self:
        return super().create()  # Error: Argument type `Self@create` does not satisfy upper bound `Parent`
```

We now track two additional variants on `SuperOwnerKind` for TypeVar owners:

- `InstanceTypeVar`: for instance methods where self is a TypeVar (e.g., `self: Self`).
- `ClassTypeVar`: for classmethods where `cls` is a `TypeVar` wrapped in `type[...]` (e.g., `cls: type[Self]`).

Closes https://github.com/astral-sh/ty/issues/2122.
