### PR TITLE
Add `CLAUDE.local.md` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,6 @@ cython_debug/
 !crates/ruff_python_resolver/resources/test/airflow/venv/lib
 !crates/ruff_python_resolver/resources/test/airflow/venv/lib/python3.11/site-packages/_watchdog_fsevents.cpython-311-darwin.so
 !crates/ruff_python_resolver/resources/test/airflow/venv/lib/python3.11/site-packages/orjson/orjson.cpython-311-darwin.so
+
+# Personal project-specific preferences
+CLAUDE.local.md


### PR DESCRIPTION
## Summary

I've some local instructions that isn't relevant to everyone for CLAUDE that is stored in `CLAUDE.local.md` file. This is officially recognized file as ["Project memory (local)"](https://code.claude.com/docs/en/memory). I don't know if others are using this or not.