### PR TITLE
[ty] Support constrained TypeVar compatibility across function boundaries

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -808,3 +808,79 @@ reveal_type(result)  # revealed: Derived
 # Accessing an attribute that only exists on Derived should work
 print(result.attr)  # No error
 ```
+
+## Passing a constrained TypeVar to a function expecting a compatible constrained TypeVar
+
+A constrained TypeVar should be assignable to a different constrained TypeVar if each constraint of
+the actual TypeVar is equivalent to at least one constraint of the formal TypeVar. This commonly
+arises when wrapping functions from external packages that define private TypeVars with the same
+constraints.
+
+See: <https://github.com/astral-sh/ty/issues/2728>
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T", int, str)
+S = TypeVar("S", int, str)
+
+def callee(x: T) -> T:
+    return x
+
+def caller(x: S) -> S:
+    return callee(x)
+
+reveal_type(caller(1))  # revealed: int
+reveal_type(caller("hello"))  # revealed: str
+```
+
+A constrained TypeVar with a subset of constraints is also compatible:
+
+```py
+from typing import TypeVar
+
+Wide = TypeVar("Wide", int, str, bytes)
+Narrow = TypeVar("Narrow", int, str)
+
+def wide(x: Wide) -> Wide:
+    return x
+
+def narrow(x: Narrow) -> Narrow:
+    return wide(x)
+
+reveal_type(narrow(1))  # revealed: int
+reveal_type(narrow("hello"))  # revealed: str
+```
+
+But a constrained TypeVar with constraints not satisfied by the formal TypeVar should still error:
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T", int, str)
+U = TypeVar("U", int, bytes)
+
+def target(x: T) -> T:
+    return x
+
+def source(x: U) -> U:
+    return target(x)  # error: [invalid-argument-type]
+```
+
+We require equivalence rather than mere assignability when matching constraints. Constrained
+TypeVars allow narrowing via `isinstance` checks in the function body, so a constraint that is a
+strict subtype would be unsound. For example, a function constrained to `(int, str)` may narrow `T`
+to `int` and return `int(x)`, which would violate a caller's `bool` constraint:
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T", int, str)
+S = TypeVar("S", bool, str)
+
+def f(x: T) -> T:
+    return x
+
+def g(x: S) -> S:
+    return f(x)  # error: [invalid-argument-type]
+```

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1004,5 +1004,61 @@ def _(keys: list[str]):
     reveal_type(reduce(lambda total, k: total + len(k), keys, 0))
 ```
 
+## Passing a constrained TypeVar to a function expecting a compatible constrained TypeVar
+
+A constrained TypeVar should be assignable to a different constrained TypeVar if each constraint of
+the actual TypeVar is equivalent to at least one constraint of the formal TypeVar. This commonly
+arises when wrapping functions from external packages that define private TypeVars with the same
+constraints.
+
+See: <https://github.com/astral-sh/ty/issues/2728>
+
+```py
+def callee[T: (int, str)](x: T) -> T:
+    return x
+
+def caller[S: (int, str)](x: S) -> S:
+    return callee(x)
+
+reveal_type(caller(1))  # revealed: int
+reveal_type(caller("hello"))  # revealed: str
+```
+
+A constrained TypeVar with a subset of constraints is also compatible:
+
+```py
+def wide[T: (int, str, bytes)](x: T) -> T:
+    return x
+
+def narrow[S: (int, str)](x: S) -> S:
+    return wide(x)
+
+reveal_type(narrow(1))  # revealed: int
+reveal_type(narrow("hello"))  # revealed: str
+```
+
+But a constrained TypeVar with constraints not satisfied by the formal TypeVar should still error:
+
+```py
+def target[T: (int, str)](x: T) -> T:
+    return x
+
+def source[U: (int, bytes)](x: U) -> U:
+    return target(x)  # error: [invalid-argument-type]
+```
+
+We require equivalence rather than mere assignability when matching constraints. Constrained
+TypeVars allow narrowing via `isinstance` checks in the function body, so a constraint that is a
+strict subtype would be unsound. For example, a function constrained to `(int, str)` may narrow `T`
+to `int` and return `int(x)`, which would violate a caller's `bool` constraint:
+
+```py
+def f[T: (int, str)](x: T) -> T:
+    return x
+
+def g[S: (bool, str)](x: S) -> S:
+    return f(x)  # error: [invalid-argument-type]
+```
+
 [implies_subtype_of]: ../../type_properties/implies_subtype_of.md
 [ty#2371]: https://github.com/astral-sh/ty/issues/2371

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2133,6 +2133,38 @@ impl<'db> SpecializationBuilder<'db> {
                             }
                         }
 
+                        // If `ty` is itself a constrained TypeVar, check whether each
+                        // of its constraints is equivalent to at least one constraint of
+                        // the formal TypeVar. This handles the case where two TypeVars
+                        // with identical constraint sets are used across function
+                        // boundaries.
+                        //
+                        // We require equivalence rather than assignability to maintain
+                        // soundness: constrained TypeVars allow narrowing via
+                        // `isinstance` checks inside the function body, so a constraint
+                        // that is a strict subtype (e.g. `bool` vs `int`) would allow
+                        // the callee to return a widened type that violates the caller's
+                        // constraint.
+                        if let Type::TypeVar(actual_typevar) = ty
+                            && let Some(actual_constraints) =
+                                actual_typevar.typevar(self.db).constraints(self.db)
+                        {
+                            let all_satisfied =
+                                actual_constraints.iter().all(|actual_constraint| {
+                                    constraints
+                                        .elements(self.db)
+                                        .iter()
+                                        .any(|formal_constraint| {
+                                            actual_constraint
+                                                .is_equivalent_to(self.db, *formal_constraint)
+                                        })
+                                });
+                            if all_satisfied {
+                                self.add_type_mapping(bound_typevar, ty, polarity, f);
+                                return Ok(());
+                            }
+                        }
+
                         for constraint in constraints.elements(self.db) {
                             let is_satisfied = if polarity.is_contravariant() {
                                 constraint


### PR DESCRIPTION
## Summary

Allow passing constrained TypeVars to functions expecting compatible constrained TypeVars.

Fixes https://github.com/astral-sh/ty/issues/2728

## Test Plan

Added mdtests.

Ecosystem results look good. After filtering out non-determinism, it's mostly removing the expected false positives, and then revealing some already-known other issues with constrained typevars as fallout. For example the new scrapy diagnostics are astral-sh/ty#1503.
