### PR TITLE
[ty] Resolve type aliases in `filter_union` method

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -396,6 +396,51 @@ def _(values: list[int]) -> OptionalList[int]:
     return result
 ```
 
+Union type aliases also work correctly with TypedDict dict literal inference:
+
+```py
+from typing import TypedDict
+
+class Person(TypedDict):
+    name: str
+    age: int
+
+type MaybePerson = Person | None
+
+def _(p: MaybePerson):
+    # Dict literal should be inferred as Person, not dict[str, str | int]
+    x: MaybePerson = {"name": "Alice", "age": 30}
+    reveal_type(x)  # revealed: Person
+```
+
+And with `dict()` calls in TypedDict context:
+
+```py
+from typing import TypedDict
+
+class Dog(TypedDict):
+    name: str
+    breed: str
+
+type MaybeDog = Dog | None
+
+def _():
+    # dict() call with keyword args should be inferred as Dog
+    animal: MaybeDog = dict(name="Buddy", breed="Labrador")
+    reveal_type(animal)  # revealed: Dog
+```
+
+And with set literal inference:
+
+```py
+type MaybeSet[T] = set[T] | T
+
+def _():
+    # Set literal should be inferred as set[int]
+    x: MaybeSet[int] = {1, 2, 3}
+    reveal_type(x)  # revealed: set[int]
+```
+
 ## Fully qualified type alias names in error messages
 
 When two type aliases have the same name but are in different scopes, they should be fully qualified

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1541,7 +1541,8 @@ impl<'db> Type<'db> {
         }
     }
 
-    /// If the type is a union, filters union elements based on the provided predicate.
+    /// If the type is a union (or a type alias that resolves to a union), filters union elements
+    /// based on the provided predicate.
     ///
     /// Otherwise, returns the type unchanged.
     pub(crate) fn filter_union(
@@ -1549,7 +1550,7 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         f: impl FnMut(&Type<'db>) -> bool,
     ) -> Type<'db> {
-        if let Type::Union(union) = self {
+        if let Type::Union(union) = self.resolve_type_alias(db) {
             union.filter(db, f)
         } else {
             self

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3144,12 +3144,6 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // type parameters from generic classes.
         let preferred_type_mappings = return_with_tcx
             .and_then(|(return_ty, tcx)| {
-                // Expand type aliases to their value types so that union members can be
-                // correctly filtered. This is necessary for PEP 695 type aliases like
-                // `type MaybeList[T] = list[T] | T` where the expanded union contains
-                // class instances that we want to use for specialization inference.
-                let tcx = tcx.resolve_type_alias(self.db);
-
                 tcx.filter_union(self.db, |ty| ty.class_specialization(self.db).is_some())
                     .class_specialization(self.db)?;
 


### PR DESCRIPTION
## Summary

Update the `filter_union` method to resolve type aliases before checking if a type is a union. This ensures that union filtering works correctly when the type is a type alias that resolves to a union, not just direct union types.

## Test Plan

Added tests exercising various uses of `filter_union` that fail without this fix.