### PR TITLE
Stabilize `UP042`

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/replace_str_enum.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/replace_str_enum.rs
@@ -81,7 +81,7 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 ///
 /// [breaking change]: https://blog.pecar.me/python-enum
 #[derive(ViolationMetadata)]
-#[violation_metadata(preview_since = "v0.3.6")]
+#[violation_metadata(stable_since = "0.15.0")]
 pub(crate) struct ReplaceStrEnum {
     name: String,
 }


### PR DESCRIPTION
Closes #22816. As I note on the issue, I was previously hesitant to stabilize
this rule because of its long `## Fix safety` docs and the TODO comment in the
source code. However, the behavior change in the docs is simply handled by
making the fix unsafe, and resolving the TODO shouldn't require a breaking
change. It will only allow the fix to be offered in more cases.

The docs and tests looked good.
