### PR TITLE
[ty] Fix narrowing of nonlocal variables with conditional assignments

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
@@ -446,3 +446,23 @@ def foo():
         if isinstance(x, str):
             reveal_type(x)  # revealed: Never
 ```
+
+## Narrowing nonlocal variables with conditional assignments
+
+When a nonlocal variable is conditionally reassigned and then narrowed via an assertion, the
+narrowing constraint should be applied correctly, even when the enclosing scope's type was itself
+narrowed (e.g., via an `isinstance` check).
+
+```py
+def _(maybe_float: float | None, certain_int: int, flag: bool) -> None:
+    if isinstance(maybe_float, int):
+        return
+    x = maybe_float
+    def _() -> None:
+        nonlocal x
+        if flag:
+            x = certain_int
+        assert x is not None
+        reveal_type(x)  # revealed: int | float
+        +x
+```

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11621,10 +11621,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // Since an unbound binding is recorded even for an undefined place,
                     // this can only happen if the code is unreachable
                     // and therefore it is correct to set the result to `Never`.
-                    let union = union.build();
-                    if union.is_assignable_to(db, ty) {
-                        ty = union;
-                    }
+                    ty = union.build();
                 }
             }
         }


### PR DESCRIPTION
## Summary

Given:

```python
def _(maybe_float: float | None, certain_int: int, flag: bool) -> None:
  if isinstance(maybe_float, int):
      return
  x = maybe_float
  def _() -> None:
      nonlocal x
      if flag:
          x = certain_int
      assert x is not None
      +x  # error: Unary operator `+` is not supported for operand of type `int | float | None`
```

With the guard (removed in this PR), `assert x is not None` would have no effect, since `int | (float & ~int)` is not assignable to `(float & ~int) | None`.

Closes https://github.com/astral-sh/ty/issues/2649.
