### PR TITLE
Support arbitrary length code fences in markdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,7 +977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a867d7322eb69cf3a68a5426387a25b45cb3b9c5ee41023ee6cea92e2afadd82"
 dependencies = [
  "camino",
- "fancy-regex",
+ "fancy-regex 0.14.0",
  "libtest-mimic 0.8.1",
  "walkdir",
 ]
@@ -1160,6 +1160,17 @@ name = "fancy-regex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -3270,6 +3281,7 @@ dependencies = [
 name = "ruff_markdown"
 version = "0.0.0"
 dependencies = [
+ "fancy-regex 0.17.0",
  "insta",
  "regex",
  "ruff_python_ast",

--- a/crates/ruff_markdown/Cargo.toml
+++ b/crates/ruff_markdown/Cargo.toml
@@ -17,6 +17,7 @@ ruff_workspace = { workspace = true }
 
 insta = { workspace = true }
 regex = { workspace = true }
+fancy-regex = "0.17.0"
 
 [lints]
 workspace = true


### PR DESCRIPTION
- Use `fancy_regex` crate
- Use backreference in regex to match arbitrary length code fences
- Support `~~~` style code fences as well
