### PR TITLE
[ty] Set `None` as the `definition` of `Self` type variables

### DIFF
--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4578,9 +4578,7 @@ impl<'db> BindingError<'db> {
                     }
                 }
 
-                if !typevar.is_self(context.db())
-                    && let Some(typevar_definition) = typevar.definition(context.db())
-                {
+                if let Some(typevar_definition) = typevar.definition(context.db()) {
                     let module = parsed_module(context.db(), typevar_definition.file(context.db()))
                         .load(context.db());
                     let typevar_range = typevar_definition.full_range(context.db(), &module);

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -96,7 +96,14 @@ pub(crate) fn typing_self<'db>(
     let identity = TypeVarIdentity::new(
         db,
         ast::name::Name::new_static("Self"),
-        class.definition(db),
+        // `Self` has a different upper bound dependent on the containing class,
+        // so pointing to the definition of the symbol `typing.Self` itself is
+        // not useful here. We could point to the class definition, but the full
+        // range of the class definition is much larger than the full range of a
+        // TypeVar would usually be, which leads to bugs like
+        // https://github.com/astral-sh/ty/issues/2514. So we just pass `None`
+        // for the definition field here.
+        None,
         TypeVarKind::TypingSelf,
     );
     let bounds = TypeVarBoundOrConstraints::UpperBound(Type::instance(


### PR DESCRIPTION
## Summary

https://github.com/astral-sh/ty/issues/2514 was fixed in https://github.com/astral-sh/ruff/pull/22646, but the underlying cause of the bug was that the `definition` field of a `Self` typevar currently points to the `Definition` of the typevar's containing class. That's a bug magnet, because the `Definition` range of a class will often be far larger than the normal `Definition` range of a TypeVar.

This PR makes such bugs impossible by setting `None` as the `definition` of `Self` type variables.

## Test Plan

`cargo test`
