### PR TITLE
[ty] add regression test for bounded typevar union-context inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -670,6 +670,20 @@ def _(x: list[int], y: dict[int, int]):
     reveal_type(h(y))  # revealed: int | None
 ```
 
+## Bounded typevar call context through a union
+
+Regression test for an `invalid-assignment` false positive: `list(items)` should be assignable to
+`list[str] | list[int]` when `items` has type `list[T]` and `T: int`.
+
+```py
+def test[T: int](items: list[T]) -> list[T]:
+    ok1: list[str] | list[int] = list(items)
+    ok2: list[int] | list[str] = list(items)
+
+    bad: list[str] | list[bytes] = list(items)  # error: [invalid-assignment]
+    return items
+```
+
 ## Nested functions see typevars bound in outer function
 
 ```py


### PR DESCRIPTION
## Summary

Adds an mdtest-only non-regression case for the false-positive reported in https://github.com/astral-sh/ty/issues/2314

The behavior change itself comes from #22124 

The test focuses on bounded typevar call-context behavior for:
- `list(items)` assignable to `list[str] | list[int]` (both union orders).
- A nearby negative control (`list[str] | list[bytes]`) that must still emit `invalid-assignment`.

Fixes https://github.com/astral-sh/ty/issues/2314
