### PR TITLE
Remove hidden `--output-format` warning

### DIFF
--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -17,7 +17,6 @@ use args::{GlobalConfigArgs, ServerCommand};
 use ruff_db::diagnostic::{Diagnostic, Severity};
 use ruff_linter::logging::{LogLevel, set_up_logging};
 use ruff_linter::settings::flags::FixMode;
-use ruff_linter::settings::types::OutputFormat;
 use ruff_linter::{fs, warn_user, warn_user_once};
 use ruff_workspace::Settings;
 


### PR DESCRIPTION
Summary
--

I forgot to include this in #22908, but I think it's okay just to land this on
`main` instead of the release branch because the warning isn't actually visible
to users anyway, as reported in #19552. We're stabilizing `--output-format`
actually being used with `--watch`, so we can just delete this warning.

Fixes #19552
