### PR TITLE
renovate: don't bump npm devDependencies every week

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -81,12 +81,6 @@
       description: "Weekly update of pre-commit dependencies",
     },
     {
-      groupName: "NPM Development dependencies",
-      matchManagers: ["npm"],
-      matchDepTypes: ["devDependencies"],
-      description: "Weekly update of NPM development dependencies",
-    },
-    {
       groupName: "Monaco",
       matchManagers: ["npm"],
       matchPackageNames: ["monaco"],


### PR DESCRIPTION
## Summary

This weekly bump is noisy and overwrites our range constraints, which serves no purpose since we're locking our JS dependencies anyways.

See #22248 for context.

## Test Plan

NFC.