### PR TITLE
[`flake8-pytest-style`] Support `check` parameter in `PT011`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT011.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT011.py
@@ -51,3 +51,13 @@ def test_error_match_is_empty():
 def test_ok_t_string_match():
     with pytest.raises(ValueError, match=t""):
         raise ValueError("Can't divide 1 by 0")
+
+
+def test_ok_check_provided():
+    with pytest.raises(ValueError, check=lambda e: str(e) == "error"):
+        raise ValueError("error")
+
+
+def test_error_check_is_none():
+    with pytest.raises(ValueError, check=None):
+        raise ValueError("Can't divide 1 by 0")

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/raises.rs
@@ -62,13 +62,14 @@ impl Violation for PytestRaisesWithMultipleStatements {
 }
 
 /// ## What it does
-/// Checks for `pytest.raises` calls without a `match` parameter.
+/// Checks for `pytest.raises` calls without a `match` or `check` parameter.
 ///
 /// ## Why is this bad?
 /// `pytest.raises(Error)` will catch any `Error` and may catch errors that are
 /// unrelated to the code under test. To avoid this, `pytest.raises` should be
-/// called with a `match` parameter. The exception names that require a `match`
-/// parameter can be configured via the
+/// called with a `match` parameter (to constrain the exception message) or a
+/// `check` parameter (to constrain the exception itself). The exception names
+/// that require a `match` or `check` parameter can be configured via the
 /// [`lint.flake8-pytest-style.raises-require-match-for`] and
 /// [`lint.flake8-pytest-style.raises-extend-require-match-for`] settings.
 ///
@@ -93,6 +94,16 @@ impl Violation for PytestRaisesWithMultipleStatements {
 ///
 /// def test_foo():
 ///     with pytest.raises(ValueError, match="expected message"):
+///         ...
+/// ```
+///
+/// Or, for pytest 8.4.0 and later:
+/// ```python
+/// import pytest
+///
+///
+/// def test_foo():
+///     with pytest.raises(OSError, check=lambda e: e.errno == 42):
 ///         ...
 /// ```
 ///
@@ -201,11 +212,15 @@ pub(crate) fn raises_call(checker: &Checker, call: &ast::ExprCall) {
             if call.arguments.find_argument("func", 1).is_none() {
                 if let Some(exception) = call.arguments.find_argument_value("expected_exception", 0)
                 {
-                    if call
+                    let match_is_empty_or_absent = call
                         .arguments
                         .find_keyword("match")
-                        .is_none_or(|k| is_empty_or_null_string(&k.value))
-                    {
+                        .is_none_or(|k| is_empty_or_null_string(&k.value));
+                    let check_is_absent_or_none = call
+                        .arguments
+                        .find_keyword("check")
+                        .is_none_or(|k| k.value.is_none_literal_expr());
+                    if match_is_empty_or_absent && check_is_absent_or_none {
                         exception_needs_match(checker, exception);
                     }
                 }

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT011_default.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT011_default.snap
@@ -58,3 +58,12 @@ PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use
    |                        ^^^^^^^^^^
 49 |         raise ValueError("Can't divide 1 by 0")
    |
+
+PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
+  --> PT011.py:62:24
+   |
+61 | def test_error_check_is_none():
+62 |     with pytest.raises(ValueError, check=None):
+   |                        ^^^^^^^^^^
+63 |         raise ValueError("Can't divide 1 by 0")
+   |

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT011_extend_broad_exceptions.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT011_extend_broad_exceptions.snap
@@ -67,3 +67,12 @@ PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use
    |                        ^^^^^^^^^^
 49 |         raise ValueError("Can't divide 1 by 0")
    |
+
+PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
+  --> PT011.py:62:24
+   |
+61 | def test_error_check_is_none():
+62 |     with pytest.raises(ValueError, check=None):
+   |                        ^^^^^^^^^^
+63 |         raise ValueError("Can't divide 1 by 0")
+   |

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT011_glob_all.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT011_glob_all.snap
@@ -87,3 +87,12 @@ PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use
    |                        ^^^^^^^^^^
 49 |         raise ValueError("Can't divide 1 by 0")
    |
+
+PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
+  --> PT011.py:62:24
+   |
+61 | def test_error_check_is_none():
+62 |     with pytest.raises(ValueError, check=None):
+   |                        ^^^^^^^^^^
+63 |         raise ValueError("Can't divide 1 by 0")
+   |


### PR DESCRIPTION
## Summary

PT011 (`pytest-raises-too-broad`) now recognizes the `check` parameter introduced in pytest 8.4.0.

Closes #22673

## Test plan

Added test cases for `check` parameter (valid callback and `check=None`).
