### PR TITLE
[ty] Fix narrowing for transparent enums (StrEnum, IntEnum)

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/match_enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match_enums.md
@@ -1,0 +1,83 @@
+# Narrowing for enums in `match` statements
+
+## StrEnum narrowing
+
+`StrEnum` members compare equal to their underlying string values at runtime. Type narrowing should
+recognize this.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from enum import StrEnum
+from typing import Literal
+
+class Color(StrEnum):
+    RED = "r"
+    GREEN = "g"
+    BLUE = "b"
+
+def test_literal_matches_strenum(x: Literal["g"]):
+    match x:
+        case Color.RED:
+            reveal_type(x)  # revealed: Never
+        case Color.GREEN:
+            # This branch IS taken at runtime
+            reveal_type(x)  # revealed: Literal["g"]
+        case Color.BLUE:
+            reveal_type(x)  # revealed: Never
+        case _:
+            reveal_type(x)  # revealed: Never
+```
+
+## Enum with custom `__eq__`
+
+If an enum explicitly overrides `__eq__`, narrowing should be disabled if it's unsafe.
+
+```py
+from enum import Enum
+from typing import Literal
+
+class CustomEqEnum(Enum):
+    A = 1
+    B = 2
+
+    def __eq__(self, other):
+        return True  # Always returns True
+
+def test_custom_eq(x: Literal[1] | Literal[2]):
+    match x:
+        case CustomEqEnum.A:
+            # We cannot narrow here because __eq__ is overridden
+            reveal_type(x)  # revealed: Literal[1, 2]
+```
+
+## Tagged union narrowing with StrEnum
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from enum import StrEnum
+from typing import TypedDict
+
+class Tag(StrEnum):
+    FOO = "a"
+    BAR = "b"
+
+class Foo(TypedDict):
+    tag: Tag
+    x: int
+
+class Bar(TypedDict):
+    tag: Tag
+    y: str
+
+def test_string_literal_match(x: Foo | Bar):
+    if x["tag"] == Tag.FOO:
+        reveal_type(x)  # revealed: Foo | Bar
+```


### PR DESCRIPTION
## Summary

This PR fixes incorrect type narrowing in `match` statements for enums with "transparent" equality (`StrEnum`, `IntEnum`, etc.) where enum members compare equal to their underlying primitive values.

**Problem**: When matching a primitive literal (e.g., `Literal["g"]`) against a transparent enum member (e.g., `Color.GREEN`), the type checker incorrectly narrowed the type to `Never` because it treated them as disjoint types. This was reported in issue https://github.com/astral-sh/ty/issues/1454.

**Root Cause**: 
1. `is_disjoint_from` treated enum literals and primitive literals as disjoint based solely on type differences
2. `IntersectionBuilder` couldn't simplify intersections like `Literal["g"] & ~Color.GREEN` correctly

**Solution**:
1. Added `has_transparent_equality()` in `enums.rs` to explicitly detect enums inheriting from both `Enum` and primitive types (`str`, `int`, `bytes`)
2. Modified `is_disjoint_from_impl()` in `relation.rs` to compare underlying values when dealing with transparent enums instead of just checking type identity
3. Updated `add_negative()` in `builder.rs` to correctly simplify `PrimitiveLiteral & ~TransparentEnumLiteral` to `Never`

## Test Plan

- **New regression tests**: Created `match_enums.md` with targeted tests for transparent enum narrowing in match statements
- All tests pass successfully.