### PR TITLE
[ty] Don't show diagnostics for excluded files

### DIFF
--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -910,7 +910,15 @@ impl Session {
 
                 let db = self.project_db_mut(path);
                 match system_path_to_file(db, system_path) {
-                    Ok(file) => db.project().open_file(db, file),
+                    Ok(file) => {
+                        let project = db.project();
+
+                        // Only mark this file as open if it's part of the project.
+                        // This ensures that we don't show diagnostics for files outside the project.
+                        if project.is_file_included(db, system_path) {
+                            project.open_file(db, file);
+                        }
+                    }
                     Err(err) => tracing::warn!("Failed to open file {system_path}: {err}"),
                 }
             }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__excluded.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__excluded.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ty_server/tests/e2e/pull_diagnostics.rs
+expression: excluded_diagnostics
+---
+{"kind": "full", "items": []}

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__main.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__main.snap
@@ -1,0 +1,45 @@
+---
+source: crates/ty_server/tests/e2e/pull_diagnostics.rs
+expression: main_diagnostics
+---
+{
+  "kind": "full",
+  "resultId": "[RESULT_ID]",
+  "items": [
+    {
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 0,
+          "character": 11
+        }
+      },
+      "severity": 2,
+      "code": "undefined-reveal",
+      "codeDescription": {
+        "href": "https://ty.dev/rules#undefined-reveal"
+      },
+      "source": "ty",
+      "message": "`reveal_type` used without importing it"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 12
+        },
+        "end": {
+          "line": 0,
+          "character": 22
+        }
+      },
+      "severity": 3,
+      "code": "revealed-type",
+      "source": "ty",
+      "message": "Revealed type: `Literal[/"included/"]`"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Respect the `exclude` patterns in the LSP so that we don't show diagnostics in excluded files. 


## Test Plan

Added e2e test
