### PR TITLE
add CCfW hooks

### DIFF
--- a/.claude/hooks/session-start-web.sh
+++ b/.claude/hooks/session-start-web.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install `gh`
+if ! command -v gh &> /dev/null; then
+    apt-get update -qq
+    apt-get install -y -qq gh
+fi
+
+# Install clippy and rustfmt for the active toolchain.
+rustup component add clippy rustfmt

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+# Dispatch to web hook if running remotely
+if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
+  exec "$(dirname "$0")/session-start-web.sh"
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Shamelessly lifted from uv.

Biggest win here is giving CCfW access to the `gh` CLI tool, which it always otherwise tries and fails to use.
