### PR TITLE
feat: added isort options for completeness (WIP)

### DIFF
--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -78,6 +78,7 @@ pub(crate) fn format_imports(
     settings: &Settings,
     tokens: &Tokens,
 ) -> String {
+    let line_length = settings.line_length.unwrap_or(line_length);
     let trailer = &block.trailer;
     let block = annotate_imports(
         &block.imports,

--- a/crates/ruff_linter/src/rules/isort/order.rs
+++ b/crates/ruff_linter/src/rules/isort/order.rs
@@ -82,7 +82,7 @@ pub(crate) fn order_imports<'a>(
                     .map(Import),
             )
             .collect()
-    } else if settings.force_sort_within_sections {
+    } else if settings.force_sort_within_sections || settings.lexicographical {
         straight_imports
             .map(Import)
             .chain(from_imports.map(ImportFrom))

--- a/crates/ruff_linter/src/rules/isort/settings.rs
+++ b/crates/ruff_linter/src/rules/isort/settings.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 
 use crate::display_settings;
+use crate::line_width::LineLength;
 use crate::rules::isort::ImportType;
 use crate::rules::isort::categorize::KnownModules;
 use ruff_macros::CacheKey;
@@ -47,6 +48,8 @@ pub struct Settings {
     pub combine_as_imports: bool,
     pub force_single_line: bool,
     pub force_sort_within_sections: bool,
+    pub lexicographical: bool,
+    pub group_by_package: bool,
     pub case_sensitive: bool,
     pub force_wrap_aliases: bool,
     pub force_to_top: FxHashSet<String>,
@@ -69,6 +72,7 @@ pub struct Settings {
     pub from_first: bool,
     pub length_sort: bool,
     pub length_sort_straight: bool,
+    pub line_length: Option<LineLength>,
 }
 
 impl Settings {
@@ -101,6 +105,8 @@ impl Default for Settings {
             combine_as_imports: false,
             force_single_line: false,
             force_sort_within_sections: false,
+            lexicographical: false,
+            group_by_package: false,
             detect_same_package: true,
             case_sensitive: false,
             force_wrap_aliases: false,
@@ -123,6 +129,7 @@ impl Default for Settings {
             from_first: false,
             length_sort: false,
             length_sort_straight: false,
+            line_length: None,
         }
     }
 }
@@ -137,6 +144,8 @@ impl Display for Settings {
                 self.combine_as_imports,
                 self.force_single_line,
                 self.force_sort_within_sections,
+                self.lexicographical,
+                self.group_by_package,
                 self.detect_same_package,
                 self.case_sensitive,
                 self.force_wrap_aliases,
@@ -158,7 +167,8 @@ impl Display for Settings {
                 self.no_sections,
                 self.from_first,
                 self.length_sort,
-                self.length_sort_straight
+                self.length_sort_straight,
+                self.line_length | optional
             ]
         }
         Ok(())

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2341,11 +2341,34 @@ pub struct IsortOptions {
     #[option(
         default = r#"false"#,
         value_type = "bool",
-        example = r#"
-            force-sort-within-sections = true
-        "#
+        example = r#"force-sort-within-sections = true"#
     )]
     pub force_sort_within_sections: Option<bool>,
+
+    /// Whether to sort imports lexicographically, which ignores case unless
+    /// [`case-sensitive`](#lint_isort_case-sensitive) is enabled.
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
+        example = r#"lexicographical = true"#
+    )]
+    pub lexicographical: Option<bool>,
+
+    /// Whether to group imports by package when sorting.
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
+        example = r#"group-by-package = true"#
+    )]
+    pub group_by_package: Option<bool>,
+
+    /// The line length to use for `isort` specifically.
+    #[option(
+        default = r#"null"#,
+        value_type = "int",
+        example = r#"line-length = 1000"#
+    )]
+    pub line_length: Option<LineLength>,
 
     /// Sort imports taking into account case sensitivity.
     ///
@@ -2862,6 +2885,8 @@ impl IsortOptions {
             combine_as_imports: self.combine_as_imports.unwrap_or(false),
             force_single_line: self.force_single_line.unwrap_or(false),
             force_sort_within_sections,
+            lexicographical: self.lexicographical.unwrap_or(false),
+            group_by_package: self.group_by_package.unwrap_or(false),
             case_sensitive: self.case_sensitive.unwrap_or(false),
             force_wrap_aliases: self.force_wrap_aliases.unwrap_or(false),
             detect_same_package: self.detect_same_package.unwrap_or(true),
@@ -2892,6 +2917,7 @@ impl IsortOptions {
             from_first,
             length_sort: self.length_sort.unwrap_or(false),
             length_sort_straight: self.length_sort_straight.unwrap_or(false),
+            line_length: self.line_length,
         })
     }
 }


### PR DESCRIPTION
WIP to add completeness for isort options like:

```toml
[tool.ruff.lint.isort]
lexicographical = true
line-length = 1000
group-by-package = true
force-single-line = true
force-sort-within-sections = true
single-line-exclusions = [
  "collections.abc",
  "six.moves",
  "typing",
  "typing-extensions"
]
order-by-type = false
```
