### PR TITLE
[ty] support __new__ return type in constructor calls

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -430,3 +430,26 @@ reveal_type(C())  # revealed: C
 # Meta.__lt__ is implicitly called here:
 reveal_type(C < C)  # revealed: Literal[True]
 ```
+
+## `__new__` return type
+
+When a class has a `__new__` method with a custom return type annotation,
+that return type should be used when calling the class constructor.
+
+```py
+from typing import TypeVar
+
+class SimpleField:
+    def __new__(cls, **kwargs) -> str:
+      return super().__new__(cls)
+
+x = SimpleField()
+reveal_type(x)  # revealed: str
+
+class IntField:
+    def __new__(cls) -> int:
+      return super().__new__(cls)
+
+y = IntField()
+reveal_type(y)  # revealed: int
+```


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

fix https://github.com/astral-sh/ty/issues/281

When a class defines a `__new__` method with a custom return type annotation, that return type is now used when calling the class constructor.

## Test Plan

Added test cases.