### PR TITLE
[ty] Prioritize real submodules over module `__getattr__`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/import/module_getattr.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/module_getattr.md
@@ -140,16 +140,16 @@ def __getattr__(name: Literal["known_attr"]) -> int:
 When a package defines a module-level `__getattr__`, we should expect real submodules to take precedence over that result.
 
 ```py
-import anyio
+import anyio_like
 
 # Submodule should be found as a real module, not via __getattr__
-reveal_type(anyio.to_thread.current_default_thread_limiter()) # revealed: int
+reveal_type(anyio_like.to_thread.current_default_thread_limiter()) # revealed: int
 
 # The alias handled by __getattr__ should still work
-reveal_type(anyio.BrokenWorkerIntepreter) # revealed: type[BrokenWorkerInterpreter]
+reveal_type(anyio_like.BrokenWorkerIntepreter) # revealed: type[BrokenWorkerInterpreter]
 ```
 
-`anyio/__init__.py`:
+`anyio_like/__init__.py`:
 
 ```py
 from ._core import BrokenWorkerInterpreter
@@ -162,14 +162,14 @@ def __getattr__(attr: str) -> type[BrokenWorkerInterpreter]:
     raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
 ```
 
-`anyio/_core.py`:
+`anyio_like/_core.py`:
 
 ```py
 class BrokenWorkerInterpreter(Exception):
     ...
 ```
 
-`anyio/to_thread.py`:
+`anyio_like/to_thread.py`:
 
 ```py
 def current_default_thread_limiter() -> int:

--- a/crates/ty_python_semantic/resources/mdtest/import/module_getattr.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/module_getattr.md
@@ -73,8 +73,8 @@ def __getattr__(name: str) -> str:
 value = 42
 ```
 
-If you `import mod` (without importing the submodule directly), accessing `mod.sub` will prefer
-the actual submodule if it exists, matching the behavior of other type checkers and user expectations.
+If you `import mod` (without importing the submodule directly), accessing `mod.sub` will prefer the
+actual submodule if it exists, matching the behavior of other type checkers and user expectations.
 
 `test_import_mod.py`:
 
@@ -137,23 +137,23 @@ def __getattr__(name: Literal["known_attr"]) -> int:
 
 ## Submodule wins over alias-only `__getattr__`
 
-When a package defines a module-level `__getattr__`, we should expect real submodules to take precedence over that result.
+When a package defines a module-level `__getattr__`, we should expect real submodules to take
+precedence over that result.
 
 ```py
 import anyio_like
 
 # Submodule should be found as a real module, not via __getattr__
-reveal_type(anyio_like.to_thread.current_default_thread_limiter()) # revealed: int
+reveal_type(anyio_like.to_thread.current_default_thread_limiter())  # revealed: int
 
 # The alias handled by __getattr__ should still work
-reveal_type(anyio_like.BrokenWorkerIntepreter) # revealed: type[BrokenWorkerInterpreter]
+reveal_type(anyio_like.BrokenWorkerIntepreter)  # revealed: type[BrokenWorkerInterpreter]
 ```
 
 `anyio_like/__init__.py`:
 
 ```py
 from ._core import BrokenWorkerInterpreter
-
 
 def __getattr__(attr: str) -> type[BrokenWorkerInterpreter]:
     if attr == "BrokenWorkerIntepreter":
@@ -165,8 +165,7 @@ def __getattr__(attr: str) -> type[BrokenWorkerInterpreter]:
 `anyio_like/_core.py`:
 
 ```py
-class BrokenWorkerInterpreter(Exception):
-    ...
+class BrokenWorkerInterpreter(Exception): ...
 ```
 
 `anyio_like/to_thread.py`:
@@ -226,8 +225,7 @@ class Qt:
 `pyside_like/QtWidgets.py`:
 
 ```py
-class QFileDialog:
-    ...
+class QFileDialog: ...
 ```
 
 ## Module `__getattr__` requires Python 3.7+

--- a/crates/ty_python_semantic/resources/mdtest/import/module_getattr.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/module_getattr.md
@@ -73,15 +73,15 @@ def __getattr__(name: str) -> str:
 value = 42
 ```
 
-If you `import mod` (without importing the submodule directly), accessing `mod.sub` will call
-`mod.__getattr__('sub')`, so `reveal_type(mod.sub)` will show the return type of `__getattr__`.
+If you `import mod` (without importing the submodule directly), accessing `mod.sub` will prefer
+the actual submodule if it exists, matching the behavior of other type checkers and user expectations.
 
 `test_import_mod.py`:
 
 ```py
 import mod
 
-reveal_type(mod.sub)  # revealed: str
+reveal_type(mod.sub)  # revealed: <module 'mod.sub'>
 ```
 
 If you `import mod.sub` (importing the submodule directly), then `mod.sub` refers to the actual

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -16,8 +16,8 @@ use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagno
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
-use ruff_python_ast::name::Name;
 use ruff_python_ast::PythonVersion;
+use ruff_python_ast::name::Name;
 use ruff_text_size::{Ranged, TextRange};
 use smallvec::{SmallVec, smallvec};
 use ty_module_resolver::{KnownModule, Module, ModuleName, resolve_module};
@@ -13590,13 +13590,14 @@ impl<'db> ModuleLiteralType<'db> {
         // discovered while indexing the package directory. This should ensure we pick
         // the real submodule over a package-level `__getattr__` return type when the
         // normal resolver can't find it (eg. when the submodule hasn't been imported yet).
-        let submodule = resolve_module(db, importing_file, &absolute_submodule_name).or_else(|| {
-            self.module(db)
-                .all_submodules(db)
-                .iter()
-                .copied()
-                .find(|candidate| candidate.name(db) == &absolute_submodule_name)
-        })?;
+        let submodule =
+            resolve_module(db, importing_file, &absolute_submodule_name).or_else(|| {
+                self.module(db)
+                    .all_submodules(db)
+                    .iter()
+                    .copied()
+                    .find(|candidate| candidate.name(db) == &absolute_submodule_name)
+            })?;
         Some(Type::module_literal(db, importing_file, submodule))
     }
 


### PR DESCRIPTION
Related to https://github.com/astral-sh/ty/issues/1053 (PySide6 submodules)
Related to https://github.com/astral-sh/ty/issues/1361 (aiohttp.web)
Related to https://github.com/astral-sh/ty/issues/133 (implicit submodule imports)


## Summary

This PR extends the work from [PR #21260](https://github.com/astral-sh/ruff/pull/21260) by adding:
1. **Improved submodule resolution**: Uses `all_submodules` fallback to discover real submodules on disk before falling back to `__getattr__`, ensuring packages like `anyio`, `aiohttp`, and `PySide6` resolve correctly
2. **Python version gate** for module `__getattr__` (PEP 562 requires Python 3.7+)
3. **Additional test coverage** for the submodule precedence behavior

Fixes an issue where the type checker would incorrectly use a module's `__getattr__` return type instead of recognizing real submodules that exist on disk.

**Example**

Before this change, accessing `anyio.to_thread` would return the type from `anyio.__getattr__()` even though `anyio/to_thread.py` exists as a real submodule:

```python
import anyio

# Before: returned type from __getattr__ (incorrect)
# After: correctly resolves to <module 'anyio.to_thread'>
reveal_type(anyio.to_thread.current_default_thread_limiter())  # revealed: int
```


There are two key decisions to consider before merging this PR:

### Python 3.7+ Version Gate

Module-level `__getattr__` was introduced in PEP 562 (Python 3.7). ty now correctly ignores `__getattr__` when targeting Python < 3.7, while still allowing stub files to use it on older versions. This [aligns with the pyright implementation](https://github.com/microsoft/pyright/blob/1576956c32c8b75f3202203f3cdedd21c8d3f9f7/packages/pyright-internal/src/analyzer/typeEvaluator.ts#L5997C15-L6019C22) and [not with the mypy implementation](https://github.com/python/mypy/blob/c5c12fad9e69525fa5b12058b328d284c5feecc4/mypy/checker.py#L2066C1-L2068C43). 

### Submodule vs `__getattr__` precedence

MyPy, Pyright, and this PR all prioritize real submodules over `__getattr__` return types, even though **at runtime** the precedence is reversed (module attributes win over submodules). This is a deliberate departure from runtime semantics based on the assumption that well-behaved `__getattr__` implementations will raise `AttributeError` for names that are also real submodules. This decision attempts to follow [PR #21260](https://github.com/astral-sh/ruff/pull/21260), which showed ecosystem improvements: ~364 false positives removed vs ~114 new diagnostics added. Major packages like `anyio`, `sklearn`, and `scipy` benefit from this behavior.

## Test Plan

All changes are covered by mdtests in `crates/ty_python_semantic/resources/mdtest/import/module_getattr.md`:

1. **Updated existing test**: Modified "Precedence: submodules vs `__getattr__`" to expect submodules to win (updated to match [PR #21260](https://github.com/astral-sh/ruff/pull/21260))
2. **Real-world scenario**: Tests anyio-like package with both `__getattr__` and real submodules
3. **Fallback behavior**: Verifies `__getattr__` still works when no matching submodule exists
4. **Complex packages**: Tests PySide-like packages with nested attribute access
5. **Python version**: Confirms `__getattr__` is ignored on Python 3.6
6. **Stub files**: Verifies stub files allow `__getattr__` on older Python versions
