### PR TITLE
[ty] Improve completion rankings for raise-from/except contexts

### DIFF
--- a/crates/ty_completion_eval/completion-evaluation-tasks.csv
+++ b/crates/ty_completion_eval/completion-evaluation-tasks.csv
@@ -27,6 +27,8 @@ object-attr-instance-methods,main.py,0,1
 object-attr-instance-methods,main.py,1,1
 pass-keyword-completion,main.py,0,1
 raise-uses-base-exception,main.py,0,1
+raise-uses-base-exception,main.py,1,1
+raise-uses-base-exception,main.py,2,1
 scope-existing-over-new-import,main.py,0,1
 scope-prioritize-closer,main.py,0,2
 scope-simple-long-identifier,main.py,0,1

--- a/crates/ty_completion_eval/truth/raise-uses-base-exception/main.py
+++ b/crates/ty_completion_eval/truth/raise-uses-base-exception/main.py
@@ -1,2 +1,8 @@
 # ref: https://github.com/astral-sh/ty/issues/1262
 raise NotImplement<CURSOR: NotImplementedError>
+
+raise AssertionError from NotImplement<CURSOR: NotImplementedError>
+
+try:
+    raise AssertionError("invalid")
+except NotImplement<CURSOR: NotImplementedError>

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -81,7 +81,7 @@ impl<'db> Type<'db> {
         Type::tuple_instance(tuple)
     }
 
-    pub(crate) fn homogeneous_tuple(db: &'db dyn Db, element: Type<'db>) -> Self {
+    pub fn homogeneous_tuple(db: &'db dyn Db, element: Type<'db>) -> Self {
         Type::tuple_instance(TupleType::homogeneous(db, element))
     }
 


### PR DESCRIPTION
Completions of the correct types are now favoured in `except <CURSOR>` and `raise <EXPR> from <CURSOR>` contexts

Fixes https://github.com/astral-sh/ty/issues/1779

This does regress the completions when no character is typed after the raise keyword `raise <CURSOR>` but I think that's a reasonable trade-off to greatly simplify the implementation with AST-traversal rather than extending the token-based approach.

## Test Plan
New completion evaluation tasks with correct rankings (that produces incorrect rankings on main)
