### PR TITLE
[ty] Simple syntactic validation for PEP-613 type aliases

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7299,7 +7299,7 @@ impl std::fmt::Display for DynamicType<'_> {
 bitflags! {
     /// Type qualifiers that appear in an annotation expression.
     #[derive(Copy, Clone, Debug, Eq, PartialEq, Default, salsa::Update, Hash)]
-    pub(crate) struct TypeQualifiers: u16 {
+    pub(crate) struct TypeQualifiers: u8 {
         /// `typing.ClassVar`
         const CLASS_VAR = 1 << 0;
         /// `typing.Final`
@@ -7320,8 +7320,6 @@ bitflags! {
         /// `__getattr__` function. We need this in order to implement precedence of submodules
         /// over module-level `__getattr__`, for compatibility with other type checkers.
         const FROM_MODULE_GETATTR = 1 << 7;
-        /// A non-standard type qualifier that marks a PEP 613 type alias.
-        const PEP_613_ALIAS = 1 << 8;
     }
 }
 
@@ -7389,11 +7387,6 @@ impl<'db> TypeAndQualifiers<'db> {
     /// Insert/add an additional type qualifier.
     pub(crate) fn add_qualifier(&mut self, qualifier: TypeQualifiers) {
         self.qualifiers |= qualifier;
-    }
-
-    pub(crate) fn with_qualifier(mut self, qualifier: TypeQualifiers) -> Self {
-        self.add_qualifier(qualifier);
-        self
     }
 
     /// Return the set of type qualifiers.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7523,8 +7523,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             DeferredExpressionState::from(self.defer_annotations()),
         );
 
-        if let Some(value) = value
-            && declared.qualifiers.contains(TypeQualifiers::PEP_613_ALIAS)
+        let is_pep_613_type_alias = declared.inner_type().is_typealias_special_form();
+
+        if is_pep_613_type_alias
+            && let Some(value) = value
             && !alias_syntax_validation(value)
             && let Some(builder) = self.context.report_lint(
                 &INVALID_TYPE_FORM,
@@ -7584,10 +7586,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             declared.inner = Type::BooleanLiteral(true);
         }
-
-        // Check if this is a PEP 613 `TypeAlias`. (This must come below the SpecialForm handling
-        // immediately below, since that can overwrite the type to be `TypeAlias`.)
-        let is_pep_613_type_alias = declared.inner_type().is_typealias_special_form();
 
         // Handle various singletons.
         if let Some(name_expr) = target.as_name_expr()

--- a/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
@@ -115,7 +115,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 Type::SpecialForm(SpecialFormType::TypeAlias)
                     if pep_613_policy == PEP613Policy::Allowed =>
                 {
-                    TypeAndQualifiers::declared(ty).with_qualifier(TypeQualifiers::PEP_613_ALIAS)
+                    TypeAndQualifiers::declared(ty)
                 }
                 // Conditional import of `typing.TypeAlias` or `typing_extensions.TypeAlias` on a
                 // Python version where the former doesn't exist.


### PR DESCRIPTION
## Summary

Full validation of PEP-613 type aliases is hard, but we can improve our typing conformance-suite score by quite a bit by adding some simple syntactic checks.

## Test Plan

mdtests added
