### PR TITLE
[ty] Move the location of more `invalid-overload` diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -329,9 +329,8 @@ At least two `@overload`-decorated definitions must be present.
 from typing import overload
 
 @overload
-def func(x: int) -> int: ...
-
 # error: [invalid-overload]
+def func(x: int) -> int: ...
 def func(x: int | str) -> int | str:
     return x
 ```
@@ -357,16 +356,16 @@ non-`@overload`-decorated definition (for the same function/method).
 from typing import overload
 
 @overload
+# error: [invalid-overload] "Overloads for function `func` must be followed by a non-`@overload`-decorated implementation function"
 def func(x: int) -> int: ...
 @overload
-# error: [invalid-overload] "Overloads for function `func` must be followed by a non-`@overload`-decorated implementation function"
 def func(x: str) -> str: ...
 
 class Foo:
     @overload
+    # error: [invalid-overload] "Overloads for function `method` must be followed by a non-`@overload`-decorated implementation function"
     def method(self, x: int) -> int: ...
     @overload
-    # error: [invalid-overload] "Overloads for function `method` must be followed by a non-`@overload`-decorated implementation function"
     def method(self, x: str) -> str: ...
 ```
 
@@ -433,10 +432,10 @@ class Fine(metaclass=CustomAbstractMetaclass):
 class Foo:
     @overload
     @abstractmethod
+    # error: [invalid-overload]
     def f(self, x: int) -> int: ...
     @overload
     @abstractmethod
-    # error: [invalid-overload]
     def f(self, x: str) -> str: ...
 ```
 
@@ -446,17 +445,17 @@ And, the `@abstractmethod` decorator must be present on all the `@overload`-ed m
 class PartialFoo1(ABC):
     @overload
     @abstractmethod
+    # error: [invalid-overload]
     def f(self, x: int) -> int: ...
     @overload
-    # error: [invalid-overload]
     def f(self, x: str) -> str: ...
 
 class PartialFoo(ABC):
     @overload
+    # error: [invalid-overload]
     def f(self, x: int) -> int: ...
     @overload
     @abstractmethod
-    # error: [invalid-overload]
     def f(self, x: str) -> str: ...
 ```
 
@@ -498,11 +497,10 @@ if TYPE_CHECKING:
 
 if TYPE_CHECKING:
     @overload
-    def c() -> None: ...
+    # not all overloads are in a `TYPE_CHECKING` block, so this is an error
+    def c() -> None: ...  # error: [invalid-overload]
 
-# not all overloads are in a `TYPE_CHECKING` block, so this is an error
 @overload
-# error: [invalid-overload]
 def c(x: int) -> int: ...
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloa…_(84dadf8abd8f2f2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloa…_(84dadf8abd8f2f2).snap
@@ -16,11 +16,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 1 | from typing import overload
 2 | 
 3 | @overload
-4 | def func(x: int) -> int: ...
-5 | 
-6 | # error: [invalid-overload]
-7 | def func(x: int | str) -> int | str:
-8 |     return x
+4 | # error: [invalid-overload]
+5 | def func(x: int) -> int: ...
+6 | def func(x: int | str) -> int | str:
+7 |     return x
 ```
 
 ## mdtest_snippet.pyi
@@ -37,16 +36,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 
 ```
 error[invalid-overload]: Overloaded function `func` requires at least two overloads
- --> src/mdtest_snippet.py:4:5
+ --> src/mdtest_snippet.py:5:5
   |
 3 | @overload
-4 | def func(x: int) -> int: ...
-  |     ---- Only one overload defined here
-5 |
-6 | # error: [invalid-overload]
-7 | def func(x: int | str) -> int | str:
-  |     ^^^^
-8 |     return x
+4 | # error: [invalid-overload]
+5 | def func(x: int) -> int: ...
+  |     ^^^^ Only one overload defined here
+6 | def func(x: int | str) -> int | str:
+7 |     return x
   |
 info: rule `invalid-overload` is enabled by default
 
@@ -59,9 +56,7 @@ error[invalid-overload]: Overloaded function `func` requires at least two overlo
 3 | @overload
 4 | # error: [invalid-overload]
 5 | def func(x: int) -> int: ...
-  |     ----
-  |     |
-  |     Only one overload defined here
+  |     ^^^^ Only one overload defined here
   |
 info: rule `invalid-overload` is enabled by default
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Overload_without_an_…_-_Regular_modules_(5c8e81664d1c7470).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Overload_without_an_…_-_Regular_modules_(5c8e81664d1c7470).snap
@@ -16,16 +16,16 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
  1 | from typing import overload
  2 | 
  3 | @overload
- 4 | def func(x: int) -> int: ...
- 5 | @overload
- 6 | # error: [invalid-overload] "Overloads for function `func` must be followed by a non-`@overload`-decorated implementation function"
+ 4 | # error: [invalid-overload] "Overloads for function `func` must be followed by a non-`@overload`-decorated implementation function"
+ 5 | def func(x: int) -> int: ...
+ 6 | @overload
  7 | def func(x: str) -> str: ...
  8 | 
  9 | class Foo:
 10 |     @overload
-11 |     def method(self, x: int) -> int: ...
-12 |     @overload
-13 |     # error: [invalid-overload] "Overloads for function `method` must be followed by a non-`@overload`-decorated implementation function"
+11 |     # error: [invalid-overload] "Overloads for function `method` must be followed by a non-`@overload`-decorated implementation function"
+12 |     def method(self, x: int) -> int: ...
+13 |     @overload
 14 |     def method(self, x: str) -> str: ...
 ```
 
@@ -33,14 +33,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 
 ```
 error[invalid-overload]: Overloads for function `func` must be followed by a non-`@overload`-decorated implementation function
- --> src/mdtest_snippet.py:7:5
+ --> src/mdtest_snippet.py:5:5
   |
-5 | @overload
-6 | # error: [invalid-overload] "Overloads for function `func` must be followed by a non-`@overload`-decorated implementation function"
-7 | def func(x: str) -> str: ...
+3 | @overload
+4 | # error: [invalid-overload] "Overloads for function `func` must be followed by a non-`@overload`-decorated implementation function"
+5 | def func(x: int) -> int: ...
   |     ^^^^
-8 |
-9 | class Foo:
+6 | @overload
+7 | def func(x: str) -> str: ...
   |
 info: Attempting to call `func` will raise `TypeError` at runtime
 info: Overloaded functions without implementations are only permitted:
@@ -55,12 +55,14 @@ info: rule `invalid-overload` is enabled by default
 
 ```
 error[invalid-overload]: Overloads for function `method` must be followed by a non-`@overload`-decorated implementation function
-  --> src/mdtest_snippet.py:14:9
+  --> src/mdtest_snippet.py:12:9
    |
-12 |     @overload
-13 |     # error: [invalid-overload] "Overloads for function `method` must be followed by a non-`@overload`-decorated implementation functi…
-14 |     def method(self, x: str) -> str: ...
+10 |     @overload
+11 |     # error: [invalid-overload] "Overloads for function `method` must be followed by a non-`@overload`-decorated implementation functi…
+12 |     def method(self, x: int) -> int: ...
    |         ^^^^^^
+13 |     @overload
+14 |     def method(self, x: str) -> str: ...
    |
 info: Attempting to call `method` will raise `TypeError` at runtime
 info: Overloaded functions without implementations are only permitted:

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1497,7 +1497,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Check that the overloaded function has at least two overloads
             if let [single_overload] = overloads {
-                let function_node = function.node(self.db(), self.file(), self.module());
+                let function_node = single_overload.node(self.db(), self.file(), self.module());
                 if let Some(builder) = self
                     .context
                     .report_lint(&INVALID_OVERLOAD, &function_node.name)
@@ -1506,11 +1506,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         "Overloaded function `{}` requires at least two overloads",
                         &function_node.name
                     ));
-                    diagnostic.annotate(
-                        self.context
-                            .secondary(single_overload.focus_range(self.db(), self.module()))
-                            .message(format_args!("Only one overload defined here")),
-                    );
+                    diagnostic.set_primary_message("Only one overload defined here");
                 }
             }
 
@@ -1552,7 +1548,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
 
                 if implementation_required {
-                    let function_node = function.node(self.db(), self.file(), self.module());
+                    let function_node = overloads[0].node(self.db(), self.file(), self.module());
                     if let Some(builder) = self
                         .context
                         .report_lint(&INVALID_OVERLOAD, &function_node.name)


### PR DESCRIPTION
The conformance suite expects these to be in a different place. I'm not sure that the new location is any better, but I'm also not sure that it's any worse, and there's value in emitting these diagnostics on the same lines as other type checkers -- it makes it easier for folks to run multiple type checkers on their codebase