### PR TITLE
Correct comment about public functions starting with an underscore.

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
@@ -101,7 +101,7 @@ pub(crate) fn private_member_access(checker: &Checker, expr: &Expr) {
         }
     }
 
-    // Allow some documented private methods, like `os._exit()`.
+    // Allow some public functions whose names start with an underscore, like `os._exit()`.
     if let Some(qualified_name) = semantic.resolve_qualified_name(expr) {
         if matches!(qualified_name.segments(), ["os", "_exit"]) {
             return;


### PR DESCRIPTION
Currently, the code to which the comment applies only handles `os._exit`. It is a public function, not a “documented private” one (neither in the sense of “documented to be private” nor in the sense of “documented and private”). Here are a few reasons why it should be considered a public function:

[PEP 8](https://peps.python.org/pep-0008/#public-and-internal-interfaces) says “Documented interfaces are considered public, unless the documentation explicitly declares them to be provisional or internal interfaces exempt from the usual backwards compatibility guarantees.” The documentation for `os._exit` doesn’t say that the function is non-public or internal.

[The documentation for modules’ `__all__`](https://docs.python.org/3/reference/simple_stmts.html#module.__all__) says “The names given in `__all__` are all considered public and are required to exist.”. [`os._exit` is part of `os.__all__`](https://github.com/python/cpython/blob/v3.14.2/Lib/os.py#L58). Therefore, it should be considered public.

`os._exit` was named like this because it calls the C function `_exit`, not because it’s private.