### PR TITLE
[`ruff`] document `RUF100` trailing comment fix behavior

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/unused_noqa.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unused_noqa.rs
@@ -52,6 +52,25 @@ impl UnusedNOQAKind {
 ///     foo.bar()
 /// ```
 ///
+/// ## Conflict with other linters
+/// When using `RUF100` with the `--fix` option, Ruff may remove trailing comments
+/// that follow a `# noqa` directive on the same line, as it interprets the
+/// remainder of the line as a description for the suppression.
+///
+/// To prevent Ruff from removing suppressions for other tools (like `pylint`
+/// or `mypy`), separate them with a second `#` character:
+///
+/// ```python
+/// # Bad: Ruff --fix will remove the pylint comment
+/// def visit_ImportFrom(self, node):  # noqa: N802, pylint: disable=invalid-name
+///     pass
+///
+///
+/// # Good: Ruff will preserve the pylint comment
+/// def visit_ImportFrom(self, node):  # noqa: N802 # pylint: disable=invalid-name
+///     pass
+/// ```
+///
 /// ## Options
 /// - `lint.external`
 ///


### PR DESCRIPTION
## Summary
Ruff's `--fix` for `RUF100` can inadvertently remove trailing comments (e.g., `pylint` or `mypy` suppressions) by interpreting them as descriptions. This PR adds a "Conflict with other linters" section to the rule documentation to clarify this behavior and provide the double-hash (`# noqa # pylint`) workaround.

## Fixes
Fixes #20762