### PR TITLE
Include configured `src` directories when resolving graphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2928,6 +2928,7 @@ dependencies = [
  "filetime",
  "globwalk",
  "ignore",
+ "indexmap",
  "indoc",
  "insta",
  "insta-cmd",

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -48,6 +48,7 @@ colored = { workspace = true }
 filetime = { workspace = true }
 globwalk = { workspace = true }
 ignore = { workspace = true }
+indexmap = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }
 jiff = { workspace = true }

--- a/crates/ruff/src/commands/analyze_graph.rs
+++ b/crates/ruff/src/commands/analyze_graph.rs
@@ -2,6 +2,7 @@ use crate::args::{AnalyzeGraphArgs, ConfigArguments};
 use crate::resolve::resolve;
 use crate::{ExitStatus, resolve_default_files};
 use anyhow::Result;
+use indexmap::IndexSet;
 use log::{debug, warn};
 use path_absolutize::CWD;
 use ruff_db::system::{SystemPath, SystemPathBuf};
@@ -11,7 +12,7 @@ use ruff_linter::source_kind::SourceKind;
 use ruff_linter::{warn_user, warn_user_once};
 use ruff_python_ast::{PySourceType, SourceType};
 use ruff_workspace::resolver::{ResolvedFile, match_exclusion, python_files_in_path};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -59,17 +60,13 @@ pub(crate) fn analyze_graph(
         })
         .collect::<FxHashMap<_, _>>();
 
-    // Create a database from the source roots, combining detected package roots with configured
-    // `src` paths.
-    let mut src_roots: Vec<SystemPathBuf> = package_roots
-        .values()
-        .filter_map(|package| package.as_deref())
-        .filter_map(|package| package.parent())
-        .map(Path::to_path_buf)
-        .filter_map(|path| SystemPathBuf::from_path_buf(path).ok())
-        .collect();
+    // Create a database from the source roots, combining configured `src` paths with detected
+    // package roots. Configured paths are added first so they take precedence, and duplicates
+    // are removed.
+    let mut src_roots: IndexSet<SystemPathBuf, FxBuildHasher> = IndexSet::default();
 
-    // Add configured `src` paths, filtering to only include existing directories.
+    // Add configured `src` paths first (for precedence), filtering to only include existing
+    // directories.
     src_roots.extend(
         pyproject_config
             .settings
@@ -80,8 +77,17 @@ pub(crate) fn analyze_graph(
             .filter_map(|path| SystemPathBuf::from_path_buf(path.clone()).ok()),
     );
 
+    // Add detected package roots.
+    src_roots.extend(
+        package_roots
+            .values()
+            .filter_map(|package| package.as_deref())
+            .filter_map(|path| path.parent())
+            .filter_map(|path| SystemPathBuf::from_path_buf(path.to_path_buf()).ok()),
+    );
+
     let db = ModuleDb::from_src_roots(
-        src_roots,
+        src_roots.into_iter().collect(),
         pyproject_config
             .settings
             .analyze


### PR DESCRIPTION
## Summary

This PR augments the detected source paths with the user-configured `src` when computing roots for `ruff analyze graph`.
