### PR TITLE
[ty] Early return in `Type::has_relation_to_impl` for `Type` variants that are always mutually disjoint

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/fields.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/fields.md
@@ -23,6 +23,17 @@ alice.role = "moderator"
 bob = Member(name="Bob", tag="VIP")
 ```
 
+## With `Literal` types
+
+```py
+from typing import Literal
+import dataclasses
+
+@dataclasses.dataclass
+class Foo:
+    x: Literal["f"] = dataclasses.field(init=False, default="f")
+```
+
 ## `default_factory`
 
 The `default_factory` argument can be used to specify a callable that provides a default value for a


### PR DESCRIPTION
## Summary

This PR improves a pre-existing optimisation in `Type::has_relation_to_impl`, for a 4% speedup on static-frame (according to codspeed) and a 2-3% speedup on pandas (codspeed says 2%; I measure 3% locally with ty_benchmark).

I'm in two minds about this PR -- I'm really not sure I like this. It feels like it makes the code uglier and harder to understand, and this is already a very complicated function.

On the other hand, we already _have_ this optimisation lower down in `Type::has_relation_to_impl` -- it's just not as complete as it could be! All this PR does is move the optimisation higher up and make it more complete.

Anyway, curious for other folks' thoughts here.

## Test Plan

- Existing tests all pass
