### PR TITLE
[ty] Fix generally poor ranking in playground completions

### DIFF
--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -337,6 +337,7 @@ class PlaygroundServer
     const digitsLength = String(completions.length - 1).length;
 
     return {
+      incomplete: true,
       suggestions: completions.map((completion, i) => ({
         label: {
           label: completion.name,


### PR DESCRIPTION
We enabled [`CompletionList::isIncomplete`] in our LSP server a while back
in order to have more of a say in how we rank and filter completions.
When it isn't set, the client tends to ask for completions less
frequently and will instead do its own filtering.

But... we did not enable it for the playground. Which I guess didn't
result in anything noticeably bad until we started limiting completions
to 1,000 suggestions. This meant that if the _initial_ completion
response didn't include the ultimate desired answer, then it would never
show up in the results until the client requested completions again.
This in turn led to some very poor completions in some cases.

This all gets fixed by simply enabling `isIncomplete` for Monaco.

Fixes astral-sh/ty#2340

[`CompletionList::isIncomplete`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionList
