### PR TITLE
[`pyupgrade`] Properly trigger `super` change in nested class (`UP008`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP008.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP008.py
@@ -315,5 +315,31 @@ class Outer(Base):
 
     class Inner(Base):
         def __init__(self, foo):
-            super(Outer.Inner, self).__init__(foo)  # Should trigger UP008
+            super(Outer.Inner, self).__init__(foo)  # UP008: matches enclosing class chain
+
+
+# super() first arg is an attribute that only matches on the last segment,
+# but refers to a different class (Outer.Inner, not __class__ which is Inner).
+class Inner(Outer.Inner):
+    def __init__(self, foo):
+        super(Outer.Inner, self).__init__(foo)  # Should NOT trigger UP008
+
+# super() first arg has an unrelated module prefix
+class Outer2:
+    class Inner2(Base):
+        def __init__(self, foo):
+            super(some_module.Outer2.Inner2, self).__init__(foo)  # Should NOT trigger UP008
+
+# 3-level deep nesting: super(A.B.C, self) should trigger UP008
+class A:
+    class B:
+        class C(Base):
+            def __init__(self, foo):
+                super(A.B.C, self).__init__(foo)  # UP008: matches full chain
+
+# Mismatched middle segment: Wrong.Inner doesn't match Outer3.Inner
+class Outer3:
+    class Inner(Base):
+        def __init__(self, foo):
+            super(Wrong.Inner, self).__init__(foo)  # Should NOT trigger UP008
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -122,14 +122,6 @@ pub(crate) fn super_call_with_parameters(checker: &Checker, call: &ast::ExprCall
         return;
     };
 
-    let first_arg_id = match first_arg {
-        // Simple case: super(MyClass, self)
-        Expr::Name(ast::ExprName { id, .. }) => id,
-        // Nested class case: super(OuterClass.InnerClass, self)
-        Expr::Attribute(ast::ExprAttribute { attr, .. }) => &attr.id,
-        _ => return,
-    };
-
     let Expr::Name(ast::ExprName {
         id: second_arg_id, ..
     }) = second_arg
@@ -137,14 +129,42 @@ pub(crate) fn super_call_with_parameters(checker: &Checker, call: &ast::ExprCall
         return;
     };
 
-    // The `super(__class__, self)` and `super(ParentClass, self)` patterns are redundant in Python 3
-    // when the first argument refers to the implicit `__class__` cell or to the enclosing class.
-    // Avoid triggering if a local variable shadows either name.
-    if !(((first_arg_id == "__class__") || (first_arg_id == parent_name.as_str()))
-        && !checker.semantic().current_scope().has(first_arg_id)
-        && second_arg_id == parent_arg.name().as_str())
-    {
+    if second_arg_id != parent_arg.name().as_str() {
         return;
+    }
+
+    // Verify the first argument matches the enclosing class chain.
+    // For `super(__class__, self)` or `super(ClassName, self)`, just check the immediate class.
+    // For `super(Outer.Inner, self)`, verify each segment matches the enclosing class nesting.
+    match first_arg {
+        Expr::Name(ast::ExprName { id, .. }) => {
+            if !((id == "__class__" || id == parent_name.as_str())
+                && !checker.semantic().current_scope().has(id))
+            {
+                return;
+            }
+        }
+        Expr::Attribute(_) => {
+            let chain = collect_attribute_chain(first_arg);
+            // The innermost name must match the immediately enclosing class.
+            if chain.last() != Some(&parent_name.as_str()) {
+                return;
+            }
+            // Each preceding name must match the next enclosing class.
+            for name in chain.iter().rev().skip(1) {
+                let Some(Stmt::ClassDef(ast::StmtClassDef {
+                    name: enclosing_name,
+                    ..
+                })) = parents.find(|stmt| stmt.is_class_def_stmt())
+                else {
+                    return;
+                };
+                if *name != enclosing_name.as_str() {
+                    return;
+                }
+            }
+        }
+        _ => return,
     }
 
     drop(parents);
@@ -197,6 +217,29 @@ pub(crate) fn super_call_with_parameters(checker: &Checker, call: &ast::ExprCall
             applicability,
         ));
     }
+}
+
+/// Collects the chain of names from an attribute expression.
+///
+/// For example, `A.B.C` returns `["A", "B", "C"]`.
+fn collect_attribute_chain(expr: &Expr) -> Vec<&str> {
+    let mut chain = Vec::new();
+    let mut current = expr;
+    loop {
+        match current {
+            Expr::Attribute(ast::ExprAttribute { value, attr, .. }) => {
+                chain.push(attr.id.as_str());
+                current = value;
+            }
+            Expr::Name(ast::ExprName { id, .. }) => {
+                chain.push(id.as_str());
+                break;
+            }
+            _ => return Vec::new(),
+        }
+    }
+    chain.reverse();
+    chain
 }
 
 /// Returns `true` if a call is an argumented `super` invocation.

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP008.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP008.py.snap
@@ -482,13 +482,35 @@ UP008 [*] Use `super()` instead of `super(__class__, self)`
     |
 316 |     class Inner(Base):
 317 |         def __init__(self, foo):
-318 |             super(Outer.Inner, self).__init__(foo)  # Should trigger UP008
+318 |             super(Outer.Inner, self).__init__(foo)  # UP008: matches enclosing class chain
     |                  ^^^^^^^^^^^^^^^^^^^
     |
 help: Remove `super()` parameters
 315 | 
 316 |     class Inner(Base):
 317 |         def __init__(self, foo):
-    -             super(Outer.Inner, self).__init__(foo)  # Should trigger UP008
-318 +             super().__init__(foo)  # Should trigger UP008
-319 |
+    -             super(Outer.Inner, self).__init__(foo)  # UP008: matches enclosing class chain
+318 +             super().__init__(foo)  # UP008: matches enclosing class chain
+319 | 
+320 | 
+321 | # super() first arg is an attribute that only matches on the last segment,
+
+UP008 [*] Use `super()` instead of `super(__class__, self)`
+   --> UP008.py:338:22
+    |
+336 |         class C(Base):
+337 |             def __init__(self, foo):
+338 |                 super(A.B.C, self).__init__(foo)  # UP008: matches full chain
+    |                      ^^^^^^^^^^^^^
+339 |
+340 | # Mismatched middle segment: Wrong.Inner doesn't match Outer3.Inner
+    |
+help: Remove `super()` parameters
+335 |     class B:
+336 |         class C(Base):
+337 |             def __init__(self, foo):
+    -                 super(A.B.C, self).__init__(foo)  # UP008: matches full chain
+338 +                 super().__init__(foo)  # UP008: matches full chain
+339 | 
+340 | # Mismatched middle segment: Wrong.Inner doesn't match Outer3.Inner
+341 | class Outer3:


### PR DESCRIPTION
While debugging, I noticed that the function parameters were of type `Expr::Name` in the normal case and `Expr::Attribute` when the function was in a nested class. Reading the [documentation](https://docs.python.org/3/library/ast.html#ast.expr), it seems that being an `Expr::Attribute` makes sense because `Inner` is an attribute of `Outer`.

I did some thinking and could not identify any additional `Expr` types I should be pattern-matching here, but I would like some input from you.

The change seems to fix the issue without any regression.

```console
echo 'class Base:
      def __init__(self, foo):
          self.foo = foo


  class Outer(Base):
      def __init__(self, foo):
          super().__init__(foo)  # Should not trigger UP008

      class Inner(Base):
          def __init__(self, foo):
              super().__init__(foo)  # Should not trigger UP008

      class InnerInner(Base):
          def __init__(self, foo):
              super(Outer.Inner.InnerInner, self).__init__(foo)  # Should trigger UP008

  ' | cargo run -p ruff -- check --select UP008 -
UP008 Use `super()` instead of `super(__class__, self)`
  --> -:16:18
   |
14 |     class InnerInner(Base):
15 |         def __init__(self, foo):
16 |             super(Outer.Inner.InnerInner, self).__init__(foo)  # Should trigger UP008
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
help: Remove `super()` parameters

Found 1 error.
No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).
```

Closes #22597 