### PR TITLE
[ty] Optimize `Type::negate()`

### DIFF
--- a/crates/ty_python_semantic/src/types/property_tests.rs
+++ b/crates/ty_python_semantic/src/types/property_tests.rs
@@ -81,7 +81,7 @@ macro_rules! type_property_test {
 
 mod stable {
     use super::union;
-    use crate::types::{CallableType, KnownClass, Type};
+    use crate::types::{CallableType, IntersectionBuilder, KnownClass, Type};
 
     // Reflexivity: `T` is equivalent to itself.
     type_property_test!(
@@ -234,8 +234,15 @@ mod stable {
     // the Liskov violation). All you need to do is to create a class that subclasses
     // `Iterable` but assigns `__iter__ = None` in the class body (or similar).
     type_property_test!(
-        all_type_assignable_to_iterable_are_iterable, db,
+        all_types_assignable_to_iterable_are_iterable, db,
         forall types t. t.is_assignable_to(db, KnownClass::Iterable.to_specialized_instance(db, [Type::object()])) => t.try_iterate(db).is_ok()
+    );
+
+    // Our optimized `Type::negate()` function should always produce the exact same type
+    // as going "the long way" via the `IntersectionBuilder`.
+    type_property_test!(
+        all_negated_types_identical_to_intersection_with_single_negated_element, db,
+        forall types t. t.negate(db) == IntersectionBuilder::new(db).add_negative(t).build()
     );
 }
 


### PR DESCRIPTION
## Summary

`Type::negate()` is a hot function that is called in many places across the codebase. Currently we always compute a type's negation by invoking the `IntersectionBuilder`, adding a single negative element, and calling `.build()` to create a new `Type`. But this is unnecessary overhead for many trivial cases where we know what the negation of a type is (and always will be). In these cases, we can create the negation directly instead of invoking the `IntersectionBuilder`.

This PR leads to speedups of 1-4% across a wide range of benchmarks according to codspeed: https://codspeed.io/astral-sh/ruff/branches/alex%2Foptimize-negate-2?utm_source=github&utm_medium=check&utm_content=details

## Test Plan

- Existing tests all pass
- `QUICKCHECK_TESTS=1000000 cargo test --profile=profiling -p ty_python_semantic -- --ignored types::property_tests::stable` passes
- The primer report is clean except for our standard set of flakes
