### PR TITLE
`PIE794`: Detect duplicated declared class fields

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pie/PIE794.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pie/PIE794.py
@@ -50,3 +50,8 @@ class Person:
     name: str = "Foo"
     name: str = name + " Bar"
     name: str = "Bar"  # PIE794
+
+
+class TextEdit:
+    start_line: int
+    start_line: int  # PIE794

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/duplicate_class_field_definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/duplicate_class_field_definition.rs
@@ -58,17 +58,17 @@ pub(crate) fn duplicate_class_field_definition(checker: &Checker, body: &[Stmt])
     let mut seen_targets: FxHashSet<&str> = FxHashSet::default();
     for stmt in body {
         // Extract the property name from the assignment statement.
-        let target = match stmt {
-            Stmt::Assign(ast::StmtAssign { targets, .. }) => {
-                if let [Expr::Name(id)] = targets.as_slice() {
-                    id
-                } else {
+        let (target, value) = match stmt {
+            Stmt::Assign(ast::StmtAssign { targets, value, .. }) => {
+                let [Expr::Name(target)] = targets.as_slice() else {
                     continue;
-                }
+                };
+
+                (target, Some(&**value))
             }
-            Stmt::AnnAssign(ast::StmtAnnAssign { target, .. }) => {
+            Stmt::AnnAssign(ast::StmtAnnAssign { target, value, .. }) => {
                 if let Expr::Name(id) = target.as_ref() {
-                    id
+                    (id, value.as_deref())
                 } else {
                     continue;
                 }
@@ -77,24 +77,12 @@ pub(crate) fn duplicate_class_field_definition(checker: &Checker, body: &[Stmt])
         };
 
         // If this is an unrolled augmented assignment (e.g., `x = x + 1`), skip it.
-        match stmt {
-            Stmt::Assign(ast::StmtAssign { value, .. }) => {
-                if any_over_expr(value.as_ref(), &|expr| {
-                    expr.as_name_expr().is_some_and(|name| name.id == target.id)
-                }) {
-                    continue;
-                }
-            }
-            Stmt::AnnAssign(ast::StmtAnnAssign {
-                value: Some(value), ..
-            }) => {
-                if any_over_expr(value.as_ref(), &|expr| {
-                    expr.as_name_expr().is_some_and(|name| name.id == target.id)
-                }) {
-                    continue;
-                }
-            }
-            _ => continue,
+        if let Some(value) = value
+            && any_over_expr(value, &|expr| {
+                expr.as_name_expr().is_some_and(|name| name.id == target.id)
+            })
+        {
+            continue;
         }
 
         if !seen_targets.insert(target.id.as_str()) {

--- a/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE794_PIE794.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE794_PIE794.py.snap
@@ -108,4 +108,22 @@ help: Remove duplicate field definition for `name`
 50 |     name: str = "Foo"
 51 |     name: str = name + " Bar"
    -     name: str = "Bar"  # PIE794
+52 | 
+53 | 
+54 | class TextEdit:
+note: This is an unsafe fix and may change runtime behavior
+
+PIE794 [*] Class field `start_line` is defined multiple times
+  --> PIE794.py:57:5
+   |
+55 | class TextEdit:
+56 |     start_line: int
+57 |     start_line: int  # PIE794
+   |     ^^^^^^^^^^^^^^^
+   |
+help: Remove duplicate field definition for `start_line`
+54 | 
+55 | class TextEdit:
+56 |     start_line: int
+   -     start_line: int  # PIE794
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/22683

The rule skipped annotated assignments without a value. This seems an unintentional change that was introduced in https://github.com/astral-sh/ruff/pull/8634. This PR re-enables detecting duplicated class fields where a later declaration is an annotated assignment without a value.

We might have to preview gate this change if there are many ecosystem hits. Although I doubt that, given that this is unlikely very common.

## Test Plan

Added regression test. 


