### PR TITLE
Add a `fast-test` profile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,12 @@ Run all tests (using `nextest` for faster execution):
 cargo nextest run
 ```
 
+For faster test execution, use the `fast-test` profile which enables optimizations while retaining debug info:
+
+```sh
+cargo nextest run --cargo-profile fast-test
+```
+
 Run tests for a specific crate:
 
 ```sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,13 +335,10 @@ strip = false
 debug = "full"
 lto = false
 
-# Profile for faster iteration: optimizes for the build + test cycle by
-# skipping debug info and applying minimal optimizations for faster tests.
-[profile.fast-build]
+# Profile for faster iteration: applies minimal optimizations for faster tests.
+[profile.fast-test]
 inherits = "dev"
 opt-level = 1
-debug = 0
-strip = "debuginfo"
 
 # The profile that 'cargo dist' will build with.
 [profile.dist]


### PR DESCRIPTION
## Summary

We use this profile in uv to create success, as an optimization for the iterative test loop. We include `opt-level=1` because it ends up being "worth it" for testing (empirically), even though it means the build is actually a big slower than `dev` (if you remove `opt-level=1`, clean compile is about 22% faster than `dev`).

Here are some benchmarks I generated with Claude -- the main motivator here is the incremental testing for `ty_python_semantic` which is 2.4x faster:

### `ty_python_semantic`

Full test suite (471 tests):
| Scenario    | dev   | fast-test | Improvement |
|-------------|-------|------------|-------------|
| Clean       | 53s   | 49s        | 8% faster   |
| Incremental | 17.8s | 6.8s       | 2.4x faster |

Single test:
| Scenario    | dev   | fast-test | Improvement |
|-------------|-------|------------|-------------|
| Clean       | 42.5s | 55.3s      | 30% slower  |
| Incremental | 6.5s  | 6.1s       | ~same       |

### `ruff_linter`

Full test suite (2622 tests):
| Scenario    | dev   | fast-test | Improvement |
|-------------|-------|------------|-------------|
| Clean       | 31s   | 41s        | 32% slower  |
| Incremental | 11.9s | 10.5s      | 12% faster  |

Single test:
| Scenario    | dev  | fast-test | Improvement |
|-------------|------|------------|-------------|
| Clean       | 26s  | 36.5s      | 40% slower  |
| Incremental | 4.5s | 5.5s       | 22% slower  |
