### PR TITLE
[ty] Fix panic on malformed mdtest assertion

### DIFF
--- a/crates/ty_test/src/matcher.rs
+++ b/crates/ty_test/src/matcher.rs
@@ -1395,4 +1395,28 @@ mod tests {
             )],
         );
     }
+
+    #[test]
+    fn trailing_quote_without_message_not_allowed() {
+        let source = "x  # error: [some-rule]\"";
+        let result = get_result(
+            source,
+            vec![ExpectedDiagnostic::new(
+                DiagnosticId::lint("some-rule"),
+                "some message",
+                0,
+            )],
+        );
+
+        assert_fail(
+            result,
+            &[(
+                0,
+                &[
+                    "invalid assertion: expected message text and closing '\"' after opening '\"'",
+                    r#"unexpected error: 1 [some-rule] "some message""#,
+                ],
+            )],
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes [#2548](https://github.com/astral-sh/ty/issues/2548)
Fix a panic in the mdtest assertion parser when encountering a malformed `# error` assertion that ends with a trailing quote (e.g. `# error: [rule]"`). The parser now treats this as an invalid/unclosed message instead of slicing with invalid bounds.

## Test Plan

Added this test : `cargo test -p ty_test trailing_quote_without_message_not_allowed`
