### PR TITLE
Use configured extension mapping to select code block language

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3259,6 +3259,7 @@ version = "0.0.0"
 dependencies = [
  "insta",
  "regex",
+ "ruff_linter",
  "ruff_python_ast",
  "ruff_python_formatter",
  "ruff_python_trivia",

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -500,6 +500,11 @@ impl ExtensionMapping {
         let ext = path.extension()?.to_str()?;
         self.0.get(ext).copied()
     }
+
+    /// Return the [`Language`] for a given file extension.
+    pub fn get_extension(&self, ext: &str) -> Option<Language> {
+        self.0.get(ext).copied()
+    }
 }
 
 impl From<FxHashMap<String, Language>> for ExtensionMapping {

--- a/crates/ruff_markdown/Cargo.toml
+++ b/crates/ruff_markdown/Cargo.toml
@@ -17,8 +17,12 @@ ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 ruff_workspace = { workspace = true }
 
-insta = { workspace = true }
 regex = { workspace = true }
+
+[dev-dependencies]
+ruff_linter = { workspace = true }
+
+insta = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
- Adds `Language::get_extension` to look up extension mappings without a `Path` object
- Adds logic to `format_code_blocks` to obey any configured extension mapping when determining the source type of a code block
- Adds test case showing formatting a `py` code block as if it was `pyi` by using the configured extension map

This will allow ty run ruff formatting on md test files while force-mapping `py` blocks to `pyi` for condensed formatting results.

Issue #22639