### PR TITLE
[ty] Improve `UnionBuilder` performance by changing `Type::is_subtype_of` calls to `Type::is_redundant_with`

### DIFF
--- a/crates/ty_python_semantic/src/types/builder.rs
+++ b/crates/ty_python_semantic/src/types/builder.rs
@@ -28,14 +28,13 @@
 //!
 //! In practice, there are two kinds of unions found in the wild: relatively-small unions made up
 //! of normal user types (classes, etc), and large unions made up of literals, which can occur via
-//! large enums (not yet implemented) or from string/integer/bytes literals, which can grow due to
-//! literal arithmetic or operations on literal strings/bytes. For normal unions, it's most
-//! efficient to just store the member types in a vector, and do O(n^2) `is_subtype_of` checks to
-//! maintain the union in simplified form. But literal unions can grow to a size where this becomes
-//! a performance problem. For this reason, we group literal types in `UnionBuilder`. Since every
-//! different string literal type shares exactly the same possible super-types, and none of them
-//! are subtypes of each other (unless exactly the same literal type), we can avoid many
-//! unnecessary `is_subtype_of` checks.
+//! large enums or from string/integer/bytes literals, which can grow due to literal arithmetic or
+//! operations on literal strings/bytes. For normal unions, it's most efficient to just store the
+//! member types in a vector, and do O(n^2) redundancy checks to maintain the union in simplified
+//! form. But literal unions can grow to a size where this becomes a performance problem. For this
+//! reason, we group literal types in `UnionBuilder`. Since every different string literal type
+//! shares exactly the same possible super-types, and none of them are subtypes of each other
+//! (unless exactly the same literal type), we can avoid many unnecessary redundancy checks.
 
 use crate::types::enums::{enum_member_literals, enum_metadata};
 use crate::types::type_ordering::union_or_intersection_elements_ordering;


### PR DESCRIPTION
## Summary

This PR is stacked on top of https://github.com/astral-sh/ruff/pull/22339; review that one first.

`Type::is_redundant_with` has mostly the same semantics as `Type::is_subtype_of`, but:
- More aggressively simplifies unions in some situations
- Is cached!

There are several places in the `UnionBuilder` where it looks like we can safely used `Type::is_redundant_with` instead of `Type::is_subtype_of`. This significantly improves performance, has no impact on our test suite, and (according to mypy_primer) has no impact on any ecosystem diagnostics or ty's memory usage. (The reported changes in diagnostics are all just our standard ecosystem flakes.)
