### PR TITLE
[ty] Add diagnostic disambiguation for type aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -435,3 +435,21 @@ def i(x: P.UniqueAlias1, y: Q.UniqueAlias2) -> None:
     # error: [invalid-assignment] "Object of type `UniqueAlias2` is not assignable to `UniqueAlias1`"
     a: P.UniqueAlias1 = y
 ```
+
+## Class and type alias with same name
+
+When a class and a type alias have the same name in different scopes, both should be fully qualified
+to distinguish them in error messages:
+
+```py
+class Container1:
+    class Item:
+        pass
+
+class Container2:
+    type Item = str
+
+def j(x: Container1.Item, y: Container2.Item) -> None:
+    # error: [invalid-assignment] "Object of type `mdtest_snippet.Container2.Item` is not assignable to `mdtest_snippet.Container1.Item`"
+    a: Container1.Item = y
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -11766,16 +11766,6 @@ impl<'db> TypeAliasType<'db> {
     }
 }
 
-impl<'db> display::QualifiableName<'db> for TypeAliasType<'db> {
-    fn name(self, db: &'db dyn Db) -> &'db str {
-        TypeAliasType::name(self, db)
-    }
-
-    fn qualified_name_components(self, db: &'db dyn Db) -> Vec<String> {
-        self.qualified_name(db).components_excluding_self()
-    }
-}
-
 // N.B. It would be incorrect to derive `Eq`, `PartialEq`, or `Hash` for this struct,
 // because two `QualifiedTypeAliasName` instances might refer to different type aliases but
 // have the same components. You'd expect them to compare equal, but they'd compare

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -3,12 +3,12 @@ use std::cell::RefCell;
 use std::fmt::Write;
 use std::sync::{LazyLock, Mutex};
 
-use super::TypeVarVariance;
 use super::{
     BoundTypeVarInstance, MemberLookupPolicy, Mro, MroIterator, SpecialFormType, StaticMroError,
     SubclassOfType, Truthiness, Type, TypeQualifiers, class_base::ClassBase,
     function::FunctionType,
 };
+use super::{TypeVarVariance, display};
 use crate::place::{DefinedPlace, TypeOrigin};
 use crate::semantic_index::definition::{Definition, DefinitionState};
 use crate::semantic_index::scope::{NodeWithScopeKind, Scope};
@@ -786,16 +786,6 @@ impl<'db> From<DynamicClassLiteral<'db>> for ClassLiteral<'db> {
 impl<'db> From<DynamicNamedTupleLiteral<'db>> for ClassLiteral<'db> {
     fn from(literal: DynamicNamedTupleLiteral<'db>) -> Self {
         ClassLiteral::DynamicNamedTuple(literal)
-    }
-}
-
-impl<'db> super::display::QualifiableName<'db> for ClassLiteral<'db> {
-    fn name(self, db: &'db dyn Db) -> &'db str {
-        ClassLiteral::name(self, db)
-    }
-
-    fn qualified_name_components(self, db: &'db dyn Db) -> Vec<String> {
-        self.qualified_name(db).components_excluding_self()
     }
 }
 
@@ -6198,12 +6188,7 @@ impl<'db> QualifiedClassName<'db> {
             }
         };
 
-        super::display::qualified_name_components_from_scope(
-            self.db,
-            file,
-            file_scope_id,
-            skip_count,
-        )
+        display::qualified_name_components_from_scope(self.db, file, file_scope_id, skip_count)
     }
 }
 


### PR DESCRIPTION
## Summary

The intent here is to follow the implementation used for classes as closely as possible.

Closes https://github.com/astral-sh/ty/issues/2606.
