### PR TITLE
[ty] Remove `source_order` fields from constraint sets; go back to fully reduced BDDs

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -260,8 +260,13 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     fn from_node_and_support(
         builder: &'c ConstraintSetBuilder<'db>,
         node: NodeId,
-        support: SupportId,
+        mut support: SupportId,
     ) -> Self {
+        // The support should only contain constraints that participate in making a constraint set
+        // satisfiable.
+        if node == ALWAYS_FALSE {
+            support = SupportId::Empty;
+        }
         Self {
             node,
             support,

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1533,10 +1533,8 @@ impl ConstraintId {
 /// construction, interior nodes can only refer to nodes with smaller indexes (since the nodes that
 /// outgoing edges point at must already exist).
 ///
-/// BDD nodes are _quasi-reduced_, which means that there are no duplicate nodes (which we handle
-/// via Salsa interning). Unlike the typical BDD representation, which is (fully) reduced, we do
-/// allow redundant nodes, with `if_true` and `if_false` edges that point at the same node. That
-/// means that our BDDs "remember" all of the individual constraints that they were created with.
+/// BDD nodes are _reduced_, which means that there are no duplicate nodes or redundant nodes
+/// (those with `if_true` and `if_false` edges that point at the same node).
 ///
 /// BDD nodes are also _ordered_, meaning that every path from the root of a BDD to a terminal node
 /// visits variables in the same order. [`ConstraintId::ordering`] defines the variable
@@ -1559,7 +1557,7 @@ enum Node {
 }
 
 impl NodeId {
-    /// Creates a new BDD node, ensuring that it is quasi-reduced.
+    /// Creates a new BDD node, ensuring that it is fully reduced.
     fn new(
         builder: &ConstraintSetBuilder<'_>,
         constraint: ConstraintId,
@@ -1580,8 +1578,8 @@ impl NodeId {
                     root_constraint.ordering() > constraint.ordering()
                 })
         );
-        if if_true == ALWAYS_FALSE && if_false == ALWAYS_FALSE {
-            return ALWAYS_FALSE;
+        if if_true == if_false {
+            return if_true;
         }
         builder.intern_interior_node(InteriorNodeData {
             constraint,
@@ -1848,15 +1846,7 @@ impl NodeId {
     /// Returns the `or` or union of two BDDs.
     fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
         match (self.node(), other.node()) {
-            (Node::AlwaysTrue, Node::AlwaysTrue) => ALWAYS_TRUE,
-            (Node::AlwaysTrue, Node::Interior(_)) => {
-                let other_interior = builder.interior_node_data(other);
-                NodeId::new(builder, other_interior.constraint, ALWAYS_TRUE, ALWAYS_TRUE)
-            }
-            (Node::Interior(_), Node::AlwaysTrue) => {
-                let self_interior = builder.interior_node_data(self);
-                NodeId::new(builder, self_interior.constraint, ALWAYS_TRUE, ALWAYS_TRUE)
-            }
+            (Node::AlwaysTrue, _) | (_, Node::AlwaysTrue) => ALWAYS_TRUE,
             (Node::AlwaysFalse, _) => other,
             (_, Node::AlwaysFalse) => self,
             (Node::Interior(self_interior), Node::Interior(other_interior)) => {
@@ -1985,25 +1975,7 @@ impl NodeId {
     /// Returns the `and` or intersection of two BDDs.
     fn and(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
         match (self.node(), other.node()) {
-            (Node::AlwaysFalse, Node::AlwaysFalse) => ALWAYS_FALSE,
-            (Node::AlwaysFalse, Node::Interior(_)) => {
-                let other_interior = builder.interior_node_data(other);
-                NodeId::new(
-                    builder,
-                    other_interior.constraint,
-                    ALWAYS_FALSE,
-                    ALWAYS_FALSE,
-                )
-            }
-            (Node::Interior(_), Node::AlwaysFalse) => {
-                let self_interior = builder.interior_node_data(self);
-                NodeId::new(
-                    builder,
-                    self_interior.constraint,
-                    ALWAYS_FALSE,
-                    ALWAYS_FALSE,
-                )
-            }
+            (Node::AlwaysFalse, _) | (_, Node::AlwaysFalse) => ALWAYS_FALSE,
             (Node::AlwaysTrue, _) => other,
             (_, Node::AlwaysTrue) => self,
             (Node::Interior(self_interior), Node::Interior(other_interior)) => {
@@ -5032,17 +5004,13 @@ mod tests {
     fn test_display_graph_output() {
         let expected = indoc! {r#"
             <0> (U = bool)
-            ┡━₁ <1> (U = str)
-            │   ┡━₁ <2> (T = bool)
-            │   │   ┡━₁ <3> (T = str)
-            │   │   │   ┡━₁ always
-            │   │   │   └─₀ always
-            │   │   └─₀ <4> (T = str)
-            │   │       ┡━₁ always
-            │   │       └─₀ never
-            │   └─₀ <2> SHARED
-            └─₀ <5> (U = str)
-                ┡━₁ <2> SHARED
+            ┡━₁ <1> (T = bool)
+            │   ┡━₁ always
+            │   └─₀ <2> (T = str)
+            │       ┡━₁ always
+            │       └─₀ never
+            └─₀ <3> (U = str)
+                ┡━₁ <1> SHARED
                 └─₀ never
         "#}
         .trim_end();

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -731,42 +731,30 @@ impl<'db> ConstraintSetBuilder<'db> {
         // builder's orderings. That's not the quickest thing in the world, but that's fine, since
         // `OwnedConstraintSet` is only used in mdtests, and not in type inference of user code.
 
-        fn rebuild_node<'db>(
-            db: &'db dyn Db,
-            builder: &ConstraintSetBuilder<'db>,
-            other: &OwnedConstraintSet<'db>,
-            cache: &mut FxHashMap<NodeId, NodeId>,
-            old_node: NodeId,
-        ) -> NodeId {
-            if old_node.is_terminal() {
-                return old_node;
+        let mut nodes = IndexVec::with_capacity(other.nodes.len());
+        let remap_node = |nodes: &IndexVec<NodeId, NodeId>, node: NodeId| {
+            if node.is_terminal() {
+                return node;
             }
-            if let Some(remapped) = cache.get(&old_node) {
-                return *remapped;
-            }
+            nodes[node]
+        };
 
-            let old_interior = other.nodes[old_node];
+        for old_interior in &other.nodes {
             let old_constraint = other.constraints[old_interior.constraint];
             let condition = Constraint::new_node(
                 db,
-                builder,
+                self,
                 old_constraint.typevar,
                 old_constraint.lower,
                 old_constraint.upper,
             );
-
-            let if_true = rebuild_node(db, builder, other, cache, old_interior.if_true);
-            let if_false = rebuild_node(db, builder, other, cache, old_interior.if_false);
-            let remapped = condition.ite(builder, if_true, if_false);
-
-            cache.insert(old_node, remapped);
-            remapped
+            let if_true = remap_node(&nodes, old_interior.if_true);
+            let if_false = remap_node(&nodes, old_interior.if_false);
+            let remapped = condition.ite(self, if_true, if_false);
+            nodes.push(remapped);
         }
 
-        // Maps NodeIds in the OwnedConstraintSet to the corresponding NodeIds in this builder.
-        let mut cache = FxHashMap::default();
-        let node = rebuild_node(db, self, other, &mut cache, other.node);
-
+        let node = remap_node(&nodes, other.node);
         let support =
             other
                 .support
@@ -777,7 +765,6 @@ impl<'db> ConstraintSetBuilder<'db> {
                     let remapped_constraint = self.intern_constraint(db, old_constraint_data);
                     self.ordered_union_support(support, SupportId::Singleton(remapped_constraint))
                 });
-
         ConstraintSet::from_node_and_support(self, node, support)
     }
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1542,7 +1542,7 @@ impl ConstraintId {
 /// BDD nodes are also _ordered_, meaning that every path from the root of a BDD to a terminal node
 /// visits variables in the same order. [`ConstraintId::ordering`] defines the variable
 /// ordering that we use for constraint set BDDs.
-#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd, get_size2::GetSize, salsa::Update)]
+#[derive(Clone, Copy, Eq, Hash, PartialEq, get_size2::GetSize, salsa::Update)]
 struct NodeId(u32);
 
 /// A special ID that is used for an "always true" / "always visible" constraint.
@@ -2669,13 +2669,19 @@ impl InteriorNode {
         result
     }
 
-    fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> NodeId {
-        // OR is commutative, which lets us halve our cache requirements
-        let key = if self.node() < other.node() {
-            (self.node(), other.node())
+    /// Returns a cache key for a commutative binary operator
+    fn commutative_key(a: Self, b: Self) -> (NodeId, NodeId) {
+        let a = a.node();
+        let b = b.node();
+        if a.index() < b.index() {
+            (a, b)
         } else {
-            (other.node(), self.node())
-        };
+            (b, a)
+        }
+    }
+
+    fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> NodeId {
+        let key = Self::commutative_key(self, other);
         let storage = builder.storage.borrow();
         if let Some(result) = storage.or_cache.get(&key) {
             return *result;
@@ -2713,12 +2719,7 @@ impl InteriorNode {
     }
 
     fn and(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> NodeId {
-        // AND is commutative, which lets us halve our cache requirements
-        let key = if self.node() < other.node() {
-            (self.node(), other.node())
-        } else {
-            (other.node(), self.node())
-        };
+        let key = Self::commutative_key(self, other);
         let storage = builder.storage.borrow();
         if let Some(result) = storage.and_cache.get(&key) {
             return *result;
@@ -2756,12 +2757,7 @@ impl InteriorNode {
     }
 
     fn iff(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> NodeId {
-        // IFF is commutative, which lets us halve our cache requirements
-        let key = if self.node() < other.node() {
-            (self.node(), other.node())
-        } else {
-            (other.node(), self.node())
-        };
+        let key = Self::commutative_key(self, other);
         let storage = builder.storage.borrow();
         if let Some(result) = storage.iff_cache.get(&key) {
             return *result;

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -227,7 +227,7 @@ pub struct OwnedConstraintSet<'db> {
     nodes: IndexVec<NodeId, InteriorNodeData>,
 
     /// Materialized support for this constraint set, in deterministic order.
-    support: Box<[ConstraintId]>,
+    support: Box<[(ConstraintId, bool)]>,
 }
 
 /// A set of constraints under which a type property holds.
@@ -755,16 +755,20 @@ impl<'db> ConstraintSetBuilder<'db> {
         }
 
         let node = remap_node(&nodes, other.node);
-        let support =
-            other
-                .support
-                .iter()
-                .copied()
-                .fold(SupportId::Empty, |support, old_constraint| {
-                    let old_constraint_data = other.constraints[old_constraint];
-                    let remapped_constraint = self.intern_constraint(db, old_constraint_data);
-                    self.ordered_union_support(support, SupportId::Singleton(remapped_constraint))
-                });
+        let mut support = SupportId::Empty;
+        let mut previous_origin_constraint = None;
+        for (old_constraint, derived) in other.support.iter().copied() {
+            let old_constraint_data = other.constraints[old_constraint];
+            let constraint = self.intern_constraint(db, old_constraint_data);
+            if derived {
+                let origin = previous_origin_constraint
+                    .expect("derived constraint should not appear before any origin constraints");
+                support = self.add_derived_support(support, origin, constraint);
+            } else {
+                previous_origin_constraint = Some(constraint);
+                support = self.ordered_union_support(support, SupportId::Singleton(constraint));
+            }
+        }
         ConstraintSet::from_node_and_support(self, node, support)
     }
 
@@ -919,17 +923,17 @@ impl<'db> ConstraintSetBuilder<'db> {
         SupportId::AddDerived(id)
     }
 
-    fn build_support(&self, support: SupportId) -> FxIndexSet<ConstraintId> {
+    fn build_support(&self, support: SupportId) -> FxIndexMap<ConstraintId, bool> {
         fn build_into(
             builder: &ConstraintSetBuilder<'_>,
             support: SupportId,
-            constraints: &mut FxIndexSet<ConstraintId>,
+            constraints: &mut FxIndexMap<ConstraintId, bool>,
         ) {
             match support {
                 SupportId::Empty => {}
 
                 SupportId::Singleton(constraint) => {
-                    constraints.insert(constraint);
+                    constraints.insert(constraint, false);
                 }
 
                 SupportId::OrderedUnion(union_support) => {
@@ -968,14 +972,14 @@ impl<'db> ConstraintSetBuilder<'db> {
                     let origin_index = constraints
                         .get_index_of(&add_derived.origin)
                         .expect("constraint should exist in support");
-                    if !constraints.contains(&add_derived.derived) {
-                        constraints.shift_insert(origin_index + 1, add_derived.derived);
+                    if !constraints.contains_key(&add_derived.derived) {
+                        constraints.shift_insert(origin_index + 1, add_derived.derived, true);
                     }
                 }
             }
         }
 
-        let mut constraints = FxIndexSet::default();
+        let mut constraints = FxIndexMap::default();
         build_into(self, support, &mut constraints);
         constraints
     }

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -72,7 +72,6 @@ use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 use std::ops::Range;
 
-use indexmap::map::Entry;
 use itertools::Itertools;
 use ruff_index::{Idx, IndexVec, newtype_index};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -397,7 +396,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
             FxHashSet<BoundTypeVarIdentity<'db>>,
         > = FxHashMap::default();
         self.node
-            .for_each_constraint(self.builder, &mut |constraint, _| {
+            .for_each_constraint(self.builder, &mut |constraint| {
                 let visitor = CollectReachability::default();
                 let constraint = self.builder.constraint_data(constraint);
                 visitor.visit_type(db, constraint.lower);
@@ -465,9 +464,6 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     }
 
     /// Updates this constraint set to hold the union of itself and another constraint set.
-    ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
     pub(crate) fn union(
         &mut self,
         _db: &'db dyn Db,
@@ -475,15 +471,12 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         other: Self,
     ) -> Self {
         self.verify_builder(builder);
-        self.node = self.node.or_with_offset(builder, other.node);
+        self.node = self.node.or(builder, other.node);
         self.support = builder.ordered_union_support(self.support, other.support);
         *self
     }
 
     /// Updates this constraint set to hold the intersection of itself and another constraint set.
-    ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
     pub(crate) fn intersect(
         &mut self,
         _db: &'db dyn Db,
@@ -491,7 +484,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         other: Self,
     ) -> Self {
         self.verify_builder(builder);
-        self.node = self.node.and_with_offset(builder, other.node);
+        self.node = self.node.and(builder, other.node);
         self.support = builder.ordered_union_support(self.support, other.support);
         *self
     }
@@ -505,9 +498,6 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     /// Returns the intersection of this constraint set and another. The other constraint set is
     /// provided as a thunk, to implement short-circuiting: the thunk is not forced if the
     /// constraint set is already saturated.
-    ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
     pub(crate) fn and(
         mut self,
         db: &'db dyn Db,
@@ -526,9 +516,6 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     /// Returns the union of this constraint set and another. The other constraint set is provided
     /// as a thunk, to implement short-circuiting: the thunk is not forced if the constraint set is
     /// already saturated.
-    ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
     pub(crate) fn or(
         mut self,
         db: &'db dyn Db,
@@ -545,9 +532,6 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     }
 
     /// Returns a constraint set encoding that this constraint set implies another.
-    ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
     pub(crate) fn implies(
         self,
         db: &'db dyn Db,
@@ -558,9 +542,6 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     }
 
     /// Returns a constraint set encoding that this constraint set is equivalent to another.
-    ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
     pub(crate) fn iff(
         self,
         _db: &'db dyn Db,
@@ -568,7 +549,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         other: Self,
     ) -> Self {
         self.verify_builder(builder);
-        let node = self.node.iff_with_offset(builder, other.node);
+        let node = self.node.iff(builder, other.node);
         let support = builder.ordered_union_support(self.support, other.support);
         Self::from_node_and_support(builder, node, support)
     }
@@ -694,9 +675,9 @@ struct ConstraintSetStorage<'db> {
     node_cache: FxHashMap<InteriorNodeData, NodeId>,
 
     negate_cache: FxHashMap<NodeId, NodeId>,
-    or_cache: FxHashMap<(NodeId, NodeId, usize), NodeId>,
-    and_cache: FxHashMap<(NodeId, NodeId, usize), NodeId>,
-    iff_cache: FxHashMap<(NodeId, NodeId, usize), NodeId>,
+    or_cache: FxHashMap<(NodeId, NodeId), NodeId>,
+    and_cache: FxHashMap<(NodeId, NodeId), NodeId>,
+    iff_cache: FxHashMap<(NodeId, NodeId), NodeId>,
     exists_one_cache:
         FxHashMap<(NodeId, SupportId, BoundTypeVarIdentity<'db>), (NodeId, SupportId)>,
     restrict_one_cache: FxHashMap<(NodeId, ConstraintAssignment), (NodeId, bool)>,
@@ -1160,7 +1141,7 @@ impl<'db> Constraint<'db> {
             for lower_element in lower_union.elements(db) {
                 let (next_node, next_support) =
                     Constraint::new_node_with_support(db, builder, typevar, *lower_element, upper);
-                result = result.and_with_offset(builder, next_node);
+                result = result.and(builder, next_node);
                 support = builder.ordered_union_support(support, next_support);
             }
             return (result, support);
@@ -1176,7 +1157,7 @@ impl<'db> Constraint<'db> {
             for upper_element in upper_intersection.iter_positive(db) {
                 let (next_node, next_support) =
                     Constraint::new_node_with_support(db, builder, typevar, lower, upper_element);
-                result = result.and_with_offset(builder, next_node);
+                result = result.and(builder, next_node);
                 support = builder.ordered_union_support(support, next_support);
             }
             for upper_element in upper_intersection.iter_negative(db) {
@@ -1187,7 +1168,7 @@ impl<'db> Constraint<'db> {
                     lower,
                     upper_element.negate(db),
                 );
-                result = result.and_with_offset(builder, next_node);
+                result = result.and(builder, next_node);
                 support = builder.ordered_union_support(support, next_support);
             }
             return (result, support);
@@ -1219,7 +1200,7 @@ impl<'db> Constraint<'db> {
             {
                 let constraint =
                     ConstraintId::new(db, builder, typevar, Type::Never, Type::object());
-                let node = Node::new_constraint(builder, constraint, 1).negate(builder);
+                let node = Node::new_constraint(builder, constraint).negate(builder);
                 let support = SupportId::Singleton(constraint);
                 return (node, support);
             }
@@ -1272,7 +1253,7 @@ impl<'db> Constraint<'db> {
                     Type::TypeVar(bound),
                     Type::TypeVar(bound),
                 );
-                let node = Node::new_constraint(builder, constraint, 1);
+                let node = Node::new_constraint(builder, constraint);
                 let support = SupportId::Singleton(constraint);
                 (node, support)
             }
@@ -1284,10 +1265,10 @@ impl<'db> Constraint<'db> {
             {
                 let lower_constraint =
                     ConstraintId::new(db, builder, lower, Type::Never, Type::TypeVar(typevar));
-                let lower = Node::new_constraint(builder, lower_constraint, 1);
+                let lower = Node::new_constraint(builder, lower_constraint);
                 let upper_constraint =
                     ConstraintId::new(db, builder, upper, Type::TypeVar(typevar), Type::object());
-                let upper = Node::new_constraint(builder, upper_constraint, 1);
+                let upper = Node::new_constraint(builder, upper_constraint);
                 let node = lower.and(builder, upper);
                 let support = builder.ordered_union_support(
                     SupportId::Singleton(lower_constraint),
@@ -1300,7 +1281,7 @@ impl<'db> Constraint<'db> {
             (Type::TypeVar(lower), _) if typevar.can_be_bound_for(db, builder, lower) => {
                 let lower_constraint =
                     ConstraintId::new(db, builder, lower, Type::Never, Type::TypeVar(typevar));
-                let lower = Node::new_constraint(builder, lower_constraint, 1);
+                let lower = Node::new_constraint(builder, lower_constraint);
                 let (upper, upper_support) = if upper.is_object() {
                     (ALWAYS_TRUE, SupportId::Empty)
                 } else {
@@ -1321,7 +1302,7 @@ impl<'db> Constraint<'db> {
                 };
                 let upper_constraint =
                     ConstraintId::new(db, builder, upper, Type::TypeVar(typevar), Type::object());
-                let upper = Node::new_constraint(builder, upper_constraint, 1);
+                let upper = Node::new_constraint(builder, upper_constraint);
                 let node = lower.and(builder, upper);
                 let support = builder
                     .ordered_union_support(lower_support, SupportId::Singleton(upper_constraint));
@@ -1330,7 +1311,7 @@ impl<'db> Constraint<'db> {
 
             _ => {
                 let constraint = ConstraintId::new(db, builder, typevar, lower, upper);
-                let node = Node::new_constraint(builder, constraint, 1);
+                let node = Node::new_constraint(builder, constraint);
                 let support = SupportId::Singleton(constraint);
                 (node, support)
             }
@@ -1569,15 +1550,7 @@ impl ConstraintId {
 /// BDD nodes are also _ordered_, meaning that every path from the root of a BDD to a terminal node
 /// visits variables in the same order. [`ConstraintId::ordering`] defines the variable
 /// ordering that we use for constraint set BDDs.
-///
-/// In addition to this BDD variable ordering, we also track a `source_order` for each individual
-/// constraint. This records the order in which constraints are added to the constraint set, which
-/// typically tracks when they appear in the underlying Python source code. This provides an
-/// ordering that is stable across multiple runs, for consistent test and diagnostic output. (We
-/// cannot use this ordering as our BDD variable ordering, since we calculate it from already
-/// constructed BDDs, and we need the BDD variable ordering to be fixed and available before
-/// construction starts.)
-#[derive(Clone, Copy, Eq, Hash, PartialEq, get_size2::GetSize, salsa::Update)]
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd, get_size2::GetSize, salsa::Update)]
 struct NodeId(u32);
 
 /// A special ID that is used for an "always true" / "always visible" constraint.
@@ -1601,7 +1574,6 @@ impl NodeId {
         constraint: ConstraintId,
         if_true: NodeId,
         if_false: NodeId,
-        source_order: usize,
     ) -> NodeId {
         debug_assert!(
             if_true
@@ -1620,15 +1592,10 @@ impl NodeId {
         if if_true == ALWAYS_FALSE && if_false == ALWAYS_FALSE {
             return ALWAYS_FALSE;
         }
-        let max_source_order = source_order
-            .max(if_true.max_source_order(builder))
-            .max(if_false.max_source_order(builder));
         builder.intern_interior_node(InteriorNodeData {
             constraint,
             if_true,
             if_false,
-            source_order,
-            max_source_order,
         })
     }
 }
@@ -1636,17 +1603,11 @@ impl NodeId {
 impl Node {
     /// Creates a new BDD node for an individual constraint. (The BDD will evaluate to `true` when
     /// the constraint holds, and to `false` when it does not.)
-    fn new_constraint(
-        builder: &ConstraintSetBuilder<'_>,
-        constraint: ConstraintId,
-        source_order: usize,
-    ) -> NodeId {
+    fn new_constraint(builder: &ConstraintSetBuilder<'_>, constraint: ConstraintId) -> NodeId {
         builder.intern_interior_node(InteriorNodeData {
             constraint,
             if_true: ALWAYS_TRUE,
             if_false: ALWAYS_FALSE,
-            source_order,
-            max_source_order: source_order,
         })
     }
 
@@ -1656,7 +1617,6 @@ impl Node {
     fn new_satisfied_constraint(
         builder: &ConstraintSetBuilder<'_>,
         constraint: ConstraintAssignment,
-        source_order: usize,
     ) -> NodeId {
         match constraint {
             ConstraintAssignment::Positive(constraint) => {
@@ -1664,8 +1624,6 @@ impl Node {
                     constraint,
                     if_true: ALWAYS_TRUE,
                     if_false: ALWAYS_FALSE,
-                    source_order,
-                    max_source_order: source_order,
                 })
             }
             ConstraintAssignment::Negative(constraint) => {
@@ -1673,8 +1631,6 @@ impl Node {
                     constraint,
                     if_true: ALWAYS_FALSE,
                     if_false: ALWAYS_TRUE,
-                    source_order,
-                    max_source_order: source_order,
                 })
             }
         }
@@ -1702,34 +1658,6 @@ impl NodeId {
         }
         let interior = builder.interior_node_data(self);
         Some(interior.constraint)
-    }
-
-    fn max_source_order(self, builder: &ConstraintSetBuilder<'_>) -> usize {
-        if self.is_terminal() {
-            return 0;
-        }
-        let interior = builder.interior_node_data(self);
-        interior.max_source_order
-    }
-
-    /// Returns a copy of this BDD node with all `source_order`s adjusted by the given amount.
-    fn with_adjusted_source_order(self, builder: &ConstraintSetBuilder<'_>, delta: usize) -> Self {
-        if delta == 0 {
-            return self;
-        }
-        match self.node() {
-            Node::AlwaysTrue | Node::AlwaysFalse => self,
-            Node::Interior(_) => {
-                let interior = builder.interior_node_data(self);
-                NodeId::new(
-                    builder,
-                    interior.constraint,
-                    interior.if_true.with_adjusted_source_order(builder, delta),
-                    interior.if_false.with_adjusted_source_order(builder, delta),
-                    interior.source_order + delta,
-                )
-            }
-        }
     }
 
     fn for_each_path_with_support<'db>(
@@ -1766,12 +1694,11 @@ impl NodeId {
                     db,
                     builder,
                     interior.constraint.when_true(),
-                    interior.source_order,
                     |path, new_range| {
                         let support = path.assignments[new_range]
                             .iter()
                             .rev() // add_derived supports are applied in reverse order
-                            .fold(support, |support, (assignment, _)| {
+                            .fold(support, |support, assignment| {
                                 builder.add_derived_support(
                                     support,
                                     interior.constraint,
@@ -1787,12 +1714,11 @@ impl NodeId {
                     db,
                     builder,
                     interior.constraint.when_false(),
-                    interior.source_order,
                     |path, new_range| {
                         let support = path.assignments[new_range]
                             .iter()
                             .rev() // add_derived supports are applied in reverse order
-                            .fold(support, |support, (assignment, _)| {
+                            .fold(support, |support, assignment| {
                                 builder.add_derived_support(
                                     support,
                                     interior.constraint,
@@ -1839,34 +1765,22 @@ impl NodeId {
                 // impossible paths, and so we treat them as passing the "always satisfied" check.
                 let interior = builder.interior_node_data(self);
                 let true_always_satisfied = path
-                    .walk_edge(
-                        db,
-                        builder,
-                        interior.constraint.when_true(),
-                        interior.source_order,
-                        |path, _| {
-                            interior
-                                .if_true
-                                .is_always_satisfied_inner(db, builder, path)
-                        },
-                    )
+                    .walk_edge(db, builder, interior.constraint.when_true(), |path, _| {
+                        interior
+                            .if_true
+                            .is_always_satisfied_inner(db, builder, path)
+                    })
                     .unwrap_or(true);
                 if !true_always_satisfied {
                     return false;
                 }
 
                 // Ditto for the if_false branch
-                path.walk_edge(
-                    db,
-                    builder,
-                    interior.constraint.when_false(),
-                    interior.source_order,
-                    |path, _| {
-                        interior
-                            .if_false
-                            .is_always_satisfied_inner(db, builder, path)
-                    },
-                )
+                path.walk_edge(db, builder, interior.constraint.when_false(), |path, _| {
+                    interior
+                        .if_false
+                        .is_always_satisfied_inner(db, builder, path)
+                })
                 .unwrap_or(true)
             }
         }
@@ -1899,30 +1813,20 @@ impl NodeId {
                 // impossible paths, and so we treat them as passing the "never satisfied" check.
                 let interior = builder.interior_node_data(self);
                 let true_never_satisfied = path
-                    .walk_edge(
-                        db,
-                        builder,
-                        interior.constraint.when_true(),
-                        interior.source_order,
-                        |path, _| interior.if_true.is_never_satisfied_inner(db, builder, path),
-                    )
+                    .walk_edge(db, builder, interior.constraint.when_true(), |path, _| {
+                        interior.if_true.is_never_satisfied_inner(db, builder, path)
+                    })
                     .unwrap_or(true);
                 if !true_never_satisfied {
                     return false;
                 }
 
                 // Ditto for the if_false branch
-                path.walk_edge(
-                    db,
-                    builder,
-                    interior.constraint.when_false(),
-                    interior.source_order,
-                    |path, _| {
-                        interior
-                            .if_false
-                            .is_never_satisfied_inner(db, builder, path)
-                    },
-                )
+                path.walk_edge(db, builder, interior.constraint.when_false(), |path, _| {
+                    interior
+                        .if_false
+                        .is_never_satisfied_inner(db, builder, path)
+                })
                 .unwrap_or(true)
             }
         }
@@ -1951,57 +1855,21 @@ impl NodeId {
     }
 
     /// Returns the `or` or union of two BDDs.
-    ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
-    fn or_with_offset(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        // To ensure that `self` appears before `other` in `source_order`, we add the maximum
-        // `source_order` of the lhs to all of the `source_order`s in the rhs.
-        //
-        // TODO: If we store `other_offset` as a new field on InteriorNode, we might be able to
-        // avoid all of the extra work in the calls to with_adjusted_source_order, and apply the
-        // adjustment lazily when walking a BDD tree. (ditto below in the other _with_offset
-        // methods)
-        let other_offset = self.max_source_order(builder);
-        self.or_inner(builder, other, other_offset)
-    }
-
     fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        self.or_inner(builder, other, 0)
-    }
-
-    fn or_inner(
-        self,
-        builder: &ConstraintSetBuilder<'_>,
-        other: Self,
-        other_offset: usize,
-    ) -> Self {
         match (self.node(), other.node()) {
             (Node::AlwaysTrue, Node::AlwaysTrue) => ALWAYS_TRUE,
             (Node::AlwaysTrue, Node::Interior(_)) => {
                 let other_interior = builder.interior_node_data(other);
-                NodeId::new(
-                    builder,
-                    other_interior.constraint,
-                    ALWAYS_TRUE,
-                    ALWAYS_TRUE,
-                    other_interior.source_order + other_offset,
-                )
+                NodeId::new(builder, other_interior.constraint, ALWAYS_TRUE, ALWAYS_TRUE)
             }
             (Node::Interior(_), Node::AlwaysTrue) => {
                 let self_interior = builder.interior_node_data(self);
-                NodeId::new(
-                    builder,
-                    self_interior.constraint,
-                    ALWAYS_TRUE,
-                    ALWAYS_TRUE,
-                    self_interior.source_order,
-                )
+                NodeId::new(builder, self_interior.constraint, ALWAYS_TRUE, ALWAYS_TRUE)
             }
-            (Node::AlwaysFalse, _) => other.with_adjusted_source_order(builder, other_offset),
+            (Node::AlwaysFalse, _) => other,
             (_, Node::AlwaysFalse) => self,
             (Node::Interior(self_interior), Node::Interior(other_interior)) => {
-                self_interior.or(builder, other_interior, other_offset)
+                self_interior.or(builder, other_interior)
             }
         }
     }
@@ -2104,7 +1972,7 @@ impl NodeId {
             nodes,
             ALWAYS_FALSE,
             Self::is_always_satisfied,
-            Self::or_with_offset,
+            Self::or,
         )
     }
 
@@ -2119,31 +1987,12 @@ impl NodeId {
             nodes,
             ALWAYS_TRUE,
             Self::is_never_satisfied,
-            Self::and_with_offset,
+            Self::and,
         )
     }
 
     /// Returns the `and` or intersection of two BDDs.
-    ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
-    fn and_with_offset(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        // To ensure that `self` appears before `other` in `source_order`, we add the maximum
-        // `source_order` of the lhs to all of the `source_order`s in the rhs.
-        let other_offset = self.max_source_order(builder);
-        self.and_inner(builder, other, other_offset)
-    }
-
     fn and(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        self.and_inner(builder, other, 0)
-    }
-
-    fn and_inner(
-        self,
-        builder: &ConstraintSetBuilder<'_>,
-        other: Self,
-        other_offset: usize,
-    ) -> Self {
         match (self.node(), other.node()) {
             (Node::AlwaysFalse, Node::AlwaysFalse) => ALWAYS_FALSE,
             (Node::AlwaysFalse, Node::Interior(_)) => {
@@ -2153,7 +2002,6 @@ impl NodeId {
                     other_interior.constraint,
                     ALWAYS_FALSE,
                     ALWAYS_FALSE,
-                    other_interior.source_order + other_offset,
                 )
             }
             (Node::Interior(_), Node::AlwaysFalse) => {
@@ -2163,13 +2011,12 @@ impl NodeId {
                     self_interior.constraint,
                     ALWAYS_FALSE,
                     ALWAYS_FALSE,
-                    self_interior.source_order,
                 )
             }
-            (Node::AlwaysTrue, _) => other.with_adjusted_source_order(builder, other_offset),
+            (Node::AlwaysTrue, _) => other,
             (_, Node::AlwaysTrue) => self,
             (Node::Interior(self_interior), Node::Interior(other_interior)) => {
-                self_interior.and(builder, other_interior, other_offset)
+                self_interior.and(builder, other_interior)
             }
         }
     }
@@ -2181,26 +2028,7 @@ impl NodeId {
 
     /// Returns a new BDD that evaluates to `true` when both input BDDs evaluate to the same
     /// result.
-    ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
-    fn iff_with_offset(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        // To ensure that `self` appears before `other` in `source_order`, we add the maximum
-        // `source_order` of the lhs to all of the `source_order`s in the rhs.
-        let other_offset = self.max_source_order(builder);
-        self.iff_inner(builder, other, other_offset)
-    }
-
     fn iff(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        self.iff_inner(builder, other, 0)
-    }
-
-    fn iff_inner(
-        self,
-        builder: &ConstraintSetBuilder<'_>,
-        other: Self,
-        other_offset: usize,
-    ) -> Self {
         match (self.node(), other.node()) {
             (Node::AlwaysFalse, Node::AlwaysFalse) | (Node::AlwaysTrue, Node::AlwaysTrue) => {
                 ALWAYS_TRUE
@@ -2213,9 +2041,8 @@ impl NodeId {
                 NodeId::new(
                     builder,
                     interior.constraint,
-                    self.iff_inner(builder, interior.if_true, other_offset),
-                    self.iff_inner(builder, interior.if_false, other_offset),
-                    interior.source_order + other_offset,
+                    self.iff(builder, interior.if_true),
+                    self.iff(builder, interior.if_false),
                 )
             }
             (Node::Interior(_), Node::AlwaysTrue | Node::AlwaysFalse) => {
@@ -2223,12 +2050,11 @@ impl NodeId {
                 NodeId::new(
                     builder,
                     interior.constraint,
-                    interior.if_true.iff_inner(builder, other, other_offset),
-                    interior.if_false.iff_inner(builder, other, other_offset),
-                    interior.source_order,
+                    interior.if_true.iff(builder, other),
+                    interior.if_false.iff(builder, other),
                 )
             }
-            (Node::Interior(a), Node::Interior(b)) => a.iff(builder, b, other_offset),
+            (Node::Interior(a), Node::Interior(b)) => a.iff(builder, b),
         }
     }
 
@@ -2292,7 +2118,7 @@ impl NodeId {
         }
 
         let mut typevars = FxHashSet::default();
-        self.for_each_constraint(builder, &mut |constraint, _| {
+        self.for_each_constraint(builder, &mut |constraint| {
             let constraint = builder.constraint_data(constraint);
             typevars.insert(constraint.typevar);
         });
@@ -2434,15 +2260,12 @@ impl NodeId {
     }
 
     /// Returns a new BDD with any occurrence of `left ∧ right` replaced with `replacement`.
-    #[expect(clippy::too_many_arguments)]
     fn substitute_intersection<'db>(
         self,
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         left: ConstraintAssignment,
-        left_source_order: usize,
         right: ConstraintAssignment,
-        right_source_order: usize,
         replacement: NodeId,
     ) -> Self {
         // We perform a Shannon expansion to find out what the input BDD evaluates to when:
@@ -2476,8 +2299,8 @@ impl NodeId {
         //     false
         //
         //  (Note that the `else` branch shouldn't be reachable, but we have to provide something!)
-        let left_node = Node::new_satisfied_constraint(builder, left, left_source_order);
-        let right_node = Node::new_satisfied_constraint(builder, right, right_source_order);
+        let left_node = Node::new_satisfied_constraint(builder, left);
+        let right_node = Node::new_satisfied_constraint(builder, right);
         let right_result = right_node.ite(builder, ALWAYS_FALSE, when_left_but_not_right);
         let left_result = left_node.ite(builder, right_result, when_not_left);
         let result = replacement.ite(builder, when_left_and_right, left_result);
@@ -2496,15 +2319,12 @@ impl NodeId {
     }
 
     /// Returns a new BDD with any occurrence of `left ∨ right` replaced with `replacement`.
-    #[expect(clippy::too_many_arguments)]
     fn substitute_union<'db>(
         self,
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         left: ConstraintAssignment,
-        left_source_order: usize,
         right: ConstraintAssignment,
-        right_source_order: usize,
         replacement: NodeId,
     ) -> Self {
         // We perform a Shannon expansion to find out what the input BDD evaluates to when:
@@ -2544,8 +2364,8 @@ impl NodeId {
         // Lastly, verify that the result is consistent with the input. (It must produce the same
         // results when `left ∨ right`.) If it doesn't, the substitution isn't valid, and we should
         // return the original BDD unmodified.
-        let left_node = Node::new_satisfied_constraint(builder, left, left_source_order);
-        let right_node = Node::new_satisfied_constraint(builder, right, right_source_order);
+        let left_node = Node::new_satisfied_constraint(builder, left);
+        let right_node = Node::new_satisfied_constraint(builder, right);
         let validity = replacement.iff(builder, left_node.or(builder, right_node));
         let constrained_original = self.and(builder, validity);
         let constrained_replacement = result.and(builder, validity);
@@ -2563,13 +2383,13 @@ impl NodeId {
     fn for_each_constraint(
         self,
         builder: &ConstraintSetBuilder<'_>,
-        f: &mut dyn FnMut(ConstraintId, usize),
+        f: &mut dyn FnMut(ConstraintId),
     ) {
         if self.is_terminal() {
             return;
         }
         let interior = builder.interior_node_data(self);
-        f(interior.constraint, interior.source_order);
+        f(interior.constraint);
         interior.if_true.for_each_constraint(builder, f);
         interior.if_false.for_each_constraint(builder, f);
     }
@@ -2722,13 +2542,7 @@ impl NodeId {
                         return write!(f, "<{index}> SHARED");
                     }
                     let interior = builder.interior_node_data(node);
-                    write!(
-                        f,
-                        "<{index}> {} {}/{}",
-                        interior.constraint.display(db, builder),
-                        interior.source_order,
-                        interior.max_source_order,
-                    )?;
+                    write!(f, "<{index}> {}", interior.constraint.display(db, builder),)?;
                     // Calling display_graph recursively here causes rustc to claim that the
                     // expect(unused) up above is unfulfilled!
                     write!(f, "\n{prefix}┡━₁ ",)?;
@@ -2810,16 +2624,6 @@ struct InteriorNodeData {
     constraint: ConstraintId,
     if_true: NodeId,
     if_false: NodeId,
-
-    /// Represents the order in which this node's constraint was added to the containing constraint
-    /// set, relative to all of the other constraints in the set. This starts off at 1 for a simple
-    /// single-constraint set (e.g. created with [`Node::new_constraint`] or
-    /// [`Node::new_satisfied_constraint`]). It will get incremented, if needed, as that simple BDD
-    /// is combined into larger BDDs.
-    source_order: usize,
-
-    /// The maximum `source_order` across this node and all of its descendants.
-    max_source_order: usize,
 }
 
 impl InteriorNode {
@@ -2841,7 +2645,6 @@ impl InteriorNode {
             interior.constraint,
             interior.if_true.negate(builder),
             interior.if_false.negate(builder),
-            interior.source_order,
         );
 
         let mut storage = builder.storage.borrow_mut();
@@ -2849,8 +2652,13 @@ impl InteriorNode {
         result
     }
 
-    fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self, other_offset: usize) -> NodeId {
-        let key = (self.node(), other.node(), other_offset);
+    fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> NodeId {
+        // OR is commutative, which lets us halve our cache requirements
+        let key = if self.node() < other.node() {
+            (self.node(), other.node())
+        } else {
+            (other.node(), self.node())
+        };
         let storage = builder.storage.borrow();
         if let Some(result) = storage.or_cache.get(&key) {
             return *result;
@@ -2865,33 +2673,20 @@ impl InteriorNode {
             Ordering::Equal => NodeId::new(
                 builder,
                 self_interior.constraint,
-                self_interior
-                    .if_true
-                    .or_inner(builder, other_interior.if_true, other_offset),
-                self_interior
-                    .if_false
-                    .or_inner(builder, other_interior.if_false, other_offset),
-                self_interior.source_order,
+                self_interior.if_true.or(builder, other_interior.if_true),
+                self_interior.if_false.or(builder, other_interior.if_false),
             ),
             Ordering::Less => NodeId::new(
                 builder,
                 self_interior.constraint,
-                self_interior
-                    .if_true
-                    .or_inner(builder, other.node(), other_offset),
-                self_interior
-                    .if_false
-                    .or_inner(builder, other.node(), other_offset),
-                self_interior.source_order,
+                self_interior.if_true.or(builder, other.node()),
+                self_interior.if_false.or(builder, other.node()),
             ),
             Ordering::Greater => NodeId::new(
                 builder,
                 other_interior.constraint,
-                self.node()
-                    .or_inner(builder, other_interior.if_true, other_offset),
-                self.node()
-                    .or_inner(builder, other_interior.if_false, other_offset),
-                other_interior.source_order + other_offset,
+                self.node().or(builder, other_interior.if_true),
+                self.node().or(builder, other_interior.if_false),
             ),
         };
 
@@ -2900,8 +2695,13 @@ impl InteriorNode {
         result
     }
 
-    fn and(self, builder: &ConstraintSetBuilder<'_>, other: Self, other_offset: usize) -> NodeId {
-        let key = (self.node(), other.node(), other_offset);
+    fn and(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> NodeId {
+        // AND is commutative, which lets us halve our cache requirements
+        let key = if self.node() < other.node() {
+            (self.node(), other.node())
+        } else {
+            (other.node(), self.node())
+        };
         let storage = builder.storage.borrow();
         if let Some(result) = storage.and_cache.get(&key) {
             return *result;
@@ -2916,33 +2716,20 @@ impl InteriorNode {
             Ordering::Equal => NodeId::new(
                 builder,
                 self_interior.constraint,
-                self_interior
-                    .if_true
-                    .and_inner(builder, other_interior.if_true, other_offset),
-                self_interior
-                    .if_false
-                    .and_inner(builder, other_interior.if_false, other_offset),
-                self_interior.source_order,
+                self_interior.if_true.and(builder, other_interior.if_true),
+                self_interior.if_false.and(builder, other_interior.if_false),
             ),
             Ordering::Less => NodeId::new(
                 builder,
                 self_interior.constraint,
-                self_interior
-                    .if_true
-                    .and_inner(builder, other.node(), other_offset),
-                self_interior
-                    .if_false
-                    .and_inner(builder, other.node(), other_offset),
-                self_interior.source_order,
+                self_interior.if_true.and(builder, other.node()),
+                self_interior.if_false.and(builder, other.node()),
             ),
             Ordering::Greater => NodeId::new(
                 builder,
                 other_interior.constraint,
-                self.node()
-                    .and_inner(builder, other_interior.if_true, other_offset),
-                self.node()
-                    .and_inner(builder, other_interior.if_false, other_offset),
-                other_interior.source_order + other_offset,
+                self.node().and(builder, other_interior.if_true),
+                self.node().and(builder, other_interior.if_false),
             ),
         };
 
@@ -2951,8 +2738,13 @@ impl InteriorNode {
         result
     }
 
-    fn iff(self, builder: &ConstraintSetBuilder<'_>, other: Self, other_offset: usize) -> NodeId {
-        let key = (self.node(), other.node(), other_offset);
+    fn iff(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> NodeId {
+        // IFF is commutative, which lets us halve our cache requirements
+        let key = if self.node() < other.node() {
+            (self.node(), other.node())
+        } else {
+            (other.node(), self.node())
+        };
         let storage = builder.storage.borrow();
         if let Some(result) = storage.iff_cache.get(&key) {
             return *result;
@@ -2967,33 +2759,20 @@ impl InteriorNode {
             Ordering::Equal => NodeId::new(
                 builder,
                 self_interior.constraint,
-                self_interior
-                    .if_true
-                    .iff_inner(builder, other_interior.if_true, other_offset),
-                self_interior
-                    .if_false
-                    .iff_inner(builder, other_interior.if_false, other_offset),
-                self_interior.source_order,
+                self_interior.if_true.iff(builder, other_interior.if_true),
+                self_interior.if_false.iff(builder, other_interior.if_false),
             ),
             Ordering::Less => NodeId::new(
                 builder,
                 self_interior.constraint,
-                self_interior
-                    .if_true
-                    .iff_inner(builder, other.node(), other_offset),
-                self_interior
-                    .if_false
-                    .iff_inner(builder, other.node(), other_offset),
-                self_interior.source_order,
+                self_interior.if_true.iff(builder, other.node()),
+                self_interior.if_false.iff(builder, other.node()),
             ),
             Ordering::Greater => NodeId::new(
                 builder,
                 other_interior.constraint,
-                self.node()
-                    .iff_inner(builder, other_interior.if_true, other_offset),
-                self.node()
-                    .iff_inner(builder, other_interior.if_false, other_offset),
-                other_interior.source_order + other_offset,
+                self.node().iff(builder, other_interior.if_true),
+                self.node().iff(builder, other_interior.if_false),
             ),
         };
 
@@ -3069,18 +2848,12 @@ impl InteriorNode {
             //
             // We also have to check if there are any derived facts that depend on the constraint
             // we're about to remove. If so, we need to "remember" them by AND-ing them in with the
-            // corresponding branch. We currently reuse the `source_order` of the constraint being
-            // removed when we add these derived facts.
-            //
-            // TODO: This might not be stable enough, if we add more than one derived fact for this
-            // constraint. If we still see inconsistent test output, we might need a more complex
-            // way of tracking source order for derived facts.
+            // corresponding branch.
             let (if_true_node, if_true_support) = path
                 .walk_edge(
                     db,
                     builder,
                     self_interior.constraint.when_true(),
-                    self_interior.source_order,
                     |path, new_range| {
                         let (branch_node, branch_support) = self_interior
                             .if_true
@@ -3088,19 +2861,16 @@ impl InteriorNode {
                         path.assignments[new_range]
                             .iter()
                             .rev() // add_derived supports are applied in reverse order
-                            .filter(|(assignment, _)| {
+                            .filter(|assignment| {
                                 // Don't add back any derived facts if they are ones that we would have
                                 // removed!
                                 !should_remove(assignment.constraint())
                             })
                             .fold(
                                 (branch_node, branch_support),
-                                |(branch_node, branch_support), (assignment, source_order)| {
-                                    let constraint = Node::new_satisfied_constraint(
-                                        builder,
-                                        *assignment,
-                                        *source_order,
-                                    );
+                                |(branch_node, branch_support), assignment| {
+                                    let constraint =
+                                        Node::new_satisfied_constraint(builder, *assignment);
                                     (
                                         branch_node.and(builder, constraint),
                                         builder.add_derived_support(
@@ -3119,7 +2889,6 @@ impl InteriorNode {
                     db,
                     builder,
                     self_interior.constraint.when_false(),
-                    self_interior.source_order,
                     |path, new_range| {
                         let (branch_node, branch_support) = self_interior
                             .if_false
@@ -3127,19 +2896,16 @@ impl InteriorNode {
                         path.assignments[new_range]
                             .iter()
                             .rev() // add_derived supports are applied in reverse order
-                            .filter(|(assignment, _)| {
+                            .filter(|assignment| {
                                 // Don't add back any derived facts if they are ones that we would have
                                 // removed!
                                 !should_remove(assignment.constraint())
                             })
                             .fold(
                                 (branch_node, branch_support),
-                                |(branch_node, branch_support), (assignment, source_order)| {
-                                    let constraint = Node::new_satisfied_constraint(
-                                        builder,
-                                        *assignment,
-                                        *source_order,
-                                    );
+                                |(branch_node, branch_support), assignment| {
+                                    let constraint =
+                                        Node::new_satisfied_constraint(builder, *assignment);
                                     (
                                         branch_node.and(builder, constraint),
                                         builder.add_derived_support(
@@ -3164,7 +2930,6 @@ impl InteriorNode {
                     db,
                     builder,
                     self_interior.constraint.when_true(),
-                    self_interior.source_order,
                     |path, _| {
                         self_interior.if_true.abstract_one_inner(
                             db,
@@ -3181,7 +2946,6 @@ impl InteriorNode {
                     db,
                     builder,
                     self_interior.constraint.when_false(),
-                    self_interior.source_order,
                     |path, _| {
                         self_interior.if_false.abstract_one_inner(
                             db,
@@ -3196,11 +2960,7 @@ impl InteriorNode {
             // NB: We cannot use `Node::new` here, because the recursive calls might introduce new
             // derived constraints into the result, and those constraints might appear before this
             // one in the BDD ordering.
-            let constraint = Node::new_constraint(
-                builder,
-                self_interior.constraint,
-                self_interior.source_order,
-            );
+            let constraint = Node::new_constraint(builder, self_interior.constraint);
             let node = constraint.ite(builder, if_true_node, if_false_node);
             let support = builder.ordered_union_support(if_true_support, if_false_support);
             let support = builder
@@ -3242,13 +3002,7 @@ impl InteriorNode {
                 let (if_false, found_in_false) =
                     self_interior.if_false.restrict_one(db, builder, assignment);
                 (
-                    NodeId::new(
-                        builder,
-                        self_interior.constraint,
-                        if_true,
-                        if_false,
-                        self_interior.source_order,
-                    ),
+                    NodeId::new(builder, self_interior.constraint, if_true, if_false),
                     found_in_true || found_in_false,
                 )
             }
@@ -3317,17 +3071,15 @@ impl InteriorNode {
                 return solutions;
             }
 
-            // Sort the constraints in each path by their `source_order`s, to ensure that we construct
-            // any unions or intersections in our type mappings in a stable order. Constraints might
-            // come out of `PathAssignment`s with identical `source_order`s, but if they do, those
-            // "tied" constraints will still be ordered in a stable way. So we need a stable sort to
-            // retain that stable per-tie ordering.
+            // Sort the constraints in each path by where they appear in the constraint set's
+            // support. That ensures that we construct any unions or intersections in our type
+            // mappings in a stable order.
             let mut sorted_paths = Vec::new();
             interior.for_each_path_with_support(db, builder, support, |path, path_support| {
                 let support_order = builder.build_support(path_support);
                 let mut path: Vec<_> = path
                     .positive_constraints()
-                    .map(|(constraint, _source_order)| {
+                    .map(|constraint| {
                         let source_order = support_order
                             .get_index_of(&constraint)
                             .expect("constraint should exist in support order");
@@ -3459,18 +3211,11 @@ impl InteriorNode {
     }
 
     fn path_assignments(self, builder: &ConstraintSetBuilder<'_>) -> PathAssignments {
-        // Sort the constraints in this BDD by their `source_order`s before adding them to the
-        // sequent map. This ensures that constraints appear in the sequent map in a stable order.
-        // The constraints mentioned in a BDD should all have distinct `source_order`s, so an
-        // unstable sort is fine.
         let mut constraints: SmallVec<[_; 8]> = SmallVec::new();
-        self.node()
-            .for_each_constraint(builder, &mut |constraint, source_order| {
-                constraints.push((constraint, source_order));
-            });
-        constraints.sort_unstable_by_key(|(_, source_order)| *source_order);
-
-        PathAssignments::new(constraints.into_iter().map(|(constraint, _)| constraint))
+        self.node().for_each_constraint(builder, &mut |constraint| {
+            constraints.push(constraint);
+        });
+        PathAssignments::new(constraints)
     }
 
     /// Returns a simplified version of a BDD.
@@ -3502,28 +3247,18 @@ impl InteriorNode {
         // visit queue with all pairs of those constraints. (We use "combinations" because we don't
         // need to compare a constraint against itself, and because ordering doesn't matter.)
         let mut seen_constraints = FxHashSet::default();
-        let mut source_orders = FxHashMap::default();
-        self.node()
-            .for_each_constraint(builder, &mut |constraint, source_order| {
-                seen_constraints.insert(constraint);
-                source_orders.insert(constraint, source_order);
-            });
+        self.node().for_each_constraint(builder, &mut |constraint| {
+            seen_constraints.insert(constraint);
+        });
         let mut to_visit: Vec<(_, _)> = (seen_constraints.iter().copied())
             .tuple_combinations()
             .collect();
 
         // Repeatedly pop constraint pairs off of the visit queue, checking whether each pair can
         // be simplified. If we add any derived constraints, we will place them at the end in
-        // source order. (We do not have any test cases that depend on constraint sets being
-        // displayed in a consistent ordering, so we don't need to be clever in assigning these
-        // `source_order`s.)
+        // source order.
         let mut simplified = self.node();
-        let self_interior = builder.interior_node_data(self.node());
-        let mut next_source_order = self_interior.max_source_order + 1;
         while let Some((left_constraint, right_constraint)) = to_visit.pop() {
-            let left_source_order = source_orders[&left_constraint];
-            let right_source_order = source_orders[&right_constraint];
-
             // If the constraints refer to different typevars, the only simplifications we can make
             // are of the form `S ≤ T ∧ T ≤ int → S ≤ int`.
             let left_constraint_data = builder.constraint_data(left_constraint);
@@ -3585,18 +3320,11 @@ impl InteriorNode {
                 if seen_constraints.contains(&new_constraint) {
                     continue;
                 }
-                let new_node = Node::new_constraint(builder, new_constraint, next_source_order);
-                next_source_order += 1;
-                let positive_left_node = Node::new_satisfied_constraint(
-                    builder,
-                    left_constraint.when_true(),
-                    left_source_order,
-                );
-                let positive_right_node = Node::new_satisfied_constraint(
-                    builder,
-                    right_constraint.when_true(),
-                    right_source_order,
-                );
+                let new_node = Node::new_constraint(builder, new_constraint);
+                let positive_left_node =
+                    Node::new_satisfied_constraint(builder, left_constraint.when_true());
+                let positive_right_node =
+                    Node::new_satisfied_constraint(builder, right_constraint.when_true());
                 let lhs = positive_left_node.and(builder, positive_right_node);
                 let intersection = new_node.ite(builder, lhs, ALWAYS_FALSE);
                 simplified = simplified.and(builder, intersection);
@@ -3619,48 +3347,24 @@ impl InteriorNode {
             // Containment: The range of one constraint might completely contain the range of the
             // other. If so, there are several potential simplifications.
             let larger_smaller = if left_constraint.implies(db, builder, right_constraint) {
-                Some((
-                    right_constraint,
-                    right_source_order,
-                    left_constraint,
-                    left_source_order,
-                ))
+                Some((right_constraint, left_constraint))
             } else if right_constraint.implies(db, builder, left_constraint) {
-                Some((
-                    left_constraint,
-                    left_source_order,
-                    right_constraint,
-                    right_source_order,
-                ))
+                Some((left_constraint, right_constraint))
             } else {
                 None
             };
-            if let Some((
-                larger_constraint,
-                larger_source_order,
-                smaller_constraint,
-                smaller_source_order,
-            )) = larger_smaller
-            {
-                let positive_larger_node = Node::new_satisfied_constraint(
-                    builder,
-                    larger_constraint.when_true(),
-                    larger_source_order,
-                );
-                let negative_larger_node = Node::new_satisfied_constraint(
-                    builder,
-                    larger_constraint.when_false(),
-                    larger_source_order,
-                );
+            if let Some((larger_constraint, smaller_constraint)) = larger_smaller {
+                let positive_larger_node =
+                    Node::new_satisfied_constraint(builder, larger_constraint.when_true());
+                let negative_larger_node =
+                    Node::new_satisfied_constraint(builder, larger_constraint.when_false());
 
                 // larger ∨ smaller = larger
                 simplified = simplified.substitute_union(
                     db,
                     builder,
                     larger_constraint.when_true(),
-                    larger_source_order,
                     smaller_constraint.when_true(),
-                    smaller_source_order,
                     positive_larger_node,
                 );
 
@@ -3669,9 +3373,7 @@ impl InteriorNode {
                     db,
                     builder,
                     larger_constraint.when_false(),
-                    larger_source_order,
                     smaller_constraint.when_false(),
-                    smaller_source_order,
                     negative_larger_node,
                 );
 
@@ -3681,9 +3383,7 @@ impl InteriorNode {
                     db,
                     builder,
                     larger_constraint.when_false(),
-                    larger_source_order,
                     smaller_constraint.when_true(),
-                    smaller_source_order,
                     ALWAYS_FALSE,
                 );
 
@@ -3693,9 +3393,7 @@ impl InteriorNode {
                     db,
                     builder,
                     larger_constraint.when_true(),
-                    larger_source_order,
                     smaller_constraint.when_false(),
-                    smaller_source_order,
                     ALWAYS_TRUE,
                 );
             }
@@ -3712,7 +3410,6 @@ impl InteriorNode {
                     // represent that intersection. We also need to add the new constraint to our
                     // seen set and (if we haven't already seen it) to the to-visit queue.
                     if seen_constraints.insert(intersection_constraint) {
-                        source_orders.insert(intersection_constraint, next_source_order);
                         to_visit.extend(
                             (seen_constraints.iter().copied())
                                 .filter(|seen| *seen != intersection_constraint)
@@ -3722,45 +3419,28 @@ impl InteriorNode {
                     let positive_intersection_node = Node::new_satisfied_constraint(
                         builder,
                         intersection_constraint.when_true(),
-                        next_source_order,
                     );
                     let negative_intersection_node = Node::new_satisfied_constraint(
                         builder,
                         intersection_constraint.when_false(),
-                        next_source_order,
-                    );
-                    next_source_order += 1;
-
-                    let positive_left_node = Node::new_satisfied_constraint(
-                        builder,
-                        left_constraint.when_true(),
-                        left_source_order,
-                    );
-                    let negative_left_node = Node::new_satisfied_constraint(
-                        builder,
-                        left_constraint.when_false(),
-                        left_source_order,
                     );
 
-                    let positive_right_node = Node::new_satisfied_constraint(
-                        builder,
-                        right_constraint.when_true(),
-                        right_source_order,
-                    );
-                    let negative_right_node = Node::new_satisfied_constraint(
-                        builder,
-                        right_constraint.when_false(),
-                        right_source_order,
-                    );
+                    let positive_left_node =
+                        Node::new_satisfied_constraint(builder, left_constraint.when_true());
+                    let negative_left_node =
+                        Node::new_satisfied_constraint(builder, left_constraint.when_false());
+
+                    let positive_right_node =
+                        Node::new_satisfied_constraint(builder, right_constraint.when_true());
+                    let negative_right_node =
+                        Node::new_satisfied_constraint(builder, right_constraint.when_false());
 
                     // left ∧ right = intersection
                     simplified = simplified.substitute_intersection(
                         db,
                         builder,
                         left_constraint.when_true(),
-                        left_source_order,
                         right_constraint.when_true(),
-                        right_source_order,
                         positive_intersection_node,
                     );
 
@@ -3769,9 +3449,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_false(),
-                        left_source_order,
                         right_constraint.when_false(),
-                        right_source_order,
                         negative_intersection_node,
                     );
 
@@ -3782,9 +3460,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_true(),
-                        left_source_order,
                         right_constraint.when_false(),
-                        right_source_order,
                         positive_left_node.and(builder, negative_intersection_node),
                     );
 
@@ -3794,9 +3470,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_false(),
-                        left_source_order,
                         right_constraint.when_true(),
-                        right_source_order,
                         positive_right_node.and(builder, negative_intersection_node),
                     );
 
@@ -3807,9 +3481,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_true(),
-                        left_source_order,
                         right_constraint.when_false(),
-                        right_source_order,
                         negative_right_node.or(builder, positive_intersection_node),
                     );
 
@@ -3819,9 +3491,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_false(),
-                        left_source_order,
                         right_constraint.when_true(),
-                        right_source_order,
                         negative_left_node.or(builder, positive_intersection_node),
                     );
                 }
@@ -3834,25 +3504,17 @@ impl InteriorNode {
                     // All of the below hold because we just proved that the intersection of left
                     // and right is empty.
 
-                    let positive_left_node = Node::new_satisfied_constraint(
-                        builder,
-                        left_constraint.when_true(),
-                        left_source_order,
-                    );
-                    let positive_right_node = Node::new_satisfied_constraint(
-                        builder,
-                        right_constraint.when_true(),
-                        right_source_order,
-                    );
+                    let positive_left_node =
+                        Node::new_satisfied_constraint(builder, left_constraint.when_true());
+                    let positive_right_node =
+                        Node::new_satisfied_constraint(builder, right_constraint.when_true());
 
                     // left ∧ right = false
                     simplified = simplified.substitute_intersection(
                         db,
                         builder,
                         left_constraint.when_true(),
-                        left_source_order,
                         right_constraint.when_true(),
-                        right_source_order,
                         ALWAYS_FALSE,
                     );
 
@@ -3861,9 +3523,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_false(),
-                        left_source_order,
                         right_constraint.when_false(),
-                        right_source_order,
                         ALWAYS_TRUE,
                     );
 
@@ -3873,9 +3533,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_true(),
-                        left_source_order,
                         right_constraint.when_false(),
-                        right_source_order,
                         positive_left_node,
                     );
 
@@ -3885,9 +3543,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_false(),
-                        left_source_order,
                         right_constraint.when_true(),
-                        right_source_order,
                         positive_right_node,
                     );
                 }
@@ -4807,7 +4463,7 @@ impl SequentMap {
 #[derive(Debug)]
 pub(crate) struct PathAssignments {
     map: SequentMap,
-    assignments: FxIndexMap<ConstraintAssignment, usize>,
+    assignments: FxIndexSet<ConstraintAssignment>,
     /// Constraints that we have discovered, mapped to whether we have processed them yet. (This
     /// ensures a stable order for all of the derived constraints that we create, while still
     /// letting us create them lazily.)
@@ -4822,7 +4478,7 @@ impl PathAssignments {
             .collect();
         Self {
             map: SequentMap::default(),
-            assignments: FxIndexMap::default(),
+            assignments: FxIndexSet::default(),
             discovered,
         }
     }
@@ -4854,7 +4510,6 @@ impl PathAssignments {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         assignment: ConstraintAssignment,
-        source_order: usize,
         f: impl FnOnce(&mut Self, Range<usize>) -> R,
     ) -> Option<R> {
         // Record a snapshot of the assignments that we already knew held — both so that we can
@@ -4867,14 +4522,14 @@ impl PathAssignments {
             target: "ty_python_semantic::types::constraints::PathAssignment",
             before = %format_args!(
                 "[{}]",
-                self.assignments[..start].iter().map(|(assignment, _)| {
+                self.assignments[..start].iter().map(|assignment| {
                     assignment.display(db, builder)
                 }).format(", "),
             ),
             edge = %assignment.display(db, builder),
             "walk edge",
         );
-        let found_conflict = self.add_assignment(db, builder, assignment, source_order, false);
+        let found_conflict = self.add_assignment(db, builder, assignment);
         let result = if found_conflict.is_err() {
             // If that results in the path now being impossible due to a contradiction, return
             // without invoking the callback.
@@ -4889,7 +4544,7 @@ impl PathAssignments {
                 target: "ty_python_semantic::types::constraints::PathAssignment",
                 new = %format_args!(
                     "[{}]",
-                    self.assignments[start..].iter().map(|(assignment, _)| {
+                    self.assignments[start..].iter().map(|assignment| {
                         assignment.display(db, builder)
                     }).format(", "),
                 ),
@@ -4905,17 +4560,17 @@ impl PathAssignments {
         result
     }
 
-    pub(crate) fn positive_constraints(&self) -> impl Iterator<Item = (ConstraintId, usize)> + '_ {
+    pub(crate) fn positive_constraints(&self) -> impl Iterator<Item = ConstraintId> + '_ {
         self.assignments
             .iter()
-            .filter_map(|(assignment, source_order)| match assignment {
-                ConstraintAssignment::Positive(constraint) => Some((*constraint, *source_order)),
+            .filter_map(|assignment| match assignment {
+                ConstraintAssignment::Positive(constraint) => Some(*constraint),
                 ConstraintAssignment::Negative(_) => None,
             })
     }
 
     fn assignment_holds(&self, assignment: ConstraintAssignment) -> bool {
-        self.assignments.contains_key(&assignment)
+        self.assignments.contains(&assignment)
     }
 
     /// Update our sequent map to ensure that it holds all of the sequents that involve the given
@@ -4954,18 +4609,16 @@ impl PathAssignments {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         assignment: ConstraintAssignment,
-        source_order: usize,
-        derived: bool,
     ) -> Result<(), PathAssignmentConflict> {
         // First add this assignment. If it causes a conflict, return that as an error. If we've
         // already know this assignment holds, just return.
-        if self.assignments.contains_key(&assignment.negated()) {
+        if self.assignments.contains(&assignment.negated()) {
             tracing::trace!(
                 target: "ty_python_semantic::types::constraints::PathAssignment",
                 assignment = %assignment.display(db, builder),
                 facts = %format_args!(
                     "[{}]",
-                    self.assignments.iter().map(|(assignment, _)| {
+                    self.assignments.iter().map(|assignment| {
                         assignment.display(db, builder)
                     }).format(", "),
                 ),
@@ -4974,27 +4627,11 @@ impl PathAssignments {
             return Err(PathAssignmentConflict);
         }
 
-        match self.assignments.entry(assignment) {
-            Entry::Vacant(entry) => entry.insert(source_order),
-            Entry::Occupied(mut entry) => {
-                // If a constraint appears both as an "origin" constraint (it actually appears in
-                // the BDD structure) and as a "derived" constraint (we infer it from other
-                // constraints), we should prefer the origin source_order, regardless of which
-                // order we encounter the various constraints in the BDD.
-                if !derived {
-                    *entry.get_mut() = source_order;
-                }
-                return Ok(());
-            }
-        };
+        if !self.assignments.insert(assignment) {
+            return Ok(());
+        }
 
-        // Then use our sequents to add additional facts that we know to be true. We currently
-        // reuse the `source_order` of the "real" constraint passed into `walk_edge` when we add
-        // these derived facts.
-        //
-        // TODO: This might not be stable enough, if we add more than one derived fact for this
-        // constraint. If we still see inconsistent test output, we might need a more complex
-        // way of tracking source order for derived facts.
+        // Then use our sequents to add additional facts that we know to be true.
         //
         // TODO: This is very naive at the moment, partly for expediency, and partly because we
         // don't anticipate the sequent maps to be very large. We might consider avoiding the
@@ -5011,7 +4648,7 @@ impl PathAssignments {
                     ante = %ante.display(db, builder),
                     facts = %format_args!(
                         "[{}]",
-                        self.assignments.iter().map(|(assignment, _)| {
+                        self.assignments.iter().map(|assignment| {
                             assignment.display(db, builder)
                         }).format(", "),
                     ),
@@ -5032,7 +4669,7 @@ impl PathAssignments {
                     ante2 = %ante2.display(db, builder),
                     facts = %format_args!(
                         "[{}]",
-                        self.assignments.iter().map(|(assignment, _)| {
+                        self.assignments.iter().map(|assignment| {
                             assignment.display(db, builder)
                         }).format(", "),
                     ),
@@ -5062,7 +4699,7 @@ impl PathAssignments {
         }
 
         for new_constraint in new_constraints {
-            self.add_assignment(db, builder, new_constraint.when_true(), source_order, true)?;
+            self.add_assignment(db, builder, new_constraint.when_true())?;
         }
 
         Ok(())
@@ -5327,7 +4964,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                 for constraint in constraints.elements(db) {
                     let constraint_lower = constraint.bottom_materialization(db);
                     let constraint_upper = constraint.top_materialization(db);
-                    specializations = specializations.or_with_offset(
+                    specializations = specializations.or(
                         builder,
                         Constraint::new_node(db, builder, self, constraint_lower, constraint_upper),
                     );
@@ -5378,8 +5015,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                     let constraint =
                         Constraint::new_node(db, builder, self, constraint_lower, constraint_upper);
                     if constraint_lower == constraint_upper {
-                        non_gradual_constraints =
-                            non_gradual_constraints.or_with_offset(builder, constraint);
+                        non_gradual_constraints = non_gradual_constraints.or(builder, constraint);
                     } else {
                         gradual_constraints.push(constraint);
                     }
@@ -5404,17 +5040,17 @@ mod tests {
     #[test]
     fn test_display_graph_output() {
         let expected = indoc! {r#"
-            <0> (U = bool) 2/4
-            ┡━₁ <1> (U = str) 1/4
-            │   ┡━₁ <2> (T = bool) 4/4
-            │   │   ┡━₁ <3> (T = str) 3/3
+            <0> (U = bool)
+            ┡━₁ <1> (U = str)
+            │   ┡━₁ <2> (T = bool)
+            │   │   ┡━₁ <3> (T = str)
             │   │   │   ┡━₁ always
             │   │   │   └─₀ always
-            │   │   └─₀ <4> (T = str) 3/3
+            │   │   └─₀ <4> (T = str)
             │   │       ┡━₁ always
             │   │       └─₀ never
             │   └─₀ <2> SHARED
-            └─₀ <5> (U = str) 1/4
+            └─₀ <5> (U = str)
                 ┡━₁ <2> SHARED
                 └─₀ never
         "#}
@@ -5432,8 +5068,9 @@ mod tests {
         let t_bool = ConstraintSet::constrain_typevar(&db, &constraints, t, bool_type, bool_type);
         let u_str = ConstraintSet::constrain_typevar(&db, &constraints, u, str_type, str_type);
         let u_bool = ConstraintSet::constrain_typevar(&db, &constraints, u, bool_type, bool_type);
-        // Construct this in a different order than above to make the source_orders more
-        // interesting.
+        // Construct this in a different order than the "source order" used above, to make the
+        // construction more interesting. Note that the BDD variable ordering is the reverse of the
+        // order that constraints are added to the builder.
         let set = (u_str.or(&db, &constraints, || u_bool))
             .and(&db, &constraints, || t_str.or(&db, &constraints, || t_bool));
         let actual = set.node.display_graph(&db, &constraints, &"").to_string();

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -72,6 +72,7 @@ use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 use std::ops::Range;
 
+use indexmap::map::Slice;
 use itertools::Itertools;
 use ruff_index::{Idx, IndexVec, newtype_index};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -923,11 +924,11 @@ impl<'db> ConstraintSetBuilder<'db> {
         SupportId::AddDerived(id)
     }
 
-    fn build_support(&self, support: SupportId) -> FxIndexMap<ConstraintId, bool> {
+    fn build_support(&self, support: SupportId) -> BuiltSupport {
         fn build_into(
             builder: &ConstraintSetBuilder<'_>,
             support: SupportId,
-            constraints: &mut FxIndexMap<ConstraintId, bool>,
+            constraints: &mut BuiltSupport,
         ) {
             match support {
                 SupportId::Empty => {}
@@ -979,7 +980,7 @@ impl<'db> ConstraintSetBuilder<'db> {
             }
         }
 
-        let mut constraints = FxIndexMap::default();
+        let mut constraints = BuiltSupport::default();
         build_into(self, support, &mut constraints);
         constraints
     }
@@ -1067,6 +1068,8 @@ struct AddDerivedSupportData {
     origin: ConstraintId,
     derived: ConstraintId,
 }
+
+type BuiltSupport = FxIndexMap<ConstraintId, bool>;
 
 /// An individual constraint in a constraint set. This restricts a single typevar to be within a
 /// lower and upper bound.
@@ -1675,7 +1678,17 @@ impl NodeId {
         path: &mut PathAssignments,
     ) {
         match self.node() {
-            Node::AlwaysTrue => f(path, support),
+            Node::AlwaysTrue => {
+                let built_support = builder.build_support(support);
+                self.for_each_path_with_support_missing(
+                    db,
+                    builder,
+                    support,
+                    built_support.as_slice(),
+                    f,
+                    path,
+                )
+            }
             Node::AlwaysFalse => {}
             Node::Interior(_) => {
                 let interior = builder.interior_node_data(self);
@@ -1721,6 +1734,47 @@ impl NodeId {
                 );
             }
         }
+    }
+
+    fn for_each_path_with_support_missing<'db>(
+        self,
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        support: SupportId,
+        slice: &Slice<ConstraintId, bool>,
+        f: &mut dyn FnMut(&PathAssignments, SupportId),
+        path: &mut PathAssignments,
+    ) {
+        let Some(((next_constraint, is_derived), rest)) = slice.split_first() else {
+            f(path, support);
+            return;
+        };
+
+        // If the next element of the support is not derived, and not already present in the path,
+        // we need to consider two candidate paths: one with that includes the support constraint,
+        // and one that does not. (The latter is handled below.)
+        if !is_derived && !path.contains_constraint(*next_constraint) {
+            path.walk_edge(
+                db,
+                builder,
+                next_constraint.when_true(),
+                |path, new_range| {
+                    let support = path.assignments[new_range]
+                        .iter()
+                        .rev() // add_derived supports are applied in reverse order
+                        .fold(support, |support, assignment| {
+                            builder.add_derived_support(
+                                support,
+                                *next_constraint,
+                                assignment.constraint(),
+                            )
+                        });
+                    self.for_each_path_with_support_missing(db, builder, support, rest, f, path);
+                },
+            );
+        }
+
+        self.for_each_path_with_support_missing(db, builder, support, rest, f, path);
     }
 
     /// Returns whether this BDD represent the constant function `true`.
@@ -4534,6 +4588,11 @@ impl PathAssignments {
 
     fn assignment_holds(&self, assignment: ConstraintAssignment) -> bool {
         self.assignments.contains(&assignment)
+    }
+
+    fn contains_constraint(&self, constraint: ConstraintId) -> bool {
+        self.assignment_holds(constraint.when_true())
+            || self.assignment_holds(constraint.when_false())
     }
 
     /// Update our sequent map to ensure that it holds all of the sequents that involve the given


### PR DESCRIPTION
AS of #23538, we no longer use salsa to intern the nodes of a constraint set BDD. They are still interned, but manually within a specific `ConstraintSetBuilder`. Those builders are constructed per type comparison. That means that we no longer need to store a separate `source_order` in our BDD nodes. That was used in an attempt to have something more robust than salsa IDs, which would order constraints based on their relative ordering in the underlying Python source. That ordering is exactly what `ConstraintSetBuilder` now gives us.

This also lets us revert our short-lived experiment with quasi-reduced BDDs. We introduced quasi-reduction #21744 in an attempt to remove some non-determinism in our tests. This non-determinism came about because a constraint set BDD might contain different sets of individual constraints depending on the (arbitrary) BDD variable ordering that is in force for a particular run of `ty`. Quasi-reduction ensured that all of the constraints explicitly mentioned when constructing a constraint set actually appeared in the BDD structure, giving us a deterministic set of constraints to iterate over.

