### PR TITLE
[ty] Use `Unknown` specialization for assignability of unspecialized class literals

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -420,8 +420,11 @@ expects_type_p_of_str(P[str])
 # Not OK if the specializations don't line up:
 expects_type_p(P[int])  # error: [invalid-argument-type]
 expects_type_p_of_int(P[str])  # error: [invalid-argument-type]
-expects_type_p_of_int(P)  # error: [invalid-argument-type]
 expects_type_p_of_str(P[int])  # error: [invalid-argument-type]
+
+# OK if we can choose an implicit assignable specialization:
+expects_type_p_of_int(P)
+expects_type_p_of_str(P)
 ```
 
 This also works with `ParamSpec`:

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -520,6 +520,14 @@ impl<'db> ClassLiteral<'db> {
         }
     }
 
+    /// Returns the unknown specialization for this class (same as default for non-generic).
+    pub(crate) fn unknown_specialization(self, db: &'db dyn Db) -> ClassType<'db> {
+        match self {
+            Self::Static(class) => class.unknown_specialization(db),
+            Self::Dynamic(_) | Self::DynamicNamedTuple(_) => ClassType::NonGeneric(self),
+        }
+    }
+
     /// Returns the generic context if this is a generic class.
     pub(crate) fn generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
         self.as_static().and_then(|class| class.generic_context(db))

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1287,7 +1287,7 @@ impl<'db> Type<'db> {
                 .subclass_of()
                 .into_class(db)
                 .map(|subclass_of_class| {
-                    class.default_specialization(db).has_relation_to_impl(
+                    class.unknown_specialization(db).has_relation_to_impl(
                         db,
                         subclass_of_class,
                         inferable,
@@ -1303,7 +1303,7 @@ impl<'db> Type<'db> {
             // with final generic types, where `type[C[...]]` is simplified to the generic-alias
             // type `<class 'C[...]'>`, due to the fact that `C[...]` has no subclasses.
             (Type::ClassLiteral(class), Type::GenericAlias(target_alias)) => {
-                class.default_specialization(db).has_relation_to_impl(
+                class.unknown_specialization(db).has_relation_to_impl(
                     db,
                     ClassType::Generic(target_alias),
                     inferable,
@@ -2128,7 +2128,7 @@ impl<'db> Type<'db> {
 
             (Type::ClassLiteral(class_literal), other @ Type::GenericAlias(_))
             | (other @ Type::GenericAlias(_), Type::ClassLiteral(class_literal)) => class_literal
-                .default_specialization(db)
+                .unknown_specialization(db)
                 .into_generic_alias()
                 .when_none_or(|alias| {
                     other.is_disjoint_from_impl(


### PR DESCRIPTION
This seems to be a simpler fix to https://github.com/astral-sh/ty/issues/1624.

There's some issues here around upper bounds, but I can address that in a followup PR as it's a wider-reaching issue.