### PR TITLE
[`pydocstyle`] Clarify which quote styles are allowed (`D300`)

### DIFF
--- a/crates/ruff_linter/src/rules/pydocstyle/rules/triple_quotes.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/triple_quotes.rs
@@ -7,8 +7,7 @@ use crate::docstrings::Docstring;
 use crate::{Edit, Fix, FixAvailability, Violation};
 
 /// ## What it does
-/// Checks for docstrings that use `'''triple single quotes'''` instead of
-/// `"""triple double quotes"""`.
+/// Checks for docstrings that don't use `"""triple double quotes"""`.
 ///
 /// ## Why is this bad?
 /// [PEP 257](https://peps.python.org/pep-0257/#what-is-a-docstring) recommends
@@ -19,12 +18,18 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// ```python
 /// def kos_root():
 ///     '''Return the pathname of the KOS root directory.'''
+///
+/// def kos_branch():
+///     'Return the branch name.'
 /// ```
 ///
 /// Use instead:
 /// ```python
 /// def kos_root():
 ///     """Return the pathname of the KOS root directory."""
+///
+/// def kos_branch():
+///     """Return the branch name."""
 /// ```
 ///
 /// ## Formatter compatibility


### PR DESCRIPTION
## Summary

This PR updates the documentation for the `D300` (`triple-single-quotes`) rule. 

The description now explicitly mentions that the rule flags both single quotes (`'`) and triple single quotes (`'''`). I've also added a Python example to show the single-quote violation.

Documentation was regenerated using `cargo run -p ruff_dev -- generate-docs`.

## Fixes

Fixes #20838