### PR TITLE
Fix suppression indentation matching

### DIFF
--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -504,13 +504,12 @@ impl<'a> SuppressionsBuilder<'a> {
             let mut count = 0;
             let last_indent = before
                 .iter()
-                .filter(|token| matches!(token.kind(), TokenKind::Indent | TokenKind::Dedent))
                 .rfind(|token| {
-                    // ignore matching dedents and indents above until we find
+                    // look for the last indent not matched by a dedent
                     count += match token.kind() {
                         TokenKind::Dedent => 1,
                         TokenKind::Indent => -1,
-                        _ => 0,
+                        _ => return false,
                     };
                     token.kind() == TokenKind::Indent && count < 0
                 })


### PR DESCRIPTION
When loading suppression comments from tokens, fix the token lookback
to look far enough back to find an indent token that isn't matched by
a dedent token. This prevents the system from marking "enable" comments
as having "invalid indentation".

Fix #22869

- **New test cases exercising issue #22869**
- **Track indent levels when looking backwards through tokens**
