### PR TITLE
[ty] Avoid using `.node()` for detecting `Self`

### DIFF
--- a/crates/ty_python_semantic/src/semantic_index.rs
+++ b/crates/ty_python_semantic/src/semantic_index.rs
@@ -526,6 +526,15 @@ impl<'db> SemanticIndex<'db> {
         self.scopes_by_node.get(&node.node_key()).copied()
     }
 
+    /// Returns the id of the scope that the node identified by `key` creates.
+    ///
+    /// This is useful when you have a [`NodeWithScopeKey`] constructed from an
+    /// [`AstNodeRef`](crate::ast_node_ref::AstNodeRef) and want to avoid loading
+    /// the parsed module just to look up the scope.
+    pub(crate) fn node_scope_by_key(&self, key: NodeWithScopeKey) -> FileScopeId {
+        self.scopes_by_node[&key]
+    }
+
     /// Checks if there is an import of `__future__.annotations` in the global scope, which affects
     /// the logic for type inference.
     pub(super) fn has_future_annotations(&self) -> bool {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -8,8 +8,9 @@ use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use crate::node_key::NodeKey;
 use crate::semantic_index::definition::{Definition, DefinitionKind};
-use crate::semantic_index::scope::{FileScopeId, NodeWithScopeKind, NodeWithScopeRef, ScopeId};
+use crate::semantic_index::scope::{FileScopeId, NodeWithScopeKey, NodeWithScopeKind, ScopeId};
 use crate::semantic_index::{SemanticIndex, semantic_index};
 use crate::types::class::ClassType;
 use crate::types::class_base::ClassBase;
@@ -30,7 +31,6 @@ use crate::types::{
     UnionType, declaration_type, walk_type_var_bounds,
 };
 use crate::{Db, FxOrderMap, FxOrderSet};
-use ruff_db::parsed::parsed_module;
 
 /// Returns an iterator of any generic context introduced by the given scope or any enclosing
 /// scope.
@@ -167,8 +167,11 @@ pub(crate) fn typing_self<'db>(
             let DefinitionKind::Function(func_ref) = def.kind(db) else {
                 return None;
             };
-            let module = parsed_module(db, file).load(db);
-            Some(index.node_scope(NodeWithScopeRef::Function(func_ref.node(&module))))
+            Some(
+                index.node_scope_by_key(NodeWithScopeKey::Function(NodeKey::from_node_ref(
+                    func_ref,
+                ))),
+            )
         })
         .unwrap_or_else(|| scope_id.file_scope_id(db));
 


### PR DESCRIPTION
## Summary

See: https://github.com/astral-sh/ruff/pull/22964#discussion_r2748316990.
