### PR TITLE
[ty] Inline cycle initial and recovery functions

### DIFF
--- a/crates/ty_python_semantic/src/dunder_all.rs
+++ b/crates/ty_python_semantic/src/dunder_all.rs
@@ -11,17 +11,9 @@ use crate::Db;
 use crate::semantic_index::{SemanticIndex, semantic_index};
 use crate::types::{Truthiness, Type, TypeContext, infer_expression_types};
 
-fn dunder_all_names_cycle_initial(
-    _db: &dyn Db,
-    _id: salsa::Id,
-    _file: File,
-) -> Option<FxHashSet<Name>> {
-    None
-}
-
 /// Returns a set of names in the `__all__` variable for `file`, [`None`] if it is not defined or
 /// if it contains invalid elements.
-#[salsa::tracked(returns(as_ref), cycle_initial=dunder_all_names_cycle_initial, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::tracked(returns(as_ref), cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
 pub(crate) fn dunder_all_names(db: &dyn Db, file: File) -> Option<FxHashSet<Name>> {
     let _span = tracing::trace_span!("dunder_all_names", file=?file.path(db)).entered();
 

--- a/crates/ty_python_semantic/src/semantic_index/re_exports.rs
+++ b/crates/ty_python_semantic/src/semantic_index/re_exports.rs
@@ -31,11 +31,11 @@ use ty_module_resolver::{ModuleName, resolve_module};
 
 use crate::Db;
 
-fn exports_cycle_initial(_db: &dyn Db, _id: salsa::Id, _file: File) -> Box<[Name]> {
-    Box::default()
-}
-
-#[salsa::tracked(returns(deref), cycle_initial=exports_cycle_initial, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::tracked(
+    returns(deref),
+    cycle_initial=|_, _, _| Box::default(),
+    heap_size=ruff_memory_usage::heap_size)
+]
 pub(super) fn exported_names(db: &dyn Db, file: File) -> Box<[Name]> {
     let module = parsed_module(db, file).load(db);
     let mut finder = ExportFinder::new(db, file);

--- a/crates/ty_python_semantic/src/semantic_index/reachability_constraints.rs
+++ b/crates/ty_python_semantic/src/semantic_index/reachability_constraints.rs
@@ -375,7 +375,10 @@ fn type_excluded_by_previous_patterns<'db>(
 /// statement with N cases where each case references the subject (e.g., `self`), we would
 /// re-analyze each pattern O(N) times (once per reference), leading to O(N²) total work.
 /// With memoization, each pattern is analyzed exactly once.
-#[salsa::tracked(cycle_initial = analyze_pattern_predicate_cycle_initial, heap_size = get_size2::GetSize::get_heap_size)]
+#[salsa::tracked(
+    cycle_initial = |_, _, _| Truthiness::Ambiguous,
+    heap_size = get_size2::GetSize::get_heap_size
+)]
 fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'db>) -> Truthiness {
     let subject_ty = infer_expression_type(db, predicate.subject(db), TypeContext::default());
 
@@ -414,14 +417,6 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
     } else {
         truthiness
     }
-}
-
-fn analyze_pattern_predicate_cycle_initial<'db>(
-    _db: &'db dyn Db,
-    _id: salsa::Id,
-    _predicate: PatternPredicate<'db>,
-) -> Truthiness {
-    Truthiness::Ambiguous
 }
 
 /// A collection of reachability constraints for a given scope.

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -39,18 +39,9 @@ impl EnumMetadata<'_> {
     }
 }
 
-#[allow(clippy::unnecessary_wraps)]
-fn enum_metadata_cycle_initial<'db>(
-    _db: &'db dyn Db,
-    _id: salsa::Id,
-    _class: ClassLiteral<'db>,
-) -> Option<EnumMetadata<'db>> {
-    Some(EnumMetadata::empty())
-}
-
 /// List all members of an enum.
 #[allow(clippy::ref_option, clippy::unnecessary_wraps)]
-#[salsa::tracked(returns(as_ref), cycle_initial=enum_metadata_cycle_initial, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::tracked(returns(as_ref), cycle_initial=|_, _, _| Some(EnumMetadata::empty()), heap_size=ruff_memory_usage::heap_size)]
 pub(crate) fn enum_metadata<'db>(
     db: &'db dyn Db,
     class: ClassLiteral<'db>,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -346,7 +346,7 @@ impl<'db> GenericContext<'db> {
 
         #[salsa::tracked(
             returns(ref),
-            cycle_initial=inferable_typevars_cycle_initial,
+            cycle_initial=|_, _, _| FxHashSet::default(),
             heap_size=ruff_memory_usage::heap_size,
         )]
         fn inferable_typevars_inner<'db>(
@@ -703,14 +703,6 @@ impl<'db> GenericContext<'db> {
 
         Self::from_typevar_instances(db, variables)
     }
-}
-
-fn inferable_typevars_cycle_initial<'db>(
-    _db: &'db dyn Db,
-    _id: salsa::Id,
-    _self: GenericContext<'db>,
-) -> FxHashSet<BoundTypeVarIdentity<'db>> {
-    FxHashSet::default()
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -66,7 +66,14 @@ mod tests;
 
 /// Infer all types for a [`Definition`] (including sub-expressions).
 /// Use when resolving a place use or public type of a place.
-#[salsa::tracked(returns(ref), cycle_fn=definition_cycle_recover, cycle_initial=definition_cycle_initial, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::tracked(
+    returns(ref),
+    cycle_initial=definition_cycle_initial,
+    cycle_fn=|db, cycle, previous: &DefinitionInference<'db>, inference: DefinitionInference<'db>, _| {
+        inference.cycle_normalized(db, previous, cycle)
+    },
+    heap_size=ruff_memory_usage::heap_size
+)]
 pub(crate) fn infer_definition_types<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
@@ -86,16 +93,6 @@ pub(crate) fn infer_definition_types<'db>(
         .finish_definition()
 }
 
-fn definition_cycle_recover<'db>(
-    db: &'db dyn Db,
-    cycle: &salsa::Cycle,
-    previous_inference: &DefinitionInference<'db>,
-    inference: DefinitionInference<'db>,
-    _definition: Definition<'db>,
-) -> DefinitionInference<'db> {
-    inference.cycle_normalized(db, previous_inference, cycle)
-}
-
 fn definition_cycle_initial<'db>(
     db: &'db dyn Db,
     id: salsa::Id,
@@ -108,7 +105,14 @@ fn definition_cycle_initial<'db>(
 ///
 /// Deferred expressions are type expressions (annotations, base classes, aliases...) in a stub
 /// file, or in a file with `from __future__ import annotations`, or stringified annotations.
-#[salsa::tracked(returns(ref), cycle_fn=deferred_cycle_recovery, cycle_initial=deferred_cycle_initial, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::tracked(
+    returns(ref),
+    cycle_initial=deferred_cycle_initial,
+    cycle_fn=|db, cycle, previous: &DefinitionInference<'db>, inference: DefinitionInference<'db>, _| {
+        inference.cycle_normalized(db, previous, cycle)
+    },
+    heap_size=ruff_memory_usage::heap_size
+)]
 pub(crate) fn infer_deferred_types<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
@@ -127,16 +131,6 @@ pub(crate) fn infer_deferred_types<'db>(
 
     TypeInferenceBuilder::new(db, InferenceRegion::Deferred(definition), index, &module)
         .finish_definition()
-}
-
-fn deferred_cycle_recovery<'db>(
-    db: &'db dyn Db,
-    cycle: &salsa::Cycle,
-    previous_inference: &DefinitionInference<'db>,
-    inference: DefinitionInference<'db>,
-    _definition: Definition<'db>,
-) -> DefinitionInference<'db> {
-    inference.cycle_normalized(db, previous_inference, cycle)
 }
 
 fn deferred_cycle_initial<'db>(
@@ -189,7 +183,14 @@ pub(crate) fn infer_scope_types<'db>(
     infer_scope_types_impl(db, InferScope::new(db, scope, tcx))
 }
 
-#[salsa::tracked(returns(ref), cycle_fn=scope_cycle_recover, cycle_initial=scope_cycle_initial, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::tracked(
+    returns(ref),
+    cycle_initial=|_, id, _| ScopeInference::cycle_initial(Type::divergent(id)),
+    cycle_fn=|db, cycle, previous: &ScopeInference<'db>, inference: ScopeInference<'db>, _| {
+        inference.cycle_normalized(db, previous, cycle)
+    },
+    heap_size=ruff_memory_usage::heap_size
+)]
 pub(crate) fn infer_scope_types_impl<'db>(
     db: &'db dyn Db,
     input: InferScope<'db>,
@@ -207,24 +208,6 @@ pub(crate) fn infer_scope_types_impl<'db>(
     TypeInferenceBuilder::new(db, InferenceRegion::Scope(scope, tcx), index, &module).finish_scope()
 }
 
-fn scope_cycle_recover<'db>(
-    db: &'db dyn Db,
-    cycle: &salsa::Cycle,
-    previous_inference: &ScopeInference<'db>,
-    inference: ScopeInference<'db>,
-    _input: InferScope<'db>,
-) -> ScopeInference<'db> {
-    inference.cycle_normalized(db, previous_inference, cycle)
-}
-
-fn scope_cycle_initial<'db>(
-    _db: &'db dyn Db,
-    id: salsa::Id,
-    _input: InferScope<'db>,
-) -> ScopeInference<'db> {
-    ScopeInference::cycle_initial(Type::divergent(id))
-}
-
 /// Infer all types for an [`Expression`] (including sub-expressions).
 /// Use rarely; only for cases where we'd otherwise risk double-inferring an expression: RHS of an
 /// assignment, which might be unpacking/multi-target and thus part of multiple definitions, or a
@@ -237,7 +220,14 @@ pub(crate) fn infer_expression_types<'db>(
     infer_expression_types_impl(db, InferExpression::new(db, expression, tcx))
 }
 
-#[salsa::tracked(returns(ref), cycle_fn=expression_cycle_recover, cycle_initial=expression_cycle_initial, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::tracked(
+    returns(ref),
+    cycle_initial=expression_cycle_initial,
+    cycle_fn=|db, cycle, previous: &ExpressionInference<'db>, inference: ExpressionInference<'db>, _| {
+        inference.cycle_normalized(db, previous, cycle)
+    },
+    heap_size=ruff_memory_usage::heap_size
+)]
 pub(super) fn infer_expression_types_impl<'db>(
     db: &'db dyn Db,
     input: InferExpression<'db>,
@@ -263,16 +253,6 @@ pub(super) fn infer_expression_types_impl<'db>(
         &module,
     )
     .finish_expression()
-}
-
-fn expression_cycle_recover<'db>(
-    db: &'db dyn Db,
-    cycle: &salsa::Cycle,
-    previous_inference: &ExpressionInference<'db>,
-    inference: ExpressionInference<'db>,
-    _input: InferExpression<'db>,
-) -> ExpressionInference<'db> {
-    inference.cycle_normalized(db, previous_inference, cycle)
 }
 
 fn expression_cycle_initial<'db>(
@@ -315,7 +295,13 @@ pub(crate) fn infer_expression_type<'db>(
     infer_expression_type_impl(db, InferExpression::new(db, expression, tcx))
 }
 
-#[salsa::tracked(cycle_fn=single_expression_cycle_recover, cycle_initial=single_expression_cycle_initial, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::tracked(
+    cycle_initial=|_, id, _| Type::divergent(id),
+    cycle_fn=|db, cycle, previous: &Type<'db>, result: Type<'db>, _| {
+        result.cycle_normalized(db, *previous, cycle)
+    },
+    heap_size=ruff_memory_usage::heap_size
+)]
 fn infer_expression_type_impl<'db>(db: &'db dyn Db, input: InferExpression<'db>) -> Type<'db> {
     let (expression, _) = input.into_inner(db);
 
@@ -326,24 +312,6 @@ fn infer_expression_type_impl<'db>(db: &'db dyn Db, input: InferExpression<'db>)
     let inference = infer_expression_types_impl(db, input);
 
     inference.expression_type(expression.node_ref(db, &module))
-}
-
-fn single_expression_cycle_recover<'db>(
-    db: &'db dyn Db,
-    cycle: &salsa::Cycle,
-    previous_cycle_value: &Type<'db>,
-    result: Type<'db>,
-    _input: InferExpression<'db>,
-) -> Type<'db> {
-    result.cycle_normalized(db, *previous_cycle_value, cycle)
-}
-
-fn single_expression_cycle_initial<'db>(
-    _db: &'db dyn Db,
-    id: salsa::Id,
-    _input: InferExpression<'db>,
-) -> Type<'db> {
-    Type::divergent(id)
 }
 
 /// An `Expression` with an optional `TypeContext`.
@@ -464,7 +432,10 @@ impl<'db> TypeContext<'db> {
 ///
 /// Returns [`Truthiness::Ambiguous`] in case any non-definitely bound places
 /// were encountered while inferring the type of the expression.
-#[salsa::tracked(cycle_initial=static_expression_truthiness_cycle_initial, heap_size=get_size2::GetSize::get_heap_size)]
+#[salsa::tracked(
+    cycle_initial=|_, _, _| Truthiness::Ambiguous,
+    heap_size=get_size2::GetSize::get_heap_size
+)]
 pub(crate) fn static_expression_truthiness<'db>(
     db: &'db dyn Db,
     expression: Expression<'db>,
@@ -481,21 +452,20 @@ pub(crate) fn static_expression_truthiness<'db>(
     inference.expression_type(node).bool(db)
 }
 
-fn static_expression_truthiness_cycle_initial<'db>(
-    _db: &'db dyn Db,
-    _id: salsa::Id,
-    _expression: Expression<'db>,
-) -> Truthiness {
-    Truthiness::Ambiguous
-}
-
 /// Infer the types for an [`Unpack`] operation.
 ///
 /// This infers the expression type and performs structural match against the target expression
 /// involved in an unpacking operation. It returns a result-like object that can be used to get the
 /// type of the variables involved in this unpacking along with any violations that are detected
 /// during this unpacking.
-#[salsa::tracked(returns(ref), cycle_fn=unpack_cycle_recover, cycle_initial=unpack_cycle_initial, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::tracked(
+    returns(ref),
+    cycle_initial=|_, id, _| UnpackResult::cycle_initial(Type::divergent(id)),
+    cycle_fn=|db, cycle, previous: &UnpackResult<'db>, result: UnpackResult<'db>, _| {
+        result.cycle_normalized(db, previous, cycle)
+    },
+    heap_size=ruff_memory_usage::heap_size
+)]
 pub(super) fn infer_unpack_types<'db>(db: &'db dyn Db, unpack: Unpack<'db>) -> UnpackResult<'db> {
     let file = unpack.file(db);
     let module = parsed_module(db, file).load(db);
@@ -505,24 +475,6 @@ pub(super) fn infer_unpack_types<'db>(db: &'db dyn Db, unpack: Unpack<'db>) -> U
     let mut unpacker = Unpacker::new(db, unpack.target_scope(db), &module);
     unpacker.unpack(unpack.target(db, &module), unpack.value(db));
     unpacker.finish()
-}
-
-fn unpack_cycle_initial<'db>(
-    _db: &'db dyn Db,
-    id: salsa::Id,
-    _unpack: Unpack<'db>,
-) -> UnpackResult<'db> {
-    UnpackResult::cycle_initial(Type::divergent(id))
-}
-
-fn unpack_cycle_recover<'db>(
-    db: &'db dyn Db,
-    cycle: &salsa::Cycle,
-    previous_cycle_result: &UnpackResult<'db>,
-    result: UnpackResult<'db>,
-    _unpack: Unpack<'db>,
-) -> UnpackResult<'db> {
-    result.cycle_normalized(db, previous_cycle_result, cycle)
 }
 
 /// Returns the type of the nearest enclosing class for the given scope.

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -704,7 +704,7 @@ impl<'db> ProtocolInstanceType<'db> {
     /// Such a protocol is therefore an equivalent type to `object`, which would in fact be
     /// normalised to `object`.
     pub(super) fn is_equivalent_to_object(self, db: &'db dyn Db) -> bool {
-        #[salsa::tracked(cycle_initial=initial, heap_size=ruff_memory_usage::heap_size)]
+        #[salsa::tracked(cycle_initial=|_, _, _, ()| true, heap_size=ruff_memory_usage::heap_size)]
         fn is_equivalent_to_object_inner<'db>(
             db: &'db dyn Db,
             protocol: ProtocolInstanceType<'db>,
@@ -720,15 +720,6 @@ impl<'db> ProtocolInstanceType<'db> {
                     &IsDisjointVisitor::default(),
                 )
                 .is_always_satisfied(db)
-        }
-
-        fn initial<'db>(
-            _db: &'db dyn Db,
-            _id: salsa::Id,
-            _value: ProtocolInstanceType<'db>,
-            _: (),
-        ) -> bool {
-            true
         }
 
         is_equivalent_to_object_inner(db, self, ())

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -86,7 +86,7 @@ fn all_narrowing_constraints_for_pattern<'db>(
 
 #[salsa::tracked(
     returns(as_ref),
-    cycle_initial=constraints_for_expression_cycle_initial,
+    cycle_initial=|_, _, _| None,
     heap_size=ruff_memory_usage::heap_size,
 )]
 fn all_narrowing_constraints_for_expression<'db>(
@@ -100,7 +100,7 @@ fn all_narrowing_constraints_for_expression<'db>(
 
 #[salsa::tracked(
     returns(as_ref),
-    cycle_initial=negative_constraints_for_expression_cycle_initial,
+    cycle_initial=|_, _, _| None,
     heap_size=ruff_memory_usage::heap_size,
 )]
 fn all_negative_narrowing_constraints_for_expression<'db>(
@@ -119,22 +119,6 @@ fn all_negative_narrowing_constraints_for_pattern<'db>(
 ) -> Option<NarrowingConstraints<'db>> {
     let module = parsed_module(db, pattern.file(db)).load(db);
     NarrowingConstraintsBuilder::new(db, &module, PredicateNode::Pattern(pattern), false).finish()
-}
-
-fn constraints_for_expression_cycle_initial<'db>(
-    _db: &'db dyn Db,
-    _id: salsa::Id,
-    _expression: Expression<'db>,
-) -> Option<NarrowingConstraints<'db>> {
-    None
-}
-
-fn negative_constraints_for_expression_cycle_initial<'db>(
-    _db: &'db dyn Db,
-    _id: salsa::Id,
-    _expression: Expression<'db>,
-) -> Option<NarrowingConstraints<'db>> {
-    None
 }
 
 /// Functions that can be used to narrow the type of a first argument using a "classinfo" second argument.

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -294,7 +294,7 @@ impl<'db> Type<'db> {
     ///
     /// See [`TypeRelation::Redundancy`] for more details.
     pub(super) fn is_redundant_with(self, db: &'db dyn Db, other: Type<'db>) -> bool {
-        #[salsa::tracked(cycle_initial=is_redundant_with_cycle_initial, heap_size=ruff_memory_usage::heap_size)]
+        #[salsa::tracked(cycle_initial=|_, _, _, _| true, heap_size=ruff_memory_usage::heap_size)]
         fn is_redundant_with_impl<'db>(
             db: &'db dyn Db,
             self_ty: Type<'db>,
@@ -2466,16 +2466,6 @@ impl<'db> Type<'db> {
                 .negate(db),
         }
     }
-}
-
-#[allow(clippy::trivially_copy_pass_by_ref)]
-fn is_redundant_with_cycle_initial<'db>(
-    _db: &'db dyn Db,
-    _id: salsa::Id,
-    _subtype: Type<'db>,
-    _supertype: Type<'db>,
-) -> bool {
-    true
 }
 
 /// A [`PairVisitor`] that is used in `has_relation_to` methods.


### PR DESCRIPTION
## Summary

Salsa now supports inline definitions for the cycle recovery and initial functions. 

This PR makes use of that new feature for "simple" initial and recovery functions. 

Knowing the initial and recovery function is important to fully understand a salsa query
and I find that having to jump to the initial or recovery function makes it harder to build that understanding.

## Test Plan

`cargo test`
