### PR TITLE
[ty] always resolve type aliases in `Type::as_*`

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -1381,7 +1381,7 @@ fn add_class_arg_completions<'db>(
 
     let is_typed_dict = class_def
         .inferred_type(model)
-        .and_then(Type::as_class_literal)
+        .and_then(|ty| ty.as_class_literal(model.db()))
         .is_some_and(|t| t.is_typed_dict(model.db()));
 
     // TODO: Handle PEP 728 that adds two extra keywords,

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1743,7 +1743,7 @@ pub(crate) mod implicit_globals {
     fn module_type_symbols<'db>(db: &'db dyn Db) -> smallvec::SmallVec<[ast::name::Name; 8]> {
         let Some(module_type) = KnownClass::ModuleType
             .to_class_literal(db)
-            .as_class_literal()
+            .as_class_literal(db)
         else {
             // The most likely way we get here is if a user specified a `--custom-typeshed-dir`
             // without a `types.pyi` stub in the `stdlib/` directory

--- a/crates/ty_python_semantic/src/semantic_index/reachability_constraints.rs
+++ b/crates/ty_python_semantic/src/semantic_index/reachability_constraints.rs
@@ -823,7 +823,7 @@ impl ReachabilityConstraints {
             }
             PatternPredicateKind::Class(class_expr, kind) => {
                 let class_ty = infer_expression_type(db, *class_expr, TypeContext::default())
-                    .as_class_literal()
+                    .as_class_literal(db)
                     .map(|class| Type::instance(db, class.top_materialization(db)));
 
                 class_ty.map_or(Truthiness::Ambiguous, |class_ty| {

--- a/crates/ty_python_semantic/src/semantic_index/scope.rs
+++ b/crates/ty_python_semantic/src/semantic_index/scope.rs
@@ -451,7 +451,7 @@ impl NodeWithScopeKind {
             NodeWithScopeKind::Class(class) => {
                 let definition = index.expect_single_definition(class);
                 binding_type(db, definition)
-                    .as_class_literal()?
+                    .as_class_literal(db)?
                     .generic_context(db)
             }
             NodeWithScopeKind::Function(function) => {
@@ -459,7 +459,7 @@ impl NodeWithScopeKind {
                 infer_definition_types(db, definition)
                     .undecorated_type()
                     .expect("function should have undecorated type")
-                    .as_function_literal()?
+                    .as_function_literal(db)?
                     .last_definition_signature(db)
                     .generic_context
             }

--- a/crates/ty_python_semantic/src/types/builder.rs
+++ b/crates/ty_python_semantic/src/types/builder.rs
@@ -826,7 +826,7 @@ impl<'db> IntersectionBuilder<'db> {
                 for intersection in &self.intersections {
                     if intersection.negative.iter().any(|negative| {
                         negative
-                            .as_enum_literal()
+                            .as_enum_literal(self.db)
                             .is_some_and(|lit| lit.enum_class_instance(self.db) == ty)
                     }) {
                         contains_enum_literal_as_negative_element = true;
@@ -1443,7 +1443,7 @@ mod tests {
 
         let t0 = Type::IntLiteral(0);
         let t1 = Type::IntLiteral(1);
-        let union = UnionType::from_elements(&db, [t0, t1]).expect_union();
+        let union = UnionType::from_elements(&db, [t0, t1]).expect_union(&db);
 
         assert_eq!(union.elements(&db), &[t0, t1]);
     }
@@ -1508,23 +1508,23 @@ mod tests {
             .ignore_possibly_undefined()
             .unwrap();
 
-        let literals = enum_member_literals(&db, safe_uuid_class.expect_class_literal(), None)
+        let literals = enum_member_literals(&db, safe_uuid_class.expect_class_literal(&db), None)
             .unwrap()
             .collect::<Vec<_>>();
         assert_eq!(literals.len(), 3);
 
         // SafeUUID.safe
         let l_safe = literals[0];
-        assert_eq!(l_safe.expect_enum_literal().name(&db), "safe");
+        assert_eq!(l_safe.expect_enum_literal(&db).name(&db), "safe");
         // SafeUUID.unsafe
         let l_unsafe = literals[1];
-        assert_eq!(l_unsafe.expect_enum_literal().name(&db), "unsafe");
+        assert_eq!(l_unsafe.expect_enum_literal(&db).name(&db), "unsafe");
         // SafeUUID.unknown
         let l_unknown = literals[2];
-        assert_eq!(l_unknown.expect_enum_literal().name(&db), "unknown");
+        assert_eq!(l_unknown.expect_enum_literal(&db).name(&db), "unknown");
 
         // The enum itself: SafeUUID
-        let safe_uuid = l_safe.expect_enum_literal().enum_class_instance(&db);
+        let safe_uuid = l_safe.expect_enum_literal(&db).enum_class_instance(&db);
 
         {
             let actual = IntersectionBuilder::new(&db)

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -568,7 +568,7 @@ impl<'db> ConstrainedTypeVar<'db> {
             }
             Type::Intersection(intersection)
                 if intersection.positive(db).iter().any(|element| {
-                    element.as_typevar().is_some_and(|element_bound_typevar| {
+                    element.as_typevar(db).is_some_and(|element_bound_typevar| {
                         typevar.is_same_typevar_as(db, element_bound_typevar)
                     })
                 }) =>
@@ -577,7 +577,7 @@ impl<'db> ConstrainedTypeVar<'db> {
             }
             Type::Intersection(intersection)
                 if intersection.negative(db).iter().any(|element| {
-                    element.as_typevar().is_some_and(|element_bound_typevar| {
+                    element.as_typevar(db).is_some_and(|element_bound_typevar| {
                         typevar.is_same_typevar_as(db, element_bound_typevar)
                     })
                 }) =>
@@ -599,7 +599,7 @@ impl<'db> ConstrainedTypeVar<'db> {
             }
             Type::Union(union)
                 if union.elements(db).iter().any(|element| {
-                    element.as_typevar().is_some_and(|element_bound_typevar| {
+                    element.as_typevar(db).is_some_and(|element_bound_typevar| {
                         typevar.is_same_typevar_as(db, element_bound_typevar)
                     })
                 }) =>

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -9,7 +9,7 @@ use ruff_db::{
 };
 use ruff_text_size::{Ranged, TextRange};
 
-use super::{Type, TypeCheckDiagnostics, binding_type};
+use super::{TypeCheckDiagnostics, binding_type};
 
 use crate::diagnostic::DiagnosticGuard;
 use crate::lint::LintSource;
@@ -195,7 +195,7 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
                     .ancestor_scopes(scope_id)
                     .filter_map(|(_, scope)| scope.node().as_function())
                     .map(|node| binding_type(self.db, index.expect_single_definition(node)))
-                    .filter_map(Type::as_function_literal);
+                    .filter_map(|ty| ty.as_function_literal(self.db));
 
                 // Iterate over all functions and test if any is decorated with `@no_type_check`.
                 function_scope_tys.any(|function_ty| {

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -2904,7 +2904,7 @@ pub(crate) fn is_invalid_typed_dict_literal(
 ) -> bool {
     target_ty
         .filter_union(db, Type::is_typed_dict)
-        .as_typed_dict()
+        .as_typed_dict(db)
         .is_some()
         && matches!(source, AnyNodeRef::ExprDict(_))
 }

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1034,7 +1034,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         Type::PropertyInstance(property),
                         property
                             .getter(self.db)
-                            .and_then(Type::as_function_literal)
+                            .and_then(|g| g.as_function_literal(self.db))
                             .map(|getter| &**getter.name(self.db)),
                     ),
                     KnownBoundMethodType::PropertyDunderSet(property) => (
@@ -1044,7 +1044,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         Type::PropertyInstance(property),
                         property
                             .getter(self.db)
-                            .and_then(Type::as_function_literal)
+                            .and_then(|g| g.as_function_literal(self.db))
                             .map(|getter| &**getter.name(self.db)),
                     ),
                     KnownBoundMethodType::StrStartswith(literal) => (

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -331,7 +331,7 @@ impl<'db> OverloadLiteral<'db> {
         needle: KnownFunction,
     ) -> Option<Span> {
         self.find_decorator_span(db, |ty| {
-            ty.as_function_literal()
+            ty.as_function_literal(db)
                 .is_some_and(|f| f.is_known(db, needle))
         })
     }
@@ -1659,7 +1659,7 @@ impl KnownFunction {
                         return;
                     }
                     let mut diagnostic = if let Some(message) = message
-                        .and_then(Type::as_string_literal)
+                        .and_then(|m| m.as_string_literal(db))
                         .map(|s| s.value(db))
                     {
                         builder.into_diagnostic(format_args!("Static assertion error: {message}"))
@@ -2119,7 +2119,7 @@ pub(crate) mod tests {
             let function_definition = known_module_symbol(&db, module, function_name)
                 .place
                 .expect_type()
-                .expect_function_literal()
+                .expect_function_literal(&db)
                 .definition(&db);
 
             assert_eq!(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1820,7 +1820,7 @@ impl<'db> SpecializationBuilder<'db> {
                 let mut bound_typevars = union_formal
                     .elements(self.db)
                     .iter()
-                    .filter_map(|ty| ty.as_typevar());
+                    .filter_map(|ty| ty.as_typevar(self.db));
 
                 // TODO:
                 // Handling more than one bare typevar is something that we can't handle yet.

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -159,7 +159,7 @@ pub fn definitions_for_name<'db>(
         if matches!(name_str, "float" | "complex")
             && let Some(expr) = node.expr_name()
             && let Some(ty) = expr.inferred_type(model)
-            && let Some(union) = ty.as_union()
+            && let Some(union) = ty.as_union(db)
             && is_float_or_complex_annotation(db, union, name_str)
         {
             return union
@@ -200,7 +200,7 @@ fn is_float_or_complex_annotation(db: &dyn Db, ty: UnionType, name: &str) -> boo
         "complex" => KnownUnion::Complex.to_type(db),
         _ => return false,
     }
-    .expect_union();
+    .expect_union(db);
 
     ty == float_or_complex_ty
 }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -498,7 +498,7 @@ pub(crate) fn nearest_enclosing_class<'db>(
             let definition = semantic.expect_single_definition(class);
             declaration_type(db, definition)
                 .inner_type()
-                .as_class_literal()
+                .as_class_literal(db)
                 .and_then(ClassLiteral::as_static)
         })
 }
@@ -523,7 +523,7 @@ pub(crate) fn nearest_enclosing_function<'db>(
             inference
                 .undecorated_type()
                 .unwrap_or_else(|| inference.declaration_type(definition).inner_type())
-                .as_function_literal()
+                .as_function_literal(db)
         })
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -603,7 +603,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             element_ty: Type,
             builder: &mut TypeInferenceBuilder,
         ) -> bool {
-            if !element_ty.is_todo() {
+            if !element_ty.is_todo(builder.db()) {
                 return false;
             }
 
@@ -807,7 +807,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         if class_literal.is_protocol(self.db()) {
                             SubclassOfType::from(
                                 self.db(),
-                                todo_type!("type[T] for protocols").expect_dynamic(),
+                                todo_type!("type[T] for protocols").expect_dynamic(self.db()),
                             )
                         } else if class_literal.is_tuple(self.db()) {
                             let class_type = self
@@ -1896,7 +1896,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     // We currently infer `Todo` for the parameters to avoid invalid diagnostics
                     // when trying to check for assignability or any other relation. For example,
                     // `*tuple[int, str]`, `Unpack[]`, etc. are not yet supported.
-                    return_todo |= param_type.is_todo()
+                    return_todo |= param_type.is_todo(self.db())
                         && matches!(param, ast::Expr::Starred(_) | ast::Expr::Subscript(_));
                     parameter_types.push(param_type);
                 }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -190,7 +190,7 @@ impl<'db> Type<'db> {
             // from a protocol `Q` to be a subtype of `Q` to be a subtype of `Q` if it overrides
             // `Q`'s members in a Liskov-incompatible way.
             let type_to_test = self
-                .as_protocol_instance()
+                .as_protocol_instance(db)
                 .and_then(ProtocolInstanceType::to_nominal_instance)
                 .map(Type::NominalInstance)
                 .unwrap_or(self);

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -125,7 +125,7 @@ fn create_bound_method<'db>(
 ) -> Type<'db> {
     Type::BoundMethod(BoundMethodType::new(
         db,
-        function.expect_function_literal(),
+        function.expect_function_literal(db),
         builtins_class.to_instance(db).unwrap(),
     ))
 }
@@ -147,7 +147,7 @@ impl Ty {
                 known_module_symbol(db, KnownModule::Uuid, "SafeUUID")
                     .place
                     .expect_type()
-                    .expect_class_literal(),
+                    .expect_class_literal(db),
                 Name::new(name),
             )),
             Ty::SingleMemberEnumLiteral => {
@@ -211,7 +211,7 @@ impl Ty {
                 builtins_symbol(db, s)
                     .place
                     .expect_type()
-                    .expect_class_literal()
+                    .expect_class_literal(db)
                     .default_specialization(db),
             ),
             Ty::SubclassOfAbcClass(s) => SubclassOfType::from(
@@ -219,7 +219,7 @@ impl Ty {
                 known_module_symbol(db, KnownModule::Abc, s)
                     .place
                     .expect_type()
-                    .expect_class_literal()
+                    .expect_class_literal(db)
                     .default_specialization(db),
             ),
             Ty::AlwaysTruthy => Type::AlwaysTruthy,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -264,7 +264,7 @@ impl<'db> ProtocolInterface<'db> {
 
     pub(super) fn non_method_members(self, db: &'db dyn Db) -> Vec<ProtocolMember<'db, 'db>> {
         self.members(db)
-            .filter(|member| !member.is_method() && !member.ty().is_todo())
+            .filter(|member| !member.is_method() && !member.ty().is_todo(db))
             .collect()
     }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2702,7 +2702,7 @@ mod tests {
         global_symbol(db, module, "f")
             .place
             .expect_type()
-            .expect_function_literal()
+            .expect_function_literal(db)
     }
 
     #[track_caller]

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -425,14 +425,14 @@ impl<'db> SubclassOfInner<'db> {
             Type::TypedDict(typed_dict) => match typed_dict {
                 TypedDictType::Class(class) => SubclassOfInner::Class(class),
                 TypedDictType::Synthesized(_) => SubclassOfInner::Dynamic(
-                    todo_type!("type[T] for synthesized TypedDicts").expect_dynamic(),
+                    todo_type!("type[T] for synthesized TypedDicts").expect_dynamic(db),
                 ),
             },
             Type::TypeVar(bound_typevar) => SubclassOfInner::TypeVar(bound_typevar),
             Type::Dynamic(DynamicType::Any) => SubclassOfInner::Dynamic(DynamicType::Any),
             Type::Dynamic(DynamicType::Unknown) => SubclassOfInner::Dynamic(DynamicType::Unknown),
             Type::ProtocolInstance(_) => {
-                SubclassOfInner::Dynamic(todo_type!("type[T] for protocols").expect_dynamic())
+                SubclassOfInner::Dynamic(todo_type!("type[T] for protocols").expect_dynamic(db))
             }
             _ => return None,
         })

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -255,7 +255,7 @@ impl<'db> SubscriptErrorKind<'db> {
                     }
                 }
                 CallErrorKind::BindingError => {
-                    if let Some(typed_dict) = value_ty.as_typed_dict() {
+                    if let Some(typed_dict) = value_ty.as_typed_dict(db) {
                         report_invalid_key_on_typed_dict(
                             context,
                             value_node.into(),
@@ -789,7 +789,7 @@ impl<'db> Type<'db> {
 
             // TODO: properly handle old-style generics; get rid of this temporary hack
             if !value_ty
-                .as_class_literal()
+                .as_class_literal(db)
                 .is_some_and(|class| class.iter_mro(db).contains(&ClassBase::Generic))
             {
                 return Err(SubscriptError::new(


### PR DESCRIPTION
I'm not sure we should do this. But I would like to see the performance impact (if it turns out to be negligible, then maybe we should do this) and the ecosystem report (whether we land this or not, it might reveals bugs we need to fix.)