### PR TITLE
Stabilize `--output-format` in `--watch` mode

### DIFF
--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -408,11 +408,6 @@ impl Printer {
             }
 
             let context = EmitterContext::new(&diagnostics.notebook_indexes);
-            let format = if preview {
-                self.format
-            } else {
-                OutputFormat::Concise
-            };
             let config = DisplayDiagnosticConfig::default()
                 .preview(preview)
                 .hide_severity(true)
@@ -420,7 +415,7 @@ impl Printer {
                 .with_show_fix_status(show_fix_status(self.fix_mode, fixables.as_ref()))
                 .with_fix_applicability(self.unsafe_fixes.required_applicability())
                 .show_fix_diff(preview);
-            render_diagnostics(writer, format, config, &context, &diagnostics.inner)?;
+            render_diagnostics(writer, self.format, config, &context, &diagnostics.inner)?;
         }
         writer.flush()?;
 


### PR DESCRIPTION
Summary
--

This PR stabilizes the changes from #21097 and closes #19552. Note that this has
two effects:

- the default output format in `--watch` mode becomes `full` instead of `concise`
- the `--output-format` flag will now be respected

So the default output is now more verbose, but the old stable behavior can be
retained by passing `--output-format=concise` (or any other supported format)
instead.

Test Plan
--

Manual testing. I think we tried to set up automated tests in an earlier PR but
decided they were too complex.

I really should have cropped these, but I'll just collapse them instead:

<details><summary>Screenshots</summary>
<p>

### Current output, no `--output-format`

<img width="783" height="514" alt="image" src="https://github.com/user-attachments/assets/a758daa8-534e-4dab-9cff-858321cede61" />

### Current output, `--output-format=json`

The same as above, the flag has no effect

<img width="783" height="514" alt="image" src="https://github.com/user-attachments/assets/e5b0743a-6bd5-4dec-83e0-de24e44567ca" />

### PR branch output, no `--output-format`

Default format is now `full` rather than `concise`

<img width="783" height="514" alt="image" src="https://github.com/user-attachments/assets/cf51947d-52e3-4420-83e7-73530557c324" />

### PR branch output, `--output-format=json`

JSON output, the flag works

<img width="783" height="514" alt="image" src="https://github.com/user-attachments/assets/e7127c5a-88ad-4b2a-80b4-193b63b631ee" />

</p>
</details> 