### PR TITLE
[ty] Support literal types in comparison methods

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/comparison/instances/rich_comparison.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/instances/rich_comparison.md
@@ -507,8 +507,8 @@ def compare_complex_eq(a: Y, b: Y) -> bool:
 
 ## Literal Types in Comparison Methods
 
-Classes can define comparison methods that accept literal types. The type checker should preserve
-the literal type when checking these comparisons.
+Classes can define comparison methods that accept literal types. We should preserve the literal type
+when checking these comparisons.
 
 ### Integer Literals
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -14325,46 +14325,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     right_ty: right,
                 }),
             }),
-            (Type::IntLiteral(_), Type::NominalInstance(_)) => {
-                // First try with the literal type, then fall back to widening to int
-                Some(
-                    try_dunder(self, MemberLookupPolicy::default())
-                        .or_else(|_| {
-                            self.infer_binary_type_comparison(
-                                KnownClass::Int.to_instance(self.db()),
-                                op,
-                                right,
-                                range,
-                                visitor,
-                            )
-                        })
-                        .map_err(|_| UnsupportedComparisonError {
-                            op,
-                            left_ty: left,
-                            right_ty: right,
-                        }),
-                )
-            }
-            (Type::NominalInstance(_), Type::IntLiteral(_)) => {
-                // First try with the literal type, then fall back to widening to int
-                Some(
-                    try_dunder(self, MemberLookupPolicy::default())
-                        .or_else(|_| {
-                            self.infer_binary_type_comparison(
-                                left,
-                                op,
-                                KnownClass::Int.to_instance(self.db()),
-                                range,
-                                visitor,
-                            )
-                        })
-                        .map_err(|_| UnsupportedComparisonError {
-                            op,
-                            left_ty: left,
-                            right_ty: right,
-                        }),
-                )
-            }
 
             // Booleans are coded as integers (False = 0, True = 1)
             (Type::IntLiteral(n), Type::BooleanLiteral(b)) => {
@@ -14424,46 +14384,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 };
                 Some(Ok(result))
             }
-            (Type::StringLiteral(_), Type::NominalInstance(_)) => {
-                // First try with the literal type, then fall back to widening to str
-                Some(
-                    try_dunder(self, MemberLookupPolicy::default())
-                        .or_else(|_| {
-                            self.infer_binary_type_comparison(
-                                KnownClass::Str.to_instance(self.db()),
-                                op,
-                                right,
-                                range,
-                                visitor,
-                            )
-                        })
-                        .map_err(|_| UnsupportedComparisonError {
-                            op,
-                            left_ty: left,
-                            right_ty: right,
-                        }),
-                )
-            }
-            (Type::NominalInstance(_), Type::StringLiteral(_)) => {
-                // First try with the literal type, then fall back to widening to str
-                Some(
-                    try_dunder(self, MemberLookupPolicy::default())
-                        .or_else(|_| {
-                            self.infer_binary_type_comparison(
-                                left,
-                                op,
-                                KnownClass::Str.to_instance(self.db()),
-                                range,
-                                visitor,
-                            )
-                        })
-                        .map_err(|_| UnsupportedComparisonError {
-                            op,
-                            left_ty: left,
-                            right_ty: right,
-                        }),
-                )
-            }
             (Type::BytesLiteral(salsa_b1), Type::BytesLiteral(salsa_b2)) => {
                 let b1 = salsa_b1.value(self.db());
                 let b2 = salsa_b2.value(self.db());
@@ -14496,46 +14416,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                 };
                 Some(Ok(result))
-            }
-            (Type::BytesLiteral(_), Type::NominalInstance(_)) => {
-                // First try with the literal type, then fall back to widening to bytes
-                Some(
-                    try_dunder(self, MemberLookupPolicy::default())
-                        .or_else(|_| {
-                            self.infer_binary_type_comparison(
-                                KnownClass::Bytes.to_instance(self.db()),
-                                op,
-                                right,
-                                range,
-                                visitor,
-                            )
-                        })
-                        .map_err(|_| UnsupportedComparisonError {
-                            op,
-                            left_ty: left,
-                            right_ty: right,
-                        }),
-                )
-            }
-            (Type::NominalInstance(_), Type::BytesLiteral(_)) => {
-                // First try with the literal type, then fall back to widening to bytes
-                Some(
-                    try_dunder(self, MemberLookupPolicy::default())
-                        .or_else(|_| {
-                            self.infer_binary_type_comparison(
-                                left,
-                                op,
-                                KnownClass::Bytes.to_instance(self.db()),
-                                range,
-                                visitor,
-                            )
-                        })
-                        .map_err(|_| UnsupportedComparisonError {
-                            op,
-                            left_ty: left,
-                            right_ty: right,
-                        }),
-                )
             }
             (Type::EnumLiteral(literal_1), Type::EnumLiteral(literal_2))
                 if op == ast::CmpOp::Eq =>


### PR DESCRIPTION
Fixes https://github.com/astral-sh/ty/issues/2727

## Summary

This change improves type inference for comparison operations involving literal types (int, str, bytes) with nominal instances. Previously, when comparing a literal type with a class instance, we would immediately widen the literal to its base type (e.g., `Literal[0]` → `int`). This prevented proper type checking of comparison methods that explicitly accept specific literal types.

## Test Plan

Added mdtests.