### PR TITLE
Add trailing slashes to `npm publish` paths

### DIFF
--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -32,9 +32,9 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: "Publish (dry-run)"
         if: ${{ inputs.plan == '' || fromJson(inputs.plan).announcement_tag_is_implicit }}
-        run: npm publish --dry-run pkg
+        run: npm publish --dry-run pkg/
       - name: "Publish"
         if: ${{ inputs.plan != '' && !fromJson(inputs.plan).announcement_tag_is_implicit }}
-        run: npm publish --provenance --access public pkg
+        run: npm publish --provenance --access public pkg/
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Summary
--

The WASM builds in the 0.14.12 release were failing with an error about trying
to publish over an existing version 5.8.1 ([example]). This seems to be because
it's trying to publish a package named `pkg` instead of the `pkg` directory.

Micha found that a trailing slash causes `npm` to interpret the path correctly.

Test Plan
--

I think we can test this with a dry run of the release workflow, otherwise
another release attempt for 0.14.12

[example]: https://github.com/astral-sh/ruff/actions/runs/21037103249/job/60492735499#step:5:281
