### PR TITLE
[ty] Support diagnostics in newly created files inside neovim

### DIFF
--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -323,7 +323,7 @@ pub struct File {
     /// Salsa doesn't support deleting inputs. The only way to signal dependent queries that
     /// the file has been deleted is to change the status to `Deleted`.
     #[default]
-    status: FileStatus,
+    pub status: FileStatus,
 
     /// Overrides the result of [`source_text`](crate::source::source_text).
     ///

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -147,8 +147,9 @@ impl ProjectDatabase {
 
                     if self.system().is_file(&path) {
                         if project.is_file_included(self, &path) {
-                            // Add the parent directory because `walkdir` always visits explicitly passed files
-                            // even if they match an exclude filter.
+                            // Add the parent directory because `walkdir`
+                            // always visits explicitly passed files even if
+                            // they match an exclude filter.
                             added_paths.insert(path.parent().unwrap().to_path_buf());
                         }
                     } else if project.is_directory_included(self, &path) {

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -463,7 +463,22 @@ impl Project {
             CheckMode::OpenFiles => self.open_files(db).contains(&file),
             CheckMode::AllFiles => {
                 // Virtual files are always checked.
-                path.is_system_virtual_path() || self.files(db).contains(&file)
+                //
+                // We also check the open file set. In theory, we
+                // shouldn't need to do this since it is accounted for
+                // by the virtual file check (for the case when a file
+                // wants to be checked but isn't saved to disk yet).
+                // However, not all clients follow the LSP convention
+                // that URIs for documents not on disk yet use the
+                // `untitled://...` scheme. That is, we assume that a
+                // `file://...` scheme corresponds to a saved file on
+                // disk, and anything else is "virtual." For example,
+                // neovim uses `file://...` even for an open buffer
+                // that does not correspond to a file saved to disk
+                // yet.
+                path.is_system_virtual_path()
+                    || self.files(db).contains(&file)
+                    || self.open_files(db).contains(&file)
             }
         }
     }

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -786,6 +786,21 @@ impl TestServer {
         self.test_context.root().join(path)
     }
 
+    #[expect(dead_code)]
+    pub(crate) fn write_file(
+        &self,
+        path: impl AsRef<SystemPath>,
+        content: impl AsRef<str>,
+    ) -> Result<()> {
+        let file_path = self.file_path(path);
+        // Ensure parent directories exists
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent.as_std_path())?;
+        }
+        fs::write(file_path.as_std_path(), content.as_ref())?;
+        Ok(())
+    }
+
     /// Send a `textDocument/didOpen` notification
     pub(crate) fn open_text_document(
         &mut self,

--- a/crates/ty_server/tests/e2e/publish_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/publish_diagnostics.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use lsp_types::{
-    DidOpenTextDocumentParams, FileChangeType, FileEvent, TextDocumentItem,
+    DidOpenTextDocumentParams, FileChangeType, FileEvent, TextDocumentItem, Url,
     notification::{DidOpenTextDocument, PublishDiagnostics},
 };
 use ruff_db::system::SystemPath;
@@ -29,6 +29,119 @@ def foo() -> str:
     server.open_text_document(foo, foo_content, 1);
     let diagnostics = server.await_notification::<PublishDiagnostics>();
 
+    insta::assert_debug_snapshot!(diagnostics);
+
+    Ok(())
+}
+
+/// Tests that we get diagnostics for a file that is NOT saved to
+/// disk when using `OpenFilesOnly` diagnostic mode.
+#[test]
+fn on_did_open_non_existing_file_open_files_only() -> Result<()> {
+    let workspace_root = SystemPath::new("src");
+    let foo = SystemPath::new("src/foo.py");
+    let foo_content = "\
+def foo() -> str:
+    return 42
+";
+
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(
+            workspace_root,
+            Some(
+                ClientOptions::default()
+                    .with_diagnostic_mode(ty_server::DiagnosticMode::OpenFilesOnly),
+            ),
+        )?
+        .enable_pull_diagnostics(false)
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(foo, foo_content, 1);
+    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    insta::assert_debug_snapshot!(diagnostics);
+
+    Ok(())
+}
+
+/// Tests that we get diagnostics for a file that is NOT saved to disk when
+/// using `Workspace` diagnostic mode.
+///
+/// Basically, ty currently doesn't know whether a `file://...` path refers
+/// to a file that doesn't exist or not. To work around that, we always check
+/// the open file set for whether we should "check" a file or not.
+#[test]
+fn on_did_open_non_existing_file_workspace_with_file_uri() -> Result<()> {
+    let workspace_root = SystemPath::new("src");
+    let foo = SystemPath::new("src/foo.py");
+    let foo_content = "\
+def foo() -> str:
+    return 42
+";
+
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(
+            workspace_root,
+            Some(
+                ClientOptions::default().with_diagnostic_mode(ty_server::DiagnosticMode::Workspace),
+            ),
+        )?
+        .enable_pull_diagnostics(false)
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(foo, foo_content, 1);
+    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    insta::assert_debug_snapshot!(diagnostics);
+
+    Ok(())
+}
+
+/// Like `on_did_open_non_existing_file_workspace_with_file_uri`, but uses
+/// a `untitled://...` URL instead of `file://...`.
+///
+/// Notably, this makes diagnostics for opened files that aren't saved to
+/// disk yet work without needing to check the open file set explicitly. It's
+/// because ty follows the LSP protocol convention that URIs to files that
+/// _don't_ use the `file` scheme refer to documents that aren't saved to disk
+/// yet. So ty correctly detects this as a virtual file and returns diagnostics
+/// for it.
+///
+/// Ref: <https://github.com/astral-sh/ruff/issues/15392>
+/// Ref: <https://github.com/neovim/neovim/issues/21276>
+/// Ref: <https://github.com/microsoft/language-server-protocol/issues/1030>
+#[test]
+fn on_did_open_non_existing_file_workspace_with_untitled_uri() -> Result<()> {
+    let workspace_root = SystemPath::new("src");
+    let foo = SystemPath::new("src/foo.py");
+    let foo_content = "\
+def foo() -> str:
+    return 42
+";
+
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(
+            workspace_root,
+            Some(
+                ClientOptions::default().with_diagnostic_mode(ty_server::DiagnosticMode::Workspace),
+            ),
+        )?
+        .enable_pull_diagnostics(false)
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.send_notification::<DidOpenTextDocument>(DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: {
+                let uri = server.file_uri(foo);
+                Url::parse(&format!("untitled://{}", uri.path())).unwrap()
+            },
+            language_id: "python".to_string(),
+            version: 1,
+            text: foo_content.to_string(),
+        },
+    });
+    let diagnostics = server.await_notification::<PublishDiagnostics>();
     insta::assert_debug_snapshot!(diagnostics);
 
     Ok(())

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_non_existing_file_open_files_only.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_non_existing_file_open_files_only.snap
@@ -1,0 +1,70 @@
+---
+source: crates/ty_server/tests/e2e/publish_diagnostics.rs
+expression: diagnostics
+---
+PublishDiagnosticsParams {
+    uri: Url {
+        scheme: "file",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: None,
+        port: None,
+        path: "<temp_dir>/src/foo.py",
+        query: None,
+        fragment: None,
+    },
+    diagnostics: [
+        Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 11,
+                },
+                end: Position {
+                    line: 1,
+                    character: 13,
+                },
+            },
+            severity: Some(
+                Error,
+            ),
+            code: Some(
+                String(
+                    "invalid-return-type",
+                ),
+            ),
+            code_description: Some(
+                CodeDescription {
+                    href: Url {
+                        scheme: "https",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "ty.dev",
+                            ),
+                        ),
+                        port: None,
+                        path: "/rules",
+                        query: None,
+                        fragment: Some(
+                            "invalid-return-type",
+                        ),
+                    },
+                },
+            ),
+            source: Some(
+                "ty",
+            ),
+            message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
+            related_information: None,
+            tags: None,
+            data: None,
+        },
+    ],
+    version: Some(
+        1,
+    ),
+}

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_non_existing_file_workspace_with_file_uri.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_non_existing_file_workspace_with_file_uri.snap
@@ -1,0 +1,70 @@
+---
+source: crates/ty_server/tests/e2e/publish_diagnostics.rs
+expression: diagnostics
+---
+PublishDiagnosticsParams {
+    uri: Url {
+        scheme: "file",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: None,
+        port: None,
+        path: "<temp_dir>/src/foo.py",
+        query: None,
+        fragment: None,
+    },
+    diagnostics: [
+        Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 11,
+                },
+                end: Position {
+                    line: 1,
+                    character: 13,
+                },
+            },
+            severity: Some(
+                Error,
+            ),
+            code: Some(
+                String(
+                    "invalid-return-type",
+                ),
+            ),
+            code_description: Some(
+                CodeDescription {
+                    href: Url {
+                        scheme: "https",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "ty.dev",
+                            ),
+                        ),
+                        port: None,
+                        path: "/rules",
+                        query: None,
+                        fragment: Some(
+                            "invalid-return-type",
+                        ),
+                    },
+                },
+            ),
+            source: Some(
+                "ty",
+            ),
+            message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
+            related_information: None,
+            tags: None,
+            data: None,
+        },
+    ],
+    version: Some(
+        1,
+    ),
+}

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_non_existing_file_workspace_with_untitled_uri.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_non_existing_file_workspace_with_untitled_uri.snap
@@ -1,0 +1,70 @@
+---
+source: crates/ty_server/tests/e2e/publish_diagnostics.rs
+expression: diagnostics
+---
+PublishDiagnosticsParams {
+    uri: Url {
+        scheme: "untitled",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: None,
+        port: None,
+        path: "<temp_dir>/src/foo.py",
+        query: None,
+        fragment: None,
+    },
+    diagnostics: [
+        Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 11,
+                },
+                end: Position {
+                    line: 1,
+                    character: 13,
+                },
+            },
+            severity: Some(
+                Error,
+            ),
+            code: Some(
+                String(
+                    "invalid-return-type",
+                ),
+            ),
+            code_description: Some(
+                CodeDescription {
+                    href: Url {
+                        scheme: "https",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "ty.dev",
+                            ),
+                        ),
+                        port: None,
+                        path: "/rules",
+                        query: None,
+                        fragment: Some(
+                            "invalid-return-type",
+                        ),
+                    },
+                },
+            ),
+            source: Some(
+                "ty",
+            ),
+            message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
+            related_information: None,
+            tags: None,
+            data: None,
+        },
+    ],
+    version: Some(
+        1,
+    ),
+}


### PR DESCRIPTION
This fixes an issue where one could open a new Python file in neovim,
save it, write some code but not get any diagnostics from ty.

There are two separate issues here.

One is that we currently use `CheckMode::AllFiles` by default and this
_specifically_ ignores opened files that haven't been picked up as a
project file on disk yet. This PR does not address that issue. Notably,
we do have a `CheckMode::OpenFiles`, but I'm currently not clear on why
`AllFiles` explicitly ignores open files.

The second issue is that even after the file is saved on disk, our LSP
doesn't add it to its internal project state. Such that once the client
asks for diagnostics, we return nothing. This seems like a state
synchronization issue, because if you create a second new file, then
this will force directory re-scanning and cause the LSP to pick up the
first file created. That is, when a file is "opened," ty will do a
directory scan. But if the opened file doesn't actually exist on disk
yet, it won't see it.

The third issue is that `workspace/didChangeWatchedFiles` is turned off
by default in neovim's LSP client on Linux for performance reasons. It
can be turned back on with this config:

```lua
local capabilities = vim.lsp.protocol.make_client_capabilities()
capabilities.workspace.didChangeWatchedFiles.dynamicRegistration = true

vim.lsp.config('ty', {
  capabilities = capabilities,
})
vim.lsp.enable('ty')
```

Once enabled, everything _almost_ works, except that neovim will
sometimes send a CHANGE event without a corresponding CREATED event.
This also messes up our state handling because a CHANGE event never
results in rescanning the directory to pick up new files.

This PR attempts to address this problem somewhat narrowly by adding
some logic that will force a directory rescan in response to a CHANGE
event. Specifically, when all of the following is true:

* The CHANGE event refers to a file.
* The file is considered to be included in the project.
* It already has a `File` inside our salsa DB.
* The `project.files()` doesn't contain it yet.

This, in combination with enabling `workspace/didChangeWatchedFiles`,
causes ty to pick up newly added *and saved to disk* files.

Fixes astral-sh/ty#2616
