### PR TITLE
[`pyflakes`] `F401` autofix should only add a first-party import to `__all__` if the import is from the same package

### DIFF
--- a/crates/ruff/tests/snapshots/integration_test__rule_f401_output_json.snap
+++ b/crates/ruff/tests/snapshots/integration_test__rule_f401_output_json.snap
@@ -32,7 +32,7 @@ exit_code: 0
   },
   "source_location": {
     "file": "<FILE>",
-    "line": 144
+    "line": 143
   }
 }
 ----- stderr -----

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_same_package/__init__.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_same_package/__init__.py
@@ -1,0 +1,3 @@
+import resources.F401_same_package
+__all__ = ['FOO']
+FOO = 42

--- a/crates/ruff_linter/src/rules/isort/categorize.rs
+++ b/crates/ruff_linter/src/rules/isort/categorize.rs
@@ -150,7 +150,7 @@ pub(crate) fn categorize<'a>(
     import_type
 }
 
-fn same_package(package: Option<PackageRoot<'_>>, module_base: &str) -> bool {
+pub fn same_package(package: Option<PackageRoot<'_>>, module_base: &str) -> bool {
     package
         .map(PackageRoot::path)
         .is_some_and(|package| package.ends_with(module_base))

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -301,6 +301,24 @@ mod tests {
         assert_diagnostics!(snapshot, diagnostics);
     }
 
+    #[test_case(Rule::UnusedImport, Path::new("F401_same_package/__init__.py"))]
+    fn f401_preview_same_package(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!(
+            "preview__{}_{}",
+            rule_code.noqa_code(),
+            path.to_string_lossy()
+        );
+        let diagnostics = test_path(
+            Path::new("pyflakes").join(path).as_path(),
+            &LinterSettings {
+                preview: PreviewMode::Enabled,
+                ..LinterSettings::for_rule(rule_code)
+            },
+        )?;
+        assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
+
     // Regression test for https://github.com/astral-sh/ruff/issues/12897
     #[test_case(Rule::UnusedImport, Path::new("F401_33/__init__.py"))]
     fn f401_preview_local_init_import(rule_code: Rule, path: &Path) -> Result<()> {

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -408,7 +408,10 @@ pub(crate) fn unused_import(checker: &Checker, scope: &Scope) {
                     UnusedImportContext::ExceptHandler
                 } else if in_init
                     && binding.scope.is_global()
-                    && is_first_party(&binding.import, checker)
+                    && isort::categorize::same_package(
+                        checker.package(),
+                        binding.import.source_name()[0],
+                    )
                     // In the situation where we have
                     // ```
                     // import a.b # <-- at this binding
@@ -422,10 +425,7 @@ pub(crate) fn unused_import(checker: &Checker, scope: &Scope) {
                     // So we look up the name `a` and see if it has
                     // a reference in `__all__`.
                     && (!is_refined_submodule_import_match_enabled(checker.settings())||!symbol_used_in_dunder_all(checker.semantic(), &binding))
-                    && isort::categorize::same_package(
-                        checker.package(),
-                        binding.import.source_name()[0],
-                    )
+
                 {
                     UnusedImportContext::DunderInitSamePackage {
                         dunder_all_count: DunderAllCount::from(dunder_all_exprs.len()),

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -424,7 +424,7 @@ pub(crate) fn unused_import(checker: &Checker, scope: &Scope) {
                     && (!is_refined_submodule_import_match_enabled(checker.settings())||!symbol_used_in_dunder_all(checker.semantic(), &binding))
                     && isort::categorize::same_package(
                         checker.package(),
-                        &binding.import.source_name()[0],
+                        binding.import.source_name()[0],
                     )
                 {
                     UnusedImportContext::DunderInitSamePackage {

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -4,6 +4,15 @@ use std::iter;
 use anyhow::{Result, anyhow, bail};
 use std::collections::BTreeMap;
 
+use crate::checkers::ast::Checker;
+use crate::fix;
+use crate::preview::{
+    is_dunder_init_fix_unused_import_enabled, is_refined_submodule_import_match_enabled,
+};
+use crate::registry::Rule;
+use crate::rules::isort;
+use crate::settings::LinterSettings;
+use crate::{Applicability, Fix, FixAvailability, Violation};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::name::{QualifiedName, QualifiedNameBuilder};
 use ruff_python_ast::{self as ast, Stmt};
@@ -12,16 +21,6 @@ use ruff_python_semantic::{
     ScopeId, SemanticModel, SubmoduleImport,
 };
 use ruff_text_size::{Ranged, TextRange};
-
-use crate::checkers::ast::Checker;
-use crate::fix;
-use crate::preview::{
-    is_dunder_init_fix_unused_import_enabled, is_refined_submodule_import_match_enabled,
-};
-use crate::registry::Rule;
-use crate::rules::{isort, isort::ImportSection, isort::ImportType};
-use crate::settings::LinterSettings;
-use crate::{Applicability, Fix, FixAvailability, Violation};
 
 /// ## What it does
 /// Checks for unused imports.

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -267,26 +267,6 @@ enum UnusedImportContext {
     Other,
 }
 
-fn is_first_party(import: &AnyImport, checker: &Checker) -> bool {
-    let source_name = import.source_name().join(".");
-    let category = isort::categorize(
-        &source_name,
-        import.qualified_name().is_unresolved_import(),
-        &checker.settings().src,
-        checker.package(),
-        checker.settings().isort.detect_same_package,
-        &checker.settings().isort.known_modules,
-        checker.target_version(),
-        checker.settings().isort.no_sections,
-        &checker.settings().isort.section_order,
-        &checker.settings().isort.default_section,
-    );
-    matches! {
-        category,
-        ImportSection::Known(ImportType::FirstParty | ImportType::LocalFolder)
-    }
-}
-
 /// Find the `Expr` for top-level `__all__` bindings.
 fn find_dunder_all_exprs<'a>(semantic: &'a SemanticModel) -> Vec<&'a ast::Expr> {
     semantic

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_deprecated_option_F401_24____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_deprecated_option_F401_24____init__.py.snap
@@ -17,7 +17,7 @@ help: Remove unused import: `sys`
 21 | # first-party
 note: This is an unsafe fix and may change runtime behavior
 
-F401 [*] `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.unused` imported but unused
   --> __init__.py:33:15
    |
 33 | from . import unused  # F401: change to redundant alias
@@ -33,7 +33,7 @@ help: Remove unused import: `.unused`
 35 | from . import renamed as bees  # F401: no fix
 note: This is an unsafe fix and may change runtime behavior
 
-F401 [*] `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.renamed` imported but unused
   --> __init__.py:36:26
    |
 36 | from . import renamed as bees  # F401: no fix

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_deprecated_option_F401_25__all_nonempty____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_deprecated_option_F401_25__all_nonempty____init__.py.snap
@@ -17,7 +17,7 @@ help: Remove unused import: `sys`
 21 | # first-party
 note: This is an unsafe fix and may change runtime behavior
 
-F401 [*] `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.unused` imported but unused
   --> __init__.py:36:15
    |
 36 | from . import unused  # F401: add to __all__
@@ -33,7 +33,7 @@ help: Remove unused import: `.unused`
 38 | from . import renamed as bees  # F401: add to __all__
 note: This is an unsafe fix and may change runtime behavior
 
-F401 [*] `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.renamed` imported but unused
   --> __init__.py:39:26
    |
 39 | from . import renamed as bees  # F401: add to __all__

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_deprecated_option_F401_26__all_empty____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_deprecated_option_F401_26__all_empty____init__.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F401 [*] `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.unused` imported but unused
  --> __init__.py:5:15
   |
 5 | from . import unused  # F401: add to __all__
@@ -17,7 +17,7 @@ help: Remove unused import: `.unused`
 7 | from . import renamed as bees  # F401: add to __all__
 note: This is an unsafe fix and may change runtime behavior
 
-F401 [*] `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.renamed` imported but unused
  --> __init__.py:8:26
   |
 8 | from . import renamed as bees  # F401: add to __all__

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_deprecated_option_F401_27__all_mistyped____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_deprecated_option_F401_27__all_mistyped____init__.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F401 [*] `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.unused` imported but unused
  --> __init__.py:5:15
   |
 5 | from . import unused  # F401: recommend add to all w/o fix
@@ -17,7 +17,7 @@ help: Remove unused import: `.unused`
 7 | from . import renamed as bees  # F401: recommend add to all w/o fix
 note: This is an unsafe fix and may change runtime behavior
 
-F401 [*] `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.renamed` imported but unused
  --> __init__.py:8:26
   |
 8 | from . import renamed as bees  # F401: recommend add to all w/o fix

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_deprecated_option_F401_28__all_multiple____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_deprecated_option_F401_28__all_multiple____init__.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F401 [*] `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.unused` imported but unused
  --> __init__.py:5:15
   |
 5 | from . import unused, renamed as bees  # F401: add to __all__
@@ -17,7 +17,7 @@ help: Remove unused import
 7 | __all__ = [];
 note: This is an unsafe fix and may change runtime behavior
 
-F401 [*] `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.renamed` imported but unused
  --> __init__.py:5:34
   |
 5 | from . import unused, renamed as bees  # F401: add to __all__

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_deprecated_option_F401_29__all_conditional____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_deprecated_option_F401_29__all_conditional____init__.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F401 [*] `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.unused` imported but unused
   --> __init__.py:8:15
    |
  6 | import sys
@@ -22,7 +22,7 @@ help: Remove unused import
 11 |     from . import also_exported
 note: This is an unsafe fix and may change runtime behavior
 
-F401 [*] `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.renamed` imported but unused
   --> __init__.py:8:44
    |
  6 | import sys

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_stable_F401_24____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_stable_F401_24____init__.py.snap
@@ -9,18 +9,18 @@ F401 `sys` imported but unused
    |
 help: Remove unused import: `sys`
 
-F401 `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 `.unused` imported but unused
   --> __init__.py:33:15
    |
 33 | from . import unused  # F401: change to redundant alias
    |               ^^^^^^
    |
-help: Use an explicit re-export: `unused as unused`
+help: Remove unused import: `.unused`
 
-F401 `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 `.renamed` imported but unused
   --> __init__.py:36:26
    |
 36 | from . import renamed as bees  # F401: no fix
    |                          ^^^^
    |
-help: Use an explicit re-export: `renamed as renamed`
+help: Remove unused import: `.renamed`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_stable_F401_25__all_nonempty____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_stable_F401_25__all_nonempty____init__.py.snap
@@ -9,18 +9,18 @@ F401 `sys` imported but unused
    |
 help: Remove unused import: `sys`
 
-F401 `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 `.unused` imported but unused
   --> __init__.py:36:15
    |
 36 | from . import unused  # F401: add to __all__
    |               ^^^^^^
    |
-help: Add unused import `unused` to __all__
+help: Remove unused import: `.unused`
 
-F401 `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 `.renamed` imported but unused
   --> __init__.py:39:26
    |
 39 | from . import renamed as bees  # F401: add to __all__
    |                          ^^^^
    |
-help: Add unused import `bees` to __all__
+help: Remove unused import: `.renamed`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_stable_F401_26__all_empty____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_stable_F401_26__all_empty____init__.py.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F401 `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 `.unused` imported but unused
  --> __init__.py:5:15
   |
 5 | from . import unused  # F401: add to __all__
   |               ^^^^^^
   |
-help: Add unused import `unused` to __all__
+help: Remove unused import: `.unused`
 
-F401 `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 `.renamed` imported but unused
  --> __init__.py:8:26
   |
 8 | from . import renamed as bees  # F401: add to __all__
   |                          ^^^^
   |
-help: Add unused import `bees` to __all__
+help: Remove unused import: `.renamed`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_stable_F401_27__all_mistyped____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_stable_F401_27__all_mistyped____init__.py.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F401 `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 `.unused` imported but unused
  --> __init__.py:5:15
   |
 5 | from . import unused  # F401: recommend add to all w/o fix
   |               ^^^^^^
   |
-help: Add unused import `unused` to __all__
+help: Remove unused import: `.unused`
 
-F401 `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 `.renamed` imported but unused
  --> __init__.py:8:26
   |
 8 | from . import renamed as bees  # F401: recommend add to all w/o fix
   |                          ^^^^
   |
-help: Add unused import `bees` to __all__
+help: Remove unused import: `.renamed`

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_stable_F401_28__all_multiple____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_stable_F401_28__all_multiple____init__.py.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F401 `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 `.unused` imported but unused
  --> __init__.py:5:15
   |
 5 | from . import unused, renamed as bees  # F401: add to __all__
   |               ^^^^^^
   |
-help: Add unused import `unused` to __all__
+help: Remove unused import
 
-F401 `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 `.renamed` imported but unused
  --> __init__.py:5:34
   |
 5 | from . import unused, renamed as bees  # F401: add to __all__
   |                                  ^^^^
   |
-help: Add unused import `bees` to __all__
+help: Remove unused import

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_stable_F401_29__all_conditional____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_stable_F401_29__all_conditional____init__.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F401 `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 `.unused` imported but unused
   --> __init__.py:8:15
    |
  6 | import sys
@@ -13,7 +13,7 @@ F401 `.unused` imported but unused; consider removing, adding to `__all__`, or u
    |
 help: Remove unused import
 
-F401 `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 `.renamed` imported but unused
   --> __init__.py:8:44
    |
  6 | import sys

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__f401_preview_first_party_submodule_dunder_all.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__f401_preview_first_party_submodule_dunder_all.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F401 [*] `submodule.a` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `submodule.a` imported but unused
  --> __init__.py:2:8
   |
 2 | import submodule.a
@@ -9,9 +9,9 @@ F401 [*] `submodule.a` imported but unused; consider removing, adding to `__all_
 3 | __all__ = ['FOO']
 4 | FOO = 42
   |
-help: Add `submodule` to __all__
+help: Remove unused import: `submodule.a`
 1 | 
-2 | import submodule.a
-  - __all__ = ['FOO']
-3 + __all__ = ['FOO', 'submodule']
-4 | FOO = 42
+  - import submodule.a
+2 | __all__ = ['FOO']
+3 | FOO = 42
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__f401_preview_first_party_submodule_no_dunder_all.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__f401_preview_first_party_submodule_no_dunder_all.snap
@@ -1,10 +1,12 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F401 `submodule.a` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `submodule.a` imported but unused
  --> __init__.py:1:8
   |
 1 | import submodule.a
   |        ^^^^^^^^^^^
   |
-help: Use an explicit re-export: `import submodule as submodule; import submodule.a`
+help: Remove unused import: `submodule.a`
+  - import submodule.a
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__preview__F401_F401_24____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__preview__F401_F401_24____init__.py.snap
@@ -17,26 +17,31 @@ help: Remove unused import: `sys`
 21 | # first-party
 note: This is an unsafe fix and may change runtime behavior
 
-F401 [*] `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.unused` imported but unused
   --> __init__.py:33:15
    |
 33 | from . import unused  # F401: change to redundant alias
    |               ^^^^^^
    |
-help: Use an explicit re-export: `unused as unused`
+help: Remove unused import: `.unused`
 30 | from . import aliased as aliased  # Ok: is redundant alias
 31 | 
 32 | 
    - from . import unused  # F401: change to redundant alias
-33 + from . import unused as unused  # F401: change to redundant alias
+33 | 
 34 | 
-35 | 
-36 | from . import renamed as bees  # F401: no fix
+35 | from . import renamed as bees  # F401: no fix
+note: This is an unsafe fix and may change runtime behavior
 
-F401 `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.renamed` imported but unused
   --> __init__.py:36:26
    |
 36 | from . import renamed as bees  # F401: no fix
    |                          ^^^^
    |
-help: Use an explicit re-export: `renamed as renamed`
+help: Remove unused import: `.renamed`
+33 | from . import unused  # F401: change to redundant alias
+34 | 
+35 | 
+   - from . import renamed as bees  # F401: no fix
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__preview__F401_F401_25__all_nonempty____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__preview__F401_F401_25__all_nonempty____init__.py.snap
@@ -17,28 +17,34 @@ help: Remove unused import: `sys`
 21 | # first-party
 note: This is an unsafe fix and may change runtime behavior
 
-F401 [*] `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.unused` imported but unused
   --> __init__.py:36:15
    |
 36 | from . import unused  # F401: add to __all__
    |               ^^^^^^
    |
-help: Add unused import `unused` to __all__
-39 | from . import renamed as bees  # F401: add to __all__
-40 | 
-41 | 
-   - __all__ = ["argparse", "exported"]
-42 + __all__ = ["argparse", "exported", "unused"]
+help: Remove unused import: `.unused`
+33 | from . import exported  # Ok: is exported in __all__
+34 | 
+35 | 
+   - from . import unused  # F401: add to __all__
+36 | 
+37 | 
+38 | from . import renamed as bees  # F401: add to __all__
+note: This is an unsafe fix and may change runtime behavior
 
-F401 [*] `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.renamed` imported but unused
   --> __init__.py:39:26
    |
 39 | from . import renamed as bees  # F401: add to __all__
    |                          ^^^^
    |
-help: Add unused import `bees` to __all__
-39 | from . import renamed as bees  # F401: add to __all__
+help: Remove unused import: `.renamed`
+36 | from . import unused  # F401: add to __all__
+37 | 
+38 | 
+   - from . import renamed as bees  # F401: add to __all__
+39 | 
 40 | 
-41 | 
-   - __all__ = ["argparse", "exported"]
-42 + __all__ = ["argparse", "exported", "bees"]
+41 | __all__ = ["argparse", "exported"]
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__preview__F401_F401_26__all_empty____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__preview__F401_F401_26__all_empty____init__.py.snap
@@ -1,28 +1,34 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F401 [*] `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.unused` imported but unused
  --> __init__.py:5:15
   |
 5 | from . import unused  # F401: add to __all__
   |               ^^^^^^
   |
-help: Add unused import `unused` to __all__
-8  | from . import renamed as bees  # F401: add to __all__
-9  | 
-10 | 
-   - __all__ = []
-11 + __all__ = ["unused"]
+help: Remove unused import: `.unused`
+2 | """
+3 | 
+4 | 
+  - from . import unused  # F401: add to __all__
+5 | 
+6 | 
+7 | from . import renamed as bees  # F401: add to __all__
+note: This is an unsafe fix and may change runtime behavior
 
-F401 [*] `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.renamed` imported but unused
  --> __init__.py:8:26
   |
 8 | from . import renamed as bees  # F401: add to __all__
   |                          ^^^^
   |
-help: Add unused import `bees` to __all__
-8  | from . import renamed as bees  # F401: add to __all__
+help: Remove unused import: `.renamed`
+5  | from . import unused  # F401: add to __all__
+6  | 
+7  | 
+   - from . import renamed as bees  # F401: add to __all__
+8  | 
 9  | 
-10 | 
-   - __all__ = []
-11 + __all__ = ["bees"]
+10 | __all__ = []
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__preview__F401_F401_27__all_mistyped____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__preview__F401_F401_27__all_mistyped____init__.py.snap
@@ -1,18 +1,34 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F401 `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.unused` imported but unused
  --> __init__.py:5:15
   |
 5 | from . import unused  # F401: recommend add to all w/o fix
   |               ^^^^^^
   |
-help: Add unused import `unused` to __all__
+help: Remove unused import: `.unused`
+2 | """
+3 | 
+4 | 
+  - from . import unused  # F401: recommend add to all w/o fix
+5 | 
+6 | 
+7 | from . import renamed as bees  # F401: recommend add to all w/o fix
+note: This is an unsafe fix and may change runtime behavior
 
-F401 `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.renamed` imported but unused
  --> __init__.py:8:26
   |
 8 | from . import renamed as bees  # F401: recommend add to all w/o fix
   |                          ^^^^
   |
-help: Add unused import `bees` to __all__
+help: Remove unused import: `.renamed`
+5  | from . import unused  # F401: recommend add to all w/o fix
+6  | 
+7  | 
+   - from . import renamed as bees  # F401: recommend add to all w/o fix
+8  | 
+9  | 
+10 | __all__ = None
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__preview__F401_F401_28__all_multiple____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__preview__F401_F401_28__all_multiple____init__.py.snap
@@ -1,28 +1,34 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F401 [*] `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.unused` imported but unused
  --> __init__.py:5:15
   |
 5 | from . import unused, renamed as bees  # F401: add to __all__
   |               ^^^^^^
   |
-help: Add unused import `unused` to __all__
-5 | from . import unused, renamed as bees  # F401: add to __all__
+help: Remove unused import
+2 | """
+3 | 
+4 | 
+  - from . import unused, renamed as bees  # F401: add to __all__
+5 | 
 6 | 
-7 | 
-  - __all__ = [];
-8 + __all__ = ["bees", "unused"];
+7 | __all__ = [];
+note: This is an unsafe fix and may change runtime behavior
 
-F401 [*] `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.renamed` imported but unused
  --> __init__.py:5:34
   |
 5 | from . import unused, renamed as bees  # F401: add to __all__
   |                                  ^^^^
   |
-help: Add unused import `bees` to __all__
-5 | from . import unused, renamed as bees  # F401: add to __all__
+help: Remove unused import
+2 | """
+3 | 
+4 | 
+  - from . import unused, renamed as bees  # F401: add to __all__
+5 | 
 6 | 
-7 | 
-  - __all__ = [];
-8 + __all__ = ["bees", "unused"];
+7 | __all__ = [];
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__preview__F401_F401_29__all_conditional____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__preview__F401_F401_29__all_conditional____init__.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F401 `.unused` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.unused` imported but unused
   --> __init__.py:8:15
    |
  6 | import sys
@@ -12,8 +12,17 @@ F401 `.unused` imported but unused; consider removing, adding to `__all__`, or u
 10 | if sys.version_info > (3, 9):
    |
 help: Remove unused import
+5  | 
+6  | import sys
+7  | 
+   - from . import unused, exported, renamed as bees
+8  + from . import exported
+9  | 
+10 | if sys.version_info > (3, 9):
+11 |     from . import also_exported
+note: This is an unsafe fix and may change runtime behavior
 
-F401 `.renamed` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+F401 [*] `.renamed` imported but unused
   --> __init__.py:8:44
    |
  6 | import sys
@@ -24,3 +33,12 @@ F401 `.renamed` imported but unused; consider removing, adding to `__all__`, or 
 10 | if sys.version_info > (3, 9):
    |
 help: Remove unused import
+5  | 
+6  | import sys
+7  | 
+   - from . import unused, exported, renamed as bees
+8  + from . import exported
+9  | 
+10 | if sys.version_info > (3, 9):
+11 |     from . import also_exported
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__preview__F401_F401_same_package____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__preview__F401_F401_same_package____init__.py.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+F401 [*] `resources.F401_same_package` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+ --> __init__.py:1:8
+  |
+1 | import resources.F401_same_package
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2 | __all__ = ['FOO']
+3 | FOO = 42
+  |
+help: Add `resources` to __all__
+1 | import resources.F401_same_package
+  - __all__ = ['FOO']
+2 + __all__ = ['FOO', 'resources']
+3 | FOO = 42


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This PR fixes #13008 

## Test Plan

<!-- How was it tested? -->

This changes a lot of snapshots 20+, currently have not included , making it a draft PR