### PR TITLE
[ty] Fix panic when overriding final method using an assignment

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/final.md
@@ -354,6 +354,39 @@ class C(B):
     def method(self) -> None: ...  # no diagnostic here (see prose discussion above)
 ```
 
+## Overriding a `@final` method by assigning a function to a class variable
+
+When a subclass overrides a `@final` method by assigning a function to a class variable, we emit a
+diagnostic but do not provide an autofix (since the function may be defined in a different file).
+
+<!-- snapshot-diagnostics -->
+
+`base.py`:
+
+```py
+from typing import final
+
+class Base:
+    @final
+    def method(self) -> None: ...
+```
+
+`other.py`:
+
+```py
+def replacement_method() -> None: ...
+```
+
+`derived.py`:
+
+```py
+from base import Base
+from other import replacement_method
+
+class Derived(Base):
+    method = replacement_method  # error: [override-of-final-method]
+```
+
 ## Constructor methods are also checked
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overriding_a_`@final…_(c004aaab38745318).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overriding_a_`@final…_(c004aaab38745318).snap
@@ -1,0 +1,61 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: final.md - Tests for the `@typing(_extensions).final` decorator - Overriding a `@final` method by assigning a function to a class variable
+mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
+---
+
+# Python source files
+
+## base.py
+
+```
+1 | from typing import final
+2 | 
+3 | class Base:
+4 |     @final
+5 |     def method(self) -> None: ...
+```
+
+## other.py
+
+```
+1 | def replacement_method() -> None: ...
+```
+
+## derived.py
+
+```
+1 | from base import Base
+2 | from other import replacement_method
+3 | 
+4 | class Derived(Base):
+5 |     method = replacement_method  # error: [override-of-final-method]
+```
+
+# Diagnostics
+
+```
+error[override-of-final-method]: Cannot override `Base.method`
+ --> src/derived.py:5:5
+  |
+4 | class Derived(Base):
+5 |     method = replacement_method  # error: [override-of-final-method]
+  |     ^^^^^^ Overrides a definition from superclass `Base`
+  |
+info: `Base.method` is decorated with `@final`, forbidding overrides
+ --> src/base.py:4:5
+  |
+3 | class Base:
+4 |     @final
+  |     ------
+5 |     def method(self) -> None: ...
+  |         ------ `Base.method` defined here
+  |
+help: Remove the override of `method`
+info: rule `override-of-final-method` is enabled by default
+
+```

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4559,7 +4559,13 @@ pub(super) fn report_overridden_final_method<'db>(
     // It's tempting to autofix properties as well,
     // but you'd want to delete the `@my_property.deleter` as well as the getter and the deleter,
     // and we don't model property deleters at all right now.
-    if let Type::FunctionLiteral(function) = subclass_type {
+    //
+    // We also only provide autofixes if the subclass member is a function definition (not an
+    // assignment like `method = some_function`). If it's an assignment, the function type
+    // might be from a different file, and the autofix should delete the assignment instead, which we don't handle today.
+    if let Type::FunctionLiteral(function) = subclass_type
+        && subclass_definition.kind(db).is_function_def()
+    {
         let Some((subclass_literal, _)) = subclass.static_class_literal(db) else {
             return;
         };


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/2602

The root cause was that the fix tried to delete the function definition even
if the method was assigned using an assignment statement. 

Ideally, the fix would delete the assignment but I opted to not offer a fix in that case for now


## Test Plan

Added mdtest
