### PR TITLE
[ty] remove special handling for `Any()` in match class patterns

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -118,32 +118,6 @@ def f(x: Covariant[int]):
             assert_never(x)
 ```
 
-## Class patterns where the class pattern does not resolve to a class
-
-In general this does not allow for narrowing, but we make an exception for `Any`. This is to support
-[real ecosystem code](https://github.com/jax-ml/jax/blob/d2ce04b6c3d03ae18b145965b8b8b92e09e8009c/jax/_src/pallas/mosaic_gpu/lowering.py#L3372-L3387)
-found in `jax`.
-
-```py
-from typing import Any
-
-X = Any
-
-def f(obj: object):
-    match obj:
-        case int():
-            reveal_type(obj)  # revealed: int
-        case X():
-            reveal_type(obj)  # revealed: Any & ~int
-
-def g(obj: object, Y: Any):
-    match obj:
-        case int():
-            reveal_type(obj)  # revealed: int
-        case Y():
-            reveal_type(obj)  # revealed: Any & ~int
-```
-
 ## Value patterns
 
 Value patterns are evaluated by equality, which is overridable. Therefore successfully matching on

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1497,7 +1497,6 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     .negate_if(self.db, !is_positive)
             }
             dynamic @ Type::Dynamic(_) => dynamic,
-            Type::SpecialForm(SpecialFormType::Any) => Type::any(),
             _ => return None,
         };
 


### PR DESCRIPTION
## Summary

`Any` does not support `isinstance` checks and cannot be used in class patterns. If the arm with `Any()` is hit, it will raise an error at runtime:

```py
[nav] In [1]: from typing import Any
         ...:
         ...: X = Any
         ...:
         ...: def f(obj: object):
         ...:     match obj:
         ...:         case int():
         ...:             ...
         ...:         case X():
         ...:             ...

[ins] In [2]: f("")
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], line 1
----> 1 f("")

Cell In[1], line 9, in f(obj)
      7 case int():
      8     ...
----> 9 case X():
     10     ...

# << snipped for brevity >>

TypeError: typing.Any cannot be used with isinstance()
```

Because this fails at runtime, we should ideally raise a diagnostic on seeing `Any()` in a match pattern. That could potentially be done as part of https://github.com/astral-sh/ty/issues/2592. But for now, this PR only removes the special support that we have.

The special-case handling does not reduce any diagnostics on `jax` as of today either.

## Test Plan

Removed tests :)

