### PR TITLE
`scripts/conformance.py`: fix collection of diagnostics

### DIFF
--- a/.github/workflows/typing_conformance.yaml
+++ b/.github/workflows/typing_conformance.yaml
@@ -91,7 +91,7 @@ jobs:
             python "./scripts/conformance.py" \
              --old-ty "./ty-old" \
              --new-ty "./ty-new" \
-             --tests-path "${GITHUB_WORKSPACE}/typing/conformance/tests/" \
+             --tests-path "${GITHUB_WORKSPACE}/typing/conformance/" \
              --python-version "$PYTHON_VERSION" \
              --output ../typing_conformance_diagnostics.diff
           )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ ignore = [
 
 [tool.ruff.lint.isort]
 required-imports = ["from __future__ import annotations"]
+combine-as-imports = true
 
 [tool.ruff.per-file-target-version]
 "crates/ty_python_semantic/mdtest.py" = "py310"

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -37,6 +37,8 @@ import os
 import re
 import subprocess
 import sys
+import tomllib
+from collections.abc import Sequence, Set as AbstractSet
 from dataclasses import dataclass
 from enum import Flag, StrEnum, auto
 from functools import reduce
@@ -295,14 +297,10 @@ class Statistics:
         return self.true_positives + self.false_positives
 
 
-def collect_expected_diagnostics(path: Path) -> list[Diagnostic]:
+def collect_expected_diagnostics(test_files: Sequence[Path]) -> list[Diagnostic]:
     diagnostics: list[Diagnostic] = []
-    for entry in path.iterdir():
-        if not entry.is_file():
-            continue
-        if entry.suffix not in {".py", ".pyi"}:
-            continue
-        for idx, line in enumerate(entry.read_text().splitlines(), 1):
+    for file in test_files:
+        for idx, line in enumerate(file.read_text().splitlines(), 1):
             if error := re.search(CONFORMANCE_ERROR_PATTERN, line):
                 diagnostics.append(
                     Diagnostic(
@@ -315,7 +313,7 @@ def collect_expected_diagnostics(path: Path) -> list[Diagnostic]:
                         severity="major",
                         fingerprint=None,
                         location=Location(
-                            path=entry,
+                            path=file,
                             positions=Positions(
                                 begin=Position(
                                     line=idx,
@@ -339,7 +337,7 @@ def collect_expected_diagnostics(path: Path) -> list[Diagnostic]:
 def collect_ty_diagnostics(
     ty_path: list[str],
     source: Source,
-    tests_path: str = ".",
+    test_files: Sequence[Path],
     python_version: str = "3.12",
 ) -> list[Diagnostic]:
     process = subprocess.run(
@@ -349,11 +347,7 @@ def collect_ty_diagnostics(
             f"--python-version={python_version}",
             "--output-format=gitlab",
             "--exit-zero",
-            *(
-                str(path)
-                for path in Path(tests_path).iterdir()
-                if path.suffix in {".py", ".pyi"} and not path.name.startswith("_")
-            ),
+            *map(str, test_files),
         ],
         capture_output=True,
         text=True,
@@ -520,7 +514,9 @@ def diff_format(
             assert_never((greater_is_better, increased))  # ty: ignore[type-assertion-failure]
 
 
-def render_summary(grouped_diagnostics: list[GroupedDiagnostics]):
+def render_summary(
+    grouped_diagnostics: list[GroupedDiagnostics], *, force_summary_table: bool
+) -> str:
     def format_metric(diff: float, old: float, new: float):
         if diff > 0:
             return f"increased from {old:.2%} to {new:.2%}"
@@ -545,7 +541,9 @@ def render_summary(grouped_diagnostics: list[GroupedDiagnostics]):
 
     base_header = f"[Typing conformance results]({CONFORMANCE_DIR_WITH_README})"
 
-    if all(diag.change is Change.UNCHANGED for diag in grouped_diagnostics):
+    if not force_summary_table and all(
+        diag.change is Change.UNCHANGED for diag in grouped_diagnostics
+    ):
         return dedent(
             f"""
             ## {base_header}
@@ -600,6 +598,29 @@ def render_summary(grouped_diagnostics: list[GroupedDiagnostics]):
     )
 
 
+def get_test_groups(root_dir: Path) -> AbstractSet[str]:
+    """Adapted from typing/conformance/test_groups.py."""
+    # Read the TOML file that defines the test groups. Each test
+    # group has a name that associated test cases must start with.
+    test_group_file = root_dir / "src" / "test_groups.toml"
+    with open(test_group_file, "rb") as f:
+        return tomllib.load(f).keys()
+
+
+def get_test_cases(
+    test_group_names: AbstractSet[str], tests_dir: Path
+) -> Sequence[Path]:
+    """Adapted from typing/conformance/test_groups.py."""
+    # Filter test cases based on test group names. Files that do
+    # not begin with a known test group name are assumed to be
+    # files that support one or more tests.
+    return [
+        p
+        for p in chain(tests_dir.glob("*.py"), tests_dir.glob("*.pyi"))
+        if p.name.split("_")[0] in test_group_names
+    ]
+
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description=__doc__,
@@ -622,8 +643,8 @@ def parse_args():
     parser.add_argument(
         "--tests-path",
         type=Path,
-        default=Path("typing/conformance/tests"),
-        help="Path to conformance tests directory (default: typing/conformance/tests)",
+        default=Path("typing/conformance"),
+        help="Path to conformance tests directory (default: typing/conformance)",
     )
 
     parser.add_argument(
@@ -649,6 +670,12 @@ def parse_args():
         help="Write output to file instead of stdout",
     )
 
+    parser.add_argument(
+        "--force-summary-table",
+        action="store_true",
+        help="Always print the summary table, even if no changes were detected",
+    )
+
     args = parser.parse_args()
 
     if args.old_ty is None:
@@ -659,21 +686,21 @@ def parse_args():
 
 def main():
     args = parse_args()
-
-    tests_path = args.tests_path.resolve().absolute()
-
-    expected = collect_expected_diagnostics(tests_path)
+    tests_dir = args.tests_path.resolve().absolute()
+    test_groups = get_test_groups(tests_dir)
+    test_files = get_test_cases(test_groups, tests_dir / "tests")
+    expected = collect_expected_diagnostics(test_files)
 
     old = collect_ty_diagnostics(
         ty_path=args.old_ty,
-        tests_path=str(tests_path),
+        test_files=test_files,
         source=Source.OLD,
         python_version=args.python_version,
     )
 
     new = collect_ty_diagnostics(
         ty_path=args.new_ty,
-        tests_path=str(tests_path),
+        test_files=test_files,
         source=Source.NEW,
         python_version=args.python_version,
     )
@@ -686,7 +713,7 @@ def main():
 
     rendered = "\n\n".join(
         [
-            render_summary(grouped),
+            render_summary(grouped, force_summary_table=args.force_summary_table),
             render_grouped_diagnostics(
                 grouped, changed_only=not args.all, format=args.format
             ),


### PR DESCRIPTION
## Summary

There were two issues with how the script was collecting diagnostics:
- It was using the pattern `path.rglob("*.py")` to find what the expected diagnostics were, but some tests in the conformance suite use `.pyi` files.
- It was running ty on the whole `conformance/tests` directory, and reporting all ty errors on that directory that weren't accompanied by `# E` comments as being false positives. But some of the files in that directory (in particular, all files starting with a leading underscore) are not actually test files -- they're just "supporting" files that are imported by the test files. Diagnostics on these files should not be considered as false positives.

## Test Plan

I commented out this section of the script on `main`:

```diff
diff --git a/scripts/conformance.py b/scripts/conformance.py
index 00cbe69181..055aa2801e 100644
--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -537,14 +537,14 @@ def render_summary(grouped_diagnostics: list[GroupedDiagnostics]):
 
     base_header = f"[Typing conformance results]({CONFORMANCE_DIR_WITH_README})"
 
-    if all(diag.change is Change.UNCHANGED for diag in grouped_diagnostics):
-        return dedent(
-            f"""
-            ## {base_header}
-
-            No changes detected ✅
-            """
-        )
+    # if all(diag.change is Change.UNCHANGED for diag in grouped_diagnostics):
+    #     return dedent(
+    #         f"""
+    #         ## {base_header}
+
+    #         No changes detected ✅
+    #         """
+    #     )
 
     true_pos_diff = diff_format(true_pos_change, greater_is_better=True)
     false_pos_diff = diff_format(false_pos_change, greater_is_better=False)
```

and then ran `uv run --no-project scripts/conformance.py --old-ty=./target/debug/ty --new-ty=./target/debug/ty --tests-path=../typing/conformance/tests`, with this result:

---

## [Typing conformance results](https://github.com/python/typing/blob/main/conformance/)

The percentage of diagnostics emitted that were expected errors held steady at 75.87%. The percentage of expected errors that received a diagnostic held steady at 60.50%.

### Summary

| Metric | Old | New | Diff | Outcome |
|--------|-----|-----|------|---------|
| True Positives  | 654 | 654 | +0 |  |
| False Positives | 208 | 208 | +0 |  |
| False Negatives | 427 | 427 | +0 |  |
| Total Diagnostics | 862 | 862 | +0 |  |
| Precision | 75.87% | 75.87% | +0.00% |  |
| Recall | 60.50% | 60.50% | +0.00% |  |

---

I then checked out this branch, applied the same patch above, and ran the same command, with this result:

---

## [Typing conformance results](https://github.com/python/typing/blob/main/conformance/)

The percentage of diagnostics emitted that were expected errors held steady at 77.13%. The percentage of expected errors that received a diagnostic held steady at 59.50%.

### Summary

| Metric | Old | New | Diff | Outcome |
|--------|-----|-----|------|---------|
| True Positives  | 661 | 661 | +0 |  |
| False Positives | 196 | 196 | +0 |  |
| False Negatives | 450 | 450 | +0 |  |
| Total Diagnostics | 857 | 857 | +0 |  |
| Precision | 77.13% | 77.13% | +0.00% |  |
| Recall | 59.50% | 59.50% | +0.00% |  |

---

These are results consistent with what I'd expect given that errors on files beginning with `_` are now not considered false positives, and given that `# E` comments on `.pyi` files are now collected as error assertions.

Cc. @WillDuke, if you have time to review 😃 (obviously no obligation to!)