### PR TITLE
[ty] Make root directory fallback more consistent, and improve documentation

### DIFF
--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -278,14 +278,13 @@ The root paths of the project, used for finding first-party modules.
 
 Accepts a list of directory paths searched in priority order (first has highest priority).
 
-If left unspecified, ty will try to detect common project layouts and initialize `root` accordingly:
+If left unspecified, ty will try to detect common project layouts and initialize `root` accordingly.
+The project root (`.`) is always included. Additionally, the following directories are included
+if they exist and are not packages (i.e. they do not contain `__init__.py` or `__init__.pyi` files):
 
-* if a `./src` directory exists, include `.` and `./src` in the first party search path (src layout or flat)
-* if a `./<project-name>/<project-name>` directory exists, include `.` and `./<project-name>` in the first party search path
-* otherwise, default to `.` (flat layout)
-
-Additionally, if a `./python` directory exists and is not a package (i.e. it does not contain an `__init__.py` or `__init__.pyi` file),
-it will also be included in the first party search path.
+* `./src`
+* `./<project-name>` (if a `./<project-name>/<project-name>` directory exists)
+* `./python`
 
 **Default value**: `null`
 
@@ -731,14 +730,13 @@ Enabled by default.
 
 The root of the project, used for finding first-party modules.
 
-If left unspecified, ty will try to detect common project layouts and initialize `src.root` accordingly:
+If left unspecified, ty will try to detect common project layouts and initialize `src.root` accordingly.
+The project root (`.`) is always included. Additionally, the following directories are included
+if they exist and are not packages (i.e. they do not contain `__init__.py` or `__init__.pyi` files):
 
-* if a `./src` directory exists, include `.` and `./src` in the first party search path (src layout or flat)
-* if a `./<project-name>/<project-name>` directory exists, include `.` and `./<project-name>` in the first party search path
-* otherwise, default to `.` (flat layout)
-
-Additionally, if a `./python` directory exists and is not a package (i.e. it does not contain an `__init__.py` file),
-it will also be included in the first party search path.
+* `./src`
+* `./<project-name>` (if a `./<project-name>/<project-name>` directory exists)
+* `./python`
 
 **Default value**: `null`
 

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -145,7 +145,7 @@
           ]
         },
         "root": {
-          "description": "The root paths of the project, used for finding first-party modules.\n\nAccepts a list of directory paths searched in priority order (first has highest priority).\n\nIf left unspecified, ty will try to detect common project layouts and initialize `root` accordingly:\n\n* if a `./src` directory exists, include `.` and `./src` in the first party search path (src layout or flat)\n* if a `./<project-name>/<project-name>` directory exists, include `.` and `./<project-name>` in the first party search path\n* otherwise, default to `.` (flat layout)\n\nAdditionally, if a `./python` directory exists and is not a package (i.e. it does not contain an `__init__.py` or `__init__.pyi` file),\nit will also be included in the first party search path.",
+          "description": "The root paths of the project, used for finding first-party modules.\n\nAccepts a list of directory paths searched in priority order (first has highest priority).\n\nIf left unspecified, ty will try to detect common project layouts and initialize `root` accordingly.\nThe project root (`.`) is always included. Additionally, the following directories are included\nif they exist and are not packages (i.e. they do not contain `__init__.py` or `__init__.pyi` files):\n\n* `./src`\n* `./<project-name>` (if a `./<project-name>/<project-name>` directory exists)\n* `./python`",
           "type": [
             "array",
             "null"
@@ -1418,7 +1418,7 @@
           ]
         },
         "root": {
-          "description": "The root of the project, used for finding first-party modules.\n\nIf left unspecified, ty will try to detect common project layouts and initialize `src.root` accordingly:\n\n* if a `./src` directory exists, include `.` and `./src` in the first party search path (src layout or flat)\n* if a `./<project-name>/<project-name>` directory exists, include `.` and `./<project-name>` in the first party search path\n* otherwise, default to `.` (flat layout)\n\nAdditionally, if a `./python` directory exists and is not a package (i.e. it does not contain an `__init__.py` file),\nit will also be included in the first party search path.",
+          "description": "The root of the project, used for finding first-party modules.\n\nIf left unspecified, ty will try to detect common project layouts and initialize `src.root` accordingly.\nThe project root (`.`) is always included. Additionally, the following directories are included\nif they exist and are not packages (i.e. they do not contain `__init__.py` or `__init__.pyi` files):\n\n* `./src`\n* `./<project-name>` (if a `./<project-name>/<project-name>` directory exists)\n* `./python`",
           "anyOf": [
             {
               "$ref": "#/definitions/RelativePathBuf"


### PR DESCRIPTION
Refs https://github.com/astral-sh/ty/issues/2722

Currently in the `environment.root` auto-detection we handle `./src` and `./<project-name>` as mutually exclusive alternatives, but `./python` is independent and additive. I don't think there's any good rationale for this difference. It's generally better to err on the side of including paths than excluding them, so this PR modifies the logic so that all three auto-detected paths are independently additive.

The main motivation here is just to make the behavior easier to explain accurately in the documentation, which is also updated.
