### PR TITLE
[ty] Infer `TypedDict` types with >=1 required key as being always truthy

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/truthiness.md
@@ -221,15 +221,14 @@ class Normal(TypedDict):
     b: int
 
 def _(n: Normal) -> None:
-    # Could be `Literal[True]`
-    reveal_type(bool(n))  # revealed: bool
+    reveal_type(bool(n))  # revealed: Literal[True]
 
 class OnlyFalsyItems(TypedDict):
     wrong: Literal[False]
 
 def _(n: OnlyFalsyItems) -> None:
-    # Could be `Literal[True]` (it does not matter if all items are falsy)
-    reveal_type(bool(n))  # revealed: bool
+    # (it does not matter if all items are falsy)
+    reveal_type(bool(n))  # revealed: Literal[True]
 
 class Empty(TypedDict):
     pass


### PR DESCRIPTION
## Summary

This fixes the symptom described in https://github.com/astral-sh/ty/issues/2591. It doesn't fix the underlying cause, which is that we only run the `invalid-key` check currently on `TypedDict` types, not on intersections that include `TypedDict` types. But it seems good to avoid complex intersection types where possible anyway, and this change achieves that.

## Test Plan

Mdtests added
