### PR TITLE
tell CCfW that cargo-nextest is not available

### DIFF
--- a/.claude/hooks/session-start-web.sh
+++ b/.claude/hooks/session-start-web.sh
@@ -10,5 +10,6 @@ fi
 # Install clippy and rustfmt for the active toolchain.
 rustup component add clippy rustfmt
 
-# Install cargo-nextest
-cargo install --locked cargo-nextest
+# Our CLAUDE.md says to use nextest, but it's slow to install, so just tell
+# CCfW not to try to use it.
+echo "nextest is not installed, so just use 'cargo test' instead."


### PR DESCRIPTION
CCfW always tries and fails to use `nextest`, since our `CLAUDE.md` tells it to.

I tried having the startup hook install it, but it's really slow to install; not worth paying that cost on every session startup.

So just tell CCfW that it's not available, so it doesn't try to use it.

Tested this by starting a CCfW session on this branch and asking it to just run some tests -- it used `cargo test` right away, without trying `cargo nextest` first.