### PR TITLE
[ty] remove `static_expression_truthiness` and improve reachability analysis

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2571,8 +2571,9 @@ class Toggle:
         if check(self.y):
             self.y = True
 
-reveal_type(Toggle().x)  # revealed: Literal[True]
-reveal_type(Toggle().y)  # revealed:  Unknown | Literal[True]
+# Literal[True] or undefined
+reveal_type(Toggle().x)  # revealed: Literal[True] | Unknown
+reveal_type(Toggle().y)  # revealed: Unknown | Literal[True]
 ```
 
 Make sure that the growing union of literals `Literal[0, 1, 2, ...]` collapses to `int` during

--- a/crates/ty_python_semantic/resources/mdtest/statically_known_branches.md
+++ b/crates/ty_python_semantic/resources/mdtest/statically_known_branches.md
@@ -1578,8 +1578,23 @@ def _(flag: bool):
     if True and ALWAYS_TRUE_IF_BOUND:
         x = 1
 
-    # error: [possibly-unresolved-reference] "Name `x` used when possibly not defined"
+    # no error, x is considered definitely bound
     x
+```
+
+```py
+def _(flag: bool):
+    if flag:
+        ALWAYS_TRUE_IF_BOUND = True
+
+    # error: [possibly-unresolved-reference] "Name `ALWAYS_TRUE_IF_BOUND` used when possibly not defined"
+    if True and ALWAYS_TRUE_IF_BOUND:
+        x = 1
+    else:
+        x = 2
+
+    # If `ALWAYS_TRUE_IF_BOUND` were not defined, an error would occur, and therefore the `x = 2` branch would never be executed.
+    reveal_type(x)  # revealed: Literal[1]
 ```
 
 ## Unreachable code

--- a/crates/ty_python_semantic/src/semantic_index/reachability_constraints.rs
+++ b/crates/ty_python_semantic/src/semantic_index/reachability_constraints.rs
@@ -209,7 +209,7 @@ use crate::semantic_index::predicate::{
 };
 use crate::types::{
     CallableTypes, IntersectionBuilder, Truthiness, Type, TypeContext, UnionBuilder, UnionType,
-    infer_expression_type, static_expression_truthiness,
+    infer_expression_type,
 };
 
 /// A ternary formula that defines under what conditions a binding is visible. (A ternary formula
@@ -856,7 +856,9 @@ impl ReachabilityConstraints {
 
         match predicate.node {
             PredicateNode::Expression(test_expr) => {
-                static_expression_truthiness(db, test_expr).negate_if(!predicate.is_positive)
+                infer_expression_type(db, test_expr, TypeContext::default())
+                    .bool(db)
+                    .negate_if(!predicate.is_positive)
             }
             PredicateNode::ReturnsNever(CallableAndCallExpr {
                 callable,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -32,7 +32,7 @@ pub(crate) use self::diagnostic::register_lints;
 pub use self::diagnostic::{TypeCheckDiagnostics, UNDEFINED_REVEAL, UNRESOLVED_REFERENCE};
 pub(crate) use self::infer::{
     TypeContext, infer_complete_scope_types, infer_deferred_types, infer_definition_types,
-    infer_expression_type, infer_expression_types, infer_scope_types, static_expression_truthiness,
+    infer_expression_type, infer_expression_types, infer_scope_types,
 };
 pub use self::signatures::ParameterKind;
 pub(crate) use self::signatures::{CallableSignature, Signature};


### PR DESCRIPTION
## Summary

cf: https://github.com/astral-sh/ruff/pull/19579, https://github.com/astral-sh/ruff/pull/20566#discussion_r2553196955

Currently, we use the query `static_expression_truthiness` to determine the truthiness of an expression.
This always determines the truthinesses of non-definitely-bound places as `Ambiguous`, preventing cycles that occur when their reachabilities depend on themselves. However, this can lead to inaccurate analysis of code like the following.

```python
def _(flag: bool):
    if flag:
        ALWAYS_TRUE_IF_BOUND = True

    # error: [possibly-unresolved-reference] "Name `ALWAYS_TRUE_IF_BOUND` used when possibly not defined"
    if ALWAYS_TRUE_IF_BOUND:
        x = 1
    else:
        x = 2

    # If `ALWAYS_TRUE_IF_BOUND` were not defined, an error would occur, and therefore the `x = 2` branch would never be executed.
    reveal_type(x)  # expected: Literal[1], but: Literal[1, 2]
```

Since #20566, we can determine the `Place` by looking at the previous cycle result.
Therefore, we can now remove `static_expression_truthiness`, improving reachability analysis of the above code.

## Test Plan

mdtest updated
