### PR TITLE
[ty] Improve rendering of ReST directives in docstrings

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -2585,7 +2585,7 @@ type<CURSOR>
 
         assert_snapshot!(
             test.type_signatures().skip_auto_import().build().snapshot(),
-            @r"
+            @"
         type :: <class 'type'>
         TypeError :: <class 'TypeError'>
         ",
@@ -8009,7 +8009,7 @@ my_list[0].remove<CURSOR>
         );
         assert_snapshot!(
             builder.build().snapshot(),
-            @r"
+            @"
         removeprefix
         removesuffix
         ",
@@ -8030,7 +8030,7 @@ def f(x: Any | str):
         );
         assert_snapshot!(
             builder.build().snapshot(),
-            @r"
+            @"
         removeprefix
         removesuffix
         ",
@@ -8052,7 +8052,7 @@ def f(x: Intersection[int, Any] | str):
         );
         assert_snapshot!(
             builder.build().snapshot(),
-            @r"
+            @"
         removeprefix
         removesuffix
         ",


### PR DESCRIPTION
## Summary
Improves the rendering of ReST version directives in docstrings to use human-readable phrases matching Sphinx/Pylance output.
**Before:**
  - `**version-added:** *3.0*`
  - `**version-changed:** *4.0*`
  - `**deprecated:** *1.2.3*`
  
**After:**
  - `**Added in version 3.0:**`
  - `**Changed in version 4.0:**`
  - `**Deprecated since version 1.2.3:**`

Mapping follows Sphinx's documentation:
  - `versionadded` / `version-added` → "Added in version"
  - `versionchanged` / `version-changed` → "Changed in version"
  - `deprecated` / `version-deprecated` → "Deprecated since version"
  - `versionremoved` / `version-removed` → "Removed in version"

  Fixes https://github.com/astral-sh/ty/issues/2147

  ## Test Plan

  - Updated existing snapshot tests (`version_blocks`, `deprecated_prefix_gunk`)
  - All 1078 ty_ide tests pass
  - `cargo clippy` passes with no warnings
