### PR TITLE
[ty] Ban `Required`, `NotRequired` and `ReadOnly` in parameter annotations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1651,6 +1651,21 @@ from typing import TypedDict
 x: TypedDict = {"name": "Alice"}
 ```
 
+### `ReadOnly`, `Required` and `NotRequired` not allowed in parameter annotations
+
+```py
+from typing_extensions import Required, NotRequired, ReadOnly
+
+def bad(
+    # error: [invalid-type-form] "`Required` is not allowed in function parameter annotations"
+    a: Required[int],
+    # error: [invalid-type-form] "`NotRequired` is not allowed in function parameter annotations"
+    b: NotRequired[int],
+    # error: [invalid-type-form] "`ReadOnly` is not allowed in function parameter annotations"
+    c: ReadOnly[int],
+): ...
+```
+
 ### `dict`-subclass inhabitants
 
 Values that inhabit a `TypedDict` type must be instances of `dict` itself, not a subclass:

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7477,8 +7477,11 @@ impl TypeQualifiers {
             Self::INIT_VAR => "InitVar",
             Self::REQUIRED => "Required",
             Self::NOT_REQUIRED => "NotRequired",
+            Self::READ_ONLY => "ReadOnly",
             _ => {
-                unreachable!("Only a single bit should be set when calling `TypeQualifiers::name`")
+                unreachable!(
+                    "Only a single bit should be set when calling `TypeQualifiers::name` (got {self:?})"
+                )
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2860,6 +2860,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             TypeQualifiers::FINAL,
             TypeQualifiers::CLASS_VAR,
             TypeQualifiers::INIT_VAR,
+            TypeQualifiers::REQUIRED,
+            TypeQualifiers::NOT_REQUIRED,
+            TypeQualifiers::READ_ONLY,
         ] {
             if qualifiers.contains(qualifier)
                 && let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, parameter)


### PR DESCRIPTION
This is mandated by the typing conformance suite