### PR TITLE
[ty] Avoid showing misleading hint for unpacked tuple arguments

### DIFF
--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -788,6 +788,12 @@ pub fn inlay_hint_call_argument_details<'db>(
             continue;
         }
 
+        // Skip if this argument maps to multiple parameters (e.g., unpacked tuple filling
+        // multiple slots). Showing a single parameter name would be misleading.
+        if arg_mapping.parameters.len() > 1 {
+            continue;
+        }
+
         let Some(param_index) = arg_mapping.parameters.first() else {
             continue;
         };


### PR DESCRIPTION
## Summary

We could implement support for showing multiple argument names, though this seems to match PyCharm.

Closes https://github.com/astral-sh/ty/issues/2250.
