### PR TITLE
[ruff server] Open new workspace when opening a file outside of current workspace

### DIFF
--- a/crates/ruff_server/src/server/api/notifications/did_open.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_open.rs
@@ -28,7 +28,7 @@ impl super::SyncNotificationHandler for DidOpen {
     ) -> Result<()> {
         let document = TextDocument::new(text, version).with_language_id(&language_id);
 
-        session.open_text_document(uri.clone(), document);
+        session.open_text_document(uri.clone(), document, client);
 
         // Publish diagnostics if the client doesn't support pull diagnostics
         if !session.resolved_client_capabilities().pull_diagnostics {

--- a/crates/ruff_server/src/session.rs
+++ b/crates/ruff_server/src/session.rs
@@ -157,8 +157,9 @@ impl Session {
 
     /// Registers a text document at the provided `url`.
     /// If a document is already open here, it will be overwritten.
-    pub(crate) fn open_text_document(&mut self, url: Url, document: TextDocument) {
-        self.index.open_text_document(url, document);
+    pub(crate) fn open_text_document(&mut self, url: Url, document: TextDocument, client: &Client) {
+        self.index
+            .open_text_document(url, document, &self.global_settings, client);
     }
 
     /// De-registers a document, specified by its key.

--- a/crates/ruff_server/src/session/index/ruff_settings.rs
+++ b/crates/ruff_server/src/session/index/ruff_settings.rs
@@ -385,6 +385,13 @@ impl RuffSettingsIndex {
             .clone()
     }
 
+    pub(super) fn has_settings_for(&self, document_path: &Path) -> bool {
+        self.index
+            .range(..document_path.to_path_buf())
+            .rfind(|(path, _)| document_path.starts_with(path))
+            .is_some()
+    }
+
     pub(super) fn fallback(&self) -> Arc<RuffSettings> {
         self.fallback.clone()
     }


### PR DESCRIPTION
Fixes #17944

## Summary

Here we check if we have settings for the file we're trying to open, as a proxy for checking if it's in an open workspace or not.

Given this filesystem layout:

```
.
├── dir_0
│   ├── ruff.toml
│   └── test_0.py
└── dir_1
    ├── ruff.toml
    └── test_1.py
```

This fixes:

- cwd at top-level, opening `dir_0/test_0.py`
- cwd at top-level, opening `dir_0/test_0.py`, then `../dir_1/test_1.py` in same session
- cwd in `dir_0`, opening `../dir_1/test_1.py`
- cwd in `dir_0`, opening `test_0.py` first, then `../dir_1/test_1.py` in same session

without negatively affecting non-default workspaces (such as opening the folder in VS Code or `lsp-mode` in Emacs).

---

This doesn't work for the situation where we're opening a file in a nested directory below the default workspace, where we _do_ have a config file:

```
.
├── subdir
│   ├── ruff.toml
│   └── test_1.py
├── ruff.toml
└── test_0.py
```

Opening `test_0.py` first (in single file mode), and then opening `subdir/test_1.py` still uses the settings from `./ruff.toml` instead of `subdir/ruff.toml`

## Test Plan

Tested using the files described in [this comment](https://github.com/astral-sh/ruff/issues/17944#issuecomment-3745670262)

I noticed that ty has e2e testing of its lsp server, but this hasn't been implemented for ruff yet. I think this would need something like that to test automatically
