### PR TITLE
Fix link to Sphinx code block directives

### DIFF
--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -147,7 +147,7 @@ assumed to be Python code examples and also formatted.
 * reStructuredText [literal blocks]. While literal blocks may contain things
 other than Python, this is meant to reflect a long-standing convention in the
 Python ecosystem where literal blocks often contain Python code.
-* reStructuredText [`code-block` and `sourcecode` directives]. As with
+* reStructuredText [`code-block` and `sourcecode` directives][directives]. As with
 Markdown, the language names recognized for Python are `python`, `py`,
 `python3`, or `py3`.
 
@@ -223,7 +223,7 @@ def f(x):
 [doctest]: https://docs.python.org/3/library/doctest.html
 [fenced code blocks]: https://spec.commonmark.org/0.30/#fenced-code-blocks
 [literal blocks]: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#literal-blocks
-[`code-block` and `sourcecode` directives]: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block
+[directives]: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block
 
 ## Format suppression
 


### PR DESCRIPTION
Summary
--

I noticed this while reviewing #22990. I'm not really sure why the current version doesn't work, but the new one definitely does.

Test Plan
--

[Before](https://docs.astral.sh/ruff/formatter/#docstring-formatting):

<img width="457" height="77" alt="image" src="https://github.com/user-attachments/assets/3d4394b7-eadf-41ec-81c9-cea6190fa0bb" />


After:

<img width="493" height="84" alt="image" src="https://github.com/user-attachments/assets/66f0700c-9312-40b9-b3ae-11edcaec7562" />
