### PR TITLE
[ty] ecosystem-analyzer: Support bare git repositories

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -73,7 +73,7 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@2e1816eac09c90140b1ba51d19afc5f59da460f5"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@c6ccb9fc56755ccd826721a24f53fc871a603474"
 
           ecosystem-analyzer \
             --repository ruff \

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -56,7 +56,7 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@2e1816eac09c90140b1ba51d19afc5f59da460f5"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@c6ccb9fc56755ccd826721a24f53fc871a603474"
 
           ecosystem-analyzer \
             --verbose \


### PR DESCRIPTION
This pulls in https://github.com/astral-sh/ecosystem-analyzer/commit/c6ccb9fc56755ccd826721a24f53fc871a603474, which updates the ecosystem-analyzer to work with bare `ty` repos. This should have no affect on our CI job, since we don't use bare repos there, but I want to pull in the update anyway to (a) make sure it didn't break anything and (b) make sure we're not using a stale dependency.