### PR TITLE
[ty] Fix assignment in decorated method causing Unknown fallback

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2686,9 +2686,11 @@ reveal_type(C().x)  # revealed: int
 
 ### Attributes defined in methods with unknown decorators
 
-When an attribute is defined in a method that is decorated with an unknown decorator, we consider it
-to be accessible on both the class itself and instances of that class. This is consistent with the
-gradual guarantee, because the unknown decorator *could* be an alias for `builtins.classmethod`.
+When an attribute is defined in a method that is decorated with an unknown decorator, the method is
+treated as a regular instance method. The attribute is accessible on instances but not on the class
+itself. We don't assume that an unknown decorator might be an alias for `@classmethod`, because that
+would cause the attribute to pollute class-level lookups and potentially override instance-level
+declarations.
 
 ```py
 # error: [unresolved-import]
@@ -2699,8 +2701,57 @@ class C:
     def f(self):
         self.x: int = 1
 
-reveal_type(C.x)  # revealed: int
+# error: [unresolved-attribute]
+reveal_type(C.x)  # revealed: Unknown
 reveal_type(C().x)  # revealed: int
+
+class D:
+    def __init__(self):
+        self.x: int = 1
+
+    @unknown_decorator
+    def f(self):
+        self.x = 2
+
+reveal_type(D().x)  # revealed: int
+```
+
+### Attributes declared in `__init__` but also assigned in a decorated method
+
+When an attribute is declared with a type annotation in `__init__`, and then assigned (without
+annotation) in a method decorated with a known decorator like `@cache`, we should respect the
+declared type from `__init__`. The decorated method's assignment should not cause the type to
+include `Unknown`.
+
+```py
+from functools import cache
+
+class C:
+    def __init__(self) -> None:
+        self.x: int = 0
+
+    @cache
+    def method(self) -> None:
+        self.x = 1
+
+def f(c: C) -> None:
+    reveal_type(c.x)  # revealed: int
+```
+
+### Attributes defined in a property
+
+Instance attributes can be defined in a `@property` getter. Properties are still instance methods
+that take `self`, so attribute assignments in them should be recognized.
+
+```py
+class C:
+    @property
+    def prop(self) -> int:
+        self.x: int = 1
+        return self.x
+
+def f(c: C) -> None:
+    reveal_type(c.x)  # revealed: int
 ```
 
 ## Enum classes


### PR DESCRIPTION
Fixes https://github.com/astral-sh/ty/issues/2566

Fix a bug where assigning to an instance attribute in a decorated method (like @cache) incorrectly resulted in `Unknown | int` instead of just `int` when the attribute was explicitly declared in `__init__`.

The bug was in the `is_valid_scope` closure in `implicit_attribute_inner`. When looking up class members for the descriptor protocol, it calls `implicit_attribute` with `MethodDecorator::ClassMethod`. The previous code relied on the final evaluated type of the method (after all decorators are applied) to determine if it's a classmethod. For methods wrapped by `@cache`, the final type becomes `_lru_cache_wrapper[...]` instead of `FunctionLiteral`, which caused incorrect behavior.

The fix changes the approach to directly iterate through the decorators on the AST node and check if any of their types evaluate to `classmethod` or `staticmethod`. This is more reliable because it checks the original decorator types, not the final wrapped result. It also results in fewer cycles, because attribute lookup no longer depends on a full attribute lookup of every method; instead it just depends on the types of the specific decorator nodes on each method.

Also removes the assumption that unknown decorators might be classmethod/staticmethod aliases. This caused attributes defined in methods with unknown decorators to pollute class-level lookups and potentially override instance-level attributes.
