### PR TITLE
[ty] Emit an error if a TypeVarTuple is used to subscript `Generic` or `Protocol` without being unpacked

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_types.md
@@ -45,3 +45,10 @@ class Baz[*Ts]: ...
 # TODO: false positive
 z: Baz[int, str, bytes]  # error: [not-subscriptable]
 ```
+
+And we also provide some basic validation in some cases:
+
+```py
+# error: [invalid-generic-class] "`TypeVarTuple` must be unpacked with `*` or `Unpack[]` when used as an argument to `Generic`"
+class Spam(Generic[Ts]): ...
+```

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -147,6 +147,8 @@ pub(crate) enum SubscriptErrorKind<'db> {
         origin: LegacyGenericOrigin,
         typevar_name: &'db str,
     },
+    /// A `TypeVarTuple` was provided to `Generic` or `Protocol` without being unpacked.
+    TypeVarTupleNotUnpacked { origin: LegacyGenericOrigin },
 }
 
 impl<'db> SubscriptError<'db> {
@@ -331,6 +333,14 @@ impl<'db> SubscriptErrorKind<'db> {
                     builder.into_diagnostic(format_args!(
                         "Type parameter `{typevar_name}` cannot appear multiple times \
                         in `{origin}` subscription",
+                    ));
+                }
+            }
+            Self::TypeVarTupleNotUnpacked { origin } => {
+                if let Some(builder) = context.report_lint(&INVALID_GENERIC_CLASS, subscript) {
+                    builder.into_diagnostic(format_args!(
+                        "`TypeVarTuple` must be unpacked with `*` or `Unpack[]` when \
+                        used as an argument to `{origin}`",
                     ));
                 }
             }


### PR DESCRIPTION
(Stacked on top of https://github.com/astral-sh/ruff/pull/22950; review that PR first)

## Summary

This is an error.

The way this is implemented feels a bit awkwardly special-cased, but I think it will have to be awkwardly special-cased even after we add proper support for `TypeVarTuple`?

## Test Plan

mdtests
