### PR TITLE
Skip EXE0xx tests on WSL

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_executable/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/mod.rs
@@ -32,6 +32,12 @@ mod tests {
     #[test_case(Path::new("EXE005_2.py"))]
     #[test_case(Path::new("EXE005_3.py"))]
     fn rules(path: &Path) -> Result<()> {
+        if is_wsl::is_wsl() {
+            // these rules are always ignored on WSL, so skip testing them in a WSL environment
+            // see https://github.com/astral-sh/ruff/pull/21724 for latest discussion
+            return Ok(());
+        }
+
         let snapshot = path.to_string_lossy().into_owned();
         let diagnostics = test_path(
             Path::new("flake8_executable").join(path).as_path(),


### PR DESCRIPTION
The rule itself is always ignored on WSL, which makes the tests fail due to false negatives when run in a WSL environment.

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
