### PR TITLE
feat(TD003): allow Jira-style issue IDs on the same line as TODO

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
@@ -38,6 +38,12 @@ def foo(x):
 
 # TODO: #9627 A todo with a number on the same line
 
+# TODO: RFFU-6877 A todo with a Jira-style ID on the same line
+
+# TODO: ABC123 A todo with a Jira-style ID without hyphen
+
+# TODO: Move this part to the other place JIRA-123
+
 # TODO: A todo with a random number, 5431
 
 # TODO: here's a TODO on the last line with no link

--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -102,6 +102,8 @@ impl Violation for MissingTodoAuthor {
 ///
 /// # TODO(charlie): this comment has an issue code (matches the regex `[A-Z]+\-?\d+`)
 /// # SIXCHR-003
+///
+/// # TODO(charlie): JIRA-123 this comment has a Jira-style issue ID on the same line
 /// ```
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.269")]
@@ -251,6 +253,7 @@ static ISSUE_LINK_TODO_LINE_REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     RegexSet::new([
         r"\s*(http|https)://.*", // issue link
         r"\s*#\d+.*",            // issue code - like "#003"
+        r"\s*[A-Z]+-?\d+",       // issue code - like "RFFU-6877" or "ABC123" (Jira-style)
     ])
     .unwrap()
 });


### PR DESCRIPTION
## Summary

Extends TD003 to accept Jira-style issue IDs (e.g., `RFFU-6877`, `ABC123`) on the same line as the TODO comment, not just on subsequent lines.

Fixes #20809

## Problem

Previously, only GitHub-style issue numbers with `#` prefix were accepted on the same line:

```python
# TODO: Fix the bug #123  # ✅ Accepted
```

Jira-style IDs had to be on a separate line:

```python
# TODO: Fix the bug  # ❌ TD003 error
# JIRA-123
```

## Solution

Added a new regex pattern to `ISSUE_LINK_TODO_LINE_REGEX_SET` that matches Jira-style issue IDs: `[A-Z]+-?\d+`

Now both of these are valid:

```python
# TODO: Move this part RFFU-6877  # ✅ Accepted
# TODO: Fix the bug ABC123        # ✅ Accepted
```

## Changes

- Added regex pattern `\s*[A-Z]+-?\d+` to match Jira-style IDs on the same line
- Updated `MissingTodoLink` documentation with new example
- Added test cases in `TD003.py` fixture

## Test Plan

Added test cases in `TD003.py`:

```python
# TODO: RFFU-6877 A todo with a Jira-style ID on the same line
# TODO: ABC123 A todo with a Jira-style ID without hyphen
# TODO: Move this part to the other place JIRA-123
```

These should all be accepted and not trigger TD003.