### PR TITLE
[ty] Allow `...` as a default value for any parameter if the function is in an `if TYPE_CHECKING` block

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/function/parameters.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/parameters.md
@@ -107,3 +107,15 @@ def x(y: None = ...) -> None: ...
 def x(y: int) -> str: ...
 def x(y: int | None = None) -> str | None: ...
 ```
+
+### In `if TYPE_CHECKING` blocks
+
+We generally view code in `if TYPE_CHECKING` blocks as having the same semantics and exemptions to
+code in stub files:
+
+```py
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    def foo(x: bool = ...): ...  # fine
+```

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2769,6 +2769,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if !default_ty.is_assignable_to(self.db(), declared_ty)
                     && !((self.in_stub()
                         || self.in_function_overload_or_abstractmethod()
+                        || self.scope().scope(self.db()).in_type_checking_block()
                         || self
                             .class_context_of_current_method()
                             .is_some_and(|class| class.is_protocol(self.db())))


### PR DESCRIPTION
Fixes https://github.com/astral-sh/ty/issues/2534