### PR TITLE
[ty] Complete minor TODO in ty_python_semantic crate

### DIFF
--- a/crates/ty_python_semantic/src/semantic_index.rs
+++ b/crates/ty_python_semantic/src/semantic_index.rs
@@ -783,7 +783,9 @@ mod tests {
 
         fn first_public_declaration(&self, symbol: ScopedSymbolId) -> Option<Definition<'_>> {
             self.end_of_scope_symbol_declarations(symbol)
-                .find_map(|declaration_with_constraint| declaration_with_constraint.declaration.definition())
+                .find_map(|declaration_with_constraint| {
+                    declaration_with_constraint.declaration.definition()
+                })
         }
 
         fn first_binding_at_use(&self, use_id: ScopedUseId) -> Option<Definition<'_>> {


### PR DESCRIPTION
This TODO is very old -- we have long since recorded this definition. Updating the test to actually assert the declaration requires a new helper method for declarations, to complement the existing `first_public_binding` helper.
