### PR TITLE
isort: Add `sort-by-qualified-name` option

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/isort/sort_by_qualified_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/sort_by_qualified_name.py
@@ -1,0 +1,16 @@
+from collections import OrderedDict
+from collections.abc import Mapping
+from collections import Counter
+from collections.abc import Sequence
+
+import collections.abc
+import collections
+
+# Relative imports
+from . import foo
+from .bar import baz
+from .. import parent
+
+# Star imports
+from xml import *
+from xml.etree import ElementTree

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -1664,4 +1664,22 @@ mod tests {
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())
     }
+
+    #[test_case(Path::new("sort_by_qualified_name.py"))]
+    fn sort_by_qualified_name(path: &Path) -> Result<()> {
+        let snapshot = format!("sort_by_qualified_name__{}", path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("isort").join(path).as_path(),
+            &LinterSettings {
+                isort: super::settings::Settings {
+                    sort_by_qualified_name: true,
+                    ..super::settings::Settings::default()
+                },
+                src: vec![test_resource_path("fixtures/isort")],
+                ..LinterSettings::for_rule(Rule::UnsortedImports)
+            },
+        )?;
+        assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
 }

--- a/crates/ruff_linter/src/rules/isort/settings.rs
+++ b/crates/ruff_linter/src/rules/isort/settings.rs
@@ -70,6 +70,7 @@ pub struct Settings {
     pub from_first: bool,
     pub length_sort: bool,
     pub length_sort_straight: bool,
+    pub sort_by_qualified_name: bool,
 }
 
 impl Settings {
@@ -125,6 +126,7 @@ impl Default for Settings {
             from_first: false,
             length_sort: false,
             length_sort_straight: false,
+            sort_by_qualified_name: false,
         }
     }
 }
@@ -161,7 +163,8 @@ impl Display for Settings {
                 self.no_sections,
                 self.from_first,
                 self.length_sort,
-                self.length_sort_straight
+                self.length_sort_straight,
+                self.sort_by_qualified_name
             ]
         }
         Ok(())

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__sort_by_qualified_name__sort_by_qualified_name.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__sort_by_qualified_name__sort_by_qualified_name.py.snap
@@ -1,0 +1,51 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+assertion_line: 1465
+---
+I001 [*] Import block is un-sorted or un-formatted
+  --> sort_by_qualified_name.py:1:1
+   |
+ 1 | / from collections import OrderedDict
+ 2 | | from collections.abc import Mapping
+ 3 | | from collections import Counter
+ 4 | | from collections.abc import Sequence
+ 5 | |
+ 6 | | import collections.abc
+ 7 | | import collections
+ 8 | |
+ 9 | | # Relative imports
+10 | | from . import foo
+11 | | from .bar import baz
+12 | | from .. import parent
+13 | |
+14 | | # Star imports
+15 | | from xml import *
+16 | | from xml.etree import ElementTree
+   | |_________________________________^
+   |
+help: Organize imports
+   - from collections import OrderedDict
+   - from collections.abc import Mapping
+   - from collections import Counter
+   - from collections.abc import Sequence
+1  + import collections
+2  + import collections.abc
+3  + from collections.abc import Mapping, Sequence
+4  + from collections import Counter, OrderedDict
+5  + 
+6  + # Star imports
+7  + from xml import *
+8  + from xml.etree import ElementTree
+9  | 
+   - import collections.abc
+   - import collections
+10 + from .. import parent
+11 | 
+12 | # Relative imports
+13 | from . import foo
+14 | from .bar import baz
+   - from .. import parent
+   - 
+   - # Star imports
+   - from xml import *
+   - from xml.etree import ElementTree

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2707,6 +2707,35 @@ pub struct IsortOptions {
     )]
     pub length_sort_straight: Option<bool>,
 
+    /// Sort imports by their fully-qualified names.
+    ///
+    /// By default, `from X import Y` statements are sorted by the module name (`X`) first,
+    /// then by the member name (`Y`). When enabled, they are sorted by the fully-qualified
+    /// name `X.Y` instead.
+    ///
+    /// For example, with this option disabled (default):
+    /// ```python
+    /// from collections import OrderedDict
+    /// from collections.abc import Mapping
+    /// ```
+    ///
+    /// With `sort-by-qualified-name = true`:
+    /// ```python
+    /// from collections.abc import Mapping  # collections.abc.Mapping
+    /// from collections import OrderedDict  # collections.OrderedDict
+    /// ```
+    ///
+    /// This only affects `from X import Y` statements. Regular `import X` statements
+    /// already sort by the full module name.
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
+        example = r#"
+            sort-by-qualified-name = true
+        "#
+    )]
+    pub sort_by_qualified_name: Option<bool>,
+
     // Tables are required to go last.
     /// A list of mappings from section names to modules.
     ///
@@ -2951,6 +2980,7 @@ impl IsortOptions {
             from_first,
             length_sort: self.length_sort.unwrap_or(false),
             length_sort_straight: self.length_sort_straight.unwrap_or(false),
+            sort_by_qualified_name: self.sort_by_qualified_name.unwrap_or(false),
         })
     }
 }


### PR DESCRIPTION
## Summary

Currently, the isort rules sort imports purely based on module path. For example, the following would pass isort with the default configuration:

    from foo import baz
    from foo.bar import wow

since `foo` < `foo.bar`. However, the [hacking][1] plugin for flake8 provides rule `H306`, which expects [that imports are sorted by their fully qualified name][2]. Therefore it would expect the following:

    from foo.bar import wow
    from foo import baz

since `foo.bar.wow` < `foo.baz`.

Add support for this functionality via a new `sort-by-qualified-name` knob which defaults to `false`. As discussed inline, this is superseded by the `length-sort` option to preserve existing behavior.

## Test Plan

Unit tests included. Change ran against a subset of the many OpenStack projects using ruff for linting.

[1]: https://opendev.org/openstack/hacking/
[2]: https://opendev.org/openstack/hacking/src/commit/235d79d911d55abb0978fcf5ac92e193ebf9efa5/hacking/checks/imports.py#L81-L106
