### PR TITLE
[ty] Use fluent style more, and reduce allocations, when constructing `Parameters` instances

### DIFF
--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -80,7 +80,7 @@ impl CallableParams {
             CallableParams::List(params) => Parameters::new(
                 db,
                 params.into_iter().map(|param| {
-                    let mut parameter = match param.kind {
+                    let parameter = match param.kind {
                         ParamKind::PositionalOnly => Parameter::positional_only(param.name),
                         ParamKind::PositionalOrKeyword => {
                             Parameter::positional_or_keyword(param.name.unwrap())
@@ -91,11 +91,9 @@ impl CallableParams {
                             Parameter::keyword_variadic(param.name.unwrap())
                         }
                     };
-                    parameter = parameter.with_annotated_type(param.annotated_ty.into_type(db));
-                    if let Some(default_ty) = param.default_ty {
-                        parameter = parameter.with_default_type(default_ty.into_type(db));
-                    }
                     parameter
+                        .with_annotated_type(param.annotated_ty.into_type(db))
+                        .with_optional_default_type(param.default_ty.map(|t| t.into_type(db)))
                 }),
             ),
         }

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2297,6 +2297,14 @@ impl<'db> Parameter<'db> {
         self
     }
 
+    pub(crate) fn with_optional_default_type(self, default: Option<Type<'db>>) -> Self {
+        if let Some(default) = default {
+            self.with_default_type(default)
+        } else {
+            self
+        }
+    }
+
     pub(crate) fn type_form(mut self) -> Self {
         self.form = ParameterForm::Type;
         self


### PR DESCRIPTION
## Summary

This is a standalone refactor pulled out of https://github.com/astral-sh/ruff/pull/22718. It shouldn't have any behaviour change associated with it.

The PR adds a new `Parameter::with_optional_default()` method that makes it easier to use fluent style when constructing `Parameter` instances.

## Test Plan

existing tests
