### PR TITLE
[ty] give Claude better test-running instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Run a single mdtest file:
 cargo nextest run -p ty_python_semantic --test mdtest -- mdtest::<path/to/mdtest_file.md>
 ```
 
-Run a specific mdtest within a file (use a substring of the Markdown header text) -- this is usually not needed:
+To run a specific mdtest within a file, use a substring of the Markdown header text as `MDTEST_TEST_FILTER`. Only use this if it's necessary to isolate a single test case:
 
 ```sh
 MDTEST_TEST_FILTER="<filter>" cargo nextest run -p ty_python_semantic --test mdtest -- mdtest::<path/to/mdtest_file.md>


### PR DESCRIPTION
Claude tends to over-use `MDTEST_TEST_FILTER` when it's not necessary. It uses it for running a full mdtest file -- it's only actually needed if you want to run a single test section within an mdtest file.

This overuse is a problem because I can't get wildcards to work correctly in permission lines with `MDTEST_TEST_FILTER`, so Claude will always separately ask for permissions for each individual test file it wants to run.

Try to give it better instructions so it will stop doing that.