### PR TITLE
[ty] Publish diagnostics for all open files (#1652)

### DIFF
--- a/crates/ty_server/src/capabilities.rs
+++ b/crates/ty_server/src/capabilities.rs
@@ -2,11 +2,12 @@ use lsp_types::{
     self as types, ClientCapabilities, CodeActionKind, CodeActionOptions, CompletionOptions,
     DeclarationCapability, DiagnosticOptions, DiagnosticServerCapabilities,
     HoverProviderCapability, InlayHintOptions, InlayHintServerCapabilities, MarkupKind,
-    NotebookCellSelector, NotebookSelector, OneOf, RenameOptions, SelectionRangeProviderCapability,
-    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
-    SemanticTokensServerCapabilities, ServerCapabilities, SignatureHelpOptions,
-    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
-    TypeDefinitionProviderCapability, WorkDoneProgressOptions,
+    NotebookCellSelector, NotebookSelector, OneOf, RenameOptions, SaveOptions,
+    SelectionRangeProviderCapability, SemanticTokensFullOptions, SemanticTokensLegend,
+    SemanticTokensOptions, SemanticTokensServerCapabilities, ServerCapabilities,
+    SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
+    TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability,
+    WorkDoneProgressOptions,
 };
 use std::str::FromStr;
 
@@ -407,6 +408,9 @@ pub(crate) fn server_capabilities(
             TextDocumentSyncOptions {
                 open_close: Some(true),
                 change: Some(TextDocumentSyncKind::INCREMENTAL),
+                save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
+                    include_text: Some(false),
+                })),
                 ..Default::default()
             },
         )),

--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -157,6 +157,9 @@ pub(super) fn notification(notif: server::Notification) -> Task {
         notifications::DidCloseNotebookHandler::METHOD => {
             sync_notification_task::<notifications::DidCloseNotebookHandler>(notif)
         }
+        notifications::DidSaveTextDocumentHandler::METHOD => {
+            sync_notification_task::<notifications::DidSaveTextDocumentHandler>(notif)
+        }
         notifications::DidChangeWatchedFiles::METHOD => {
             sync_notification_task::<notifications::DidChangeWatchedFiles>(notif)
         }

--- a/crates/ty_server/src/server/api/notifications.rs
+++ b/crates/ty_server/src/server/api/notifications.rs
@@ -6,6 +6,7 @@ mod did_close;
 mod did_close_notebook;
 mod did_open;
 mod did_open_notebook;
+mod did_save;
 
 pub(super) use cancel::CancelNotificationHandler;
 pub(super) use did_change::DidChangeTextDocumentHandler;
@@ -15,3 +16,4 @@ pub(super) use did_close::DidCloseTextDocumentHandler;
 pub(super) use did_close_notebook::DidCloseNotebookHandler;
 pub(super) use did_open::DidOpenTextDocumentHandler;
 pub(super) use did_open_notebook::DidOpenNotebookHandler;
+pub(super) use did_save::DidSaveTextDocumentHandler;

--- a/crates/ty_server/src/server/api/notifications/did_save.rs
+++ b/crates/ty_server/src/server/api/notifications/did_save.rs
@@ -1,0 +1,33 @@
+use lsp_types::DidSaveTextDocumentParams;
+use lsp_types::notification::DidSaveTextDocument;
+
+use crate::server::Result;
+use crate::server::api::diagnostics::publish_diagnostics_if_needed;
+use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
+use crate::session::Session;
+use crate::session::client::Client;
+
+pub(crate) struct DidSaveTextDocumentHandler;
+
+impl NotificationHandler for DidSaveTextDocumentHandler {
+    type NotificationType = DidSaveTextDocument;
+}
+
+impl SyncNotificationHandler for DidSaveTextDocumentHandler {
+    fn run(
+        session: &mut Session,
+        client: &Client,
+        params: DidSaveTextDocumentParams,
+    ) -> Result<()> {
+        let DidSaveTextDocumentParams {
+            text_document: _,
+            text: _,
+        } = params;
+
+        for document in session.text_document_handles() {
+            publish_diagnostics_if_needed(&document, session, client);
+        }
+
+        Ok(())
+    }
+}

--- a/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization.snap
@@ -7,7 +7,10 @@ expression: initialization_result
     "positionEncoding": "utf-16",
     "textDocumentSync": {
       "openClose": true,
-      "change": 2
+      "change": 2,
+      "save": {
+        "includeText": false
+      }
     },
     "notebookDocumentSync": {
       "notebookSelector": [

--- a/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization_with_workspace.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization_with_workspace.snap
@@ -7,7 +7,10 @@ expression: initialization_result
     "positionEncoding": "utf-16",
     "textDocumentSync": {
       "openClose": true,
-      "change": 2
+      "change": 2,
+      "save": {
+        "includeText": false
+      }
     },
     "notebookDocumentSync": {
       "notebookSelector": [


### PR DESCRIPTION
This commit fixes https://github.com/astral-sh/ty/issues/1652, improving support for LSP clients that don't support pull diagnostics by doing the following:

- Implemented support for the `didSave` notification type:
  - Registered handler and advertise this capability on server init
  - Updated tests: init snapshots now include the new capability
- On `didSave` for any document, we call `publish_diagnostics_if_needed` on any open documents.

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
