### PR TITLE
[ty] Remove `TY_MAX_PARALLELISM` as conformance runs no longer panic

### DIFF
--- a/.github/workflows/typing_conformance.yaml
+++ b/.github/workflows/typing_conformance.yaml
@@ -59,9 +59,6 @@ jobs:
 
       - name: Compute diagnostic diff
         shell: bash
-        env:
-          # TODO: Remove this once we fixed the remaining panics in the conformance suite.
-          TY_MAX_PARALLELISM: 1
         run: |
           RUFF_DIR="$GITHUB_WORKSPACE/ruff"
 


### PR DESCRIPTION
## Summary

The `# TODO` in workflow appears to be resolved running a local build of `main` with `TY_MAX_PARALLELISM` set/unset has the same behaviour (i.e no panics, same diagnostic count) except one is a bit faster ⚡ 


## Test Plan

```sh
TY_MAX_PARALLELISM=1 cargo run --bin ty check ~/dev/typing/conformance/ --output-format concise
...
Found 1324 diagnostics
```

```sh
cargo run --bin ty check ~/dev/typing/conformance/ --output-format concise
...
Found 1324 diagnostics
```

<!-- How was it tested? -->
