### PR TITLE
[ty] Avoid duplicate syntax errors for `await` outside functions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
@@ -136,7 +136,6 @@ yield
 # error: [invalid-syntax] "`yield from` statement outside of a function"
 yield from []
 
-# error: [invalid-syntax] "`await` statement outside of a function"
 # error: [invalid-syntax] "`await` outside of an asynchronous function"
 await C()
 


### PR DESCRIPTION
Summary
--

This PR fixes astral-sh/ty#2598 by not emitting the `YieldOutsideFunction`
syntax error for `await` expressions outside of functions. This isn't the most
elegant fix, but as I noted in the TODO comment, I think a better long-term fix
like not emitting `YieldOutsideFunction` errors for `await` at all would change
the behavior of Ruff's stable `F704` lint rule. We should be able to fix that
and this TODO when resolving #19122.

Test Plan
--

We already had an existing mdtest for this behavior, so I just had to update it
to remove the less specific error message
