### PR TITLE
[ty] Use distributed versions of AND and OR on constraint sets

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1203,13 +1203,13 @@ impl<'db> Node<'db> {
         //
         // Walking through the example above, our vector ends up looking like:
         //
-        //                                   a/0
-        //                        a/0 b/0 => a∨b/1
-        //                                   a∨b/1 c/0
-        //   a∨b/1 c/0 d/0 => a∨b/1 c∨d/1 => a∨b∨c∨d/2
-        //                                   a∨b∨c∨d/2 e/0
-        //              a∨b∨c∨d/2 e/0 f/0 => a∨b∨c∨d/2 e∨f/1
-        //                                   a∨b∨c∨d/2 e∨f/1 g/0
+        //                                a/0
+        //                     a/0 b/0 => ab/1
+        //                                ab/1 c/0
+        //   ab/1 c/0 d/0 => ab/1 cd/1 => abcd/2
+        //                                abcd/2 e/0
+        //              abcd/2 e/0 f/0 => abcd/2 ef/1
+        //                                abcd/2 ef/1 g/0
         //
         // We use a SmallVec for the accumulator so that we don't have to spill over to the heap
         // until the iterator passes 256 elements.


### PR DESCRIPTION
There are some pathological examples where we create a constraint set which is the AND or OR of several smaller constraint sets. For example, when calling a function with many overloads, where the argument is a typevar, we create an OR of the typevar specializing to a type compatible with the respective parameter of each overload.

Most functions have a small number of overloads. But there are some examples of methods with 15-20 overloads (pydantic, numpy, our own auto-generated `__getitem__` for large tuple literals). For those cases, it is helpful to be more clever about how we construct the final result.

Before, we would just step through the `Iterator` of elements and accumulate them into a result constraint set. That results in an `O(n)` number of calls to the underlying `and` or `or` operator — each of which might have to construct a large temporary BDD tree.

AND and OR are both associative, so we can do better! We now invoke the operator in a "tree" shape (described in more detail in the doc comment). We still have to perform the same number of calls, but more of the calls operate on smaller BDDs, resulting in a much smaller amount of overall work.