### PR TITLE
[ty] Fix `__contains__` to respect descriptors

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/comparison/instances/membership_test.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/instances/membership_test.md
@@ -65,6 +65,27 @@ reveal_type(42 in A())  # revealed: bool
 reveal_type(42 not in A())  # revealed: bool
 ```
 
+## `__contains__` implemented via descriptor
+
+If `__contains__` is implemented as a descriptor (e.g., a class with `__get__` that returns a
+callable), the descriptor protocol should be properly invoked:
+
+```py
+class Target:
+    def __call__(self, item: object) -> bool:
+        return True
+
+class Descriptor:
+    def __get__(self, instance: object, owner: type) -> Target:
+        return Target()
+
+class Container:
+    __contains__: Descriptor = Descriptor()
+
+reveal_type(1 in Container())  # revealed: bool
+reveal_type("hello" not in Container())  # revealed: bool
+```
+
 ## Wrong Return Type
 
 Python coerces the results of containment checks to `bool`, even if `__contains__` returns a

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -14446,26 +14446,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> Result<Type<'db>, UnsupportedComparisonError<'db>> {
         let db = self.db();
 
-        let contains_dunder = right.class_member(db, "__contains__".into()).place;
-        let compare_result_opt = match contains_dunder {
-            Place::Defined(DefinedPlace {
-                ty: contains_dunder,
-                definedness: Definedness::AlwaysDefined,
-                ..
-            }) => {
-                // If `__contains__` is available, it is used directly for the membership test.
-                contains_dunder
-                    .try_call(db, &CallArguments::positional([right, left]))
-                    .map(|bindings| bindings.return_type(db))
-                    .ok()
-            }
-            _ => {
-                // iteration-based membership test
-                right
-                    .try_iterate(db)
-                    .map(|_| KnownClass::Bool.to_instance(db))
-                    .ok()
-            }
+        let compare_result_opt = match right.try_call_dunder(
+            db,
+            "__contains__",
+            CallArguments::positional([left]),
+            TypeContext::default(),
+        ) {
+            // If `__contains__` is available, it is used directly for the membership test.
+            Ok(bindings) => Some(bindings.return_type(db)),
+            // If `__contains__` is not available or possibly unbound,
+            // fall back to iteration-based membership test.
+            Err(CallDunderError::MethodNotAvailable | CallDunderError::PossiblyUnbound(_)) => right
+                .try_iterate(db)
+                .map(|_| KnownClass::Bool.to_instance(db))
+                .ok(),
+            // `__contains__` exists but can't be called with the given arguments.
+            Err(CallDunderError::CallError(..)) => None,
         };
 
         compare_result_opt


### PR DESCRIPTION
## Summary

Matches the pattern we use for `__getitem__`.

See: https://github.com/astral-sh/ty/issues/190.
