### PR TITLE
Stabilize `RUF060`

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/in_empty_collection.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/in_empty_collection.rs
@@ -7,10 +7,10 @@ use crate::Violation;
 use crate::checkers::ast::Checker;
 
 /// ## What it does
-/// Checks for membership tests on empty collections (such as `list`, `tuple`, `set` or `dict`).
+/// Checks for membership tests on empty collections (such as `list`, `tuple`, `set`, or `dict`).
 ///
 /// ## Why is this bad?
-/// If the collection is always empty, the check is unnecessary, and can be removed.
+/// If the collection is always empty, the check is unnecessary and can be removed.
 ///
 /// ## Example
 ///
@@ -25,7 +25,7 @@ use crate::checkers::ast::Checker;
 /// print("got it!")
 /// ```
 #[derive(ViolationMetadata)]
-#[violation_metadata(preview_since = "0.11.9")]
+#[violation_metadata(stable_since = "0.15.0")]
 pub(crate) struct InEmptyCollection;
 
 impl Violation for InEmptyCollection {


### PR DESCRIPTION
Tests look good, just two very small comma changes to the docs

I cherry-picked the docs changes from last time (#20231)

https://docs.astral.sh/ruff/rules/in-empty-collection/
