### PR TITLE
[ty] Add a conformance script to compare ty diagnostics with expected errors

### DIFF
--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -412,8 +412,8 @@ def render_grouped_diagnostics(
     ):
         group = list(group)
 
-        lines.append(f"## {classification.into_title()}:")
-        lines.append("")
+        lines.append(f"## {classification.into_title()}")
+        lines.extend(["", "<details>", ""])
 
         lines.extend(header)
 
@@ -421,6 +421,7 @@ def render_grouped_diagnostics(
             lines.append(diag.display(format=format))
 
         lines.append(footer)
+        lines.extend(["", "</details>", ""])
 
     return "\n".join(lines)
 
@@ -433,8 +434,8 @@ def diff_format(
     is_percentage: bool = False,
 ):
     increased = diff > 0
-    good = "(✅)" if not neutral else ""
-    bad = "(❌)" if not neutral else ""
+    good = " (✅)" if not neutral else ""
+    bad = " (❌)" if not neutral else ""
     up = "⏫"
     down = "⏬"
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

I had a go at improving the typing conformance workflow. I compared the path and beginning line from `ty`'s `gitlab` output to the path and line numbers matching "# E" in the conformance suite. Based on the presence of a corresponding error in the conformance tests, I broke out the diagnostics on the current branch into groups (true positives, false positives, etc.) that changed compared to the merge base. I've used Github's diff syntax to make new positives appear in green and new negatives appear in red (displaying the old diagnostic). I've also added a summary with counts for each group and a sentence indicating whether performance improved overall.

Here's a standalone version of the script comparing `0.0.1a35` to `0.0.7`.

<details>
  <summary>conformance.sh</summary>

```console

#!/bin/bash

git clone git@github.com:python/typing.git || true

uvx 'ty@@0.0.1a35' check \
  typing/conformance/tests \
  --output-format gitlab \
  | jq '.[] |
    .key = .location?.path? + ":" + (.location?.positions?.begin?.line? | tostring) |
    .source = "old"
  ' \
  > old.jsonl

uvx 'ty@0.0.7' check \
  typing/conformance/tests \
  --output-format gitlab \
  | jq '.[] |
    .key = .location?.path? + ":" + (.location?.positions?.begin?.line? | tostring) |
    .source = "new"
  ' \
  > new.jsonl

rg '# E\:?' typing/conformance/tests \
  --json \
  | jq '
    select(.type == "match") |
    {
      key: (.data?.path?.text? + ":" + (.data?.line_number? | tostring)),
      source: "expected"
    }' \
  > expected.jsonl

jq -s -r '
  def xor($a; $b): ($a or $b) and (($a and $b) | not);
  def has($a; $b): $a | index($b) != null;
  def missing($a; $b): $a | index($b) == null;
  def severity_to_level:
    {
      "major": "error",
      "minor": "warning",
      "info": "note"
    }[.] // "error";
    def to_concise($d): "\($d.location.path | gsub("^.*typing"; "typing")):" +
      "\($d.location.positions.begin.line):\($d.location.positions.begin.column): " +
      "\( $d.severity | severity_to_level)[\($d.check_name)]" +
      "\($d.description | gsub("^[a-z-]*:"; ""))";
  def ascii_titlecase:
      split(" ") | map((.[0:1] | ascii_upcase) + .[1:]) | join(" ");
  def sign($s):
    if $s | contains("positive") then "+ " else "- " end;
  group_by(.key)
  | map({
      key: .[0].key,
      sources: (map(.source) | unique),
      changed: xor(
        has(map(.source); "new");
        has(map(.source); "old")
      ),
      classification: (
        if has(map(.source); "new") and has(map(.source); "expected") then "true_positive"
        elif has(map(.source); "new") and missing(map(.source); "expected") then "false_positive"
        elif missing(map(.source); "new") and has(map(.source); "expected") then "false_negative"
        elif missing(map(.source); "new") and missing(map(.source); "expected") then "true_negative"
        else "unknown"
        end
      ),
      old: map(select(.source == "old")) | first,
      new: map(select(.source == "new")) | first,
      expected: map(select(.source == "expected")) | first
    })
  | map(select(.changed))
  | map({
      classification: .classification?,
      concise: (
        if .classification == "true_positive" then to_concise(.new)
        elif .classification == "false_positive" then to_concise(.new)
        elif .classification == "false_negative" then to_concise(.old)
        elif .classification == "true_negative" then to_concise(.old)
        else "unknown"
        end
      )
    })
  | group_by(.classification)
  | .[]
  | "### \(. [0].classification | gsub("_"; " ") | ascii_titlecase)s\n"
    + "\n```diff\n"
    + (map(sign(.classification) + .concise) | join("\n"))
    + "\n```\n"
' old.jsonl \
  new.jsonl \
  expected.jsonl \
  > changed.md

jq -s -r '
  def has($a; $b): $a | index($b) != null;
  def stats(fp_source):
    map(select(has(.source; fp_source) or has(.source; "expected")))
    | group_by(.key)
    | map(map(.source) | unique)
    | reduce .[] as $s (
        { tp: 0, fp: 0, fn: 0 };
        if      $s == [fp_source]  then .fp += 1
        elif    $s == ["expected"] then .fn += 1
        elif    ($s | length == 2) then .tp += 1
        else .
        end
      )
    | .precision = (if (.tp + .fp) > 0 then .tp / (.tp + .fp) else 1 end)
    | .recall    = (if (.tp + .fn) > 0 then .tp / (.tp + .fn) else 1 end);
  def sign(x):
    if x > 0 then "+"
    elif x < 0 then "-"
    else "±0"
    end;
  def trend(x):
    if x > 0 then "improves"
    elif x < 0 then "regresses"
    else "does not change"
    end;
  def pct(x):
    (x * 100 | tostring | .[0:5]) + "%";
  def summary:
    [
      "## Typing Conformance",
      "\n",
      "### Summary",
      "\n",
      "| Metric     | Old | New | Δ |",
      "|------------|-----|-----|---|",
      "| True Positives | \(.old.tp) | \(.new.tp) | \(.new.tp - .old.tp) |",
      "| False Positives | \(.old.fp) | \(.new.fp) | \(.new.fp - .old.fp) |",
      "| False Negatives | \(.old.fn) | \(.new.fn) | \(.new.fn - .old.fn) |",
      "| Precision  | \(pct(.old.precision)) | \(pct(.new.precision)) | \(sign(.comparison.precision_delta))\(pct(.comparison.precision_delta)) |",
      "| Recall     | \(pct(.old.recall)) | \(pct(.new.recall)) | \(sign(.comparison.recall_delta))\(pct(.comparison.recall_delta)) |",
      "",
      (
        "Compared to the current merge base, this PR "
        + trend(.comparison.precision_delta)
        + " precision and "
        + trend(.comparison.recall_delta)
        + " recall "
        + "(TP: \(.new.tp - .old.tp), "
        + "FP: \(.new.fp - .old.fp), "
        + "FN: \(.new.fn - .old.fn))."
      )
    ]
    | join("\n");
  {
    new: stats("new"),
    old: stats("old")
  }
  | .comparison = {
      precision_delta: (.new.precision - .old.precision),
      recall_delta:    (.new.recall    - .old.recall)
    }
  | summary
' \
new.jsonl \
old.jsonl \
expected.jsonl \
> stats.md

{
  cat stats.md
  echo
  cat changed.md
} > comment.md


```
</details>

Which produces the following markdown output:

<details>
  <summary>comment.md</summary>

## Typing Conformance


### Summary


| Metric     | Old | New | Δ |
|------------|-----|-----|---|
| True Positives | 647 | 654 | 7 |
| False Positives | 227 | 227 | 0 |
| False Negatives | 539 | 532 | -7 |
| Precision  | 74.02% | 74.23% | +0.206% |
| Recall     | 54.55% | 55.14% | +0.590% |

Compared to the current merge base, this PR improves precision and improves recall (TP: 7, FP: 0, FN: -7).

### False Positives

```diff
+ typing/conformance/tests/constructors_callable.py:143:27: error[invalid-argument-type] Argument to function `accepts_callable` is incorrect: Expected `() -> Any | Class6Any`, found `<class 'Class6Any'>`
+ typing/conformance/tests/constructors_callable.py:145:1: error[type-assertion-failure] Type `Any` does not match asserted type `Any | Class6Any`
+ typing/conformance/tests/dataclasses_transform_converter.py:102:42: error[invalid-argument-type] Argument to function `model_field` is incorrect: Expected `(str | bytes, /) -> ConverterClass`, found `<class 'ConverterClass'>`
+ typing/conformance/tests/dataclasses_transform_converter.py:103:31: error[invalid-argument-type] Argument to function `model_field` is incorrect: Expected `(str | list[str], /) -> int`, found `Overload[(s: str) -> int, (s: list[str]) -> int]`
+ typing/conformance/tests/dataclasses_transform_converter.py:104:30: error[invalid-assignment] Object of type `dict[str, str] | dict[bytes, bytes]` is not assignable to `dict[str, str]`
```

### True Negatives

```diff
- typing/conformance/tests/constructors_callable.py:128:1: error[type-assertion-failure] Argument does not have asserted type `Class6Proxy`
- typing/conformance/tests/constructors_callable.py:37:1: error[type-assertion-failure] Argument does not have asserted type `Class1`
- typing/conformance/tests/constructors_callable.py:50:1: error[type-assertion-failure] Argument does not have asserted type `Class2`
- typing/conformance/tests/constructors_callable.py:65:1: error[type-assertion-failure] Argument does not have asserted type `Class3`
- typing/conformance/tests/constructors_callable.py:80:1: error[type-assertion-failure] Argument does not have asserted type `int`
```

### True Positives

```diff
+ typing/conformance/tests/constructors_callable.py:146:8: error[too-many-positional-arguments] Too many positional arguments: expected 0, got 1
+ typing/conformance/tests/constructors_callable.py:186:4: error[invalid-argument-type] Argument is incorrect: Expected `list[T@Class8]`, found `list[Unknown | int]`
+ typing/conformance/tests/dataclasses_transform_converter.py:133:31: error[invalid-argument-type] Argument to function `model_field` is incorrect: Expected `(str | int, /) -> int`, found `def converter_simple(s: str) -> int`
+ typing/conformance/tests/dataclasses_usage.py:88:14: error[invalid-assignment] Object of type `dataclasses.Field[str | int]` is not assignable to `int`
+ typing/conformance/tests/namedtuples_usage.py:43:5: error[non-subscriptable] Cannot delete subscript on object of type `Point` with no `__delitem__` method
+ typing/conformance/tests/typeddicts_extra_items.py:128:15: error[invalid-argument-type] Cannot delete required key "name" from TypedDict `MovieEI`
+ typing/conformance/tests/typeddicts_operations.py:49:11: error[invalid-argument-type] Cannot delete required key "name" from TypedDict `Movie`
```

</details>

Partially addresses [#2205](https://github.com/astral-sh/ty/issues/2205).



## Test Plan

<!-- How was it tested? -->

I have only tested the standalone version of this. I think I'd need some guidance on how to test the action if you think this is worth merging. For example, I'm just piping the markdown content into the original diff file.

-------

Edit: I've replaced the inline `jq` script with a python version at `scripts/conformance.py`. Invoking that script with e.g. 

```
uv run scripts/conformance.py --target ../typing/conformance/tests/
```

produces the same output assuming the `typing` repository has been cloned into the same parent as `ruff`. I also noticed in the interim that some errors in the conformance suite are tagged as accepted in one or more of a set of lines or are marked as optional, which I haven't yet implemented here. Instead, every line with a "# E" is currently matched to a single diagnostic on the same line in the old and new `ty` versions.