### PR TITLE
[ty] Improve tracebacks when installing dependencies fails in ty_benchmark

### DIFF
--- a/scripts/ty_benchmark/src/benchmark/projects.py
+++ b/scripts/ty_benchmark/src/benchmark/projects.py
@@ -92,7 +92,7 @@ class Project(NamedTuple):
             )
 
         except subprocess.CalledProcessError as e:
-            raise RuntimeError(f"Failed to clone {self.name}: {e.stderr}")
+            raise RuntimeError(f"Failed to clone {self.name}:\n\n{e.stderr}") from e
 
         logging.info(f"Cloned {self.name} to {checkout_dir}.")
 

--- a/scripts/ty_benchmark/src/benchmark/run.py
+++ b/scripts/ty_benchmark/src/benchmark/run.py
@@ -147,7 +147,9 @@ def main() -> None:
             cwd = Path(tempdir)
             project.clone(cwd)
 
-            venv = Venv.create(cwd, project.python_version)
+            venv = Venv.create(
+                project=project.name, parent=cwd, python_version=project.python_version
+            )
             venv.install(project.install_arguments)
 
             commands = []

--- a/scripts/ty_benchmark/src/benchmark/test_lsp_diagnostics.py
+++ b/scripts/ty_benchmark/src/benchmark/test_lsp_diagnostics.py
@@ -42,7 +42,9 @@ def project_setup(
         cwd = Path(tempdir)
         project.clone(cwd)
 
-        venv = Venv.create(cwd, project.python_version)
+        venv = Venv.create(
+            project=project.name, parent=cwd, python_version=project.python_version
+        )
         venv.install(project.install_arguments)
 
         yield project, venv


### PR DESCRIPTION
## Summary

I tried running ty_benchmark locally, and installation of homeassistant's dependencies kept failing. However, the traceback didn't tell me which project was the problem, and also implied that the exception handling itself was buggy ("during handling of the exception, another exception occurred"):

```pytb
Traceback (most recent call last):
  File "/Users/alexw/dev/ruff/scripts/ty_benchmark/src/benchmark/venv.py", line 82, in install
    subprocess.run(
    ~~~~~~~~~~~~~~^
        command,
        ^^^^^^^^
    ...<3 lines>...
        text=True,
        ^^^^^^^^^^
    )
    ^
  File "/Users/alexw/Library/Application Support/uv/python/cpython-3.14.0-macos-aarch64-none/lib/python3.14/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['uv', 'pip', 'install', '--python', '/var/folders/gd/1czdxc454j15y8gns2krv8vc0000gn/T/tmp1_b6us7f/venv/bin/python', '--quiet', '--exclude-newer', '2025-12-13T00:00:00Z', 'mypy', '-r', 'requirements_test_all.txt', '-r', 'requirements.txt']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/alexw/dev/ruff/scripts/ty_benchmark/.venv/bin/benchmark", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/alexw/dev/ruff/scripts/ty_benchmark/src/benchmark/run.py", line 151, in main
    venv.install(project.install_arguments)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alexw/dev/ruff/scripts/ty_benchmark/src/benchmark/venv.py", line 90, in install
    raise RuntimeError(f"Failed to install dependencies: {e.stderr}")
RuntimeError: Failed to install dependencies:   × Failed to download `mbddns==0.1.2`
  ├─▶ Failed to write to the client cache
  ╰─▶ Too many open files (os error 24) at path "/Users/alexw/.cache/uv/wheels-v5/pypi/mbddns/.tmpM2R0B4"
```

This PR improves the traceback when dependencies fail to install, fixing both of the above issues; it is now:

```pytb
Traceback (most recent call last):
  File "/Users/alexw/dev/ruff/scripts/ty_benchmark/src/benchmark/venv.py", line 83, in install
    subprocess.run(
    ~~~~~~~~~~~~~~^
        command,
        ^^^^^^^^
    ...<3 lines>...
        text=True,
        ^^^^^^^^^^
    )
    ^
  File "/Users/alexw/Library/Application Support/uv/python/cpython-3.14.0-macos-aarch64-none/lib/python3.14/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['uv', 'pip', 'install', '--python', '/var/folders/gd/1czdxc454j15y8gns2krv8vc0000gn/T/tmph9w6alp7/venv/bin/python', '--quiet', '--exclude-newer', '2025-12-13T00:00:00Z', 'mypy', '-r', 'requirements_test_all.txt', '-r', 'requirements.txt']' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/alexw/dev/ruff/scripts/ty_benchmark/.venv/bin/benchmark", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/alexw/dev/ruff/scripts/ty_benchmark/src/benchmark/run.py", line 153, in main
    venv.install(project.install_arguments)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alexw/dev/ruff/scripts/ty_benchmark/src/benchmark/venv.py", line 92, in install
    raise RuntimeError(msg) from e
RuntimeError: Failed to install dependencies for homeassistant:

  × Failed to build `motionblindsble==0.1.3`
  ├─▶ Failed to run `/Users/alexw/.cache/uv/builds-v0/.tmpjjjo8s/bin/python`
  ╰─▶ Too many open files (os error 24)
```

## Test Plan

- See above
- `uvx prek run -a`
- `uv run --project=./scripts/ty_benchmark cargo run -p ty check --project=./scripts/ty_benchmark`
