### PR TITLE
[ty] Use a more lenient fallback type for failed `namedtuple()` and `NamedTuple` calls

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -795,22 +795,26 @@ from typing import NamedTuple
 # Missing both typename and fields
 # error: [missing-argument] "Missing required arguments `typename` and `fields` to `NamedTuple()`"
 Bad1 = NamedTuple()
-reveal_type(Bad1)  # revealed: type[NamedTupleFallback]
+reveal_type(Bad1)  # revealed: type[tuple[Unknown, ...]] & type[NamedTupleLike] & Unknown
+Bad1()  # no error
 
 # Missing fields argument
 # error: [missing-argument] "Missing required argument `fields` to `NamedTuple()`"
 Bad2 = NamedTuple("Bad2")
-reveal_type(Bad2)  # revealed: type[NamedTupleFallback]
+reveal_type(Bad2)  # revealed: type[tuple[Unknown, ...]] & type[NamedTupleLike] & Unknown
+Bad2(Bad2, foo=56)  # no error
 
 # Missing both typename and field_names for collections.namedtuple
 # error: [missing-argument] "Missing required arguments `typename` and `field_names` to `namedtuple()`"
 Bad3 = collections.namedtuple()
-reveal_type(Bad3)  # revealed: type[NamedTupleFallback]
+reveal_type(Bad3)  # revealed: type[tuple[Unknown, ...]] & type[NamedTupleLike] & Unknown
+Bad3(56, foo="foo")  # no error
 
 # Missing field_names argument
 # error: [missing-argument] "Missing required argument `field_names` to `namedtuple()`"
 Bad4 = collections.namedtuple("Bad4")
-reveal_type(Bad4)  # revealed: type[NamedTupleFallback]
+reveal_type(Bad4)  # revealed: type[tuple[Unknown, ...]] & type[NamedTupleLike] & Unknown
+Bad4(42, 56, 79)  # no error
 ```
 
 ### Starred and double-starred arguments
@@ -826,15 +830,15 @@ kwargs = {"rename": True}
 
 # Starred positional arguments - falls back to NamedTupleFallback
 Point1 = collections.namedtuple(*args)
-reveal_type(Point1)  # revealed: type[NamedTupleFallback]
+reveal_type(Point1)  # revealed: type[tuple[Unknown, ...]] & type[NamedTupleLike] & Unknown
 
 # Double-starred keyword arguments - falls back to NamedTupleFallback
 Point2 = collections.namedtuple("Point", ["x", "y"], **kwargs)
-reveal_type(Point2)  # revealed: type[NamedTupleFallback]
+reveal_type(Point2)  # revealed: type[tuple[Unknown, ...]] & type[NamedTupleLike] & Unknown
 
 # Both starred and double-starred
 Point3 = collections.namedtuple(*args, **kwargs)
-reveal_type(Point3)  # revealed: type[NamedTupleFallback]
+reveal_type(Point3)  # revealed: type[tuple[Unknown, ...]] & type[NamedTupleLike] & Unknown
 ```
 
 For `typing.NamedTuple`, variadic arguments are not supported and result in an error:
@@ -847,19 +851,20 @@ kwargs = {"extra": True}
 
 # error: [invalid-argument-type] "Variadic positional arguments are not supported in `NamedTuple()` calls"
 Point1 = NamedTuple(*args)
-reveal_type(Point1)  # revealed: type[NamedTupleFallback]
+reveal_type(Point1)  # revealed: type[tuple[Unknown, ...]] & type[NamedTupleLike] & Unknown
 
 # error: [invalid-argument-type] "Variadic positional arguments are not supported in `NamedTuple()` calls"
 Point2 = NamedTuple("Point", *args)
-reveal_type(Point2)  # revealed: type[NamedTupleFallback]
+reveal_type(Point2)  # revealed: type[tuple[Unknown, ...]] & type[NamedTupleLike] & Unknown
 
 # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `NamedTuple()` calls"
 Point3 = NamedTuple("Point", [("x", int), ("y", int)], **kwargs)
-reveal_type(Point3)  # revealed: type[NamedTupleFallback]
+reveal_type(Point3)  # revealed: type[tuple[Unknown, ...]] & type[NamedTupleLike] & Unknown
 
 # error: [invalid-argument-type] "Variadic positional and keyword arguments are not supported in `NamedTuple()` calls"
 Point4 = NamedTuple(*args, **kwargs)
-reveal_type(Point4)  # revealed: type[NamedTupleFallback]
+reveal_type(Point4)  # revealed: type[tuple[Unknown, ...]] & type[NamedTupleLike] & Unknown
+Point4(x=46, y=72)  # no error
 ```
 
 ### Definition


### PR DESCRIPTION
## Summary

This is stacked on top of #22718; review that first.

Currently if a user makes a bad `NamedTuple()` call like this:

```py
from typing import NamedTuple, reveal_type

Bad1 = NamedTuple()
Bad1()
```

then we emit errors on _both_ calls: one correct error for the bad `NamedTuple()` call (it's missing required arguments), and then another spurious error on the `Bad1()` call:

```
No overload of bound method `__init__` matches arguments
```

The reason for this second, spurious error is that we inferred `type[NamedTupleFallback]` for the result of the `Bad1()` call, and `NamedTupleFallback` has this `__init__` signature, which isn't appropriate in this context -- it actually reflects the arguments you need to pass to the `NamedTuple` function itself in order to _create_ a `NamedTuple` class, not the signature of the constructors that all `NamedTuple` classes have:

https://github.com/astral-sh/ruff/blob/7e1f07e5c606990e3a67c2c7d0c7367740636904/crates/ty_vendored/vendor/typeshed/stdlib/_typeshed/_type_checker_internals.pyi#L63-L69

This PR updates the fallback type we use when `NamedTuple` parsing fails, so that it's more lenient and the spurious error is no longer emitted.

## Test Plan

mdtests updated
