### PR TITLE
[`flake8-boolean-trap`] Add `multiprocessing.Value` to excluded functions for `FBT003`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_boolean_trap/FBT.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_boolean_trap/FBT.py
@@ -73,6 +73,9 @@ sa.func.coalesce(tbl.c.valid, False)
 setVisible(True)
 set_visible(True)
 
+from multiprocessing import Value as m_Value
+m_Value("b", True)
+
 
 class Registry:
     def __init__(self) -> None:

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__FBT001_FBT.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__FBT001_FBT.py.snap
@@ -90,27 +90,27 @@ FBT001 Boolean-typed positional argument in function definition
    |
 
 FBT001 Boolean-typed positional argument in function definition
-  --> FBT.py:90:19
+  --> FBT.py:93:19
    |
-89 |     # FBT001: Boolean positional arg in function definition
-90 |     def foo(self, value: bool) -> None:
+92 |     # FBT001: Boolean positional arg in function definition
+93 |     def foo(self, value: bool) -> None:
    |                   ^^^^^
-91 |         pass
+94 |         pass
    |
 help: Consider adding `@typing.override` if changing the function signature would violate the Liskov Substitution Principle
 
 FBT001 Boolean-typed positional argument in function definition
-   --> FBT.py:100:10
+   --> FBT.py:103:10
     |
-100 | def func(x: Union[list, Optional[int | str | float | bool]]):
+103 | def func(x: Union[list, Optional[int | str | float | bool]]):
     |          ^
-101 |     pass
+104 |     pass
     |
 
 FBT001 Boolean-typed positional argument in function definition
-   --> FBT.py:104:10
+   --> FBT.py:107:10
     |
-104 | def func(x: bool | str):
+107 | def func(x: bool | str):
     |          ^
-105 |     pass
+108 |     pass
     |

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__FBT003_FBT.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__FBT003_FBT.py.snap
@@ -32,37 +32,37 @@ FBT003 Boolean positional value in function call
    |
 
 FBT003 Boolean positional value in function call
-   --> FBT.py:120:10
+   --> FBT.py:123:10
     |
-120 | settings(True)
+123 | settings(True)
     |          ^^^^
     |
 
 FBT003 Boolean positional value in function call
-   --> FBT.py:144:20
+   --> FBT.py:147:20
     |
-142 |     is_foo_or_bar=Case(
-143 |         When(Q(is_foo=True) | Q(is_bar=True)),
-144 |         then=Value(True),
+145 |     is_foo_or_bar=Case(
+146 |         When(Q(is_foo=True) | Q(is_bar=True)),
+147 |         then=Value(True),
     |                    ^^^^
-145 |     ),
-146 |     default=Value(False),
+148 |     ),
+149 |     default=Value(False),
     |
 
 FBT003 Boolean positional value in function call
-   --> FBT.py:146:19
+   --> FBT.py:149:19
     |
-144 |         then=Value(True),
-145 |     ),
-146 |     default=Value(False),
+147 |         then=Value(True),
+148 |     ),
+149 |     default=Value(False),
     |                   ^^^^^
-147 | )
+150 | )
     |
 
 FBT003 Boolean positional value in function call
-   --> FBT.py:156:23
+   --> FBT.py:159:23
     |
-155 | class Settings(BaseSettings):
-156 |     foo: bool = Field(True, exclude=True)
+158 | class Settings(BaseSettings):
+159 |     foo: bool = Field(True, exclude=True)
     |                       ^^^^
     |

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__extend_allowed_callable.snap
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__extend_allowed_callable.snap
@@ -32,8 +32,8 @@ FBT003 Boolean positional value in function call
    |
 
 FBT003 Boolean positional value in function call
-   --> FBT.py:120:10
+   --> FBT.py:123:10
     |
-120 | settings(True)
+123 | settings(True)
     |          ^^^^
     |


### PR DESCRIPTION
> This method is commonly used in multiprocessing.

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This PR excludes ´multiprocessing.Value("b", boolean)` from FBT003.
As a pure wrappper function and its distinctive capitalization it might be worthwhile to allow it.

```python
from multiprocessing import Value
from ctypes import c_bool

mv1 = Value(c_bool, False)
print(mv1)
mv2 = Value("b", False)
print(mv2)
```


Something similar has been done in #6307 after a discussion in #6302.

## Test Plan

<!-- How was it tested? -->
A new test has been added to the test fixtures of FBT and uses `Value` like in `multiprocessing`.

I ran the test locally:

```console
cargo run -p ruff -- check crates/ruff_linter/resources/test/fixtures/flake8_boolean_trap/FBT.py --no-cache --preview --select FBT003
```