### PR TITLE
[ty] Fix bidirectional inference with PEP 695 union type aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -363,6 +363,39 @@ def _(x: MyList[int]):
     reveal_type(head(x))  # revealed: int
 ```
 
+## Bidirectional type inference with union type aliases
+
+When a PEP 695 type alias expands to a union, bidirectional type inference should still work
+correctly. The type alias should be expanded to its value type when determining the expected type
+for specialization inference.
+
+```py
+type MaybeList[T] = list[T] | T
+
+def test[X: int](items: list[X]) -> list[X]:
+    # The annotation MaybeList[str | int] expands to `list[str | int] | str | int`.
+    # Bidirectional inference should infer list[str | int] from the list() call.
+    a: MaybeList[str | int] = list(items)
+    # The revealed type is list[str | int] because that's what list() returns.
+    reveal_type(a)  # revealed: list[str | int]
+    return items
+```
+
+This also works for more complex cases with multiple generic functions:
+
+```py
+type OptionalList[T] = list[T] | None
+
+def copy_list[T](items: list[T]) -> list[T]:
+    return list(items)
+
+def _(values: list[int]) -> OptionalList[int]:
+    result: OptionalList[int] = copy_list(values)
+    # The revealed type is list[int] because that's what copy_list returns.
+    reveal_type(result)  # revealed: list[int]
+    return result
+```
+
 ## Fully qualified type alias names in error messages
 
 When two type aliases have the same name but are in different scopes, they should be fully qualified

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3144,6 +3144,12 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // type parameters from generic classes.
         let preferred_type_mappings = return_with_tcx
             .and_then(|(return_ty, tcx)| {
+                // Expand type aliases to their value types so that union members can be
+                // correctly filtered. This is necessary for PEP 695 type aliases like
+                // `type MaybeList[T] = list[T] | T` where the expanded union contains
+                // class instances that we want to use for specialization inference.
+                let tcx = tcx.resolve_type_alias(self.db);
+
                 tcx.filter_union(self.db, |ty| ty.class_specialization(self.db).is_some())
                     .class_specialization(self.db)?;
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/2682

Fix bidirectional type inference when PEP 695 type aliases expand to union types. Previously, when a type alias like `type MaybeList[T] = list[T] | T` was used as a type annotation, the specialization inference would fail to correctly infer type parameters from the assigned value.

The issue was that type aliases were not being expanded to their value types before filtering union members for specialization inference. This prevented the type checker from identifying class instances within the expanded union that could be used to infer generic type parameters.

The fix expands type aliases to their underlying value types before performing the union filtering and reverse type inference. This allows bidirectional inference to work correctly with union type aliases while maintaining proper variance handling.

## Test Plan

Added test cases in `crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md`.
