### PR TITLE
[`flake8-pytest-style`] Add `check` parameter example to `PT017` docs

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -106,6 +106,16 @@ impl Violation for PytestCompositeAssertion {
 ///     assert exc_info.value.args
 /// ```
 ///
+/// Or, for pytest 8.4.0 and later:
+/// ```python
+/// import pytest
+///
+///
+/// def test_foo():
+///     with pytest.raises(ZeroDivisionError, check=lambda e: e.args):
+///         1 / 0
+/// ```
+///
 /// ## References
 /// - [`pytest` documentation: `pytest.raises`](https://docs.pytest.org/en/latest/reference/reference.html#pytest-raises)
 #[derive(ViolationMetadata)]


### PR DESCRIPTION
## Summary

- Adds an alternative example to the PT017 (`pytest-assert-in-except`) rule documentation showing pytest's `check` parameter for validating exceptions, available since pytest 8.4.0

Closes #22529

## Test plan

Documentation-only change. Verified with `uvx prek run -a`.