### PR TITLE
[ty] Add skip_dunders option to CompletionTestBuilder

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -2075,6 +2075,7 @@ fn token_suffix_by_kinds<const N: usize>(
 #[cfg(test)]
 mod tests {
     use insta::assert_snapshot;
+    use ruff_python_ast::helpers::is_dunder;
     use ruff_python_ast::token::{TokenKind, Tokens};
     use ruff_python_parser::{Mode, ParseOptions};
     use ty_module_resolver::ModuleName;
@@ -7562,9 +7563,7 @@ TypedDi<CURSOR>
                 .iter()
                 .filter(|c| !self.skip_builtins || !c.builtin)
                 .filter(|c| !self.skip_keywords || c.kind != Some(CompletionKind::Keyword))
-                .filter(|c| {
-                    !self.skip_dunders || !c.name.starts_with("__") || !c.name.ends_with("__")
-                })
+                .filter(|c| !self.skip_dunders || !is_dunder(&c.name))
                 .filter(|c| {
                     self.predicate
                         .as_ref()


### PR DESCRIPTION
This is useful to remove noise when asserting
snapshots on method or attribute completions.

## Summary

Most tests that checks completions on attributes and methods are written on the form `builder.build().contains("x").not_contains("y")` instead of asserting snapshots. These tests would be more robust if they were asserting exact snapshots (and IMO, in most cases also easier to read). This is however not really sustainable to do as long as we suggest dunders, as the snapshots become very large.

This adds a helper to skip dunder suggestions in the completion test builder.

## Test Plan
This only changes test ergonomics and is not enabled by default. A single test was changed to use this helper to avoid hitting dead code lints.
