### PR TITLE
[ty] Consider keyword arguments when unpacking a variadic argument

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -779,6 +779,65 @@ def _(
     reveal_type(f(*args6))  # revealed: int
 ```
 
+### Variable-length unpacking with explicit keyword arguments
+
+When a variable-length iterable (like a list) is unpacked and followed by explicit keyword
+arguments, the variadic unpacking should not greedily consume parameters that have explicit keyword
+bindings. This prevents false positive "parameter already assigned" errors.
+
+Regression test for <https://github.com/astral-sh/ty/issues/1584>.
+
+```py
+from typing import TypedDict
+
+def f(a: str, b: str, c: float) -> None: ...
+
+# Explicit keyword argument takes precedence over variable-length variadic expansion.
+# The list unpacking should only fill `a` and `b`, leaving `c` for the keyword argument.
+def _(args: list[str]) -> None:
+    f(*args, c=1.0)
+
+# Fixed-length tuple unpacking with keyword argument also works correctly.
+def _(args: tuple[str, str]) -> None:
+    f(*args, c=1.0)
+
+# But, with a fixed-length tuple that is too long, we get the expected error.
+def _(args: tuple[str, str, str]) -> None:
+    # error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int | float`, found `str`"
+    # error: [parameter-already-assigned] "Multiple values provided for parameter `c` of function `f`"
+    f(*args, c=1.0)
+```
+
+However, when there's no explicit keyword argument, the behavior remains conservative:
+
+```py
+# Positional argument after variable-length variadic is ambiguous
+def _(args: list[str]) -> None:
+    # error: [invalid-argument-type]
+    # error: [too-many-positional-arguments]
+    f(*args, 1.0)
+
+# Multiple variable-length variadics are also ambiguous
+def _(args1: list[str], args2: list[float]) -> None:
+    # error: [invalid-argument-type]
+    f(*args1, *args2)
+
+# Keyword variadic (**dict) with unknown keys is also ambiguous
+def _(args: list[str], kwargs: dict[str, float]) -> None:
+    # error: [invalid-argument-type]
+    f(*args, **kwargs)
+
+# Keyword variadic with TypedDict has known keys but is still handled conservatively
+# but we could possibly improve this in the future.
+class CKwargs(TypedDict):
+    c: float
+
+def _(args: list[str]) -> None:
+    # error: [invalid-argument-type]
+    # error: [parameter-already-assigned]
+    f(*args, **CKwargs(c=1.0))
+```
+
 ### Keyword argument, positional-or-keyword parameter
 
 ```py

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2656,15 +2656,32 @@ struct ArgumentMatcher<'a, 'db> {
     first_excess_positional: Option<usize>,
     num_synthetic_args: usize,
     variadic_argument_matched_to_variadic_parameter: bool,
+
+    /// Parameter indices that have explicit keyword arguments (e.g., `foo=value`).
+    ///
+    /// This is used to prevent variadic arguments from greedily matching parameters that will be
+    /// explicitly provided via keyword arguments.
+    explicit_keyword_parameters: FxHashSet<usize>,
 }
 
 impl<'a, 'db> ArgumentMatcher<'a, 'db> {
     fn new(
-        arguments: &CallArguments,
+        arguments: &CallArguments<'a, 'db>,
         parameters: &'a Parameters<'db>,
         argument_forms: &'a mut ArgumentForms,
         errors: &'a mut Vec<BindingError<'db>>,
     ) -> Self {
+        let explicit_keyword_parameters: FxHashSet<usize> = arguments
+            .iter()
+            .filter_map(|(argument, _)| {
+                if let Argument::Keyword(name) = argument {
+                    parameters.keyword_by_name(name).map(|(idx, _)| idx)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
         Self {
             parameters,
             argument_forms,
@@ -2675,6 +2692,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             first_excess_positional: None,
             num_synthetic_args: 0,
             variadic_argument_matched_to_variadic_parameter: false,
+            explicit_keyword_parameters,
         }
     }
 
@@ -2889,13 +2907,20 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         }
 
         // If the tuple is variable-length, we assume that it will soak up all remaining positional
-        // parameters.
+        // parameters, stopping only when we reach a parameter that has an explicit keyword argument
+        // or a parameter that can only be provided via keyword argument.
         if is_variable {
             while self
                 .parameters
                 .get_positional(self.next_positional)
                 .is_some()
             {
+                if self
+                    .explicit_keyword_parameters
+                    .contains(&self.next_positional)
+                {
+                    break;
+                }
                 self.match_positional(
                     argument_index,
                     argument,


### PR DESCRIPTION
## Summary

fixes: https://github.com/astral-sh/ty/issues/1584

This PR fixes a bug where ty would unpack a variadic argument consuming all the remaining unmatched parameters. The way this fix is implemented is by collecting the parameters for which an argument is provided via keyword e.g., `func(foo=1)`. For example,

```py
def foo(x: str, y: int): ...

def _(args: list[str]):
    foo(*args, y=1)
```

In the above example, `main` would currently raise `parameter-already-assigned` because we don't know how many elements would `args` unpack into so we consider assigning the type to all the remaining parameters. But, in the above case `y` has been provided as keyword argument explicitly.

Now, there are other cases like `foo(*args, 1)` or `foo(*args, *(1,))` which is not considered in this PR i.e., this PR only handles explicit keyword argument and we would still emit diagnostic for positional, variadic, and keyword-variadic. Pyright behaves in the same way i.e., it only handles keyword argument while other type checkers (mypy, pyrefly) does not handle any cases. Refer to the new mdtest cases for all the cases.

## Test Plan

Add new mdtests.