### PR TITLE
feat: added new rule for double indentation on function parameters: f…

### DIFF
--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_extend_from_shared_config.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_extend_from_shared_config.snap
@@ -276,6 +276,7 @@ formatter.quote_style = double
 formatter.magic_trailing_comma = respect
 formatter.docstring_code_format = disabled
 formatter.docstring_code_line_width = dynamic
+formatter.function_parameter_indent = single
 
 # Analyze Settings
 analyze.exclude = []

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool.snap
@@ -278,6 +278,7 @@ formatter.quote_style = double
 formatter.magic_trailing_comma = respect
 formatter.docstring_code_format = disabled
 formatter.docstring_code_line_width = dynamic
+formatter.function_parameter_indent = single
 
 # Analyze Settings
 analyze.exclude = []

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_preview_enabled.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_preview_enabled.snap
@@ -280,6 +280,7 @@ formatter.quote_style = double
 formatter.magic_trailing_comma = respect
 formatter.docstring_code_format = disabled
 formatter.docstring_code_line_width = dynamic
+formatter.function_parameter_indent = single
 
 # Analyze Settings
 analyze.exclude = []

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_target_version_override.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_target_version_override.snap
@@ -280,6 +280,7 @@ formatter.quote_style = double
 formatter.magic_trailing_comma = respect
 formatter.docstring_code_format = disabled
 formatter.docstring_code_line_width = dynamic
+formatter.function_parameter_indent = single
 
 # Analyze Settings
 analyze.exclude = []

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above.snap
@@ -277,6 +277,7 @@ formatter.quote_style = double
 formatter.magic_trailing_comma = respect
 formatter.docstring_code_format = disabled
 formatter.docstring_code_line_width = dynamic
+formatter.function_parameter_indent = single
 
 # Analyze Settings
 analyze.exclude = []

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above_with_tool.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above_with_tool.snap
@@ -278,6 +278,7 @@ formatter.quote_style = double
 formatter.magic_trailing_comma = respect
 formatter.docstring_code_format = disabled
 formatter.docstring_code_line_width = dynamic
+formatter.function_parameter_indent = single
 
 # Analyze Settings
 analyze.exclude = []

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above-2.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above-2.snap
@@ -276,6 +276,7 @@ formatter.quote_style = double
 formatter.magic_trailing_comma = respect
 formatter.docstring_code_format = disabled
 formatter.docstring_code_line_width = dynamic
+formatter.function_parameter_indent = single
 
 # Analyze Settings
 analyze.exclude = []

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above.snap
@@ -276,6 +276,7 @@ formatter.quote_style = double
 formatter.magic_trailing_comma = respect
 formatter.docstring_code_format = disabled
 formatter.docstring_code_line_width = dynamic
+formatter.function_parameter_indent = single
 
 # Analyze Settings
 analyze.exclude = []

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_no_target_fallback.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_no_target_fallback.snap
@@ -276,6 +276,7 @@ formatter.quote_style = double
 formatter.magic_trailing_comma = respect
 formatter.docstring_code_format = disabled
 formatter.docstring_code_line_width = dynamic
+formatter.function_parameter_indent = single
 
 # Analyze Settings
 analyze.exclude = []

--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -389,6 +389,7 @@ formatter.quote_style = double
 formatter.magic_trailing_comma = respect
 formatter.docstring_code_format = disabled
 formatter.docstring_code_line_width = dynamic
+formatter.function_parameter_indent = single
 
 # Analyze Settings
 analyze.exclude = []

--- a/crates/ruff/tests/snapshots/show_settings__display_settings_from_nested_directory.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_settings_from_nested_directory.snap
@@ -397,6 +397,7 @@ formatter.quote_style = double
 formatter.magic_trailing_comma = respect
 formatter.docstring_code_format = disabled
 formatter.docstring_code_line_width = dynamic
+formatter.function_parameter_indent = single
 
 # Analyze Settings
 analyze.exclude = []

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -40,7 +40,7 @@ use ruff_linter::{
 };
 use ruff_python_ast as ast;
 use ruff_python_formatter::{
-    DocstringCode, DocstringCodeLineWidth, MagicTrailingComma, QuoteStyle,
+    DocstringCode, DocstringCodeLineWidth, FunctionParameterIndent, MagicTrailingComma, QuoteStyle,
 };
 
 use crate::options::{
@@ -206,6 +206,9 @@ impl Configuration {
             docstring_code_line_width: format
                 .docstring_code_line_width
                 .unwrap_or(format_defaults.docstring_code_line_width),
+            function_parameter_indent: format
+                .function_parameter_indent
+                .unwrap_or(format_defaults.function_parameter_indent),
         };
 
         let analyze = self.analyze;
@@ -1237,6 +1240,7 @@ pub struct FormatConfiguration {
     pub line_ending: Option<LineEnding>,
     pub docstring_code_format: Option<DocstringCode>,
     pub docstring_code_line_width: Option<DocstringCodeLineWidth>,
+    pub function_parameter_indent: Option<FunctionParameterIndent>,
 }
 
 impl FormatConfiguration {
@@ -1273,6 +1277,7 @@ impl FormatConfiguration {
                 }
             }),
             docstring_code_line_width: options.docstring_code_line_length,
+            function_parameter_indent: options.function_parameter_indent,
         })
     }
 
@@ -1290,6 +1295,9 @@ impl FormatConfiguration {
             docstring_code_line_width: self
                 .docstring_code_line_width
                 .or(config.docstring_code_line_width),
+            function_parameter_indent: self
+                .function_parameter_indent
+                .or(config.function_parameter_indent),
         }
     }
 }

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -38,7 +38,7 @@ use ruff_linter::{RuleSelector, warn_user_once};
 use ruff_macros::{CombineOptions, OptionsMetadata};
 use ruff_options_metadata::{OptionsMetadata, Visit};
 use ruff_python_ast::name::Name;
-use ruff_python_formatter::{DocstringCodeLineWidth, QuoteStyle};
+use ruff_python_formatter::{DocstringCodeLineWidth, FunctionParameterIndent, QuoteStyle};
 use ruff_python_semantic::NameImports;
 use ruff_python_stdlib::identifiers::is_identifier;
 
@@ -3638,6 +3638,43 @@ pub struct FormatOptions {
         "#
     )]
     pub quote_style: Option<QuoteStyle>,
+
+    /// Controls how many indentation levels are used when a function or method
+    /// signature wraps and its parameters are formatted on multiple lines.
+    ///
+    /// With `function-parameter-indent = "single"` (the default), parameters are
+    /// indented one level from the opening parenthesis:
+    ///
+    /// ```python
+    /// async def test_delay_in_plan(
+    ///     stepping_orchestrator: SteppingOrchestrator,
+    ///     mock_http_client: MockHttpClient,
+    ///     operation_responder: OperationResponder,
+    /// ) -> None:
+    ///     ...
+    /// ```
+    ///
+    /// With `function-parameter-indent = "double"`, parameters are indented two
+    /// levels (for an effective “double indent” when using the default
+    /// `indent-width = 4`):
+    ///
+    /// ```python
+    /// async def test_delay_in_plan(
+    ///         stepping_orchestrator: SteppingOrchestrator,
+    ///         mock_http_client: MockHttpClient,
+    ///         operation_responder: OperationResponder,
+    /// ) -> None:
+    ///     ...
+    /// ```
+    #[option(
+        default = r#""single""#,
+        value_type = r#""single" | "double""#,
+        example = r#"
+            # Use a double indent for wrapped function parameters.
+            function-parameter-indent = "double"
+        "#
+    )]
+    pub function_parameter_indent: Option<FunctionParameterIndent>,
 
     /// Ruff uses existing trailing commas as an indication that short lines should be left separate.
     /// If this option is set to `true`, the magic trailing comma is ignored.

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -11,8 +11,8 @@ use ruff_linter::settings::types::{
 use ruff_macros::CacheKey;
 use ruff_python_ast::{PySourceType, PythonVersion};
 use ruff_python_formatter::{
-    DocstringCode, DocstringCodeLineWidth, MagicTrailingComma, PreviewMode, PyFormatOptions,
-    QuoteStyle,
+    DocstringCode, DocstringCodeLineWidth, FunctionParameterIndent, MagicTrailingComma,
+    PreviewMode, PyFormatOptions, QuoteStyle,
 };
 use ruff_source_file::find_newline;
 use std::fmt;
@@ -196,6 +196,8 @@ pub struct FormatterSettings {
 
     pub docstring_code_format: DocstringCode,
     pub docstring_code_line_width: DocstringCodeLineWidth,
+
+    pub function_parameter_indent: FunctionParameterIndent,
 }
 
 impl FormatterSettings {
@@ -241,6 +243,7 @@ impl FormatterSettings {
             .with_line_width(self.line_width)
             .with_docstring_code(self.docstring_code_format)
             .with_docstring_code_line_width(self.docstring_code_line_width)
+            .with_function_parameter_indent(self.function_parameter_indent)
     }
 
     /// Resolve the [`PythonVersion`] to use for formatting.
@@ -273,6 +276,7 @@ impl Default for FormatterSettings {
             magic_trailing_comma: default_options.magic_trailing_comma(),
             docstring_code_format: default_options.docstring_code(),
             docstring_code_line_width: default_options.docstring_code_line_width(),
+            function_parameter_indent: default_options.function_parameter_indent(),
         }
     }
 }
@@ -296,6 +300,7 @@ impl fmt::Display for FormatterSettings {
                 self.magic_trailing_comma,
                 self.docstring_code_format,
                 self.docstring_code_line_width,
+                self.function_parameter_indent,
             ]
         }
         Ok(())

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1553,6 +1553,17 @@
             "type": "string"
           }
         },
+        "function-parameter-indent": {
+          "description": "Controls how many indentation levels are used when a function or method\nsignature wraps and its parameters are formatted on multiple lines.\n\nWith `function-parameter-indent = \"single\"` (the default), parameters are\nindented one level from the opening parenthesis:\n\n```python\nasync def test_delay_in_plan(\n    stepping_orchestrator: SteppingOrchestrator,\n    mock_http_client: MockHttpClient,\n    operation_responder: OperationResponder,\n) -> None:\n    ...\n```\n\nWith `function-parameter-indent = \"double\"`, parameters are indented two\nlevels (for an effective “double indent” when using the default\n`indent-width = 4`):\n\n```python\nasync def test_delay_in_plan(\n        stepping_orchestrator: SteppingOrchestrator,\n        mock_http_client: MockHttpClient,\n        operation_responder: OperationResponder,\n) -> None:\n    ...\n```",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FunctionParameterIndent"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "indent-style": {
           "description": "Whether to use spaces or tabs for indentation.\n\n`indent-style = \"space\"` (default):\n\n```python\ndef f():\n    print(\"Hello\") #  Spaces indent the `print` statement.\n```\n\n`indent-style = \"tab\"`:\n\n```python\ndef f():\n    print(\"Hello\") #  A tab `\\t` indents the `print` statement.\n```\n\nPEP 8 recommends using spaces for [indentation](https://peps.python.org/pep-0008/#indentation).\nWe care about accessibility; if you do not need tabs for accessibility, we do not recommend you use them.\n\nSee [`indent-width`](#indent-width) to configure the number of spaces per indentation and the tab width.",
           "anyOf": [
@@ -1602,6 +1613,20 @@
         }
       },
       "additionalProperties": false
+    },
+    "FunctionParameterIndent": {
+      "oneOf": [
+        {
+          "description": "Use a single extra indentation level for wrapped parameters (default).",
+          "type": "string",
+          "const": "single"
+        },
+        {
+          "description": "Use two indentation levels for wrapped parameters.",
+          "type": "string",
+          "const": "double"
+        }
+      ]
     },
     "ImportSection": {
       "anyOf": [


### PR DESCRIPTION
### Summary

Adds a new formatter option function-parameter-indent that controls the indentation level of wrapped function and method parameters.
The option lives under [tool.ruff.format] (or [format] in ruff.toml) and accepts "single" (current behavior, default) or "double" (one extra indent level), e.g.:

```
[tool.ruff.format]
function-parameter-indent = "double"
```

With "double", multi-line parameter lists for functions, methods, and nested functions are indented one level further than the function body, while lambdas are unchanged. 
The option is plumbed through ruff_workspace settings/options, exposed in `--show-settings`, and documented in the generated schema.

### Test Plan

- Ran RUFF_UPDATE_SCHEMA=1 cargo test at the repo root to update schemas and validate all tests.
- Verified new formatter behavior via a dedicated unit test in ruff_python_formatter (double-indented async def parameters).
- Updated and re-ran CLI snapshot tests (cargo test -p ruff --test cli) to cover the new formatter.function_parameter_indent field in --show-settings output.
- Updated and re-ran show_settings tests to ensure default and nested-directory settings output includes the new option.
