### PR TITLE
[ty] Use constraint-set assignability (rather than assignability) when bounds contain negated types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/regression/1880_list_not_iterable.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/1880_list_not_iterable.md
@@ -1,0 +1,16 @@
+# `list[Not[str]]` is iterable
+
+This is a regression test for <https://github.com/astral-sh/ty/issues/1880>.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from ty_extensions import Not
+
+def foo(value: list[Not[str]]) -> None:
+    for item in value:
+        reveal_type(item)  # revealed: ~str
+```


### PR DESCRIPTION
## Summary

I suspect this is wrong; I just want to see the ecosystem report.