### PR TITLE
[ty] Generalize union-type subtyping fast path

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -907,6 +907,23 @@ def _(x: list[str]):
     reveal_type(accepts_callable(GenericClass)(x, x))
 ```
 
+### `Callable`s that return union types
+
+```py
+from typing import Callable
+
+class Box[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+def my_iter[T](f: Callable[[], T | None]) -> Box[T]:
+    return Box()
+
+def get_int() -> int | None: ...
+
+reveal_type(my_iter(get_int))  # revealed: Box[int]
+```
+
 ### Don't include identical lower/upper bounds in type mapping multiple times
 
 This is was a performance regression reported in

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1840,7 +1840,7 @@ impl<'db> Type<'db> {
     ///
     /// This method may have false negatives, but it should not have false positives. It should be
     /// a cheap shallow check, not an exhaustive recursive check.
-    fn subtyping_is_always_reflexive(self) -> bool {
+    const fn subtyping_is_always_reflexive(self) -> bool {
         match self {
             Type::Never
             | Type::FunctionLiteral(..)
@@ -1861,6 +1861,9 @@ impl<'db> Type<'db> {
             | Type::AlwaysFalsy
             | Type::AlwaysTruthy
             | Type::PropertyInstance(_)
+            // `T` is always a subtype of itself,
+            // and `T` is always a subtype of `T | None`
+            | Type::TypeVar(_)
             // might inherit `Any`, but subtyping is still reflexive
             | Type::ClassLiteral(_)
              => true,
@@ -1872,7 +1875,6 @@ impl<'db> Type<'db> {
             | Type::Union(_)
             | Type::Intersection(_)
             | Type::Callable(_)
-            | Type::TypeVar(_)
             | Type::BoundSuper(_)
             | Type::TypeIs(_)
             | Type::TypeGuard(_)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -195,6 +195,17 @@ impl TypeRelation<'_> {
     pub(crate) const fn is_subtyping(self) -> bool {
         matches!(self, TypeRelation::Subtyping)
     }
+
+    pub(crate) const fn can_safely_assume_reflexivity(self, ty: Type) -> bool {
+        match self {
+            TypeRelation::Assignability
+            | TypeRelation::ConstraintSetAssignability
+            | TypeRelation::Redundancy => true,
+            TypeRelation::Subtyping | TypeRelation::SubtypingAssuming(_) => {
+                ty.subtyping_is_always_reflexive()
+            }
+        }
+    }
 }
 
 #[salsa::tracked]
@@ -329,7 +340,7 @@ impl<'db> Type<'db> {
         //
         // Note that we could do a full equivalence check here, but that would be both expensive
         // and unnecessary. This early return is only an optimisation.
-        if (!relation.is_subtyping() || self.subtyping_is_always_reflexive()) && self == target {
+        if relation.can_safely_assume_reflexivity(self) && self == target {
             return ConstraintSet::from(true);
         }
 
@@ -460,44 +471,41 @@ impl<'db> Type<'db> {
                 },
             }),
 
-            // In general, a TypeVar `T` is not a subtype of a type `S` unless one of the two conditions is satisfied:
+            // In general, a TypeVar `T` is not redundant with a type `S` unless one of the two conditions is satisfied:
             // 1. `T` is a bound TypeVar and `T`'s upper bound is a subtype of `S`.
             //    TypeVars without an explicit upper bound are treated as having an implicit upper bound of `object`.
             // 2. `T` is a constrained TypeVar and all of `T`'s constraints are subtypes of `S`.
             //
             // However, there is one exception to this general rule: for any given typevar `T`,
             // `T` will always be a subtype of any union containing `T`.
-            (Type::TypeVar(bound_typevar), Type::Union(union))
-                if !bound_typevar.is_inferable(db, inferable)
+            (_, Type::Union(union))
+                if relation.can_safely_assume_reflexivity(self)
                     && union.elements(db).contains(&self) =>
             {
                 ConstraintSet::from(true)
             }
 
             // A similar rule applies in reverse to intersection types.
-            (Type::Intersection(intersection), Type::TypeVar(bound_typevar))
-                if !bound_typevar.is_inferable(db, inferable)
+            (Type::Intersection(intersection), _)
+                if relation.can_safely_assume_reflexivity(target)
                     && intersection.positive(db).contains(&target) =>
             {
                 ConstraintSet::from(true)
             }
-            (Type::Intersection(intersection), Type::TypeVar(bound_typevar))
-                if !bound_typevar.is_inferable(db, inferable)
+            (Type::Intersection(intersection), _)
+                if relation.is_assignability()
+                    && intersection.positive(db).iter().any(Type::is_dynamic) =>
+            {
+                // If the intersection contains `Any`/`Unknown`/`@Todo`, it is assignable to any type.
+                // `Any` could materialize to `Never`, `Never & T & ~S` simplifies to `Never` for any
+                // `T` and any `S`, and `Never` is a subtype of all types.
+                ConstraintSet::from(true)
+            }
+            (Type::Intersection(intersection), _)
+                if relation.can_safely_assume_reflexivity(target)
                     && intersection.negative(db).contains(&target) =>
             {
                 ConstraintSet::from(false)
-            }
-
-            // Two identical typevars must always solve to the same type, so they are always
-            // subtypes of each other and assignable to each other.
-            //
-            // Note that this is not handled by the early return at the beginning of this method,
-            // since subtyping between a TypeVar and an arbitrary other type cannot be guaranteed to be reflexive.
-            (Type::TypeVar(lhs_bound_typevar), Type::TypeVar(rhs_bound_typevar))
-                if !lhs_bound_typevar.is_inferable(db, inferable)
-                    && lhs_bound_typevar.is_same_typevar_as(db, rhs_bound_typevar) =>
-            {
-                ConstraintSet::from(true)
             }
 
             // `type[T]` is a subtype of the class object `A` if every instance of `T` is a subtype of an instance


### PR DESCRIPTION
## Summary

Currently we have a branch near the top of `Type::has_relation_to_impl` that returns `ConstraintSet::from(true)` if the l.h.s. is a typevar `T` and the right-hand side is a union `U` where `T` is one of the elements of `U`:

https://github.com/astral-sh/ruff/blob/337e3ebd27407f50b96dd686631c4ac4697fa973/crates/ty_python_semantic/src/types/relation.rs#L463-L475

But this branch isn't only correct for type variables! In general, it is true for _any_ type `T` that it will be assignable to, redundant with, and -- in some cases -- a subtype of a union `U` if `T` is contained within the elements of `U`. The branch is only _necessary_ for type variables, because for non-type-variables we apply a more generalized handling lower down here:

https://github.com/astral-sh/ruff/blob/337e3ebd27407f50b96dd686631c4ac4697fa973/crates/ty_python_semantic/src/types/relation.rs#L730-L739

But the generalized handling for `T <: U` can be very slow in certain pathological cases (*cough* pydantic) where a union type contains very complicated types early on in its list of elements. For example, consider the following scenario: we want to check whether `C` is a subtype of `U`, and `U` is a union with the following elements list:

```
-------------
| A | B | C |
-------------
```

Unfortunately, `A` and `B` are both complex recursive structural types (*cough* pydantic's huge `TypedDict`s), and checking whether `C` is a subtype of `A` or `B` is a question that takes us a long time to answer. But with our current generalized handling for determining whether `C <: U` for a union type `U`, we _must_ answer these questions before we even ask the question "Is `C` a subtype of `C`?", for which the answer is trivial.

By extending the trivial `if union.elements(db).contains(self)` check early on in `Type::has_relation_to()` to _all_ types (not just type variables), we can achieve a significant speedup over what we have on the `main` branch. Now, in the above example, we quickly iterate over the elements of `U` once, discover that `C` is trivially contained in `U`'s elements, and return `true` for the overall subtyping check without ever having to ask whether `C` is a subtype of `A` or `B`.

Essentially this means that for _any_ type `T`, if we want to check whether `T` is a subtype of a union `U` we _may_ iterate over the elements of the union twice: once for this fast path to check whether the union trivially contains `T` in its elements, and (if it is not trivially contained) once again to do the full (slow) `has_relation_to_impl` check for each element in the union.

It's perhaps surprising that iterating over the union elements twice would be consistently faster than iterating over the union elements once. However, the Codspeed results on this PR have very consistently shown some impressive speedups and no performance regressions.

## Behaviour change

As well as achieving a big speedup, this PR also (to my surprise) improves our type-variable solving for `Callable` types. I've added a regression test for this to the PR:

```py
from typing import Callable

class Box[T]:
    def get(self) -> T:
        raise NotImplementedError

def my_iter[T](f: Callable[[], T | None]) -> Box[T]:
    return Box()

def get_int() -> int | None: ...

reveal_type(my_iter(get_int))  # `main`: Box[int | None]`; PR: Box[int]
```

I've stared at it for a while, but I don't _fully_ understand why this PR fixes the bug. It makes me a bit nervous, because I worry that the bug is still there _somewhere_ else in our code, and that this PR merely papers over the bug somehow. But @carljm encouraged me to open this up for review, so that's what I'm doing! I'm curious if the reason for the behaviour change is obvious to somebody else.

This behaviour change has a significant, positive impact on the ecosystem, because of typeshed's third overload for `builtins.iter()`:

https://github.com/astral-sh/ruff/blob/337e3ebd27407f50b96dd686631c4ac4697fa973/crates/ty_vendored/vendor/typeshed/stdlib/builtins.pyi#L3746-L3761

## Reduction in nondeterminism??

I _may_ be imagining it -- and it's very hard to tell -- but I think this PR _may_ reduce our level of nondeterminism? There are still some flakes in the mypy_primer report, but I _think_ the level of flakes on this PR has been consistently lower than I've seen on other ty PRs recently. Since we know that the number of flakes significantly increased after https://github.com/astral-sh/ruff/pull/21551, and we know that this PR impacts our behaviour when solving type variables in `Callable` types, I wonder if this _might_ also accidentally be improving the situation there somewhat?

It's again a bit of a mystery to me why this would be the case, however. It's also hard to confirm, since there is definitely still some flakiness in the ecosystem report (and there was _some_ flakiness in the report prior to #21551, too!).

## Reflexivity of subtyping for type variables

An implementation detail of this PR is that we currently return `false` from the `Type::subtyping_is_always_reflexive()` method on `main` if a type is a `Type::TypeVar` variant, but this PR changes that so we return `true` for `Type::TypeVar` variants.

The rationale for the current return-type of `false` is stated in this comment here:

https://github.com/astral-sh/ruff/blob/337e3ebd27407f50b96dd686631c4ac4697fa973/crates/ty_python_semantic/src/types/relation.rs#L491-L501

But the `subtyping_is_always_reflexive` method only has a single callsite on `main`, and that is here:

https://github.com/astral-sh/ruff/blob/337e3ebd27407f50b96dd686631c4ac4697fa973/crates/ty_python_semantic/src/types/relation.rs#L327-L334

and we also implement on `main` that `T` is always a subtype of `T | None` if `T` is a type variable, which I think is also only safe if we are able to assume that subtyping is always reflexive for `Type::TypeVar` variants. It therefore seems like we _de-facto_ treat `Type::TypeVar` variants in exactly the same way as all `Type` variants for which we return `true` from `Type::subtyping_is_always_reflexive()`, and that therefore life becomes much simpler if we simply return `true` from that method for `Type::TypeVar()` types.

I'm curious if I'm missing something here?

## Open questions

It's _possible_ that there are pathologically large unions where iterating over the union twice would mean that this new implementation of subtyping against union types is actually slower. Should we skip the fast path for non-type-variable types if the length of the union is above a certain arbitrary threshhold? Or is that something we should just leave for now, until we have hard evidence that this is a real problem?

I initially played around with using an `FxOrderSet` for `UnionType::elements()`, in https://github.com/astral-sh/ruff/pull/22458. That would make the `.contains()` fast path `O(1)` rather than `O(n)`, which would alleviate the concern about pathologically large unions. But (to my surprise) the Codspeed reports appear to show that this PR is ~as fast as #22458, and #22458 has a memory-usage regression which this PR does not. So for now, I am proposing adding the fast path while still keeping `UnionType::elements` as a boxed slice.

## Test Plan

- Existing tests
- One new mdtest for the improvement to typevar solving for `Callable` types
