### PR TITLE
[`FastAPI`] Add sub-diagnostic explaining why a fix was unavailable (`FAST002`)

### DIFF
--- a/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-non-annotated-dependency_FAST002_0.py.snap
+++ b/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-non-annotated-dependency_FAST002_0.py.snap
@@ -358,4 +358,4 @@ FAST002 FastAPI dependency without `Annotated`
 72 |     pass
    |
 help: Replace with `typing.Annotated`
-info: Automatic fix unavailable: a required parameter comes after an optional parameter. Consider reordering arguments to enable the fix.
+info: Automatic fix is unavailable because a required parameter would follow an optional parameter. Consider reordering arguments to enable the fix.

--- a/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-non-annotated-dependency_FAST002_0.py_py38.snap
+++ b/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-non-annotated-dependency_FAST002_0.py_py38.snap
@@ -358,4 +358,4 @@ FAST002 FastAPI dependency without `Annotated`
 72 |     pass
    |
 help: Replace with `typing_extensions.Annotated`
-info: Automatic fix unavailable: a required parameter comes after an optional parameter. Consider reordering arguments to enable the fix.
+info: Automatic fix is unavailable because a required parameter would follow an optional parameter. Consider reordering arguments to enable the fix.

--- a/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-non-annotated-dependency_FAST002_2.py.snap
+++ b/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-non-annotated-dependency_FAST002_2.py.snap
@@ -273,7 +273,7 @@ FAST002 FastAPI dependency without `Annotated`
 85 |     another_optional_param: int = Query(42, description="Another optional"),
    |
 help: Replace with `typing.Annotated`
-info: Automatic fix unavailable: a required parameter ('...') comes after an optional parameter. Consider reordering arguments to enable the fix.
+info: Automatic fix is unavailable because a required parameter would follow an optional parameter. Consider reordering arguments to enable the fix.
 
 FAST002 [*] FastAPI dependency without `Annotated`
   --> FAST002_2.py:85:5

--- a/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-non-annotated-dependency_FAST002_2.py_py38.snap
+++ b/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-non-annotated-dependency_FAST002_2.py_py38.snap
@@ -273,7 +273,7 @@ FAST002 FastAPI dependency without `Annotated`
 85 |     another_optional_param: int = Query(42, description="Another optional"),
    |
 help: Replace with `typing_extensions.Annotated`
-info: Automatic fix unavailable: a required parameter ('...') comes after an optional parameter. Consider reordering arguments to enable the fix.
+info: Automatic fix is unavailable because a required parameter would follow an optional parameter. Consider reordering arguments to enable the fix.
 
 FAST002 [*] FastAPI dependency without `Annotated`
   --> FAST002_2.py:85:5


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR fixes #22188 by adding autofix skipped reason as diagnostic info.

## Test Plan

<!-- How was it tested? -->
snapshots are updated accordingly.
