### PR TITLE
[ty] Use upstream `GetSize` implementation for `OrderMap` and `OrderSet`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,7 +3246,6 @@ name = "ruff_memory_usage"
 version = "0.0.0"
 dependencies = [
  "get-size2",
- "ordermap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ get-size2 = { version = "0.7.3", features = [
     "smallvec",
     "hashbrown",
     "compact-str",
+    "ordermap"
 ] }
 getrandom = { version = "0.3.1" }
 glob = { version = "0.3.1" }

--- a/crates/ruff_memory_usage/Cargo.toml
+++ b/crates/ruff_memory_usage/Cargo.toml
@@ -12,7 +12,6 @@ license = { workspace = true }
 
 [dependencies]
 get-size2 = { workspace = true }
-ordermap = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ruff_memory_usage/src/lib.rs
+++ b/crates/ruff_memory_usage/src/lib.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 
 use get_size2::{GetSize, StandardTracker};
-use ordermap::{OrderMap, OrderSet};
 
 thread_local! {
     pub static TRACKER: RefCell<Option<StandardTracker>>= const { RefCell::new(None) };
@@ -41,17 +40,4 @@ pub fn heap_size<T: GetSize>(value: &T) -> usize {
             value.get_heap_size()
         }
     })
-}
-
-/// An implementation of [`GetSize::get_heap_size`] for [`OrderSet`].
-pub fn order_set_heap_size<T: GetSize, S>(set: &OrderSet<T, S>) -> usize {
-    (set.capacity() * T::get_stack_size()) + set.iter().map(heap_size).sum::<usize>()
-}
-
-/// An implementation of [`GetSize::get_heap_size`] for [`OrderMap`].
-pub fn order_map_heap_size<K: GetSize, V: GetSize, S>(map: &OrderMap<K, V, S>) -> usize {
-    (map.capacity() * (K::get_stack_size() + V::get_stack_size()))
-        + (map.iter())
-            .map(|(k, v)| heap_size(k) + heap_size(v))
-            .sum::<usize>()
 }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -14364,7 +14364,7 @@ impl KnownUnion {
     }
 }
 
-#[salsa::interned(debug, heap_size=IntersectionType::heap_size)]
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct IntersectionType<'db> {
     /// The intersection type includes only values in all of these types.
     #[returns(ref)]
@@ -14652,11 +14652,6 @@ impl<'db> IntersectionType<'db> {
 
     pub(crate) fn is_simple_negation(self, db: &'db dyn Db) -> bool {
         self.positive(db).is_empty() && self.negative(db).len() == 1
-    }
-
-    fn heap_size((positive, negative): &(FxOrderSet<Type<'db>>, FxOrderSet<Type<'db>>)) -> usize {
-        ruff_memory_usage::order_set_heap_size(positive)
-            + ruff_memory_usage::order_set_heap_size(negative)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -202,7 +202,7 @@ impl<'a, 'db> InferableTypeVars<'a, 'db> {
 /// # Ordering
 /// Ordering is based on the context's salsa-assigned id and not on its values.
 /// The id may change between runs, or when the context was garbage collected and recreated.
-#[salsa::interned(debug, constructor=new_internal, heap_size=GenericContext::heap_size)]
+#[salsa::interned(debug, constructor=new_internal, heap_size=ruff_memory_usage::heap_size)]
 #[derive(PartialOrd, Ord)]
 pub struct GenericContext<'db> {
     #[returns(ref)]
@@ -688,12 +688,6 @@ impl<'db> GenericContext<'db> {
             .map(|bound_typevar| bound_typevar.normalized_impl(db, visitor));
 
         Self::from_typevar_instances(db, variables)
-    }
-
-    fn heap_size(
-        (variables,): &(FxOrderMap<BoundTypeVarIdentity<'db>, BoundTypeVarInstance<'db>>,),
-    ) -> usize {
-        ruff_memory_usage::order_map_heap_size(variables)
     }
 }
 


### PR DESCRIPTION
This should also be more accurate for `OrderMap` or `OrderSet` that store any `Arc`s because it avoids double counting.