### PR TITLE
[ty] increase the max number of diagnostics for `sympy` in `ty_walltime` benchmark

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -194,7 +194,7 @@ static SYMPY: Benchmark = Benchmark::new(
         max_dep_date: "2025-06-17",
         python_version: PythonVersion::PY312,
     },
-    13106,
+    13116,
 );
 
 static TANJUN: Benchmark = Benchmark::new(


### PR DESCRIPTION
## Summary

After #22088 was merged into main, CI failures are occurring due to sympy diagnostic counts slightly exceeding the configured maximum.

## Test Plan

N/A
