### PR TITLE
Add Alex Waygood back as a ty_ide codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,7 +21,7 @@
 /crates/ty* @carljm @MichaReiser @AlexWaygood @sharkdp @dcreager
 /crates/ruff_db/ @carljm @MichaReiser @sharkdp @dcreager
 /crates/ty_project/ @carljm @MichaReiser @sharkdp @dcreager @Gankra
-/crates/ty_ide/ @carljm @MichaReiser @sharkdp @dcreager @Gankra
+/crates/ty_ide/ @carljm @MichaReiser @AlexWaygood @sharkdp @dcreager @Gankra
 /crates/ty_server/ @carljm @MichaReiser @sharkdp @dcreager @Gankra
 /crates/ty/ @carljm @MichaReiser @sharkdp @dcreager
 /crates/ty_wasm/ @carljm @MichaReiser @sharkdp @dcreager @Gankra


### PR DESCRIPTION
@Gankra removed me as a codeowner in https://github.com/astral-sh/ruff/pull/22420, I think by accident, but this is where all the cool autocomplete work goes on, which I love to keep track of
