### PR TITLE
[ty] Support `Unpack[TypedDict]` for precise **kwargs typing (PEP 692)

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/unpack_kwargs.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unpack_kwargs.md
@@ -1,0 +1,287 @@
+# Unpack for \*\*kwargs (PEP 692)
+
+PEP 692 introduced the ability to use `Unpack[TypedDict]` to more precisely type `**kwargs`
+parameters.
+
+## Basic usage
+
+Inside a function with `**kwargs: Unpack[TypedDict]`, the kwargs parameter is typed as the TypedDict
+itself:
+
+```py
+from typing import TypedDict
+from typing_extensions import Unpack
+
+class Movie(TypedDict):
+    name: str
+    year: int
+
+def foo(**kwargs: Unpack[Movie]) -> None:
+    reveal_type(kwargs)  # revealed: Movie
+```
+
+## kwargs is typed as TypedDict
+
+```py
+from typing import TypedDict
+from typing_extensions import Unpack
+
+class Config(TypedDict):
+    debug: bool
+    verbose: bool
+
+def configure(**kwargs: Unpack[Config]) -> None:
+    # kwargs is typed as Config
+    reveal_type(kwargs)  # revealed: Config
+
+    # We can access keys from the TypedDict
+    debug = kwargs["debug"]
+    reveal_type(debug)  # revealed: bool
+```
+
+## Required and NotRequired keys
+
+TypedDict keys can be required or not required:
+
+```py
+from typing import TypedDict
+from typing_extensions import Unpack, NotRequired
+
+class Options(TypedDict):
+    required_key: str
+    optional_key: NotRequired[int]
+
+def with_options(**kwargs: Unpack[Options]) -> None:
+    reveal_type(kwargs)  # revealed: Options
+```
+
+## Invalid Unpack usage
+
+`Unpack` should only be used with TypedDict types (or TypeVarTuple for variadic generics):
+
+```py
+from typing_extensions import Unpack
+
+# error: [invalid-type-form] "`Unpack` must be used with a TypedDict, TypeVarTuple, or tuple type, got `int`"
+def invalid(**kwargs: Unpack[int]) -> None:
+    pass
+```
+
+## Using a regular TypeVar with Unpack is invalid
+
+```py
+from typing import TypeVar
+from typing_extensions import Unpack
+
+T = TypeVar("T")
+
+# error: [invalid-type-form] "`Unpack` must be used with a TypedDict, TypeVarTuple, or tuple type, got `T@invalid_typevar`"
+def invalid_typevar(**kwargs: Unpack[T]) -> None:
+    pass
+```
+
+## Unpack without argument
+
+`Unpack` requires exactly one type argument:
+
+```py
+from typing_extensions import Unpack
+
+# error: [invalid-type-form] "`typing.Unpack` requires exactly one argument when used in a type expression"
+x: Unpack
+```
+
+## Call binding with Unpack[TypedDict]
+
+When calling a function with `**kwargs: Unpack[TypedDict]`, keyword arguments are validated against
+the TypedDict fields.
+
+### Valid calls with all required fields
+
+```py
+from typing import TypedDict
+from typing_extensions import Unpack
+
+class Movie(TypedDict):
+    name: str
+    year: int
+
+def foo(**kwargs: Unpack[Movie]) -> None:
+    pass
+
+# Valid: all required fields provided
+foo(name="Life of Brian", year=1979)
+```
+
+### Unknown keyword argument
+
+```py
+from typing import TypedDict
+from typing_extensions import Unpack
+
+class Movie(TypedDict):
+    name: str
+    year: int
+
+def foo(**kwargs: Unpack[Movie]) -> None:
+    pass
+
+# error: [unknown-argument] "Argument `extra` does not match any known parameter"
+foo(name="Life of Brian", year=1979, extra=True)
+```
+
+### Missing required fields
+
+```py
+from typing import TypedDict
+from typing_extensions import Unpack
+
+class Movie(TypedDict):
+    name: str
+    year: int
+
+def foo(**kwargs: Unpack[Movie]) -> None:
+    pass
+
+# error: [missing-argument] "Missing required keyword argument `year` for function `foo`"
+foo(name="Life of Brian")
+
+# error: [missing-argument] "Missing required keyword arguments `name`, `year` for function `foo`"
+foo()
+```
+
+### Mixed regular parameters and Unpack[TypedDict]
+
+```py
+from typing import TypedDict
+from typing_extensions import Unpack
+
+class Movie(TypedDict):
+    name: str
+    year: int
+
+def with_prefix(prefix: str, **kwargs: Unpack[Movie]) -> None:
+    pass
+
+# Valid: regular parameter and TypedDict fields
+with_prefix(">>", name="Life of Brian", year=1979)
+
+# error: [unknown-argument] "Argument `extra` does not match any known parameter"
+with_prefix(">>", name="Life of Brian", year=1979, extra=True)
+
+# error: [missing-argument] "Missing required keyword argument `year` for function `with_prefix`"
+with_prefix(">>", name="Life of Brian")
+```
+
+### NotRequired fields are optional
+
+```py
+from typing import TypedDict
+from typing_extensions import Unpack, NotRequired
+
+class MovieWithRating(TypedDict):
+    name: str
+    year: int
+    rating: NotRequired[float]
+
+def with_optional(**kwargs: Unpack[MovieWithRating]) -> None:
+    pass
+
+# Valid: NotRequired field can be omitted
+with_optional(name="Life of Brian", year=1979)
+
+# Valid: NotRequired field can be provided
+with_optional(name="Life of Brian", year=1979, rating=9.5)
+
+# error: [unknown-argument] "Argument `extra` does not match any known parameter"
+with_optional(name="Life of Brian", year=1979, extra=True)
+```
+
+### Type checking for field types
+
+```py
+from typing import TypedDict
+from typing_extensions import Unpack
+
+class Movie(TypedDict):
+    name: str
+    year: int
+
+def foo(**kwargs: Unpack[Movie]) -> None:
+    pass
+
+# error: [invalid-argument-type] "Argument to function `foo` is incorrect: Expected `str`, found `Literal[123]`"
+foo(name=123, year=1979)
+
+# error: [invalid-argument-type]
+foo(name="Life of Brian", year="1979")
+```
+
+### Passing TypedDict variables via \*\*
+
+```py
+from typing import TypedDict
+from typing_extensions import Unpack
+
+class Movie(TypedDict):
+    name: str
+    year: int
+
+def foo(**kwargs: Unpack[Movie]) -> None:
+    pass
+
+# Valid: Passing a compatible TypedDict via **
+movie: Movie = {"name": "Life of Brian", "year": 1979}
+foo(**movie)
+```
+
+### Passing incompatible TypedDict via \*\*
+
+```py
+from typing import TypedDict
+from typing_extensions import Unpack
+
+class Movie(TypedDict):
+    name: str
+    year: int
+
+class BadMovie(TypedDict):
+    name: int  # Wrong type
+    year: str  # Wrong type
+
+def foo(**kwargs: Unpack[Movie]) -> None:
+    pass
+
+bad_movie: BadMovie = {"name": 123, "year": "1979"}
+
+# error: [invalid-argument-type]
+# error: [invalid-argument-type]
+foo(**bad_movie)
+```
+
+### Passing TypedDict with extra fields via \*\*
+
+When passing a TypedDict with extra fields that are not in the parameter TypedDict, the extra fields
+are reported as unknown arguments:
+
+```py
+from typing import TypedDict
+from typing_extensions import Unpack
+
+class Movie(TypedDict):
+    name: str
+    year: int
+
+class MovieWithDirector(TypedDict):
+    name: str
+    year: int
+    director: str
+
+def foo(**kwargs: Unpack[Movie]) -> None:
+    pass
+
+movie_with_director: MovieWithDirector = {"name": "Life of Brian", "year": 1979, "director": "Terry Jones"}
+
+# error: [unknown-argument] "Argument `director` does not match any known parameter of function `foo`"
+foo(**movie_with_director)
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5707,6 +5707,9 @@ impl<'db> Type<'db> {
                 }
                 KnownInstanceType::Callable(callable) => Ok(Type::Callable(*callable)),
                 KnownInstanceType::LiteralStringAlias(ty) => Ok(ty.inner(db)),
+                // Unpack[TypedDict] is valid in annotation expressions but has special handling
+                // in **kwargs context. When used directly in a type expression, we return it as-is.
+                KnownInstanceType::UnpackedTypedDict(_) => Ok(*self),
             },
 
             Type::SpecialForm(special_form) => match special_form {
@@ -6118,6 +6121,11 @@ impl<'db> Type<'db> {
                     // TODO: For some of these, we may need to apply the type mapping to inner types.
                     self
                 },
+                KnownInstanceType::UnpackedTypedDict(typed_dict) => {
+                    Type::KnownInstance(KnownInstanceType::UnpackedTypedDict(
+                        typed_dict.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                    ))
+                },
             }
 
             Type::FunctionLiteral(function) => {
@@ -6522,7 +6530,8 @@ impl<'db> Type<'db> {
                 | KnownInstanceType::Literal(_)
                 | KnownInstanceType::LiteralStringAlias(_)
                 | KnownInstanceType::NamedTupleSpec(_)
-                | KnownInstanceType::NewType(_) => {
+                | KnownInstanceType::NewType(_)
+                | KnownInstanceType::UnpackedTypedDict(_) => {
                     // TODO: For some of these, we may need to try to find legacy typevars in inner types.
                 }
             },
@@ -7162,6 +7171,10 @@ pub enum KnownInstanceType<'db> {
 
     /// The inferred spec for a functional `NamedTuple` class.
     NamedTupleSpec(NamedTupleSpec<'db>),
+
+    /// A single instance of `typing.Unpack[TypedDict]` (PEP 692).
+    /// This is used for more precise `**kwargs` typing.
+    UnpackedTypedDict(TypedDictType<'db>),
 }
 
 fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
@@ -7213,6 +7226,9 @@ fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
                 visitor.visit_type(db, field.ty);
             }
         }
+        KnownInstanceType::UnpackedTypedDict(typed_dict) => {
+            visitor.visit_type(db, Type::TypedDict(typed_dict));
+        }
     }
 }
 
@@ -7254,6 +7270,9 @@ impl<'db> KnownInstanceType<'db> {
                     .map_base_class_type(db, |class_type| class_type.normalized_impl(db, visitor)),
             ),
             Self::NamedTupleSpec(spec) => Self::NamedTupleSpec(spec.normalized_impl(db, visitor)),
+            Self::UnpackedTypedDict(typed_dict) => {
+                Self::UnpackedTypedDict(typed_dict.normalized_impl(db, visitor))
+            }
             Self::Deprecated(_)
             | Self::ConstraintSet(_)
             | Self::GenericContext(_)
@@ -7313,6 +7332,10 @@ impl<'db> KnownInstanceType<'db> {
             Self::NamedTupleSpec(spec) => spec
                 .recursive_type_normalized_impl(db, div, true)
                 .map(Self::NamedTupleSpec),
+            Self::UnpackedTypedDict(typed_dict) => {
+                // TypedDict doesn't need recursive type normalization in this context
+                Some(Self::UnpackedTypedDict(typed_dict))
+            }
         }
     }
 
@@ -7340,6 +7363,8 @@ impl<'db> KnownInstanceType<'db> {
             Self::LiteralStringAlias(_) => KnownClass::Str,
             Self::NewType(_) => KnownClass::NewType,
             Self::NamedTupleSpec(_) => KnownClass::Sequence,
+            // Unpack[TypedDict] is represented as a _SpecialForm at runtime
+            Self::UnpackedTypedDict(_) => KnownClass::SpecialForm,
         }
     }
 
@@ -13112,7 +13137,7 @@ pub(super) fn determine_upper_bound<'db>(
 // Make sure that the `Type` enum does not grow unexpectedly.
 #[cfg(not(debug_assertions))]
 #[cfg(target_pointer_width = "64")]
-static_assertions::assert_eq_size!(Type, [u8; 16]);
+static_assertions::assert_eq_size!(Type, [u8; 24]);
 
 #[cfg(test)]
 pub(crate) mod tests {

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -200,7 +200,9 @@ impl<'db> ClassBase<'db> {
                 // A class inheriting from a newtype would make intuitive sense, but newtype
                 // wrappers are just identity callables at runtime, so this sort of inheritance
                 // doesn't work and isn't allowed.
-                | KnownInstanceType::NewType(_) => None,
+                | KnownInstanceType::NewType(_)
+                // Unpack[TypedDict] is not a valid base class
+                | KnownInstanceType::UnpackedTypedDict(_) => None,
                 KnownInstanceType::TypeGenericAlias(_) => {
                     Self::try_from_type(db, KnownClass::Type.to_class_literal(db), subclass)
                 }

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -2904,6 +2904,13 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
                 f.write_str("'>")
             }
             KnownInstanceType::NamedTupleSpec(_) => f.write_str("NamedTupleSpec"),
+            KnownInstanceType::UnpackedTypedDict(typed_dict) => {
+                f.write_str("Unpack[")?;
+                Type::TypedDict(typed_dict)
+                    .display(self.db)
+                    .fmt_detailed(f)?;
+                f.write_char(']')
+            }
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3138,7 +3138,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     /// Set initial declared/inferred types for a `**kwargs` keyword-variadic parameter.
     ///
-    /// The annotated type is implicitly wrapped in a string-keyed dictionary.
+    /// The annotated type is implicitly wrapped in a string-keyed dictionary,
+    /// unless it's `Unpack[TypedDict]` (PEP 692) in which case kwargs is typed as the `TypedDict`.
     ///
     /// See [`infer_parameter_definition`] doc comment for some relevant observations about scopes.
     ///
@@ -3185,6 +3186,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         )
                     }
                 }
+            } else if let Type::KnownInstance(KnownInstanceType::UnpackedTypedDict(typed_dict)) =
+                annotated_type
+            {
+                // PEP 692: `**kwargs: Unpack[TypedDict]`
+                // The kwargs inside the function is typed as the TypedDict itself
+                Type::TypedDict(typed_dict)
             } else {
                 KnownClass::Dict.to_specialized_instance(
                     self.db(),


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ty/issues/1746 Partially addresses https://github.com/astral-sh/ty/issues/154 ("Support for `Unpack`" checkbox)

This PR implements PEP 692 support for using `Unpack[TypedDict]` to provide more precise type annotations for `**kwargs` parameters. Previously, `**kwargs: str` meant all keyword arguments are strings. With this change, you can specify exactly which keyword arguments are expected:

```python
class Movie(TypedDict):
    name: str
    year: int

def foo(**kwargs: Unpack[Movie]) -> None:
    reveal_type(kwargs)  # revealed: Movie
```

Implementation details:
- Add `KnownInstanceType::UnpackedTypedDict(TypedDictType)` variant
- Parse `Unpack[TypedDict]` in type expressions, emit errors for invalid usage
- Type `kwargs` as the TypedDict itself inside function bodies
- Validate keyword arguments against TypedDict fields at call sites
- Report `unknown-argument` for kwargs not in the TypedDict
- Report `missing-argument` for required TypedDict fields not provided
- Check argument types against specific TypedDict field types
- Handle `**typed_dict_var` passthrough with field-by-field type checking

Not yet implemented (out of scope, separate PEP 646 features):
- `Unpack[TypeVarTuple]` - returns `todo_type!`
- `Unpack[tuple[...]]` - returns `todo_type!`

## Test Plan

New mdtest file `annotations/unpack_kwargs.md` with comprehensive coverage:
- Basic usage and `reveal_type` verification
- Required/NotRequired field handling
- Invalid Unpack usage errors (int, regular TypeVar)
- Call binding: valid calls, unknown kwargs, missing required fields
- Type checking for individual field types
- Passing compatible/incompatible TypedDict via `**`
- Passing TypedDict with extra fields via `**`

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->