### PR TITLE
[`flake8-bugbear`] point previous occurrence (`B033`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/duplicate_value.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/duplicate_value.rs
@@ -82,7 +82,7 @@ pub(crate) fn duplicate_value(checker: &Checker, set: &ast::ExprSet) {
                     },
                     value.range(),
                 );
-                diagnostic.secondary_annotation(format_args!("previous occurrence here"), existing);
+                diagnostic.secondary_annotation("Previous occurrence here", existing);
                 diagnostic.try_set_fix(|| {
                     edits::remove_member(&set.elts, index, checker.locator().contents()).map(
                         |edit| {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B033_B033.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B033_B033.py.snap
@@ -9,7 +9,7 @@ B033 [*] Sets should not contain duplicate item `"value1"`
 4 | incorrect_set = {"value1", 23, 5, "value1"}
   |                  --------         ^^^^^^^^
   |                  |
-  |                  previous occurrence here
+  |                  Previous occurrence here
 5 | incorrect_set = {1, 1, 2}
 6 | incorrect_set_multiline = {
   |
@@ -31,7 +31,7 @@ B033 [*] Sets should not contain duplicate item `1`
 5 | incorrect_set = {1, 1, 2}
   |                  -  ^
   |                  |
-  |                  previous occurrence here
+  |                  Previous occurrence here
 6 | incorrect_set_multiline = {
 7 |     "value1",
   |
@@ -51,7 +51,7 @@ B033 [*] Sets should not contain duplicate item `"value1"`
  5 | incorrect_set = {1, 1, 2}
  6 | incorrect_set_multiline = {
  7 |     "value1",
-   |     -------- previous occurrence here
+   |     -------- Previous occurrence here
  8 |     23,
  9 |     5,
 10 |     "value1",
@@ -76,7 +76,7 @@ B033 [*] Sets should not contain duplicate item `1`
 13 | incorrect_set = {1, 1}
    |                  -  ^
    |                  |
-   |                  previous occurrence here
+   |                  Previous occurrence here
 14 | incorrect_set = {1, 1,}
 15 | incorrect_set = {0, 1, 1,}
    |
@@ -98,7 +98,7 @@ B033 [*] Sets should not contain duplicate item `1`
 14 | incorrect_set = {1, 1,}
    |                  -  ^
    |                  |
-   |                  previous occurrence here
+   |                  Previous occurrence here
 15 | incorrect_set = {0, 1, 1,}
 16 | incorrect_set = {0, 1, 1}
    |
@@ -120,7 +120,7 @@ B033 [*] Sets should not contain duplicate item `1`
 15 | incorrect_set = {0, 1, 1,}
    |                     -  ^
    |                     |
-   |                     previous occurrence here
+   |                     Previous occurrence here
 16 | incorrect_set = {0, 1, 1}
 17 | incorrect_set = {
    |
@@ -142,7 +142,7 @@ B033 [*] Sets should not contain duplicate item `1`
 16 | incorrect_set = {0, 1, 1}
    |                     -  ^
    |                     |
-   |                     previous occurrence here
+   |                     Previous occurrence here
 17 | incorrect_set = {
 18 |     0,
    |
@@ -162,7 +162,7 @@ B033 [*] Sets should not contain duplicate item `1`
 17 | incorrect_set = {
 18 |     0,
 19 |     1,
-   |     - previous occurrence here
+   |     - Previous occurrence here
 20 |     1,
    |     ^
 21 | }
@@ -185,7 +185,7 @@ B033 [*] Sets should not contain duplicate items, but `False` and `0` has the sa
 22 | incorrect_set = {False, 1, 0}
    |                  -----     ^
    |                  |
-   |                  previous occurrence here
+   |                  Previous occurrence here
 23 | incorrect_set_multiline_with_comment = {
 24 |     "value1",
    |
@@ -205,7 +205,7 @@ B033 [*] Sets should not contain duplicate item `"value1"`
 22 | incorrect_set = {False, 1, 0}
 23 | incorrect_set_multiline_with_comment = {
 24 |     "value1",
-   |     -------- previous occurrence here
+   |     -------- Previous occurrence here
 25 |     23,
 26 |     # B033
 27 |     "value1",


### PR DESCRIPTION
Improves B033 linting error by pointing to the previous occurrence of the duplicate item.

# Before
```text
B033 [*] Sets should not contain duplicate item `"value1"`
 --> B033.py:4:35
4 | incorrect_set = {"value1", 23, 5, "value1"}
  |                                   ^^^^^^^^
help: Remove duplicate item
  - incorrect_set = {"value1", 23, 5, "value1"}
4 + incorrect_set = {"value1", 23, 5}
```

# After
```text
B033 [*] Sets should not contain duplicate item `"value1"`
 --> B033.py:4:18
4 | incorrect_set = {"value1", 23, 5, "value1"}
  |                  --------         ^^^^^^^^ duplicated here
  |                  |
  |                  previous occurrence here
help: Remove duplicate item
  - incorrect_set = {"value1", 23, 5, "value1"}
4 + incorrect_set = {"value1", 23, 5}
```