### PR TITLE
Error on unused `ty: ignore` comments when dogfooding ty on our own scripts

### DIFF
--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -17,3 +17,4 @@ exclude = ["./ty_benchmark"]
 [tool.ty.rules]
 possibly-unresolved-reference = "error"
 division-by-zero = "error"
+unused-ignore-comment = "error"

--- a/scripts/ty_benchmark/pyproject.toml
+++ b/scripts/ty_benchmark/pyproject.toml
@@ -34,3 +34,4 @@ ignore = [
 [tool.ty.rules]
 possibly-unresolved-reference = "error"
 division-by-zero = "error"
+unused-ignore-comment = "error"


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
