### PR TITLE
[ty] Add tests for variable-length tuple iteration

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -448,6 +448,10 @@ python-version = "3.11"
 from ty_extensions import Intersection
 
 def _(x: Intersection[tuple[int, *tuple[str, ...], bytes], tuple[object, *tuple[str, ...]]]):
+    # After resizing, the intersection becomes:
+    # tuple[int & object, *tuple[str & str, ...], bytes & str]
+    # = tuple[int, *tuple[str, ...], Never]
+    # Iterating yields: int | str | Never = int | str
     for item in x:
         reveal_type(item)  # revealed: int | str
 ```


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Resolves https://github.com/astral-sh/ty/issues/2202.

Both of the following snippets are still not covered.

I'm not sure if these are completely unreachable, or I just can't think of a case to test them.

But the two new added tests add more coverage.

```rs
(TupleSpecBuilder::Fixed(_), TupleSpec::Fixed(_)) => None,
```

```rs
.or_else(|| {
    self_built.resize(db, var.len()).ok().and_then(|resized| {
        TupleSpecBuilder::from(&resized).intersect(db, other)
    })
})
```

## Test Plan

`cargo nextest run -p ty_python_semantic -- mdtest::loops`
