### PR TITLE
[ty] Limit the returned completions to reduce lag

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -117,6 +117,9 @@ impl<'db> Completions<'db> {
         self.items.sort_by(|c1, c2| self.context.compare(c1, c2));
         self.items
             .dedup_by(|c1, c2| (&c1.name, c1.module_name) == (&c2.name, c2.module_name));
+        // A user should refine its completion request if the searched symbol doesn't appear in the first 1k results.
+        // Serializing/deserializing 1k completions can be expensive and result in noticeable lag.
+        self.items.truncate(1000);
         self.items
     }
 

--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -224,7 +224,7 @@ where
             // Test again if the request was cancelled since it was scheduled on the background task
             // and, if so, return early
             if cancellation_token.is_cancelled() {
-                tracing::trace!(
+                tracing::debug!(
                     "Ignoring request id={id} method={} because it was cancelled",
                     R::METHOD
                 );
@@ -291,7 +291,7 @@ where
             // Test again if the request was cancelled since it was scheduled on the background task
             // and, if so, return early
             if cancellation_token.is_cancelled() {
-                tracing::trace!(
+                tracing::debug!(
                     "Ignoring request id={id} method={} because it was cancelled",
                     R::METHOD
                 );
@@ -325,14 +325,14 @@ fn panic_response<R>(
         // If the query supports retry, re-queue the request.
         // The query is still likely to succeed if the user modified any other document.
         if let Some(request) = request {
-            tracing::trace!(
+            tracing::debug!(
                 "request id={} method={} was cancelled by salsa, re-queueing for retry",
                 request.id,
                 request.method
             );
             client.retry(request);
         } else {
-            tracing::trace!(
+            tracing::debug!(
                 "request id={} was cancelled by salsa, sending content modified",
                 id
             );

--- a/crates/ty_server/src/server/main_loop.rs
+++ b/crates/ty_server/src/server/main_loop.rs
@@ -110,11 +110,11 @@ impl Server {
                             .complete(&response.id)
                         {
                             let duration = start_time.elapsed();
-                            tracing::trace!(name: "message response", method, %response.id, duration = format_args!("{:0.2?}", duration));
+                            tracing::debug!(name: "message response", method, %response.id, duration = format_args!("{:0.2?}", duration));
 
                             self.connection.sender.send(Message::Response(response))?;
                         } else {
-                            tracing::trace!(
+                            tracing::debug!(
                                 "Ignoring response for canceled request id={}",
                                 response.id
                             );


### PR DESCRIPTION
## Summary

Reduce the number of completions sent to clients to reduce serialization/deserialization overhead, thereby reducing lag.

Serializing large responses can cause noticeable lag because serialization occurs on the server's main thread. 
Not only is serializing large responses expensive on the server, but deserializing them is equally expensive for the client. 

This PR limits the number of completions sent to the client to at most 1k. I picked the number rather arbitrarily, and we could maybe even go as low as 100
But the serialization/deserialization cost between 100 and 1000 is minimal. 


I also made some changes to our tracing setup, which allowed me to debug this more easily:

* Change the response logging from `trace` to `debug`, it includes the end-to-end time it took to process a response (including wait time for an available worker thread and serialization)
* Add spans to `all_symbols` and `workspace_symbols` so that tracing preserves the request information for the spawned tasks running on a worker thread (tracing now logs that `symbols_for_file_globals_only` is part of the `completions `request`)


Mitigates https://github.com/astral-sh/ty/issues/2254

## Test Plan

**before**


https://github.com/user-attachments/assets/ced8ab40-20dd-4291-af08-e8544c574ca2

**After**


https://github.com/user-attachments/assets/3873e4f0-bae8-41d4-a102-6da6fe1e2967

