### PR TITLE
[ty] Make the implicit shadowing message on invalid assignment diagnostic `info` 

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1867,7 +1867,7 @@ def external_getattribute(name) -> int:
 
 class ThisFails:
     def __init__(self):
-        # error: [invalid-assignment] "Implicit shadowing of function `__getattribute__`"
+        # error: [invalid-assignment]
         self.__getattribute__ = external_getattribute
 
 # error: [unresolved-attribute]

--- a/crates/ty_python_semantic/resources/mdtest/call/dunder.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/dunder.md
@@ -205,7 +205,7 @@ class C:
         return str(key)
 
     def f(self):
-        # error: [invalid-assignment] "Implicit shadowing of function `__getitem__`"
+        # error: [invalid-assignment]
         self.__getitem__ = None
 
 # This is still fine, and simply calls the `__getitem__` method on the class

--- a/crates/ty_python_semantic/resources/mdtest/shadowing/class.md
+++ b/crates/ty_python_semantic/resources/mdtest/shadowing/class.md
@@ -5,7 +5,7 @@
 ```py
 class C: ...
 
-C = 1  # error: "Implicit shadowing of class `C`"
+C = 1  # error: [invalid-assignment]
 ```
 
 ## Explicit

--- a/crates/ty_python_semantic/resources/mdtest/shadowing/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/shadowing/function.md
@@ -15,7 +15,7 @@ def f(x: str):
 ```py
 def f(): ...
 
-f = 1  # error: "Implicit shadowing of function `f`"
+f = 1  # error: [invalid-assignment]
 ```
 
 ## Explicit shadowing

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shado…_(c8ff9e3a079e8bd5).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shado…_(c8ff9e3a079e8bd5).snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/shadowing.md
 # Diagnostics
 
 ```
-error[invalid-assignment]: Implicit shadowing of class `C`
+error[invalid-assignment]: Object of type `Literal[1]` is not assignable to `<class 'C'>`
  --> src/mdtest_snippet.py:3:1
   |
 1 | class C: ...
@@ -30,7 +30,7 @@ error[invalid-assignment]: Implicit shadowing of class `C`
   | |
   | Declared type `<class 'C'>`
   |
-info: Annotate to make it explicit if this is intentional
+info: Implicit shadowing of class `C`, add an annotation to make it explicit if this is intentional
 info: rule `invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_sh…_(a1515328b775ebc1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_sh…_(a1515328b775ebc1).snap
@@ -20,7 +20,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/shadowing.md
 # Diagnostics
 
 ```
-error[invalid-assignment]: Implicit shadowing of function `f`
+error[invalid-assignment]: Object of type `Literal[1]` is not assignable to `def f() -> Unknown`
  --> src/mdtest_snippet.py:3:1
   |
 1 | def f(): ...
@@ -30,7 +30,7 @@ error[invalid-assignment]: Implicit shadowing of function `f`
   | |
   | Declared type `def f() -> Unknown`
   |
-info: Annotate to make it explicit if this is intentional
+info: Implicit shadowing of function `f`, add an annotation to make it explicit if this is intentional
 info: rule `invalid-assignment` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -2452,29 +2452,25 @@ fn report_invalid_assignment_with_message<'db, 'ctx: 'db, T: Ranged>(
     message: std::fmt::Arguments,
 ) -> Option<LintDiagnosticGuard<'db, 'ctx>> {
     let builder = context.report_lint(&INVALID_ASSIGNMENT, node)?;
+
+    let mut diag = builder.into_diagnostic(message);
+
     match target_ty {
         Type::ClassLiteral(class) => {
-            let mut diag = builder.into_diagnostic(format_args!(
-                "Implicit shadowing of class `{}`",
+            diag.info(format_args!(
+                "Implicit shadowing of class `{}`, add an annotation to make it explicit if this is intentional",
                 class.name(context.db()),
             ));
-            diag.info("Annotate to make it explicit if this is intentional");
-            Some(diag)
         }
         Type::FunctionLiteral(function) => {
-            let mut diag = builder.into_diagnostic(format_args!(
-                "Implicit shadowing of function `{}`",
+            diag.info(format_args!(
+                "Implicit shadowing of function `{}`, add an annotation to make it explicit if this is intentional",
                 function.name(context.db()),
             ));
-            diag.info("Annotate to make it explicit if this is intentional");
-            Some(diag)
         }
-
-        _ => {
-            let diag = builder.into_diagnostic(message);
-            Some(diag)
-        }
+        _ => {}
     }
+    Some(diag)
 }
 
 pub(super) fn report_invalid_assignment<'db>(


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Resolves https://github.com/astral-sh/ty/issues/1981

## Test Plan

Update mdtests. Removed the message from the inline `error` assertions as they now show nothing abnormal.

Update snapshots to show new single line info about shadowing.
