### PR TITLE
[ty] Remove redundant `apply_specialization` type mappings

### DIFF
--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -1,6 +1,6 @@
 use crate::Db;
 use crate::types::class::CodeGeneratorKind;
-use crate::types::generics::Specialization;
+use crate::types::generics::{ApplySpecialization, Specialization};
 use crate::types::tuple::TupleType;
 use crate::types::{
     ApplyTypeMappingVisitor, ClassLiteral, ClassType, DynamicType, KnownClass, KnownInstanceType,
@@ -335,7 +335,9 @@ impl<'db> ClassBase<'db> {
         if let Some(specialization) = specialization {
             let new_self = self.apply_type_mapping_impl(
                 db,
-                &TypeMapping::Specialization(specialization),
+                &TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(
+                    specialization,
+                )),
                 TypeContext::default(),
                 &ApplyTypeMappingVisitor::default(),
             );

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -219,53 +219,30 @@ impl<'db> CallableSignature<'db> {
             }
         }
 
-        match type_mapping {
-            TypeMapping::Specialization(specialization) => {
-                if let [self_signature] = self.overloads.as_slice()
-                    && let Some((prefix_parameters, paramspec)) = self_signature
-                        .parameters
-                        .find_paramspec_from_args_kwargs(db)
-                    && let Some(paramspec_value) = specialization.get(db, paramspec)
-                    && let Some(result) = try_apply_type_mapping_for_paramspec(
-                        db,
-                        self_signature,
-                        prefix_parameters,
-                        paramspec_value,
-                        type_mapping,
-                        tcx,
-                        visitor,
-                    )
-                {
-                    return result;
-                }
-            }
-            TypeMapping::ApplySpecialization(partial) => {
-                if let [self_signature] = self.overloads.as_slice()
-                    && let Some((prefix_parameters, paramspec)) = self_signature
-                        .parameters
-                        .find_paramspec_from_args_kwargs(db)
-                    && let Some(paramspec_value) = partial.get(db, paramspec)
-                    && let Some(result) = try_apply_type_mapping_for_paramspec(
-                        db,
-                        self_signature,
-                        prefix_parameters,
-                        paramspec_value,
-                        type_mapping,
-                        tcx,
-                        visitor,
-                    )
-                {
-                    return result;
-                }
-            }
-            _ => {}
+        if let TypeMapping::ApplySpecialization(specialization) = type_mapping
+            && let [self_signature] = self.overloads.as_slice()
+            && let Some((prefix_parameters, paramspec)) = self_signature
+                .parameters
+                .find_paramspec_from_args_kwargs(db)
+            && let Some(paramspec_value) = specialization.get(db, paramspec)
+            && let Some(result) = try_apply_type_mapping_for_paramspec(
+                db,
+                self_signature,
+                prefix_parameters,
+                paramspec_value,
+                type_mapping,
+                tcx,
+                visitor,
+            )
+        {
+            result
+        } else {
+            Self::from_overloads(
+                self.overloads.iter().map(|signature| {
+                    signature.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                }),
+            )
         }
-
-        Self::from_overloads(
-            self.overloads
-                .iter()
-                .map(|signature| signature.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
-        )
     }
 
     pub(crate) fn find_legacy_typevars_impl(


### PR DESCRIPTION
@dhruvmanila encountered this in #22416 — there are two different `TypeMapping` variants for apply a specialization to a type. One operates on a full `Specialization` instance, the other on a partially constructed one. If we move this enum-ness "down a level" it reduces some copy/paste in places where we are operating on a `TypeMapping`.