### PR TITLE
[ty] Support `type[None]` in type expressions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_of/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/basic.md
@@ -132,6 +132,29 @@ def f(a: type[BasicUser | Union[ProUser, A.B.C]], b: type[Union[BasicUser | Unio
     reveal_type(b)  # revealed: type[BasicUser | ProUser | C | str]
 ```
 
+## Special case for `None`
+
+The typing conformance suite contains this test case. It's debatable whether it's correct to do so,
+since the spec states that:
+
+> The value corresponding to `type[C]` must be an actual class object that’s a subtype of `C`, not a
+> special form or other kind of type.
+
+However, for now we support this annotation in the way the conformance suite expects, until and
+unless the spec is amended.
+
+```py
+import types
+
+def f(x: type[None]):
+    reveal_type(x)  # revealed: <class 'NoneType'>
+
+f(type(None))
+f(None.__class__)
+f(types.NoneType)
+f(None)  # error: [invalid-argument-type]
+```
+
 ## Illegal parameters
 
 ```py

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -778,6 +778,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
                 Type::unknown()
             }
+            ast::Expr::NoneLiteral(_) => {
+                self.infer_expression(slice, TypeContext::default());
+                KnownClass::NoneType.to_subclass_of(self.db())
+            }
             ast::Expr::Subscript(
                 subscript @ ast::ExprSubscript {
                     value,


### PR DESCRIPTION
## Summary

This is mandated by the typing conformance suite.

I'm honestly quite sceptical that it _should_ be mandated by the conformance suite, but that's a battle for another day. It's trivial to support it now, and it'll be trivial to rip it out and emit an error instead at a later date if the spec is amended. Anything is better than that status quo (which is a `@Todo` type).

## Test Plan

mdtests
