### PR TITLE
Use rustfmt directly in prek

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -778,9 +778,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version: 24
@@ -794,7 +791,7 @@ jobs:
           echo '```console' > "$GITHUB_STEP_SUMMARY"
           # Enable color output for prek and remove it for the summary
           # Use --hook-stage=manual to enable slower hooks that are skipped by default
-          SKIP=cargo-fmt uvx prek run --all-files --show-diff-on-failure --color always --hook-stage manual | \
+          SKIP=rustfmt uvx prek run --all-files --show-diff-on-failure --color always --hook-stage manual | \
             tee >(sed -E 's/\x1B\[([0-9]{1,2}(;[0-9]{1,2})*)?[mGK]//g' >> "$GITHUB_STEP_SUMMARY") >&1
           exit_code="${PIPESTATUS[0]}"
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,12 +42,11 @@ repos:
 
   - repo: local
     hooks:
-      - id: cargo-fmt
-        name: cargo fmt
-        entry: cargo fmt --
+      - id: rustfmt
+        name: rustfmt
+        entry: rustfmt
         language: system
         types: [rust]
-        pass_filenames: false # This makes it a lot faster
         priority: 0
 
   # Prettier

--- a/crates/ruff_formatter/shared_traits.rs
+++ b/crates/ruff_formatter/shared_traits.rs
@@ -13,7 +13,10 @@ impl<T, C> AsFormat<C> for &T
 where
     T: AsFormat<C>,
 {
-    type Format<'a> = T::Format<'a> where Self: 'a;
+    type Format<'a>
+        = T::Format<'a>
+    where
+        Self: 'a;
 
     fn format(&self) -> Self::Format<'_> {
         AsFormat::format(&**self)

--- a/fuzz/fuzz_targets/ruff_fix_validity.rs
+++ b/fuzz/fuzz_targets/ruff_fix_validity.rs
@@ -3,7 +3,7 @@
 
 #![no_main]
 
-use libfuzzer_sys::{fuzz_target, Corpus};
+use libfuzzer_sys::{Corpus, fuzz_target};
 use ruff_linter::settings::LinterSettings;
 use std::sync::OnceLock;
 

--- a/fuzz/fuzz_targets/ruff_formatter_idempotency.rs
+++ b/fuzz/fuzz_targets/ruff_formatter_idempotency.rs
@@ -3,10 +3,10 @@
 
 #![no_main]
 
-use libfuzzer_sys::{fuzz_target, Corpus};
+use libfuzzer_sys::{Corpus, fuzz_target};
 use similar::TextDiff;
 
-use ruff_python_formatter::{format_module_source, PyFormatOptions};
+use ruff_python_formatter::{PyFormatOptions, format_module_source};
 
 fn do_fuzz(case: &[u8]) -> Corpus {
     // Throw away inputs which aren't utf-8

--- a/fuzz/fuzz_targets/ruff_formatter_validity.rs
+++ b/fuzz/fuzz_targets/ruff_formatter_validity.rs
@@ -6,13 +6,13 @@
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
-use libfuzzer_sys::{fuzz_target, Corpus};
+use libfuzzer_sys::{Corpus, fuzz_target};
 use ruff_linter::linter::ParseSource;
-use ruff_linter::settings::flags::Noqa;
 use ruff_linter::settings::LinterSettings;
+use ruff_linter::settings::flags::Noqa;
 use ruff_linter::source_kind::SourceKind;
 use ruff_python_ast::PySourceType;
-use ruff_python_formatter::{format_module_source, PyFormatOptions};
+use ruff_python_formatter::{PyFormatOptions, format_module_source};
 use similar::TextDiff;
 
 static SETTINGS: OnceLock<LinterSettings> = OnceLock::new();

--- a/fuzz/fuzz_targets/ruff_parse_idempotency.rs
+++ b/fuzz/fuzz_targets/ruff_parse_idempotency.rs
@@ -3,7 +3,7 @@
 
 #![no_main]
 
-use libfuzzer_sys::{fuzz_target, Corpus};
+use libfuzzer_sys::{Corpus, fuzz_target};
 use ruff_python_codegen::round_trip;
 use similar::TextDiff;
 

--- a/fuzz/fuzz_targets/ruff_parse_simple.rs
+++ b/fuzz/fuzz_targets/ruff_parse_simple.rs
@@ -3,9 +3,9 @@
 
 #![no_main]
 
-use libfuzzer_sys::{fuzz_target, Corpus};
+use libfuzzer_sys::{Corpus, fuzz_target};
 use ruff_python_codegen::{Generator, Stylist};
-use ruff_python_parser::{parse_module, ParseError};
+use ruff_python_parser::{ParseError, parse_module};
 use ruff_text_size::Ranged;
 
 fn do_fuzz(case: &[u8]) -> Corpus {


### PR DESCRIPTION
## Summary

Apparently this is about ~18x faster (2.25s → 0.12s) for a single-file change, and ~2x faster (2.36s → 1.25s) for `prek run -a`.
