### PR TITLE
[`flake8-bandit`] Fix false positive for `zipfile.extractall` (`S202`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S202.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S202.py
@@ -76,3 +76,14 @@ def zipfile_safe_handler(filename):
 
     zf2 = zipfile.ZipFile(asset_path, "r")
     zf2.extractall(extract_dir)
+
+class MyClass:
+    def extractall(self, path):
+        pass
+
+def custom_class_handler(filename):
+    mc = MyClass()
+    mc.extractall("path")
+
+    with MyClass() as mc2:
+        mc2.extractall("path")

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/tarfile_unsafe_members.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/tarfile_unsafe_members.rs
@@ -83,7 +83,7 @@ pub(crate) fn tarfile_unsafe_members(checker: &Checker, call: &ast::ExprCall) {
                             vars.as_name_expr().is_some_and(|n| n.id == name.id)
                         })
                     }) {
-                        if is_zipfile(&item.context_expr, checker.semantic()) {
+                        if is_likely_safe_source(&item.context_expr, checker.semantic()) {
                             return;
                         }
                     }
@@ -96,7 +96,7 @@ pub(crate) fn tarfile_unsafe_members(checker: &Checker, call: &ast::ExprCall) {
                     }),
                 ) = binding.statement(checker.semantic())
                 {
-                    if is_zipfile(value, checker.semantic()) {
+                    if is_likely_safe_source(value, checker.semantic()) {
                         return;
                     }
                 }
@@ -107,7 +107,7 @@ pub(crate) fn tarfile_unsafe_members(checker: &Checker, call: &ast::ExprCall) {
     checker.report_diagnostic(TarfileUnsafeMembers, call.func.range());
 }
 
-fn is_zipfile(expr: &Expr, semantic: &SemanticModel) -> bool {
+fn is_likely_safe_source(expr: &Expr, semantic: &SemanticModel) -> bool {
     let expr = if let Expr::Call(ast::ExprCall { func, .. }) = expr {
         func.as_ref()
     } else {
@@ -115,5 +115,5 @@ fn is_zipfile(expr: &Expr, semantic: &SemanticModel) -> bool {
     };
     semantic
         .resolve_qualified_name(expr)
-        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["zipfile", "ZipFile"]))
+        .is_some_and(|qualified_name| qualified_name.segments().first() != Some(&"tarfile"))
 }


### PR DESCRIPTION
## Summary
Fixes a false positive in `S202` (`tarfile-unsafe-members`) where `zipfile.ZipFile.extractall` (and other methods named `extractall`) were incorrectly flagged when `tarfile` was also imported.

Fixes #22821.

## Problem
The rule assumed any call to `extractall` was a `tarfile` violation if the `tarfile` module was imported in the file, failing to distinguish between `tarfile.TarFile.extractall` and other `extractall` methods (like `zipfile.ZipFile.extractall` or custom classes).

## Approach
Updated the rule to check the binding of the object calling `extractall`. If the object resolves to a qualified name that does *not* start with `tarfile` (e.g. `zipfile.ZipFile`), the rule now effectively suppresses the violation. If the object cannot be resolved (heuristic), the rule continues to flag it to avoid false negatives.

## Test Plan
Added new test cases to `S202.py` verifying that `zipfile.ZipFile.extractall` and a custom class `MyClass.extractall` do not trigger the violation. Verified with `cargo test -p ruff_linter flake8_bandit`.