### PR TITLE
[ty] Handle playground file updates in the monaco editor onChange

### DIFF
--- a/playground/ty/src/Editor/Chrome.tsx
+++ b/playground/ty/src/Editor/Chrome.tsx
@@ -58,6 +58,8 @@ export interface Props {
   onSelectVendoredFile(handle: FileHandle): void;
 
   onClearVendoredFile(): void;
+
+  onError(error: string | null): void;
 }
 
 export default function Chrome({
@@ -72,6 +74,7 @@ export default function Chrome({
   onChangeFile,
   onSelectVendoredFile,
   onClearVendoredFile,
+  onError,
 }: Props) {
   const workspace = use(workspacePromise);
 
@@ -222,6 +225,7 @@ export default function Chrome({
                     workspace={workspace}
                     onMount={handleEditorMount}
                     onChange={(content) => onChangeFile(workspace, content)}
+                    onError={onError}
                     onOpenFile={onSelectFile}
                     onVendoredFileChange={onSelectVendoredFile}
                     onBackToUserFile={handleBackToUserFile}

--- a/playground/ty/src/Playground.tsx
+++ b/playground/ty/src/Playground.tsx
@@ -81,11 +81,9 @@ export default function Playground() {
       content,
     });
 
-    const handle = files.handles[files.selected];
-
-    if (handle != null) {
-      updateFile(workspace, handle, content, setError);
-    } else if (fileName === SETTINGS_FILE_NAME) {
+    // Updates to user files are handled by the editor,
+    // only the settings file is managed here
+    if (fileName === SETTINGS_FILE_NAME) {
       updateOptions(workspace, content, setError);
     }
   };
@@ -192,6 +190,7 @@ export default function Playground() {
           onChangeFile={handleFileChanged}
           onSelectVendoredFile={handleVendoredFileSelected}
           onClearVendoredFile={handleVendoredFileCleared}
+          onError={setError}
         />
       </Suspense>
       {error ? (
@@ -534,20 +533,6 @@ function updateOptions(
     setError(null);
   } catch (error) {
     setError(`Failed to update 'ty.json' options: ${formatError(error)}`);
-  }
-}
-
-function updateFile(
-  workspace: Workspace,
-  handle: FileHandle,
-  content: string,
-  setError: (error: string | null) => void,
-) {
-  try {
-    workspace.updateFile(handle, content);
-    setError(null);
-  } catch (error) {
-    setError(`Failed to update file: ${formatError(error)}`);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/2415 I think?

Previously, completions could be computed on stale file content because they were requested before the file objects were fully updated.

This became apparent when we configured `incomplete = True` as this causes completions to be re-fetched as more text is typed.

I don't really know if this is the best fix but it seems to work 🤷 


## Test Plan
Verifying that https://github.com/astral-sh/ty/issues/2415 does not reproduce and that the playground seems fine in general.
