### PR TITLE
[ty] Correct return type for synthesized NamedTuple.__new__ methods

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -5208,11 +5208,11 @@ fn synthesize_namedtuple_class_member<'db>(
                 BoundTypeVarInstance::synthetic_self(db, instance_ty, BindingContext::Synthetic);
             let self_ty = Type::TypeVar(self_typevar);
 
-            let mut variables = Vec::new();
-            if let Some(ctx) = inherited_generic_context {
-                variables.extend(ctx.variables(db));
-            }
-            variables.push(self_typevar);
+            let variables = inherited_generic_context
+                .iter()
+                .flat_map(|ctx| ctx.variables(db))
+                .chain(std::iter::once(self_typevar));
+
             let generic_context = GenericContext::from_typevar_instances(db, variables);
 
             let mut parameters = vec![


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixed the synthesized `NamedTuple.__new__` method to correctly return `Self` instead of the base class literal. This resolves `invalid-return-type` errors in subclasses that override `__new__` and call `super().__new__()`.

The change introduces a synthetic `Self` type variable for the `__new__` signature, making it properly generic. The `cls` parameter now uses `type[Self]` and the return type is `Self`, matching Python's runtime behavior and typing conventions.

Fixes https://github.com/astral-sh/ty/issues/2522

## Test Plan

- Added regression test to `crates/ty_python_semantic/resources/mdtest/named_tuple.md` verifying:
  - `reveal_type(instance)` inside `Child.__new__` shows `Self@__new__`
  - `reveal_type(Child(1, 2))` correctly shows `Child`
  
- Updated existing assertions in `named_tuple.md` to reflect the new generic signature:
  ```
  reveal_type(Url.__new__)  # revealed: [Self](cls: type[Self], protocol: str, host: str, port: int | None = ...) -> Self
  ```