### PR TITLE
refactor(refurb): mark MetaClassABCMeta fix as unsafe if comments would be deleted

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB180.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB180.py
@@ -56,3 +56,11 @@ class A6(abc.ABC):
 class A7(B0, abc.ABC, B1):
     @abstractmethod
     def foo(self): pass
+
+# Issue 22631 reproduction
+class C(
+    other_kwarg=1,
+    # comment
+    metaclass=abc.ABCMeta,
+):
+    pass

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB180_FURB180.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB180_FURB180.py.snap
@@ -75,3 +75,25 @@ help: Replace with `abc.ABC`
 33 | 
 34 | 
 note: This is an unsafe fix and may change runtime behavior
+
+FURB180 [*] Use of `metaclass=abc.ABCMeta` to define abstract base class
+  --> FURB180.py:64:5
+   |
+62 |     other_kwarg=1,
+63 |     # comment
+64 |     metaclass=abc.ABCMeta,
+   |     ^^^^^^^^^^^^^^^^^^^^^
+65 | ):
+66 |     pass
+   |
+help: Replace with `abc.ABC`
+59 | 
+60 | # Issue 22631 reproduction
+61 | class C(
+   -     other_kwarg=1,
+   -     # comment
+   -     metaclass=abc.ABCMeta,
+62 +     abc.ABC, other_kwarg=1,
+63 | ):
+64 |     pass
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Fixes #22631.

The fix for FURB180 (metaclass=abc.ABCMeta) currently involves a range deletion (when not the first argument) or replacement. If this range contains comments, they are silently deleted.

This PR ensures the fix is marked as `Unsafe` whenever comments are detected in the affected range, preventing accidental loss of code documentation.

Regression tests added in `FURB180.py`.