### PR TITLE
[ty] Add a new diagnostic to detect invalid class patterns in `match` statements

### DIFF
--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -1611,16 +1611,16 @@ Checks for invalid match patterns.
 
 **Why is this bad?**
 
-Such called patterns lead to runtime errors.
+Matching on invalid patterns will lead to a runtime error.
 
 **Examples**
 
 ```python
-def _(foo):
-    bar = "bar"
-    match foo:
-        case bar():    # class pattern must refer to a class
-            ...
+NotAClass = 42
+
+match x:
+    case NotAClass():    # TypeError at runtime: must be a class
+        ...
 ```
 
 ## `invalid-metaclass`

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1642,15 +1642,15 @@ declare_lint! {
     /// Checks for invalid match patterns.
     ///
     /// ## Why is this bad?
-    /// Such called patterns lead to runtime errors.
+    /// Matching on invalid patterns will lead to a runtime error.
     ///
     /// ## Examples
     /// ```python
-    /// def _(foo):
-    ///     bar = "bar"
-    ///     match foo:
-    ///         case bar():    # class pattern must refer to a class
-    ///             ...
+    /// NotAClass = 42
+    ///
+    /// match x:
+    ///     case NotAClass():    # TypeError at runtime: must be a class
+    ///         ...
     /// ```
     pub(crate) static INVALID_MATCH_PATTERN = {
         summary: "detect invalid match patterns",

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5070,7 +5070,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     protocol_class,
                 );
             }
-        } else if !matches!(cls_ty, Type::Dynamic(_))
+        } else if !cls_ty.is_dynamic()
             && !cls_ty.is_subtype_of(self.db(), KnownClass::Type.to_instance(self.db()))
         {
             report_invalid_class_match_pattern(&self.context, &*pattern.cls, cls_ty);

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -817,7 +817,7 @@
         },
         "invalid-match-pattern": {
           "title": "detect invalid match patterns",
-          "description": "## What it does\nChecks for invalid match patterns.\n\n## Why is this bad?\nSuch called patterns lead to runtime errors.\n\n## Examples\n```python\ndef _(foo):\n    bar = \"bar\"\n    match foo:\n        case bar():    # class pattern must refer to a class\n            ...\n```",
+          "description": "## What it does\nChecks for invalid match patterns.\n\n## Why is this bad?\nMatching on invalid patterns will lead to a runtime error.\n\n## Examples\n```python\nNotAClass = 42\n\nmatch x:\n    case NotAClass():    # TypeError at runtime: must be a class\n        ...\n```",
           "default": "error",
           "oneOf": [
             {


### PR DESCRIPTION
## Summary

Fixes: https://github.com/astral-sh/ty/issues/2592

Adds a new diagnostic to flag called match patterns where the called object is not a class literal.

## Test Plan

New mdtests

## Ecosystem changes


