### PR TITLE
[ty] Infer `type[Unknown]` for calls to `type()` when overload evaluation is ambiguous

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_A_class_constructor_…_(dd9f8a8f736a329).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_A_class_constructor_…_(dd9f8a8f736a329).snap
@@ -25,6 +25,7 @@ error[no-matching-overload]: No overload of class `type` matches arguments
 1 | type()  # error: [no-matching-overload]
   | ^^^^^^
   |
+help: `builtins.type()` can either be called with one or three positional arguments (got 0)
 info: rule `no-matching-overload` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4111,55 +4111,6 @@ impl<'db> Type<'db> {
                     .into()
                 }
 
-                Some(KnownClass::Type) => {
-                    let str_instance = KnownClass::Str.to_instance(db);
-                    let type_instance = KnownClass::Type.to_instance(db);
-
-                    // ```py
-                    // class type:
-                    //     @overload
-                    //     def __init__(self, o: object, /) -> None: ...
-                    //     @overload
-                    //     def __init__(self, name: str, bases: tuple[type, ...], dict: dict[str, Any], /, **kwds: Any) -> None: ...
-                    // ```
-                    CallableBinding::from_overloads(
-                        self,
-                        [
-                            Signature::new(
-                                Parameters::new(
-                                    db,
-                                    [Parameter::positional_only(Some(Name::new_static("o")))
-                                        .with_annotated_type(Type::any())],
-                                ),
-                                type_instance,
-                            ),
-                            Signature::new(
-                                Parameters::new(
-                                    db,
-                                    [
-                                        Parameter::positional_only(Some(Name::new_static("name")))
-                                            .with_annotated_type(str_instance),
-                                        Parameter::positional_only(Some(Name::new_static("bases")))
-                                            .with_annotated_type(Type::homogeneous_tuple(
-                                                db,
-                                                type_instance,
-                                            )),
-                                        Parameter::positional_only(Some(Name::new_static("dict")))
-                                            .with_annotated_type(
-                                                KnownClass::Dict.to_specialized_instance(
-                                                    db,
-                                                    &[str_instance, Type::any()],
-                                                ),
-                                            ),
-                                    ],
-                                ),
-                                type_instance,
-                            ),
-                        ],
-                    )
-                    .into()
-                }
-
                 Some(KnownClass::Object) => {
                     // ```py
                     // class object:

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1443,12 +1443,6 @@ impl<'db> Bindings<'db> {
                             }
                         }
 
-                        Some(KnownClass::Type) if overload_index == 0 => {
-                            if let [Some(arg)] = overload.parameter_types() {
-                                overload.set_return_type(arg.dunder_class(db));
-                            }
-                        }
-
                         Some(KnownClass::Property) => {
                             if let [getter, setter, ..] = overload.parameter_types() {
                                 overload.set_return_type(Type::PropertyInstance(


### PR DESCRIPTION
## Summary

This is an alternative PR to https://github.com/astral-sh/ruff/pull/22502

## Test Plan

Mdtests
