### PR TITLE
Set priority for prek to enable concurrent execution

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,15 +21,62 @@ exclude: |
   )$
 
 repos:
+  # Priority 0: Read-only hooks; hooks that modify disjoint file types.
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: check-merge-conflict
+        priority: 0
 
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.24.1
     hooks:
       - id: validate-pyproject
+        priority: 0
+
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.40.0
+    hooks:
+      - id: typos
+        priority: 0
+
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --
+        language: system
+        types: [rust]
+        pass_filenames: false # This makes it a lot faster
+        priority: 0
+
+  # Prettier
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.7.4
+    hooks:
+      - id: prettier
+        types: [yaml]
+        priority: 0
+
+  # zizmor detects security vulnerabilities in GitHub Actions workflows.
+  # Additional configuration for the tool is found in `.github/zizmor.yml`
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.19.0
+    hooks:
+      - id: zizmor
+        priority: 0
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.36.0
+    hooks:
+      - id: check-github-workflows
+        priority: 0
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        priority: 0
 
   - repo: https://github.com/executablebooks/mdformat
     rev: 1.0.0
@@ -44,7 +91,20 @@ repos:
             docs/formatter/black\.md
             | docs/\w+\.md
           )$
+        priority: 0
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.10
+    hooks:
+      - id: ruff-format
+        priority: 0
+      - id: ruff-check
+        args: [--fix, --exit-non-zero-on-fix]
+        types_or: [python, pyi]
+        require_serial: true
+        priority: 1
+
+  # Priority 1: Second-pass fixers (e.g., markdownlint-fix runs after mdformat).
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.47.0
     hooks:
@@ -54,7 +114,9 @@ repos:
             docs/formatter/black\.md
             | docs/\w+\.md
           )$
+        priority: 1
 
+  # Priority 2: blacken-docs runs after markdownlint-fix (both modify markdown).
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.20.0
     hooks:
@@ -68,48 +130,7 @@ repos:
           )$
         additional_dependencies:
           - black==25.12.0
-
-  - repo: https://github.com/crate-ci/typos
-    rev: v1.40.0
-    hooks:
-      - id: typos
-
-  - repo: local
-    hooks:
-      - id: cargo-fmt
-        name: cargo fmt
-        entry: cargo fmt --
-        language: system
-        types: [rust]
-        pass_filenames: false # This makes it a lot faster
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
-    hooks:
-      - id: ruff-format
-      - id: ruff-check
-        args: [--fix, --exit-non-zero-on-fix]
-        types_or: [python, pyi]
-        require_serial: true
-
-  # Prettier
-  - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.7.4
-    hooks:
-      - id: prettier
-        types: [yaml]
-
-  # zizmor detects security vulnerabilities in GitHub Actions workflows.
-  # Additional configuration for the tool is found in `.github/zizmor.yml`
-  - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.19.0
-    hooks:
-      - id: zizmor
-
-  - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.36.0
-    hooks:
-      - id: check-github-workflows
+        priority: 2
 
   # `actionlint` hook, for verifying correct syntax in GitHub Actions workflows.
   # Some additional configuration for `actionlint` can be found in `.github/actionlint.yaml`.
@@ -131,8 +152,4 @@ repos:
           # and checks these with shellcheck. This is arguably its most useful feature,
           # but the integration only works if shellcheck is installed
           - "github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1"
-
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.11.0.1
-    hooks:
-      - id: shellcheck
+        priority: 0


### PR DESCRIPTION
## Summary

prek allows you to set priorities, and can run tasks of the same priority concurrently (e.g., we can run Ruff's Python formatting and `cargo fmt` at the same time). On my machine, this takes `uvx prek run -a` from 19.4s to 5.0s (~a 4x speed-up).
