### PR TITLE
[`flake8-async`] Tweak explanation to focus on latency/efficiency tradeoff (`ASYNC110`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_async/rules/async_busy_wait.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/async_busy_wait.rs
@@ -10,9 +10,14 @@ use crate::rules::flake8_async::helpers::AsyncModule;
 /// Checks for the use of an async sleep function in a `while` loop.
 ///
 /// ## Why is this bad?
-/// Instead of sleeping in a `while` loop, and waiting for a condition
-/// to become true, it's preferable to `await` on an `Event` object such
-/// as: `asyncio.Event`, `trio.Event`, or `anyio.Event`.
+/// Busy-waiting for a condition in a loop forces a tradeoff between
+/// efficiency and latency: shorter sleep times improve responsiveness
+/// but waste more CPU cycles, while longer sleep times reduce CPU usage
+/// but delay reaction to state changes.
+///
+/// Waiting on an `Event` object like `asyncio.Event`, `trio.Event`, or
+/// `anyio.Event` eliminates this tradeoff, allowing immediate response
+/// with minimal wasted CPU time.
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
Now the "Why is this bad" section actually answers the question
