### PR TITLE
Document `-` stdin convention in CLI help text

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -207,7 +207,7 @@ pub struct AnalyzeGraphCommand {
 #[expect(clippy::struct_excessive_bools)]
 pub struct CheckCommand {
     /// List of files or directories to check.
-    #[clap(help = "List of files or directories to check [default: .]")]
+    #[clap(help = "List of files or directories to check, or `-` to read from stdin [default: .]")]
     pub files: Vec<PathBuf>,
     /// Apply fixes to resolve lint violations.
     /// Use `--no-fix` to disable or `--unsafe-fixes` to include unsafe fixes.
@@ -475,7 +475,9 @@ pub struct CheckCommand {
 #[expect(clippy::struct_excessive_bools)]
 pub struct FormatCommand {
     /// List of files or directories to format.
-    #[clap(help = "List of files or directories to format [default: .]")]
+    #[clap(
+        help = "List of files or directories to format, or `-` to read from stdin [default: .]"
+    )]
     pub files: Vec<PathBuf>,
     /// Avoid writing any formatted files back; instead, exit with a non-zero status code if any
     /// files would have been modified, and zero otherwise.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -575,7 +575,8 @@ Run Ruff on the given files or directories
 Usage: ruff check [OPTIONS] [FILES]...
 
 Arguments:
-  [FILES]...  List of files or directories to check [default: .]
+  [FILES]...  List of files or directories to check, or `-` to read from stdin
+              [default: .]
 
 Options:
       --fix
@@ -710,7 +711,8 @@ Run the Ruff formatter on the given files or directories
 Usage: ruff format [OPTIONS] [FILES]...
 
 Arguments:
-  [FILES]...  List of files or directories to format [default: .]
+  [FILES]...  List of files or directories to format, or `-` to read from stdin
+              [default: .]
 
 Options:
       --check


### PR DESCRIPTION
Summary
--

While responding to https://github.com/astral-sh/ruff/discussions/13690#discussioncomment-15558697, I realized that the `-` convention for reading from stdin wasn't mentioned in
our CLI help anywhere. I thought it made sense to add a brief note to the `FILES`
help section, but I'm happy to put it somewhere else or rephrase it if someone
has a better suggestion!

Test Plan
--

Updated CLI tests
