### PR TITLE
[ty] Add a benchmark for very large tuples with lots of literals

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -562,6 +562,49 @@ fn benchmark_many_enum_members(criterion: &mut Criterion) {
     });
 }
 
+/// Micro-benchmark that tests our performance when slicing and unpacking
+/// a very large tuple that has many varied literal strings inside it.
+///
+/// Adapted from <https://github.com/MMD-Blender/blender_mmd_tools/blob/6ae13d6039763b6813832622c13da464983e93b3/mmd_tools/m17n.py>
+fn benchmark_very_large_tuple(criterion: &mut Criterion) {
+    /// Number of entries in the tuple -- must be >64 to trigger the literal-promotion optimization
+    const NUM_ENTRIES: usize = 65;
+
+    setup_rayon();
+
+    let mut code = "translations_tuple = (\n".to_string();
+    for i in 0..NUM_ENTRIES {
+        writeln!(
+            &mut code,
+            r#"    (("*", "Description {i}"), (("ref.path.{i}",), ()), ("ja_JP", "翻訳{i}", (False, ())), ("zh_HANS", "翻译{i}", (False, ()))),"#
+        )
+        .ok();
+    }
+    code.push_str(")\n\n");
+
+    // This slice operation (msg[2:]) is what triggers the expensive type inference:
+    // ty must compute the union of all possible slice results.
+    code.push_str(
+        "\
+for msg in translations_tuple:
+    for lang, trans, (is_fuzzy, comments) in msg[2:]:
+        pass
+",
+    );
+
+    criterion.bench_function("ty_micro[very_large_tuple]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 fn benchmark_many_enum_members_2(criterion: &mut Criterion) {
     const NUM_ENUM_MEMBERS: usize = 48;
 
@@ -777,6 +820,7 @@ criterion_group!(
     benchmark_complex_constrained_attributes_3,
     benchmark_many_enum_members,
     benchmark_many_enum_members_2,
+    benchmark_very_large_tuple,
 );
 criterion_group!(project, anyio, attrs, hydra, datetype);
 criterion_main!(check_file, micro, project);


### PR DESCRIPTION
## Summary

This PR adds a benchmark that reproduces the pathological performance when type-checking <https://github.com/MMD-Blender/blender_mmd_tools/blob/6ae13d6039763b6813832622c13da464983e93b3/mmd_tools/m17n.py>, for measuring the performance impact of https://github.com/astral-sh/ruff/pull/22841

## Test Plan

I used [this Rust playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=7d71c7e28397b72a105a08ad58bfc1c5) to check that the generated code was created as expected. Meanwhile, https://github.com/astral-sh/ruff/pull/22841#issuecomment-3795714995 demonstrates that it's effective at demonstrating the performance improvement of #22841!

Codspeed [reports](https://codspeed.io/astral-sh/ruff/branches/alex/big-tuple-bench?utm_source=github&utm_medium=check&utm_content=details&page=1&uri=crates%2Fruff_benchmark%2Fbenches%2Fty.rs%3A%3Amicro%3A%3Abenchmark_very_large_tuple%3A%3Aty_micro%255Bvery_large_tuple%255D&runnerMode=Simulation) that it takes 338ms to run the benchmark on `main`, which is on the longer side for a microbenchmark. It goes down to 70ms on the PR branch for https://github.com/astral-sh/ruff/pull/22841, however, which is well within the range of timings for our other ty microbenchmarks.