### PR TITLE
Bump docstring-adder pin

### DIFF
--- a/scripts/codemod_docstrings.sh
+++ b/scripts/codemod_docstrings.sh
@@ -18,7 +18,7 @@
 
 set -eu
 
-docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@93e8fdf5f65410c2aa88bc8523e3fc2a598e3917"
+docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@11ffed4b2bb56f2d2659afc3fe0916df025623a4"
 stdlib_path="./crates/ty_vendored/vendor/typeshed/stdlib"
 
 for python_version in 3.14 3.13 3.12 3.11 3.10 3.9


### PR DESCRIPTION
## Summary

Pulls in https://github.com/astral-sh/docstring-adder/commit/fbbce284c42245e014051cb9f1b7022381b45021 and https://github.com/astral-sh/docstring-adder/commit/480576ad0cb0b7e607ea17398bc2a63edb12c54a, which will mean that docstring-adder will add attribute docstrings to the stdlib

## Test Plan

I'll trigger a typeshed sync using this PR branch to check that everything's working as expected: https://github.com/astral-sh/ruff/actions/runs/20601501314