### PR TITLE
[ty] Enforce `Final` assignments after conditional bindings

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -165,6 +165,77 @@ FINAL_E = 2  # error: [invalid-assignment] "Reassignment of `Final` symbol `FINA
 FINAL_F = 2  # error: [invalid-assignment] "Reassignment of `Final` symbol `FINAL_F` is not allowed"
 ```
 
+### Reassignment after conditional assignment
+
+If a `Final` symbol is conditionally assigned, a subsequent unconditional assignment is still a
+reassignment error, because the symbol may have already been bound:
+
+```py
+from typing import Final
+
+def cond() -> bool:
+    return True
+
+ABC: Final[int]
+
+if cond():
+    ABC = 1
+
+ABC = 2  # error: [invalid-assignment] "Reassignment of `Final` symbol `ABC` is not allowed"
+```
+
+Assigning in both branches of an `if/else` is fine — each branch is a first assignment:
+
+```py
+from typing import Final
+
+def cond() -> bool:
+    return True
+
+X: Final[int]
+
+if cond():
+    X = 1
+else:
+    X = 2
+```
+
+But assigning in both branches and then again unconditionally is an error:
+
+```py
+from typing import Final
+
+def cond() -> bool:
+    return True
+
+Y: Final[int]
+
+if cond():
+    Y = 1
+else:
+    Y = 2
+
+Y = 3  # error: [invalid-assignment] "Reassignment of `Final` symbol `Y` is not allowed"
+```
+
+Multiple conditional blocks don't help — the second `if` body sees that the first may have already
+bound the symbol:
+
+```py
+from typing import Final
+
+def cond() -> bool:
+    return True
+
+Z: Final[int]
+
+if cond():
+    Z = 1
+
+if cond():
+    Z = 2  # error: [invalid-assignment] "Reassignment of `Final` symbol `Z` is not allowed"
+```
+
 ### Attributes
 
 Assignments to attributes qualified with `Final` are also not allowed:

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -16198,9 +16198,7 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
 
             // An assignment to a local `Final`-qualified symbol is only an error if there are prior bindings
 
-            let previous_definition = previous_bindings
-                .next()
-                .and_then(|r| r.binding.definition());
+            let previous_definition = previous_bindings.find_map(|r| r.binding.definition());
 
             if !self.is_local || previous_definition.is_some() {
                 let place = place_table.place(self.binding.place(db));


### PR DESCRIPTION
## Summary

When a `Final` symbol had a conditional prior binding, the iterator could yield `Undefined` (from the control flow path where the condition was false) as the first element.

Closes https://github.com/astral-sh/ty/issues/2674.
