### PR TITLE
[ty] Point to an overload with an invalid `@final` decorator when emitting `invalid-overload` errors for invalid `@final` decorators

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/final.md
@@ -279,21 +279,17 @@ class ChildOfGood(Good):
 class Bad:
     @overload
     @final
-    def f(self, x: str) -> str: ...
+    def f(self, x: str) -> str: ...  # error: [invalid-overload]
     @overload
     def f(self, x: int) -> int: ...
-
-    # error: [invalid-overload]
     def f(self, x: int | str) -> int | str:
         return x
 
     @final
     @overload
-    def g(self, x: str) -> str: ...
+    def g(self, x: str) -> str: ...  # error: [invalid-overload]
     @overload
     def g(self, x: int) -> int: ...
-
-    # error: [invalid-overload]
     def g(self, x: int | str) -> int | str:
         return x
 
@@ -301,9 +297,7 @@ class Bad:
     def h(self, x: str) -> str: ...
     @overload
     @final
-    def h(self, x: int) -> int: ...
-
-    # error: [invalid-overload]
+    def h(self, x: int) -> int: ...  # error: [invalid-overload]
     def h(self, x: int | str) -> int | str:
         return x
 
@@ -311,9 +305,7 @@ class Bad:
     def i(self, x: str) -> str: ...
     @final
     @overload
-    def i(self, x: int) -> int: ...
-
-    # error: [invalid-overload]
+    def i(self, x: int) -> int: ...  # error: [invalid-overload]
     def i(self, x: int | str) -> int | str:
         return x
 

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -694,10 +694,10 @@ class Foo:
 
     @overload
     @final
+    # error: [invalid-overload]
     def method2(self, x: int) -> int: ...
     @overload
     def method2(self, x: str) -> str: ...
-    # error: [invalid-overload]
     def method2(self, x: int | str) -> int | str:
         return x
 
@@ -705,8 +705,8 @@ class Foo:
     def method3(self, x: int) -> int: ...
     @overload
     @final
-    def method3(self, x: str) -> str: ...
     # error: [invalid-overload]
+    def method3(self, x: str) -> str: ...
     def method3(self, x: int | str) -> int | str:
         return x
 ```
@@ -774,18 +774,18 @@ class Sub2(Base):
     def method(self, x: int) -> int: ...
     @overload
     @override
-    def method(self, x: str) -> str: ...
     # error: [invalid-overload]
+    def method(self, x: str) -> str: ...
     def method(self, x: int | str) -> int | str:
         return x
 
 class Sub3(Base):
     @overload
     @override
+    # error: [invalid-overload]
     def method(self, x: int) -> int: ...
     @overload
     def method(self, x: str) -> str: ...
-    # error: [invalid-overload]
     def method(self, x: int | str) -> int | str:
         return x
 ```

--- a/crates/ty_python_semantic/resources/mdtest/override.md
+++ b/crates/ty_python_semantic/resources/mdtest/override.md
@@ -415,24 +415,23 @@ class Spam:
 
     @overload
     @override
+    # error: [invalid-overload] "`@override` decorator should be applied only to the overload implementation"
     def bar(self, x: str) -> str: ...
     @overload
     @override
+    # error: [invalid-overload] "`@override` decorator should be applied only to the overload implementation"
     def bar(self, x: int) -> int: ...
     @override
-    # error: [invalid-overload] "`@override` decorator should be applied only to the overload implementation"
-    # error: [invalid-overload] "`@override` decorator should be applied only to the overload implementation"
     # error: [invalid-explicit-override]
     def bar(self, x: str | int) -> str | int:
         return x
 
     @overload
     @override
+    # error: [invalid-overload] "`@override` decorator should be applied only to the overload implementation"
     def baz(self, x: str) -> str: ...
     @overload
     def baz(self, x: int) -> int: ...
-
-    # error: [invalid-overload] "`@override` decorator should be applied only to the overload implementation"
     # error: [invalid-explicit-override]
     def baz(self, x: str | int) -> str | int:
         return x

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overloaded_methods_d…_(861757f48340ed92).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overloaded_methods_d…_(861757f48340ed92).snap
@@ -93,50 +93,42 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 22 | class Bad:
 23 |     @overload
 24 |     @final
-25 |     def f(self, x: str) -> str: ...
+25 |     def f(self, x: str) -> str: ...  # error: [invalid-overload]
 26 |     @overload
 27 |     def f(self, x: int) -> int: ...
-28 | 
-29 |     # error: [invalid-overload]
-30 |     def f(self, x: int | str) -> int | str:
-31 |         return x
-32 | 
-33 |     @final
+28 |     def f(self, x: int | str) -> int | str:
+29 |         return x
+30 | 
+31 |     @final
+32 |     @overload
+33 |     def g(self, x: str) -> str: ...  # error: [invalid-overload]
 34 |     @overload
-35 |     def g(self, x: str) -> str: ...
-36 |     @overload
-37 |     def g(self, x: int) -> int: ...
+35 |     def g(self, x: int) -> int: ...
+36 |     def g(self, x: int | str) -> int | str:
+37 |         return x
 38 | 
-39 |     # error: [invalid-overload]
-40 |     def g(self, x: int | str) -> int | str:
-41 |         return x
-42 | 
-43 |     @overload
-44 |     def h(self, x: str) -> str: ...
-45 |     @overload
-46 |     @final
-47 |     def h(self, x: int) -> int: ...
-48 | 
-49 |     # error: [invalid-overload]
-50 |     def h(self, x: int | str) -> int | str:
-51 |         return x
-52 | 
-53 |     @overload
-54 |     def i(self, x: str) -> str: ...
-55 |     @final
-56 |     @overload
-57 |     def i(self, x: int) -> int: ...
-58 | 
-59 |     # error: [invalid-overload]
-60 |     def i(self, x: int | str) -> int | str:
-61 |         return x
-62 | 
-63 | class ChildOfBad(Bad):
-64 |     # TODO: these should all cause us to emit Liskov violations as well
-65 |     f = None  # error: [override-of-final-method]
-66 |     g = None  # error: [override-of-final-method]
-67 |     h = None  # error: [override-of-final-method]
-68 |     i = None  # error: [override-of-final-method]
+39 |     @overload
+40 |     def h(self, x: str) -> str: ...
+41 |     @overload
+42 |     @final
+43 |     def h(self, x: int) -> int: ...  # error: [invalid-overload]
+44 |     def h(self, x: int | str) -> int | str:
+45 |         return x
+46 | 
+47 |     @overload
+48 |     def i(self, x: str) -> str: ...
+49 |     @final
+50 |     @overload
+51 |     def i(self, x: int) -> int: ...  # error: [invalid-overload]
+52 |     def i(self, x: int | str) -> int | str:
+53 |         return x
+54 | 
+55 | class ChildOfBad(Bad):
+56 |     # TODO: these should all cause us to emit Liskov violations as well
+57 |     f = None  # error: [override-of-final-method]
+58 |     g = None  # error: [override-of-final-method]
+59 |     h = None  # error: [override-of-final-method]
+60 |     i = None  # error: [override-of-final-method]
 ```
 
 # Diagnostics
@@ -234,6 +226,7 @@ error[invalid-overload]: `@final` decorator should be applied only to the first 
    |         --- First overload defined here
 30 |     @overload
 31 |     @final
+   |     ------
 32 |     # error: [invalid-overload]
 33 |     def bar(self, x: int) -> int: ...
    |         ^^^
@@ -252,6 +245,7 @@ error[invalid-overload]: `@final` decorator should be applied only to the first 
 36 |     def baz(self, x: str) -> str: ...
    |         --- First overload defined here
 37 |     @final
+   |     ------
 38 |     @overload
 39 |     # error: [invalid-overload]
 40 |     def baz(self, x: int) -> int: ...
@@ -380,29 +374,19 @@ note: This is an unsafe fix and may change runtime behavior
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/main.py:30:9
+  --> src/main.py:24:5
    |
-29 |     # error: [invalid-overload]
-30 |     def f(self, x: int | str) -> int | str:
-   |         -
-   |         |
-   |         Implementation defined here
-31 |         return x
-   |
-info: rule `invalid-overload` is enabled by default
-
-```
-
-```
-error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/main.py:40:9
-   |
-39 |     # error: [invalid-overload]
-40 |     def g(self, x: int | str) -> int | str:
-   |         -
-   |         |
-   |         Implementation defined here
-41 |         return x
+22 | class Bad:
+23 |     @overload
+24 |     @final
+   |     ------
+25 |     def f(self, x: str) -> str: ...  # error: [invalid-overload]
+   |         ^
+26 |     @overload
+27 |     def f(self, x: int) -> int: ...
+28 |     def f(self, x: int | str) -> int | str:
+   |         - Implementation defined here
+29 |         return x
    |
 info: rule `invalid-overload` is enabled by default
 
@@ -410,14 +394,20 @@ info: rule `invalid-overload` is enabled by default
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/main.py:50:9
+  --> src/main.py:31:5
    |
-49 |     # error: [invalid-overload]
-50 |     def h(self, x: int | str) -> int | str:
-   |         -
-   |         |
-   |         Implementation defined here
-51 |         return x
+29 |         return x
+30 |
+31 |     @final
+   |     ------
+32 |     @overload
+33 |     def g(self, x: str) -> str: ...  # error: [invalid-overload]
+   |         ^
+34 |     @overload
+35 |     def g(self, x: int) -> int: ...
+36 |     def g(self, x: int | str) -> int | str:
+   |         - Implementation defined here
+37 |         return x
    |
 info: rule `invalid-overload` is enabled by default
 
@@ -425,14 +415,36 @@ info: rule `invalid-overload` is enabled by default
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/main.py:60:9
+  --> src/main.py:42:5
    |
-59 |     # error: [invalid-overload]
-60 |     def i(self, x: int | str) -> int | str:
-   |         -
-   |         |
-   |         Implementation defined here
-61 |         return x
+40 |     def h(self, x: str) -> str: ...
+41 |     @overload
+42 |     @final
+   |     ------
+43 |     def h(self, x: int) -> int: ...  # error: [invalid-overload]
+   |         ^
+44 |     def h(self, x: int | str) -> int | str:
+   |         - Implementation defined here
+45 |         return x
+   |
+info: rule `invalid-overload` is enabled by default
+
+```
+
+```
+error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
+  --> src/main.py:49:5
+   |
+47 |     @overload
+48 |     def i(self, x: str) -> str: ...
+49 |     @final
+   |     ------
+50 |     @overload
+51 |     def i(self, x: int) -> int: ...  # error: [invalid-overload]
+   |         ^
+52 |     def i(self, x: int | str) -> int | str:
+   |         - Implementation defined here
+53 |         return x
    |
 info: rule `invalid-overload` is enabled by default
 
@@ -440,22 +452,23 @@ info: rule `invalid-overload` is enabled by default
 
 ```
 error[override-of-final-method]: Cannot override `Bad.f`
-  --> src/main.py:65:5
+  --> src/main.py:57:5
    |
-63 | class ChildOfBad(Bad):
-64 |     # TODO: these should all cause us to emit Liskov violations as well
-65 |     f = None  # error: [override-of-final-method]
+55 | class ChildOfBad(Bad):
+56 |     # TODO: these should all cause us to emit Liskov violations as well
+57 |     f = None  # error: [override-of-final-method]
    |     ^ Overrides a definition from superclass `Bad`
-66 |     g = None  # error: [override-of-final-method]
-67 |     h = None  # error: [override-of-final-method]
+58 |     g = None  # error: [override-of-final-method]
+59 |     h = None  # error: [override-of-final-method]
    |
 info: `Bad.f` is decorated with `@final`, forbidding overrides
-  --> src/main.py:30:9
+  --> src/main.py:28:9
    |
-29 |     # error: [invalid-overload]
-30 |     def f(self, x: int | str) -> int | str:
+26 |     @overload
+27 |     def f(self, x: int) -> int: ...
+28 |     def f(self, x: int | str) -> int | str:
    |         - `Bad.f` defined here
-31 |         return x
+29 |         return x
    |
 help: Remove the override of `f`
 info: rule `override-of-final-method` is enabled by default
@@ -464,22 +477,23 @@ info: rule `override-of-final-method` is enabled by default
 
 ```
 error[override-of-final-method]: Cannot override `Bad.g`
-  --> src/main.py:66:5
+  --> src/main.py:58:5
    |
-64 |     # TODO: these should all cause us to emit Liskov violations as well
-65 |     f = None  # error: [override-of-final-method]
-66 |     g = None  # error: [override-of-final-method]
+56 |     # TODO: these should all cause us to emit Liskov violations as well
+57 |     f = None  # error: [override-of-final-method]
+58 |     g = None  # error: [override-of-final-method]
    |     ^ Overrides a definition from superclass `Bad`
-67 |     h = None  # error: [override-of-final-method]
-68 |     i = None  # error: [override-of-final-method]
+59 |     h = None  # error: [override-of-final-method]
+60 |     i = None  # error: [override-of-final-method]
    |
 info: `Bad.g` is decorated with `@final`, forbidding overrides
-  --> src/main.py:40:9
+  --> src/main.py:36:9
    |
-39 |     # error: [invalid-overload]
-40 |     def g(self, x: int | str) -> int | str:
+34 |     @overload
+35 |     def g(self, x: int) -> int: ...
+36 |     def g(self, x: int | str) -> int | str:
    |         - `Bad.g` defined here
-41 |         return x
+37 |         return x
    |
 help: Remove the override of `g`
 info: rule `override-of-final-method` is enabled by default
@@ -488,21 +502,22 @@ info: rule `override-of-final-method` is enabled by default
 
 ```
 error[override-of-final-method]: Cannot override `Bad.h`
-  --> src/main.py:67:5
+  --> src/main.py:59:5
    |
-65 |     f = None  # error: [override-of-final-method]
-66 |     g = None  # error: [override-of-final-method]
-67 |     h = None  # error: [override-of-final-method]
+57 |     f = None  # error: [override-of-final-method]
+58 |     g = None  # error: [override-of-final-method]
+59 |     h = None  # error: [override-of-final-method]
    |     ^ Overrides a definition from superclass `Bad`
-68 |     i = None  # error: [override-of-final-method]
+60 |     i = None  # error: [override-of-final-method]
    |
 info: `Bad.h` is decorated with `@final`, forbidding overrides
-  --> src/main.py:50:9
+  --> src/main.py:44:9
    |
-49 |     # error: [invalid-overload]
-50 |     def h(self, x: int | str) -> int | str:
+42 |     @final
+43 |     def h(self, x: int) -> int: ...  # error: [invalid-overload]
+44 |     def h(self, x: int | str) -> int | str:
    |         - `Bad.h` defined here
-51 |         return x
+45 |         return x
    |
 help: Remove the override of `h`
 info: rule `override-of-final-method` is enabled by default
@@ -511,20 +526,21 @@ info: rule `override-of-final-method` is enabled by default
 
 ```
 error[override-of-final-method]: Cannot override `Bad.i`
-  --> src/main.py:68:5
+  --> src/main.py:60:5
    |
-66 |     g = None  # error: [override-of-final-method]
-67 |     h = None  # error: [override-of-final-method]
-68 |     i = None  # error: [override-of-final-method]
+58 |     g = None  # error: [override-of-final-method]
+59 |     h = None  # error: [override-of-final-method]
+60 |     i = None  # error: [override-of-final-method]
    |     ^ Overrides a definition from superclass `Bad`
    |
 info: `Bad.i` is decorated with `@final`, forbidding overrides
-  --> src/main.py:60:9
+  --> src/main.py:52:9
    |
-59 |     # error: [invalid-overload]
-60 |     def i(self, x: int | str) -> int | str:
+50 |     @overload
+51 |     def i(self, x: int) -> int: ...  # error: [invalid-overload]
+52 |     def i(self, x: int | str) -> int | str:
    |         - `Bad.i` defined here
-61 |         return x
+53 |         return x
    |
 help: Remove the override of `i`
 info: rule `override-of-final-method` is enabled by default

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@final`_(f8e529ec23a61665).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@final`_(f8e529ec23a61665).snap
@@ -26,10 +26,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 11 | 
 12 |     @overload
 13 |     @final
-14 |     def method2(self, x: int) -> int: ...
-15 |     @overload
-16 |     def method2(self, x: str) -> str: ...
-17 |     # error: [invalid-overload]
+14 |     # error: [invalid-overload]
+15 |     def method2(self, x: int) -> int: ...
+16 |     @overload
+17 |     def method2(self, x: str) -> str: ...
 18 |     def method2(self, x: int | str) -> int | str:
 19 |         return x
 20 | 
@@ -37,8 +37,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 22 |     def method3(self, x: int) -> int: ...
 23 |     @overload
 24 |     @final
-25 |     def method3(self, x: str) -> str: ...
-26 |     # error: [invalid-overload]
+25 |     # error: [invalid-overload]
+26 |     def method3(self, x: str) -> str: ...
 27 |     def method3(self, x: int | str) -> int | str:
 28 |         return x
 ```
@@ -78,14 +78,18 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:18:9
+  --> src/mdtest_snippet.py:13:5
    |
-16 |     def method2(self, x: str) -> str: ...
-17 |     # error: [invalid-overload]
+12 |     @overload
+13 |     @final
+   |     ------
+14 |     # error: [invalid-overload]
+15 |     def method2(self, x: int) -> int: ...
+   |         ^^^^^^^
+16 |     @overload
+17 |     def method2(self, x: str) -> str: ...
 18 |     def method2(self, x: int | str) -> int | str:
-   |         -------
-   |         |
-   |         Implementation defined here
+   |         ------- Implementation defined here
 19 |         return x
    |
 info: rule `invalid-overload` is enabled by default
@@ -94,14 +98,17 @@ info: rule `invalid-overload` is enabled by default
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:27:9
+  --> src/mdtest_snippet.py:24:5
    |
-25 |     def method3(self, x: str) -> str: ...
-26 |     # error: [invalid-overload]
+22 |     def method3(self, x: int) -> int: ...
+23 |     @overload
+24 |     @final
+   |     ------
+25 |     # error: [invalid-overload]
+26 |     def method3(self, x: str) -> str: ...
+   |         ^^^^^^^
 27 |     def method3(self, x: int | str) -> int | str:
-   |         -------
-   |         |
-   |         Implementation defined here
+   |         ------- Implementation defined here
 28 |         return x
    |
 info: rule `invalid-overload` is enabled by default
@@ -116,6 +123,7 @@ error[invalid-overload]: `@final` decorator should be applied only to the first 
 11 |     def method2(self, x: int) -> int: ...
    |         ------- First overload defined here
 12 |     @final
+   |     ------
 13 |     @overload
 14 |     # error: [invalid-overload]
 15 |     def method2(self, x: str) -> str: ...
@@ -135,6 +143,7 @@ error[invalid-overload]: `@final` decorator should be applied only to the first 
 18 |     def method3(self, x: int) -> int: ...
    |         ------- First overload defined here
 19 |     @final
+   |     ------
 20 |     @overload
 21 |     def method3(self, x: str) -> int: ...  # error: [invalid-overload]
    |         ^^^^^^^
@@ -147,22 +156,21 @@ info: rule `invalid-overload` is enabled by default
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
-  --> src/mdtest_snippet.pyi:24:9
-   |
-22 |     @overload
-23 |     @final
-24 |     def method3(self, x: bytes) -> bytes: ...  # error: [invalid-overload]
-   |         ^^^^^^^
-25 |     @overload
-26 |     def method3(self, x: bytearray) -> bytearray: ...
-   |
-  ::: src/mdtest_snippet.pyi:18:9
+  --> src/mdtest_snippet.pyi:18:9
    |
 17 |     @overload
 18 |     def method3(self, x: int) -> int: ...
    |         ------- First overload defined here
 19 |     @final
 20 |     @overload
+21 |     def method3(self, x: str) -> int: ...  # error: [invalid-overload]
+22 |     @overload
+23 |     @final
+   |     ------
+24 |     def method3(self, x: bytes) -> bytes: ...  # error: [invalid-overload]
+   |         ^^^^^^^
+25 |     @overload
+26 |     def method3(self, x: bytearray) -> bytearray: ...
    |
 info: rule `invalid-overload` is enabled by default
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@override`_(2df210735ca532f9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@override`_(2df210735ca532f9).snap
@@ -37,18 +37,18 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 22 |     def method(self, x: int) -> int: ...
 23 |     @overload
 24 |     @override
-25 |     def method(self, x: str) -> str: ...
-26 |     # error: [invalid-overload]
+25 |     # error: [invalid-overload]
+26 |     def method(self, x: str) -> str: ...
 27 |     def method(self, x: int | str) -> int | str:
 28 |         return x
 29 | 
 30 | class Sub3(Base):
 31 |     @overload
 32 |     @override
-33 |     def method(self, x: int) -> int: ...
-34 |     @overload
-35 |     def method(self, x: str) -> str: ...
-36 |     # error: [invalid-overload]
+33 |     # error: [invalid-overload]
+34 |     def method(self, x: int) -> int: ...
+35 |     @overload
+36 |     def method(self, x: str) -> str: ...
 37 |     def method(self, x: int | str) -> int | str:
 38 |         return x
 ```
@@ -84,14 +84,17 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 
 ```
 error[invalid-overload]: `@override` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:27:9
+  --> src/mdtest_snippet.py:24:5
    |
-25 |     def method(self, x: str) -> str: ...
-26 |     # error: [invalid-overload]
+22 |     def method(self, x: int) -> int: ...
+23 |     @overload
+24 |     @override
+   |     ---------
+25 |     # error: [invalid-overload]
+26 |     def method(self, x: str) -> str: ...
+   |         ^^^^^^
 27 |     def method(self, x: int | str) -> int | str:
-   |         ------
-   |         |
-   |         Implementation defined here
+   |         ------ Implementation defined here
 28 |         return x
    |
 info: rule `invalid-overload` is enabled by default
@@ -100,14 +103,19 @@ info: rule `invalid-overload` is enabled by default
 
 ```
 error[invalid-overload]: `@override` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:37:9
+  --> src/mdtest_snippet.py:32:5
    |
-35 |     def method(self, x: str) -> str: ...
-36 |     # error: [invalid-overload]
+30 | class Sub3(Base):
+31 |     @overload
+32 |     @override
+   |     ---------
+33 |     # error: [invalid-overload]
+34 |     def method(self, x: int) -> int: ...
+   |         ^^^^^^
+35 |     @overload
+36 |     def method(self, x: str) -> str: ...
 37 |     def method(self, x: int | str) -> int | str:
-   |         ------
-   |         |
-   |         Implementation defined here
+   |         ------ Implementation defined here
 38 |         return x
    |
 info: rule `invalid-overload` is enabled by default
@@ -124,6 +132,7 @@ error[invalid-overload]: `@override` decorator should be applied only to the fir
    |         ------ First overload defined here
 19 |     @overload
 20 |     @override
+   |     ---------
 21 |     # error: [invalid-overload]
 22 |     def method(self, x: str) -> str: ...
    |         ^^^^^^


### PR DESCRIPTION
## Summary

This means that our error is emitted in the location the conformance suite expects

## Test Plan

mdtests and snapshots updated
