### PR TITLE
[ty] fix(conformance): Add tests directory as extra search path

### DIFF
--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -454,7 +454,11 @@ def collect_ty_diagnostics(
     source: Source,
     test_files: Sequence[Path],
     python_version: str = "3.12",
+    extra_search_paths: Sequence[Path] = (),
 ) -> list[Diagnostic]:
+    extra_search_path_args = [
+        f"--extra-search-path={path}" for path in extra_search_paths
+    ]
     process = subprocess.run(
         [
             *ty_path,
@@ -464,6 +468,7 @@ def collect_ty_diagnostics(
             "--ignore=assert-type-unspellable-subtype",
             "--error=invalid-legacy-positional-parameter",
             "--exit-zero",
+            *extra_search_path_args,
             *map(str, test_files),
         ],
         capture_output=True,
@@ -819,11 +824,14 @@ def main():
 
     expected = collect_expected_diagnostics(test_files)
 
+    extra_search_paths = [tests_dir / "tests"]
+
     old = collect_ty_diagnostics(
         ty_path=args.old_ty,
         test_files=test_files,
         source=Source.OLD,
         python_version=args.python_version,
+        extra_search_paths=extra_search_paths,
     )
 
     new = collect_ty_diagnostics(
@@ -831,6 +839,7 @@ def main():
         test_files=test_files,
         source=Source.NEW,
         python_version=args.python_version,
+        extra_search_paths=extra_search_paths,
     )
 
     grouped = group_diagnostics_by_key(


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

The conformance test suite has some underscore-prefixed helper files from which some of the test files import items. This change adds the tests/ directory as a search path so that these imports no longer raise spurious unresolved-import diagnostics.

## Test Plan

<!-- How was it tested? -->

Running `scripts/conformance.py` after this change removes any unresolved-import diagnostics and improves the number of true positives.


<details>

# Command

```
uv run --no-project --python 3.12 scripts/conformance.py --tests-path ../typing/conformance/ --old-ty uvx ty@0.0.6 --output scripts/test.md
```

## Before

### Summary

| Metric | Old | New | Diff | Outcome |
|--------|-----|-----|------|---------|
| True Positives  | 686 | 747 | +61 | ⏫ (✅) |
| False Positives | 244 | 201 | -43 | ⏬ (✅) |
| False Negatives | 387 | 332 | -55 | ⏬ (✅) |
| Total Diagnostics | 930 | 948 | +18 | ⏫ |
| Precision | 73.76% | 78.80% | +5.03% | ⏫ (✅) |
| Recall | 63.93% | 69.23% | +5.30% | ⏫ (✅) |

## After

### Summary

| Metric | Old | New | Diff | Outcome |
|--------|-----|-----|------|---------|
| True Positives  | 691 | 752 | +61 | ⏫ (✅) |
| False Positives | 234 | 191 | -43 | ⏬ (✅) |
| False Negatives | 383 | 328 | -55 | ⏬ (✅) |
| Total Diagnostics | 925 | 943 | +18 | ⏫ |
| Precision | 74.70% | 79.75% | +5.04% | ⏫ (✅) |
| Recall | 64.34% | 69.63% | +5.29% | ⏫ (✅) |

</details>