### PR TITLE
fix(wasm): suppress globset debug logs in jodejs build. Fixes #22535

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,6 +3568,7 @@ dependencies = [
  "ruff_workspace",
  "serde",
  "serde-wasm-bindgen",
+ "tracing",
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-test",

--- a/crates/ruff_wasm/Cargo.toml
+++ b/crates/ruff_wasm/Cargo.toml
@@ -34,7 +34,8 @@ console_log = { workspace = true }
 # See https://docs.rs/getrandom/latest/getrandom/#webassembly-support
 getrandom = { workspace = true, features = ["wasm_js"] }
 js-sys = { workspace = true }
-log = { workspace = true }
+log = { workspace = true, features = ["release_max_level_info"] }
+tracing = { workspace = true, features = ["release_max_level_info"] }
 serde = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 # Not a direct dependency but required to compile for Wasm.


### PR DESCRIPTION
## Summary

This PR silences internal debug output from the `globset` crate that was leaking to `stdout` in the WASM Node.js package. By adding the `release_max_level_info` feature flag to the `log` and `tracing` dependencies in `ruff_wasm`, all `debug` and `trace` level messages are stripped during compilation.

Verified by building with `wasm-pack build --target nodejs` and confirming the "built glob set" messages no longer appear in the console during execution.

Fixes #22535