### PR TITLE
[ty] Preserve pure negation types in descriptor protocol

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -960,5 +960,21 @@ def f(x: Not) -> None:
     reveal_type(x)  # revealed: Unknown
 ```
 
+## Attribute access on pure negation types
+
+When an attribute has a pure negation type (an intersection with only negative contributions, like
+`~AlwaysFalsy`), accessing it should preserve the negation information rather than falling back to
+`object`.
+
+```py
+from ty_extensions import Not, AlwaysFalsy
+
+class C:
+    x: Not[AlwaysFalsy]
+
+def f(c: C):
+    reveal_type(c.x)  # revealed: ~AlwaysFalsy
+```
+
 [complement laws]: https://en.wikipedia.org/wiki/Complement_(set_theory)
 [de morgan's laws]: https://en.wikipedia.org/wiki/De_Morgan%27s_laws

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -261,9 +261,16 @@ impl<'db> Place<'db> {
                     ty: Type::Intersection(intersection),
                     ..
                 },
-            ) => intersection.map_with_boundness(db, |elem| {
-                Place::Defined(DefinedPlace { ty: *elem, ..place }).try_call_dunder_get(db, owner)
-            }),
+            ) => {
+                if intersection.is_pure_negation(db) {
+                    self
+                } else {
+                    intersection.map_with_boundness(db, |elem| {
+                        Place::Defined(DefinedPlace { ty: *elem, ..place })
+                            .try_call_dunder_get(db, owner)
+                    })
+                }
+            }
 
             Place::Defined(defined) => {
                 if let Some((dunder_get_return_ty, _)) =

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -261,16 +261,9 @@ impl<'db> Place<'db> {
                     ty: Type::Intersection(intersection),
                     ..
                 },
-            ) => {
-                if intersection.is_pure_negation(db) {
-                    self
-                } else {
-                    intersection.map_with_boundness(db, |elem| {
-                        Place::Defined(DefinedPlace { ty: *elem, ..place })
-                            .try_call_dunder_get(db, owner)
-                    })
-                }
-            }
+            ) => intersection.map_with_boundness(db, |elem| {
+                Place::Defined(DefinedPlace { ty: *elem, ..place }).try_call_dunder_get(db, owner)
+            }),
 
             Place::Defined(defined) => {
                 if let Some((dunder_get_return_ty, _)) =


### PR DESCRIPTION
## Summary

When accessing an attribute with a pure negation type (an intersection with only negative contributions, like `~AlwaysFalsy`), the descriptor protocol would incorrectly return object instead of preserving the negation type, because `map_with_boundness` iterates over `positive_elements_or_object`, which falls back to `object` when there are no positive elements.
