### PR TITLE
fix: Fix false negative when sequence is an attribute

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/len_as_condition.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/len_as_condition.py
@@ -248,3 +248,21 @@ if len(
     fruits  # comment
 ):
     ...
+
+# regression tests for https://github.com/astral-sh/ruff/issues/22780
+class Fruits:
+    fruits: list[str]
+
+    def __init__(self):
+        self.fruits = ["apple", "orange"]
+
+        if len(self.fruits):  # [PLC1802]
+            ...
+
+        if not len(self.fruits):  # [PLC1802]
+            ...
+
+    def check_fruits(self):
+        # This should NOT trigger because we can't trace the assignment
+        if len(self.fruits):
+            ...

--- a/crates/ruff_linter/src/rules/pylint/rules/len_test.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/len_test.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::Applicability;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::{self as ast, Expr, ExprCall};
+use ruff_python_ast::{self as ast, Expr, ExprCall, Stmt};
 use ruff_python_semantic::SemanticModel;
 use ruff_python_semantic::analyze::type_inference::{PythonType, ResolvedPythonType};
 use ruff_python_semantic::analyze::typing::find_binding_value;
@@ -101,7 +101,7 @@ pub(crate) fn len_test(checker: &Checker, call: &ExprCall) {
     }
 
     // Simple inferred sequence type (e.g., list, set, dict, tuple, string, bytes, varargs, kwargs).
-    if !is_sequence(argument, semantic) && !is_indirect_sequence(argument, semantic) {
+    if !is_sequence(argument, semantic) && !is_indirect_sequence(argument, semantic, checker) {
         return;
     }
 
@@ -127,39 +127,125 @@ pub(crate) fn len_test(checker: &Checker, call: &ExprCall) {
         ));
 }
 
-fn is_indirect_sequence(expr: &Expr, semantic: &SemanticModel) -> bool {
-    let Expr::Name(ast::ExprName { id: name, .. }) = expr else {
-        return false;
-    };
+fn is_indirect_sequence(expr: &Expr, semantic: &SemanticModel, checker: &Checker) -> bool {
+    match expr {
+        Expr::Name(ast::ExprName { id: name, .. }) => {
+            let scope = semantic.current_scope();
+            let Some(binding_id) = scope.get(name) else {
+                return false;
+            };
 
-    let scope = semantic.current_scope();
-    let Some(binding_id) = scope.get(name) else {
-        return false;
-    };
+            let binding = semantic.binding(binding_id);
 
-    let binding = semantic.binding(binding_id);
+            // Attempt to find the binding's value
+            let Some(binding_value) = find_binding_value(binding, semantic) else {
+                // If the binding is not an argument, return false
+                if !binding.kind.is_argument() {
+                    return false;
+                }
 
-    // Attempt to find the binding's value
-    let Some(binding_value) = find_binding_value(binding, semantic) else {
-        // If the binding is not an argument, return false
-        if !binding.kind.is_argument() {
-            return false;
+                // Attempt to retrieve the function definition statement
+                let Some(function) = binding
+                    .statement(semantic)
+                    .and_then(|statement| statement.as_function_def_stmt())
+                else {
+                    return false;
+                };
+
+                // If not find in non-default params, it must be varargs or kwargs
+                return function.parameters.find(name).is_none();
+            };
+
+            // If `binding_value` is found, check if it is a sequence
+            is_sequence(binding_value, semantic)
         }
+        Expr::Attribute(ast::ExprAttribute { value, attr, .. }) => {
+            // For attribute access like `self.fruits`, we check if the attribute
+            // was assigned a sequence value in the current statement hierarchy
+            if let Expr::Name(ast::ExprName { id: base_name, .. }) = value.as_ref() {
+                // Look through the current statement hierarchy for assignments to this attribute
+                for stmt in semantic.current_statements() {
+                    if let Some(assign_value) =
+                        find_attribute_assignment(stmt, base_name, attr, semantic)
+                    {
+                        return is_sequence(assign_value, semantic);
+                    }
+                }
 
-        // Attempt to retrieve the function definition statement
-        let Some(function) = binding
-            .statement(semantic)
-            .and_then(|statement| statement.as_function_def_stmt())
-        else {
-            return false;
-        };
+                // Also check the function body if we're in a function
+                if let Some(function_def) = checker
+                    .semantic()
+                    .current_statements()
+                    .find_map(|stmt| stmt.as_function_def_stmt())
+                {
+                    for stmt in &function_def.body {
+                        if let Some(assign_value) =
+                            find_attribute_assignment(stmt, base_name, attr, semantic)
+                        {
+                            return is_sequence(assign_value, semantic);
+                        }
+                    }
+                }
+            }
+            false
+        }
+        _ => false,
+    }
+}
 
-        // If not find in non-default params, it must be varargs or kwargs
-        return function.parameters.find(name).is_none();
-    };
-
-    // If `binding_value` is found, check if it is a sequence
-    is_sequence(binding_value, semantic)
+/// Find an assignment to an attribute in a statement.
+/// Returns the assigned value if found.
+fn find_attribute_assignment<'a>(
+    stmt: &'a Stmt,
+    base_name: &str,
+    attr_name: &str,
+    _semantic: &SemanticModel,
+) -> Option<&'a Expr> {
+    match stmt {
+        Stmt::Assign(ast::StmtAssign { targets, value, .. }) => {
+            for target in targets {
+                if let Expr::Attribute(ast::ExprAttribute {
+                    value: target_value,
+                    attr: target_attr,
+                    ..
+                }) = target
+                {
+                    if let Expr::Name(ast::ExprName {
+                        id: target_base, ..
+                    }) = target_value.as_ref()
+                    {
+                        if target_base == base_name && target_attr == attr_name {
+                            return Some(value);
+                        }
+                    }
+                }
+            }
+            None
+        }
+        Stmt::AnnAssign(ast::StmtAnnAssign {
+            target,
+            value: Some(value),
+            ..
+        }) => {
+            if let Expr::Attribute(ast::ExprAttribute {
+                value: target_value,
+                attr: target_attr,
+                ..
+            }) = target.as_ref()
+            {
+                if let Expr::Name(ast::ExprName {
+                    id: target_base, ..
+                }) = target_value.as_ref()
+                {
+                    if target_base == base_name && target_attr == attr_name {
+                        return Some(value);
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
+    }
 }
 
 fn is_sequence(expr: &Expr, semantic: &SemanticModel) -> bool {

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC1802_len_as_condition.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC1802_len_as_condition.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
+assertion_line: 252
 ---
 PLC1802 [*] `len('TEST')` used as condition without comparison
  --> len_as_condition.py:1:4
@@ -550,4 +551,44 @@ help: Remove `len`
     - ):
 247 + if fruits:
 248 |     ...
+249 | 
+250 | # regression tests for https://github.com/astral-sh/ruff/issues/22780
 note: This is an unsafe fix and may change runtime behavior
+
+PLC1802 [*] `len(self.fruits)` used as condition without comparison
+   --> len_as_condition.py:259:12
+    |
+257 |         self.fruits = ["apple", "orange"]
+258 |
+259 |         if len(self.fruits):  # [PLC1802]
+    |            ^^^^^^^^^^^^^^^^
+260 |             ...
+    |
+help: Remove `len`
+256 |     def __init__(self):
+257 |         self.fruits = ["apple", "orange"]
+258 | 
+    -         if len(self.fruits):  # [PLC1802]
+259 +         if self.fruits:  # [PLC1802]
+260 |             ...
+261 | 
+262 |         if not len(self.fruits):  # [PLC1802]
+
+PLC1802 [*] `len(self.fruits)` used as condition without comparison
+   --> len_as_condition.py:262:16
+    |
+260 |             ...
+261 |
+262 |         if not len(self.fruits):  # [PLC1802]
+    |                ^^^^^^^^^^^^^^^^
+263 |             ...
+    |
+help: Remove `len`
+259 |         if len(self.fruits):  # [PLC1802]
+260 |             ...
+261 | 
+    -         if not len(self.fruits):  # [PLC1802]
+262 +         if not self.fruits:  # [PLC1802]
+263 |             ...
+264 | 
+265 |     def check_fruits(self):


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #22780

PLC1802 was not triggering when the sequence passed to len() was an attribute like `self.fruits`, for example. I had the similar issue in my code.

I extended `is_indirect_sequence` to handle Expr::Attribute in addition to Expr::Name.

This is my first contribution here, so, happy to make any change.

## Test Plan

Added test cases to `len_as_condition.py `and updated the snapshot. And I ran the exact example from the issue:

```sh
$ echo 'class Fruits:
    fruits: list[str]

    def __init__(self):
        self.fruits = ["apple", "orange"]

        if len(self.fruits):
            ...

fruits = ["apple", "orange"]
if len(fruits):
    ...' | cargo run -p ruff -- check --select PLC1802 -
```


