### PR TITLE
[ty] Optimize subtyping/assignability/redundancy checks against union types

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -11718,8 +11718,8 @@ pub(super) struct MetaclassCandidate<'db> {
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct UnionType<'db> {
     /// The union type includes values in any of these types.
-    #[returns(deref)]
-    pub elements: Box<[Type<'db>]>,
+    #[returns(ref)]
+    pub elements: FxOrderSet<Type<'db>>,
     /// Whether the value pointed to by this type is recursively defined.
     /// If `Yes`, union literal widening is performed early.
     recursively_defined: RecursivelyDefined,

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::FxIndexSet;
+use crate::FxOrderSet;
 use crate::place::builtins_module_scope;
 use crate::semantic_index::definition::Definition;
 use crate::semantic_index::definition::DefinitionKind;
@@ -229,8 +230,8 @@ pub fn definitions_for_attribute<'db>(
     };
 
     let tys = match lhs_ty {
-        Type::Union(union) => union.elements(model.db()).to_vec(),
-        _ => vec![lhs_ty],
+        Type::Union(union) => union.elements(model.db()).clone(),
+        _ => FxOrderSet::from_iter([lhs_ty]),
     };
 
     // Expand intersections for each subtype into their components

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8685,15 +8685,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .any(|overload| overload.signature.generic_context.is_some());
 
         // If the type context is a union, attempt to narrow to a specific element.
-        let narrow_targets: &[_] = match call_expression_tcx.annotation {
+        let narrow_targets = match call_expression_tcx.annotation {
             // TODO: We could theoretically attempt to narrow to every element of
             // the power set of this union. However, this leads to an exponential
             // explosion of inference attempts, and is rarely needed in practice.
             //
             // We only need to attempt narrowing on generic calls, otherwise the type
             // context has no effect.
-            Some(Type::Union(union)) if has_generic_context => union.elements(db),
-            _ => &[],
+            Some(Type::Union(union)) if has_generic_context => {
+                Either::Left(union.elements(db).iter().copied())
+            }
+            _ => Either::Right(std::iter::empty()),
         };
 
         // We silence diagnostics until we successfully narrow to a specific type.
@@ -8765,10 +8767,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // Prefer the declared type of generic classes.
         for narrowed_ty in narrow_targets
-            .iter()
+            .clone()
             .filter(|ty| ty.class_specialization(db).is_some())
         {
-            if let Some(result) = try_narrow(*narrowed_ty) {
+            if let Some(result) = try_narrow(narrowed_ty) {
                 return result;
             }
         }
@@ -8777,11 +8779,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         //
         // TODO: We could also attempt an inference without type context, but this
         // leads to similar performance issues.
-        for narrowed_ty in narrow_targets
-            .iter()
-            .filter(|ty| ty.class_specialization(db).is_none())
-        {
-            if let Some(result) = try_narrow(*narrowed_ty) {
+        for narrowed_ty in narrow_targets.filter(|ty| ty.class_specialization(db).is_none()) {
+            if let Some(result) = try_narrow(narrowed_ty) {
                 return result;
             }
         }

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -1793,7 +1793,7 @@ impl<'db> Tuple<Type<'db>> {
 
         // TODO: just grab this type from typeshed (it's a `sys._ReleaseLevel` type alias there)
         let release_level_ty = {
-            let elements: Box<[Type<'db>]> = ["alpha", "beta", "candidate", "final"]
+            let elements: FxOrderSet<_> = ["alpha", "beta", "candidate", "final"]
                 .iter()
                 .map(|level| Type::string_literal(db, level))
                 .collect();


### PR DESCRIPTION
## Summary

If we store the elements list in a `UnionType` as an `FxOrderSet` rather than a `Vec`, we can add an `O(1)` fast path for `T :< U` where `T` is trivially contained in the elements of `U`. This provides a huge speedup on code that makes use of deeply recursive union such as pydantic (and all code that uses pydantic!).

## Test Plan

Existing tests all pass.
