### PR TITLE
Fix F401 infinite loop when adding duplicate symbols to __all__

### DIFF
--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -601,6 +601,7 @@ fn fix_by_reexporting<'a>(
             bail!("Expected import bindings");
         }
         imports.sort_unstable();
+        imports.dedup(); // Remove duplicate symbols to prevent infinite loops
         imports
     };
 


### PR DESCRIPTION
## Summary

Fixes #22221

Running `ruff check --fix` could enter an infinite loop when fixing F401 (unused imports) in `__init__.py` files that combine star imports with explicit imports of the same symbol.

## Problem

When adding symbols to `__all__` in `fix_by_reexporting`, duplicate symbols could be collected (e.g., when a module has both `from foo import *` and `from foo import bar`). Without deduplication, ruff would repeatedly add the same symbol to `__all__`, creating an infinite fix loop.

## Changes

Added a `dedup()` call after `sort_unstable()` in `fix_by_reexporting` to remove duplicate symbols before adding them to `__all__`.

## Test Plan

Tested with:
```python
# __init__.py
from .foo import *
from .foo import bar

__all__ = []
```

Before this fix, `ruff check --fix --unsafe-fixes` would loop infinitely. After this fix, it correctly adds each symbol once.