### PR TITLE
[`pylint`] Restore the fix safety docs for `PLW0133`

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/useless_exception_statement.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_exception_statement.rs
@@ -36,6 +36,7 @@ use ruff_python_ast::PythonVersion;
 ///
 /// ## Fix safety
 /// This rule's fix is marked as unsafe, as converting a useless exception
+/// statement to a `raise` statement will change the program's behavior.
 ///
 /// [preview]: https://docs.astral.sh/ruff/preview/
 #[derive(ViolationMetadata)]


### PR DESCRIPTION
Summary
--

Noticed while responding to #22201 that the last sentence here just ends abruptly. It turns out that I missed this change when reviewing #21382.

Test Plan
--

CI
