### PR TITLE
Bump docstring-adder pin

### DIFF
--- a/scripts/codemod_docstrings.sh
+++ b/scripts/codemod_docstrings.sh
@@ -18,7 +18,7 @@
 
 set -eu
 
-docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@11ffed4b2bb56f2d2659afc3fe0916df025623a4"
+docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@c2ea1baeab2a1696ee67c4b1f59926361f69a087"
 stdlib_path="./crates/ty_vendored/vendor/typeshed/stdlib"
 
 for python_version in 3.14 3.13 3.12 3.11 3.10 3.9


### PR DESCRIPTION
## Summary

Pulls in https://github.com/astral-sh/docstring-adder/commit/938940acf99b4374c77863df705a40eb45808f1b and https://github.com/astral-sh/docstring-adder/commit/c2ea1baeab2a1696ee67c4b1f59926361f69a087, which mean:
- We get attribute docstrings for non-global-scope attributes
- Improved handling of `sys.version_info` conditions for attribute docstrings
- Improved formatting for attribute docstrings when they appear as the last statement in an `if` suite`, `elif` suite or `else` suite

## Test Plan

The scheduled typeshed-sync worfklow will run in a couple of hours and we'll be able to see if this wrecked anything by eyeballing the changes the bot makes in that PR
