### PR TITLE
Bump shellcheck to the latest version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,10 +129,10 @@ repos:
           # actionlint has a shellcheck integration which extracts shell scripts in `run:` steps from GitHub Actions
           # and checks these with shellcheck. This is arguably its most useful feature,
           # but the integration only works if shellcheck is installed
-          - "github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.10.0"
+          - "github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1"
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
 


### PR DESCRIPTION
## Summary

This dependency isn't updated by Renovate because Renovate can only update `additional_dependencies` in `.pre-commit-config.yaml` if they're additional Python dependencies for a Python pre-commit hook, or additional node dependencies for a node pre-commit hook. In this case, it's an additional Go dependency for a Go pre-commit hook (x-ref https://github.com/renovatebot/renovate/pull/39469).

Renovate should be able to update the separate shellcheck-py hook, though. Not sure why that one was so stale.

## Test Plan

`uvx prek run -a --hook-stage=manual`
