### PR TITLE
[ty] walk all types with `walk_signature`

### DIFF
--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -635,9 +635,6 @@ pub(super) fn walk_signature<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
         if let Some(ty) = parameter.annotated_type() {
             visitor.visit_type(db, ty);
         }
-        if let Some(default) = parameter.default_type() {
-            visitor.visit_type(db, default);
-        }
     }
     if let ParametersKind::ParamSpec(bound_typevar) = &signature.parameters.kind() {
         walk_bound_type_var_type(db, *bound_typevar, visitor);


### PR DESCRIPTION
## Summary

There were attributes that were not checked by `walk_signature`, so I made sure to walk those as well.

This is probably an oversight, but it's a small change and no change was observed on mdtest.

## Test Plan

N/A
