### PR TITLE
[ty] Discard the types of parameter defaults during cycle normalization

### DIFF
--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2438,40 +2438,17 @@ impl<'db> Parameter<'db> {
         let kind = match kind {
             ParameterKind::PositionalOnly { name, default_type } => ParameterKind::PositionalOnly {
                 name: name.clone(),
-                default_type: match default_type {
-                    Some(ty) if nested => Some(ty.recursive_type_normalized_impl(db, div, true)?),
-                    Some(ty) => Some(
-                        ty.recursive_type_normalized_impl(db, div, true)
-                            .unwrap_or(div),
-                    ),
-                    None => None,
-                },
+                default_type: default_type.map(|_| Type::Never),
             },
             ParameterKind::PositionalOrKeyword { name, default_type } => {
                 ParameterKind::PositionalOrKeyword {
                     name: name.clone(),
-                    default_type: match default_type {
-                        Some(ty) if nested => {
-                            Some(ty.recursive_type_normalized_impl(db, div, true)?)
-                        }
-                        Some(ty) => Some(
-                            ty.recursive_type_normalized_impl(db, div, true)
-                                .unwrap_or(div),
-                        ),
-                        None => None,
-                    },
+                    default_type: default_type.map(|_| Type::Never),
                 }
             }
             ParameterKind::KeywordOnly { name, default_type } => ParameterKind::KeywordOnly {
                 name: name.clone(),
-                default_type: match default_type {
-                    Some(ty) if nested => Some(ty.recursive_type_normalized_impl(db, div, true)?),
-                    Some(ty) => Some(
-                        ty.recursive_type_normalized_impl(db, div, true)
-                            .unwrap_or(div),
-                    ),
-                    None => None,
-                },
+                default_type: default_type.map(|_| Type::Never),
             },
             ParameterKind::Variadic { name } => ParameterKind::Variadic { name: name.clone() },
             ParameterKind::KeywordVariadic { name } => {


### PR DESCRIPTION
## Summary

This PR tweaks ty's cycle recovery normalization for `Callable` types (and other types that have load-bearing `Signature`s) so that the exact type of a parameter default is discarded: a `Callable` with type `(x: bool = True) -> int` becomes a `Callable` with type `(x: bool = ...) -> int`.

## Background

The motivation for this PR stems from the observation that applying this diff to the `main` branch:

```diff
diff --git a/crates/ty_python_semantic/src/types.rs b/crates/ty_python_semantic/src/types.rs
index 01bfd61d11..c396615242 100644
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -11915,6 +11915,9 @@ impl<'db> UnionType<'db> {
         db: &'db dyn Db,
         mut f: impl FnMut(&Type<'db>) -> bool,
     ) -> Type<'db> {
+        if self.elements(db).iter().all(&mut f) {
+            return Type::Union(self);
+        }
         self.elements(db)
             .iter()
             .filter(|ty| f(ty))
```

leads to a behaviour change on this snippet:

```py
from typing_extensions import ParamSpec, TypeVar, Callable

T = TypeVar("T")
P = ParamSpec("P")

def dispatch(
    _: Callable[P, T] | str
) -> Callable[[Callable[P, T]], Callable[P, T]]:
    raise NotImplementedError

def inject_client(fn: Callable[P, T]) -> Callable[P, T]:
    return fn

@inject_client
def aload(x: T, name: str, validate: bool = True) -> T:
    return x

@dispatch(aload)
def load(x: T, name: str) -> T:
    return x

load("", _sync=False)
```

On `main`, we emit 4 diagnostics on that snippet; but with the above patch applied, we emit 0. That's odd, because the patch _should_ be a no-op in terms of behaviour!

Adding some debug prints appeared to indicate that we appear to enter a cycle when inferring a type for the `aload` function, and different iterations of the cycle yield different types: in one iteration we infer this type:

```py
[T](x: T, name: str, validate: bool = ...) -> T
```

and in another iteration we infer this type:

```py
[T](x: T, name: str, validate: bool = True) -> T
```

now: these are equivalent types! Normally, therefore, our `UnionBuilder` would never allow them to coexist in a `UnionType` together. Unfortunately, however, the union simplification we are able to do in cycle recovery is much more limited than the union simplification we are able to do in other scenarios: we cannot do any `is_redundant_with` calls during cycle recovery, because that could lead to further nested cycles! As such, we are unable to detect the mutual subtype relationship between the two types (because they are not _identical_ types), and so the solved type of `aload` after cycle recovery is the union of the two:

```py
([T](x: T, name: str, validate: bool = ...) -> T) | ([T](x: T, name: str, validate: bool = True) -> T)
```

On `main`, it appears that a `UnionType::filter()` call somewhere (I'm not sure _exactly_ where) is then simplifying that union back into a `Callable` type, but with the `UnionType::filter()` patch above applied, this no longer happens, so it remains a `UnionType`. The result of that is that somewhere down the line, we appear to have a branch of code that treats a single `Callable` differently to a union of `Callable`s (again, I haven't been able to track down _precisely_ where this is, unfortunately), so that with the patch applied we infer the type of `load` as being `(...) -> Unknown` whereas on `main` we infer the type of `load` as being `[T](x: T, name: str, validate: bool = ...) -> T`. The inference on `main` seems clearly better to me!

It's desirable to be able to apply something similar to the patch above, because it leads to a [significant speedup](https://github.com/astral-sh/ruff/pull/22352), especially on the incremental benchmark. Meanwhile, it's desirable to avoid the behaviour change, because the above snippet is a minimized repro of code in the prefect ecosystem project (specifically, `src/integrations/prefect-azure/prefect_azure/experimental/bundles/execute.py`). These weren't the flakes that we usually see on `prefect`: the reduction in diagnostics on this file persisted across several mypy_primer runs and could also be consistently reproduced locally.

<details>
<summary>More debugging details</summary>

<br>

The reason for the behaviour change appears to be that `load` is inferred as having type `(...) -> Unknown` with the above patch applied, whereas on `main` it's inferred as having type `[T](x: T, name: str, validate: bool = ...) -> T`.

---

To investigate further, I added some debug prints to the `main` branch:

```diff
diff --git a/crates/ty_python_semantic/src/types.rs b/crates/ty_python_semantic/src/types.rs
index 01bfd61d11..0229b7c4cb 100644
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -11915,14 +11915,23 @@ impl<'db> UnionType<'db> {
         db: &'db dyn Db,
         mut f: impl FnMut(&Type<'db>) -> bool,
     ) -> Type<'db> {
-        self.elements(db)
+        let already_filtered = self.elements(db).iter().all(&mut f);
+        if already_filtered {
+            println!("Old = `{}`", Type::Union(self).display(db));
+        }
+        let new = self
+            .elements(db)
             .iter()
             .filter(|ty| f(ty))
             .fold(UnionBuilder::new(db), |builder, element| {
                 builder.add(*element)
             })
             .recursively_defined(self.recursively_defined(db))
-            .build()
+            .build();
+        if already_filtered {
+            println!("New = `{}`", new.display(db));
+        }
+        new
     }
```

And then ran the `main` branch on the above repro, with these results:

```
Old = `([T](x: T, name: str, validate: bool = ...) -> T) | ([T](x: T, name: str, validate: bool = True) -> T)`
New = `[T](x: T, name: str, validate: bool = ...) -> T`
Old = `((**P@dispatch) -> T@dispatch) | str`
New = `((**P@dispatch) -> T@dispatch) | str`
Old = `([T](x: T, name: str, validate: bool = ...) -> T) | ([T](x: T, name: str, validate: bool = True) -> T)`
New = `[T](x: T, name: str, validate: bool = ...) -> T`
Old = `((**P@dispatch) -> T@dispatch) | str`
New = `((**P@dispatch) -> T@dispatch) | str`
```

So we can see that on `main`, the type of `aload` is inferred to be a union _with redundant elements in it_ (presumably due to cycle recovery somewhere), and then the `UnionType::filter()` call simplifies that union to a non-union type. Whereas on this branch, the `UnionType::filter()` call sees that all elements in the union satisfy the `filter` predicate, assumes that the union will already have been adequately normalized, and returns the union as-is.

The next question to investigate is: why are we treating a union of two identical callables differently to a single callable? They _should_ be treated equivalently by ty...

---

Adding _these_ debug prints indicates that after inferring the type of `aload` as (in different cycle iterations) `([T](x: T, name: str, validate: bool = ...) -> T)` and `([T](x: T, name: str, validate: bool = True) -> T)`, at some point we fallback to `(...) -> Unknown`:

```diff
diff --git a/crates/ty_python_semantic/src/types.rs b/crates/ty_python_semantic/src/types.rs
index 01bfd61d11..bfd168bcd1 100644
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -11915,6 +11915,9 @@ impl<'db> UnionType<'db> {
         db: &'db dyn Db,
         mut f: impl FnMut(&Type<'db>) -> bool,
     ) -> Type<'db> {
+        if self.elements(db).iter().all(|ty| f(ty)) {
+            return Type::Union(self);
+        }
         self.elements(db)
             .iter()
             .filter(|ty| f(ty))
diff --git a/crates/ty_python_semantic/src/types/infer/builder.rs b/crates/ty_python_semantic/src/types/infer/builder.rs
index b728f41cd0..d4163b00c2 100644
--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2740,7 +2740,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.undecorated_type = Some(inferred_ty);
 
         for (decorator_ty, decorator_node) in decorator_types_and_nodes.iter().rev() {
+            println!("decorator_ty = {}", decorator_ty.display(self.db()));
+            println!("Before decorator application = {}", inferred_ty.display(self.db()));
             inferred_ty = self.apply_decorator(*decorator_ty, inferred_ty, decorator_node);
+            println!("After decorator application = {}", inferred_ty.display(self.db()));
+            println!();
         }
 
         self.add_declaration_with_binding(
```

```
decorator_ty = def inject_client[**P, T](fn: (**P@inject_client) -> T) -> (**P@inject_client) -> T
Before decorator application = def aload[T](x: T, name: str, validate: bool = ...) -> T
After decorator application = [T](x: T, name: str, validate: bool = ...) -> T

decorator_ty = def inject_client[**P, T](fn: (**P@inject_client) -> T) -> (**P@inject_client) -> T
Before decorator application = def aload[T](x: T, name: str, validate: bool = True) -> T
After decorator application = [T](x: T, name: str, validate: bool = True) -> T

decorator_ty = def inject_client[**P, T](fn: (**P@inject_client) -> T) -> (**P@inject_client) -> T
Before decorator application = def aload[T](x: T, name: str, validate: bool = True) -> T
After decorator application = [T](x: T, name: str, validate: bool = True) -> T

decorator_ty = ((...) -> Unknown, /) -> (...) -> Unknown
Before decorator application = def load[T](x: T, name: str) -> T
After decorator application = (...) -> Unknown
```

</details>

## Unanswered questions

There's still a lot I don't fully understand about what's going on here. I've tried to figure out some of them, but without _much_ success:
1. Why do we enter a cycle when inferring the type for `aload`?
2. Why do we infer different types for the parameter defaults in `aload` on different iterations of the cycle?
3. Where is the `UnionType::filter()` call that simplifies the union back to a single `Callable` type on `main` and "saves" us?
4. Where in our code do we treat a union of callables differently to a single callable, such that it leads to much worse inference for the type of `load` if `aload` is inferred as having a union type at some point?

## Proposed change in this PR

Despite the unanswered questions above, I'm proposing a change to our cycle normalization for `Parameter`s. I don't think the questions above _need_ to be answered for this PR to be a demonstrably worthwhile change.

On this PR branch, we discard the exact type of a parameter default (replacing it with `Never`, simply because it's an extremely simple type) when cycle-normalizing `Parameter`s. We now retain only the knowledge that the parameter _has_ a default value -- which is all that is relevant for type-checking. The _only_ situation where we ever use the _type_ of the default value is when we're displaying a signature to the user in a diagnostic or on-hover. This is exactly the same as what we already do for "regular" (non-cycle) normalization:

https://github.com/astral-sh/ruff/blob/e8e8235078b3dbfa5cdde8a46fa3767df2c7d3d3/crates/ty_python_semantic/src/types/signatures.rs#L2376-L2403

The change made here means that we are able to identify _even inside cycle recovery_ that `[T](x: T, name: str, validate: bool = ...) -> T` is equivalent to `[T](x: T, name: str, validate: bool = True) -> T` -- because they both cycle-normalize to the same type: `[T](x: T, name: str, validate: bool = ...) -> T`. As such, applying the above patch to this PR branch does not cause ty to exhibit the same behaviour change as applying the same patch to `main` does.

This PR therefore unblocks the performance optimisation proposed in https://github.com/astral-sh/ruff/pull/22352. I also think it makes sense on its own merits:
- This means we have to do less work during cycle normalization for `Parameter`s, which should theoretically speed us up when analyzing projects with many nested cycles.
- There's a chance this could improve the likelihood that cycles involving `Callable` types converge successfully.
- Cycle normalization should (hopefully) happen rarely, so this shouldn't result in many user-visible changes. We should still show the parameter's real default value in most cases. The mypy_primer report appears to confirm this.

As well as the above motivations, I'm making this a standalone change to demonstrate that it has no impact on the ecosystem, our test suite, or our benchmarks. (Codspeed [reports speedups of 1-2%](https://codspeed.io/astral-sh/ruff/branches/alex%2Fparam-default-cycle-recovery?utm_source=github&utm_medium=check&utm_content=button) on some benchmarks, but that's small enough that it could well just be noise.)

## Test Plan

- Existing tests all pass
- The primer report is clean
