### PR TITLE
[ty] fix nested `NewType`s with add `Type::as_union_like`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
@@ -263,6 +263,20 @@ static_assert(is_assignable_to(Bar, int | float | complex | None))
 static_assert(is_assignable_to(Bar, Bar | None))
 ```
 
+`NewType`s can be arbitrarily deeply nested. Check the same properties on a doubly nested example:
+
+```py
+FooFoo = NewType("FooFoo", Foo)
+reveal_type(FooFoo(Foo(3.14)).__class__)  # revealed: type[int | float]
+reveal_type(FooFoo(Foo(42)).__class__)  # revealed: type[int | float]
+static_assert(is_assignable_to(FooFoo, float))
+static_assert(is_assignable_to(FooFoo, Foo))
+static_assert(is_assignable_to(FooFoo, int | float))
+static_assert(is_assignable_to(FooFoo, int | float | None))
+static_assert(is_assignable_to(FooFoo, FooFoo | None))
+static_assert(is_assignable_to(FooFoo, Foo | None))
+```
+
 We don't currently try to distinguish between an implicit union (e.g. `float`) and the equivalent
 explicit union (e.g. `int | float`), so these two explicit unions are also allowed. But again, most
 unions are not allowed:
@@ -299,6 +313,10 @@ reveal_type(Foo(3.14) < Foo(42))  # revealed: bool
 reveal_type(Foo(3.14) == Foo(42))  # revealed: bool
 reveal_type(Foo(3.14) + Foo(42))  # revealed: int | float
 reveal_type(Foo(3.14) / Foo(42))  # revealed: int | float
+reveal_type(FooFoo(Foo(3.14)) < FooFoo(Foo(42)))  # revealed: bool
+reveal_type(FooFoo(Foo(3.14)) == FooFoo(Foo(42)))  # revealed: bool
+reveal_type(FooFoo(Foo(3.14)) + FooFoo(Foo(42)))  # revealed: int | float
+reveal_type(FooFoo(Foo(3.14)) / FooFoo(Foo(42)))  # revealed: int | float
 ```
 
 But again as above, we can't _always_ lower `Foo` to `int | float`, because there are also binary
@@ -345,6 +363,10 @@ reveal_type(-Bar(1 + 2j))  # revealed: int | float | complex
 reveal_type(+Bar(1 + 2j))  # revealed: int | float | complex
 ~Bar(1 + 2j)  # error: [unsupported-operator]
 reveal_type(not Bar(1 + 2j))  # revealed: bool
+reveal_type(-FooFoo(Foo(3.14)))  # revealed: int | float
+reveal_type(+FooFoo(Foo(3.14)))  # revealed: int | float
+~FooFoo(Foo(3.14))  # error: [unsupported-operator]
+reveal_type(not FooFoo(Foo(3.14)))  # revealed: bool
 
 class Unary:
     # __pos__ is deliberately left out, giving an error below.

--- a/crates/ty_python_semantic/src/types/newtype.rs
+++ b/crates/ty_python_semantic/src/types/newtype.rs
@@ -206,13 +206,6 @@ impl<'db> NewType<'db> {
         self.try_map_base_class_type(db, |class_type| Some(f(class_type)))
             .unwrap()
     }
-
-    pub(crate) fn base_is_union(self, db: &'db dyn Db) -> bool {
-        match self.base(db) {
-            NewTypeBase::ClassType(_) | NewTypeBase::NewType(_) => false,
-            NewTypeBase::Float | NewTypeBase::Complex => true,
-        }
-    }
 }
 
 pub(crate) fn walk_newtype_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(


### PR DESCRIPTION
This method was part of my implementation of https://github.com/astral-sh/ty/issues/1656, but I found a bug in nested `NewType`s of (surprise) `float` and `complex` that could be fixed by landing it separately, so I want to factor it out into its own PR.