### PR TITLE
[ty] Optimize `Type::negate()` by caching expensive invocations of the `IntersectionBuilder`

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1499,7 +1499,7 @@ impl<'db> Type<'db> {
             | Type::BoundMethod(_) => Type::Intersection(IntersectionType::new(
                 db,
                 FxOrderSet::default(),
-                FxOrderSet::from_iter([*self]),
+                NegativeIntersectionElements::Single(*self),
             )),
 
             Type::Union(_) | Type::Intersection(_) | Type::TypeAlias(_) | Type::EnumLiteral(_) => {


### PR DESCRIPTION
## Summary

## Test Plan

<!-- How was it tested? -->
