### PR TITLE
[ty] Detect invalid `@total_ordering` applications in non-decorator contexts

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/decorators/total_ordering.md
+++ b/crates/ty_python_semantic/resources/mdtest/decorators/total_ordering.md
@@ -244,3 +244,36 @@ reveal_type(n1 > n2)  # revealed: bool
 n1 <= n2  # error: [unsupported-operator]
 n1 >= n2  # error: [unsupported-operator]
 ```
+
+## Function call form
+
+When `total_ordering` is called as a function (not as a decorator), the same validation is
+performed:
+
+```py
+from functools import total_ordering
+
+class NoOrderingMethod:
+    def __eq__(self, other: object) -> bool:
+        return True
+
+# error: [invalid-total-ordering]
+InvalidOrderedClass = total_ordering(NoOrderingMethod)
+```
+
+When the class does define an ordering method, no error is emitted:
+
+```py
+from functools import total_ordering
+
+class HasOrderingMethod:
+    def __eq__(self, other: object) -> bool:
+        return True
+
+    def __lt__(self, other: "HasOrderingMethod") -> bool:
+        return True
+
+# No error (class defines `__lt__`).
+ValidOrderedClass = total_ordering(HasOrderingMethod)
+reveal_type(ValidOrderedClass)  # revealed: type[HasOrderingMethod]
+```

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4684,6 +4684,29 @@ pub(super) fn report_invalid_total_ordering(
     diagnostic.info("The decorator will raise `ValueError` at runtime");
 }
 
+/// Reports an invalid `total_ordering(cls)` function call where the class
+/// does not define any ordering method.
+pub(super) fn report_invalid_total_ordering_call(
+    context: &InferContext<'_, '_>,
+    class: ClassLiteral<'_>,
+    call_expression: &ast::ExprCall,
+) {
+    let db = context.db();
+
+    let Some(builder) = context.report_lint(&INVALID_TOTAL_ORDERING, call_expression) else {
+        return;
+    };
+
+    let mut diagnostic = builder.into_diagnostic(
+        "`@functools.total_ordering` requires at least one ordering method (`__lt__`, `__le__`, `__gt__`, or `__ge__`) to be defined",
+    );
+    diagnostic.set_primary_message(format_args!(
+        "`{}` does not define `__lt__`, `__le__`, `__gt__`, or `__ge__`",
+        class.name(db)
+    ));
+    diagnostic.info("The function will raise `ValueError` at runtime");
+}
+
 /// This function receives an unresolved `from foo import bar` import,
 /// where `foo` can be resolved to a module but that module does not
 /// have a `bar` member or submodule.

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -70,6 +70,7 @@ use crate::types::context::InferContext;
 use crate::types::diagnostic::{
     INVALID_ARGUMENT_TYPE, REDUNDANT_CAST, STATIC_ASSERT_ERROR, TYPE_ASSERTION_FAILURE,
     report_bad_argument_to_get_protocol_members, report_bad_argument_to_protocol_interface,
+    report_invalid_total_ordering_call,
     report_runtime_check_against_non_runtime_checkable_protocol,
 };
 use crate::types::display::DisplaySettings;
@@ -2005,6 +2006,41 @@ impl KnownFunction {
 
                 overload.set_return_type(Type::module_literal(db, file, module));
             }
+
+            KnownFunction::TotalOrdering => {
+                // When `total_ordering(cls)` is called as a function (not as a decorator),
+                // check that the class defines at least one ordering method.
+                let [Some(class_type)] = parameter_types else {
+                    return;
+                };
+
+                let class = match class_type {
+                    Type::ClassLiteral(class) => ClassType::NonGeneric(*class),
+                    Type::GenericAlias(generic) => ClassType::Generic(*generic),
+                    _ => return,
+                };
+
+                // Check if any class in the MRO (except object) defines an ordering method.
+                let has_ordering_method = class
+                    .iter_mro(db)
+                    .filter_map(ClassBase::into_class)
+                    .filter(|base_class| {
+                        !base_class
+                            .class_literal(db)
+                            .0
+                            .is_known(db, KnownClass::Object)
+                    })
+                    .any(|base_class| base_class.class_literal(db).0.has_own_ordering_method(db));
+
+                if !has_ordering_method {
+                    report_invalid_total_ordering_call(
+                        context,
+                        class.class_literal(db).0,
+                        call_expression,
+                    );
+                }
+            }
+
             _ => {}
         }
     }

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -2020,19 +2020,7 @@ impl KnownFunction {
                     _ => return,
                 };
 
-                // Check if any class in the MRO (except object) defines an ordering method.
-                let has_ordering_method = class
-                    .iter_mro(db)
-                    .filter_map(ClassBase::into_class)
-                    .filter(|base_class| {
-                        !base_class
-                            .class_literal(db)
-                            .0
-                            .is_known(db, KnownClass::Object)
-                    })
-                    .any(|base_class| base_class.class_literal(db).0.has_own_ordering_method(db));
-
-                if !has_ordering_method {
+                if !class.has_ordering_method_in_mro(db) {
                     report_invalid_total_ordering_call(
                         context,
                         class.class_literal(db).0,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -857,7 +857,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if class.total_ordering(self.db()) {
                 let has_ordering_method = class
                     .iter_mro(self.db(), None)
-                    .filter_map(super::super::class_base::ClassBase::into_class)
+                    .filter_map(ClassBase::into_class)
                     .filter(|base_class| {
                         !base_class
                             .class_literal(self.db())


### PR DESCRIPTION
## Summary

E.g., `ValidOrderedClass = total_ordering(HasOrderingMethod)`.
