### PR TITLE
[WIP] Prefer vertical alignment of arguments

### DIFF
--- a/crates/ruff_python_formatter/src/other/arguments.rs
+++ b/crates/ruff_python_formatter/src/other/arguments.rs
@@ -106,7 +106,7 @@ impl FormatNodeRule<Arguments> for FormatArguments {
                 //     hey_this_is_a_very_long_call, it_has_funny_attributes_asdf_asdf, really=True
                 // )
                 // ```
-                parenthesized("(", &group(&all_arguments), ")")
+                parenthesized("(", &all_arguments, ")")
                     .with_hugging(is_arguments_huggable(item, f.context()))
                     .with_dangling_comments(dangling_comments)
             ]

--- a/crates/ruff_python_formatter/src/pattern/pattern_arguments.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_arguments.rs
@@ -66,8 +66,7 @@ impl FormatNodeRule<PatternArguments> for FormatPatternArguments {
 
         write!(
             f,
-            [parenthesized("(", &group(&all_arguments), ")")
-                .with_dangling_comments(dangling_comments)]
+            [parenthesized("(", &all_arguments, ")").with_dangling_comments(dangling_comments)]
         )
     }
 }

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__cantfit.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__cantfit.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/cantfit.py
 ---
 ## Input
 
@@ -47,7 +46,7 @@ del (),
 ```diff
 --- Black
 +++ Ruff
-@@ -1,18 +1,12 @@
+@@ -1,23 +1,24 @@
  # long variable name
 -this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = (
 -    0
@@ -67,9 +66,45 @@ del (),
 -)
 +this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = function()
  this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = function(
-     arg1, arg2, arg3
+-    arg1, arg2, arg3
++    arg1,
++    arg2,
++    arg3,
  )
-@@ -58,4 +52,4 @@
+ this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = function(
+-    [1, 2, 3], arg1, [1, 2, 3], arg2, [1, 2, 3], arg3
++    [1, 2, 3],
++    arg1,
++    [1, 2, 3],
++    arg2,
++    [1, 2, 3],
++    arg3,
+ )
+ # long function name
+ normal_name = (
+@@ -25,12 +26,19 @@
+ )
+ normal_name = (
+     but_the_function_name_is_now_ridiculously_long_and_it_is_still_super_annoying(
+-        arg1, arg2, arg3
++        arg1,
++        arg2,
++        arg3,
+     )
+ )
+ normal_name = (
+     but_the_function_name_is_now_ridiculously_long_and_it_is_still_super_annoying(
+-        [1, 2, 3], arg1, [1, 2, 3], arg2, [1, 2, 3], arg3
++        [1, 2, 3],
++        arg1,
++        [1, 2, 3],
++        arg2,
++        [1, 2, 3],
++        arg3,
+     )
+ )
+ string_variable_name = "a string that is waaaaaaaayyyyyyyy too long, even in parens, there's nothing you can do"  # noqa
+@@ -58,4 +66,4 @@
      [(), [], name_4, name_3],
      name_1[[name_2 for name_1 in name_0]],
  )
@@ -90,10 +125,17 @@ this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_li
 ]
 this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = function()
 this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = function(
-    arg1, arg2, arg3
+    arg1,
+    arg2,
+    arg3,
 )
 this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = function(
-    [1, 2, 3], arg1, [1, 2, 3], arg2, [1, 2, 3], arg3
+    [1, 2, 3],
+    arg1,
+    [1, 2, 3],
+    arg2,
+    [1, 2, 3],
+    arg3,
 )
 # long function name
 normal_name = (
@@ -101,12 +143,19 @@ normal_name = (
 )
 normal_name = (
     but_the_function_name_is_now_ridiculously_long_and_it_is_still_super_annoying(
-        arg1, arg2, arg3
+        arg1,
+        arg2,
+        arg3,
     )
 )
 normal_name = (
     but_the_function_name_is_now_ridiculously_long_and_it_is_still_super_annoying(
-        [1, 2, 3], arg1, [1, 2, 3], arg2, [1, 2, 3], arg3
+        [1, 2, 3],
+        arg1,
+        [1, 2, 3],
+        arg2,
+        [1, 2, 3],
+        arg3,
     )
 )
 string_variable_name = "a string that is waaaaaaaayyyyyyyy too long, even in parens, there's nothing you can do"  # noqa

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__composition.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__composition.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/composition.py
 ---
 ## Input
 
@@ -193,7 +192,56 @@ class C:
 ```diff
 --- Black
 +++ Ruff
-@@ -161,9 +161,7 @@
+@@ -2,7 +2,8 @@
+     def test(self) -> None:
+         with patch("black.out", print):
+             self.assertEqual(
+-                unstyle(str(report)), "1 file reformatted, 1 file failed to reformat."
++                unstyle(str(report)),
++                "1 file reformatted, 1 file failed to reformat.",
+             )
+             self.assertEqual(
+                 unstyle(str(report)),
+@@ -46,10 +47,14 @@
+ 
+     def omitting_trailers(self) -> None:
+         get_collection(
+-            hey_this_is_a_very_long_call, it_has_funny_attributes, really=True
++            hey_this_is_a_very_long_call,
++            it_has_funny_attributes,
++            really=True,
+         )[OneLevelIndex]
+         get_collection(
+-            hey_this_is_a_very_long_call, it_has_funny_attributes, really=True
++            hey_this_is_a_very_long_call,
++            it_has_funny_attributes,
++            really=True,
+         )[OneLevelIndex][TwoLevelIndex][ThreeLevelIndex][FourLevelIndex]
+         d[0][1][2][3][4][5][6][7][8][9][10][11][12][13][14][15][16][17][18][19][20][21][
+             22
+@@ -107,7 +112,9 @@
+             key8: value8,
+             key9: value9,
+         } == expected(
+-            value, is_going_to_be="too long to fit in a single line", srsly=True
++            value,
++            is_going_to_be="too long to fit in a single line",
++            srsly=True,
+         ), "Not what we expected"
+ 
+         assert {
+@@ -125,7 +132,9 @@
+         )
+ 
+         assert expected(
+-            value, is_going_to_be="too long to fit in a single line", srsly=True
++            value,
++            is_going_to_be="too long to fit in a single line",
++            srsly=True,
+         ) == {
+             key1: value1,
+             key2: value2,
+@@ -161,9 +170,7 @@
                        8 STORE_ATTR               0 (x)
                       10 LOAD_CONST               0 (None)
                       12 RETURN_VALUE
@@ -213,7 +261,8 @@ class C:
     def test(self) -> None:
         with patch("black.out", print):
             self.assertEqual(
-                unstyle(str(report)), "1 file reformatted, 1 file failed to reformat."
+                unstyle(str(report)),
+                "1 file reformatted, 1 file failed to reformat.",
             )
             self.assertEqual(
                 unstyle(str(report)),
@@ -257,10 +306,14 @@ class C:
 
     def omitting_trailers(self) -> None:
         get_collection(
-            hey_this_is_a_very_long_call, it_has_funny_attributes, really=True
+            hey_this_is_a_very_long_call,
+            it_has_funny_attributes,
+            really=True,
         )[OneLevelIndex]
         get_collection(
-            hey_this_is_a_very_long_call, it_has_funny_attributes, really=True
+            hey_this_is_a_very_long_call,
+            it_has_funny_attributes,
+            really=True,
         )[OneLevelIndex][TwoLevelIndex][ThreeLevelIndex][FourLevelIndex]
         d[0][1][2][3][4][5][6][7][8][9][10][11][12][13][14][15][16][17][18][19][20][21][
             22
@@ -318,7 +371,9 @@ class C:
             key8: value8,
             key9: value9,
         } == expected(
-            value, is_going_to_be="too long to fit in a single line", srsly=True
+            value,
+            is_going_to_be="too long to fit in a single line",
+            srsly=True,
         ), "Not what we expected"
 
         assert {
@@ -336,7 +391,9 @@ class C:
         )
 
         assert expected(
-            value, is_going_to_be="too long to fit in a single line", srsly=True
+            value,
+            is_going_to_be="too long to fit in a single line",
+            srsly=True,
         ) == {
             key1: value1,
             key2: value2,

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__composition_no_trailing_comma.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__composition_no_trailing_comma.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/composition_no_trailing_comma.py
 ---
 ## Input
 
@@ -193,7 +192,56 @@ class C:
 ```diff
 --- Black
 +++ Ruff
-@@ -161,9 +161,7 @@
+@@ -2,7 +2,8 @@
+     def test(self) -> None:
+         with patch("black.out", print):
+             self.assertEqual(
+-                unstyle(str(report)), "1 file reformatted, 1 file failed to reformat."
++                unstyle(str(report)),
++                "1 file reformatted, 1 file failed to reformat.",
+             )
+             self.assertEqual(
+                 unstyle(str(report)),
+@@ -46,10 +47,14 @@
+ 
+     def omitting_trailers(self) -> None:
+         get_collection(
+-            hey_this_is_a_very_long_call, it_has_funny_attributes, really=True
++            hey_this_is_a_very_long_call,
++            it_has_funny_attributes,
++            really=True,
+         )[OneLevelIndex]
+         get_collection(
+-            hey_this_is_a_very_long_call, it_has_funny_attributes, really=True
++            hey_this_is_a_very_long_call,
++            it_has_funny_attributes,
++            really=True,
+         )[OneLevelIndex][TwoLevelIndex][ThreeLevelIndex][FourLevelIndex]
+         d[0][1][2][3][4][5][6][7][8][9][10][11][12][13][14][15][16][17][18][19][20][21][
+             22
+@@ -107,7 +112,9 @@
+             key8: value8,
+             key9: value9,
+         } == expected(
+-            value, is_going_to_be="too long to fit in a single line", srsly=True
++            value,
++            is_going_to_be="too long to fit in a single line",
++            srsly=True,
+         ), "Not what we expected"
+ 
+         assert {
+@@ -125,7 +132,9 @@
+         )
+ 
+         assert expected(
+-            value, is_going_to_be="too long to fit in a single line", srsly=True
++            value,
++            is_going_to_be="too long to fit in a single line",
++            srsly=True,
+         ) == {
+             key1: value1,
+             key2: value2,
+@@ -161,9 +170,7 @@
                        8 STORE_ATTR               0 (x)
                       10 LOAD_CONST               0 (None)
                       12 RETURN_VALUE
@@ -213,7 +261,8 @@ class C:
     def test(self) -> None:
         with patch("black.out", print):
             self.assertEqual(
-                unstyle(str(report)), "1 file reformatted, 1 file failed to reformat."
+                unstyle(str(report)),
+                "1 file reformatted, 1 file failed to reformat.",
             )
             self.assertEqual(
                 unstyle(str(report)),
@@ -257,10 +306,14 @@ class C:
 
     def omitting_trailers(self) -> None:
         get_collection(
-            hey_this_is_a_very_long_call, it_has_funny_attributes, really=True
+            hey_this_is_a_very_long_call,
+            it_has_funny_attributes,
+            really=True,
         )[OneLevelIndex]
         get_collection(
-            hey_this_is_a_very_long_call, it_has_funny_attributes, really=True
+            hey_this_is_a_very_long_call,
+            it_has_funny_attributes,
+            really=True,
         )[OneLevelIndex][TwoLevelIndex][ThreeLevelIndex][FourLevelIndex]
         d[0][1][2][3][4][5][6][7][8][9][10][11][12][13][14][15][16][17][18][19][20][21][
             22
@@ -318,7 +371,9 @@ class C:
             key8: value8,
             key9: value9,
         } == expected(
-            value, is_going_to_be="too long to fit in a single line", srsly=True
+            value,
+            is_going_to_be="too long to fit in a single line",
+            srsly=True,
         ), "Not what we expected"
 
         assert {
@@ -336,7 +391,9 @@ class C:
         )
 
         assert expected(
-            value, is_going_to_be="too long to fit in a single line", srsly=True
+            value,
+            is_going_to_be="too long to fit in a single line",
+            srsly=True,
         ) == {
             key1: value1,
             key2: value2,

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__context_managers_38.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__context_managers_38.py.snap
@@ -1,0 +1,112 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+---
+## Input
+
+```python
+with \
+     make_context_manager1() as cm1, \
+     make_context_manager2() as cm2, \
+     make_context_manager3() as cm3, \
+     make_context_manager4() as cm4 \
+:
+    pass
+
+
+with \
+     make_context_manager1() as cm1, \
+     make_context_manager2(), \
+     make_context_manager3() as cm3, \
+     make_context_manager4() \
+:
+    pass
+
+
+with \
+     new_new_new1() as cm1, \
+     new_new_new2() \
+:
+    pass
+
+
+with mock.patch.object(
+    self.my_runner, "first_method", autospec=True
+) as mock_run_adb, mock.patch.object(
+    self.my_runner, "second_method", autospec=True, return_value="foo"
+):
+    pass
+```
+
+## Black Differences
+
+```diff
+--- Black
++++ Ruff
+@@ -11,8 +11,13 @@
+ 
+ 
+ with mock.patch.object(
+-    self.my_runner, "first_method", autospec=True
++    self.my_runner,
++    "first_method",
++    autospec=True,
+ ) as mock_run_adb, mock.patch.object(
+-    self.my_runner, "second_method", autospec=True, return_value="foo"
++    self.my_runner,
++    "second_method",
++    autospec=True,
++    return_value="foo",
+ ):
+     pass
+```
+
+## Ruff Output
+
+```python
+with make_context_manager1() as cm1, make_context_manager2() as cm2, make_context_manager3() as cm3, make_context_manager4() as cm4:
+    pass
+
+
+with make_context_manager1() as cm1, make_context_manager2(), make_context_manager3() as cm3, make_context_manager4():
+    pass
+
+
+with new_new_new1() as cm1, new_new_new2():
+    pass
+
+
+with mock.patch.object(
+    self.my_runner,
+    "first_method",
+    autospec=True,
+) as mock_run_adb, mock.patch.object(
+    self.my_runner,
+    "second_method",
+    autospec=True,
+    return_value="foo",
+):
+    pass
+```
+
+## Black Output
+
+```python
+with make_context_manager1() as cm1, make_context_manager2() as cm2, make_context_manager3() as cm3, make_context_manager4() as cm4:
+    pass
+
+
+with make_context_manager1() as cm1, make_context_manager2(), make_context_manager3() as cm3, make_context_manager4():
+    pass
+
+
+with new_new_new1() as cm1, new_new_new2():
+    pass
+
+
+with mock.patch.object(
+    self.my_runner, "first_method", autospec=True
+) as mock_run_adb, mock.patch.object(
+    self.my_runner, "second_method", autospec=True, return_value="foo"
+):
+    pass
+```

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__context_managers_39.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__context_managers_39.py.snap
@@ -1,0 +1,320 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+---
+## Input
+
+```python
+with \
+     make_context_manager1() as cm1, \
+     make_context_manager2() as cm2, \
+     make_context_manager3() as cm3, \
+     make_context_manager4() as cm4 \
+:
+    pass
+
+
+# Leading comment
+with \
+     make_context_manager1() as cm1, \
+     make_context_manager2(), \
+     make_context_manager3() as cm3, \
+     make_context_manager4() \
+:
+    pass
+
+
+with \
+     new_new_new1() as cm1, \
+     new_new_new2() \
+:
+    pass
+
+
+with (
+     new_new_new1() as cm1,
+     new_new_new2()
+):
+    pass
+
+
+# Leading comment.
+with (
+     # First comment.
+     new_new_new1() as cm1,
+     # Second comment.
+     new_new_new2()
+     # Last comment.
+):
+    pass
+
+
+with \
+    this_is_a_very_long_call(looong_arg1=looong_value1, looong_arg2=looong_value2) as cm1, \
+    this_is_a_very_long_call(looong_arg1=looong_value1, looong_arg2=looong_value2, looong_arg3=looong_value3, looong_arg4=looong_value4) as cm2 \
+:
+    pass
+
+
+with mock.patch.object(
+    self.my_runner, "first_method", autospec=True
+) as mock_run_adb, mock.patch.object(
+    self.my_runner, "second_method", autospec=True, return_value="foo"
+):
+    pass
+
+
+with xxxxxxxx.some_kind_of_method(
+    some_argument=[
+        "first",
+        "second",
+        "third",
+    ]
+).another_method() as cmd:
+    pass
+
+
+async def func():
+    async with \
+        make_context_manager1() as cm1, \
+        make_context_manager2() as cm2, \
+        make_context_manager3() as cm3, \
+        make_context_manager4() as cm4 \
+    :
+        pass
+
+    async with some_function(
+        argument1, argument2, argument3="some_value"
+    ) as some_cm, some_other_function(
+        argument1, argument2, argument3="some_value"
+    ):
+        pass
+
+
+
+# don't remove the brackets here, it changes the meaning of the code.
+with (x, y) as z:
+    pass
+```
+
+## Black Differences
+
+```diff
+--- Black
++++ Ruff
+@@ -38,7 +38,8 @@
+ 
+ with (
+     this_is_a_very_long_call(
+-        looong_arg1=looong_value1, looong_arg2=looong_value2
++        looong_arg1=looong_value1,
++        looong_arg2=looong_value2,
+     ) as cm1,
+     this_is_a_very_long_call(
+         looong_arg1=looong_value1,
+@@ -53,7 +54,10 @@
+ with (
+     mock.patch.object(self.my_runner, "first_method", autospec=True) as mock_run_adb,
+     mock.patch.object(
+-        self.my_runner, "second_method", autospec=True, return_value="foo"
++        self.my_runner,
++        "second_method",
++        autospec=True,
++        return_value="foo",
+     ),
+ ):
+     pass
+```
+
+## Ruff Output
+
+```python
+with (
+    make_context_manager1() as cm1,
+    make_context_manager2() as cm2,
+    make_context_manager3() as cm3,
+    make_context_manager4() as cm4,
+):
+    pass
+
+
+# Leading comment
+with (
+    make_context_manager1() as cm1,
+    make_context_manager2(),
+    make_context_manager3() as cm3,
+    make_context_manager4(),
+):
+    pass
+
+
+with new_new_new1() as cm1, new_new_new2():
+    pass
+
+
+with new_new_new1() as cm1, new_new_new2():
+    pass
+
+
+# Leading comment.
+with (
+    # First comment.
+    new_new_new1() as cm1,
+    # Second comment.
+    new_new_new2(),
+    # Last comment.
+):
+    pass
+
+
+with (
+    this_is_a_very_long_call(
+        looong_arg1=looong_value1,
+        looong_arg2=looong_value2,
+    ) as cm1,
+    this_is_a_very_long_call(
+        looong_arg1=looong_value1,
+        looong_arg2=looong_value2,
+        looong_arg3=looong_value3,
+        looong_arg4=looong_value4,
+    ) as cm2,
+):
+    pass
+
+
+with (
+    mock.patch.object(self.my_runner, "first_method", autospec=True) as mock_run_adb,
+    mock.patch.object(
+        self.my_runner,
+        "second_method",
+        autospec=True,
+        return_value="foo",
+    ),
+):
+    pass
+
+
+with xxxxxxxx.some_kind_of_method(
+    some_argument=[
+        "first",
+        "second",
+        "third",
+    ]
+).another_method() as cmd:
+    pass
+
+
+async def func():
+    async with (
+        make_context_manager1() as cm1,
+        make_context_manager2() as cm2,
+        make_context_manager3() as cm3,
+        make_context_manager4() as cm4,
+    ):
+        pass
+
+    async with (
+        some_function(argument1, argument2, argument3="some_value") as some_cm,
+        some_other_function(argument1, argument2, argument3="some_value"),
+    ):
+        pass
+
+
+# don't remove the brackets here, it changes the meaning of the code.
+with (x, y) as z:
+    pass
+```
+
+## Black Output
+
+```python
+with (
+    make_context_manager1() as cm1,
+    make_context_manager2() as cm2,
+    make_context_manager3() as cm3,
+    make_context_manager4() as cm4,
+):
+    pass
+
+
+# Leading comment
+with (
+    make_context_manager1() as cm1,
+    make_context_manager2(),
+    make_context_manager3() as cm3,
+    make_context_manager4(),
+):
+    pass
+
+
+with new_new_new1() as cm1, new_new_new2():
+    pass
+
+
+with new_new_new1() as cm1, new_new_new2():
+    pass
+
+
+# Leading comment.
+with (
+    # First comment.
+    new_new_new1() as cm1,
+    # Second comment.
+    new_new_new2(),
+    # Last comment.
+):
+    pass
+
+
+with (
+    this_is_a_very_long_call(
+        looong_arg1=looong_value1, looong_arg2=looong_value2
+    ) as cm1,
+    this_is_a_very_long_call(
+        looong_arg1=looong_value1,
+        looong_arg2=looong_value2,
+        looong_arg3=looong_value3,
+        looong_arg4=looong_value4,
+    ) as cm2,
+):
+    pass
+
+
+with (
+    mock.patch.object(self.my_runner, "first_method", autospec=True) as mock_run_adb,
+    mock.patch.object(
+        self.my_runner, "second_method", autospec=True, return_value="foo"
+    ),
+):
+    pass
+
+
+with xxxxxxxx.some_kind_of_method(
+    some_argument=[
+        "first",
+        "second",
+        "third",
+    ]
+).another_method() as cmd:
+    pass
+
+
+async def func():
+    async with (
+        make_context_manager1() as cm1,
+        make_context_manager2() as cm2,
+        make_context_manager3() as cm3,
+        make_context_manager4() as cm4,
+    ):
+        pass
+
+    async with (
+        some_function(argument1, argument2, argument3="some_value") as some_cm,
+        some_other_function(argument1, argument2, argument3="some_value"),
+    ):
+        pass
+
+
+# don't remove the brackets here, it changes the meaning of the code.
+with (x, y) as z:
+    pass
+```

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__context_managers_autodetect_38.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__context_managers_autodetect_38.py.snap
@@ -1,0 +1,107 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+---
+## Input
+
+```python
+# This file doesn't use any Python 3.9+ only grammars.
+
+
+# Make sure parens around a single context manager don't get autodetected as
+# Python 3.9+.
+with (a):
+    pass
+
+
+with \
+     make_context_manager1() as cm1, \
+     make_context_manager2() as cm2, \
+     make_context_manager3() as cm3, \
+     make_context_manager4() as cm4 \
+:
+    pass
+
+
+with mock.patch.object(
+    self.my_runner, "first_method", autospec=True
+) as mock_run_adb, mock.patch.object(
+    self.my_runner, "second_method", autospec=True, return_value="foo"
+):
+    pass
+```
+
+## Black Differences
+
+```diff
+--- Black
++++ Ruff
+@@ -12,8 +12,13 @@
+ 
+ 
+ with mock.patch.object(
+-    self.my_runner, "first_method", autospec=True
++    self.my_runner,
++    "first_method",
++    autospec=True,
+ ) as mock_run_adb, mock.patch.object(
+-    self.my_runner, "second_method", autospec=True, return_value="foo"
++    self.my_runner,
++    "second_method",
++    autospec=True,
++    return_value="foo",
+ ):
+     pass
+```
+
+## Ruff Output
+
+```python
+# This file doesn't use any Python 3.9+ only grammars.
+
+
+# Make sure parens around a single context manager don't get autodetected as
+# Python 3.9+.
+with a:
+    pass
+
+
+with make_context_manager1() as cm1, make_context_manager2() as cm2, make_context_manager3() as cm3, make_context_manager4() as cm4:
+    pass
+
+
+with mock.patch.object(
+    self.my_runner,
+    "first_method",
+    autospec=True,
+) as mock_run_adb, mock.patch.object(
+    self.my_runner,
+    "second_method",
+    autospec=True,
+    return_value="foo",
+):
+    pass
+```
+
+## Black Output
+
+```python
+# This file doesn't use any Python 3.9+ only grammars.
+
+
+# Make sure parens around a single context manager don't get autodetected as
+# Python 3.9+.
+with a:
+    pass
+
+
+with make_context_manager1() as cm1, make_context_manager2() as cm2, make_context_manager3() as cm3, make_context_manager4() as cm4:
+    pass
+
+
+with mock.patch.object(
+    self.my_runner, "first_method", autospec=True
+) as mock_run_adb, mock.patch.object(
+    self.my_runner, "second_method", autospec=True, return_value="foo"
+):
+    pass
+```

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__expression.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__expression.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/expression.py
 ---
 ## Input
 
@@ -275,7 +274,27 @@ last_call()
  )  # note: no trailing comma pre-3.6
  call(*gidgets[:2])
  call(a, *gidgets[:2])
-@@ -251,9 +251,9 @@
+@@ -211,7 +211,8 @@
+ result = (
+     session.query(models.Customer.id)
+     .filter(
+-        models.Customer.account_id == account_id, models.Customer.email == email_address
++        models.Customer.account_id == account_id,
++        models.Customer.email == email_address,
+     )
+     .order_by(models.Customer.id.asc())
+     .all()
+@@ -219,7 +220,8 @@
+ result = (
+     session.query(models.Customer.id)
+     .filter(
+-        models.Customer.account_id == account_id, models.Customer.email == email_address
++        models.Customer.account_id == account_id,
++        models.Customer.email == email_address,
+     )
+     .order_by(
+         models.Customer.id.asc(),
+@@ -251,9 +253,9 @@
  print(**{1: 3} if False else {x: x for x in range(3)})
  print(*lambda x: x)
  assert not Test, "Short message"
@@ -506,7 +525,8 @@ what_is_up_with_those_new_coord_names = (coord_names | set(vars_to_create)) - se
 result = (
     session.query(models.Customer.id)
     .filter(
-        models.Customer.account_id == account_id, models.Customer.email == email_address
+        models.Customer.account_id == account_id,
+        models.Customer.email == email_address,
     )
     .order_by(models.Customer.id.asc())
     .all()
@@ -514,7 +534,8 @@ result = (
 result = (
     session.query(models.Customer.id)
     .filter(
-        models.Customer.account_id == account_id, models.Customer.email == email_address
+        models.Customer.account_id == account_id,
+        models.Customer.email == email_address,
     )
     .order_by(
         models.Customer.id.asc(),

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__function2.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__function2.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/function2.py
 ---
 ## Input
 
@@ -65,7 +64,17 @@ with hmm_but_this_should_get_two_preceding_newlines():
 ```diff
 --- Black
 +++ Ruff
-@@ -36,7 +36,6 @@
+@@ -5,7 +5,8 @@
+     with cache_dir():
+         if something:
+             result = CliRunner().invoke(
+-                black.main, [str(src1), str(src2), "--diff", "--check"]
++                black.main,
++                [str(src1), str(src2), "--diff", "--check"],
+             )
+     limited.append(-limited.pop())  # negate top
+     return A(
+@@ -36,7 +37,6 @@
  
      def i_should_be_followed_by_only_one_newline():
          pass
@@ -73,7 +82,7 @@ with hmm_but_this_should_get_two_preceding_newlines():
  elif os.name == "nt":
      try:
          import msvcrt
-@@ -54,7 +53,6 @@
+@@ -54,7 +54,6 @@
      class IHopeYouAreHavingALovelyDay:
          def __call__(self):
              print("i_should_be_followed_by_only_one_newline")
@@ -93,7 +102,8 @@ def f(
     with cache_dir():
         if something:
             result = CliRunner().invoke(
-                black.main, [str(src1), str(src2), "--diff", "--check"]
+                black.main,
+                [str(src1), str(src2), "--diff", "--check"],
             )
     limited.append(-limited.pop())  # negate top
     return A(

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__function_trailing_comma.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__function_trailing_comma.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/function_trailing_comma.py
 ---
 ## Input
 
@@ -144,7 +143,20 @@ variable: (
      json = {
          "k": {
              "k2": {
-@@ -130,9 +130,7 @@
+@@ -98,7 +98,11 @@
+ 
+ # Make sure inner one-element tuple won't explode
+ some_module.some_function(
+-    argument1, (one_element_tuple,), argument4, argument5, argument6
++    argument1,
++    (one_element_tuple,),
++    argument4,
++    argument5,
++    argument6,
+ )
+ 
+ # Inner trailing comma causes outer to explode
+@@ -130,9 +134,7 @@
  
  def foo() -> (
      # comment inside parenthesised new union return type
@@ -155,7 +167,7 @@ variable: (
  ): ...
  
  
-@@ -153,16 +151,18 @@
+@@ -153,16 +155,18 @@
  
  def foo(
      arg: (  # comment with non-return annotation
@@ -283,7 +295,11 @@ def func() -> (
 
 # Make sure inner one-element tuple won't explode
 some_module.some_function(
-    argument1, (one_element_tuple,), argument4, argument5, argument6
+    argument1,
+    (one_element_tuple,),
+    argument4,
+    argument5,
+    argument6,
 )
 
 # Inner trailing comma causes outer to explode

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__long_strings_flag_disabled.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__long_strings_flag_disabled.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/long_strings_flag_disabled.py
 ---
 ## Input
 
@@ -308,7 +307,22 @@ long_unmergable_string_with_pragma = (
 ```diff
 --- Black
 +++ Ruff
-@@ -167,14 +167,14 @@
+@@ -35,9 +35,12 @@
+         string_key
+     ): "This is a really really really long string that has to go i,side of a dictionary. It is soooo bad.",
+     some_func(
+-        "calling", "some", "stuff"
++        "calling",
++        "some",
++        "stuff",
+     ): "This is a really really really long string that has to go inside of a dictionary. It is {soooo} bad (#{x}).".format(
+-        sooo="soooo", x=2
++        sooo="soooo",
++        x=2,
+     ),
+     "A %s %s"
+     % (
+@@ -167,14 +170,14 @@
  
  triple_quote_string = """This is a really really really long triple quote string assignment and it should not be touched."""
  
@@ -330,19 +344,48 @@ long_unmergable_string_with_pragma = (
  )
  
  assert some_type_of_boolean_expression, (
-@@ -255,10 +255,8 @@
-     + " that has been "
+@@ -202,7 +205,8 @@
+ )
+ 
+ return "A really really really really really really really really really really really really really long {} {}".format(
+-    "return", "value"
++    "return",
++    "value",
+ )
+ 
+ func_with_bad_comma(
+@@ -228,11 +232,17 @@
+ )
+ 
+ func_with_bad_parens_that_wont_fit_in_one_line(
+-    ("short string that should have parens stripped"), x, y, z
++    ("short string that should have parens stripped"),
++    x,
++    y,
++    z,
+ )
+ 
+ func_with_bad_parens_that_wont_fit_in_one_line(
+-    x, y, ("short string that should have parens stripped"), z
++    x,
++    y,
++    ("short string that should have parens stripped"),
++    z,
+ )
+ 
+ func_with_bad_parens(
+@@ -256,9 +266,7 @@
      + CONCATENATED
      + "using the '+' operator."
--)
+ )
 -annotated_variable: Final = (
 -    "This is a large string that has a type annotation attached to it. A type annotation should NOT stop a long string from being wrapped."
- )
+-)
 +annotated_variable: Final = "This is a large string that has a type annotation attached to it. A type annotation should NOT stop a long string from being wrapped."
  annotated_variable: Literal["fakse_literal"] = (
      "This is a large string that has a type annotation attached to it. A type annotation should NOT stop a long string from being wrapped."
  )
-@@ -267,9 +265,9 @@
+@@ -267,9 +275,9 @@
  backslashes = "This is a really long string with \"embedded\" double quotes and 'single' quotes that also handles checking for an even number of backslashes \\\\"
  backslashes = "This is a really 'long' string with \"embedded double quotes\" and 'single' quotes that also handles checking for an odd number of backslashes \\\", like this...\\\\\\"
  
@@ -396,9 +439,12 @@ D4 = {
         string_key
     ): "This is a really really really long string that has to go i,side of a dictionary. It is soooo bad.",
     some_func(
-        "calling", "some", "stuff"
+        "calling",
+        "some",
+        "stuff",
     ): "This is a really really really long string that has to go inside of a dictionary. It is {soooo} bad (#{x}).".format(
-        sooo="soooo", x=2
+        sooo="soooo",
+        x=2,
     ),
     "A %s %s"
     % (
@@ -563,7 +609,8 @@ some_function_call(
 )
 
 return "A really really really really really really really really really really really really really long {} {}".format(
-    "return", "value"
+    "return",
+    "value",
 )
 
 func_with_bad_comma(
@@ -589,11 +636,17 @@ func_with_bad_comma(
 )
 
 func_with_bad_parens_that_wont_fit_in_one_line(
-    ("short string that should have parens stripped"), x, y, z
+    ("short string that should have parens stripped"),
+    x,
+    y,
+    z,
 )
 
 func_with_bad_parens_that_wont_fit_in_one_line(
-    x, y, ("short string that should have parens stripped"), z
+    x,
+    y,
+    ("short string that should have parens stripped"),
+    z,
 )
 
 func_with_bad_parens(

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__pattern_matching_extras.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__pattern_matching_extras.py.snap
@@ -1,0 +1,362 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+---
+## Input
+
+```python
+import match
+
+match something:
+    case [a as b]:
+        print(b)
+    case [a as b, c, d, e as f]:
+        print(f)
+    case Point(a as b):
+        print(b)
+    case Point(int() as x, int() as y):
+        print(x, y)
+
+
+match = 1
+case: int = re.match(something)
+
+match re.match(case):
+    case type("match", match):
+        pass
+    case match:
+        pass
+
+
+def func(match: case, case: match) -> case:
+    match Something():
+        case func(match, case):
+            ...
+        case another:
+            ...
+
+
+match a, *b, c:
+    case [*_]:
+        assert "seq" == _
+    case {}:
+        assert "map" == b
+
+
+match match(
+    case,
+    match(
+        match, case, match, looooooooooooooooooooooooooooooooooooong, match, case, match
+    ),
+    case,
+):
+    case case(
+        match=case,
+        case=re.match(
+            loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+        ),
+    ):
+        pass
+    case [a as match]:
+        pass
+    case case:
+        pass
+    case something:
+        pass
+
+
+match match:
+    case case:
+        pass
+
+
+match a, *b(), c:
+    case d, *f, g:
+        pass
+
+
+match something:
+    case {
+        "key": key as key_1,
+        "password": PASS.ONE | PASS.TWO | PASS.THREE as password,
+    }:
+        pass
+    case {"maybe": something(complicated as this) as that}:
+        pass
+
+
+match something:
+    case 1 as a:
+        pass
+    case 2 as b, 3 as c:
+        pass
+    case 4 as d, (5 as e), (6 | 7 as g), *h:
+        pass
+
+
+match bar1:
+    case Foo(aa=Callable() as aa, bb=int()):
+        print(bar1.aa, bar1.bb)
+    case _:
+        print("no match", "\n")
+
+
+match bar1:
+    case Foo(
+        normal=x, perhaps=[list, {"x": d, "y": 1.0}] as y, otherwise=something, q=t as u
+    ):
+        pass
+```
+
+## Black Differences
+
+```diff
+--- Black
++++ Ruff
+@@ -39,7 +39,13 @@
+ match match(
+     case,
+     match(
+-        match, case, match, looooooooooooooooooooooooooooooooooooong, match, case, match
++        match,
++        case,
++        match,
++        looooooooooooooooooooooooooooooooooooong,
++        match,
++        case,
++        match,
+     ),
+     case,
+ ):
+@@ -96,6 +102,9 @@
+ 
+ match bar1:
+     case Foo(
+-        normal=x, perhaps=[list, {"x": d, "y": 1.0}] as y, otherwise=something, q=t as u
++        normal=x,
++        perhaps=[list, {"x": d, "y": 1.0}] as y,
++        otherwise=something,
++        q=t as u,
+     ):
+         pass
+```
+
+## Ruff Output
+
+```python
+import match
+
+match something:
+    case [a as b]:
+        print(b)
+    case [a as b, c, d, e as f]:
+        print(f)
+    case Point(a as b):
+        print(b)
+    case Point(int() as x, int() as y):
+        print(x, y)
+
+
+match = 1
+case: int = re.match(something)
+
+match re.match(case):
+    case type("match", match):
+        pass
+    case match:
+        pass
+
+
+def func(match: case, case: match) -> case:
+    match Something():
+        case func(match, case):
+            ...
+        case another:
+            ...
+
+
+match a, *b, c:
+    case [*_]:
+        assert "seq" == _
+    case {}:
+        assert "map" == b
+
+
+match match(
+    case,
+    match(
+        match,
+        case,
+        match,
+        looooooooooooooooooooooooooooooooooooong,
+        match,
+        case,
+        match,
+    ),
+    case,
+):
+    case case(
+        match=case,
+        case=re.match(
+            loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+        ),
+    ):
+        pass
+    case [a as match]:
+        pass
+    case case:
+        pass
+    case something:
+        pass
+
+
+match match:
+    case case:
+        pass
+
+
+match a, *b(), c:
+    case d, *f, g:
+        pass
+
+
+match something:
+    case {
+        "key": key as key_1,
+        "password": PASS.ONE | PASS.TWO | PASS.THREE as password,
+    }:
+        pass
+    case {"maybe": something(complicated as this) as that}:
+        pass
+
+
+match something:
+    case 1 as a:
+        pass
+    case 2 as b, 3 as c:
+        pass
+    case 4 as d, (5 as e), (6 | 7 as g), *h:
+        pass
+
+
+match bar1:
+    case Foo(aa=Callable() as aa, bb=int()):
+        print(bar1.aa, bar1.bb)
+    case _:
+        print("no match", "\n")
+
+
+match bar1:
+    case Foo(
+        normal=x,
+        perhaps=[list, {"x": d, "y": 1.0}] as y,
+        otherwise=something,
+        q=t as u,
+    ):
+        pass
+```
+
+## Black Output
+
+```python
+import match
+
+match something:
+    case [a as b]:
+        print(b)
+    case [a as b, c, d, e as f]:
+        print(f)
+    case Point(a as b):
+        print(b)
+    case Point(int() as x, int() as y):
+        print(x, y)
+
+
+match = 1
+case: int = re.match(something)
+
+match re.match(case):
+    case type("match", match):
+        pass
+    case match:
+        pass
+
+
+def func(match: case, case: match) -> case:
+    match Something():
+        case func(match, case):
+            ...
+        case another:
+            ...
+
+
+match a, *b, c:
+    case [*_]:
+        assert "seq" == _
+    case {}:
+        assert "map" == b
+
+
+match match(
+    case,
+    match(
+        match, case, match, looooooooooooooooooooooooooooooooooooong, match, case, match
+    ),
+    case,
+):
+    case case(
+        match=case,
+        case=re.match(
+            loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+        ),
+    ):
+        pass
+    case [a as match]:
+        pass
+    case case:
+        pass
+    case something:
+        pass
+
+
+match match:
+    case case:
+        pass
+
+
+match a, *b(), c:
+    case d, *f, g:
+        pass
+
+
+match something:
+    case {
+        "key": key as key_1,
+        "password": PASS.ONE | PASS.TWO | PASS.THREE as password,
+    }:
+        pass
+    case {"maybe": something(complicated as this) as that}:
+        pass
+
+
+match something:
+    case 1 as a:
+        pass
+    case 2 as b, 3 as c:
+        pass
+    case 4 as d, (5 as e), (6 | 7 as g), *h:
+        pass
+
+
+match bar1:
+    case Foo(aa=Callable() as aa, bb=int()):
+        print(bar1.aa, bar1.bb)
+    case _:
+        print("no match", "\n")
+
+
+match bar1:
+    case Foo(
+        normal=x, perhaps=[list, {"x": d, "y": 1.0}] as y, otherwise=something, q=t as u
+    ):
+        pass
+```

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__pattern_matching_generic.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__pattern_matching_generic.py.snap
@@ -1,0 +1,356 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+---
+## Input
+
+```python
+re.match()
+match = a
+with match() as match:
+    match = f"{match}"
+
+re.match()
+match = a
+with match() as match:
+    match = f"{match}"
+
+
+def get_grammars(target_versions: Set[TargetVersion]) -> List[Grammar]:
+    if not target_versions:
+        # No target_version specified, so try all grammars.
+        return [
+            # Python 3.7+
+            pygram.python_grammar_no_print_statement_no_exec_statement_async_keywords,
+            # Python 3.0-3.6
+            pygram.python_grammar_no_print_statement_no_exec_statement,
+            # Python 2.7 with future print_function import
+            pygram.python_grammar_no_print_statement,
+            # Python 2.7
+            pygram.python_grammar,
+        ]
+
+    match match:
+        case case:
+            match match:
+                case case:
+                    pass
+
+    if all(version.is_python2() for version in target_versions):
+        # Python 2-only code, so try Python 2 grammars.
+        return [
+            # Python 2.7 with future print_function import
+            pygram.python_grammar_no_print_statement,
+            # Python 2.7
+            pygram.python_grammar,
+        ]
+
+    re.match()
+    match = a
+    with match() as match:
+        match = f"{match}"
+
+    def test_patma_139(self):
+        x = False
+        match x:
+            case bool(z):
+                y = 0
+        self.assertIs(x, False)
+        self.assertEqual(y, 0)
+        self.assertIs(z, x)
+
+    # Python 3-compatible code, so only try Python 3 grammar.
+    grammars = []
+    if supports_feature(target_versions, Feature.PATTERN_MATCHING):
+        # Python 3.10+
+        grammars.append(pygram.python_grammar_soft_keywords)
+    # If we have to parse both, try to parse async as a keyword first
+    if not supports_feature(
+        target_versions, Feature.ASYNC_IDENTIFIERS
+    ) and not supports_feature(target_versions, Feature.PATTERN_MATCHING):
+        # Python 3.7-3.9
+        grammars.append(
+            pygram.python_grammar_no_print_statement_no_exec_statement_async_keywords
+        )
+    if not supports_feature(target_versions, Feature.ASYNC_KEYWORDS):
+        # Python 3.0-3.6
+        grammars.append(pygram.python_grammar_no_print_statement_no_exec_statement)
+
+    def test_patma_155(self):
+        x = 0
+        y = None
+        match x:
+            case 1e1000:
+                y = 0
+        self.assertEqual(x, 0)
+        self.assertIs(y, None)
+
+        x = range(3)
+        match x:
+            case [y, case as x, z]:
+                w = 0
+
+    # At least one of the above branches must have been taken, because every Python
+    # version has exactly one of the two 'ASYNC_*' flags
+    return grammars
+
+
+def lib2to3_parse(src_txt: str, target_versions: Iterable[TargetVersion] = ()) -> Node:
+    """Given a string with source, return the lib2to3 Node."""
+    if not src_txt.endswith("\n"):
+        src_txt += "\n"
+
+    grammars = get_grammars(set(target_versions))
+
+
+re.match()
+match = a
+with match() as match:
+    match = f"{match}"
+
+re.match()
+match = a
+with match() as match:
+    match = f"{match}"
+```
+
+## Black Differences
+
+```diff
+--- Black
++++ Ruff
+@@ -59,7 +59,8 @@
+         grammars.append(pygram.python_grammar_soft_keywords)
+     # If we have to parse both, try to parse async as a keyword first
+     if not supports_feature(
+-        target_versions, Feature.ASYNC_IDENTIFIERS
++        target_versions,
++        Feature.ASYNC_IDENTIFIERS,
+     ) and not supports_feature(target_versions, Feature.PATTERN_MATCHING):
+         # Python 3.7-3.9
+         grammars.append(
+```
+
+## Ruff Output
+
+```python
+re.match()
+match = a
+with match() as match:
+    match = f"{match}"
+
+re.match()
+match = a
+with match() as match:
+    match = f"{match}"
+
+
+def get_grammars(target_versions: Set[TargetVersion]) -> List[Grammar]:
+    if not target_versions:
+        # No target_version specified, so try all grammars.
+        return [
+            # Python 3.7+
+            pygram.python_grammar_no_print_statement_no_exec_statement_async_keywords,
+            # Python 3.0-3.6
+            pygram.python_grammar_no_print_statement_no_exec_statement,
+            # Python 2.7 with future print_function import
+            pygram.python_grammar_no_print_statement,
+            # Python 2.7
+            pygram.python_grammar,
+        ]
+
+    match match:
+        case case:
+            match match:
+                case case:
+                    pass
+
+    if all(version.is_python2() for version in target_versions):
+        # Python 2-only code, so try Python 2 grammars.
+        return [
+            # Python 2.7 with future print_function import
+            pygram.python_grammar_no_print_statement,
+            # Python 2.7
+            pygram.python_grammar,
+        ]
+
+    re.match()
+    match = a
+    with match() as match:
+        match = f"{match}"
+
+    def test_patma_139(self):
+        x = False
+        match x:
+            case bool(z):
+                y = 0
+        self.assertIs(x, False)
+        self.assertEqual(y, 0)
+        self.assertIs(z, x)
+
+    # Python 3-compatible code, so only try Python 3 grammar.
+    grammars = []
+    if supports_feature(target_versions, Feature.PATTERN_MATCHING):
+        # Python 3.10+
+        grammars.append(pygram.python_grammar_soft_keywords)
+    # If we have to parse both, try to parse async as a keyword first
+    if not supports_feature(
+        target_versions,
+        Feature.ASYNC_IDENTIFIERS,
+    ) and not supports_feature(target_versions, Feature.PATTERN_MATCHING):
+        # Python 3.7-3.9
+        grammars.append(
+            pygram.python_grammar_no_print_statement_no_exec_statement_async_keywords
+        )
+    if not supports_feature(target_versions, Feature.ASYNC_KEYWORDS):
+        # Python 3.0-3.6
+        grammars.append(pygram.python_grammar_no_print_statement_no_exec_statement)
+
+    def test_patma_155(self):
+        x = 0
+        y = None
+        match x:
+            case 1e1000:
+                y = 0
+        self.assertEqual(x, 0)
+        self.assertIs(y, None)
+
+        x = range(3)
+        match x:
+            case [y, case as x, z]:
+                w = 0
+
+    # At least one of the above branches must have been taken, because every Python
+    # version has exactly one of the two 'ASYNC_*' flags
+    return grammars
+
+
+def lib2to3_parse(src_txt: str, target_versions: Iterable[TargetVersion] = ()) -> Node:
+    """Given a string with source, return the lib2to3 Node."""
+    if not src_txt.endswith("\n"):
+        src_txt += "\n"
+
+    grammars = get_grammars(set(target_versions))
+
+
+re.match()
+match = a
+with match() as match:
+    match = f"{match}"
+
+re.match()
+match = a
+with match() as match:
+    match = f"{match}"
+```
+
+## Black Output
+
+```python
+re.match()
+match = a
+with match() as match:
+    match = f"{match}"
+
+re.match()
+match = a
+with match() as match:
+    match = f"{match}"
+
+
+def get_grammars(target_versions: Set[TargetVersion]) -> List[Grammar]:
+    if not target_versions:
+        # No target_version specified, so try all grammars.
+        return [
+            # Python 3.7+
+            pygram.python_grammar_no_print_statement_no_exec_statement_async_keywords,
+            # Python 3.0-3.6
+            pygram.python_grammar_no_print_statement_no_exec_statement,
+            # Python 2.7 with future print_function import
+            pygram.python_grammar_no_print_statement,
+            # Python 2.7
+            pygram.python_grammar,
+        ]
+
+    match match:
+        case case:
+            match match:
+                case case:
+                    pass
+
+    if all(version.is_python2() for version in target_versions):
+        # Python 2-only code, so try Python 2 grammars.
+        return [
+            # Python 2.7 with future print_function import
+            pygram.python_grammar_no_print_statement,
+            # Python 2.7
+            pygram.python_grammar,
+        ]
+
+    re.match()
+    match = a
+    with match() as match:
+        match = f"{match}"
+
+    def test_patma_139(self):
+        x = False
+        match x:
+            case bool(z):
+                y = 0
+        self.assertIs(x, False)
+        self.assertEqual(y, 0)
+        self.assertIs(z, x)
+
+    # Python 3-compatible code, so only try Python 3 grammar.
+    grammars = []
+    if supports_feature(target_versions, Feature.PATTERN_MATCHING):
+        # Python 3.10+
+        grammars.append(pygram.python_grammar_soft_keywords)
+    # If we have to parse both, try to parse async as a keyword first
+    if not supports_feature(
+        target_versions, Feature.ASYNC_IDENTIFIERS
+    ) and not supports_feature(target_versions, Feature.PATTERN_MATCHING):
+        # Python 3.7-3.9
+        grammars.append(
+            pygram.python_grammar_no_print_statement_no_exec_statement_async_keywords
+        )
+    if not supports_feature(target_versions, Feature.ASYNC_KEYWORDS):
+        # Python 3.0-3.6
+        grammars.append(pygram.python_grammar_no_print_statement_no_exec_statement)
+
+    def test_patma_155(self):
+        x = 0
+        y = None
+        match x:
+            case 1e1000:
+                y = 0
+        self.assertEqual(x, 0)
+        self.assertIs(y, None)
+
+        x = range(3)
+        match x:
+            case [y, case as x, z]:
+                w = 0
+
+    # At least one of the above branches must have been taken, because every Python
+    # version has exactly one of the two 'ASYNC_*' flags
+    return grammars
+
+
+def lib2to3_parse(src_txt: str, target_versions: Iterable[TargetVersion] = ()) -> Node:
+    """Given a string with source, return the lib2to3 Node."""
+    if not src_txt.endswith("\n"):
+        src_txt += "\n"
+
+    grammars = get_grammars(set(target_versions))
+
+
+re.match()
+match = a
+with match() as match:
+    match = f"{match}"
+
+re.match()
+match = a
+with match() as match:
+    match = f"{match}"
+```

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__pattern_matching_style.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__pattern_matching_style.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/pattern_matching_style.py
 ---
 ## Input
 
@@ -65,7 +64,17 @@ match match(
 ```diff
 --- Black
 +++ Ruff
-@@ -13,20 +13,26 @@
+@@ -2,7 +2,8 @@
+     case b():
+         print(1 + 1)
+     case c(
+-        very_complex=True, perhaps_even_loooooooooooooooooooooooooooooooooooooong=-1
++        very_complex=True,
++        perhaps_even_loooooooooooooooooooooooooooooooooooooong=-1,
+     ):
+         print(1)
+     case c(
+@@ -13,20 +14,26 @@
      case a:
          pass
  
@@ -104,7 +113,8 @@ match something:
     case b():
         print(1 + 1)
     case c(
-        very_complex=True, perhaps_even_loooooooooooooooooooooooooooooooooooooong=-1
+        very_complex=True,
+        perhaps_even_loooooooooooooooooooooooooooooooooooooong=-1,
     ):
         print(1)
     case c(

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__pep604_union_types_line_breaks.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__pep604_union_types_line_breaks.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep604_union_types_line_breaks.py
 ---
 ## Input
 
@@ -121,15 +120,28 @@ def f(
      *,
      s: str,
  ) -> None:
-@@ -88,7 +86,7 @@
+@@ -87,15 +85,18 @@
+ @app.get("/path/")
  async def foo(
      q: str | None = Query(
-         None, title="Some long title", description="Some long description"
+-        None, title="Some long title", description="Some long description"
 -    )
++        None,
++        title="Some long title",
++        description="Some long description",
 +    ),
  ):
      pass
  
+ 
+ def f(
+     max_jobs: int | None = Option(
+-        None, help="Maximum number of jobs to launch. And some additional text."
++        None,
++        help="Maximum number of jobs to launch. And some additional text.",
+     ),
+     another_option: bool = False,
+ ): ...
 ```
 
 ## Ruff Output
@@ -222,7 +234,9 @@ def foo(
 @app.get("/path/")
 async def foo(
     q: str | None = Query(
-        None, title="Some long title", description="Some long description"
+        None,
+        title="Some long title",
+        description="Some long description",
     ),
 ):
     pass
@@ -230,7 +244,8 @@ async def foo(
 
 def f(
     max_jobs: int | None = Option(
-        None, help="Maximum number of jobs to launch. And some additional text."
+        None,
+        help="Maximum number of jobs to launch. And some additional text.",
     ),
     another_option: bool = False,
 ): ...

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__prefer_rhs_split.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__prefer_rhs_split.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/prefer_rhs_split.py
 ---
 ## Input
 
@@ -118,7 +117,69 @@ a = (
 ```diff
 --- Black
 +++ Ruff
-@@ -60,9 +60,7 @@
+@@ -1,12 +1,16 @@
+ first_item, second_item = (
+     some_looooooooong_module.some_looooooooooooooong_function_name(
+-        first_argument, second_argument, third_argument
++        first_argument,
++        second_argument,
++        third_argument,
+     )
+ )
+ 
+ some_dict["with_a_long_key"] = (
+     some_looooooooong_module.some_looooooooooooooong_function_name(
+-        first_argument, second_argument, third_argument
++        first_argument,
++        second_argument,
++        third_argument,
+     )
+ )
+ 
+@@ -22,14 +26,18 @@
+ # Make sure chaining assignments work.
+ first_item, second_item, third_item, forth_item = m["everything"] = (
+     some_looooooooong_module.some_looooooooooooooong_function_name(
+-        first_argument, second_argument, third_argument
++        first_argument,
++        second_argument,
++        third_argument,
+     )
+ )
+ 
+ # Make sure when the RHS's first split at the non-optional paren fits,
+ # we split there instead of the outer RHS optional paren.
+ first_item, second_item = some_looooooooong_module.some_loooooog_function_name(
+-    first_argument, second_argument, third_argument
++    first_argument,
++    second_argument,
++    third_argument,
+ )
+ 
+ (
+@@ -40,7 +48,9 @@
+     fifth_item,
+     last_item_very_loooooong,
+ ) = some_looooooooong_module.some_looooooooooooooong_function_name(
+-    first_argument, second_argument, third_argument
++    first_argument,
++    second_argument,
++    third_argument,
+ )
+ 
+ (
+@@ -51,7 +61,9 @@
+     fifth_item,
+     last_item_very_loooooong,
+ ) = everything = some_looooong_function_name(
+-    first_argument, second_argument, third_argument
++    first_argument,
++    second_argument,
++    third_argument,
+ )
+ 
+ 
+@@ -60,9 +72,7 @@
      some_arg
  ).intersection(pk_cols)
  
@@ -136,13 +197,17 @@ a = (
 ```python
 first_item, second_item = (
     some_looooooooong_module.some_looooooooooooooong_function_name(
-        first_argument, second_argument, third_argument
+        first_argument,
+        second_argument,
+        third_argument,
     )
 )
 
 some_dict["with_a_long_key"] = (
     some_looooooooong_module.some_looooooooooooooong_function_name(
-        first_argument, second_argument, third_argument
+        first_argument,
+        second_argument,
+        third_argument,
     )
 )
 
@@ -158,14 +223,18 @@ some_dict["with_a_long_key"] = (
 # Make sure chaining assignments work.
 first_item, second_item, third_item, forth_item = m["everything"] = (
     some_looooooooong_module.some_looooooooooooooong_function_name(
-        first_argument, second_argument, third_argument
+        first_argument,
+        second_argument,
+        third_argument,
     )
 )
 
 # Make sure when the RHS's first split at the non-optional paren fits,
 # we split there instead of the outer RHS optional paren.
 first_item, second_item = some_looooooooong_module.some_loooooog_function_name(
-    first_argument, second_argument, third_argument
+    first_argument,
+    second_argument,
+    third_argument,
 )
 
 (
@@ -176,7 +245,9 @@ first_item, second_item = some_looooooooong_module.some_loooooog_function_name(
     fifth_item,
     last_item_very_loooooong,
 ) = some_looooooooong_module.some_looooooooooooooong_function_name(
-    first_argument, second_argument, third_argument
+    first_argument,
+    second_argument,
+    third_argument,
 )
 
 (
@@ -187,7 +258,9 @@ first_item, second_item = some_looooooooong_module.some_loooooog_function_name(
     fifth_item,
     last_item_very_loooooong,
 ) = everything = some_looooong_function_name(
-    first_argument, second_argument, third_argument
+    first_argument,
+    second_argument,
+    third_argument,
 )
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_cantfit.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_cantfit.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_cantfit.py
 ---
 ## Input
 
@@ -45,7 +44,7 @@ del concatenated_strings, string_variable_name, normal_function_name, normal_nam
 ```diff
 --- Black
 +++ Ruff
-@@ -1,18 +1,12 @@
+@@ -1,23 +1,24 @@
  # long variable name
 -this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = (
 -    0
@@ -65,8 +64,44 @@ del concatenated_strings, string_variable_name, normal_function_name, normal_nam
 -)
 +this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = function()
  this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = function(
-     arg1, arg2, arg3
+-    arg1, arg2, arg3
++    arg1,
++    arg2,
++    arg3,
  )
+ this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = function(
+-    [1, 2, 3], arg1, [1, 2, 3], arg2, [1, 2, 3], arg3
++    [1, 2, 3],
++    arg1,
++    [1, 2, 3],
++    arg2,
++    [1, 2, 3],
++    arg3,
+ )
+ # long function name
+ normal_name = (
+@@ -25,12 +26,19 @@
+ )
+ normal_name = (
+     but_the_function_name_is_now_ridiculously_long_and_it_is_still_super_annoying(
+-        arg1, arg2, arg3
++        arg1,
++        arg2,
++        arg3,
+     )
+ )
+ normal_name = (
+     but_the_function_name_is_now_ridiculously_long_and_it_is_still_super_annoying(
+-        [1, 2, 3], arg1, [1, 2, 3], arg2, [1, 2, 3], arg3
++        [1, 2, 3],
++        arg1,
++        [1, 2, 3],
++        arg2,
++        [1, 2, 3],
++        arg3,
+     )
+ )
+ string_variable_name = "a string that is waaaaaaaayyyyyyyy too long, even in parens, there's nothing you can do"  # noqa
 ```
 
 ## Ruff Output
@@ -82,10 +117,17 @@ this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_li
 ]
 this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = function()
 this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = function(
-    arg1, arg2, arg3
+    arg1,
+    arg2,
+    arg3,
 )
 this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = function(
-    [1, 2, 3], arg1, [1, 2, 3], arg2, [1, 2, 3], arg3
+    [1, 2, 3],
+    arg1,
+    [1, 2, 3],
+    arg2,
+    [1, 2, 3],
+    arg3,
 )
 # long function name
 normal_name = (
@@ -93,12 +135,19 @@ normal_name = (
 )
 normal_name = (
     but_the_function_name_is_now_ridiculously_long_and_it_is_still_super_annoying(
-        arg1, arg2, arg3
+        arg1,
+        arg2,
+        arg3,
     )
 )
 normal_name = (
     but_the_function_name_is_now_ridiculously_long_and_it_is_still_super_annoying(
-        [1, 2, 3], arg1, [1, 2, 3], arg2, [1, 2, 3], arg3
+        [1, 2, 3],
+        arg1,
+        [1, 2, 3],
+        arg2,
+        [1, 2, 3],
+        arg3,
     )
 )
 string_variable_name = "a string that is waaaaaaaayyyyyyyy too long, even in parens, there's nothing you can do"  # noqa

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_hug_parens_with_braces_and_square_brackets.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_hug_parens_with_braces_and_square_brackets.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_hug_parens_with_braces_and_square_brackets.py
 ---
 ## Input
 
@@ -242,7 +241,21 @@ for foo in ["a", "b"]:
      x
      for x in [
          x
-@@ -131,10 +137,12 @@
+@@ -123,18 +129,24 @@
+ ])
+ 
+ foooooooooooooooooooo(
+-    [{c: n + 1 for c in range(256)} for n in range(100)] + [{}], {size}
++    [{c: n + 1 for c in range(256)} for n in range(100)] + [{}],
++    {size},
+ )
+ 
+ baaaaaaaaaaaaar(
+-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], {x}, "a string", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
++    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
++    {x},
++    "a string",
++    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
  )
  
  nested_mapping = {
@@ -259,7 +272,7 @@ for foo in ["a", "b"]:
  }
  explicit_exploding = [
      [
-@@ -164,9 +172,9 @@
+@@ -164,9 +176,9 @@
  })
  
  # Edge case when deciding whether to hug the brackets without inner content.
@@ -408,11 +421,15 @@ func([
 ])
 
 foooooooooooooooooooo(
-    [{c: n + 1 for c in range(256)} for n in range(100)] + [{}], {size}
+    [{c: n + 1 for c in range(256)} for n in range(100)] + [{}],
+    {size},
 )
 
 baaaaaaaaaaaaar(
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], {x}, "a string", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    {x},
+    "a string",
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
 )
 
 nested_mapping = {

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_dict_values.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_dict_values.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_dict_values.py
 ---
 ## Input
 
@@ -228,7 +227,7 @@ class Random:
  }
  
  {
-@@ -139,17 +133,17 @@
+@@ -139,17 +133,18 @@
  
  class Random:
      def func():
@@ -245,7 +244,8 @@ class Random:
 -                            Timestamp(seconds=1530584000, nanos=0).ToJsonString()
 -                        ),
 +                        "actionTimestamp": Timestamp(
-+                            seconds=1530584000, nanos=0
++                            seconds=1530584000,
++                            nanos=0,
 +                        ).ToJsonString(),
                      }
                  },
@@ -400,7 +400,8 @@ class Random:
                         "latitude": 1,
                         "longitude": 2,
                         "actionTimestamp": Timestamp(
-                            seconds=1530584000, nanos=0
+                            seconds=1530584000,
+                            nanos=0,
                         ).ToJsonString(),
                     }
                 },

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_strings.py
 ---
 ## Input
 
@@ -355,7 +354,7 @@ x = {
 ```diff
 --- Black
 +++ Ruff
-@@ -1,175 +1,108 @@
+@@ -1,175 +1,111 @@
 -x = (
 -    "This is a really long string that can't possibly be expected to fit all together"
 -    " on one line. In fact it may even take up three or more lines... like four or"
@@ -436,18 +435,21 @@ x = {
 -    "A long and ridiculous {}".format(string_key): (
 -        "This is a really really really long string that has to go i,side of a"
 -        " dictionary. It is soooo bad."
--    ),
--    some_func("calling", "some", "stuff"): (
--        "This is a really really really long string that has to go inside of a"
--        " dictionary. It is {soooo} bad (#{x}).".format(sooo="soooo", x=2)
 +    "A long and ridiculous {}".format(
 +        string_key
 +    ): "This is a really really really long string that has to go i,side of a dictionary. It is soooo bad.",
 +    some_func(
-+        "calling", "some", "stuff"
++        "calling",
++        "some",
++        "stuff",
 +    ): "This is a really really really long string that has to go inside of a dictionary. It is {soooo} bad (#{x}).".format(
-+        sooo="soooo", x=2
++        sooo="soooo",
++        x=2,
      ),
+-    some_func("calling", "some", "stuff"): (
+-        "This is a really really really long string that has to go inside of a"
+-        " dictionary. It is {soooo} bad (#{x}).".format(sooo="soooo", x=2)
+-    ),
      "A %s %s"
 -    % ("formatted", "string"): (
 -        "This is a really really really long string that has to go inside of a"
@@ -574,7 +576,7 @@ x = {
  )
  
  bad_split2 = (
-@@ -205,11 +138,9 @@
+@@ -205,11 +141,9 @@
      xxx,
      yyy,
      zzz,
@@ -589,7 +591,7 @@ x = {
  )
  
  bad_split_func3(
-@@ -228,29 +159,28 @@
+@@ -228,29 +162,28 @@
  )
  
  inline_comments_func1(
@@ -629,7 +631,7 @@ x = {
  )
  
  fmt_string2 = "But what about when the string is {} but {}".format(
-@@ -259,8 +189,8 @@
+@@ -259,8 +192,8 @@
  )
  
  old_fmt_string1 = (
@@ -640,7 +642,7 @@ x = {
  )
  
  old_fmt_string2 = "This is a %s %s %s %s" % (
-@@ -271,8 +201,7 @@
+@@ -271,8 +204,7 @@
  )
  
  old_fmt_string3 = (
@@ -650,7 +652,7 @@ x = {
      % (
          "really really really really really",
          "old",
-@@ -281,26 +210,14 @@
+@@ -281,26 +213,14 @@
      )
  )
  
@@ -681,7 +683,7 @@ x = {
      "Arg #2",
      "Arg #3",
      "Arg #4",
-@@ -316,79 +233,75 @@
+@@ -316,79 +236,82 @@
  triple_quote_string = """This is a really really really long triple quote string assignment and it should not be touched."""
  
  assert some_type_of_boolean_expression, (
@@ -737,7 +739,8 @@ x = {
 -    "A really really really really really really really really really really really"
 -    " really really long {} {}".format("return", "value")
 +return "A really really really really really really really really really really really really really long {} {}".format(
-+    "return", "value"
++    "return",
++    "value",
  )
  
  func_with_bad_comma(
@@ -772,12 +775,18 @@ x = {
  
  func_with_bad_parens_that_wont_fit_in_one_line(
 -    "short string that should have parens stripped", x, y, z
-+    ("short string that should have parens stripped"), x, y, z
++    ("short string that should have parens stripped"),
++    x,
++    y,
++    z,
  )
  
  func_with_bad_parens_that_wont_fit_in_one_line(
 -    x, y, "short string that should have parens stripped", z
-+    x, y, ("short string that should have parens stripped"), z
++    x,
++    y,
++    ("short string that should have parens stripped"),
++    z,
  )
  
  func_with_bad_parens(
@@ -786,7 +795,7 @@ x = {
      x,
      y,
      z,
-@@ -397,7 +310,7 @@
+@@ -397,7 +320,7 @@
  func_with_bad_parens(
      x,
      y,
@@ -795,7 +804,7 @@ x = {
      z,
  )
  
-@@ -408,50 +321,27 @@
+@@ -408,50 +331,27 @@
      + CONCATENATED
      + "using the '+' operator."
  )
@@ -854,7 +863,7 @@ x = {
  
  long_unmergable_string_with_pragma = (
      "This is a really long string that can't be merged because it has a likely pragma at the end"  # type: ignore
-@@ -468,49 +358,24 @@
+@@ -468,49 +368,24 @@
      " of it."
  )
  
@@ -913,7 +922,7 @@ x = {
  )
  
  dict_with_lambda_values = {
-@@ -522,65 +387,58 @@
+@@ -522,65 +397,58 @@
  
  # Complex string concatenations with a method call in the middle.
  code = (
@@ -997,7 +1006,7 @@ x = {
  )
  
  log.info(
-@@ -588,7 +446,7 @@
+@@ -588,7 +456,7 @@
  )
  
  log.info(
@@ -1006,7 +1015,7 @@ x = {
  )
  
  x = {
-@@ -597,10 +455,10 @@
+@@ -597,10 +465,10 @@
      )
  }
  x = {
@@ -1063,9 +1072,12 @@ D4 = {
         string_key
     ): "This is a really really really long string that has to go i,side of a dictionary. It is soooo bad.",
     some_func(
-        "calling", "some", "stuff"
+        "calling",
+        "some",
+        "stuff",
     ): "This is a really really really long string that has to go inside of a dictionary. It is {soooo} bad (#{x}).".format(
-        sooo="soooo", x=2
+        sooo="soooo",
+        x=2,
     ),
     "A %s %s"
     % (
@@ -1295,7 +1307,8 @@ some_function_call(
 )
 
 return "A really really really really really really really really really really really really really long {} {}".format(
-    "return", "value"
+    "return",
+    "value",
 )
 
 func_with_bad_comma(
@@ -1321,11 +1334,17 @@ func_with_bad_comma(
 )
 
 func_with_bad_parens_that_wont_fit_in_one_line(
-    ("short string that should have parens stripped"), x, y, z
+    ("short string that should have parens stripped"),
+    x,
+    y,
+    z,
 )
 
 func_with_bad_parens_that_wont_fit_in_one_line(
-    x, y, ("short string that should have parens stripped"), z
+    x,
+    y,
+    ("short string that should have parens stripped"),
+    z,
 )
 
 func_with_bad_parens(

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings__regression.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings__regression.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_strings__regression.py
 ---
 ## Input
 
@@ -574,7 +573,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
 ```diff
 --- Black
 +++ Ruff
-@@ -25,20 +25,17 @@
+@@ -25,20 +25,20 @@
      "Jaguar",
  )
  
@@ -584,7 +583,8 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
 -        "perfect", "length"
 -    )
 +stupid_format_method_bug = "Some really long string that just so happens to be the {} {} to force the 'format' method to hang over the line length boundary. This is pretty annoying.".format(
-+    "perfect", "length"
++    "perfect",
++    "length",
  )
  
  
@@ -595,12 +595,25 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
 -            " xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx"
 -            " xxxx.".format("xxxxxxxxxx", "xxxxxx", "xxxxxxxxxx")
 +            "This is a regression test. xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxxx.".format(
-+                "xxxxxxxxxx", "xxxxxx", "xxxxxxxxxx"
++                "xxxxxxxxxx",
++                "xxxxxx",
++                "xxxxxxxxxx",
 +            )
          )
  
  
-@@ -57,9 +54,11 @@
+@@ -46,7 +46,9 @@
+     def foo():
+         XXXXXXXXXXXX.append((
+             "xxx_xxxxxxxxxx(xxxxx={}, xxxx={}, xxxxx, xxxx_xxxx_xxxxxxxxxx={})".format(
+-                xxxxx, xxxx, xxxx_xxxx_xxxxxxxxxx
++                xxxxx,
++                xxxx,
++                xxxx_xxxx_xxxxxxxxxx,
+             ),
+             my_var,
+             my_other_var,
+@@ -57,9 +59,15 @@
      class B:
          def foo():
              bar(
@@ -610,24 +623,30 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
 +                (
 +                    "[{}]: xxx_xxxxxxxxxx(xxxxx={}, xxxx={}, xxxxx={}"
 +                    " xxxx_xxxx_xxxxxxxxxx={}, xxxx={})".format(
-+                        xxxx._xxxxxxxxxxxxxx, xxxxx, xxxx, xxxx_xxxx_xxxxxxxxxx, xxxxxxx
++                        xxxx._xxxxxxxxxxxxxx,
++                        xxxxx,
++                        xxxx,
++                        xxxx_xxxx_xxxxxxxxxx,
++                        xxxxxxx,
 +                    )
                  ),
                  varX,
                  varY,
-@@ -71,8 +70,9 @@
+@@ -71,8 +79,11 @@
      for xxx_xxxx, _xxx_xxx, _xxx_xxxxx, xxx_xxxx in xxxx:
          for xxx in xxx_xxxx:
              assert ("x" in xxx) or (xxx in xxx_xxx_xxxxx), (
 -                "{0} xxxxxxx xx {1}, xxx {1} xx xxx xx xxxx xx xxx xxxx: xxx xxxx {2}"
 -                .format(xxx_xxxx, xxx, xxxxxx.xxxxxxx(xxx_xxx_xxxxx))
 +                "{0} xxxxxxx xx {1}, xxx {1} xx xxx xx xxxx xx xxx xxxx: xxx xxxx {2}".format(
-+                    xxx_xxxx, xxx, xxxxxx.xxxxxxx(xxx_xxx_xxxxx)
++                    xxx_xxxx,
++                    xxx,
++                    xxxxxx.xxxxxxx(xxx_xxx_xxxxx),
 +                )
              )
  
  
-@@ -83,7 +83,8 @@
+@@ -83,7 +94,8 @@
                  "{{xxx_xxxxxxxxxx_xxxxxxxx}} xxx xxxx {} {{xxxx}} >&2".format(
                      "{xxxx} {xxxxxx}"
                      if xxxxx.xx_xxxxxxxxxx
@@ -637,7 +656,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
                          "--xxxxxxx --xxxxxx=x --xxxxxx-xxxxx=xxxxxx"
                          " --xxxxxx-xxxx=xxxxxxxxxxx.xxx"
                      )
-@@ -113,18 +114,25 @@
+@@ -113,18 +125,25 @@
  
  
  func_call_where_string_arg_has_method_call_and_bad_parens(
@@ -669,7 +688,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
  )
  
  
-@@ -132,52 +140,60 @@
+@@ -132,52 +151,60 @@
      def append(self):
          if True:
              xxxx.xxxxxxx.xxxxx(
@@ -763,7 +782,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
  }
  
  
-@@ -185,10 +201,10 @@
+@@ -185,10 +212,10 @@
      def foo(self):
          if True:
              xxxxx_xxxxxxxxxxxx(
@@ -778,7 +797,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
              )
  
  
-@@ -232,36 +248,21 @@
+@@ -232,36 +259,21 @@
  
  some_dictionary = {
      "xxxxx006": [
@@ -823,7 +842,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
  
  
  some_tuple = ("some string", "some string which should be joined")
-@@ -279,34 +280,21 @@
+@@ -279,34 +291,21 @@
  )
  
  lpar_and_rpar_have_comments = func_call(  # LPAR Comment
@@ -864,7 +883,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
  
  fstring = f"We have to remember to escape {braces}. Like {{these}}. But not {this}."
  
-@@ -364,10 +352,7 @@
+@@ -364,10 +363,7 @@
          def foo():
              if not hasattr(module, name):
                  raise ValueError(
@@ -876,7 +895,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
                      % (name, module_name, get_docs_version())
                  )
  
-@@ -382,23 +367,19 @@
+@@ -382,23 +378,19 @@
  
  class Step(StepBase):
      def who(self):
@@ -907,7 +926,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
              # xxxxx xxxxxxxxxxxx xxxx xxx (xxxxxxxxxxxxxxxx) xx x xxxxxxxxx xx xxxxxx.
              "(x.bbbbbbbbbbbb.xxx != "
              '"xxx:xxx:xxx::cccccccccccc:xxxxxxx-xxxx/xxxxxxxxxxx/xxxxxxxxxxxxxxxxx") && '
-@@ -409,8 +390,8 @@
+@@ -409,8 +401,8 @@
  if __name__ == "__main__":
      for i in range(4, 8):
          cmd = (
@@ -918,7 +937,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
          )
  
  
-@@ -432,9 +413,7 @@
+@@ -432,9 +424,7 @@
          assert xxxxxxx_xxxx in [
              x.xxxxx.xxxxxx.xxxxx.xxxxxx,
              x.xxxxx.xxxxxx.xxxxx.xxxx,
@@ -929,7 +948,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
  
  
  value.__dict__[key] = (
-@@ -449,8 +428,7 @@
+@@ -449,8 +439,7 @@
  
  RE_TWO_BACKSLASHES = {
      "asdf_hjkl_jkl": re.compile(
@@ -939,23 +958,23 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
      ),
  }
  
-@@ -462,13 +440,9 @@
+@@ -462,13 +451,9 @@
  
  # We do NOT split on f-string expressions.
  print(
 -    "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam."
 -    f" {[f'{i}' for i in range(10)]}"
--)
++    f"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam. {[f'{i}' for i in range(10)]}"
+ )
 -x = (
 -    "This is a long string which contains an f-expr that should not split"
 -    f" {{{[i for i in range(5)]}}}."
-+    f"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam. {[f'{i}' for i in range(10)]}"
- )
+-)
 +x = f"This is a long string which contains an f-expr that should not split {{{[i for i in range(5)]}}}."
  
  # The parens should NOT be removed in this case.
  (
-@@ -478,8 +452,8 @@
+@@ -478,8 +463,8 @@
  
  # The parens should NOT be removed in this case.
  (
@@ -966,7 +985,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
  )
  
  # The parens should NOT be removed in this case.
-@@ -513,93 +487,83 @@
+@@ -513,93 +498,83 @@
  
  
  temp_msg = (
@@ -1096,7 +1115,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
      "6. Click on Create Credential at the top."
      '7. At the top click the link for "API key".'
      "8. No application restrictions are needed. Click Create at the bottom."
-@@ -608,7 +572,7 @@
+@@ -608,7 +583,7 @@
  
  # It shouldn't matter if the string prefixes are capitalized.
  temp_msg = (
@@ -1105,7 +1124,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
      f"{balance: <{bal_len + 5}} "
      f"<<{author.display_name}>>\n"
  )
-@@ -617,51 +581,34 @@
+@@ -617,51 +592,34 @@
  
  welcome_to_programming = R"hello," R" world!"
  
@@ -1171,7 +1190,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
  )
  
  # Regression test for https://github.com/psf/black/issues/3455.
-@@ -673,14 +620,6 @@
+@@ -673,14 +631,6 @@
  
  # Regression test for https://github.com/psf/black/issues/3506.
  # Regressed again by https://github.com/psf/black/pull/4498
@@ -1221,7 +1240,8 @@ long_tuple = (
 )
 
 stupid_format_method_bug = "Some really long string that just so happens to be the {} {} to force the 'format' method to hang over the line length boundary. This is pretty annoying.".format(
-    "perfect", "length"
+    "perfect",
+    "length",
 )
 
 
@@ -1229,7 +1249,9 @@ class A:
     def foo():
         os.system(
             "This is a regression test. xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxxx.".format(
-                "xxxxxxxxxx", "xxxxxx", "xxxxxxxxxx"
+                "xxxxxxxxxx",
+                "xxxxxx",
+                "xxxxxxxxxx",
             )
         )
 
@@ -1238,7 +1260,9 @@ class A:
     def foo():
         XXXXXXXXXXXX.append((
             "xxx_xxxxxxxxxx(xxxxx={}, xxxx={}, xxxxx, xxxx_xxxx_xxxxxxxxxx={})".format(
-                xxxxx, xxxx, xxxx_xxxx_xxxxxxxxxx
+                xxxxx,
+                xxxx,
+                xxxx_xxxx_xxxxxxxxxx,
             ),
             my_var,
             my_other_var,
@@ -1252,7 +1276,11 @@ class A:
                 (
                     "[{}]: xxx_xxxxxxxxxx(xxxxx={}, xxxx={}, xxxxx={}"
                     " xxxx_xxxx_xxxxxxxxxx={}, xxxx={})".format(
-                        xxxx._xxxxxxxxxxxxxx, xxxxx, xxxx, xxxx_xxxx_xxxxxxxxxx, xxxxxxx
+                        xxxx._xxxxxxxxxxxxxx,
+                        xxxxx,
+                        xxxx,
+                        xxxx_xxxx_xxxxxxxxxx,
+                        xxxxxxx,
                     )
                 ),
                 varX,
@@ -1266,7 +1294,9 @@ def foo(xxxx):
         for xxx in xxx_xxxx:
             assert ("x" in xxx) or (xxx in xxx_xxx_xxxxx), (
                 "{0} xxxxxxx xx {1}, xxx {1} xx xxx xx xxxx xx xxx xxxx: xxx xxxx {2}".format(
-                    xxx_xxxx, xxx, xxxxxx.xxxxxxx(xxx_xxx_xxxxx)
+                    xxx_xxxx,
+                    xxx,
+                    xxxxxx.xxxxxxx(xxx_xxx_xxxxx),
                 )
             )
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__python37.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__python37.py.snap
@@ -1,0 +1,121 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+---
+## Input
+
+```python
+def f():
+    return (i * 2 async for i in arange(42))
+
+
+def g():
+    return (
+        something_long * something_long
+        async for something_long in async_generator(with_an_argument)
+    )
+
+
+async def func():
+    await ...
+    if test:
+        out_batched = [
+            i
+            async for i in aitertools._async_map(
+                self.async_inc, arange(8), batch_size=3
+            )
+        ]
+
+
+def awaited_generator_value(n):
+    return (await awaitable for awaitable in awaitable_list)
+
+
+def make_arange(n):
+    return (i * 2 for i in range(n) if await wrap(i))
+```
+
+## Black Differences
+
+```diff
+--- Black
++++ Ruff
+@@ -15,7 +15,9 @@
+         out_batched = [
+             i
+             async for i in aitertools._async_map(
+-                self.async_inc, arange(8), batch_size=3
++                self.async_inc,
++                arange(8),
++                batch_size=3,
+             )
+         ]
+ 
+```
+
+## Ruff Output
+
+```python
+def f():
+    return (i * 2 async for i in arange(42))
+
+
+def g():
+    return (
+        something_long * something_long
+        async for something_long in async_generator(with_an_argument)
+    )
+
+
+async def func():
+    await ...
+    if test:
+        out_batched = [
+            i
+            async for i in aitertools._async_map(
+                self.async_inc,
+                arange(8),
+                batch_size=3,
+            )
+        ]
+
+
+def awaited_generator_value(n):
+    return (await awaitable for awaitable in awaitable_list)
+
+
+def make_arange(n):
+    return (i * 2 for i in range(n) if await wrap(i))
+```
+
+## Black Output
+
+```python
+def f():
+    return (i * 2 async for i in arange(42))
+
+
+def g():
+    return (
+        something_long * something_long
+        async for something_long in async_generator(with_an_argument)
+    )
+
+
+async def func():
+    await ...
+    if test:
+        out_batched = [
+            i
+            async for i in aitertools._async_map(
+                self.async_inc, arange(8), batch_size=3
+            )
+        ]
+
+
+def awaited_generator_value(n):
+    return (await awaitable for awaitable in awaitable_list)
+
+
+def make_arange(n):
+    return (i * 2 for i in range(n) if await wrap(i))
+```

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples.py
 ---
 ## Input
 ```python
@@ -1624,7 +1623,13 @@ def doctest_long_lines():
     # get wrapped in the docstring above because of how the line-width
     # setting gets reset at the first column in each code snippet.
     foo, bar, quux = this_is_a_long_line(
-        lion, giraffe, hippo, zeba, lemur, penguin, monkey
+        lion,
+        giraffe,
+        hippo,
+        zeba,
+        lemur,
+        penguin,
+        monkey,
     )
 
 
@@ -2997,7 +3002,13 @@ def doctest_long_lines():
   # get wrapped in the docstring above because of how the line-width
   # setting gets reset at the first column in each code snippet.
   foo, bar, quux = this_is_a_long_line(
-    lion, giraffe, hippo, zeba, lemur, penguin, monkey
+    lion,
+    giraffe,
+    hippo,
+    zeba,
+    lemur,
+    penguin,
+    monkey,
   )
 
 
@@ -4370,7 +4381,13 @@ def doctest_long_lines():
 	# get wrapped in the docstring above because of how the line-width
 	# setting gets reset at the first column in each code snippet.
 	foo, bar, quux = this_is_a_long_line(
-		lion, giraffe, hippo, zeba, lemur, penguin, monkey
+		lion,
+		giraffe,
+		hippo,
+		zeba,
+		lemur,
+		penguin,
+		monkey,
 	)
 
 
@@ -5743,7 +5760,13 @@ def doctest_long_lines():
 	# get wrapped in the docstring above because of how the line-width
 	# setting gets reset at the first column in each code snippet.
 	foo, bar, quux = this_is_a_long_line(
-		lion, giraffe, hippo, zeba, lemur, penguin, monkey
+		lion,
+		giraffe,
+		hippo,
+		zeba,
+		lemur,
+		penguin,
+		monkey,
 	)
 
 
@@ -7106,19 +7129,40 @@ def doctest_long_lines():
     line width because it doesn't exceed the line width within this
     docstring. e.g, the `f` in `foo` is treated as the first column.
     >>> foo, bar, quux = this_is_a_long_line(
-    ...     lion, giraffe, hippo, zeba, lemur, penguin, monkey
+    ...     lion,
+    ...     giraffe,
+    ...     hippo,
+    ...     zeba,
+    ...     lemur,
+    ...     penguin,
+    ...     monkey,
     ... )
 
     But this one is long enough to get wrapped.
     >>> foo, bar, quux = this_is_a_long_line(
-    ...     lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard
+    ...     lion,
+    ...     giraffe,
+    ...     hippo,
+    ...     zeba,
+    ...     lemur,
+    ...     penguin,
+    ...     monkey,
+    ...     spider,
+    ...     bear,
+    ...     leopard,
     ... )
     """
     # This demonstrates a normal line that will get wrapped but won't
     # get wrapped in the docstring above because of how the line-width
     # setting gets reset at the first column in each code snippet.
     foo, bar, quux = this_is_a_long_line(
-        lion, giraffe, hippo, zeba, lemur, penguin, monkey
+        lion,
+        giraffe,
+        hippo,
+        zeba,
+        lemur,
+        penguin,
+        monkey,
     )
 
 
@@ -8472,19 +8516,40 @@ def doctest_long_lines():
   line width because it doesn't exceed the line width within this
   docstring. e.g, the `f` in `foo` is treated as the first column.
   >>> foo, bar, quux = this_is_a_long_line(
-  ...   lion, giraffe, hippo, zeba, lemur, penguin, monkey
+  ...   lion,
+  ...   giraffe,
+  ...   hippo,
+  ...   zeba,
+  ...   lemur,
+  ...   penguin,
+  ...   monkey,
   ... )
 
   But this one is long enough to get wrapped.
   >>> foo, bar, quux = this_is_a_long_line(
-  ...   lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard
+  ...   lion,
+  ...   giraffe,
+  ...   hippo,
+  ...   zeba,
+  ...   lemur,
+  ...   penguin,
+  ...   monkey,
+  ...   spider,
+  ...   bear,
+  ...   leopard,
   ... )
   """
   # This demonstrates a normal line that will get wrapped but won't
   # get wrapped in the docstring above because of how the line-width
   # setting gets reset at the first column in each code snippet.
   foo, bar, quux = this_is_a_long_line(
-    lion, giraffe, hippo, zeba, lemur, penguin, monkey
+    lion,
+    giraffe,
+    hippo,
+    zeba,
+    lemur,
+    penguin,
+    monkey,
   )
 
 
@@ -9838,7 +9903,13 @@ def doctest_long_lines():
 	line width because it doesn't exceed the line width within this
 	docstring. e.g, the `f` in `foo` is treated as the first column.
 	>>> foo, bar, quux = this_is_a_long_line(
-	...         lion, giraffe, hippo, zeba, lemur, penguin, monkey
+	...         lion,
+	...         giraffe,
+	...         hippo,
+	...         zeba,
+	...         lemur,
+	...         penguin,
+	...         monkey,
 	... )
 
 	But this one is long enough to get wrapped.
@@ -9859,7 +9930,13 @@ def doctest_long_lines():
 	# get wrapped in the docstring above because of how the line-width
 	# setting gets reset at the first column in each code snippet.
 	foo, bar, quux = this_is_a_long_line(
-		lion, giraffe, hippo, zeba, lemur, penguin, monkey
+		lion,
+		giraffe,
+		hippo,
+		zeba,
+		lemur,
+		penguin,
+		monkey,
 	)
 
 
@@ -11213,19 +11290,40 @@ def doctest_long_lines():
 	line width because it doesn't exceed the line width within this
 	docstring. e.g, the `f` in `foo` is treated as the first column.
 	>>> foo, bar, quux = this_is_a_long_line(
-	...     lion, giraffe, hippo, zeba, lemur, penguin, monkey
+	...     lion,
+	...     giraffe,
+	...     hippo,
+	...     zeba,
+	...     lemur,
+	...     penguin,
+	...     monkey,
 	... )
 
 	But this one is long enough to get wrapped.
 	>>> foo, bar, quux = this_is_a_long_line(
-	...     lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard
+	...     lion,
+	...     giraffe,
+	...     hippo,
+	...     zeba,
+	...     lemur,
+	...     penguin,
+	...     monkey,
+	...     spider,
+	...     bear,
+	...     leopard,
 	... )
 	"""
 	# This demonstrates a normal line that will get wrapped but won't
 	# get wrapped in the docstring above because of how the line-width
 	# setting gets reset at the first column in each code snippet.
 	foo, bar, quux = this_is_a_long_line(
-		lion, giraffe, hippo, zeba, lemur, penguin, monkey
+		lion,
+		giraffe,
+		hippo,
+		zeba,
+		lemur,
+		penguin,
+		monkey,
 	)
 
 
@@ -12579,7 +12677,13 @@ def doctest_long_lines():
     line width because it doesn't exceed the line width within this
     docstring. e.g, the `f` in `foo` is treated as the first column.
     >>> foo, bar, quux = this_is_a_long_line(
-    ...     lion, giraffe, hippo, zeba, lemur, penguin, monkey
+    ...     lion,
+    ...     giraffe,
+    ...     hippo,
+    ...     zeba,
+    ...     lemur,
+    ...     penguin,
+    ...     monkey,
     ... )
 
     But this one is long enough to get wrapped.
@@ -12600,7 +12704,13 @@ def doctest_long_lines():
     # get wrapped in the docstring above because of how the line-width
     # setting gets reset at the first column in each code snippet.
     foo, bar, quux = this_is_a_long_line(
-        lion, giraffe, hippo, zeba, lemur, penguin, monkey
+        lion,
+        giraffe,
+        hippo,
+        zeba,
+        lemur,
+        penguin,
+        monkey,
     )
 
 
@@ -13954,19 +14064,40 @@ def doctest_long_lines():
     line width because it doesn't exceed the line width within this
     docstring. e.g, the `f` in `foo` is treated as the first column.
     >>> foo, bar, quux = this_is_a_long_line(
-    ...     lion, giraffe, hippo, zeba, lemur, penguin, monkey
+    ...     lion,
+    ...     giraffe,
+    ...     hippo,
+    ...     zeba,
+    ...     lemur,
+    ...     penguin,
+    ...     monkey,
     ... )
 
     But this one is long enough to get wrapped.
     >>> foo, bar, quux = this_is_a_long_line(
-    ...     lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard
+    ...     lion,
+    ...     giraffe,
+    ...     hippo,
+    ...     zeba,
+    ...     lemur,
+    ...     penguin,
+    ...     monkey,
+    ...     spider,
+    ...     bear,
+    ...     leopard,
     ... )
     """
     # This demonstrates a normal line that will get wrapped but won't
     # get wrapped in the docstring above because of how the line-width
     # setting gets reset at the first column in each code snippet.
     foo, bar, quux = this_is_a_long_line(
-        lion, giraffe, hippo, zeba, lemur, penguin, monkey
+        lion,
+        giraffe,
+        hippo,
+        zeba,
+        lemur,
+        penguin,
+        monkey,
     )
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_dynamic_line_width.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_dynamic_line_width.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples_dynamic_line_width.py
 ---
 ## Input
 ```python
@@ -320,7 +319,20 @@ def simple():
 
     ```py
     class Abcdefghijklmopqrstuvwxyz(
-        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+        Abc,
+        Def,
+        Ghi,
+        Jkl,
+        Mno,
+        Pqr,
+        Stu,
+        Vwx,
+        Yz,
+        A1,
+        A2,
+        A3,
+        A4,
+        A5,
     ):
         def abcdefghijklmnopqrstuvwxyz(
             self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -350,7 +362,20 @@ def repeated():
 
     ```py
     class Abcdefghijklmopqrstuvwxyz(
-        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+        Abc,
+        Def,
+        Ghi,
+        Jkl,
+        Mno,
+        Pqr,
+        Stu,
+        Vwx,
+        Yz,
+        A1,
+        A2,
+        A3,
+        A4,
+        A5,
     ):
         def abcdefghijklmnopqrstuvwxyz(
             self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -404,7 +429,20 @@ def repeated():
 
 
     class Abcdefghijklmopqrstuvwxyz(
-        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+        Abc,
+        Def,
+        Ghi,
+        Jkl,
+        Mno,
+        Pqr,
+        Stu,
+        Vwx,
+        Yz,
+        A1,
+        A2,
+        A3,
+        A4,
+        A5,
     ):
         def abcdefghijklmnopqrstuvwxyz(
             self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -470,7 +508,20 @@ def barely_exceeds_limit():
 
     ```py
     class Abcdefghijklmopqrstuvwxyz(
-        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+        Abc,
+        Def,
+        Ghi,
+        Jkl,
+        Mno,
+        Pqr,
+        Stu,
+        Vwx,
+        Yz,
+        A1,
+        A2,
+        A3,
+        A4,
+        A5,
     ):
         def abcdefghijklmnopqrstuvwxyz(
             self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -482,7 +533,20 @@ def barely_exceeds_limit():
                 # more than the limit. Therefore, it should get wrapped for
                 # indent_width >= 4.
                 print(
-                    abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a5678
+                    abc,
+                    ddef,
+                    ghi,
+                    jkl,
+                    mno,
+                    pqr,
+                    stu,
+                    vwx,
+                    yz,
+                    a1,
+                    a2,
+                    a3,
+                    a4,
+                    a5678,
                 )
                 return 5
 
@@ -502,7 +566,20 @@ def unindented():
 
     ```py
     class Abcdefghijklmopqrstuvwxyz(
-        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+        Abc,
+        Def,
+        Ghi,
+        Jkl,
+        Mno,
+        Pqr,
+        Stu,
+        Vwx,
+        Yz,
+        A1,
+        A2,
+        A3,
+        A4,
+        A5,
     ):
         def abcdefghijklmnopqrstuvwxyz(
             self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -532,7 +609,20 @@ def unindented_barely_exceeds_limit():
 
     ```py
     class Abcdefghijklmopqrstuvwxyz(
-        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+        Abc,
+        Def,
+        Ghi,
+        Jkl,
+        Mno,
+        Pqr,
+        Stu,
+        Vwx,
+        Yz,
+        A1,
+        A2,
+        A3,
+        A4,
+        A5,
     ):
         def abcdefghijklmnopqrstuvwxyz(
             self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -544,7 +634,20 @@ def unindented_barely_exceeds_limit():
                 # more than the limit. Therefore, it should get wrapped for
                 # indent_width >= 4.
                 print(
-                    abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a5678
+                    abc,
+                    ddef,
+                    ghi,
+                    jkl,
+                    mno,
+                    pqr,
+                    stu,
+                    vwx,
+                    yz,
+                    a1,
+                    a2,
+                    a3,
+                    a4,
+                    a5678,
                 )
                 return 5
 
@@ -600,7 +703,10 @@ def doctest_extra_indent3():
     Examples
     --------
     >>> af1, af2, af3 = pl.align_frames(
-    ...     df1, df2, df3, on="dt"
+    ...     df1,
+    ...     df2,
+    ...     df3,
+    ...     on="dt",
     ... )  # doctest: +IGNORE_RESULT
     """
 
@@ -690,7 +796,7 @@ def length_rst_in_section():
 ```diff
 --- Stable
 +++ Preview
-@@ -270,9 +270,11 @@
+@@ -374,9 +374,11 @@
  
          Examples
          --------
@@ -705,7 +811,7 @@ def length_rst_in_section():
          """
  
  
-@@ -300,9 +302,28 @@
+@@ -407,9 +409,28 @@
          Integer length of the list of numbers.
  
      Example:
@@ -737,7 +843,7 @@ def length_rst_in_section():
          20
      """
  
-@@ -317,9 +338,28 @@
+@@ -424,9 +445,28 @@
              Integer length of the list of numbers.
  
      Example:
@@ -769,7 +875,7 @@ def length_rst_in_section():
          20
      """
  
-@@ -337,9 +377,29 @@
+@@ -444,9 +484,29 @@
      Example:
  
          ```
@@ -802,7 +908,7 @@ def length_rst_in_section():
          ```
      """
  
-@@ -349,9 +409,29 @@
+@@ -456,9 +516,29 @@
      """
      Do cool stuff::
  
@@ -835,7 +941,7 @@ def length_rst_in_section():
      """
      pass
  
-@@ -362,8 +442,27 @@
+@@ -469,8 +549,27 @@
      Examples:
          Do cool stuff::
  
@@ -892,7 +998,20 @@ def simple():
 
   ```py
   class Abcdefghijklmopqrstuvwxyz(
-    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+    Abc,
+    Def,
+    Ghi,
+    Jkl,
+    Mno,
+    Pqr,
+    Stu,
+    Vwx,
+    Yz,
+    A1,
+    A2,
+    A3,
+    A4,
+    A5,
   ):
     def abcdefghijklmnopqrstuvwxyz(
       self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -922,7 +1041,20 @@ def repeated():
 
   ```py
   class Abcdefghijklmopqrstuvwxyz(
-    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+    Abc,
+    Def,
+    Ghi,
+    Jkl,
+    Mno,
+    Pqr,
+    Stu,
+    Vwx,
+    Yz,
+    A1,
+    A2,
+    A3,
+    A4,
+    A5,
   ):
     def abcdefghijklmnopqrstuvwxyz(
       self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -976,7 +1108,20 @@ def repeated():
 
 
   class Abcdefghijklmopqrstuvwxyz(
-    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+    Abc,
+    Def,
+    Ghi,
+    Jkl,
+    Mno,
+    Pqr,
+    Stu,
+    Vwx,
+    Yz,
+    A1,
+    A2,
+    A3,
+    A4,
+    A5,
   ):
     def abcdefghijklmnopqrstuvwxyz(
       self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -1042,7 +1187,20 @@ def barely_exceeds_limit():
 
   ```py
   class Abcdefghijklmopqrstuvwxyz(
-    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+    Abc,
+    Def,
+    Ghi,
+    Jkl,
+    Mno,
+    Pqr,
+    Stu,
+    Vwx,
+    Yz,
+    A1,
+    A2,
+    A3,
+    A4,
+    A5,
   ):
     def abcdefghijklmnopqrstuvwxyz(
       self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -1072,7 +1230,20 @@ def unindented():
 
   ```py
   class Abcdefghijklmopqrstuvwxyz(
-    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+    Abc,
+    Def,
+    Ghi,
+    Jkl,
+    Mno,
+    Pqr,
+    Stu,
+    Vwx,
+    Yz,
+    A1,
+    A2,
+    A3,
+    A4,
+    A5,
   ):
     def abcdefghijklmnopqrstuvwxyz(
       self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -1102,7 +1273,20 @@ def unindented_barely_exceeds_limit():
 
   ```py
   class Abcdefghijklmopqrstuvwxyz(
-    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+    Abc,
+    Def,
+    Ghi,
+    Jkl,
+    Mno,
+    Pqr,
+    Stu,
+    Vwx,
+    Yz,
+    A1,
+    A2,
+    A3,
+    A4,
+    A5,
   ):
     def abcdefghijklmnopqrstuvwxyz(
       self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -1252,7 +1436,7 @@ def length_rst_in_section():
 ```diff
 --- Stable
 +++ Preview
-@@ -290,9 +290,28 @@
+@@ -368,9 +368,28 @@
        Integer length of the list of numbers.
  
    Example:
@@ -1284,7 +1468,7 @@ def length_rst_in_section():
        20
    """
  
-@@ -307,9 +326,28 @@
+@@ -385,9 +404,28 @@
            Integer length of the list of numbers.
  
    Example:
@@ -1316,7 +1500,7 @@ def length_rst_in_section():
        20
    """
  
-@@ -327,9 +365,29 @@
+@@ -405,9 +443,29 @@
    Example:
  
        ```
@@ -1349,7 +1533,7 @@ def length_rst_in_section():
        ```
    """
  
-@@ -339,9 +397,29 @@
+@@ -417,9 +475,29 @@
    """
    Do cool stuff::
  
@@ -1382,7 +1566,7 @@ def length_rst_in_section():
    """
    pass
  
-@@ -352,8 +430,27 @@
+@@ -430,8 +508,27 @@
    Examples:
        Do cool stuff::
  
@@ -1439,7 +1623,20 @@ def simple():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+	    Abc,
+	    Def,
+	    Ghi,
+	    Jkl,
+	    Mno,
+	    Pqr,
+	    Stu,
+	    Vwx,
+	    Yz,
+	    A1,
+	    A2,
+	    A3,
+	    A4,
+	    A5,
 	):
 	    def abcdefghijklmnopqrstuvwxyz(
 	        self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -1469,7 +1666,20 @@ def repeated():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+	    Abc,
+	    Def,
+	    Ghi,
+	    Jkl,
+	    Mno,
+	    Pqr,
+	    Stu,
+	    Vwx,
+	    Yz,
+	    A1,
+	    A2,
+	    A3,
+	    A4,
+	    A5,
 	):
 	    def abcdefghijklmnopqrstuvwxyz(
 	        self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -1523,7 +1733,20 @@ def repeated():
 
 
 	class Abcdefghijklmopqrstuvwxyz(
-	    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+	    Abc,
+	    Def,
+	    Ghi,
+	    Jkl,
+	    Mno,
+	    Pqr,
+	    Stu,
+	    Vwx,
+	    Yz,
+	    A1,
+	    A2,
+	    A3,
+	    A4,
+	    A5,
 	):
 	    def abcdefghijklmnopqrstuvwxyz(
 	        self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -1589,7 +1812,20 @@ def barely_exceeds_limit():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+	    Abc,
+	    Def,
+	    Ghi,
+	    Jkl,
+	    Mno,
+	    Pqr,
+	    Stu,
+	    Vwx,
+	    Yz,
+	    A1,
+	    A2,
+	    A3,
+	    A4,
+	    A5,
 	):
 	    def abcdefghijklmnopqrstuvwxyz(
 	        self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -1601,7 +1837,20 @@ def barely_exceeds_limit():
 	            # more than the limit. Therefore, it should get wrapped for
 	            # indent_width >= 4.
 	            print(
-	                abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a5678
+	                abc,
+	                ddef,
+	                ghi,
+	                jkl,
+	                mno,
+	                pqr,
+	                stu,
+	                vwx,
+	                yz,
+	                a1,
+	                a2,
+	                a3,
+	                a4,
+	                a5678,
 	            )
 	            return 5
 
@@ -1621,7 +1870,20 @@ def unindented():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+	    Abc,
+	    Def,
+	    Ghi,
+	    Jkl,
+	    Mno,
+	    Pqr,
+	    Stu,
+	    Vwx,
+	    Yz,
+	    A1,
+	    A2,
+	    A3,
+	    A4,
+	    A5,
 	):
 	    def abcdefghijklmnopqrstuvwxyz(
 	        self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -1651,7 +1913,20 @@ def unindented_barely_exceeds_limit():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+	    Abc,
+	    Def,
+	    Ghi,
+	    Jkl,
+	    Mno,
+	    Pqr,
+	    Stu,
+	    Vwx,
+	    Yz,
+	    A1,
+	    A2,
+	    A3,
+	    A4,
+	    A5,
 	):
 	    def abcdefghijklmnopqrstuvwxyz(
 	        self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
@@ -1663,7 +1938,20 @@ def unindented_barely_exceeds_limit():
 	            # more than the limit. Therefore, it should get wrapped for
 	            # indent_width >= 4.
 	            print(
-	                abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a5678
+	                abc,
+	                ddef,
+	                ghi,
+	                jkl,
+	                mno,
+	                pqr,
+	                stu,
+	                vwx,
+	                yz,
+	                a1,
+	                a2,
+	                a3,
+	                a4,
+	                a5678,
 	            )
 	            return 5
 
@@ -1719,7 +2007,10 @@ def doctest_extra_indent3():
 	Examples
 	--------
 	>>> af1, af2, af3 = pl.align_frames(
-	...     df1, df2, df3, on="dt"
+	...     df1,
+	...     df2,
+	...     df3,
+	...     on="dt",
 	... )  # doctest: +IGNORE_RESULT
 	"""
 
@@ -1809,7 +2100,7 @@ def length_rst_in_section():
 ```diff
 --- Stable
 +++ Preview
-@@ -270,9 +270,11 @@
+@@ -374,9 +374,11 @@
  
  		Examples
  		--------
@@ -1824,7 +2115,7 @@ def length_rst_in_section():
  		"""
  
  
-@@ -300,9 +302,28 @@
+@@ -407,9 +409,28 @@
  	    Integer length of the list of numbers.
  
  	Example:
@@ -1856,7 +2147,7 @@ def length_rst_in_section():
  	    20
  	"""
  
-@@ -317,9 +338,28 @@
+@@ -424,9 +445,28 @@
  	        Integer length of the list of numbers.
  
  	Example:
@@ -1888,7 +2179,7 @@ def length_rst_in_section():
  	    20
  	"""
  
-@@ -337,9 +377,29 @@
+@@ -444,9 +484,29 @@
  	Example:
  
  	    ```
@@ -1921,7 +2212,7 @@ def length_rst_in_section():
  	    ```
  	"""
  
-@@ -349,9 +409,29 @@
+@@ -456,9 +516,29 @@
  	"""
  	Do cool stuff::
  
@@ -1954,7 +2245,7 @@ def length_rst_in_section():
  	"""
  	pass
  
-@@ -362,8 +442,27 @@
+@@ -469,8 +549,27 @@
  	Examples:
  	    Do cool stuff::
  
@@ -2011,7 +2302,20 @@ def simple():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+	        Abc,
+	        Def,
+	        Ghi,
+	        Jkl,
+	        Mno,
+	        Pqr,
+	        Stu,
+	        Vwx,
+	        Yz,
+	        A1,
+	        A2,
+	        A3,
+	        A4,
+	        A5,
 	):
 	        def abcdefghijklmnopqrstuvwxyz(
 	                self,
@@ -2081,7 +2385,20 @@ def repeated():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+	        Abc,
+	        Def,
+	        Ghi,
+	        Jkl,
+	        Mno,
+	        Pqr,
+	        Stu,
+	        Vwx,
+	        Yz,
+	        A1,
+	        A2,
+	        A3,
+	        A4,
+	        A5,
 	):
 	        def abcdefghijklmnopqrstuvwxyz(
 	                self,
@@ -2269,7 +2586,20 @@ def repeated():
 
 
 	class Abcdefghijklmopqrstuvwxyz(
-	        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+	        Abc,
+	        Def,
+	        Ghi,
+	        Jkl,
+	        Mno,
+	        Pqr,
+	        Stu,
+	        Vwx,
+	        Yz,
+	        A1,
+	        A2,
+	        A3,
+	        A4,
+	        A5,
 	):
 	        def abcdefghijklmnopqrstuvwxyz(
 	                self,
@@ -2469,7 +2799,20 @@ def barely_exceeds_limit():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+	        Abc,
+	        Def,
+	        Ghi,
+	        Jkl,
+	        Mno,
+	        Pqr,
+	        Stu,
+	        Vwx,
+	        Yz,
+	        A1,
+	        A2,
+	        A3,
+	        A4,
+	        A5,
 	):
 	        def abcdefghijklmnopqrstuvwxyz(
 	                self,
@@ -2539,7 +2882,20 @@ def unindented():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+	        Abc,
+	        Def,
+	        Ghi,
+	        Jkl,
+	        Mno,
+	        Pqr,
+	        Stu,
+	        Vwx,
+	        Yz,
+	        A1,
+	        A2,
+	        A3,
+	        A4,
+	        A5,
 	):
 	        def abcdefghijklmnopqrstuvwxyz(
 	                self,
@@ -2609,7 +2965,20 @@ def unindented_barely_exceeds_limit():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+	        Abc,
+	        Def,
+	        Ghi,
+	        Jkl,
+	        Mno,
+	        Pqr,
+	        Stu,
+	        Vwx,
+	        Yz,
+	        A1,
+	        A2,
+	        A3,
+	        A4,
+	        A5,
 	):
 	        def abcdefghijklmnopqrstuvwxyz(
 	                self,
@@ -2721,7 +3090,10 @@ def doctest_extra_indent3():
 	Examples
 	--------
 	>>> af1, af2, af3 = pl.align_frames(
-	...         df1, df2, df3, on="dt"
+	...         df1,
+	...         df2,
+	...         df3,
+	...         on="dt",
 	... )  # doctest: +IGNORE_RESULT
 	"""
 
@@ -2918,7 +3290,7 @@ def length_rst_in_section():
 ```diff
 --- Stable
 +++ Preview
-@@ -700,9 +700,11 @@
+@@ -778,9 +778,11 @@
  
  		Examples
  		--------
@@ -2933,7 +3305,7 @@ def length_rst_in_section():
  		"""
  
  
-@@ -730,30 +732,28 @@
+@@ -811,30 +813,28 @@
  	    Integer length of the list of numbers.
  
  	Example:
@@ -2986,7 +3358,7 @@ def length_rst_in_section():
  	    20
  	"""
  
-@@ -768,30 +768,28 @@
+@@ -849,30 +849,28 @@
  	        Integer length of the list of numbers.
  
  	Example:
@@ -3039,7 +3411,7 @@ def length_rst_in_section():
  	    20
  	"""
  
-@@ -809,31 +807,29 @@
+@@ -890,31 +888,29 @@
  	Example:
  
  	    ```
@@ -3094,7 +3466,7 @@ def length_rst_in_section():
  	    ```
  	"""
  
-@@ -843,31 +839,29 @@
+@@ -924,31 +920,29 @@
  	"""
  	Do cool stuff::
  
@@ -3149,7 +3521,7 @@ def length_rst_in_section():
  	"""
  	pass
  
-@@ -878,29 +872,27 @@
+@@ -959,29 +953,27 @@
  	Examples:
  	    Do cool stuff::
  

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
 ---
 ## Input
 ```python
@@ -484,7 +483,9 @@ aaaaaaaaaaa = t"hellooooooooooooooooooooooo \
 
 # Black breaks the right side first for the following expressions:
 aaaaaaaaaaaaaa + caaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaal(
-    argument1, argument2, argument3
+    argument1,
+    argument2,
+    argument3,
 )
 aaaaaaaaaaaaaa + [
     bbbbbbbbbbbbbbbbbbbbbb,

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__compare.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__compare.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/compare.py
 ---
 ## Input
 ```python
@@ -307,15 +306,18 @@ ct_match = (
 )
 
 ct_match = {aaaaaaaaaaaaaaaa} == self.get_content_type(
-    obj=rel_obj, using=instance._state.db
+    obj=rel_obj,
+    using=instance._state.db,
 ).id
 
 ct_match = (aaaaaaaaaaaaaaaa) == self.get_content_type(
-    obj=rel_obj, using=instance._state.db
+    obj=rel_obj,
+    using=instance._state.db,
 ).id
 
 ct_match = aaaaaaaaaaact_id == self.get_content_type(
-    obj=rel_obj, using=instance._state.db
+    obj=rel_obj,
+    using=instance._state.db,
 )
 
 # Call expressions with trailing subscripts.
@@ -325,11 +327,13 @@ ct_match = (
 )
 
 ct_match = {aaaaaaaaaaaaaaaa} == self.get_content_type(
-    obj=rel_obj, using=instance._state.db
+    obj=rel_obj,
+    using=instance._state.db,
 )[id]
 
 ct_match = (aaaaaaaaaaaaaaaa) == self.get_content_type(
-    obj=rel_obj, using=instance._state.db
+    obj=rel_obj,
+    using=instance._state.db,
 )[id]
 
 # Subscripts expressions with trailing attributes.

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/join_implicit_concatenated_string.py
 ---
 ## Input
 ```python
@@ -825,11 +824,13 @@ LEEEEEEEEEEEEEEEEEEEEEEFT = RRRRRRRRIIIIIIIIIIIIGGGGGHHHT | {
 # Ensure that flipping between Multiline and BestFit layout results in stable formatting
 # when using IfBreaksParenthesized layout.
 assert False, "Implicit concatenated stringuses {} layout on {} format".format(
-    "Multiline", "first"
+    "Multiline",
+    "first",
 )
 
 assert False, await "Implicit concatenated stringuses {} layout on {} format".format(
-    "Multiline", "first"
+    "Multiline",
+    "first",
 )
 
 assert False, "Implicit concatenated stringuses {} layout on {} format"[
@@ -837,7 +838,8 @@ assert False, "Implicit concatenated stringuses {} layout on {} format"[
 ]
 
 assert False, +"Implicit concatenated stringuses {} layout on {} format".format(
-    "Multiline", "first"
+    "Multiline",
+    "first",
 )
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
@@ -1216,7 +1216,9 @@ class C:
 
 
 name = re.sub(
-    r"[^\x21\x23-\x5b\x5d-\x7e]...............", lambda m: f"\\{m.group(0)}", p["name"]
+    r"[^\x21\x23-\x5b\x5d-\x7e]...............",
+    lambda m: f"\\{m.group(0)}",
+    p["name"],
 )
 
 
@@ -1292,7 +1294,9 @@ very_long_variable_name_x, very_long_variable_name_y = (
 
 very_long_variable_name_for_result += lambda x: (
     very_long_function_call_that_should_definitely_be_parenthesized_now(
-        x, more_args, additional_parameters
+        x,
+        more_args,
+        additional_parameters,
     )
 )
 
@@ -1843,7 +1847,7 @@ class CantFormat:
 ```diff
 --- Stable
 +++ Preview
-@@ -471,7 +471,8 @@
+@@ -475,7 +475,8 @@
          # inside the body.
          param(
              lambda left, right: (
@@ -1853,7 +1857,7 @@ class CantFormat:
                  .cast(dt.date)
                  .between(left, right)
                  .between(left, right)
-@@ -594,7 +595,8 @@
+@@ -598,7 +599,8 @@
  
  (
      lambda left, right: (

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
@@ -1762,7 +1762,8 @@ foo = lambda x: (
 ).foo()
 
 foo = lambda: (result := some_really_long_callable_expression)(
-    extra_argument_one, extra_argument_two
+    extra_argument_one,
+    extra_argument_two,
 )
 
 foo = lambda: (result := some_really_long_subscriptable_expression)[
@@ -1770,11 +1771,15 @@ foo = lambda: (result := some_really_long_subscriptable_expression)[
 ]
 
 foo = lambda: (await some_coroutine)(
-    extra_argument_one, extra_argument_two, extra_argument_three
+    extra_argument_one,
+    extra_argument_two,
+    extra_argument_three,
 )
 
 foo = lambda: call()(
-    extra_argument_one, extra_argument_two, extra_argument_threeeeeeeee
+    extra_argument_one,
+    extra_argument_two,
+    extra_argument_threeeeeeeee,
 )
 
 foo = lambda: call()(
@@ -1788,12 +1793,16 @@ foo = lambda: call(
 )(extra_argument_one, extra_argument_twooooooooooooooooooo, extra_argument_threeeeeeeee)
 
 foo = lambda: call(
-    argument_one, argument_two, argument_threeeeeeeeeeeeeeeeeeeeeeeeeeee
+    argument_one,
+    argument_two,
+    argument_threeeeeeeeeeeeeeeeeeeeeeeeeeee,
 )(extra_argument_one, extra_argument_twooooooooooooooooooo, extra_argument_threeeeeeeee)
 
 foo = lambda: (
     callllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll(
-        argument_one, argument_two, argument_threeeeeeeeeeeeeeeeeeeeeeeeeeee
+        argument_one,
+        argument_two,
+        argument_threeeeeeeeeeeeeeeeeeeeeeeeeeee,
     )(
         extra_argument_one,
         extra_argument_twooooooooooooooooooo,

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__split_empty_brackets.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__split_empty_brackets.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/split_empty_brackets.py
 ---
 ## Input
 ```python
@@ -110,11 +109,13 @@ ct_match = (
 )
 
 ct_match = unicodedata.normalize("NFKC", s1).casefold(0) == unicodedata.normalize(
-    "NFKCNFKCNFKCNFKCNFKC", s2
+    "NFKCNFKCNFKCNFKCNFKC",
+    s2,
 ).casefold(1)
 
 ct_match = unicodedata.normalize("NFKC", s1).casefold(1) == unicodedata.normalize(
-    "NFKCNFKCNFKCNFKCNFKC", s2
+    "NFKCNFKCNFKCNFKCNFKC",
+    s2,
 ).casefold(1)
 
 ct_match = (
@@ -137,7 +138,8 @@ ct_match = (
 )
 
 ct_match = [1].unicodedata.normalize("NFKC", s1).casefold() == [].unicodedata.normalize(
-    "NFKCNFKCNFKCNFKCNFKC", s2
+    "NFKCNFKCNFKCNFKCNFKC",
+    s2,
 ).casefold()
 
 ct_match = [1].unicodedata.normalize("NFKC", s1).casefold() == [
@@ -155,7 +157,8 @@ ct_match = (
 )
 
 ct_match = {1}.unicodedata.normalize("NFKC", s1).casefold() == {}.unicodedata.normalize(
-    "NFKCNFKCNFKCNFKCNFKC", s2
+    "NFKCNFKCNFKCNFKCNFKC",
+    s2,
 ).casefold()
 
 ct_match = {1}.unicodedata.normalize("NFKC", s1).casefold() == {
@@ -189,7 +192,8 @@ return (
 )
 
 response = await sync_to_async(
-    lambda: self.django_handler.get_response(request), thread_sensitive=True
+    lambda: self.django_handler.get_response(request),
+    thread_sensitive=True,
 )()
 ```
 
@@ -198,7 +202,7 @@ response = await sync_to_async(
 ```diff
 --- Stable
 +++ Preview
-@@ -62,9 +62,9 @@
+@@ -66,9 +66,10 @@
      1
  }.unicodedata.normalize("NFKCNFKCNFKCNFKCNFKC", s2).casefold()
  
@@ -206,7 +210,8 @@ response = await sync_to_async(
 -    []
 -).unicodedata.normalize("NFKCNFKCNFKCNFKCNFKC", s2).casefold()
 +ct_match = ([]).unicodedata.normalize(
-+    "NFKC", s1
++    "NFKC",
++    s1,
 +).casefold() == ([]).unicodedata.normalize("NFKCNFKCNFKCNFKCNFKC", s2).casefold()
  
  return await self.http_client.fetch(

--- a/crates/ruff_python_formatter/tests/snapshots/format@parentheses__call_chains.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@parentheses__call_chains.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/parentheses/call_chains.py
 ---
 ## Input
 ```python
@@ -342,7 +341,8 @@ raise OsError("sökdjffffsldkfjlhsakfjhalsökafhsöfdahsödfjösaaksjdllllllllll
 b1 = (
     session.query(models.Customer.id)
     .filter(
-        models.Customer.account_id == account_id, models.Customer.email == email_address
+        models.Customer.account_id == account_id,
+        models.Customer.email == email_address,
     )
     .count()
 )
@@ -649,9 +649,9 @@ x = (
 +    session
 +    .query(models.Customer.id)
      .filter(
-         models.Customer.account_id == account_id, models.Customer.email == email_address
-     )
-@@ -54,7 +57,8 @@
+         models.Customer.account_id == account_id,
+         models.Customer.email == email_address,
+@@ -55,7 +58,8 @@
  )
  
  b2 = (
@@ -661,7 +661,7 @@ x = (
          entry__headline__contains="Lennon",
      )
      .limit_results[:10]
-@@ -70,7 +74,8 @@
+@@ -71,7 +75,8 @@
      ).filter(
          entry__pub_date__year=2008,
      )
@@ -671,7 +671,7 @@ x = (
          entry__headline__contains="McCartney",
      )
      .limit_results[:10]
-@@ -89,7 +94,8 @@
+@@ -90,7 +95,8 @@
  d11 = x.e().e().e()  #
  d12 = x.e().e().e()  #
  d13 = (
@@ -681,7 +681,7 @@ x = (
      .e()
      .e()
  )
-@@ -101,7 +107,8 @@
+@@ -102,7 +108,8 @@
  
  # Doesn't fit, fluent style
  d3 = (
@@ -691,7 +691,7 @@ x = (
      .esadjkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk()
      .esadjkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk()
  )
-@@ -218,7 +225,8 @@
+@@ -219,7 +226,8 @@
  
  (
      (
@@ -701,7 +701,7 @@ x = (
          .groupby(
              1,
          )
-@@ -228,7 +236,8 @@
+@@ -229,7 +237,8 @@
  
  (
      (
@@ -711,7 +711,7 @@ x = (
          .groupby(
              1,
          )
-@@ -255,19 +264,19 @@
+@@ -256,19 +265,19 @@
  
  
  expr = (
@@ -742,7 +742,7 @@ x = (
          .str.extract(pattern=r"\.([a-z0-9]+)$", group_index=1)
          .str.replace_all(pattern=r"cxx|cpp|cc|c|hpp|h", value="C/C++")
          .str.replace_all(pattern="^f.*$", value="Fortran")
-@@ -288,9 +297,8 @@
+@@ -289,9 +298,8 @@
          if more_nested_because_line_length:
              identical_hidden_layer_sizes = all(
                  current_hidden_layer_sizes == first_hidden_layer_sizes
@@ -754,7 +754,7 @@ x = (
                  .values()
                  .attr
              )
-@@ -302,7 +310,8 @@
+@@ -303,7 +311,8 @@
              with self.read_ctx(book_type) as cursor:
                  if (
                      entry_count := len(

--- a/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__docstring_code_examples.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__docstring_code_examples.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/range_formatting/docstring_code_examples.py
 ---
 ## Input
 ```python
@@ -190,7 +189,13 @@ if True:
         line width because it doesn't exceed the line width within this
         docstring. e.g, the `f` in `foo` is treated as the first column.
         >>> foo, bar, quux = this_is_a_long_line(
-        ...     lion, giraffe, hippo, zeba, lemur, penguin, monkey
+        ...     lion,
+        ...     giraffe,
+        ...     hippo,
+        ...     zeba,
+        ...     lemur,
+        ...     penguin,
+        ...     monkey,
         ... )
 
         But this one is long enough to get wrapped.
@@ -212,14 +217,26 @@ if True:
 
         This one gets wrapped with `dynamic` line width and an indent width of 4 because it exceeds the width by 1
         >>> ab = this_is_a_long_line(
-        ...     lion, giraffe, hippo, zebra, lemur, penguin, monkey
+        ...     lion,
+        ...     giraffe,
+        ...     hippo,
+        ...     zebra,
+        ...     lemur,
+        ...     penguin,
+        ...     monkey,
         ... )
         """
         # This demonstrates a normal line that will get wrapped but won't
         # get wrapped in the docstring above because of how the line-width
         # setting gets reset at the first column in each code snippet.
         foo, bar, quux = this_is_a_long_line(
-            lion, giraffe, hippo, zeba, lemur, penguin, monkey
+            lion,
+            giraffe,
+            hippo,
+            zeba,
+            lemur,
+            penguin,
+            monkey,
         )
 
 
@@ -230,7 +247,13 @@ if True:
         line width because it doesn't exceed the line width within this
         docstring. e.g, the `f` in `foo` is treated as the first column.
         >>> foo, bar, quux = this_is_a_long_line(
-        ...     lion, giraffe, hippo, zeba, lemur, penguin, monkey
+        ...     lion,
+        ...     giraffe,
+        ...     hippo,
+        ...     zeba,
+        ...     lemur,
+        ...     penguin,
+        ...     monkey,
         ... )
 
         But this one is long enough to get wrapped.
@@ -252,7 +275,13 @@ if True:
 
         This one gets wrapped with `dynamic` line width and an indent width of 4 because it exceeds the width by 1
         >>> ab = this_is_a_long_line(
-        ...     lion, giraffe, hippo, zebra, lemur, penguin, monkey
+        ...     lion,
+        ...     giraffe,
+        ...     hippo,
+        ...     zebra,
+        ...     lemur,
+        ...     penguin,
+        ...     monkey,
         ... )
         """
         # This demonstrates a normal line that will get wrapped but won't
@@ -346,7 +375,16 @@ if True:
 
         But this one is long enough to get wrapped.
         >>> foo, bar, quux = this_is_a_long_line(
-        ...     lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard
+        ...     lion,
+        ...     giraffe,
+        ...     hippo,
+        ...     zeba,
+        ...     lemur,
+        ...     penguin,
+        ...     monkey,
+        ...     spider,
+        ...     bear,
+        ...     leopard,
         ... )
 
         This one doesn't get wrapped with an indent width of 4 even with `dynamic` line width
@@ -359,7 +397,13 @@ if True:
         # get wrapped in the docstring above because of how the line-width
         # setting gets reset at the first column in each code snippet.
         foo, bar, quux = this_is_a_long_line(
-            lion, giraffe, hippo, zeba, lemur, penguin, monkey
+            lion,
+            giraffe,
+            hippo,
+            zeba,
+            lemur,
+            penguin,
+            monkey,
         )
 
 
@@ -373,7 +417,16 @@ if True:
 
         But this one is long enough to get wrapped.
         >>> foo, bar, quux = this_is_a_long_line(
-        ...     lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard
+        ...     lion,
+        ...     giraffe,
+        ...     hippo,
+        ...     zeba,
+        ...     lemur,
+        ...     penguin,
+        ...     monkey,
+        ...     spider,
+        ...     bear,
+        ...     leopard,
         ... )
 
         This one doesn't get wrapped with an indent width of 4 even with `dynamic` line width

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__assignment_split_value_first.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__assignment_split_value_first.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/assignment_split_value_first.py
 ---
 ## Input
 ```python
@@ -265,7 +264,9 @@ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     first_item,
     second_item,
 ) = some_looooooooong_module.some_loooooog_function_name(
-    first_argument, second_argument, third_argument
+    first_argument,
+    second_argument,
+    third_argument,
 )
 
 
@@ -356,10 +357,17 @@ aaaaaa = a["aaa"] = bbbbb[aa, bbb, cccc] = dddddddddd = eeeeee = (
 
 # Don't parenthesize the function call if the left is unsplittable.
 this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = a.b.function(
-    arg1, arg2, arg3
+    arg1,
+    arg2,
+    arg3,
 )
 this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = function(
-    [1, 2, 3], arg1, [1, 2, 3], arg2, [1, 2, 3], arg3
+    [1, 2, 3],
+    arg1,
+    [1, 2, 3],
+    arg2,
+    [1, 2, 3],
+    arg3,
 )
 this_is_a_ridiculously_long_name_and_nobody_in_their_right_mind_would_use_one_like_it = function(
     [1, 2, 3],
@@ -378,7 +386,12 @@ this_is_a_ridiculously_long_name_and_nobodyddddddddddddddddddddddddddddddd = (
 )
 this_is_a_ridiculously_long_name_and_nobodyddddddddddddddddddddddddddddddd = function()
 this_is_a_ridiculously_long_name_and_nobodyddddddddddddddddddddddddddddddd = function(
-    [1, 2, 3], arg1, [1, 2, 3], arg2, [1, 2, 3], arg3
+    [1, 2, 3],
+    arg1,
+    [1, 2, 3],
+    arg2,
+    [1, 2, 3],
+    arg3,
 )
 this_is_a_ridiculously_long_name_and_nobodyddddddddddddddddddddddddddddddd = function(
     [1, 2, 3],

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -1125,7 +1125,8 @@ match pattern_match_class:
         pass
 
     case Point2D(  # end of line
-        0, 0
+        0,
+        0,
     ):
         pass
 
@@ -1311,7 +1312,9 @@ match n % 3, n % 5:
 # Unparenthesized tuples
 match x:
     case Child(aaaaaaaaa, bbbbbbbbbbbbbbb, cccccc), Doc(
-        aaaaa, bbbbbbbbbb, ddddddddddddd
+        aaaaa,
+        bbbbbbbbbb,
+        ddddddddddddd,
     ):
         pass
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__return.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__return.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/return.py
 ---
 ## Input
 ```python
@@ -57,7 +56,8 @@ def f():
 ## Output
 ```python
 return len(self.nodeseeeeeeeee), sum(
-    len(node.parents) for node in self.node_map.values()
+    len(node.parents)
+    for node in self.node_map.values()
 )
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
 ---
 ## Input
 ```python
@@ -741,7 +740,9 @@ if True:
         pass
 
 with Child(aaaaaaaaa, bbbbbbbbbbbbbbb, cccccc), Document(
-    aaaaa, bbbbbbbbbb, ddddddddddddd
+    aaaaa,
+    bbbbbbbbbb,
+    ddddddddddddd,
 ):
     pass
 


### PR DESCRIPTION
Another formatting experiment...

Related to #9992

Note that in that issue Micha warns that some formatting logic is shared between arguments and other expressions, e.g. dictionaries. However, as far as I can tell, this code change makes things _more_ consistent not less.

In most places that we format a list of things with a `JoinCommaSeparatedBuilder`, we then do:

```rust
parenthesized(<left>, &items, <right>)
```
It's only in the case of `Arguments` and match arguments that we (on `main`) add another `group` around the items. As far as I can tell that's what produces this sometimes-ugly "intermediate" breaking - since the parenthesized group breaking does not trigger the vertical breaking until the items alone also don't fit.