### PR TITLE
Add `--exit-non-zero-on-format` to formatter exit codes section

### DIFF
--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -364,7 +364,7 @@ When an incompatible lint rule or setting is enabled, `ruff format` will emit a 
 `ruff format` exits with the following status codes:
 
 - `0` if Ruff terminates successfully, regardless of whether any files were formatted.
-- `1` if Ruff terminates successfully, one or more files were formatted, and --exit-non-zero-on-format was specified.
+- `1` if Ruff terminates successfully, one or more files were formatted, and `--exit-non-zero-on-format` was specified.
 - `2` if Ruff terminates abnormally due to invalid configuration, invalid CLI options, or an
     internal error.
 


### PR DESCRIPTION
## Summary

The formatter's exit codes documentation at https://docs.astral.sh/ruff/formatter/#exit-codes doesn't mention the `--exit-non-zero-on-format` flag, even though it exists (it was added in https://github.com/astral-sh/ruff/pull/16009) and appears in ruff format --help, and the linter flag --exit-non-zero-on-fix is properly documented in the https://docs.astral.sh/ruff/linter/#exit-codes (which was used as a reference to add the proper section in the formatter, trying to keep the consistency)