### PR TITLE
[ty] Fix stack overflow with recursive type aliases containing tuple …

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -453,3 +453,17 @@ def _(y: Y):
     if isinstance(y, dict):
         reveal_type(y)  # revealed: dict[str, X] | dict[str, Y]
 ```
+
+### Recursive alias with tuple - stack overflow test (issue 2470)
+
+This test case used to cause a stack overflow. The returned type `list[int]` is not assignable to
+`RecursiveT = int | tuple[RecursiveT, ...]`, so we get an error.
+
+```py
+type RecursiveT = int | tuple[RecursiveT, ...]
+
+def foo(a: int, b: int) -> RecursiveT:
+    some_intermediate_var = (a, b)
+    # error: [invalid-return-type] "Return type does not match returned value: expected `RecursiveT`, found `list[int]`"
+    return list(some_intermediate_var)
+```


### PR DESCRIPTION
This fixes issue https://github.com/astral-sh/ty/issues/2470 where recursive type aliases like `type RecursiveT = int | tuple[RecursiveT, ...]` caused a stack overflow when used in return type checking with constructors like `list()`.

The fix moves all type mapping processing for `UniqueSpecialization` (and other non-EagerExpansion mappings) inside the `visitor.visit()` closure. This ensures that if we encounter the same TypeAlias recursively during type mapping, the cycle detector will properly detect it and return the fallback value instead of recursing infinitely.

The key insight is that the previous code called `apply_function_specialization` followed by another `apply_type_mapping_impl` AFTER the visitor closure returned. At that point, the TypeAlias was no longer in the visitor's `seen` set, so recursive references would not be detected as cycles.
