### PR TITLE
Bump docstring-adder pin

### DIFF
--- a/scripts/codemod_docstrings.sh
+++ b/scripts/codemod_docstrings.sh
@@ -18,7 +18,7 @@
 
 set -eu
 
-docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@1a0fb336fdc85014b22daeb34c862b695aef07d4"
+docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@e98a04941d5a6b8b9240e40392de15990b8cb8be"
 stdlib_path="./crates/ty_vendored/vendor/typeshed/stdlib"
 
 for python_version in 3.14 3.13 3.12 3.11 3.10 3.9


### PR DESCRIPTION
## Summary

Pulls in https://github.com/astral-sh/docstring-adder/commit/e98a04941d5a6b8b9240e40392de15990b8cb8be, which should have no impact on the docstrings added to typeshed's stubs, but should result in less noisy logs in the typeshed-sync workflows.

## Test Plan

CI in the docstring-adder repo
