### PR TITLE
[ty] Fix `--force-exclude` when excluding entire directories

### DIFF
--- a/crates/ty_project/src/glob.rs
+++ b/crates/ty_project/src/glob.rs
@@ -75,7 +75,7 @@ impl std::fmt::Display for IncludeExcludeFilter {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub(crate) enum GlobFilterCheckMode {
     /// The paths are checked top-to-bottom and inclusion is determined
     /// for each path during the traversal.


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/2506

`--force-exclude` didn't work when excluding an entire directory and passing a file from that directory on the cli. 

```toml
[src]
exclude = ["out"]
```

```
ty check --force-exclude out/setup.py
```

ty incorrectly checked `setup.py` even though it's excluded by the `out` pattern.

The root cause of this was that the filter tests if there's an exact match, and if so, always includes the path without checking the globs. 

The fix in this PR is to always verify if the file is included according to the globs if `force-exclude` is set

## Test plan

Added test