### PR TITLE
[ty] show final search path instead of "and 1 more paths"

### DIFF
--- a/crates/ty/tests/cli/python_environment.rs
+++ b/crates/ty/tests/cli/python_environment.rs
@@ -672,6 +672,38 @@ fn many_search_paths() -> anyhow::Result<()> {
             .arg("--extra-search-path").arg("extra1")
             .arg("--extra-search-path").arg("extra2")
             .arg("--extra-search-path").arg("extra3")
+            .arg("--extra-search-path").arg("extra4"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error[unresolved-import]: Cannot resolve imported module `baz`
+     --> test.py:1:14
+      |
+    1 | import foo1, baz
+      |              ^^^
+      |
+    info: Searched in the following paths during module resolution:
+    info:   1. <temp_dir>/extra1 (extra search path specified on the CLI or in your config file)
+    info:   2. <temp_dir>/extra2 (extra search path specified on the CLI or in your config file)
+    info:   3. <temp_dir>/extra3 (extra search path specified on the CLI or in your config file)
+    info:   4. <temp_dir>/extra4 (extra search path specified on the CLI or in your config file)
+    info:   5. <temp_dir>/ (first-party code)
+    info:   6. vendored://stdlib (stdlib typeshed stubs vendored by ty)
+    info: make sure your Python environment is properly configured: https://docs.astral.sh/ty/modules/#python-environment
+    info: rule `unresolved-import` is enabled by default
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    ");
+
+    assert_cmd_snapshot!(
+        case.command()
+            .arg("--python-platform").arg("linux")
+            .arg("--extra-search-path").arg("extra1")
+            .arg("--extra-search-path").arg("extra2")
+            .arg("--extra-search-path").arg("extra3")
             .arg("--extra-search-path").arg("extra4")
             .arg("--extra-search-path").arg("extra5")
             .arg("--extra-search-path").arg("extra6"),

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8131,10 +8131,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             "Searched in the following paths during module resolution:"
         ));
 
-        let mut search_paths = search_paths.enumerate();
+        let mut search_paths = search_paths.enumerate().peekable();
 
         while let Some((index, path)) = search_paths.next() {
-            if index > 4 && !verbose {
+            if index > 4 && !verbose && search_paths.peek().is_some() {
                 let more = search_paths.count() + 1;
                 diagnostic.info(format_args!(
                     "  ... and {more} more paths. Run with `-v` to see all paths."


### PR DESCRIPTION
## Summary

If there are six search paths, five are attached as subdiagnostic of unresolved imports but the sixth is by default hidden and replaced by "... and 1 more paths. Run with `-v` to see all paths."

```
info: Searched in the following paths during module resolution:
info:   1. <temp_dir>/extra1 (extra search path specified on the CLI or in your config file)
info:   2. <temp_dir>/extra2 (extra search path specified on the CLI or in your config file)
info:   3. <temp_dir>/extra3 (extra search path specified on the CLI or in your config file)
info:   4. <temp_dir>/extra4 (extra search path specified on the CLI or in your config file)
info:   5. <temp_dir>/ (first-party code)
info:   ... and 1 more paths. Run with `-v` to see all paths.
```

By hiding a single path this truncation does not shorten the output but still requires the user to rerun ty. We can just include the final search path instead.
The subdiagnostic "and 1 more paths" isn't helpful - we can show the hidden path instead (and still have the same number of subdiagnistics).

```
info: Searched in the following paths during module resolution:
info:   1. <temp_dir>/extra1 (extra search path specified on the CLI or in your config file)
info:   2. <temp_dir>/extra2 (extra search path specified on the CLI or in your config file)
info:   3. <temp_dir>/extra3 (extra search path specified on the CLI or in your config file)
info:   4. <temp_dir>/extra4 (extra search path specified on the CLI or in your config file)
info:   5. <temp_dir>/ (first-party code)
info:   6. vendored://stdlib (stdlib typeshed stubs vendored by ty)
```

## Test Plan

* cargo test extended
* manual invocation (with the configuration that prompted me to propose this change).