### PR TITLE
Implement new rule D219.

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydocstyle/D219.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydocstyle/D219.py
@@ -1,0 +1,26 @@
+"""Module docstring."""
+
+
+def function():
+    """Hi."""
+
+
+class Example:
+    """Class docstring."""
+
+    def method(self):
+        """Method docstring."""
+        return 1
+
+
+def already_multiline():
+    """
+    Already multi-line.
+    """
+
+
+def whitespace():
+    """  Hi.  """
+
+
+class SameLine: """Same line docstring."""

--- a/crates/ruff_linter/src/checkers/ast/analyze/definitions.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/definitions.rs
@@ -47,6 +47,7 @@ pub(crate) fn definitions(checker: &mut Checker) {
         Rule::EscapeSequenceInDocstring,
         Rule::FirstWordUncapitalized,
         Rule::UnnecessaryMultilineDocstring,
+        Rule::OneLineDocstringShouldBeMultiLine,
         Rule::DocstringTabIndentation,
         Rule::MultiLineSummaryFirstLine,
         Rule::MultiLineSummarySecondLine,
@@ -203,6 +204,9 @@ pub(crate) fn definitions(checker: &mut Checker) {
             }
             if checker.is_rule_enabled(Rule::UnnecessaryMultilineDocstring) {
                 pydocstyle::rules::one_liner(checker, &docstring);
+            }
+            if checker.is_rule_enabled(Rule::OneLineDocstringShouldBeMultiLine) {
+                pydocstyle::rules::multi_line_docstring(checker, &docstring);
             }
             if checker
                 .any_rule_enabled(&[Rule::BlankLineAfterFunction, Rule::BlankLineBeforeFunction])

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -607,6 +607,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Pydocstyle, "213") => rules::pydocstyle::rules::MultiLineSummarySecondLine,
         (Pydocstyle, "214") => rules::pydocstyle::rules::OverindentedSection,
         (Pydocstyle, "215") => rules::pydocstyle::rules::OverindentedSectionUnderline,
+        (Pydocstyle, "219") => rules::pydocstyle::rules::OneLineDocstringShouldBeMultiLine,
         (Pydocstyle, "300") => rules::pydocstyle::rules::TripleSingleQuotes,
         (Pydocstyle, "301") => rules::pydocstyle::rules::EscapeSequenceInDocstring,
         (Pydocstyle, "400") => rules::pydocstyle::rules::MissingTrailingPeriod,

--- a/crates/ruff_linter/src/registry.rs
+++ b/crates/ruff_linter/src/registry.rs
@@ -365,7 +365,7 @@ impl Rule {
 }
 
 /// Pairs of checks that shouldn't be enabled together.
-pub const INCOMPATIBLE_CODES: &[(Rule, Rule, &str); 2] = &[
+pub const INCOMPATIBLE_CODES: &[(Rule, Rule, &str); 3] = &[
     (
         Rule::BlankLineBeforeClass,
         Rule::IncorrectBlankLineBeforeClass,
@@ -377,6 +377,12 @@ pub const INCOMPATIBLE_CODES: &[(Rule, Rule, &str); 2] = &[
         Rule::MultiLineSummarySecondLine,
         "`multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are \
          incompatible. Ignoring `multi-line-summary-second-line`.",
+    ),
+    (
+        Rule::UnnecessaryMultilineDocstring,
+        Rule::OneLineDocstringShouldBeMultiLine,
+        "`unnecessary-multiline-docstring` (D200) and `one-line-docstring-should-be-multi-line` \
+         (D219) are incompatible. Ignoring `one-line-docstring-should-be-multi-line`.",
     ),
 ];
 

--- a/crates/ruff_linter/src/rules/pydocstyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/mod.rs
@@ -34,6 +34,10 @@ mod tests {
     #[test_case(Rule::FirstWordUncapitalized, Path::new("D.py"))]
     #[test_case(Rule::FirstWordUncapitalized, Path::new("D403.py"))]
     #[test_case(Rule::UnnecessaryMultilineDocstring, Path::new("D.py"))]
+    #[test_case(
+        Rule::OneLineDocstringShouldBeMultiLine,
+        Path::new("D219.py")
+    )]
     #[test_case(Rule::DocstringTabIndentation, Path::new("D.py"))]
     #[test_case(Rule::UndocumentedMagicMethod, Path::new("D.py"))]
     #[test_case(Rule::MultiLineSummaryFirstLine, Path::new("D.py"))]
@@ -110,6 +114,19 @@ mod tests {
             },
         )?;
         assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test]
+    fn multi_line_docstring_with_summary_on_second_line() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("pydocstyle/D219.py"),
+            &settings::LinterSettings::for_rules([
+                Rule::OneLineDocstringShouldBeMultiLine,
+                Rule::MultiLineSummarySecondLine,
+            ]),
+        )?;
+        assert_diagnostics!("D219_D213.py", diagnostics);
         Ok(())
     }
 

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/one_liner.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/one_liner.rs
@@ -1,9 +1,13 @@
+use std::borrow::Cow;
+
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_source_file::NewlineWithTrailingNewline;
-use ruff_text_size::Ranged;
+use ruff_python_semantic::Definition;
+use ruff_source_file::{LineRanges, NewlineWithTrailingNewline};
+use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::Docstring;
+use crate::registry::Rule;
 use crate::{Edit, Fix, FixAvailability, Violation};
 
 /// ## What it does
@@ -28,9 +32,9 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// ```
 ///
 /// ## Fix safety
-/// The fix is marked as unsafe because it could affect tools that parse docstrings,
-/// documentation generators, or custom introspection utilities that rely on
-/// specific docstring formatting.
+/// The fix is marked as unsafe because it could affect tools that parse
+/// docstrings, documentation generators, or custom introspection utilities
+/// that rely on specific docstring formatting.
 ///
 /// ## Options
 ///
@@ -54,6 +58,65 @@ impl Violation for UnnecessaryMultilineDocstring {
 
     fn fix_title(&self) -> Option<String> {
         Some("Reformat to one line".to_string())
+    }
+}
+
+/// ## What it does
+/// Checks for single-line docstrings that are formatted on a single line.
+///
+/// ## Why is this bad?
+/// Some projects prefer to use a multi-line layout for all docstrings, even
+/// for those that would otherwise fit on a single line. Doing so can reduce
+/// churn when docstrings are later expanded, and makes formatting consistent
+/// across all docstrings.
+///
+/// ## Example
+/// ```python
+/// def average(values: list[float]) -> float:
+///     """Return the mean of the given values."""
+/// ```
+///
+/// Use instead (with `D213` enabled):
+/// ```python
+/// def average(values: list[float]) -> float:
+///     """
+///     Return the mean of the given values.
+///     """
+/// ```
+///
+/// Use instead (with `D212` enabled):
+/// ```python
+/// def average(values: list[float]) -> float:
+///     """Return the mean of the given values.
+///     """
+/// ```
+///
+/// ## Fix safety
+/// The fix is marked as unsafe because it changes docstring formatting, which
+/// can affect tools that parse docstrings, documentation generators, or custom
+/// introspection utilities that rely on specific formatting.
+///
+/// ## Options
+///
+/// - `lint.pydocstyle.ignore-decorators`
+///
+/// ## References
+/// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
+///
+/// [PEP 257]: https://peps.python.org/pep-0257/
+#[derive(ViolationMetadata)]
+#[violation_metadata(preview_since = "0.14.14")]
+pub(crate) struct OneLineDocstringShouldBeMultiLine;
+
+impl Violation for OneLineDocstringShouldBeMultiLine {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
+    fn message(&self) -> String {
+        "One-line docstring should use multi-line quotes".to_string()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Reformat to multi-line".to_string())
     }
 }
 
@@ -93,5 +156,93 @@ pub(crate) fn one_liner(checker: &Checker, docstring: &Docstring) {
                 docstring.range(),
             )));
         }
+    }
+}
+
+/// D219
+pub(crate) fn multi_line_docstring(checker: &Checker, docstring: &Docstring) {
+    // If not a triple-quoted docstring, nothing to do.
+    if !docstring.is_triple_quoted() {
+        return;
+    }
+
+    // If the docstring already spans multiple lines, nothing to do.
+    if NewlineWithTrailingNewline::from(docstring.contents())
+        .nth(1)
+        .is_some()
+    {
+        return;
+    }
+
+    let body = docstring.body();
+
+    // If the body is empty, nothing to do.
+    if body.is_empty() {
+        return;
+    }
+
+    // Let's now check whether we can fix it.
+    let mut diagnostic =
+        checker.report_diagnostic(OneLineDocstringShouldBeMultiLine, docstring.range());
+
+    let mut indentation = Cow::Borrowed(docstring.compute_indentation());
+    let mut fixable = true;
+
+    // If the docstring is indented, ensure that it's only indented with
+    // whitespace.
+    if !indentation.chars().all(char::is_whitespace) {
+        fixable = false;
+
+        // If the docstring isn't on its own line, look at the statement
+        // indentation, and add the default indentation to get the "right"
+        // level.
+        if let Definition::Member(member) = &docstring.definition {
+            // Get the statement indentation.
+            let stmt_line_start = checker.locator().line_start(member.start());
+            let stmt_indentation = checker
+                .locator()
+                .slice(TextRange::new(stmt_line_start, member.start()));
+
+            // If the statement indentation is all whitespace, use that plus
+            // the default indentation.
+            if stmt_indentation.chars().all(char::is_whitespace) {
+                let indentation = indentation.to_mut();
+                indentation.clear();
+                indentation.push_str(stmt_indentation);
+                indentation.push_str(checker.stylist().indentation());
+                fixable = true;
+            }
+        }
+    }
+
+    if fixable {
+        // Construct the replacement, depending on D212 (default) or D213 being
+        // enabled (read from MultiLineSummarySecondLine).
+        let line_ending = checker.stylist().line_ending().as_str();
+        let replacement = if checker.is_rule_enabled(Rule::MultiLineSummarySecondLine) {
+            format!(
+                "{}{}{}{}{}{}",
+                docstring.opener(),
+                line_ending,
+                indentation,
+                body.as_str(),
+                line_ending,
+                format!("{}{}", indentation, docstring.closer())
+            )
+        } else {
+            format!(
+                "{}{}{}{}{}",
+                docstring.opener(),
+                body.as_str(),
+                line_ending,
+                indentation,
+                docstring.closer()
+            )
+        };
+
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+            replacement,
+            docstring.range(),
+        )));
     }
 }

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D219_D213.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D219_D213.py.snap
@@ -1,0 +1,117 @@
+---
+source: crates/ruff_linter/src/rules/pydocstyle/mod.rs
+---
+D219 [*] One-line docstring should use multi-line quotes
+ --> D219.py:1:1
+  |
+1 | """Module docstring."""
+  | ^^^^^^^^^^^^^^^^^^^^^^^
+  |
+help: Reformat to multi-line
+  - """Module docstring."""
+1 + """
+2 + Module docstring.
+3 + """
+4 | 
+5 | 
+6 | def function():
+note: This is an unsafe fix and may change runtime behavior
+
+D219 [*] One-line docstring should use multi-line quotes
+ --> D219.py:5:5
+  |
+4 | def function():
+5 |     """Hi."""
+  |     ^^^^^^^^^
+  |
+help: Reformat to multi-line
+2  | 
+3  | 
+4  | def function():
+   -     """Hi."""
+5  +     """
+6  +     Hi.
+7  +     """
+8  | 
+9  | 
+10 | class Example:
+note: This is an unsafe fix and may change runtime behavior
+
+D219 [*] One-line docstring should use multi-line quotes
+  --> D219.py:9:5
+   |
+ 8 | class Example:
+ 9 |     """Class docstring."""
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+10 |
+11 |     def method(self):
+   |
+help: Reformat to multi-line
+6  | 
+7  | 
+8  | class Example:
+   -     """Class docstring."""
+9  +     """
+10 +     Class docstring.
+11 +     """
+12 | 
+13 |     def method(self):
+14 |         """Method docstring."""
+note: This is an unsafe fix and may change runtime behavior
+
+D219 [*] One-line docstring should use multi-line quotes
+  --> D219.py:12:9
+   |
+11 |     def method(self):
+12 |         """Method docstring."""
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+13 |         return 1
+   |
+help: Reformat to multi-line
+9  |     """Class docstring."""
+10 | 
+11 |     def method(self):
+   -         """Method docstring."""
+12 +         """
+13 +         Method docstring.
+14 +         """
+15 |         return 1
+16 | 
+17 | 
+note: This is an unsafe fix and may change runtime behavior
+
+D219 [*] One-line docstring should use multi-line quotes
+  --> D219.py:23:5
+   |
+22 | def whitespace():
+23 |     """  Hi.  """
+   |     ^^^^^^^^^^^^^
+   |
+help: Reformat to multi-line
+20 | 
+21 | 
+22 | def whitespace():
+   -     """  Hi.  """
+23 +     """
+24 +       Hi.  
+25 +     """
+26 | 
+27 | 
+28 | class SameLine: """Same line docstring."""
+note: This is an unsafe fix and may change runtime behavior
+
+D219 [*] One-line docstring should use multi-line quotes
+  --> D219.py:26:17
+   |
+26 | class SameLine: """Same line docstring."""
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: Reformat to multi-line
+23 |     """  Hi.  """
+24 | 
+25 | 
+   - class SameLine: """Same line docstring."""
+26 + class SameLine: """
+27 +     Same line docstring.
+28 +     """
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D219_D219.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D219_D219.py.snap
@@ -1,0 +1,111 @@
+---
+source: crates/ruff_linter/src/rules/pydocstyle/mod.rs
+---
+D219 [*] One-line docstring should use multi-line quotes
+ --> D219.py:1:1
+  |
+1 | """Module docstring."""
+  | ^^^^^^^^^^^^^^^^^^^^^^^
+  |
+help: Reformat to multi-line
+  - """Module docstring."""
+1 + """Module docstring.
+2 + """
+3 | 
+4 | 
+5 | def function():
+note: This is an unsafe fix and may change runtime behavior
+
+D219 [*] One-line docstring should use multi-line quotes
+ --> D219.py:5:5
+  |
+4 | def function():
+5 |     """Hi."""
+  |     ^^^^^^^^^
+  |
+help: Reformat to multi-line
+2 | 
+3 | 
+4 | def function():
+  -     """Hi."""
+5 +     """Hi.
+6 +     """
+7 | 
+8 | 
+9 | class Example:
+note: This is an unsafe fix and may change runtime behavior
+
+D219 [*] One-line docstring should use multi-line quotes
+  --> D219.py:9:5
+   |
+ 8 | class Example:
+ 9 |     """Class docstring."""
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+10 |
+11 |     def method(self):
+   |
+help: Reformat to multi-line
+6  | 
+7  | 
+8  | class Example:
+   -     """Class docstring."""
+9  +     """Class docstring.
+10 +     """
+11 | 
+12 |     def method(self):
+13 |         """Method docstring."""
+note: This is an unsafe fix and may change runtime behavior
+
+D219 [*] One-line docstring should use multi-line quotes
+  --> D219.py:12:9
+   |
+11 |     def method(self):
+12 |         """Method docstring."""
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+13 |         return 1
+   |
+help: Reformat to multi-line
+9  |     """Class docstring."""
+10 | 
+11 |     def method(self):
+   -         """Method docstring."""
+12 +         """Method docstring.
+13 +         """
+14 |         return 1
+15 | 
+16 | 
+note: This is an unsafe fix and may change runtime behavior
+
+D219 [*] One-line docstring should use multi-line quotes
+  --> D219.py:23:5
+   |
+22 | def whitespace():
+23 |     """  Hi.  """
+   |     ^^^^^^^^^^^^^
+   |
+help: Reformat to multi-line
+20 | 
+21 | 
+22 | def whitespace():
+   -     """  Hi.  """
+23 +     """  Hi.  
+24 +     """
+25 | 
+26 | 
+27 | class SameLine: """Same line docstring."""
+note: This is an unsafe fix and may change runtime behavior
+
+D219 [*] One-line docstring should use multi-line quotes
+  --> D219.py:26:17
+   |
+26 | class SameLine: """Same line docstring."""
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: Reformat to multi-line
+23 |     """  Hi.  """
+24 | 
+25 | 
+   - class SameLine: """Same line docstring."""
+26 + class SameLine: """Same line docstring.
+27 +     """
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Hi all,

I was looking for a way to format single-line docstrings with ruff according to some projects internal guidelines, and found this isn't possible at the moment. The issue was raised before in ruff, so I decided it'd be worth it to see if I could get it in. **Disclaimer:** This MR contains LLM generated code, so treat with caution. It still is reviewed and tested by me, both inside the ruff container and in our codebase. Since it has already reformatted our codebase appropriately, I am happy with not merging it, but would like to give anyone the chance, if the code is up to par.

What happens in this MR:

- add a preview pydocstyle rule (D219) that flags one-line docstrings and enforces a multi-line layout;
- provide an unsafe fix that expands docstrings in a D212- (default) or D213-compatible format;
- add fixtures and snapshots for module, class, function, same-line docstrings, and whitespace preservation;
- mark D219 as incompatible with D200 to prevent collapse/expand ping-pong.

I (and my project) actually prefer D213-style fixes, but by the lower number D212 takes precedence. Happy to flip it around.

The issue #4174 describes the use case well: some projects prefer multi-line docstrings everywhere to reduce churn when docstrings expand over time. This implements the inverse of D200 as a preview rule. The motivation in my personal projects was that it simply looks more homogeneous scanning through large files, and I find it more legible if all docstrings are formatted the same.

To achieve the behaviour, we now have:

- new violation: `OneLineDocstringShouldBeMultiLine` (D219, preview)
- fix respects original opener/closer and indentation
- fix format:
  - with D213: `"""\nSummary.\n"""`
  - with D212: `"""Summary.\n"""`

Tested by:
- `INSTA_UPDATE=always cargo test -p ruff_linter pydocstyle::tests::rules -- D219`
- `INSTA_UPDATE=always cargo test -p ruff_linter pydocstyle::tests::multi_line_docstring_with_summary_on_second_line`


The fix is marked unsafe because it changes docstring formatting, which can affect docstring-parsing tools. The rule is added as preview and should require `--preview` to enable
