### PR TITLE
[ty] Fix an mdtest title

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/regression/2236_tuple_is_disjoint.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/2236_tuple_is_disjoint.md
@@ -1,6 +1,6 @@
-# Tuple pair is assignable to their union
+# Disjointness of two types implies that neither is a subtype of the other
 
-Regression test for <https://github.com/astral-sh/ty/issues/2236>.
+This is a regression test for <https://github.com/astral-sh/ty/issues/2236>.
 
 ```toml
 [environment]


### PR DESCRIPTION
Two tests were reported as failing in https://github.com/astral-sh/ty/issues/2236: `subtype_of_implies_not_disjoint_from` and `all_type_pairs_are_assignable_to_their_union`. This regression test is for the `subtype_of_implies_not_disjoint_from` test, but the mdtest title currently implies that it's a regression test for the `all_type_pairs_are_assignable_to_their_union` test.
