### PR TITLE
[ty] Narrow equality subscripts on either operand

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
@@ -334,6 +334,13 @@ def _(x: tuple[A, Literal["tag1"]] | tuple[B, Literal["tag2"]]):
         reveal_type(x)  # revealed: tuple[A, Literal["tag1"]]
     else:
         reveal_type(x)  # revealed: tuple[B, Literal["tag2"]]
+
+# Works with reversed equality operands too
+def _(x: tuple[Literal["a"], A] | tuple[Literal["b"], B]):
+    if "a" == x[0]:
+        reveal_type(x)  # revealed: tuple[Literal["a"], A]
+    else:
+        reveal_type(x)  # revealed: tuple[Literal["b"], B]
 ```
 
 Narrowing is restricted to `Literal` tag elements. If any tuple has a non-literal type at the

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2325,7 +2325,7 @@ class Bing(TypedDict):
 def _(u: Foo | Bar | Baz | Bing):
     if u["tag"] == "foo":
         reveal_type(u)  # revealed: Foo
-    elif u["tag"] == 42:
+    elif 42 == u["tag"]:
         reveal_type(u)  # revealed: Bar
     elif u["tag"] == b"baz":
         reveal_type(u)  # revealed: Baz

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1112,35 +1112,37 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         //
         // Importantly, `my_typeddict_union["tag"]` isn't the place we're going to constraint.
         // Instead, we're going to constrain `my_typeddict_union` itself.
-        if matches!(&**ops, [ast::CmpOp::Eq | ast::CmpOp::NotEq])
-            && let ast::Expr::Subscript(subscript) = &**left
-        {
+        if matches!(&**ops, [ast::CmpOp::Eq | ast::CmpOp::NotEq]) {
             // For `==`, we use equality semantics on the `if` branch (is_positive=true).
             // For `!=`, we use equality semantics on the `else` branch (is_positive=false).
             let constrain_with_equality = is_positive == (ops[0] == ast::CmpOp::Eq);
-            if let Some((place, constraint)) = self.narrow_typeddict_subscript(
-                inference.expression_type(&*subscript.value),
-                &subscript.value,
-                inference.expression_type(&*subscript.slice),
-                inference.expression_type(&comparators[0]),
-                constrain_with_equality,
-            ) {
-                constraints.insert(place, constraint);
-            }
+            for (maybe_subscript, other) in [(&**left, &comparators[0]), (&comparators[0], &**left)] {
+                if let ast::Expr::Subscript(subscript) = maybe_subscript {
+                    if let Some((place, constraint)) = self.narrow_typeddict_subscript(
+                        inference.expression_type(&*subscript.value),
+                        &subscript.value,
+                        inference.expression_type(&*subscript.slice),
+                        inference.expression_type(other),
+                        constrain_with_equality,
+                    ) {
+                        constraints.insert(place, constraint);
+                    }
 
-            // Narrow tagged unions of tuples with `Literal` elements, for example:
-            //
-            //     def _(t: tuple[Literal["a"], A] | tuple[Literal["b"], B]):
-            //         if t[0] == "a":
-            //             reveal_type(t)  # tuple[Literal["a"], A]
-            if let Some((place, constraint)) = self.narrow_tuple_subscript(
-                inference.expression_type(&*subscript.value),
-                &subscript.value,
-                inference.expression_type(&*subscript.slice),
-                inference.expression_type(&comparators[0]),
-                constrain_with_equality,
-            ) {
-                constraints.insert(place, constraint);
+                    // Narrow tagged unions of tuples with `Literal` elements, for example:
+                    //
+                    //     def _(t: tuple[Literal["a"], A] | tuple[Literal["b"], B]):
+                    //         if t[0] == "a":
+                    //             reveal_type(t)  # tuple[Literal["a"], A]
+                    if let Some((place, constraint)) = self.narrow_tuple_subscript(
+                        inference.expression_type(&*subscript.value),
+                        &subscript.value,
+                        inference.expression_type(&*subscript.slice),
+                        inference.expression_type(other),
+                        constrain_with_equality,
+                    ) {
+                        constraints.insert(place, constraint);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
### Motivation
- Equality-based subscript narrowing (TypedDict and tuple discriminant narrowing) previously only ran when the subscript expression appeared on the left side of `==`/`!=`, missing symmetric forms like `"a" == x[0]` or `42 == u["tag"]`.
- Treating equality symmetrically enables more user code to be properly narrowed without changing the existing narrowing semantics.

### Description
- Replace the single-sided `==`/`!=` subscript handling with a small loop that considers both `(left, comparator)` and `(comparator, left)` so subscripts on either side are processed the same way in `narrow.rs`.
- Call `narrow_typeddict_subscript` and `narrow_tuple_subscript` with the swapped `other` operand when appropriate so the base place is constrained regardless of operand order.
- Add mdtest examples demonstrating reversed-operand tuple narrowing (`"a" == x[0]`) and reversed-operand TypedDict tag narrowing (`42 == u["tag"]`).

### Testing
- Ran `cargo test -p ty_python_semantic narrow:: -- --nocapture`, which could not complete in this environment because `rustup` failed to download the pinned toolchain; tests were not executed to completion.
- Ran `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d19857d08327a56900f39aeda875)