### PR TITLE
[ty] Try eliminating `~AlwaysFalsy` and `~AlwaysTruthy` from intersections

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -194,7 +194,7 @@ static SYMPY: Benchmark = Benchmark::new(
         max_dep_date: "2025-06-17",
         python_version: PythonVersion::PY312,
     },
-    13106,
+    13109,
 );
 
 static TANJUN: Benchmark = Benchmark::new(

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -32,11 +32,11 @@ reveal_type(l3)  # revealed: list[int | str]
 
 def _(l: list[int] | None = None):
     l1 = l or list()
-    reveal_type(l1)  # revealed: (list[int] & ~AlwaysFalsy) | list[Unknown]
+    reveal_type(l1)  # revealed: list[int] | list[Unknown]
 
     l2: list[int] = l or list()
     # it would be better if this were `list[int]`? (https://github.com/astral-sh/ty/issues/136)
-    reveal_type(l2)  # revealed: (list[int] & ~AlwaysFalsy) | list[Unknown]
+    reveal_type(l2)  # revealed: list[int] | list[Unknown]
 
 def f[T](x: T, cond: bool) -> T | list[T]:
     return x if cond else [x]
@@ -91,7 +91,7 @@ def get_data() -> dict | None:
 def wrap_data() -> list[dict]:
     if not (res := get_data()):
         return list1({})
-    reveal_type(list1(res))  # revealed: list[dict[Unknown, Unknown] & ~AlwaysFalsy]
+    reveal_type(list1(res))  # revealed: list[dict[Unknown, Unknown]]
     # `list[dict[Unknown, Unknown] & ~AlwaysFalsy]` and `list[dict[Unknown, Unknown]]` are incompatible,
     # but the return type check passes here because the type of `list1(res)` is inferred
     # by bidirectional type inference using the annotated return type, and the type of `res` is not used.
@@ -100,7 +100,7 @@ def wrap_data() -> list[dict]:
 def wrap_data2() -> list[dict] | None:
     if not (res := get_data()):
         return None
-    reveal_type(list1(res))  # revealed: list[dict[Unknown, Unknown] & ~AlwaysFalsy]
+    reveal_type(list1(res))  # revealed: list[dict[Unknown, Unknown]]
     return list1(res)
 
 def deco[T](func: Callable[[], T]) -> Callable[[], T]:
@@ -111,7 +111,7 @@ def outer() -> Callable[[], list[dict]]:
     def inner() -> list[dict]:
         if not (res := get_data()):
             return list1({})
-        reveal_type(list1(res))  # revealed: list[dict[Unknown, Unknown] & ~AlwaysFalsy]
+        reveal_type(list1(res))  # revealed: list[dict[Unknown, Unknown]]
         return list1(res)
     return inner
 

--- a/crates/ty_python_semantic/resources/mdtest/call/union.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/union.md
@@ -189,7 +189,7 @@ def _(
     h: Literal[42] | Not[Literal[42]],
     i: Not[Literal[42]] | Literal[42],
 ):
-    reveal_type(a)  # revealed: Literal[""] | ~AlwaysFalsy
+    reveal_type(a)  # revealed: object
     reveal_type(b)  # revealed: object
     reveal_type(c)  # revealed: object
     reveal_type(d)  # revealed: object

--- a/crates/ty_python_semantic/resources/mdtest/comparison/integers.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/integers.md
@@ -13,7 +13,7 @@ reveal_type(1 is not 1)  # revealed: bool
 reveal_type(1 is 2)  # revealed: Literal[False]
 reveal_type(1 is not 7)  # revealed: Literal[True]
 # error: [unsupported-operator] "Operator `<=` is not supported between objects of type `Literal[1]` and `Literal[""]`"
-reveal_type(1 <= "" and 0 < 1)  # revealed: (Unknown & ~AlwaysTruthy) | Literal[True]
+reveal_type(1 <= "" and 0 < 1)  # revealed: Unknown | Literal[True]
 ```
 
 ## Integer instance

--- a/crates/ty_python_semantic/resources/mdtest/comparison/non_bool_returns.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/non_bool_returns.md
@@ -37,7 +37,7 @@ class C:
         return self
 
 x = A() < B() < C()
-reveal_type(x)  # revealed: (A & ~AlwaysTruthy) | B
+reveal_type(x)  # revealed: A | B
 
 y = 0 < 1 < A() < 3
 reveal_type(y)  # revealed: Literal[False] | A

--- a/crates/ty_python_semantic/resources/mdtest/expression/boolean.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/boolean.md
@@ -10,8 +10,8 @@ def _(foo: str):
     reveal_type(False or "z")  # revealed: Literal["z"]
     reveal_type(False or True)  # revealed: Literal[True]
     reveal_type(False or False)  # revealed: Literal[False]
-    reveal_type(foo or False)  # revealed: (str & ~AlwaysFalsy) | Literal[False]
-    reveal_type(foo or True)  # revealed: (str & ~AlwaysFalsy) | Literal[True]
+    reveal_type(foo or False)  # revealed: str | Literal[False]
+    reveal_type(foo or True)  # revealed: str | Literal[True]
 ```
 
 ## AND
@@ -20,8 +20,8 @@ def _(foo: str):
 def _(foo: str):
     reveal_type(True and False)  # revealed: Literal[False]
     reveal_type(False and True)  # revealed: Literal[False]
-    reveal_type(foo and False)  # revealed: (str & ~AlwaysTruthy) | Literal[False]
-    reveal_type(foo and True)  # revealed: (str & ~AlwaysTruthy) | Literal[True]
+    reveal_type(foo and False)  # revealed: str | Literal[False]
+    reveal_type(foo and True)  # revealed: str | Literal[True]
     reveal_type("x" and "y" and "z")  # revealed: Literal["z"]
     reveal_type("x" and "y" and "")  # revealed: Literal[""]
     reveal_type("" and "y")  # revealed: Literal[""]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/assert.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/assert.md
@@ -105,8 +105,8 @@ reveal_type(y)  # revealed: Unknown
 
 ```py
 def one(x: int | None):
-    assert (y := x), reveal_type(y)  # revealed: (int & ~AlwaysTruthy) | None
-    reveal_type(y)  # revealed: int & ~AlwaysFalsy
+    assert (y := x), reveal_type(y)  # revealed: int | None
+    reveal_type(y)  # revealed: int
 
 def two(x: int | None):
     assert isinstance((y := x), int), reveal_type(y)  # revealed: None

--- a/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
@@ -104,14 +104,14 @@ class C:
     value: str | None
 
 def foo(c: C):
-    # The truthiness check `c.value` narrows to `str & ~AlwaysFalsy`.
+    # The truthiness check `c.value` narrows to `str`.
     # The subsequent `len(c.value)` doesn't narrow further since `str` is not narrowable by len().
     if c.value and len(c.value):
-        reveal_type(c.value)  # revealed: str & ~AlwaysFalsy
+        reveal_type(c.value)  # revealed: str
 
     # error: [invalid-argument-type] "Argument to function `len` is incorrect: Expected `Sized`, found `str | None`"
     if len(c.value) and c.value:
-        reveal_type(c.value)  # revealed: str & ~AlwaysFalsy
+        reveal_type(c.value)  # revealed: str
 
     if c.value is None or not len(c.value):
         reveal_type(c.value)  # revealed: str | None

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/nested.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/nested.md
@@ -299,7 +299,7 @@ def f(l: list[str | None] | None):
 def f(a: A):
     if a:
         def _():
-            reveal_type(a)  # revealed: A & ~AlwaysFalsy
+            reveal_type(a)  # revealed: A
     a.x = None
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -365,12 +365,12 @@ def f(
     if isinstance(c, bool):
         reveal_type(c)  # revealed: Never
     else:
-        reveal_type(c)  # revealed: P & ~AlwaysTruthy
+        reveal_type(c)  # revealed: P
 
     if isinstance(d, bool):
         reveal_type(d)  # revealed: Never
     else:
-        reveal_type(d)  # revealed: P & ~AlwaysFalsy
+        reveal_type(d)  # revealed: P
 ```
 
 ## Narrowing if an object of type `Any` or `Unknown` is used as the second argument

--- a/crates/ty_python_semantic/resources/mdtest/narrow/len.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/len.md
@@ -58,9 +58,9 @@ and `tuple[()]` in the negative case (see <https://github.com/astral-sh/ty/issue
 ```py
 def _(x: tuple[int, ...]):
     if len(x):
-        reveal_type(x)  # revealed: tuple[int, ...] & ~AlwaysFalsy
+        reveal_type(x)  # revealed: tuple[int, ...]
     else:
-        reveal_type(x)  # revealed: tuple[int, ...] & ~AlwaysTruthy
+        reveal_type(x)  # revealed: tuple[int, ...]
 ```
 
 ## Unions of narrowable types
@@ -70,9 +70,9 @@ from typing import Literal
 
 def _(x: Literal["foo", ""] | tuple[int, ...]):
     if len(x):
-        reveal_type(x)  # revealed: Literal["foo"] | (tuple[int, ...] & ~AlwaysFalsy)
+        reveal_type(x)  # revealed: Literal["foo"] | tuple[int, ...]
     else:
-        reveal_type(x)  # revealed: Literal[""] | (tuple[int, ...] & ~AlwaysTruthy)
+        reveal_type(x)  # revealed: Literal[""] | tuple[int, ...]
 ```
 
 ## Types that are not narrowed
@@ -119,13 +119,13 @@ def _(lines: list[str]):
         if not line:
             continue
 
-        reveal_type(line)  # revealed: str & ~AlwaysFalsy
+        reveal_type(line)  # revealed: str
         value = line if len(line) < 3 else ""
-        reveal_type(value)  # revealed: (str & ~AlwaysFalsy) | Literal[""]
+        reveal_type(value)  # revealed: str
 
         if len(value):
             # `Literal[""]` is removed, `str & ~AlwaysFalsy` is unchanged
-            reveal_type(value)  # revealed: str & ~AlwaysFalsy
+            reveal_type(value)  # revealed: str
             # Accessing value[0] is safe here
             _ = value[0]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -82,19 +82,19 @@ class B: ...
 
 def f(x: A | B):
     if x:
-        reveal_type(x)  # revealed: (A & ~AlwaysFalsy) | (B & ~AlwaysFalsy)
+        reveal_type(x)  # revealed: A | B
     else:
-        reveal_type(x)  # revealed: (A & ~AlwaysTruthy) | (B & ~AlwaysTruthy)
+        reveal_type(x)  # revealed: A | B
 
     if x and not x:
-        reveal_type(x)  # revealed: (A & ~AlwaysFalsy & ~AlwaysTruthy) | (B & ~AlwaysFalsy & ~AlwaysTruthy)
+        reveal_type(x)  # revealed: A | B
     else:
         reveal_type(x)  # revealed: A | B
 
     if x or not x:
         reveal_type(x)  # revealed: A | B
     else:
-        reveal_type(x)  # revealed: (A & ~AlwaysTruthy & ~AlwaysFalsy) | (B & ~AlwaysTruthy & ~AlwaysFalsy)
+        reveal_type(x)  # revealed: A | B
 ```
 
 ### Truthiness of Types
@@ -111,9 +111,9 @@ x = int if flag() else str
 reveal_type(x)  # revealed: <class 'int'> | <class 'str'>
 
 if x:
-    reveal_type(x)  # revealed: (<class 'int'> & ~AlwaysFalsy) | (<class 'str'> & ~AlwaysFalsy)
+    reveal_type(x)  # revealed: <class 'int'> | <class 'str'>
 else:
-    reveal_type(x)  # revealed: (<class 'int'> & ~AlwaysTruthy) | (<class 'str'> & ~AlwaysTruthy)
+    reveal_type(x)  # revealed: <class 'int'> | <class 'str'>
 ```
 
 ## Determined Truthiness
@@ -179,9 +179,9 @@ if isinstance(x, str) and not isinstance(x, B):
     reveal_type(z)  # revealed: (A & str & ~B) | Literal[0, 42, "", "hello"]
 
     if z:
-        reveal_type(z)  # revealed: (A & str & ~B & ~AlwaysFalsy) | Literal[42, "hello"]
+        reveal_type(z)  # revealed: (A & str & ~B) | Literal[42, "hello"]
     else:
-        reveal_type(z)  # revealed: (A & str & ~B & ~AlwaysTruthy) | Literal[0, ""]
+        reveal_type(z)  # revealed: (A & str & ~B) | Literal[0, ""]
 ```
 
 ## Narrowing Multiple Variables
@@ -219,7 +219,7 @@ x = A()
 
 if x and not x:
     y = x
-    reveal_type(y)  # revealed: A & ~AlwaysFalsy & ~AlwaysTruthy
+    reveal_type(y)  # revealed: A
 else:
     y = x
     reveal_type(y)  # revealed: A
@@ -264,16 +264,16 @@ def _(
 ):
     reveal_type(ta)  # revealed: type[TruthyClass] | type[AmbiguousClass]
     if ta:
-        reveal_type(ta)  # revealed: type[TruthyClass] | (type[AmbiguousClass] & ~AlwaysFalsy)
+        reveal_type(ta)  # revealed: type[TruthyClass] | type[AmbiguousClass]
 
     reveal_type(af)  # revealed: type[AmbiguousClass] | type[FalsyClass]
     if af:
-        reveal_type(af)  # revealed: type[AmbiguousClass] & ~AlwaysFalsy
+        reveal_type(af)  # revealed: type[AmbiguousClass]
 
     # error: [unsupported-bool-conversion] "Boolean conversion is not supported for type `MetaDeferred`"
     if d:
         # TODO: Should be `Unknown`
-        reveal_type(d)  # revealed: type[DeferredClass] & ~AlwaysFalsy
+        reveal_type(d)  # revealed: type[DeferredClass]
 
     tf = TruthyClass if flag else FalsyClass
     reveal_type(tf)  # revealed: <class 'TruthyClass'> | <class 'FalsyClass'>
@@ -296,12 +296,12 @@ def _(x: Literal[0, 1]):
     reveal_type(x and A())  # revealed: Literal[0] | A
 
 def _(x: str):
-    reveal_type(x or A())  # revealed: (str & ~AlwaysFalsy) | A
-    reveal_type(x and A())  # revealed: (str & ~AlwaysTruthy) | A
+    reveal_type(x or A())  # revealed: str | A
+    reveal_type(x and A())  # revealed: str | A
 
 def _(x: bool | str):
-    reveal_type(x or A())  # revealed: Literal[True] | (str & ~AlwaysFalsy) | A
-    reveal_type(x and A())  # revealed: Literal[False] | (str & ~AlwaysTruthy) | A
+    reveal_type(x or A())  # revealed: Literal[True] | str | A
+    reveal_type(x and A())  # revealed: Literal[False] | str | A
 
 class Falsy:
     def __bool__(self) -> Literal[False]:

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -140,7 +140,7 @@ type IntOrStr = int | str
 
 def f(x: IntOrStr, y: str | bytes):
     z = x or y
-    reveal_type(z)  # revealed: (int & ~AlwaysFalsy) | str | bytes
+    reveal_type(z)  # revealed: int | str | bytes
 ```
 
 ## Multiple layers of union aliases

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1545,9 +1545,12 @@ impl KnownFunction {
                 {
                     let mut diag = builder.into_diagnostic("Revealed type");
                     let span = context.span(&call_expression.arguments.args[0]);
+                    // Remove ~AlwaysTruthy and ~AlwaysFalsy constraints for cleaner display,
+                    // as they make types more confusing without adding useful information.
+                    let display_type = revealed_type.remove_truthiness_constraints(db);
                     diag.annotate(Annotation::primary(span).message(format_args!(
                         "`{}`",
-                        revealed_type
+                        display_type
                             .display_with(db, DisplaySettings::default().preserve_long_unions())
                     )));
                 }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -750,7 +750,7 @@ pub struct Specialization<'db> {
 
     /// For specializations of `tuple`, we also store more detailed information about the tuple's
     /// elements, above what the class's (single) typevar can represent.
-    tuple_inner: Option<TupleType<'db>>,
+    pub(super) tuple_inner: Option<TupleType<'db>>,
 }
 
 // The Salsa heap is tracked separately.


### PR DESCRIPTION
## Summary

Following the instructions in https://github.com/astral-sh/ty/issues/2233, mostly to see the ecosystem impact.
