### PR TITLE
[ty] narrow `TypedDict` unions with `not in`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2124,18 +2124,25 @@ shows up in a subset of the union members) is present, but that isn't generally 
 field, it could be *assigned to* with another `TypedDict` that does:
 
 ```py
+from typing_extensions import Literal
+
 class Foo(TypedDict):
     foo: int
 
 class Bar(TypedDict):
     bar: int
 
-def disappointment(u: Foo | Bar):
+def disappointment(u: Foo | Bar, v: Literal["foo"]):
     if "foo" in u:
         # We can't narrow the union here...
         reveal_type(u)  # revealed: Foo | Bar
     else:
         # ...(even though we *can* narrow it here)...
+        reveal_type(u)  # revealed: Bar
+
+    if v in u:
+        reveal_type(u)  # revealed: Foo | Bar
+    else:
         reveal_type(u)  # revealed: Bar
 
 # ...because `u` could turn out to be one of these.
@@ -2147,15 +2154,37 @@ static_assert(is_assignable_to(FooBar, Foo))
 static_assert(is_assignable_to(FooBar, Bar))
 ```
 
-We can also narrow unions that contain intersections with `TypedDict` in the same way:
+`not in` works in the opposite way to `in`: we can narrow in the positive case, but we cannot narrow
+in the negative case. The following snippet also tests our narrowing behaviour for intersections
+that contain `TypedDict`s, and unions that contain intersections that contain `TypedDict`s:
 
 ```py
-from collections.abc import Mapping
+from typing_extensions import Literal, Any
 from ty_extensions import Intersection, is_assignable_to, static_assert
 
-def _(u: Foo | Intersection[Bar, Mapping[str, int]]):
+def _(t: Bar, u: Foo | Intersection[Bar, Any], v: Intersection[Bar, Any], w: Literal["bar"]):
+    reveal_type(u)  # revealed: Foo | (Bar & Any)
+    reveal_type(v)  # revealed: Bar & Any
+
+    if "bar" not in t:
+        reveal_type(t)  # revealed: Never
+    else:
+        reveal_type(t)  # revealed: Bar
+
     if "bar" not in u:
         reveal_type(u)  # revealed: Foo
+    else:
+        reveal_type(u)  # revealed: Foo | (Bar & Any)
+
+    if "bar" not in v:
+        reveal_type(v)  # revealed: Never
+    else:
+        reveal_type(v)  # revealed: Bar & Any
+
+    if w not in u:
+        reveal_type(u)  # revealed: Foo
+    else:
+        reveal_type(u)  # revealed: Foo | (Bar & Any)
 ```
 
 TODO: The narrowing that we didn't do above will become possible when we add support for


### PR DESCRIPTION
Hi, this fixes https://github.com/astral-sh/ty/issues/2191.

## Summary

Added narrowing for unions of `TypedDict` where union members can be excluded based on the absence of a key.

```python
class Foo(TypedDict):
    foo: int

class Bar(TypedDict):
    bar: int

def _(u: Foo | Bar):
    if "foo" not in u:
        reveal_type(u)  # was `Foo | Bar`, is now `Bar`
```


## Test Plan

Added markdown tests.
