### PR TITLE
[refurb] Mark FURB180 fix as unsafe when comments would be deleted

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB180.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB180.py
@@ -32,6 +32,15 @@ class A3(B0, before_metaclass=1, metaclass=abc.ABCMeta):
     pass
 
 
+# Fix should be unsafe when a comment would be deleted
+class A4_comment(
+    other_kwarg=1,
+    # comment
+    metaclass=abc.ABCMeta,
+):
+    pass
+
+
 # OK
 
 class Meta(type):

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB180_FURB180.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB180_FURB180.py.snap
@@ -75,3 +75,26 @@ help: Replace with `abc.ABC`
 33 | 
 34 | 
 note: This is an unsafe fix and may change runtime behavior
+
+FURB180 [*] Use of `metaclass=abc.ABCMeta` to define abstract base class
+  --> FURB180.py:39:5
+   |
+37 |     other_kwarg=1,
+38 |     # comment
+39 |     metaclass=abc.ABCMeta,
+   |     ^^^^^^^^^^^^^^^^^^^^^
+40 | ):
+41 |     pass
+   |
+help: Replace with `abc.ABC`
+34 | 
+35 | # Fix should be unsafe when a comment would be deleted
+36 | class A4_comment(
+   -     other_kwarg=1,
+   -     # comment
+   -     metaclass=abc.ABCMeta,
+37 +     abc.ABC, other_kwarg=1,
+38 | ):
+39 |     pass
+40 | 
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Fixes #22631

The safe fix for FURB180 could delete comments that appear between keyword arguments. For example:

```python
class C(
    other_kwarg=1,
    # comment
    metaclass=abc.ABCMeta,
):
    pass
```

The fix deletes from the previous argument to the end of the metaclass keyword, which would remove the comment. This change checks if any comments exist in that deletion range and marks the fix as unsafe if so.

Added a test case covering this scenario.