### PR TITLE
Add new option `format.markdown-code-format`

### DIFF
--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -19,8 +19,8 @@ use crate::comments::{
 pub use crate::context::PyFormatContext;
 pub use crate::db::Db;
 pub use crate::options::{
-    DocstringCode, DocstringCodeLineWidth, MagicTrailingComma, PreviewMode, PyFormatOptions,
-    QuoteStyle,
+    DocstringCode, DocstringCodeLineWidth, MagicTrailingComma, MarkdownCode, PreviewMode,
+    PyFormatOptions, QuoteStyle,
 };
 use crate::range::is_logical_line;
 pub use crate::shared_traits::{AsFormat, FormattedIter, FormattedIterExt, IntoFormat};

--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -378,6 +378,32 @@ impl fmt::Display for DocstringCode {
     }
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default, CacheKey)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum MarkdownCode {
+    #[default]
+    Disabled,
+
+    Enabled,
+}
+
+impl MarkdownCode {
+    pub const fn is_enabled(self) -> bool {
+        matches!(self, MarkdownCode::Enabled)
+    }
+}
+
+impl fmt::Display for MarkdownCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Disabled => write!(f, "disabled"),
+            Self::Enabled => write!(f, "enabled"),
+        }
+    }
+}
+
 #[derive(Copy, Clone, Default, Eq, PartialEq, CacheKey)]
 #[cfg_attr(
     feature = "serde",

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -39,7 +39,7 @@ use ruff_linter::{
 };
 use ruff_python_ast as ast;
 use ruff_python_formatter::{
-    DocstringCode, DocstringCodeLineWidth, MagicTrailingComma, QuoteStyle,
+    DocstringCode, DocstringCodeLineWidth, MagicTrailingComma, MarkdownCode, QuoteStyle,
 };
 
 use crate::options::{
@@ -1207,6 +1207,7 @@ pub struct FormatConfiguration {
     pub line_ending: Option<LineEnding>,
     pub docstring_code_format: Option<DocstringCode>,
     pub docstring_code_line_width: Option<DocstringCodeLineWidth>,
+    pub markdown_code_format: Option<MarkdownCode>,
 }
 
 impl FormatConfiguration {
@@ -1243,6 +1244,13 @@ impl FormatConfiguration {
                 }
             }),
             docstring_code_line_width: options.docstring_code_line_length,
+            markdown_code_format: options.markdown_code_format.map(|yes| {
+                if yes {
+                    MarkdownCode::Enabled
+                } else {
+                    MarkdownCode::Disabled
+                }
+            }),
         })
     }
 
@@ -1260,6 +1268,7 @@ impl FormatConfiguration {
             docstring_code_line_width: self
                 .docstring_code_line_width
                 .or(config.docstring_code_line_width),
+            markdown_code_format: self.markdown_code_format.or(config.markdown_code_format),
         }
     }
 }

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -3832,6 +3832,49 @@ pub struct FormatOptions {
         "#
     )]
     pub docstring_code_line_length: Option<DocstringCodeLineWidth>,
+
+    /// Whether to format code blocks in markdown documents.
+    ///
+    /// When this is enabled, Python code blocks within markdown files
+    /// are automatically reformatted.
+    ///
+    /// For example, when this is enabled, the following document:
+    ///
+    /// ````markdown
+    /// # Document
+    ///
+    /// This is plain text preceding a code block:
+    ///
+    /// ```py
+    /// f(  x  )
+    /// ```
+    /// ````
+    ///
+    /// ... will be reformatted (assuming the rest of the options are set to
+    /// their defaults) as:
+    ///
+    /// ````markdown
+    /// # Document
+    ///
+    /// This is plain text preceding a code block:
+    ///
+    /// ```py
+    /// f(x)
+    /// ```
+    /// ````
+    ///
+    /// If a code block in a document contains invalid Python code or if the
+    /// formatter would otherwise write invalid Python code, then the code
+    /// example is ignored by the formatter and kept as-is.
+    #[option(
+        default = "false",
+        value_type = "bool",
+        example = r#"
+            # Enable reformatting of code blocks in markdown files.
+            markdown-code-format = true
+        "#
+    )]
+    pub markdown_code_format: Option<bool>,
 }
 
 /// Configures Ruff's `analyze` command.


### PR DESCRIPTION
Adds a new formatting option to enable formatting markdown code blocks.


Issue #22636
