### PR TITLE
[ty] Specify `heap_size` for `SynthesizedTypedDictType`

### DIFF
--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -879,7 +879,7 @@ pub(super) fn validate_typed_dict_dict_literal<'db>(
     }
 }
 
-#[salsa::interned(debug)]
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct SynthesizedTypedDictType<'db> {
     #[returns(ref)]
     pub(crate) items: TypedDictSchema<'db>,


### PR DESCRIPTION
## Summary

I observed these warnings locally when running ty with `TY_MEMORY_REPORT=full` on a large project:

```
WARN expected `heap_size` to be provided by Salsa struct `SynthesizedTypedDictType`
WARN expected `heap_size` to be provided by Salsa struct `SynthesizedTypedDictType`
WARN expected `heap_size` to be provided by Salsa struct `SynthesizedTypedDictType`
WARN expected `heap_size` to be provided by Salsa struct `SynthesizedTypedDictType`
WARN expected `heap_size` to be provided by Salsa struct `SynthesizedTypedDictType`
WARN expected `heap_size` to be provided by Salsa struct `SynthesizedTypedDictType`
WARN expected `heap_size` to be provided by Salsa struct `SynthesizedTypedDictType`
WARN expected `heap_size` to be provided by Salsa struct `SynthesizedTypedDictType`
WARN expected `heap_size` to be provided by Salsa struct `SynthesizedTypedDictType`
```

This PR should fix those warnings

## Test Plan

`¯\_(ツ)_/¯`
