### PR TITLE
Don't run ruff-ecosystem on PRs that only touch ruff_benchmark

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -994,7 +994,6 @@ jobs:
       (
         github.ref == 'refs/heads/main' ||
         needs.determine_changes.outputs.ty == 'true' ||
-        needs.determine_changes.outputs.parser == 'true' ||
         needs.determine_changes.outputs.benchmarks == 'true'
       )
     timeout-minutes: 20
@@ -1080,7 +1079,6 @@ jobs:
         (
           needs.determine_changes.outputs.ty == 'true' ||
           needs.determine_changes.outputs.benchmarks == 'true' ||
-          needs.determine_changes.outputs.parser == 'true' ||
           github.ref == 'refs/heads/main'
         )
       )


### PR DESCRIPTION
## Summary

Currently we run the ruff-ecosystem CI job on any PR that touches the `ruff_benchmark` crate. This seems a bit silly, since it takes a while for this job to complete, and nowadays most commits touching the `ruff_benchmark` crate are just bumping assertions regarding the expected number of ty diagnostics.

This PR refines the logic in `ci.yaml` so that the ruff-ecosystem check only runs if code related to the linter or the formatter is changed. The benchmark job is also updated, so that the Ruff benchmarks run if code relating to the linter/formatter/parser/benchmarks changed, and the ty benchmarks run if code relating to the parser/type-checker/benchmarks changed.

The downside is that `ci.yaml` becomes even more complicated. We could consider splitting this workflow up into several workflow files to reduce its complexity.

## Test Plan

No idea.
