### PR TITLE
[ty] callable type of a type object is not function-like

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -290,4 +290,35 @@ C.f2(1)
 C().f2(1)
 ```
 
+## Types are not bound-method descriptors
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+The callable type of a type object is not function-like.
+
+```py
+from typing import ClassVar
+from ty_extensions import CallableTypeOf
+
+class WithNew:
+    def __new__(self, x: int) -> WithNew:
+        return super().__new__(WithNew)
+
+class WithInit:
+    def __init__(self, x: int) -> None:
+        pass
+
+class C:
+    with_new: ClassVar[CallableTypeOf[WithNew]]
+    with_init: ClassVar[CallableTypeOf[WithInit]]
+
+C.with_new(1)
+C().with_new(1)
+C.with_init(1)
+C().with_init(1)
+```
+
 [`tensorbase`]: https://github.com/pytorch/pytorch/blob/f3913ea641d871f04fa2b6588a77f63efeeb9f10/torch/_tensor.py#L1084-L1092

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1222,7 +1222,7 @@ impl<'db> ClassType<'db> {
             let dunder_new_bound_method = CallableType::new(
                 db,
                 dunder_new_signature.bind_self(db, Some(instance_ty)),
-                CallableTypeKind::FunctionLike,
+                CallableTypeKind::Regular,
             );
 
             if returns_non_subclass {
@@ -1292,7 +1292,7 @@ impl<'db> ClassType<'db> {
                 Some(CallableType::new(
                     db,
                     synthesized_dunder_init_signature,
-                    CallableTypeKind::FunctionLike,
+                    CallableTypeKind::Regular,
                 ))
             } else {
                 None


### PR DESCRIPTION
## Summary

The callable type of a type object should not be considered function-like.

I'm not sure if this is possible to trigger with realistic Python code; I was only able to exercise it using `CallableTypeOf`. But it still seems worth fixing.

## Test Plan

Added mdtest that failed before this PR.
