### PR TITLE
[ty] Add support for `functools.partial`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -230,6 +230,60 @@ p = partial(42)  # error: [invalid-argument-type]
 reveal_type(p)  # revealed: partial[Unknown]
 ```
 
+## Generic functions
+
+Type variables are inferred from the bound arguments:
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def identity(x: T) -> T:
+    return x
+
+p = partial(identity, 1)
+reveal_type(p)  # revealed: partial[() -> Literal[1]]
+```
+
+## Generic functions with remaining params
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def pair(a: T, b: T) -> tuple[T, T]:
+    return (a, b)
+
+p = partial(pair, 1)
+reveal_type(p)  # revealed: partial[(b: int) -> tuple[Literal[1], Literal[1]]]
+reveal_type(p(2))  # revealed: tuple[Literal[1], Literal[1]]
+```
+
+## Generic constructors
+
+```py
+from functools import partial
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Box(Generic[T]):
+    def __init__(self, value: T) -> None:
+        self.value = value
+
+list_factory = partial(list, [1])
+reveal_type(list_factory)  # revealed: partial[() -> list[int]]
+reveal_type(list_factory())  # revealed: list[int]
+
+box_factory = partial(Box, "hi")
+reveal_type(box_factory)  # revealed: partial[() -> Box[str]]
+reveal_type(box_factory())  # revealed: Box[str]
+```
+
 ## Overloaded functions
 
 ```py
@@ -264,6 +318,47 @@ p = partial(g, start=".")
 paths: list[str] = ["x"]
 reveal_type(p)  # revealed: partial[(path: str, *, start: str | None = ".") -> str]
 reveal_type(list(map(p, paths)))  # revealed: list[str]
+```
+
+## ParamSpec callable bound with `partial`
+
+```py
+from functools import partial
+from typing import Any, Callable, TypeVar
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def invoke(func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+    return func(*args, **kwargs)
+
+def pre(cfg: Any) -> Any:
+    return cfg
+
+bound = partial(invoke, pre)
+reveal_type(bound)  # revealed: partial[(cfg: Any) -> Any]
+reveal_type(bound({}))  # revealed: Any
+```
+
+## ParamSpec callable with keyword-bound wrapper parameters
+
+```py
+from functools import partial
+from typing import Callable, TypeVar
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def invoke(flag: int, func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+    return func(*args, **kwargs)
+
+def pre(*, cfg: str) -> int:
+    return 1
+
+bound = partial(invoke, flag=1, func=pre)
+reveal_type(bound(cfg="x"))  # revealed: int
 ```
 
 ## Partial assignability with a keyword-bound middle parameter
@@ -584,6 +679,24 @@ def f(a: int, b: str) -> bool:
 args: tuple[()] = ()
 p = partial(f, *args)
 reveal_type(p)  # revealed: partial[(a: int, b: str) -> bool]
+```
+
+## Generic function with multiple type variables
+
+Unresolved type variables remain generic in the resulting partial signature.
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+def combine(a: T, b: U) -> tuple[T, U]:
+    return (a, b)
+
+p = partial(combine, 1)
+reveal_type(p)  # revealed: partial[[U](b: U) -> tuple[Literal[1], U]]
 ```
 
 ## Callable object (class with `__call__`)

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -408,6 +408,48 @@ shape: list[int] = [1, 2, 3]
 reveal_type(prod(shape))  # revealed: Any
 ```
 
+## Overloaded stdlib callable with keyword-only binding
+
+`partial(zip, strict=True)` should accept the keyword-only argument and preserve the element types
+of the resulting iterator:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from functools import partial
+import builtins
+
+zips = partial(builtins.zip, strict=True)
+
+xs = [1]
+ys = ["a"]
+pairs = list(zips(xs, ys))
+
+reveal_type(pairs)  # revealed: list[tuple[int, str]]
+```
+
+## Keyword argument with literal sequence annotation
+
+`partial(...)` should accept keyword arguments whose literal container types are inferred without
+context at the call site:
+
+```py
+from functools import partial
+from typing import Literal, Sequence
+
+Distribution = Literal["sdist", "wheel", "editable"]
+
+def build(distributions: Sequence[Distribution]) -> None:
+    pass
+
+p = partial(build, distributions=["wheel"])
+reveal_type(p)  # revealed: partial[(*, distributions: Sequence[Literal["sdist", "wheel", "editable"]] = ...) -> None]
+reveal_type(p())  # revealed: None
+```
+
 ## Overloaded functions with remaining params
 
 ```py
@@ -973,6 +1015,26 @@ def task(
     )
 ```
 
+## Bound classmethod callback with weakref
+
+Binding the first explicit parameter of a bound classmethod callback should preserve assignability
+for `ReferenceType[Self]` arguments:
+
+```py
+from functools import partial
+from typing import Any, Generic, TypeVar
+from weakref import ReferenceType, ref
+
+T = TypeVar("T")
+
+class CallbackHost(Generic[T]):
+    @classmethod
+    def callback(cls, wself: ReferenceType["CallbackHost[Any]"], x: int) -> None: ...
+    def __init__(self) -> None:
+        p = partial(self.callback, ref(self))
+        reveal_type(p)  # revealed: partial[(x: int) -> None]
+```
+
 ## Assignability to protocol
 
 A `partial` result is assignable to a `Protocol` with a matching `__call__` signature. Extra
@@ -1042,4 +1104,20 @@ def f(a: int, b: str) -> bool:
 
 p = partial(f, 1)
 p.func = f  # error: [invalid-assignment]
+```
+
+## Unknown attribute assignment on partial results
+
+We intentionally reject ad-hoc attributes on `functools.partial` results. This matches `pyright` and
+`mypy`, even though these assignments work at runtime.
+
+```py
+from functools import partial
+
+def f() -> None:
+    pass
+
+p = partial(f)
+# error: [unresolved-attribute]
+p.__name__ = "renamed"
 ```

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -259,8 +259,29 @@ def pair(a: T, b: T) -> tuple[T, T]:
     return (a, b)
 
 p = partial(pair, 1)
-reveal_type(p)  # revealed: partial[(b: int) -> tuple[Literal[1], Literal[1]]]
-reveal_type(p(2))  # revealed: tuple[Literal[1], Literal[1]]
+reveal_type(p)  # revealed: partial[(b: int) -> tuple[int, int]]
+reveal_type(p(2))  # revealed: tuple[int, int]
+reveal_type(p(2)[1])  # revealed: int
+```
+
+## Generic functions preserve defaults for no-longer-inferable type params
+
+```py
+from functools import partial
+from typing import cast
+from typing_extensions import TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U", default=T)
+
+def with_default(x: T) -> tuple[T, U]:
+    return (x, cast(U, x))
+
+reveal_type(with_default(1))  # revealed: tuple[Literal[1], Literal[1]]
+
+p = partial(with_default, 1)
+reveal_type(p)  # revealed: partial[() -> tuple[Literal[1], Literal[1]]]
+reveal_type(p())  # revealed: tuple[Literal[1], Literal[1]]
 ```
 
 ## Generic constructors
@@ -492,6 +513,25 @@ reveal_type(p)  # revealed: partial[(*, distributions: Sequence[Literal["sdist",
 reveal_type(p())  # revealed: None
 ```
 
+## Keyword argument with empty literal sequence annotation
+
+`partial(...)` should still re-run argument refinement even when the initial constructor binding
+already succeeds, so empty literals keep the parameter's contextual element type:
+
+```py
+from functools import partial
+from typing import Literal, Sequence
+
+Distribution = Literal["sdist", "wheel", "editable"]
+
+def build(distributions: Sequence[Distribution]) -> None:
+    pass
+
+p = partial(build, distributions=[])
+reveal_type(p)  # revealed: partial[(*, distributions: Sequence[Literal["sdist", "wheel", "editable"]] = ...) -> None]
+reveal_type(p())  # revealed: None
+```
+
 ## Overloaded functions with remaining params
 
 ```py
@@ -671,6 +711,38 @@ p()
 p("extra")  # error: [too-many-positional-arguments]
 ```
 
+## Class constructor partial preserves one-sided bound `__new__` positional params
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self) -> None: ...
+
+p = partial(MyClass, 1)
+reveal_type(p)  # revealed: partial[(x: Never) -> MyClass]
+p()  # error: [missing-argument]
+p(1)  # error: [invalid-argument-type]
+```
+
+## Class constructor partial preserves one-sided bound `__new__` keyword params
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self) -> None: ...
+
+p = partial(MyClass, x=1)
+reveal_type(p)  # revealed: partial[(*, x: Never) -> MyClass]
+p()  # error: [missing-argument]
+p(x=1)  # error: [invalid-argument-type]
+```
+
 ## Class constructor preserves downstream params after partial binding
 
 ```py
@@ -687,6 +759,90 @@ p()  # error: [missing-argument]
 p("extra")  # error: [invalid-argument-type]
 ```
 
+## Class constructor partial preserves one-sided `__init__` params
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: int) -> None: ...
+
+p = partial(MyClass)
+reveal_type(p)  # revealed: partial[(x: Never) -> MyClass]
+p()  # error: [missing-argument]
+p(1)  # error: [invalid-argument-type]
+```
+
+## Class constructor partial preserves downstream keyword-only params
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, *, y: str) -> None: ...
+
+p = partial(MyClass, 1)
+reveal_type(p)  # revealed: partial[(x: Never, *, y: Never) -> MyClass]
+p()  # error: [missing-argument]
+# error: [missing-argument]
+# error: [invalid-argument-type]
+p(y="extra")
+```
+
+## Class constructor partial keeps the narrower subtype-compatible signature
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: object) -> None: ...
+
+p = partial(MyClass)
+reveal_type(p)  # revealed: partial[(x: int) -> MyClass]
+reveal_type(p(1))  # revealed: MyClass
+p("s")  # error: [invalid-argument-type]
+```
+
+## Class constructor partial matches reordered params by name
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int, *, y: str) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, *, y: str, x: int) -> None: ...
+
+p = partial(MyClass)
+reveal_type(p)  # revealed: partial[(*, x: int, y: str) -> MyClass]
+reveal_type(p(x=1, y="s"))  # revealed: MyClass
+p(y="s")  # error: [missing-argument]
+```
+
+## Class constructor partial keeps reordered positional params keyword-only
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int, y: str) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, y: str, x: int) -> None: ...
+
+p = partial(MyClass)
+reveal_type(p)  # revealed: partial[(*, x: int, y: str) -> MyClass]
+reveal_type(p(x=1, y="s"))  # revealed: MyClass
+# error: [missing-argument]
+# error: [too-many-positional-arguments]
+p(1, "s")
+```
+
 ## Class constructor partial preserves both `__new__` and `__init__`
 
 ```py
@@ -701,6 +857,25 @@ p = partial(MyClass)
 reveal_type(p)  # revealed: partial[(x: int) -> MyClass]
 p(1)
 p("s")  # error: [invalid-argument-type]
+```
+
+## Class constructor partial preserves per-overload correlations
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+
+class MyClass:
+    def __new__(cls, x: T, y: T) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: int, y: str) -> None: ...
+
+p = partial(MyClass)
+# error: [invalid-argument-type]
+# error: [invalid-argument-type]
+p(1, "s")
 ```
 
 ## Class constructor partial keeps non-instance `__new__` overloads
@@ -966,6 +1141,23 @@ def make_partial(x):
     return p
 
 p = make_partial(1)
+```
+
+## Invalid overloaded binding falls back to default partial type
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def f(a: int) -> int: ...
+@overload
+def f(a: str) -> str: ...
+def f(a):
+    return a
+
+p = partial(f, 1.0)  # error: [invalid-argument-type]
+reveal_type(p)  # revealed: partial[Unknown]
 ```
 
 ## Partial of bound classmethod is assignable to zero-arg callable

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -284,6 +284,27 @@ reveal_type(box_factory)  # revealed: partial[() -> Box[str]]
 reveal_type(box_factory())  # revealed: Box[str]
 ```
 
+## Stored partials specialize through generic instances
+
+```py
+from functools import partial
+from typing import Callable, Generic, TypeVar
+
+T = TypeVar("T")
+
+def identity(x: T) -> T:
+    return x
+
+class Box(Generic[T]):
+    def __init__(self, value: T) -> None:
+        self.callback = partial(identity, value)
+
+box = Box[int](1)
+reveal_type(box.callback)  # revealed: partial[() -> int]
+
+target: Callable[[], int] = box.callback
+```
+
 ## Overloaded functions
 
 ```py
@@ -299,6 +320,27 @@ def f(a: int | str) -> int | str:
 
 p = partial(f, 1)
 reveal_type(p)  # revealed: partial[() -> int]
+```
+
+## Union of callables preserves union of partials
+
+```py
+from functools import partial
+from typing import Callable
+
+def zero_arg(x: int) -> int:
+    return x
+
+def one_arg(x: int, y: str) -> int:
+    return x + len(y)
+
+def test_union_partial(
+    f: Callable[[int], int] | Callable[[int, str], int],
+) -> None:
+    p = partial(f, 1)
+    reveal_type(p)  # revealed: partial[() -> int] | partial[(str, /) -> int]
+
+    bad: Callable[[bytes, bytes], int] = p  # error: [invalid-assignment]
 ```
 
 ## Keyword-bound overload filtering

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -671,10 +671,7 @@ p()
 p("extra")  # error: [too-many-positional-arguments]
 ```
 
-## TODO: Class constructor where `__new__` and `__init__` disagree after partial binding
-
-This currently demonstrates that constructor partials can still over-prefer the `__new__` path when
-`__new__` and `__init__` disagree after binding.
+## Class constructor preserves downstream params after partial binding
 
 ```py
 from functools import partial
@@ -685,11 +682,51 @@ class MyClass:
     def __init__(self, x: int, y: str) -> None: ...
 
 p = partial(MyClass, 1)
-# TODO: should be `partial[(y: str) -> MyClass]`
-reveal_type(p)  # revealed: partial[() -> MyClass]
-# TODO: should be error: [missing-argument]
-p()
-p("extra")  # error: [too-many-positional-arguments]
+reveal_type(p)  # revealed: partial[(y: Never) -> MyClass]
+p()  # error: [missing-argument]
+p("extra")  # error: [invalid-argument-type]
+```
+
+## Class constructor partial preserves both `__new__` and `__init__`
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int | str) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: int) -> None: ...
+
+p = partial(MyClass)
+reveal_type(p)  # revealed: partial[(x: int) -> MyClass]
+p(1)
+p("s")  # error: [invalid-argument-type]
+```
+
+## Class constructor partial keeps non-instance `__new__` overloads
+
+```py
+from __future__ import annotations
+
+from functools import partial
+from typing import overload
+
+class MyClass:
+    @overload
+    def __new__(cls, x: int) -> "MyClass": ...
+    @overload
+    def __new__(cls, x: str) -> str: ...
+    def __new__(cls, x: int | str) -> "MyClass" | str:
+        if isinstance(x, str):
+            return x
+        return super().__new__(cls)
+
+    def __init__(self, x: int) -> None: ...
+
+p = partial(MyClass)
+reveal_type(p)  # revealed: partial[Overload[(x: str) -> str, (x: int) -> MyClass]]
+reveal_type(p(1))  # revealed: MyClass
+reveal_type(p("s"))  # revealed: str
 ```
 
 ## Binding a default parameter
@@ -1129,9 +1166,26 @@ def f(a: int, b: str) -> bool:
     return True
 
 p = partial(f, 1)
-reveal_type(p.func)  # revealed: (...) -> bool
+reveal_type(p.func)  # revealed: def f(a: int, b: str) -> bool
+reveal_type(p.func(2, "hello"))  # revealed: bool
 reveal_type(p.args)  # revealed: tuple[Any, ...]
 reveal_type(p.keywords)  # revealed: dict[str, Any]
+```
+
+## `partial.func` keeps the original callable type
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+def combine(a: T, b: U) -> tuple[T, U]:
+    return (a, b)
+
+p = partial(combine, 1)
+reveal_type(p.func(2, "x"))  # revealed: tuple[Literal[2], Literal["x"]]
 ```
 
 ## Attribute assignment on partial results

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -1,0 +1,932 @@
+# `functools.partial`
+
+## Basic positional binding
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(b: str) -> bool]
+```
+
+## Keyword binding
+
+Keyword-bound parameters are kept with a default, but they become keyword-only in the resulting
+callable. `partial` allows overriding them at call time, but only by keyword.
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, b="hello")
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello") -> bool]
+```
+
+## Mixed positional and keyword binding
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+p = partial(f, 1, c=3.14)
+reveal_type(p)  # revealed: partial[(b: str, *, c: int | float = ...) -> bool]
+```
+
+## All args bound
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1, "hello")
+reveal_type(p)  # revealed: partial[() -> bool]
+```
+
+## No args bound
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f)
+reveal_type(p)  # revealed: partial[(a: int, b: str) -> bool]
+```
+
+## Positional-only params
+
+```py
+from functools import partial
+
+def f(a: int, b: str, /) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(b: str, /) -> bool]
+```
+
+## Keyword-only params
+
+```py
+from functools import partial
+
+def f(a: int, *, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(*, b: str) -> bool]
+```
+
+## Keyword-only params bound by keyword
+
+```py
+from functools import partial
+
+def f(a: int, *, b: str) -> bool:
+    return True
+
+p = partial(f, b="hello")
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello") -> bool]
+```
+
+## Variadic preserved
+
+```py
+from functools import partial
+
+def f(a: int, *args: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(*args: str) -> bool]
+```
+
+## Keyword variadic preserved
+
+```py
+from functools import partial
+
+def f(a: int, **kwargs: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(**kwargs: str) -> bool]
+```
+
+## Defaults preserved
+
+```py
+from functools import partial
+
+def f(a: int, b: str = "default") -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(b: str = "default") -> bool]
+```
+
+## Lambda
+
+```py
+from functools import partial
+
+p = partial(lambda x, y: x + y, 1)
+reveal_type(p)  # revealed: partial[(y: Any) -> Unknown]
+```
+
+## Calling the partial result
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p("hello", 3.14))  # revealed: bool
+reveal_type(p(b="hello", c=3.14))  # revealed: bool
+```
+
+## Wrong positional arg type
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, "not_an_int")  # error: [invalid-argument-type]
+reveal_type(p)  # revealed: partial[(b: str) -> bool]
+```
+
+## Wrong keyword arg type
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, b=42)  # error: [invalid-argument-type]
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = 42) -> bool]
+```
+
+## Unknown keyword argument
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, c=1)  # error: [unknown-argument]
+```
+
+## Parameter already assigned
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1, a=2)  # error: [parameter-already-assigned]
+```
+
+## Bound method
+
+```py
+from functools import partial
+
+class Greeter:
+    def greet(self, name: str, greeting: str = "Hello") -> str:
+        return f"{greeting}, {name}"
+
+g = Greeter()
+p = partial(g.greet, "world")
+reveal_type(p)  # revealed: partial[(greeting: str = "Hello") -> str]
+reveal_type(p())  # revealed: str
+```
+
+## Non-callable first argument
+
+`partial(42)` is an error caught by the constructor call; we fall back to the default `partial[T]`
+type.
+
+```py
+from functools import partial
+
+p = partial(42)  # error: [invalid-argument-type]
+reveal_type(p)  # revealed: partial[Unknown]
+```
+
+## Overloaded functions
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def f(a: int) -> int: ...
+@overload
+def f(a: str) -> str: ...
+def f(a: int | str) -> int | str:
+    return a
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[() -> int]
+```
+
+## Keyword-bound overload filtering
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def g(path: bytes, start: bytes | None = b".") -> bytes: ...
+@overload
+def g(path: str, start: str | None = ".") -> str: ...
+def g(path: bytes | str, start: bytes | str | None = None) -> bytes | str:
+    return path
+
+p = partial(g, start=".")
+paths: list[str] = ["x"]
+reveal_type(p)  # revealed: partial[(path: str, *, start: str | None = ".") -> str]
+reveal_type(list(map(p, paths)))  # revealed: list[str]
+```
+
+## Partial assignability with a keyword-bound middle parameter
+
+```py
+from functools import partial
+from typing import Any, Protocol
+
+class Conv(Protocol):
+    def __call__(self, __x: Any, *, _target_: str = "set", CBuildsFn: type[Any]) -> Any: ...
+
+class ConfigFromTuple:
+    def __init__(self, _args_: tuple[Any, ...], _target_: str, CBuildsFn: type[Any]) -> None: ...
+
+p = partial(ConfigFromTuple, _target_="set")
+reveal_type(p)  # revealed: partial[(_args_: tuple[Any, ...], *, _target_: str = "set", CBuildsFn: type[Any]) -> ConfigFromTuple]
+
+conversion: dict[type, Conv] = {}
+conversion[set] = p
+```
+
+## Too-many-positional is reported at partial construction
+
+```py
+from functools import partial
+
+def f(a: int, b: int) -> int:
+    return a + b
+
+p = partial(f, 1, 2, 3)  # error: [too-many-positional-arguments]
+reveal_type(p)  # revealed: partial[() -> int]
+p()
+p(1)  # error: [too-many-positional-arguments]
+```
+
+## Overloaded stdlib callable narrowed by bound args
+
+`partial(reduce, operator.mul)` should keep the narrowed return type from the bound reducer:
+
+```py
+from functools import partial, reduce
+import operator
+
+prod = partial(reduce, operator.mul)
+shape: list[int] = [1, 2, 3]
+
+reveal_type(prod(shape))  # revealed: Any
+```
+
+## Overloaded functions with remaining params
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def g(a: int, b: str) -> int: ...
+@overload
+def g(a: str, b: str) -> str: ...
+def g(a: int | str, b: str) -> int | str:
+    return a
+
+p = partial(g, 1)
+reveal_type(p)  # revealed: partial[(b: str) -> int]
+```
+
+## Starred args with fixed-length tuple
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+args: tuple[int] = (1,)
+p = partial(f, *args)
+reveal_type(p)  # revealed: partial[(b: str) -> bool]
+```
+
+## Starred args with multiple elements
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+args: tuple[int, str] = (1, "hello")
+p = partial(f, *args)
+reveal_type(p)  # revealed: partial[(c: int | float) -> bool]
+```
+
+## Mixed positional and starred args
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+args: tuple[str] = ("hello",)
+p = partial(f, 1, *args)
+reveal_type(p)  # revealed: partial[(c: int | float) -> bool]
+```
+
+## Fallback for starred args with variable-length tuple
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+def get_args() -> tuple[int, ...]:
+    return (1,)
+
+p = partial(f, *get_args())
+reveal_type(p)  # revealed: partial[bool]
+```
+
+## Kwargs splat with TypedDict
+
+```py
+from functools import partial
+from typing import TypedDict
+
+class MyKwargs(TypedDict):
+    b: str
+
+def f(a: int, b: str) -> bool:
+    return True
+
+kwargs: MyKwargs = {"b": "hello"}
+p = partial(f, **kwargs)
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = ...) -> bool]
+```
+
+## Mixed keywords and kwargs splat
+
+```py
+from functools import partial
+from typing import TypedDict
+
+class MyKwargs(TypedDict):
+    c: float
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+kwargs: MyKwargs = {"c": 3.14}
+p = partial(f, b="hello", **kwargs)
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello", c: int | float = ...) -> bool]
+```
+
+## Fallback for kwargs splat with dict
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+kwargs = {"a": 1}
+p = partial(f, **kwargs)
+reveal_type(p)  # revealed: partial[bool]
+```
+
+## Fallback for kwargs splat with optional TypedDict keys
+
+```py
+from functools import partial
+from typing import TypedDict
+
+class MaybeKwargs(TypedDict, total=False):
+    b: str
+
+def f(a: int, *, b: str) -> None:
+    pass
+
+def make(kwargs: MaybeKwargs) -> None:
+    p = partial(f, **kwargs)
+    reveal_type(p)  # revealed: partial[None]
+```
+
+## Nested partial
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+p1 = partial(f, 1)
+reveal_type(p1)  # revealed: partial[(b: str, c: int | float) -> bool]
+
+p2 = partial(p1, "hello")
+reveal_type(p2)  # revealed: partial[(c: int | float) -> bool]
+```
+
+## Class constructor
+
+```py
+from functools import partial
+
+class MyClass:
+    def __init__(self, x: int, y: str) -> None:
+        pass
+
+p = partial(MyClass, 1)
+reveal_type(p)  # revealed: partial[(y: str) -> MyClass]
+```
+
+## Class constructor with both `__new__` and `__init__`
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: int) -> None: ...
+
+p = partial(MyClass, 1)
+reveal_type(p)  # revealed: partial[() -> MyClass]
+p()
+p("extra")  # error: [too-many-positional-arguments]
+```
+
+## TODO: Class constructor where `__new__` and `__init__` disagree after partial binding
+
+This currently demonstrates that constructor partials can still over-prefer the `__new__` path when
+`__new__` and `__init__` disagree after binding.
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: int, y: str) -> None: ...
+
+p = partial(MyClass, 1)
+# TODO: should be `partial[(y: str) -> MyClass]`
+reveal_type(p)  # revealed: partial[() -> MyClass]
+# TODO: should be error: [missing-argument]
+p()
+p("extra")  # error: [too-many-positional-arguments]
+```
+
+## Binding a default parameter
+
+Binding a parameter that has a default value removes it from the signature.
+
+```py
+from functools import partial
+
+def f(a: int, b: str = "default", c: float = 0.0) -> bool:
+    return True
+
+p = partial(f, 1, "hello")
+reveal_type(p)  # revealed: partial[(c: int | float = ...) -> bool]
+```
+
+## Multiple keyword bindings
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float, d: bool) -> int:
+    return 0
+
+p = partial(f, b="hello", d=True)
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello", c: int | float, d: bool = True) -> int]
+```
+
+## Mixed positional-only, regular, and keyword-only
+
+```py
+from functools import partial
+
+def f(a: int, /, b: str, *, c: float) -> bool:
+    return True
+
+# Bind the positional-only param
+p1 = partial(f, 1)
+reveal_type(p1)  # revealed: partial[(b: str, *, c: int | float) -> bool]
+
+# Bind a keyword-only param by keyword
+p2 = partial(f, c=3.14)
+reveal_type(p2)  # revealed: partial[(a: int, /, b: str, *, c: int | float = ...) -> bool]
+
+# Bind both positional-only and keyword-only
+p3 = partial(f, 1, c=3.14)
+reveal_type(p3)  # revealed: partial[(b: str, *, c: int | float = ...) -> bool]
+```
+
+## Starred args combined with keyword args
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+args: tuple[int] = (1,)
+p = partial(f, *args, c=3.14)
+reveal_type(p)  # revealed: partial[(b: str, *, c: int | float = ...) -> bool]
+```
+
+## Starred args with empty tuple
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+args: tuple[()] = ()
+p = partial(f, *args)
+reveal_type(p)  # revealed: partial[(a: int, b: str) -> bool]
+```
+
+## Callable object (class with `__call__`)
+
+```py
+from functools import partial
+
+class Adder:
+    def __call__(self, a: int, b: int) -> int:
+        return a + b
+
+adder = Adder()
+p = partial(adder, 1)
+reveal_type(p)  # revealed: partial[(b: int) -> int]
+```
+
+## Staticmethod
+
+```py
+from functools import partial
+
+class MyClass:
+    @staticmethod
+    def f(a: int, b: str) -> bool:
+        return True
+
+p = partial(MyClass.f, 1)
+reveal_type(p)  # revealed: partial[(b: str) -> bool]
+```
+
+## Overloaded function with later matching overload
+
+When the bound argument matches a later overload but not the first, no error should be emitted:
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def f(a: int) -> int: ...
+@overload
+def f(a: str) -> str: ...
+def f(a: int | str) -> int | str:
+    return a
+
+# "hello" matches the second overload (str -> str), so no error.
+p = partial(f, "hello")
+reveal_type(p)  # revealed: partial[() -> str]
+```
+
+## Overriding keyword-bound args at call time
+
+`partial` allows keyword arguments to be overridden when calling the result:
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+p = partial(f, b="hello")
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello", c: int | float) -> bool]
+
+# Override b at call time
+reveal_type(p(1, b="world", c=3.14))  # revealed: bool
+```
+
+## Keyword binding to positional-only param
+
+Positional-only parameters cannot be bound by keyword in `partial()`. The parameter should be
+preserved in the resulting callable, while still reporting a construction-time error:
+
+```py
+from functools import partial
+
+def f(x: int, /, y: str) -> bool:
+    return True
+
+# `x` is positional-only, so `x=1` does not bind it.
+p = partial(f, x=1)  # error: [positional-only-parameter-as-kwarg]
+reveal_type(p)  # revealed: partial[(x: int, /, y: str) -> bool]
+```
+
+## Assignability to callable
+
+A `partial` result is assignable to a `Callable` with the matching signature:
+
+```py
+from functools import partial
+from typing import Callable
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(b: str) -> bool]
+
+def takes_callable(fn: Callable[[str], bool]) -> None:
+    pass
+
+takes_callable(p)  # OK -- partial[(b: str) -> bool] is callable with (str) -> bool
+
+def takes_wrong_callable(fn: Callable[[int], bool]) -> None:
+    pass
+
+takes_wrong_callable(p)  # error: [invalid-argument-type]
+
+def returns_partial() -> partial[bool]:
+    return p  # OK -- partial[(b: str) -> bool] is assignable to partial[bool]
+```
+
+## Assignability to a stub-style function alias
+
+This matches the `TYPE_CHECKING` callback alias pattern in
+`homeassistant/components/mqtt/subscription.py:169`.
+
+```py
+from functools import partial
+from typing import TYPE_CHECKING
+
+def f(a: int, b: str | None, c: dict[str, int]) -> dict[str, int]:
+    return c
+
+if TYPE_CHECKING:
+    def g(a: int, b: str | None) -> dict[str, int]: ...
+
+g = partial(f, c={})
+```
+
+## Ambiguous binding preserves overload
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def f(a: int) -> int: ...
+@overload
+def f(a: str) -> str: ...
+def f(a: int | str) -> int | str:
+    return a
+
+def make_partial(x):
+    p = partial(f, x)
+    reveal_type(p)  # revealed: partial[Overload[() -> int, () -> str]]
+    return p
+
+p = make_partial(1)
+```
+
+## Partial of bound classmethod is assignable to zero-arg callable
+
+```py
+from functools import partial
+from typing import Callable
+from typing_extensions import Self
+
+class C:
+    @classmethod
+    def make(cls, *, x: int = 0) -> Self:
+        raise RuntimeError
+
+factory: Callable[[], C] = partial(C.make, x=0)
+```
+
+## Partials of nested local functions with same signature
+
+Two `partial(...)` values from distinct nested local functions should still be assignable when their
+remaining callable signatures match:
+
+```py
+from functools import partial
+
+def outer(n, big_n):
+    def base_case(B, offset, b, agenda, blocks, eigenvectors):
+        return agenda, blocks, eigenvectors, n
+
+    def recursive_case(B, offset, b, agenda, blocks, eigenvectors):
+        return agenda, blocks, eigenvectors, big_n
+
+    branches = [partial(base_case, 1)]
+    branches.append(partial(recursive_case, 2))
+```
+
+## Partial assignable to callable protocol with extra optional keyword-only params
+
+Partially binding required keyword-only parameters should still leave a callable that satisfies a
+protocol, even if the original function had extra optional keyword-only parameters:
+
+```py
+from functools import partial
+from typing import Protocol
+
+class Request: ...
+class Response: ...
+class Settings: ...
+class Insights: ...
+
+class WebhookFn(Protocol):
+    def __call__(
+        self,
+        request: Request,
+        *,
+        webhook: str | None = None,
+        headers: dict[str, str] | None = None,
+        sslpeer: dict[str, object] | None = None,
+    ) -> Response: ...
+
+def serve_admission_request(
+    request: Request,
+    *,
+    headers: dict[str, str] | None = None,
+    sslpeer: dict[str, object] | None = None,
+    webhook: str | None = None,
+    reason: str | None = None,
+    settings: Settings,
+    insights: Insights,
+) -> Response:
+    return Response()
+
+webhookfn: WebhookFn = partial(
+    serve_admission_request,
+    settings=Settings(),
+    insights=Insights(),
+)
+```
+
+## Keyword-bound predicate remains unary for filter
+
+Binding a predicate parameter via keyword should still produce a unary predicate acceptable to
+`filter(...)`:
+
+```py
+from functools import partial
+
+def has_same_ip_version(addr_or_net: str, is_ipv6: bool) -> bool:
+    return is_ipv6
+
+values = ["127.0.0.1", "::1"]
+predicate = partial(has_same_ip_version, is_ipv6=False)
+reveal_type(predicate)  # revealed: partial[(addr_or_net: str, *, is_ipv6: bool = False) -> bool]
+reveal_type(list(filter(predicate, values)))  # revealed: list[str]
+```
+
+## Overloaded partial reports type mismatch, not unknown keyword
+
+```py
+from functools import partial
+from typing import Callable, Literal, Optional, cast, overload
+
+@overload
+def task(__fn: Callable[[], int]) -> int: ...
+@overload
+def task(
+    __fn: Literal[None] = None,
+    *,
+    retries: int = 0,
+) -> Callable[[Callable[[], int]], int]: ...
+@overload
+def task(
+    *,
+    retries: int = 0,
+) -> Callable[[Callable[[], int]], int]: ...
+def task(
+    __fn: Optional[Callable[[], int]] = None,
+    *,
+    retries: Optional[int] = None,
+):
+    if __fn:
+        return 1
+    return cast(
+        Callable[[Callable[[], int]], int],
+        partial(task, retries=retries),  # error: [invalid-argument-type]
+    )
+```
+
+## Assignability to protocol
+
+A `partial` result is assignable to a `Protocol` with a matching `__call__` signature. Extra
+keyword-only parameters with defaults in the `partial` are allowed, since they don't need to be
+provided by the caller:
+
+```py
+from functools import partial
+from typing import Protocol
+
+class Callback(Protocol):
+    def __call__(self, *, x: int) -> None: ...
+
+def f(*, x: int, y: str) -> None: ...
+
+p = partial(f, y="hello")
+reveal_type(p)  # revealed: partial[(*, x: int, y: str = "hello") -> None]
+
+def takes_callback(cb: Callback) -> None: ...
+
+takes_callback(p)  # OK — extra `y` with default is fine
+```
+
+## Accessing `__call__` directly
+
+`__call__` on a `partial` result should reflect the refined callable signature, not the broad
+`(*args: Any, **kwargs: Any) -> T` from the `partial` class stub.
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p.__call__)  # revealed: (b: str) -> bool
+
+reveal_type(p.__call__("hello"))  # revealed: bool
+```
+
+## Attribute access on partial results
+
+Standard `partial` attributes like `.func`, `.args`, and `.keywords` should be accessible:
+
+```py
+from functools import partial
+from typing import Callable
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p.func)  # revealed: (...) -> bool
+reveal_type(p.args)  # revealed: tuple[Any, ...]
+reveal_type(p.keywords)  # revealed: dict[str, Any]
+```
+
+## Attribute assignment on partial results
+
+Attribute assignment should go through the standard nominal instance path:
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+p.func = f  # error: [invalid-assignment]
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2290,7 +2290,7 @@ impl<'db> Type<'db> {
     pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
         match self {
             // Each `partial()` call creates a distinct object at runtime.
-            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_)) => false,
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial { .. }) => false,
 
             Type::FunctionLiteral(..)
             | Type::WrapperDescriptor(_)
@@ -3479,15 +3479,37 @@ impl<'db> Type<'db> {
                     .into()
             }
 
-            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(callable))
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial { partial, .. })
                 if name_str == "__call__" =>
             {
-                Place::bound(Type::Callable(callable)).into()
+                Place::bound(Type::Callable(partial)).into()
             }
 
-            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(callable)) => callable
-                .into_functools_partial_instance(db)
-                .member_lookup_with_policy(db, name, policy),
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial { wrapped, partial }) => {
+                let wrapped = wrapped.inner(db);
+                let nominal_lookup = partial
+                    .into_functools_partial_instance(db)
+                    .member_lookup_with_policy(db, name.clone(), policy);
+                if name_str == "func" {
+                    match nominal_lookup.place {
+                        Place::Defined(DefinedPlace {
+                            origin,
+                            definedness,
+                            public_type_policy,
+                            ..
+                        }) => Place::Defined(DefinedPlace {
+                            ty: wrapped,
+                            origin,
+                            definedness,
+                            public_type_policy,
+                        })
+                        .into(),
+                        Place::Undefined => Place::bound(wrapped).into(),
+                    }
+                } else {
+                    nominal_lookup
+                }
+            }
 
             Type::NominalInstance(..)
             | Type::ProtocolInstance(..)
@@ -4158,8 +4180,8 @@ impl<'db> Type<'db> {
             )
             .into(),
 
-            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(callable)) => {
-                Type::Callable(callable).bindings(db)
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial { partial, .. }) => {
+                Type::Callable(partial).bindings(db)
             }
 
             Type::KnownInstance(known_instance) => {
@@ -5404,7 +5426,7 @@ impl<'db> Type<'db> {
                 }
                 KnownInstanceType::Callable(callable) => Ok(Type::Callable(*callable)),
                 KnownInstanceType::LiteralStringAlias(ty) => Ok(ty.inner(db)),
-                KnownInstanceType::FunctoolsPartial(_) => Err(InvalidTypeExpressionError {
+                KnownInstanceType::FunctoolsPartial { .. } => Err(InvalidTypeExpressionError {
                     invalid_expressions: smallvec_inline![InvalidTypeExpression::InvalidType(
                         *self, scope_id
                     )],
@@ -6120,7 +6142,7 @@ impl<'db> Type<'db> {
                 | KnownInstanceType::LiteralStringAlias(_)
                 | KnownInstanceType::NamedTupleSpec(_)
                 | KnownInstanceType::NewType(_)
-                | KnownInstanceType::FunctoolsPartial(_) => {
+                | KnownInstanceType::FunctoolsPartial { .. } => {
                     // TODO: For some of these, we may need to try to find legacy typevars in inner types.
                 }
             },

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3485,12 +3485,9 @@ impl<'db> Type<'db> {
                 Place::bound(Type::Callable(callable)).into()
             }
 
-            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(callable)) => {
-                let return_ty = callable.signatures(db).overload_return_type_or_unknown(db);
-                KnownClass::FunctoolsPartial
-                    .to_specialized_instance(db, &[return_ty])
-                    .member_lookup_with_policy(db, name, policy)
-            }
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(callable)) => callable
+                .into_functools_partial_instance(db)
+                .member_lookup_with_policy(db, name, policy),
 
             Type::NominalInstance(..)
             | Type::ProtocolInstance(..)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2290,7 +2290,7 @@ impl<'db> Type<'db> {
     pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
         match self {
             // Each `partial()` call creates a distinct object at runtime.
-            Type::KnownInstance(KnownInstanceType::FunctoolsPartial { .. }) => false,
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_)) => false,
 
             Type::FunctionLiteral(..)
             | Type::WrapperDescriptor(_)
@@ -3479,15 +3479,16 @@ impl<'db> Type<'db> {
                     .into()
             }
 
-            Type::KnownInstance(KnownInstanceType::FunctoolsPartial { partial, .. })
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial))
                 if name_str == "__call__" =>
             {
-                Place::bound(Type::Callable(partial)).into()
+                Place::bound(Type::Callable(partial.partial(db))).into()
             }
 
-            Type::KnownInstance(KnownInstanceType::FunctoolsPartial { wrapped, partial }) => {
-                let wrapped = wrapped.inner(db);
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
+                let wrapped = partial.wrapped(db).inner(db);
                 let nominal_lookup = partial
+                    .partial(db)
                     .into_functools_partial_instance(db)
                     .member_lookup_with_policy(db, name.clone(), policy);
                 if name_str == "func" {
@@ -4180,8 +4181,8 @@ impl<'db> Type<'db> {
             )
             .into(),
 
-            Type::KnownInstance(KnownInstanceType::FunctoolsPartial { partial, .. }) => {
-                Type::Callable(partial).bindings(db)
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
+                Type::Callable(partial.partial(db)).bindings(db)
             }
 
             Type::KnownInstance(known_instance) => {
@@ -5426,7 +5427,7 @@ impl<'db> Type<'db> {
                 }
                 KnownInstanceType::Callable(callable) => Ok(Type::Callable(*callable)),
                 KnownInstanceType::LiteralStringAlias(ty) => Ok(ty.inner(db)),
-                KnownInstanceType::FunctoolsPartial { .. } => Err(InvalidTypeExpressionError {
+                KnownInstanceType::FunctoolsPartial(_) => Err(InvalidTypeExpressionError {
                     invalid_expressions: smallvec_inline![InvalidTypeExpression::InvalidType(
                         *self, scope_id
                     )],
@@ -6142,7 +6143,7 @@ impl<'db> Type<'db> {
                 | KnownInstanceType::LiteralStringAlias(_)
                 | KnownInstanceType::NamedTupleSpec(_)
                 | KnownInstanceType::NewType(_)
-                | KnownInstanceType::FunctoolsPartial { .. } => {
+                | KnownInstanceType::FunctoolsPartial(_) => {
                     // TODO: For some of these, we may need to try to find legacy typevars in inner types.
                 }
             },

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2289,6 +2289,9 @@ impl<'db> Type<'db> {
     /// Return true if this type is non-empty and all inhabitants of this type compare equal.
     pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
         match self {
+            // Each `partial()` call creates a distinct object at runtime.
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_)) => false,
+
             Type::FunctionLiteral(..)
             | Type::WrapperDescriptor(_)
             | Type::KnownBoundMethod(_)
@@ -3476,6 +3479,19 @@ impl<'db> Type<'db> {
                     .into()
             }
 
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(callable))
+                if name_str == "__call__" =>
+            {
+                Place::bound(Type::Callable(callable)).into()
+            }
+
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(callable)) => {
+                let return_ty = callable.signatures(db).overload_return_type_or_unknown(db);
+                KnownClass::FunctoolsPartial
+                    .to_specialized_instance(db, &[return_ty])
+                    .member_lookup_with_policy(db, name, policy)
+            }
+
             Type::NominalInstance(..)
             | Type::ProtocolInstance(..)
             | Type::NewTypeInstance(..)
@@ -4145,6 +4161,10 @@ impl<'db> Type<'db> {
             )
             .into(),
 
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(callable)) => {
+                Type::Callable(callable).bindings(db)
+            }
+
             Type::KnownInstance(known_instance) => {
                 known_instance.instance_fallback(db).bindings(db)
             }
@@ -4401,6 +4421,47 @@ impl<'db> Type<'db> {
                 )
             }
 
+            KnownClass::FunctoolsPartial => {
+                // ```py
+                // class partial(Generic[_T]):
+                //     def __new__(cls, func: Callable[..., _T], /, *args: Any, **kwargs: Any) -> Self: ...
+                // ```
+                let return_ty = BoundTypeVarInstance::synthetic(
+                    db,
+                    Name::new_static("_T"),
+                    TypeVarVariance::Covariant,
+                );
+
+                Some(
+                    Binding::single(
+                        self,
+                        Signature::new_generic(
+                            Some(GenericContext::from_typevar_instances(db, [return_ty])),
+                            Parameters::new(
+                                db,
+                                [
+                                    Parameter::positional_only(Some(Name::new_static("func")))
+                                        .with_annotated_type(Type::single_callable(
+                                            db,
+                                            Signature::new(
+                                                Parameters::gradual_form(),
+                                                Type::TypeVar(return_ty),
+                                            ),
+                                        )),
+                                    Parameter::variadic(Name::new_static("args"))
+                                        .with_annotated_type(Type::any()),
+                                    Parameter::keyword_variadic(Name::new_static("kwargs"))
+                                        .with_annotated_type(Type::any()),
+                                ],
+                            ),
+                            KnownClass::FunctoolsPartial
+                                .to_specialized_instance(db, &[Type::TypeVar(return_ty)]),
+                        ),
+                    )
+                    .into(),
+                )
+            }
+
             KnownClass::Tuple => {
                 let element_ty = BoundTypeVarInstance::synthetic(
                     db,
@@ -4530,6 +4591,7 @@ impl<'db> Type<'db> {
                 KnownClass::Bool
                     | KnownClass::Type
                     | KnownClass::Object
+                    | KnownClass::FunctoolsPartial
                     | KnownClass::Property
                     | KnownClass::Super
                     | KnownClass::TypeAliasType
@@ -5345,6 +5407,12 @@ impl<'db> Type<'db> {
                 }
                 KnownInstanceType::Callable(callable) => Ok(Type::Callable(*callable)),
                 KnownInstanceType::LiteralStringAlias(ty) => Ok(ty.inner(db)),
+                KnownInstanceType::FunctoolsPartial(_) => Err(InvalidTypeExpressionError {
+                    invalid_expressions: smallvec_inline![InvalidTypeExpression::InvalidType(
+                        *self, scope_id
+                    )],
+                    fallback_type: Type::unknown(),
+                }),
             },
 
             Type::SpecialForm(special_form) => special_form
@@ -6054,7 +6122,8 @@ impl<'db> Type<'db> {
                 | KnownInstanceType::Literal(_)
                 | KnownInstanceType::LiteralStringAlias(_)
                 | KnownInstanceType::NamedTupleSpec(_)
-                | KnownInstanceType::NewType(_) => {
+                | KnownInstanceType::NewType(_)
+                | KnownInstanceType::FunctoolsPartial(_) => {
                     // TODO: For some of these, we may need to try to find legacy typevars in inner types.
                 }
             },

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -8,7 +8,10 @@ use ruff_python_ast as ast;
 mod arguments;
 pub(crate) mod bind;
 pub(super) use arguments::{Argument, CallArguments};
-pub(super) use bind::{Binding, Bindings, CallableBinding, MatchedArgument};
+pub(super) use bind::{
+    ArgumentInferenceRefinement, ArgumentInferenceRefinementBindings, Binding, Bindings,
+    CallableBinding, MatchedArgument,
+};
 
 impl<'db> Type<'db> {
     pub(crate) fn try_call_bin_op(

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -9,8 +9,7 @@ mod arguments;
 pub(crate) mod bind;
 pub(super) use arguments::{Argument, CallArguments};
 pub(super) use bind::{
-    ArgumentInferenceRefinement, ArgumentInferenceRefinementBindings, Binding, Bindings,
-    CallableBinding, MatchedArgument,
+    ArgumentInferenceRefinementBindings, Binding, Bindings, CallableBinding, MatchedArgument,
 };
 
 impl<'db> Type<'db> {

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -230,11 +230,44 @@ impl<'a, 'db> CallArguments<'a, 'db> {
     }
 
     /// Create a new [`CallArguments`] starting from the specified index.
-    pub(super) fn start_from(&self, index: usize) -> Self {
+    pub(crate) fn start_from(&self, index: usize) -> Self {
         Self {
             arguments: self.arguments[index..].to_vec(),
             types: self.types[index..].to_vec(),
         }
+    }
+
+    /// Returns the `functools.partial(...)` bound-argument slice when argument expansion is
+    /// concrete enough for partial-application analysis.
+    pub(crate) fn functools_partial_bound_arguments(&self, db: &'db dyn Db) -> Option<Self> {
+        let bound_call_arguments = self.start_from(1);
+
+        // We only handle variadics and keyword-maps that can be normalized to concrete argument
+        // positions for overload matching.
+        if bound_call_arguments.iter().any(|(argument, argument_ty)| {
+            let argument_ty = argument_ty.get_default().unwrap_or_else(Type::unknown);
+            match argument {
+                Argument::Variadic => !matches!(
+                    argument_ty
+                        .as_nominal_instance()
+                        .and_then(|nominal| nominal.tuple_spec(db)),
+                    Some(spec) if spec.as_fixed_length().is_some()
+                ),
+                // Optional TypedDict keys may be absent at runtime, so we can only refine
+                // `partial(...)` when every expanded key is guaranteed to be present.
+                Argument::Keywords => argument_ty.as_typed_dict().is_none_or(|typed_dict| {
+                    typed_dict
+                        .items(db)
+                        .values()
+                        .any(|field| !field.is_required())
+                }),
+                Argument::Positional | Argument::Synthetic | Argument::Keyword(_) => false,
+            }
+        }) {
+            return None;
+        }
+
+        Some(bound_call_arguments)
     }
 
     /// Returns an iterator on performing [argument type expansion].

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -229,6 +229,10 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         (self.arguments.iter().copied()).zip(self.types.iter_mut())
     }
 
+    pub(crate) fn type_at_mut(&mut self, index: usize) -> Option<&mut CallArgumentTypes<'db>> {
+        self.types.get_mut(index)
+    }
+
     /// Create a new [`CallArguments`] starting from the specified index.
     pub(crate) fn start_from(&self, index: usize) -> Self {
         Self {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -321,27 +321,6 @@ impl<'db> BindingsElement<'db> {
     }
 }
 
-/// A request to re-infer call arguments using refinement bindings discovered after an initial
-/// binding pass.
-#[derive(Clone, Debug)]
-pub(crate) enum ArgumentInferenceRefinement<'db> {
-    Bindings(ArgumentInferenceRefinementBindings<'db>),
-}
-
-impl<'db> ArgumentInferenceRefinement<'db> {
-    fn bindings(
-        bindings: Bindings<'db>,
-        argument_start_index: usize,
-        argument_index_offset: usize,
-    ) -> Self {
-        Self::Bindings(ArgumentInferenceRefinementBindings {
-            bindings,
-            argument_start_index,
-            argument_index_offset,
-        })
-    }
-}
-
 /// Refinement bindings to use for a suffix of the call arguments during a refinement pass.
 #[derive(Clone, Debug)]
 pub(crate) struct ArgumentInferenceRefinementBindings<'db> {
@@ -351,6 +330,18 @@ pub(crate) struct ArgumentInferenceRefinementBindings<'db> {
 }
 
 impl<'db> ArgumentInferenceRefinementBindings<'db> {
+    fn new(
+        bindings: Bindings<'db>,
+        argument_start_index: usize,
+        argument_index_offset: usize,
+    ) -> Self {
+        Self {
+            bindings,
+            argument_start_index,
+            argument_index_offset,
+        }
+    }
+
     pub(crate) fn bindings(&self) -> &Bindings<'db> {
         &self.bindings
     }
@@ -740,7 +731,7 @@ impl<'db> Bindings<'db> {
         &self,
         db: &'db dyn Db,
         call_arguments: &CallArguments<'a, 'db>,
-    ) -> Option<ArgumentInferenceRefinement<'db>> {
+    ) -> Option<ArgumentInferenceRefinementBindings<'db>> {
         if !self.may_request_argument_inference_refinement(db) {
             return None;
         }
@@ -765,7 +756,7 @@ impl<'db> Bindings<'db> {
         let (_, refinement_bindings) =
             Self::functools_partial_matched_bindings(db, wrapped_callable_ty, call_arguments)?;
 
-        Some(ArgumentInferenceRefinement::bindings(
+        Some(ArgumentInferenceRefinementBindings::new(
             refinement_bindings,
             1,
             1,

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4349,6 +4349,7 @@ struct ArgumentTypeChecker<'a, 'db> {
 
     inferable_typevars: InferableTypeVars<'db>,
     specialization: Option<Specialization<'db>>,
+    partial_specialization: Option<Specialization<'db>>,
 
     /// Argument indices for which specialization inference has already produced a sufficiently
     /// precise argument mismatch. We can then silence `check_argument_type` for those arguments to
@@ -4384,6 +4385,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             errors,
             inferable_typevars: InferableTypeVars::None,
             specialization: None,
+            partial_specialization: None,
             constraint_set_errors: vec![false; arguments.len()],
         }
     }
@@ -4634,8 +4636,11 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             };
 
         let specialization = builder.build_with(generic_context, maybe_promote);
+        let partial_specialization =
+            builder.build_preserving_unmapped_with(generic_context, maybe_promote);
         self.return_ty = self.return_ty.apply_specialization(self.db, specialization);
         self.specialization = Some(specialization);
+        self.partial_specialization = Some(partial_specialization);
     }
 
     fn infer_argument_constraints<'c>(
@@ -5102,9 +5107,15 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     ) -> (
         InferableTypeVars<'db>,
         Option<Specialization<'db>>,
+        Option<Specialization<'db>>,
         Type<'db>,
     ) {
-        (self.inferable_typevars, self.specialization, self.return_ty)
+        (
+            self.inferable_typevars,
+            self.specialization,
+            self.partial_specialization,
+            self.return_ty,
+        )
     }
 }
 
@@ -5178,6 +5189,10 @@ pub(crate) struct Binding<'db> {
     /// The specialization that was inferred from the argument types, if the callable is generic.
     specialization: Option<Specialization<'db>>,
 
+    /// A partial-application view of the inferred specialization which preserves uninferred
+    /// type variables as generic.
+    partial_specialization: Option<Specialization<'db>>,
+
     /// Information about which parameter(s) each argument was matched with, in argument source
     /// order.
     argument_matches: Box<[MatchedArgument<'db>]>,
@@ -5205,6 +5220,7 @@ impl<'db> Binding<'db> {
             constructor_context: None,
             inferable_typevars: InferableTypeVars::None,
             specialization: None,
+            partial_specialization: None,
             argument_matches: Box::from([]),
             variadic_argument_matched_to_variadic_parameter: false,
             parameter_tys: Box::from([]),
@@ -5293,7 +5309,12 @@ impl<'db> Binding<'db> {
         checker.infer_specialization(constraints);
         checker.check_argument_types(constraints);
 
-        (self.inferable_typevars, self.specialization, self.return_ty) = checker.finish();
+        (
+            self.inferable_typevars,
+            self.specialization,
+            self.partial_specialization,
+            self.return_ty,
+        ) = checker.finish();
     }
 
     pub(crate) fn set_return_type(&mut self, return_ty: Type<'db>) {
@@ -5328,13 +5349,38 @@ impl<'db> Binding<'db> {
         db: &'db dyn Db,
         arguments: &CallArguments<'_, 'db>,
     ) -> Signature<'db> {
-        let signature = self.specialization.map_or_else(
+        let signature = self.partial_specialization.map_or_else(
             || self.signature.clone(),
-            |specialization| self.signature.apply_specialization(db, specialization),
+            |specialization| {
+                if let Some(generic_context) = self.signature.generic_context {
+                    // `partial(...)` creates a reusable callable, so avoid freezing typevars to
+                    // one specific literal value from bound arguments.
+                    let promoted = generic_context.specialize_recursive(
+                        db,
+                        generic_context.variables(db).map(|typevar| {
+                            Some(
+                                specialization
+                                    .get(db, typevar)
+                                    .unwrap_or(Type::TypeVar(typevar))
+                                    .promote(db),
+                            )
+                        }),
+                    );
+                    self.signature.apply_specialization(db, promoted)
+                } else {
+                    self.signature.apply_specialization(db, specialization)
+                }
+            },
         );
 
         let parameters = signature.parameters().as_slice();
-        let return_ty = self.return_ty;
+        let return_ty = self.partial_specialization.map_or_else(
+            || self.unspecialized_return_type(db),
+            |specialization| {
+                self.unspecialized_return_type(db)
+                    .apply_specialization(db, specialization)
+            },
+        );
         let mut remove_positionally_bound = vec![false; parameters.len()];
         let mut keyword_defaults = vec![None; parameters.len()];
         let mut keyword_bound = vec![false; parameters.len()];
@@ -5378,29 +5424,41 @@ impl<'db> Binding<'db> {
         }
 
         let mut remaining = Vec::with_capacity(parameters.len());
-        let mut keyword_only = Vec::new();
-        let mut keyword_variadic = Vec::new();
-        let mut saw_keyword_bound_positional_or_keyword = false;
+        let mut first_keyword_bound_positional_or_keyword = None;
         for (index, parameter) in parameters.iter().enumerate() {
             if remove_positionally_bound[index] {
                 continue;
             }
 
-            let mut parameter = keyword_defaults[index].map_or_else(
+            let parameter = keyword_defaults[index].map_or_else(
                 || parameter.clone(),
                 |default_ty| parameter.clone().with_default_type(default_ty),
             );
 
-            if keyword_bound[index]
+            if first_keyword_bound_positional_or_keyword.is_none()
+                && keyword_bound[index]
                 && matches!(parameter.kind(), ParameterKind::PositionalOrKeyword { .. })
             {
-                saw_keyword_bound_positional_or_keyword = true;
+                first_keyword_bound_positional_or_keyword = Some(remaining.len());
             }
 
+            remaining.push(parameter);
+        }
+
+        // Expand `P.args`/`P.kwargs` while the pair is still adjacent. The keyword-only reshuffle
+        // below can separate them, which would otherwise prevent expansion.
+        let remaining = expand_paramspec_variadics(db, remaining);
+
+        let mut reordered = Vec::with_capacity(remaining.len());
+        let mut keyword_only = Vec::new();
+        let mut keyword_variadic = Vec::new();
+        for (index, parameter) in remaining.into_iter().enumerate() {
+            let mut parameter = parameter;
             // Keyword-bound positional-or-keyword parameters can only be overridden by keyword at
             // call time. Once one appears, later positional-or-keyword parameters also become
             // keyword-only to match `inspect.signature(functools.partial(...))`.
-            if saw_keyword_bound_positional_or_keyword
+            if first_keyword_bound_positional_or_keyword
+                .is_some_and(|first_bound_index| index >= first_bound_index)
                 && matches!(parameter.kind(), ParameterKind::PositionalOrKeyword { .. })
             {
                 parameter = positional_or_keyword_to_keyword_only(&parameter);
@@ -5411,17 +5469,15 @@ impl<'db> Binding<'db> {
             } else if parameter.is_keyword_only() {
                 keyword_only.push(parameter);
             } else {
-                remaining.push(parameter);
+                reordered.push(parameter);
             }
         }
 
-        remaining.extend(keyword_only);
-        remaining.extend(keyword_variadic);
-
-        let remaining = expand_paramspec_variadics(db, remaining);
+        reordered.extend(keyword_only);
+        reordered.extend(keyword_variadic);
 
         signature
-            .with_parameters(Parameters::new(db, remaining))
+            .with_parameters(Parameters::new(db, reordered))
             .with_return_type(return_ty)
     }
 
@@ -5509,6 +5565,7 @@ impl<'db> Binding<'db> {
             return_ty: self.return_ty,
             inferable_typevars: self.inferable_typevars,
             specialization: self.specialization,
+            partial_specialization: self.partial_specialization,
             argument_matches: self.argument_matches.clone(),
             parameter_tys: self.parameter_tys.clone(),
             errors: self.errors.clone(),
@@ -5520,6 +5577,7 @@ impl<'db> Binding<'db> {
             return_ty,
             inferable_typevars,
             specialization,
+            partial_specialization,
             argument_matches,
             parameter_tys,
             errors,
@@ -5528,6 +5586,7 @@ impl<'db> Binding<'db> {
         self.return_ty = return_ty;
         self.inferable_typevars = inferable_typevars;
         self.specialization = specialization;
+        self.partial_specialization = partial_specialization;
         self.argument_matches = argument_matches;
         self.parameter_tys = parameter_tys;
         self.errors = errors;
@@ -5552,6 +5611,7 @@ impl<'db> Binding<'db> {
         self.return_ty = self.initial_return_type(db);
         self.inferable_typevars = InferableTypeVars::None;
         self.specialization = None;
+        self.partial_specialization = None;
         self.argument_matches = Box::from([]);
         self.parameter_tys = Box::from([]);
         self.errors.clear();
@@ -5639,6 +5699,7 @@ struct BindingSnapshot<'db> {
     return_ty: Type<'db>,
     inferable_typevars: InferableTypeVars<'db>,
     specialization: Option<Specialization<'db>>,
+    partial_specialization: Option<Specialization<'db>>,
     argument_matches: Box<[MatchedArgument<'db>]>,
     parameter_tys: Box<[Option<Type<'db>>]>,
     errors: Vec<BindingError<'db>>,
@@ -5680,6 +5741,7 @@ impl<'db> CallableBindingSnapshot<'db> {
                 snapshot.return_ty = binding.return_ty;
                 snapshot.inferable_typevars = binding.inferable_typevars;
                 snapshot.specialization = binding.specialization;
+                snapshot.partial_specialization = binding.partial_specialization;
                 snapshot
                     .argument_matches
                     .clone_from(&binding.argument_matches);

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -44,7 +44,7 @@ use crate::types::function::{
 use crate::types::generics::{
     GenericContext, InferableTypeVars, Specialization, SpecializationBuilder, SpecializationError,
 };
-use crate::types::known_instance::FieldInstance;
+use crate::types::known_instance::{FieldInstance, FunctoolsPartialInstance};
 use crate::types::signatures::{
     CallableSignature, Parameter, ParameterForm, ParameterKind, Parameters,
 };
@@ -90,10 +90,9 @@ fn functools_partial_instance<'db>(
     wrapped: Type<'db>,
     partial: CallableType<'db>,
 ) -> Type<'db> {
-    Type::KnownInstance(KnownInstanceType::FunctoolsPartial {
-        wrapped: InternedType::new(db, wrapped),
-        partial,
-    })
+    Type::KnownInstance(KnownInstanceType::FunctoolsPartial(
+        FunctoolsPartialInstance::new(db, InternedType::new(db, wrapped), partial),
+    ))
 }
 
 impl<'db> CallableItem<'db> {
@@ -715,6 +714,18 @@ impl<'db> Bindings<'db> {
             .filter_map(CallableItem::as_constructor_mut)
     }
 
+    fn clear_deferred_constructor_errors_for_partial_application(&mut self) {
+        for binding in self.iter_flat_mut() {
+            binding.clear_deferred_constructor_errors_for_partial_application();
+        }
+
+        for constructor in self.iter_constructor_items_mut() {
+            if let Some(downstream) = constructor.downstream_constructor_mut() {
+                downstream.clear_deferred_constructor_errors_for_partial_application();
+            }
+        }
+    }
+
     fn collect_type_context_callables<'a>(&'a self, out: &mut Vec<&'a CallableBinding<'db>>) {
         for item in self.iter_callable_items() {
             out.push(item.callable());
@@ -764,19 +775,6 @@ impl<'db> Bindings<'db> {
         call_arguments: &CallArguments<'a, 'db>,
     ) -> Option<ArgumentInferenceRefinementBindings<'db>> {
         if !self.may_request_argument_inference_refinement(db) {
-            return None;
-        }
-
-        let should_refine = !matches!(
-            self.return_type(db),
-            Type::KnownInstance(KnownInstanceType::FunctoolsPartial { .. })
-        ) || self
-            .iter_flat()
-            .flat_map(CallableBinding::overloads)
-            .flat_map(Binding::errors)
-            .any(BindingError::is_relevant_for_partial_application);
-
-        if !should_refine {
             return None;
         }
 
@@ -867,6 +865,11 @@ impl<'db> Bindings<'db> {
             .match_parameters(db, &bound_call_arguments);
         for binding in partial_bindings.iter_flat_mut() {
             binding.clear_missing_argument_errors_for_partial_application();
+        }
+        for constructor in partial_bindings.iter_constructor_items_mut() {
+            if let Some(downstream) = constructor.downstream_constructor_mut() {
+                downstream.clear_deferred_constructor_errors_for_partial_application();
+            }
         }
         Some((bound_call_arguments, partial_bindings))
     }
@@ -2543,6 +2546,8 @@ impl<'db> Bindings<'db> {
                                 [Some(func_ty), ..] => *func_ty,
                                 _ => continue,
                             };
+                            let fallback_return_type = KnownClass::FunctoolsPartial
+                                .to_specialized_instance(db, &[Type::unknown()]);
 
                             let Some((bound_call_arguments, partial_bindings)) =
                                 Self::functools_partial_matched_bindings(
@@ -2591,10 +2596,11 @@ impl<'db> Bindings<'db> {
                                     };
 
                                     if let Type::KnownInstance(
-                                        KnownInstanceType::FunctoolsPartial { partial, .. },
+                                        KnownInstanceType::FunctoolsPartial(partial_instance),
                                     ) = partial_type
                                     {
-                                        for signature in partial.signatures(db) {
+                                        for signature in partial_instance.partial(db).signatures(db)
+                                        {
                                             let signature = signature.clone();
                                             let dedup_key = signature.clone().with_definition(None);
                                             if seen_overloads.insert(dedup_key) {
@@ -2636,6 +2642,7 @@ impl<'db> Bindings<'db> {
                                 }
                             };
                             if new_return_type.is_never() {
+                                overload.set_return_type(fallback_return_type);
                                 continue;
                             }
                             overload.set_return_type(new_return_type);
@@ -2843,6 +2850,18 @@ impl<'db> CallableBinding<'db> {
         }
     }
 
+    /// Ignore downstream constructor call-shape errors when constructing
+    /// `functools.partial(...)`.
+    ///
+    /// The merged partial signature decides which parameters remain callable, so downstream
+    /// arity/name mismatches caused by as-yet-unbound constructor parameters should not reject
+    /// partial construction. Explicit bound-argument type errors are still preserved.
+    fn clear_deferred_constructor_errors_for_partial_application(&mut self) {
+        for overload in &mut self.overloads {
+            overload.clear_deferred_constructor_errors_for_partial_application();
+        }
+    }
+
     /// Chooses which overload to use as the source for diagnostics when no overload fully matches.
     ///
     /// If step 1 of overload resolution identified a single arity match, we keep using that
@@ -2901,6 +2920,25 @@ impl<'db> CallableBinding<'db> {
         }
     }
 
+    fn partial_signature_source_overload_indexes(&self) -> Option<Vec<usize>> {
+        match self.matching_partial_overload_index() {
+            MatchingOverloadIndex::Single(index) => Some(vec![index]),
+            MatchingOverloadIndex::Multiple(indexes) => Some(indexes),
+            MatchingOverloadIndex::None => {
+                if self.overloads().len() > 1 {
+                    None
+                } else {
+                    Some(vec![
+                        self.best_failing_overload_index(
+                            FailingOverloadSelection::ReportableForPartial,
+                        )
+                        .unwrap_or(0),
+                    ])
+                }
+            }
+        }
+    }
+
     /// Builds the reduced callable for this `functools.partial(...)` binding.
     ///
     /// The synthesized callable preserves the reduced callable signature for this binding and reports
@@ -2931,7 +2969,14 @@ impl<'db> CallableBinding<'db> {
                         }
                     }
                 }
-                (0..self.overloads().len()).collect()
+
+                // When no overload is compatible with the bound arguments, don't manufacture a
+                // precise reduced signature from an arbitrary overloaded callable shape.
+                if self.overloads().len() > 1 {
+                    return None;
+                }
+
+                vec![source_overload_index]
             }
         };
 
@@ -4810,6 +4855,46 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
         self.errors.extend(specialization_errors);
 
+        let parameters = self.signature.parameters();
+        let mut remove_positionally_bound = vec![false; parameters.len()];
+        for ((argument, _), argument_matches) in
+            self.arguments.iter().zip(self.argument_matches.iter())
+        {
+            if !matches!(
+                argument,
+                Argument::Positional | Argument::Synthetic | Argument::Variadic
+            ) {
+                continue;
+            }
+
+            for (parameter_index, _) in argument_matches.iter() {
+                let parameter = &parameters[parameter_index];
+                if parameter.is_positional()
+                    && !parameter.is_variadic()
+                    && !parameter.is_keyword_variadic()
+                {
+                    remove_positionally_bound[parameter_index] = true;
+                }
+            }
+        }
+
+        let future_inferable_typevars: FxHashSet<BoundTypeVarIdentity<'db>> = generic_context
+            .variables(self.db)
+            .filter(|typevar| {
+                let typevar_identity = typevar.typevar(self.db).identity(self.db);
+                parameters
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, _)| !remove_positionally_bound[*index])
+                    .any(|(_, parameter)| {
+                        parameter
+                            .annotated_type()
+                            .references_typevar(self.db, typevar_identity)
+                    })
+            })
+            .map(|typevar| typevar.identity(self.db))
+            .collect();
+
         // Attempt to promote any promotable types assigned to the specialization.
         // The hook receives (typevar, lower_bound, upper_bound) and returns Some(ty) to
         // override the default solution, or None to keep it.
@@ -4859,8 +4944,11 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             };
 
         let specialization = builder.build_with(generic_context, maybe_promote);
-        let partial_specialization =
-            builder.build_preserving_unmapped_with(generic_context, maybe_promote);
+        let partial_specialization = builder.build_preserving_unmapped_with(
+            generic_context,
+            |typevar| future_inferable_typevars.contains(&typevar.identity(self.db)),
+            maybe_promote,
+        );
 
         self.return_ty = self.return_ty.apply_specialization(self.db, specialization);
         self.specialization = Some(specialization);
@@ -5561,44 +5649,27 @@ impl<'db> Binding<'db> {
             .retain(|error| !matches!(error, BindingError::MissingArguments { .. }));
     }
 
+    /// Downstream constructor validation is deferred until after partial signatures are merged.
+    fn clear_deferred_constructor_errors_for_partial_application(&mut self) {
+        self.errors.retain(|error| {
+            !matches!(
+                error,
+                BindingError::MissingArguments { .. }
+                    | BindingError::UnknownArgument { .. }
+                    | BindingError::PositionalOnlyParameterAsKwarg { .. }
+                    | BindingError::TooManyPositionalArguments { .. }
+                    | BindingError::ParameterAlreadyAssigned { .. }
+            )
+        });
+    }
+
     /// Returns the callable signature produced by partially applying this bound overload.
     fn partially_applied_signature(
         &self,
         db: &'db dyn Db,
         arguments: &CallArguments<'_, 'db>,
     ) -> Signature<'db> {
-        let signature = self.partial_specialization.map_or_else(
-            || self.signature.clone(),
-            |specialization| {
-                if let Some(generic_context) = self.signature.generic_context {
-                    // `partial(...)` creates a reusable callable, so avoid freezing typevars to
-                    // one specific literal value from bound arguments.
-                    let promoted = generic_context.specialize_recursive(
-                        db,
-                        generic_context.variables(db).map(|typevar| {
-                            Some(
-                                specialization
-                                    .get(db, typevar)
-                                    .unwrap_or(Type::TypeVar(typevar))
-                                    .promote(db),
-                            )
-                        }),
-                    );
-                    self.signature.apply_specialization(db, promoted)
-                } else {
-                    self.signature.apply_specialization(db, specialization)
-                }
-            },
-        );
-
-        let parameters = signature.parameters().as_slice();
-        let return_ty = self.partial_specialization.map_or_else(
-            || self.unspecialized_return_type(db),
-            |specialization| {
-                self.unspecialized_return_type(db)
-                    .apply_specialization(db, specialization)
-            },
-        );
+        let parameters = self.signature.parameters().as_slice();
         let mut remove_positionally_bound = vec![false; parameters.len()];
         let mut keyword_defaults = vec![None; parameters.len()];
         let mut keyword_bound = vec![false; parameters.len()];
@@ -5611,6 +5682,7 @@ impl<'db> Binding<'db> {
                     for (parameter_index, _) in argument_matches.iter() {
                         let parameter = &parameters[parameter_index];
                         if parameter.is_positional()
+                            && parameter.annotated_type() != Type::Never
                             && !parameter.is_variadic()
                             && !parameter.is_keyword_variadic()
                         {
@@ -5633,13 +5705,32 @@ impl<'db> Binding<'db> {
                         }
 
                         keyword_bound[parameter_index] = true;
-                        keyword_defaults[parameter_index] = Some(matched_ty.unwrap_or_else(|| {
-                            argument_ty.get_default().unwrap_or_else(Type::unknown)
-                        }));
+                        if parameter.annotated_type() != Type::Never {
+                            keyword_defaults[parameter_index] =
+                                Some(matched_ty.unwrap_or_else(|| {
+                                    argument_ty.get_default().unwrap_or_else(Type::unknown)
+                                }));
+                        }
                     }
                 }
             }
         }
+
+        let signature_specialization =
+            self.partial_signature_specialization(db, &remove_positionally_bound);
+        let signature = signature_specialization.map_or_else(
+            || self.signature.clone(),
+            |specialization| self.signature.apply_specialization(db, specialization),
+        );
+
+        let parameters = signature.parameters().as_slice();
+        let return_ty = self.partial_specialization.map_or_else(
+            || self.unspecialized_return_type(db),
+            |specialization| {
+                self.unspecialized_return_type(db)
+                    .apply_specialization(db, signature_specialization.unwrap_or(specialization))
+            },
+        );
 
         let mut remaining = Vec::with_capacity(parameters.len());
         let mut first_keyword_bound_positional_or_keyword = None;
@@ -5697,6 +5788,52 @@ impl<'db> Binding<'db> {
         signature
             .with_parameters(Parameters::new(db, reordered))
             .with_return_type(return_ty)
+    }
+
+    fn partial_signature_specialization(
+        &self,
+        db: &'db dyn Db,
+        remove_positionally_bound: &[bool],
+    ) -> Option<Specialization<'db>> {
+        let specialization = self.partial_specialization?;
+        let Some(generic_context) = self.signature.generic_context else {
+            return Some(specialization);
+        };
+
+        let promoted_typevars: FxHashSet<BoundTypeVarIdentity<'db>> = generic_context
+            .variables(db)
+            .filter(|typevar| {
+                self.signature
+                    .parameters()
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, _)| !remove_positionally_bound[*index])
+                    .any(|(_, parameter)| {
+                        parameter
+                            .annotated_type()
+                            .references_typevar(db, typevar.typevar(db).identity(db))
+                    })
+            })
+            .map(|typevar| typevar.identity(db))
+            .collect();
+
+        if promoted_typevars.is_empty() {
+            return Some(specialization);
+        }
+
+        Some(generic_context.specialize_recursive(
+            db,
+            generic_context.variables(db).map(|typevar| {
+                let ty = specialization
+                    .get(db, typevar)
+                    .unwrap_or(Type::TypeVar(typevar));
+                Some(if promoted_typevars.contains(&typevar.identity(db)) {
+                    ty.promote(db)
+                } else {
+                    ty
+                })
+            }),
+        ))
     }
 
     /// Returns the bound type for the specified parameter, or `None` if no argument was matched to

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2498,7 +2498,7 @@ impl<'db> Bindings<'db> {
 
                             // Reuse call-binding machinery to resolve which wrapped overloads are
                             // compatible with bound arguments and to surface binding diagnostics.
-                            let mut partial_bindings = match partial_bindings.check_types(
+                            let partial_bindings = match partial_bindings.check_types(
                                 db,
                                 &ConstraintSetBuilder::new(),
                                 &bound_call_arguments,
@@ -2508,80 +2508,63 @@ impl<'db> Bindings<'db> {
                                 Ok(bindings) => bindings,
                                 Err(CallError(_, bindings)) => *bindings,
                             };
-                            let can_synthesize_multi_binding_partial =
-                                partial_bindings.iter_constructor_items().next().is_some();
-                            if !partial_bindings.is_single()
-                                && !can_synthesize_multi_binding_partial
+                            let new_return_type = if func_ty.is_union() || func_ty.is_intersection()
                             {
-                                continue;
-                            }
-                            let mut new_overloads = Vec::new();
-                            let mut seen_overloads = FxHashSet::default();
-
-                            for partial_binding in partial_bindings.iter_flat_mut() {
-                                if partial_binding.overloads().is_empty() {
-                                    continue;
-                                }
-
-                                for overload in &mut partial_binding.overloads {
-                                    overload.retain_partial_application_errors();
-                                }
-
-                                let selected_overload_indexes =
-                                    match partial_binding.matching_overload_index() {
-                                        MatchingOverloadIndex::Single(index) => vec![index],
-                                        MatchingOverloadIndex::Multiple(indexes) => indexes,
-                                        MatchingOverloadIndex::None => {
-                                            let source_overload_index = partial_binding
-                                                .best_failing_overload_index(
-                                                    FailingOverloadSelection::ReportableForPartial,
-                                                )
-                                                .unwrap_or(0);
-                                            let source_errors = &partial_binding.overloads()
-                                                [source_overload_index]
-                                                .errors;
-                                            for error in source_errors {
-                                                if error.is_relevant_for_partial_application() {
-                                                    let error = error
-                                                        .clone()
-                                                        .maybe_apply_argument_index_offset(Some(1));
-                                                    if !overload.errors.contains(&error) {
-                                                        overload.errors.push(error);
-                                                    }
-                                                }
-                                            }
-                                            (0..partial_binding.overloads().len()).collect()
-                                        }
-                                    };
-
-                                let signature_arguments =
-                                    bound_call_arguments.with_self(partial_binding.bound_type);
-                                for index in selected_overload_indexes {
-                                    let Some(bound_overload) =
-                                        partial_binding.overloads().get(index)
+                                partial_bindings.map_types(db, |partial_binding| {
+                                    partial_binding
+                                        .functools_partial_callable(
+                                            db,
+                                            overload,
+                                            &bound_call_arguments,
+                                        )
+                                        .map(|callable| {
+                                            Type::KnownInstance(
+                                                KnownInstanceType::FunctoolsPartial(callable),
+                                            )
+                                        })
+                                })
+                            } else {
+                                let mut new_overloads = Vec::new();
+                                let mut seen_overloads = FxHashSet::default();
+                                for partial_binding in partial_bindings.iter_flat() {
+                                    let Some(callable) = partial_binding
+                                        .functools_partial_callable(
+                                            db,
+                                            overload,
+                                            &bound_call_arguments,
+                                        )
                                     else {
                                         continue;
                                     };
-                                    let signature = bound_overload.partially_applied_signature(
-                                        db,
-                                        signature_arguments.as_ref(),
-                                    );
-                                    let dedup_key = signature.clone().with_definition(None);
-                                    if seen_overloads.insert(dedup_key) {
-                                        new_overloads.push(signature);
+
+                                    for signature in callable.signatures(db) {
+                                        let signature = signature.clone();
+                                        let dedup_key = signature.clone().with_definition(None);
+                                        if seen_overloads.insert(dedup_key) {
+                                            new_overloads.push(signature);
+                                        }
                                     }
                                 }
-                            }
-                            if new_overloads.is_empty() {
+
+                                if new_overloads.is_empty() {
+                                    Type::Never
+                                } else {
+                                    let new_callable_sig =
+                                        CallableSignature::from_overloads(new_overloads);
+                                    let callable = CallableType::new(
+                                        db,
+                                        new_callable_sig,
+                                        CallableTypeKind::Regular,
+                                    );
+                                    Type::KnownInstance(KnownInstanceType::FunctoolsPartial(
+                                        callable,
+                                    ))
+                                }
+                            };
+                            if new_return_type.is_never() {
                                 continue;
                             }
-
-                            let new_callable_sig = CallableSignature::from_overloads(new_overloads);
-                            let callable =
-                                CallableType::new(db, new_callable_sig, CallableTypeKind::Regular);
-                            overload.set_return_type(Type::KnownInstance(
-                                KnownInstanceType::FunctoolsPartial(callable),
-                            ));
+                            overload.set_return_type(new_return_type);
                         }
 
                         Some(KnownClass::Tuple) if overload_index == 1 => {
@@ -2817,6 +2800,92 @@ impl<'db> CallableBinding<'db> {
                 })
                 .map(|(index, _, _)| index)
         })
+    }
+
+    /// Returns the matching overload indexes when `functools.partial(...)` ignores errors that are
+    /// only relevant at invocation time.
+    fn matching_partial_overload_index(&self) -> MatchingOverloadIndex {
+        let mut matching_overloads = self.overloads.iter().enumerate().filter(|(_, overload)| {
+            !overload
+                .errors
+                .iter()
+                .any(BindingError::is_relevant_for_partial_application)
+        });
+        match matching_overloads.next() {
+            None => MatchingOverloadIndex::None,
+            Some((first, _)) => {
+                if let Some((second, _)) = matching_overloads.next() {
+                    let mut indexes = vec![first, second];
+                    for (index, _) in matching_overloads {
+                        indexes.push(index);
+                    }
+                    MatchingOverloadIndex::Multiple(indexes)
+                } else {
+                    MatchingOverloadIndex::Single(first)
+                }
+            }
+        }
+    }
+
+    /// Builds the reduced callable for this `functools.partial(...)` binding.
+    ///
+    /// The synthesized callable preserves the reduced callable signature for this binding and reports
+    /// any partial-construction diagnostics back to the outer `partial(...)` overload.
+    fn functools_partial_callable<'a>(
+        &self,
+        db: &'db dyn Db,
+        partial_overload: &mut Binding<'db>,
+        bound_call_arguments: &CallArguments<'a, 'db>,
+    ) -> Option<CallableType<'db>> {
+        if self.overloads().is_empty() {
+            return None;
+        }
+
+        let selected_overload_indexes = match self.matching_partial_overload_index() {
+            MatchingOverloadIndex::Single(index) => vec![index],
+            MatchingOverloadIndex::Multiple(indexes) => indexes,
+            MatchingOverloadIndex::None => {
+                let source_overload_index = self
+                    .best_failing_overload_index(FailingOverloadSelection::ReportableForPartial)
+                    .unwrap_or(0);
+                let source_errors = &self.overloads()[source_overload_index].errors;
+                for error in source_errors {
+                    if error.is_relevant_for_partial_application() {
+                        let error = error.clone().maybe_apply_argument_index_offset(Some(1));
+                        if !partial_overload.errors.contains(&error) {
+                            partial_overload.errors.push(error);
+                        }
+                    }
+                }
+                (0..self.overloads().len()).collect()
+            }
+        };
+
+        let signature_arguments = bound_call_arguments.with_self(self.bound_type);
+        let mut new_overloads = Vec::new();
+        let mut seen_overloads = FxHashSet::default();
+        for index in selected_overload_indexes {
+            let Some(bound_overload) = self.overloads().get(index) else {
+                continue;
+            };
+            let signature =
+                bound_overload.partially_applied_signature(db, signature_arguments.as_ref());
+            let dedup_key = signature.clone().with_definition(None);
+            if seen_overloads.insert(dedup_key) {
+                new_overloads.push(signature);
+            }
+        }
+
+        if new_overloads.is_empty() {
+            return None;
+        }
+
+        let new_callable_sig = CallableSignature::from_overloads(new_overloads);
+        Some(CallableType::new(
+            db,
+            new_callable_sig,
+            CallableTypeKind::Regular,
+        ))
     }
 
     pub(crate) fn with_bound_type(mut self, bound_type: Type<'db>) -> Self {
@@ -5410,12 +5479,6 @@ impl<'db> Binding<'db> {
     /// argument was matched to that parameter.
     pub(crate) fn parameter_types(&self) -> &[Option<Type<'db>>] {
         &self.parameter_tys
-    }
-
-    /// Keep only call binding errors that should affect `functools.partial(...)` construction.
-    fn retain_partial_application_errors(&mut self) {
-        self.errors
-            .retain(BindingError::is_relevant_for_partial_application);
     }
 
     /// `functools.partial(...)` is allowed to leave required parameters unbound.

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -53,10 +53,10 @@ use crate::types::typevar::BoundTypeVarIdentity;
 use crate::types::{
     BoundMethodType, BoundTypeVarInstance, CallableType, ClassLiteral, DATACLASS_FLAGS,
     DataclassFlags, DataclassParams, EvaluationMode, GenericAlias, InternedConstraintSet,
-    IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
-    NominalInstanceType, PropertyInstanceType, SpecialFormType, TypeAliasType, TypeContext,
-    TypeVarBoundOrConstraints, TypeVarVariance, UnionBuilder, UnionType, WrapperDescriptorKind,
-    enums, list_members,
+    InternedType, IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType,
+    LiteralValueTypeKind, NominalInstanceType, PropertyInstanceType, SpecialFormType,
+    TypeAliasType, TypeContext, TypeVarBoundOrConstraints, TypeVarVariance, UnionBuilder,
+    UnionType, WrapperDescriptorKind, enums, list_members,
 };
 use crate::{DisplaySettings, FxOrderSet, Program};
 use ruff_db::diagnostic::{Annotation, Diagnostic, SubDiagnostic, SubDiagnosticSeverity};
@@ -83,6 +83,17 @@ enum CallErrorPriority {
 enum CallableItem<'db> {
     Regular(CallableBinding<'db>),
     Constructor(ConstructorBinding<'db>),
+}
+
+fn functools_partial_instance<'db>(
+    db: &'db dyn Db,
+    wrapped: Type<'db>,
+    partial: CallableType<'db>,
+) -> Type<'db> {
+    Type::KnownInstance(KnownInstanceType::FunctoolsPartial {
+        wrapped: InternedType::new(db, wrapped),
+        partial,
+    })
 }
 
 impl<'db> CallableItem<'db> {
@@ -187,6 +198,26 @@ impl<'db> CallableItem<'db> {
 
     fn callable_type(&self) -> Type<'db> {
         self.callable().callable_type
+    }
+
+    fn functools_partial_type<'a>(
+        &self,
+        db: &'db dyn Db,
+        wrapped_callable_ty: Type<'db>,
+        partial_overload: &mut Binding<'db>,
+        bound_call_arguments: &CallArguments<'a, 'db>,
+    ) -> Option<Type<'db>> {
+        match self {
+            CallableItem::Regular(binding) => binding
+                .functools_partial_callable(db, partial_overload, bound_call_arguments)
+                .map(|callable| functools_partial_instance(db, wrapped_callable_ty, callable)),
+            CallableItem::Constructor(binding) => binding.functools_partial_type(
+                db,
+                wrapped_callable_ty,
+                partial_overload,
+                bound_call_arguments,
+            ),
+        }
     }
 
     fn map<F>(self, f: &F) -> CallableItem<'db>
@@ -738,7 +769,7 @@ impl<'db> Bindings<'db> {
 
         let should_refine = !matches!(
             self.return_type(db),
-            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_))
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial { .. })
         ) || self
             .iter_flat()
             .flat_map(CallableBinding::overloads)
@@ -784,6 +815,33 @@ impl<'db> Bindings<'db> {
 
             if !binding_types.is_empty() {
                 element_types.push(IntersectionType::from_elements(db, binding_types));
+            }
+        }
+
+        UnionType::from_elements(db, element_types)
+    }
+
+    /// Maps each `CallableItem` to a type and combines results while preserving
+    /// the union-of-intersections structure:
+    ///
+    /// - callable items inside an element are intersected
+    /// - elements are unioned
+    fn map_item_types(
+        &self,
+        db: &'db dyn Db,
+        mut map: impl FnMut(&CallableItem<'db>) -> Option<Type<'db>>,
+    ) -> Type<'db> {
+        let mut element_types = Vec::with_capacity(self.elements.len());
+        for element in &self.elements {
+            let mut item_types = Vec::new();
+            for item in element.items() {
+                if let Some(ty) = map(item) {
+                    item_types.push(ty);
+                }
+            }
+
+            if !item_types.is_empty() {
+                element_types.push(IntersectionType::from_elements(db, item_types));
             }
         }
 
@@ -2510,55 +2568,71 @@ impl<'db> Bindings<'db> {
                             };
                             let new_return_type = if func_ty.is_union() || func_ty.is_intersection()
                             {
-                                partial_bindings.map_types(db, |partial_binding| {
-                                    partial_binding
-                                        .functools_partial_callable(
-                                            db,
-                                            overload,
-                                            &bound_call_arguments,
-                                        )
-                                        .map(|callable| {
-                                            Type::KnownInstance(
-                                                KnownInstanceType::FunctoolsPartial(callable),
-                                            )
-                                        })
+                                partial_bindings.map_item_types(db, |partial_item| {
+                                    partial_item.functools_partial_type(
+                                        db,
+                                        func_ty,
+                                        overload,
+                                        &bound_call_arguments,
+                                    )
                                 })
                             } else {
+                                let mut partial_types = Vec::new();
                                 let mut new_overloads = Vec::new();
                                 let mut seen_overloads = FxHashSet::default();
-                                for partial_binding in partial_bindings.iter_flat() {
-                                    let Some(callable) = partial_binding
-                                        .functools_partial_callable(
-                                            db,
-                                            overload,
-                                            &bound_call_arguments,
-                                        )
-                                    else {
+                                for partial_item in partial_bindings.iter_callable_items() {
+                                    let Some(partial_type) = partial_item.functools_partial_type(
+                                        db,
+                                        func_ty,
+                                        overload,
+                                        &bound_call_arguments,
+                                    ) else {
                                         continue;
                                     };
 
-                                    for signature in callable.signatures(db) {
-                                        let signature = signature.clone();
-                                        let dedup_key = signature.clone().with_definition(None);
-                                        if seen_overloads.insert(dedup_key) {
-                                            new_overloads.push(signature);
+                                    if let Type::KnownInstance(
+                                        KnownInstanceType::FunctoolsPartial { partial, .. },
+                                    ) = partial_type
+                                    {
+                                        for signature in partial.signatures(db) {
+                                            let signature = signature.clone();
+                                            let dedup_key = signature.clone().with_definition(None);
+                                            if seen_overloads.insert(dedup_key) {
+                                                new_overloads.push(signature);
+                                            }
                                         }
+                                    } else {
+                                        partial_types.push(partial_type);
                                     }
                                 }
 
-                                if new_overloads.is_empty() {
-                                    Type::Never
+                                if partial_types.is_empty() {
+                                    if new_overloads.is_empty() {
+                                        Type::Never
+                                    } else {
+                                        let new_callable_sig =
+                                            CallableSignature::from_overloads(new_overloads);
+                                        let callable = CallableType::new(
+                                            db,
+                                            new_callable_sig,
+                                            CallableTypeKind::Regular,
+                                        );
+                                        functools_partial_instance(db, func_ty, callable)
+                                    }
                                 } else {
-                                    let new_callable_sig =
-                                        CallableSignature::from_overloads(new_overloads);
-                                    let callable = CallableType::new(
-                                        db,
-                                        new_callable_sig,
-                                        CallableTypeKind::Regular,
-                                    );
-                                    Type::KnownInstance(KnownInstanceType::FunctoolsPartial(
-                                        callable,
-                                    ))
+                                    if !new_overloads.is_empty() {
+                                        let new_callable_sig =
+                                            CallableSignature::from_overloads(new_overloads);
+                                        let callable = CallableType::new(
+                                            db,
+                                            new_callable_sig,
+                                            CallableTypeKind::Regular,
+                                        );
+                                        partial_types.push(functools_partial_instance(
+                                            db, func_ty, callable,
+                                        ));
+                                    }
+                                    IntersectionType::from_elements(db, partial_types)
                                 }
                             };
                             if new_return_type.is_never() {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -710,6 +710,29 @@ impl<'db> Bindings<'db> {
         UnionType::from_elements(db, element_types)
     }
 
+    /// Builds matched bindings for the callable wrapped by `functools.partial(...)`.
+    ///
+    /// This handles the shared partial-specific preprocessing (callable validation and argument
+    /// normalization) used by both inference and known-call evaluation.
+    pub(crate) fn functools_partial_matched_bindings<'a>(
+        db: &'db dyn Db,
+        wrapped_callable_ty: Type<'db>,
+        call_arguments: &CallArguments<'a, 'db>,
+    ) -> Option<(CallArguments<'a, 'db>, Bindings<'db>)> {
+        // We can only infer bound-argument context from an actual callable.
+        wrapped_callable_ty.try_upcast_to_callable(db)?;
+
+        let bound_call_arguments = call_arguments.functools_partial_bound_arguments(db)?;
+
+        let mut partial_bindings = wrapped_callable_ty
+            .bindings(db)
+            .match_parameters(db, &bound_call_arguments);
+        for binding in partial_bindings.iter_flat_mut() {
+            binding.clear_missing_argument_errors_for_partial_application();
+        }
+        Some((bound_call_arguments, partial_bindings))
+    }
+
     fn map_with<F>(self, f: &F) -> Self
     where
         F: Fn(CallableBinding<'db>) -> CallableBinding<'db>,
@@ -2375,6 +2398,112 @@ impl<'db> Bindings<'db> {
                             }
                         }
 
+                        Some(KnownClass::FunctoolsPartial) => {
+                            // `partial(...)` receives the wrapped callable as its first explicit
+                            // argument (after constructor receiver handling).
+                            let func_ty = match overload.parameter_types() {
+                                [Some(func_ty), ..] => *func_ty,
+                                _ => continue,
+                            };
+
+                            let Some((bound_call_arguments, partial_bindings)) =
+                                Self::functools_partial_matched_bindings(
+                                    db,
+                                    func_ty,
+                                    call_arguments,
+                                )
+                            else {
+                                continue;
+                            };
+
+                            // Reuse call-binding machinery to resolve which wrapped overloads are
+                            // compatible with bound arguments and to surface binding diagnostics.
+                            let mut partial_bindings = match partial_bindings.check_types(
+                                db,
+                                &ConstraintSetBuilder::new(),
+                                &bound_call_arguments,
+                                TypeContext::default(),
+                                &[],
+                            ) {
+                                Ok(bindings) => bindings,
+                                Err(CallError(_, bindings)) => *bindings,
+                            };
+                            let can_synthesize_multi_binding_partial =
+                                partial_bindings.iter_constructor_items().next().is_some();
+                            if !partial_bindings.is_single()
+                                && !can_synthesize_multi_binding_partial
+                            {
+                                continue;
+                            }
+                            let mut new_overloads = Vec::new();
+                            let mut seen_overloads = FxHashSet::default();
+
+                            for partial_binding in partial_bindings.iter_flat_mut() {
+                                if partial_binding.overloads().is_empty() {
+                                    continue;
+                                }
+
+                                for overload in &mut partial_binding.overloads {
+                                    overload.retain_partial_application_errors();
+                                }
+
+                                let selected_overload_indexes =
+                                    match partial_binding.matching_overload_index() {
+                                        MatchingOverloadIndex::Single(index) => vec![index],
+                                        MatchingOverloadIndex::Multiple(indexes) => indexes,
+                                        MatchingOverloadIndex::None => {
+                                            let source_overload_index = partial_binding
+                                                .best_failing_overload_index(
+                                                    FailingOverloadSelection::ReportableForPartial,
+                                                )
+                                                .unwrap_or(0);
+                                            let source_errors = &partial_binding.overloads()
+                                                [source_overload_index]
+                                                .errors;
+                                            for error in source_errors {
+                                                if error.is_relevant_for_partial_application() {
+                                                    let error = error
+                                                        .clone()
+                                                        .maybe_apply_argument_index_offset(Some(1));
+                                                    if !overload.errors.contains(&error) {
+                                                        overload.errors.push(error);
+                                                    }
+                                                }
+                                            }
+                                            (0..partial_binding.overloads().len()).collect()
+                                        }
+                                    };
+
+                                let signature_arguments =
+                                    bound_call_arguments.with_self(partial_binding.bound_type);
+                                for index in selected_overload_indexes {
+                                    let Some(bound_overload) =
+                                        partial_binding.overloads().get(index)
+                                    else {
+                                        continue;
+                                    };
+                                    let signature = bound_overload.partially_applied_signature(
+                                        db,
+                                        signature_arguments.as_ref(),
+                                    );
+                                    let dedup_key = signature.clone().with_definition(None);
+                                    if seen_overloads.insert(dedup_key) {
+                                        new_overloads.push(signature);
+                                    }
+                                }
+                            }
+                            if new_overloads.is_empty() {
+                                continue;
+                            }
+
+                            let new_callable_sig = CallableSignature::from_overloads(new_overloads);
+                            let callable =
+                                CallableType::new(db, new_callable_sig, CallableTypeKind::Regular);
+                            overload.set_return_type(Type::KnownInstance(
+                                KnownInstanceType::FunctoolsPartial(callable),
+                            ));
+                        }
+
                         Some(KnownClass::Tuple) if overload_index == 1 => {
                             // `tuple(range(42))` => `tuple[int, ...]`
                             // BUT `tuple((1, 2))` => `tuple[Literal[1], Literal[2]]` rather than `tuple[Literal[1, 2], ...]`
@@ -2507,6 +2636,23 @@ pub(crate) struct CallableBinding<'db> {
     overloads: SmallVec<[Binding<'db>; 1]>,
 }
 
+#[derive(Copy, Clone)]
+enum FailingOverloadSelection {
+    /// Consider all errors that participate in overload filtering.
+    AffectsOverloadResolution,
+    /// Consider only errors that are reported during `functools.partial(...)` construction.
+    ReportableForPartial,
+}
+
+impl FailingOverloadSelection {
+    fn includes(self, error: &BindingError<'_>) -> bool {
+        match self {
+            Self::AffectsOverloadResolution => error.affects_overload_resolution(),
+            Self::ReportableForPartial => error.is_relevant_for_partial_application(),
+        }
+    }
+}
+
 impl<'db> CallableBinding<'db> {
     pub(crate) fn from_overloads(
         signature_type: Type<'db>,
@@ -2539,6 +2685,8 @@ impl<'db> CallableBinding<'db> {
         }
     }
 
+    /// Rewrites overload signatures as if an implicit bound receiver argument had already been
+    /// consumed.
     pub(crate) fn bake_bound_type_into_overloads(&mut self, db: &'db dyn Db) {
         let Some(bound_self) = self.bound_type.take() else {
             return;
@@ -2546,6 +2694,49 @@ impl<'db> CallableBinding<'db> {
         for overload in &mut self.overloads {
             overload.signature = overload.signature.bind_self(db, Some(bound_self));
         }
+    }
+
+    /// Ignore missing-argument errors when constructing `functools.partial(...)`.
+    ///
+    /// Partial application intentionally leaves some parameters unbound, so we still want to
+    /// type-check all explicitly bound arguments against each overload.
+    fn clear_missing_argument_errors_for_partial_application(&mut self) {
+        for overload in &mut self.overloads {
+            overload.clear_missing_argument_errors_for_partial_application();
+        }
+    }
+
+    /// Chooses which overload to use as the source for diagnostics when no overload fully matches.
+    ///
+    /// If step 1 of overload resolution identified a single arity match, we keep using that
+    /// overload as the diagnostic source. Otherwise, we rank failing overloads by error quality:
+    /// fewer unknown-argument errors and fewer relevant errors are preferred.
+    fn best_failing_overload_index(&self, selection: FailingOverloadSelection) -> Option<usize> {
+        self.matching_overload_before_type_checking.or_else(|| {
+            self.overloads
+                .iter()
+                .enumerate()
+                .filter_map(|(index, overload)| {
+                    let mut relevant_count = 0;
+                    let mut unknown_argument_count = 0;
+
+                    for error in &overload.errors {
+                        if !selection.includes(error) {
+                            continue;
+                        }
+                        relevant_count += 1;
+                        if matches!(error, BindingError::UnknownArgument { .. }) {
+                            unknown_argument_count += 1;
+                        }
+                    }
+
+                    (relevant_count > 0).then_some((index, unknown_argument_count, relevant_count))
+                })
+                .min_by_key(|(_, unknown_argument_count, relevant_count)| {
+                    (*unknown_argument_count, *relevant_count)
+                })
+                .map(|(index, _, _)| index)
+        })
     }
 
     pub(crate) fn with_bound_type(mut self, bound_type: Type<'db>) -> Self {
@@ -4443,7 +4634,6 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             };
 
         let specialization = builder.build_with(generic_context, maybe_promote);
-
         self.return_ty = self.return_ty.apply_specialization(self.db, specialization);
         self.specialization = Some(specialization);
     }
@@ -4760,7 +4950,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     );
                 } else {
                     let index = callable_binding
-                        .matching_overload_before_type_checking
+                        .best_failing_overload_index(
+                            FailingOverloadSelection::AffectsOverloadResolution,
+                        )
                         .unwrap_or(0);
                     // TODO: We should also update the specialization for the `ParamSpec` to reflect
                     // the matching overload here.
@@ -5118,6 +5310,121 @@ impl<'db> Binding<'db> {
         &self.parameter_tys
     }
 
+    /// Keep only call binding errors that should affect `functools.partial(...)` construction.
+    fn retain_partial_application_errors(&mut self) {
+        self.errors
+            .retain(BindingError::is_relevant_for_partial_application);
+    }
+
+    /// `functools.partial(...)` is allowed to leave required parameters unbound.
+    fn clear_missing_argument_errors_for_partial_application(&mut self) {
+        self.errors
+            .retain(|error| !matches!(error, BindingError::MissingArguments { .. }));
+    }
+
+    /// Returns the callable signature produced by partially applying this bound overload.
+    fn partially_applied_signature(
+        &self,
+        db: &'db dyn Db,
+        arguments: &CallArguments<'_, 'db>,
+    ) -> Signature<'db> {
+        let signature = self.specialization.map_or_else(
+            || self.signature.clone(),
+            |specialization| self.signature.apply_specialization(db, specialization),
+        );
+
+        let parameters = signature.parameters().as_slice();
+        let return_ty = self.return_ty;
+        let mut remove_positionally_bound = vec![false; parameters.len()];
+        let mut keyword_defaults = vec![None; parameters.len()];
+        let mut keyword_bound = vec![false; parameters.len()];
+
+        for ((argument, argument_ty), argument_matches) in
+            arguments.iter().zip(&self.argument_matches)
+        {
+            match argument {
+                Argument::Positional | Argument::Synthetic | Argument::Variadic => {
+                    for (parameter_index, _) in argument_matches.iter() {
+                        let parameter = &parameters[parameter_index];
+                        if parameter.is_positional()
+                            && !parameter.is_variadic()
+                            && !parameter.is_keyword_variadic()
+                        {
+                            remove_positionally_bound[parameter_index] = true;
+                        }
+                    }
+                }
+                Argument::Keyword(_) | Argument::Keywords => {
+                    for (parameter_index, matched_ty) in argument_matches.iter() {
+                        if remove_positionally_bound[parameter_index] {
+                            continue;
+                        }
+
+                        let parameter = &parameters[parameter_index];
+                        if parameter.is_positional_only()
+                            || parameter.is_variadic()
+                            || parameter.is_keyword_variadic()
+                        {
+                            continue;
+                        }
+
+                        keyword_bound[parameter_index] = true;
+                        keyword_defaults[parameter_index] = Some(matched_ty.unwrap_or_else(|| {
+                            argument_ty.get_default().unwrap_or_else(Type::unknown)
+                        }));
+                    }
+                }
+            }
+        }
+
+        let mut remaining = Vec::with_capacity(parameters.len());
+        let mut keyword_only = Vec::new();
+        let mut keyword_variadic = Vec::new();
+        let mut saw_keyword_bound_positional_or_keyword = false;
+        for (index, parameter) in parameters.iter().enumerate() {
+            if remove_positionally_bound[index] {
+                continue;
+            }
+
+            let mut parameter = keyword_defaults[index].map_or_else(
+                || parameter.clone(),
+                |default_ty| parameter.clone().with_default_type(default_ty),
+            );
+
+            if keyword_bound[index]
+                && matches!(parameter.kind(), ParameterKind::PositionalOrKeyword { .. })
+            {
+                saw_keyword_bound_positional_or_keyword = true;
+            }
+
+            // Keyword-bound positional-or-keyword parameters can only be overridden by keyword at
+            // call time. Once one appears, later positional-or-keyword parameters also become
+            // keyword-only to match `inspect.signature(functools.partial(...))`.
+            if saw_keyword_bound_positional_or_keyword
+                && matches!(parameter.kind(), ParameterKind::PositionalOrKeyword { .. })
+            {
+                parameter = positional_or_keyword_to_keyword_only(&parameter);
+            }
+
+            if parameter.is_keyword_variadic() {
+                keyword_variadic.push(parameter);
+            } else if parameter.is_keyword_only() {
+                keyword_only.push(parameter);
+            } else {
+                remaining.push(parameter);
+            }
+        }
+
+        remaining.extend(keyword_only);
+        remaining.extend(keyword_variadic);
+
+        let remaining = expand_paramspec_variadics(db, remaining);
+
+        signature
+            .with_parameters(Parameters::new(db, remaining))
+            .with_return_type(return_ty)
+    }
+
     /// Returns the bound type for the specified parameter, or `None` if no argument was matched to
     /// that parameter.
     ///
@@ -5249,6 +5556,82 @@ impl<'db> Binding<'db> {
         self.parameter_tys = Box::from([]);
         self.errors.clear();
     }
+}
+
+fn positional_or_keyword_to_keyword_only<'db>(parameter: &Parameter<'db>) -> Parameter<'db> {
+    let ParameterKind::PositionalOrKeyword { name, .. } = parameter.kind() else {
+        return parameter.clone();
+    };
+
+    let was_type_form = matches!(parameter.form, ParameterForm::Type);
+
+    let mut parameter = Parameter::keyword_only(name.clone())
+        .with_annotated_type(parameter.annotated_type())
+        .with_optional_default_type(parameter.default_type());
+
+    if was_type_form {
+        parameter = parameter.type_form();
+    }
+
+    parameter
+}
+
+fn expand_paramspec_variadics<'db>(
+    db: &'db dyn Db,
+    parameters: Vec<Parameter<'db>>,
+) -> Vec<Parameter<'db>> {
+    let mut variadic_index = None;
+    let mut paramspec_callable = None;
+
+    for (index, parameter) in parameters.iter().enumerate() {
+        if !parameter.is_variadic() {
+            continue;
+        }
+
+        let Type::Callable(callable) = parameter.annotated_type() else {
+            continue;
+        };
+        if callable.kind(db) != CallableTypeKind::ParamSpecValue {
+            continue;
+        }
+
+        variadic_index = Some(index);
+        paramspec_callable = Some(callable);
+        break;
+    }
+
+    let Some(variadic_index) = variadic_index else {
+        return parameters;
+    };
+    let Some(paramspec_callable) = paramspec_callable else {
+        return parameters;
+    };
+
+    let Some(keyword_variadic) = parameters.get(variadic_index + 1) else {
+        return parameters;
+    };
+    if !keyword_variadic.is_keyword_variadic() {
+        return parameters;
+    }
+
+    let Type::Callable(keyword_callable) = keyword_variadic.annotated_type() else {
+        return parameters;
+    };
+    if keyword_callable.kind(db) != CallableTypeKind::ParamSpecValue
+        || keyword_callable != paramspec_callable
+    {
+        return parameters;
+    }
+
+    let [mapped_signature] = paramspec_callable.signatures(db).overloads.as_slice() else {
+        return parameters;
+    };
+
+    let mut expanded = Vec::with_capacity(parameters.len());
+    expanded.extend_from_slice(&parameters[..variadic_index]);
+    expanded.extend_from_slice(mapped_signature.parameters().as_slice());
+    expanded.extend_from_slice(&parameters[variadic_index + 2..]);
+    expanded
 }
 
 #[derive(Clone, Debug)]
@@ -5534,6 +5917,24 @@ pub(crate) enum BindingError<'db> {
 }
 
 impl BindingError<'_> {
+    /// Returns whether this error is relevant to `functools.partial(...)` construction.
+    ///
+    /// These errors are used both to filter incompatible wrapped overloads and to report
+    /// statically-detectable call-shape errors at construction time. (Runtime `functools.partial`
+    /// can defer some call-shape errors until invocation.)
+    fn is_relevant_for_partial_application(&self) -> bool {
+        matches!(
+            self,
+            Self::InvalidArgumentType { .. }
+                | Self::InvalidKeyType { .. }
+                | Self::UnknownArgument { .. }
+                | Self::PositionalOnlyParameterAsKwarg { .. }
+                | Self::TooManyPositionalArguments { .. }
+                | Self::ParameterAlreadyAssigned { .. }
+                | Self::SpecializationError { .. }
+        )
+    }
+
     pub(crate) fn maybe_apply_argument_index_offset(mut self, offset: Option<usize>) -> Self {
         if let Some(offset) = offset {
             self.apply_argument_index_offset(offset);

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -321,6 +321,49 @@ impl<'db> BindingsElement<'db> {
     }
 }
 
+/// A request to re-infer call arguments using refinement bindings discovered after an initial
+/// binding pass.
+#[derive(Clone, Debug)]
+pub(crate) enum ArgumentInferenceRefinement<'db> {
+    Bindings(ArgumentInferenceRefinementBindings<'db>),
+}
+
+impl<'db> ArgumentInferenceRefinement<'db> {
+    fn bindings(
+        bindings: Bindings<'db>,
+        argument_start_index: usize,
+        argument_index_offset: usize,
+    ) -> Self {
+        Self::Bindings(ArgumentInferenceRefinementBindings {
+            bindings,
+            argument_start_index,
+            argument_index_offset,
+        })
+    }
+}
+
+/// Refinement bindings to use for a suffix of the call arguments during a refinement pass.
+#[derive(Clone, Debug)]
+pub(crate) struct ArgumentInferenceRefinementBindings<'db> {
+    bindings: Bindings<'db>,
+    argument_start_index: usize,
+    argument_index_offset: usize,
+}
+
+impl<'db> ArgumentInferenceRefinementBindings<'db> {
+    pub(crate) fn bindings(&self) -> &Bindings<'db> {
+        &self.bindings
+    }
+
+    pub(crate) fn argument_start_index(&self) -> usize {
+        self.argument_start_index
+    }
+
+    pub(crate) fn argument_index_offset(&self) -> usize {
+        self.argument_index_offset
+    }
+}
+
 /// Binding information for a union of callables, where each union element may be an intersection.
 ///
 /// This structure represents a union (possibly size one) of callable elements, where each element
@@ -681,6 +724,52 @@ impl<'db> Bindings<'db> {
                 .flat_map(CallableBinding::matching_overloads)
                 .any(|(_, overload)| f(overload))
         })
+    }
+
+    /// Returns `true` if this call shape may request a second argument-inference pass after the
+    /// initial binding result is known.
+    pub(crate) fn may_request_argument_inference_refinement(&self, db: &'db dyn Db) -> bool {
+        matches!(
+            self.callable_type,
+            Type::ClassLiteral(class) if class.is_known(db, KnownClass::FunctoolsPartial)
+        ) && self.argument_forms().len() > 1
+    }
+
+    /// Returns an argument-inference refinement request derived from the current binding result.
+    pub(crate) fn argument_inference_refinement_request<'a>(
+        &self,
+        db: &'db dyn Db,
+        call_arguments: &CallArguments<'a, 'db>,
+    ) -> Option<ArgumentInferenceRefinement<'db>> {
+        if !self.may_request_argument_inference_refinement(db) {
+            return None;
+        }
+
+        let should_refine = !matches!(
+            self.return_type(db),
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_))
+        ) || self
+            .iter_flat()
+            .flat_map(CallableBinding::overloads)
+            .flat_map(Binding::errors)
+            .any(BindingError::is_relevant_for_partial_application);
+
+        if !should_refine {
+            return None;
+        }
+
+        let wrapped_callable_ty = call_arguments
+            .types()
+            .first()
+            .and_then(CallArgumentTypes::get_default)?;
+        let (_, refinement_bindings) =
+            Self::functools_partial_matched_bindings(db, wrapped_callable_ty, call_arguments)?;
+
+        Some(ArgumentInferenceRefinement::bindings(
+            refinement_bindings,
+            1,
+            1,
+        ))
     }
 
     /// Maps each `CallableBinding` to a type and combines results while preserving
@@ -4638,6 +4727,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         let specialization = builder.build_with(generic_context, maybe_promote);
         let partial_specialization =
             builder.build_preserving_unmapped_with(generic_context, maybe_promote);
+
         self.return_ty = self.return_ty.apply_specialization(self.db, specialization);
         self.specialization = Some(specialization);
         self.partial_specialization = Some(partial_specialization);

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -197,18 +197,20 @@ impl<'db> ConstructorBinding<'db> {
         let Some(downstream_item) = downstream.single_item() else {
             return Some(entry_partial);
         };
-        let Some(Type::KnownInstance(KnownInstanceType::FunctoolsPartial {
-            partial: downstream_callable,
-            ..
-        })) = downstream_item.functools_partial_type(
+        let Some(downstream_partial) = downstream_item.functools_partial_type(
             db,
             wrapped_callable_ty,
             partial_overload,
             bound_call_arguments,
-        )
+        ) else {
+            return Some(entry_partial);
+        };
+        let Type::KnownInstance(KnownInstanceType::FunctoolsPartial(downstream_partial)) =
+            downstream_partial
         else {
             return Some(entry_partial);
         };
+        let downstream_callable = downstream_partial.partial(db);
 
         let Some(constructor_class_literal) = self.constructed_class_literal(db) else {
             return Some(functools_partial_instance(
@@ -226,14 +228,26 @@ impl<'db> ConstructorBinding<'db> {
                 constructor_returns_instance(db, constructor_class_literal, signature.return_ty)
             });
 
-        let mut overloads = non_instance_signatures;
-        if !instance_signatures.is_empty() {
+        let mut merged_signatures = non_instance_signatures;
+
+        if !instance_signatures.is_empty()
+            && let Some(merged_instance_callable) = merged_bound_constructor_partial_callables(
+                db,
+                wrapped_callable_ty,
+                &self.entry,
+                downstream_item.callable(),
+                constructor_class_literal,
+                bound_call_arguments,
+            )
+        {
+            merged_signatures.extend(merged_instance_callable.signatures(db).iter().cloned());
+        } else if !instance_signatures.is_empty() {
             let instance_entry_callable = CallableType::new(
                 db,
                 CallableSignature::from_overloads(instance_signatures),
                 CallableTypeKind::Regular,
             );
-            overloads.extend(
+            merged_signatures.extend(
                 merge_constructor_partial_callables(
                     db,
                     instance_entry_callable,
@@ -245,15 +259,19 @@ impl<'db> ConstructorBinding<'db> {
             );
         }
 
-        Some(functools_partial_instance(
-            db,
-            wrapped_callable_ty,
-            CallableType::new(
+        if merged_signatures.is_empty() {
+            Some(entry_partial)
+        } else {
+            Some(functools_partial_instance(
                 db,
-                CallableSignature::from_overloads(overloads),
-                CallableTypeKind::Regular,
-            ),
-        ))
+                wrapped_callable_ty,
+                CallableType::new(
+                    db,
+                    CallableSignature::from_overloads(merged_signatures),
+                    CallableTypeKind::Regular,
+                ),
+            ))
+        }
     }
 
     pub(super) fn map<F>(self, f: &F) -> ConstructorBinding<'db>
@@ -637,44 +655,449 @@ fn merge_constructor_partial_callables<'db>(
     )
 }
 
+fn merged_bound_constructor_partial_callables<'db>(
+    db: &'db dyn Db,
+    wrapped_callable_ty: Type<'db>,
+    entry: &CallableBinding<'db>,
+    downstream: &CallableBinding<'db>,
+    constructor_class_literal: ClassLiteral<'db>,
+    bound_call_arguments: &CallArguments<'_, 'db>,
+) -> Option<CallableType<'db>> {
+    let entry_indexes = entry.partial_signature_source_overload_indexes()?;
+    let downstream_indexes = downstream.partial_signature_source_overload_indexes()?;
+    let mut merged_signatures = Vec::new();
+    let mut seen_signatures = FxHashSet::default();
+
+    for entry_index in entry_indexes {
+        let Some(entry_overload) = entry.overloads().get(entry_index) else {
+            continue;
+        };
+
+        if !constructor_returns_instance(db, constructor_class_literal, entry_overload.return_ty) {
+            continue;
+        }
+
+        for downstream_index in &downstream_indexes {
+            let Some(downstream_overload) = downstream.overloads().get(*downstream_index) else {
+                continue;
+            };
+
+            let entry_signature = entry_overload.signature.bind_self(db, entry.bound_type);
+            let downstream_signature = downstream_overload
+                .signature
+                .bind_self(db, downstream.bound_type);
+            let merged_signature = merge_constructor_partial_parameters_signature(
+                db,
+                &entry_signature,
+                &downstream_signature,
+                entry_signature.return_ty,
+            );
+            let mut merged_binding = Binding::single(wrapped_callable_ty, merged_signature);
+            let mut argument_forms = ArgumentForms::new(bound_call_arguments.len());
+            merged_binding.match_parameters(db, bound_call_arguments, &mut argument_forms);
+            let signature = merged_binding.partially_applied_signature(db, bound_call_arguments);
+            let dedup_key = signature.clone().with_definition(None);
+            if seen_signatures.insert(dedup_key) {
+                merged_signatures.push(signature);
+            }
+        }
+    }
+
+    if merged_signatures.is_empty() {
+        None
+    } else {
+        Some(CallableType::new(
+            db,
+            CallableSignature::from_overloads(merged_signatures),
+            CallableTypeKind::Regular,
+        ))
+    }
+}
+
+fn merge_constructor_partial_parameters_signature<'db>(
+    db: &'db dyn Db,
+    entry: &Signature<'db>,
+    downstream: &Signature<'db>,
+    return_ty: Type<'db>,
+) -> Signature<'db> {
+    let (parameter_matches, downstream_used) =
+        find_constructor_partial_parameter_matches(entry.parameters(), downstream.parameters());
+    let entry = specialize_constructor_partial_signature_correlations(
+        db,
+        entry,
+        downstream,
+        &parameter_matches,
+    );
+    let downstream = specialize_constructor_partial_signature_correlations(
+        db,
+        downstream,
+        &entry,
+        &reverse_constructor_partial_parameter_matches(&parameter_matches, downstream.parameters()),
+    );
+
+    Signature::new_generic(
+        GenericContext::merge_optional(db, entry.generic_context, downstream.generic_context),
+        merge_constructor_partial_parameters_with_matches(
+            db,
+            entry.parameters(),
+            downstream.parameters(),
+            &parameter_matches,
+            &downstream_used,
+        ),
+        return_ty,
+    )
+}
+
 fn merge_constructor_partial_signature<'db>(
     db: &'db dyn Db,
     entry: &Signature<'db>,
     downstream: &Signature<'db>,
 ) -> Signature<'db> {
-    let entry_callable = Type::single_callable(db, entry.clone());
-    let downstream_callable = Type::single_callable(db, downstream.clone());
-    if entry_callable.is_subtype_of(db, downstream_callable) {
-        return downstream.clone();
-    }
-    if downstream_callable.is_subtype_of(db, entry_callable) {
-        return entry.clone();
-    }
+    let (parameter_matches, downstream_used) =
+        find_constructor_partial_parameter_matches(entry.parameters(), downstream.parameters());
+    let entry = specialize_constructor_partial_signature_correlations(
+        db,
+        entry,
+        downstream,
+        &parameter_matches,
+    );
+    let downstream = specialize_constructor_partial_signature_correlations(
+        db,
+        downstream,
+        &entry,
+        &reverse_constructor_partial_parameter_matches(&parameter_matches, downstream.parameters()),
+    );
 
     Signature::new_generic(
         GenericContext::merge_optional(db, entry.generic_context, downstream.generic_context),
-        merge_constructor_partial_parameters(db, entry.parameters(), downstream.parameters()),
+        merge_constructor_partial_parameters_with_matches(
+            db,
+            entry.parameters(),
+            downstream.parameters(),
+            &parameter_matches,
+            &downstream_used,
+        ),
         combine_constructor_partial_return_types(db, entry.return_ty, downstream.return_ty),
     )
 }
 
-fn merge_constructor_partial_parameters<'db>(
+#[derive(Debug, Clone, Copy)]
+enum ConstructorPartialParameterMatchKind {
+    KeywordName { same_positional_order: bool },
+    PositionalOrder,
+    SameNameConflict,
+    Variadic,
+}
+
+type ConstructorPartialParameterMatches =
+    Vec<Option<(usize, ConstructorPartialParameterMatchKind)>>;
+
+fn find_constructor_partial_parameter_matches<'db>(
+    entry: &Parameters<'db>,
+    downstream: &Parameters<'db>,
+) -> (ConstructorPartialParameterMatches, Vec<bool>) {
+    let mut entry_matches = vec![None; entry.len()];
+    let mut downstream_used = vec![false; downstream.len()];
+
+    for (entry_index, entry_parameter) in entry.iter().enumerate() {
+        let Some(entry_keyword_name) = entry_parameter.keyword_name() else {
+            continue;
+        };
+        let Some((downstream_index, _)) =
+            downstream
+                .iter()
+                .enumerate()
+                .find(|(downstream_index, downstream_parameter)| {
+                    !downstream_used[*downstream_index]
+                        && downstream_parameter.keyword_name() == Some(entry_keyword_name)
+                })
+        else {
+            continue;
+        };
+
+        entry_matches[entry_index] = Some((
+            downstream_index,
+            ConstructorPartialParameterMatchKind::KeywordName {
+                same_positional_order: entry_index == downstream_index,
+            },
+        ));
+        downstream_used[downstream_index] = true;
+    }
+
+    let mut downstream_positional_start = 0;
+    for (entry_index, entry_parameter) in entry.iter().enumerate() {
+        if entry_matches[entry_index].is_some() || !entry_parameter.is_positional() {
+            continue;
+        }
+
+        let Some(downstream_index) = next_unmatched_positional_parameter_index(
+            downstream,
+            &downstream_used,
+            &mut downstream_positional_start,
+        ) else {
+            continue;
+        };
+
+        entry_matches[entry_index] = Some((
+            downstream_index,
+            ConstructorPartialParameterMatchKind::PositionalOrder,
+        ));
+        downstream_used[downstream_index] = true;
+    }
+
+    for (entry_index, entry_parameter) in entry.iter().enumerate() {
+        if entry_matches[entry_index].is_some() {
+            continue;
+        }
+
+        let Some(entry_name) = entry_parameter.name() else {
+            continue;
+        };
+        let Some((downstream_index, _)) =
+            downstream
+                .iter()
+                .enumerate()
+                .find(|(downstream_index, downstream_parameter)| {
+                    !downstream_used[*downstream_index]
+                        && downstream_parameter.name() == Some(entry_name)
+                })
+        else {
+            continue;
+        };
+
+        entry_matches[entry_index] = Some((
+            downstream_index,
+            ConstructorPartialParameterMatchKind::SameNameConflict,
+        ));
+        downstream_used[downstream_index] = true;
+    }
+
+    for (entry_index, entry_parameter) in entry.iter().enumerate() {
+        if entry_matches[entry_index].is_some() {
+            continue;
+        }
+
+        let Some((downstream_index, _)) =
+            downstream
+                .iter()
+                .enumerate()
+                .find(|(downstream_index, downstream_parameter)| {
+                    !downstream_used[*downstream_index]
+                        && matches!(
+                            (entry_parameter.kind(), downstream_parameter.kind()),
+                            (
+                                ParameterKind::Variadic { .. },
+                                ParameterKind::Variadic { .. }
+                            ) | (
+                                ParameterKind::KeywordVariadic { .. },
+                                ParameterKind::KeywordVariadic { .. }
+                            )
+                        )
+                })
+        else {
+            continue;
+        };
+
+        entry_matches[entry_index] = Some((
+            downstream_index,
+            ConstructorPartialParameterMatchKind::Variadic,
+        ));
+        downstream_used[downstream_index] = true;
+    }
+
+    (entry_matches, downstream_used)
+}
+
+fn reverse_constructor_partial_parameter_matches(
+    parameter_matches: &ConstructorPartialParameterMatches,
+    reversed: &Parameters<'_>,
+) -> ConstructorPartialParameterMatches {
+    let mut reversed_matches = vec![None; reversed.len()];
+    for (parameter_index, matched_parameter) in parameter_matches.iter().enumerate() {
+        let Some((matched_index, match_kind)) = matched_parameter else {
+            continue;
+        };
+        reversed_matches[*matched_index] = Some((parameter_index, *match_kind));
+    }
+    reversed_matches
+}
+
+fn specialize_constructor_partial_signature_correlations<'db>(
+    db: &'db dyn Db,
+    signature: &Signature<'db>,
+    counterpart: &Signature<'db>,
+    parameter_matches: &ConstructorPartialParameterMatches,
+) -> Signature<'db> {
+    let Some(generic_context) = signature.generic_context else {
+        return signature.clone();
+    };
+
+    let mut specialization_types = Vec::with_capacity(generic_context.len(db));
+    let mut changed = false;
+    for bound_typevar in generic_context.variables(db) {
+        let typevar_identity = bound_typevar.typevar(db).identity(db);
+        let mut counterpart_types =
+            signature
+                .parameters()
+                .iter()
+                .enumerate()
+                .filter_map(|(parameter_index, parameter)| {
+                    if parameter.annotated_type() != Type::TypeVar(bound_typevar) {
+                        return None;
+                    }
+                    let (matched_index, _) = parameter_matches
+                        .get(parameter_index)
+                        .and_then(|matched_parameter| *matched_parameter)?;
+                    counterpart
+                        .parameters()
+                        .get(matched_index)
+                        .map(Parameter::annotated_type)
+                });
+        let Some(first_counterpart_type) = counterpart_types.next() else {
+            specialization_types.push(Some(Type::TypeVar(bound_typevar)));
+            continue;
+        };
+        let specialized_type = IntersectionType::from_elements(
+            db,
+            std::iter::once(first_counterpart_type).chain(counterpart_types),
+        );
+        if specialized_type == Type::TypeVar(bound_typevar)
+            || specialized_type.references_typevar(db, typevar_identity)
+        {
+            specialization_types.push(Some(Type::TypeVar(bound_typevar)));
+            continue;
+        }
+
+        changed = true;
+        specialization_types.push(Some(specialized_type));
+    }
+
+    if !changed {
+        return signature.clone();
+    }
+
+    let specialization = generic_context.specialize_recursive(db, specialization_types);
+    let mut specialized_signature = signature.apply_specialization(db, specialization);
+    specialized_signature.generic_context =
+        retain_referenced_constructor_partial_typevars(db, &specialized_signature);
+    specialized_signature
+}
+
+fn retain_referenced_constructor_partial_typevars<'db>(
+    db: &'db dyn Db,
+    signature: &Signature<'db>,
+) -> Option<GenericContext<'db>> {
+    let generic_context = signature.generic_context?;
+    let referenced_typevars: Vec<_> = generic_context
+        .variables(db)
+        .filter(|bound_typevar| {
+            let typevar_identity = bound_typevar.typevar(db).identity(db);
+            signature.parameters().iter().any(|parameter| {
+                parameter
+                    .annotated_type()
+                    .references_typevar(db, typevar_identity)
+            }) || signature.return_ty.references_typevar(db, typevar_identity)
+        })
+        .collect();
+    if referenced_typevars.is_empty() {
+        None
+    } else {
+        Some(GenericContext::from_typevar_instances(
+            db,
+            referenced_typevars,
+        ))
+    }
+}
+
+fn merge_constructor_partial_parameters_with_matches<'db>(
     db: &'db dyn Db,
     entry: &Parameters<'db>,
     downstream: &Parameters<'db>,
+    entry_matches: &ConstructorPartialParameterMatches,
+    downstream_used: &[bool],
 ) -> Parameters<'db> {
-    let len = entry.len().max(downstream.len());
+    let entry_used: Vec<_> = entry_matches.iter().map(Option::is_some).collect();
+    let mut merged_parameters = Vec::with_capacity(entry.len().max(downstream.len()));
+    for (entry_index, entry_parameter) in entry.iter().enumerate() {
+        if let Some((downstream_index, match_kind)) = entry_matches[entry_index] {
+            if let Some(downstream_parameter) = downstream.get(downstream_index) {
+                merged_parameters.push(merge_constructor_partial_parameter(
+                    db,
+                    entry_parameter,
+                    downstream_parameter,
+                    match_kind,
+                ));
+                continue;
+            }
+        }
+
+        if let Some(parameter) = merge_unmatched_constructor_partial_parameter(
+            entry_parameter,
+            downstream,
+            downstream_used,
+        ) {
+            merged_parameters.push(parameter);
+        }
+    }
+
+    for (downstream_index, downstream_parameter) in downstream.iter().enumerate() {
+        if !downstream_used[downstream_index] {
+            if let Some(parameter) = merge_unmatched_constructor_partial_parameter(
+                downstream_parameter,
+                entry,
+                &entry_used,
+            ) {
+                merged_parameters.push(parameter);
+            }
+        }
+    }
+
+    reorder_constructor_partial_parameters(db, merged_parameters)
+}
+
+fn next_unmatched_positional_parameter_index(
+    parameters: &Parameters<'_>,
+    used: &[bool],
+    start: &mut usize,
+) -> Option<usize> {
+    let (index, _parameter) = parameters
+        .iter()
+        .enumerate()
+        .skip(*start)
+        .find(|(index, parameter)| !used[*index] && parameter.is_positional())?;
+
+    *start = index + 1;
+    Some(index)
+}
+
+fn reorder_constructor_partial_parameters<'db>(
+    db: &'db dyn Db,
+    parameters: Vec<Parameter<'db>>,
+) -> Parameters<'db> {
+    let mut positional_only = Vec::new();
+    let mut positional_or_keyword = Vec::new();
+    let mut variadic = Vec::new();
+    let mut keyword_only = Vec::new();
+    let mut keyword_variadic = Vec::new();
+
+    for parameter in parameters {
+        match parameter.kind() {
+            ParameterKind::PositionalOnly { .. } => positional_only.push(parameter),
+            ParameterKind::PositionalOrKeyword { .. } => positional_or_keyword.push(parameter),
+            ParameterKind::Variadic { .. } => variadic.push(parameter),
+            ParameterKind::KeywordOnly { .. } => keyword_only.push(parameter),
+            ParameterKind::KeywordVariadic { .. } => keyword_variadic.push(parameter),
+        }
+    }
+
     Parameters::new(
         db,
-        (0..len).map(|index| match (entry.get(index), downstream.get(index)) {
-            (Some(entry_parameter), Some(downstream_parameter)) => {
-                merge_constructor_partial_parameter(db, entry_parameter, downstream_parameter)
-            }
-            (Some(entry_parameter), None) | (None, Some(entry_parameter)) => {
-                entry_parameter.clone().with_annotated_type(Type::Never)
-            }
-            (None, None) => unreachable!(),
-        }),
+        positional_only
+            .into_iter()
+            .chain(positional_or_keyword)
+            .chain(variadic)
+            .chain(keyword_only)
+            .chain(keyword_variadic),
     )
 }
 
@@ -682,12 +1105,8 @@ fn merge_constructor_partial_parameter<'db>(
     db: &'db dyn Db,
     entry: &Parameter<'db>,
     downstream: &Parameter<'db>,
+    match_kind: ConstructorPartialParameterMatchKind,
 ) -> Parameter<'db> {
-    let annotated_type = combine_constructor_partial_return_types(
-        db,
-        entry.annotated_type(),
-        downstream.annotated_type(),
-    );
     let default_type = match (entry.default_type(), downstream.default_type()) {
         (Some(entry_default), Some(downstream_default)) => Some(
             combine_constructor_partial_return_types(db, entry_default, downstream_default),
@@ -695,38 +1114,179 @@ fn merge_constructor_partial_parameter<'db>(
         _ => None,
     };
 
+    let (parameter, annotated_type) = match match_kind {
+        ConstructorPartialParameterMatchKind::KeywordName {
+            same_positional_order,
+        } => (
+            merge_constructor_partial_keyword_parameter(entry, downstream, same_positional_order),
+            combine_constructor_partial_return_types(
+                db,
+                entry.annotated_type(),
+                downstream.annotated_type(),
+            ),
+        ),
+        ConstructorPartialParameterMatchKind::PositionalOrder => (
+            merge_constructor_partial_positional_parameter(entry, downstream),
+            combine_constructor_partial_return_types(
+                db,
+                entry.annotated_type(),
+                downstream.annotated_type(),
+            ),
+        ),
+        ConstructorPartialParameterMatchKind::SameNameConflict => (entry.clone(), Type::Never),
+        ConstructorPartialParameterMatchKind::Variadic => (
+            entry.clone(),
+            combine_constructor_partial_return_types(
+                db,
+                entry.annotated_type(),
+                downstream.annotated_type(),
+            ),
+        ),
+    };
+
+    parameter
+        .with_annotated_type(annotated_type)
+        .with_optional_default_type(default_type)
+}
+
+fn merge_constructor_partial_keyword_parameter<'db>(
+    entry: &Parameter<'db>,
+    downstream: &Parameter<'db>,
+    same_positional_order: bool,
+) -> Parameter<'db> {
+    let shared_name = entry
+        .keyword_name()
+        .filter(|entry_name| downstream.keyword_name() == Some(*entry_name))
+        .cloned()
+        .unwrap_or_else(|| {
+            entry
+                .keyword_name()
+                .or_else(|| downstream.keyword_name())
+                .cloned()
+                .expect("keyword-matched parameters must have a shared keyword name")
+        });
+
     match (entry.kind(), downstream.kind()) {
-        (
-            ParameterKind::PositionalOnly { name, .. },
-            ParameterKind::PositionalOnly { .. },
-        ) => Parameter::positional_only(name.clone()),
-        (
-            ParameterKind::PositionalOnly { name, .. },
-            ParameterKind::PositionalOrKeyword { .. },
-        )
-        | (
-            ParameterKind::PositionalOrKeyword { .. },
-            ParameterKind::PositionalOnly { name, .. },
-        ) => Parameter::positional_only(name.clone()),
+        (ParameterKind::PositionalOrKeyword { .. }, ParameterKind::PositionalOrKeyword { .. })
+            if same_positional_order =>
+        {
+            Parameter::positional_or_keyword(shared_name)
+        }
+        (ParameterKind::PositionalOrKeyword { .. }, ParameterKind::PositionalOrKeyword { .. }) => {
+            Parameter::keyword_only(shared_name)
+        }
+        (ParameterKind::PositionalOrKeyword { .. }, ParameterKind::KeywordOnly { .. })
+        | (ParameterKind::KeywordOnly { .. }, ParameterKind::PositionalOrKeyword { .. })
+        | (ParameterKind::KeywordOnly { .. }, ParameterKind::KeywordOnly { .. }) => {
+            Parameter::keyword_only(shared_name)
+        }
+        _ => entry.clone(),
+    }
+}
+
+fn merge_constructor_partial_positional_parameter<'db>(
+    entry: &Parameter<'db>,
+    downstream: &Parameter<'db>,
+) -> Parameter<'db> {
+    let positional_name = entry.name().cloned().or_else(|| downstream.name().cloned());
+
+    match (entry.kind(), downstream.kind()) {
+        (ParameterKind::PositionalOnly { .. }, ParameterKind::PositionalOnly { .. })
+        | (ParameterKind::PositionalOnly { .. }, ParameterKind::PositionalOrKeyword { .. })
+        | (ParameterKind::PositionalOrKeyword { .. }, ParameterKind::PositionalOnly { .. }) => {
+            Parameter::positional_only(positional_name)
+        }
         (
             ParameterKind::PositionalOrKeyword { name, .. },
             ParameterKind::PositionalOrKeyword { .. },
-        ) => Parameter::positional_or_keyword(name.clone()),
-        (ParameterKind::Variadic { name }, ParameterKind::Variadic { .. }) => {
-            Parameter::variadic(name.clone())
+        ) if downstream.keyword_name() == Some(name) => {
+            Parameter::positional_or_keyword(name.clone())
         }
-        (
-            ParameterKind::KeywordOnly { name, .. },
-            ParameterKind::KeywordOnly { .. },
-        ) => Parameter::keyword_only(name.clone()),
-        (
-            ParameterKind::KeywordVariadic { name },
-            ParameterKind::KeywordVariadic { .. },
-        ) => Parameter::keyword_variadic(name.clone()),
+        (ParameterKind::PositionalOrKeyword { .. }, ParameterKind::PositionalOrKeyword { .. }) => {
+            Parameter::positional_only(positional_name)
+        }
         _ => entry.clone(),
     }
-    .with_annotated_type(annotated_type)
-    .with_optional_default_type(default_type)
+}
+
+fn merge_unmatched_constructor_partial_parameter<'db>(
+    parameter: &Parameter<'db>,
+    other_parameters: &Parameters<'db>,
+    other_used: &[bool],
+) -> Option<Parameter<'db>> {
+    let other_has_variadic =
+        has_unmatched_constructor_partial_variadic(other_parameters, other_used);
+    let other_has_keyword_variadic =
+        has_unmatched_constructor_partial_keyword_variadic(other_parameters, other_used);
+    let default_type = parameter.default_type();
+
+    match parameter.kind() {
+        ParameterKind::PositionalOnly { name, .. } => {
+            if other_has_variadic {
+                Some(
+                    Parameter::positional_only(name.clone())
+                        .with_annotated_type(parameter.annotated_type())
+                        .with_optional_default_type(default_type),
+                )
+            } else if default_type.is_some() {
+                None
+            } else {
+                Some(Parameter::positional_only(name.clone()).with_annotated_type(Type::Never))
+            }
+        }
+        ParameterKind::PositionalOrKeyword { name, .. } => {
+            let parameter = match (other_has_variadic, other_has_keyword_variadic) {
+                (true, true) => Some(
+                    Parameter::positional_or_keyword(name.clone())
+                        .with_annotated_type(parameter.annotated_type()),
+                ),
+                (true, false) => Some(
+                    Parameter::positional_only(Some(name.clone()))
+                        .with_annotated_type(parameter.annotated_type()),
+                ),
+                (false, true) => Some(
+                    Parameter::keyword_only(name.clone())
+                        .with_annotated_type(parameter.annotated_type()),
+                ),
+                (false, false) if default_type.is_some() => None,
+                (false, false) => Some(
+                    Parameter::positional_or_keyword(name.clone()).with_annotated_type(Type::Never),
+                ),
+            };
+            parameter.map(|parameter| parameter.with_optional_default_type(default_type))
+        }
+        ParameterKind::KeywordOnly { name, .. } => {
+            if other_has_keyword_variadic {
+                Some(
+                    Parameter::keyword_only(name.clone())
+                        .with_annotated_type(parameter.annotated_type())
+                        .with_optional_default_type(default_type),
+                )
+            } else if default_type.is_some() {
+                None
+            } else {
+                Some(Parameter::keyword_only(name.clone()).with_annotated_type(Type::Never))
+            }
+        }
+        ParameterKind::Variadic { .. } | ParameterKind::KeywordVariadic { .. } => None,
+    }
+}
+
+fn has_unmatched_constructor_partial_variadic(parameters: &Parameters<'_>, used: &[bool]) -> bool {
+    parameters
+        .iter()
+        .enumerate()
+        .any(|(index, parameter)| !used[index] && parameter.is_variadic())
+}
+
+fn has_unmatched_constructor_partial_keyword_variadic(
+    parameters: &Parameters<'_>,
+    used: &[bool],
+) -> bool {
+    parameters
+        .iter()
+        .enumerate()
+        .any(|(index, parameter)| !used[index] && parameter.is_keyword_variadic())
 }
 
 fn combine_constructor_partial_return_types<'db>(

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -1,10 +1,20 @@
-use super::{ArgumentForms, Binding, Bindings, CallableBinding, CallableItem};
+use super::{
+    ArgumentForms, Binding, Bindings, CallableBinding, CallableItem, functools_partial_instance,
+};
 use crate::db::Db;
 use crate::types::call::arguments::CallArguments;
+use crate::types::callable::CallableTypeKind;
 use crate::types::constraints::ConstraintSetBuilder;
-use crate::types::generics::Specialization;
-use crate::types::signatures::Parameter;
-use crate::types::{BoundTypeVarInstance, ClassLiteral, DynamicType, Type, TypeContext};
+use crate::types::generics::{GenericContext, Specialization};
+use crate::types::known_instance::KnownInstanceType;
+use crate::types::signatures::{
+    CallableSignature, Parameter, ParameterKind, Parameters, Signature,
+};
+use crate::types::{
+    BoundTypeVarInstance, CallableType, ClassLiteral, DynamicType, IntersectionType, Type,
+    TypeContext,
+};
+use rustc_hash::FxHashSet;
 
 /// Bindings for a constructor call.
 ///
@@ -167,6 +177,83 @@ impl<'db> ConstructorBinding<'db> {
 
     pub(super) fn downstream_constructor_mut(&mut self) -> Option<&mut Bindings<'db>> {
         self.downstream_constructor.as_deref_mut()
+    }
+
+    pub(super) fn functools_partial_type<'a>(
+        &self,
+        db: &'db dyn Db,
+        wrapped_callable_ty: Type<'db>,
+        partial_overload: &mut Binding<'db>,
+        bound_call_arguments: &CallArguments<'a, 'db>,
+    ) -> Option<Type<'db>> {
+        let entry_callable =
+            self.entry
+                .functools_partial_callable(db, partial_overload, bound_call_arguments)?;
+        let entry_partial = functools_partial_instance(db, wrapped_callable_ty, entry_callable);
+        let Some(downstream) = self.downstream_constructor() else {
+            return Some(entry_partial);
+        };
+
+        let Some(downstream_item) = downstream.single_item() else {
+            return Some(entry_partial);
+        };
+        let Some(Type::KnownInstance(KnownInstanceType::FunctoolsPartial {
+            partial: downstream_callable,
+            ..
+        })) = downstream_item.functools_partial_type(
+            db,
+            wrapped_callable_ty,
+            partial_overload,
+            bound_call_arguments,
+        )
+        else {
+            return Some(entry_partial);
+        };
+
+        let Some(constructor_class_literal) = self.constructed_class_literal(db) else {
+            return Some(functools_partial_instance(
+                db,
+                wrapped_callable_ty,
+                merge_constructor_partial_callables(db, entry_callable, downstream_callable),
+            ));
+        };
+
+        let (instance_signatures, non_instance_signatures): (Vec<_>, Vec<_>) = entry_callable
+            .signatures(db)
+            .iter()
+            .cloned()
+            .partition(|signature| {
+                constructor_returns_instance(db, constructor_class_literal, signature.return_ty)
+            });
+
+        let mut overloads = non_instance_signatures;
+        if !instance_signatures.is_empty() {
+            let instance_entry_callable = CallableType::new(
+                db,
+                CallableSignature::from_overloads(instance_signatures),
+                CallableTypeKind::Regular,
+            );
+            overloads.extend(
+                merge_constructor_partial_callables(
+                    db,
+                    instance_entry_callable,
+                    downstream_callable,
+                )
+                .signatures(db)
+                .iter()
+                .cloned(),
+            );
+        }
+
+        Some(functools_partial_instance(
+            db,
+            wrapped_callable_ty,
+            CallableType::new(
+                db,
+                CallableSignature::from_overloads(overloads),
+                CallableTypeKind::Regular,
+            ),
+        ))
     }
 
     pub(super) fn map<F>(self, f: &F) -> ConstructorBinding<'db>
@@ -509,6 +596,164 @@ impl<'db> ConstructorBinding<'db> {
     fn constructor_kind(&self) -> ConstructorCallableKind {
         self.constructor_context.kind()
     }
+}
+
+fn merge_constructor_partial_callables<'db>(
+    db: &'db dyn Db,
+    entry: CallableType<'db>,
+    downstream: CallableType<'db>,
+) -> CallableType<'db> {
+    let mut satisfiable = Vec::new();
+    let mut fallback = Vec::new();
+    let mut seen_overloads = FxHashSet::default();
+
+    for entry_signature in entry.signatures(db) {
+        for downstream_signature in downstream.signatures(db) {
+            let merged =
+                merge_constructor_partial_signature(db, entry_signature, downstream_signature);
+            let dedup_key = merged.clone().with_definition(None);
+            if !seen_overloads.insert(dedup_key) {
+                continue;
+            }
+
+            if constructor_partial_signature_has_possible_call(&merged) {
+                satisfiable.push(merged);
+            } else {
+                fallback.push(merged);
+            }
+        }
+    }
+
+    let overloads = if satisfiable.is_empty() {
+        fallback
+    } else {
+        satisfiable
+    };
+
+    CallableType::new(
+        db,
+        CallableSignature::from_overloads(overloads),
+        CallableTypeKind::Regular,
+    )
+}
+
+fn merge_constructor_partial_signature<'db>(
+    db: &'db dyn Db,
+    entry: &Signature<'db>,
+    downstream: &Signature<'db>,
+) -> Signature<'db> {
+    let entry_callable = Type::single_callable(db, entry.clone());
+    let downstream_callable = Type::single_callable(db, downstream.clone());
+    if entry_callable.is_subtype_of(db, downstream_callable) {
+        return downstream.clone();
+    }
+    if downstream_callable.is_subtype_of(db, entry_callable) {
+        return entry.clone();
+    }
+
+    Signature::new_generic(
+        GenericContext::merge_optional(db, entry.generic_context, downstream.generic_context),
+        merge_constructor_partial_parameters(db, entry.parameters(), downstream.parameters()),
+        combine_constructor_partial_return_types(db, entry.return_ty, downstream.return_ty),
+    )
+}
+
+fn merge_constructor_partial_parameters<'db>(
+    db: &'db dyn Db,
+    entry: &Parameters<'db>,
+    downstream: &Parameters<'db>,
+) -> Parameters<'db> {
+    let len = entry.len().max(downstream.len());
+    Parameters::new(
+        db,
+        (0..len).map(|index| match (entry.get(index), downstream.get(index)) {
+            (Some(entry_parameter), Some(downstream_parameter)) => {
+                merge_constructor_partial_parameter(db, entry_parameter, downstream_parameter)
+            }
+            (Some(entry_parameter), None) | (None, Some(entry_parameter)) => {
+                entry_parameter.clone().with_annotated_type(Type::Never)
+            }
+            (None, None) => unreachable!(),
+        }),
+    )
+}
+
+fn merge_constructor_partial_parameter<'db>(
+    db: &'db dyn Db,
+    entry: &Parameter<'db>,
+    downstream: &Parameter<'db>,
+) -> Parameter<'db> {
+    let annotated_type = combine_constructor_partial_return_types(
+        db,
+        entry.annotated_type(),
+        downstream.annotated_type(),
+    );
+    let default_type = match (entry.default_type(), downstream.default_type()) {
+        (Some(entry_default), Some(downstream_default)) => Some(
+            combine_constructor_partial_return_types(db, entry_default, downstream_default),
+        ),
+        _ => None,
+    };
+
+    match (entry.kind(), downstream.kind()) {
+        (
+            ParameterKind::PositionalOnly { name, .. },
+            ParameterKind::PositionalOnly { .. },
+        ) => Parameter::positional_only(name.clone()),
+        (
+            ParameterKind::PositionalOnly { name, .. },
+            ParameterKind::PositionalOrKeyword { .. },
+        )
+        | (
+            ParameterKind::PositionalOrKeyword { .. },
+            ParameterKind::PositionalOnly { name, .. },
+        ) => Parameter::positional_only(name.clone()),
+        (
+            ParameterKind::PositionalOrKeyword { name, .. },
+            ParameterKind::PositionalOrKeyword { .. },
+        ) => Parameter::positional_or_keyword(name.clone()),
+        (ParameterKind::Variadic { name }, ParameterKind::Variadic { .. }) => {
+            Parameter::variadic(name.clone())
+        }
+        (
+            ParameterKind::KeywordOnly { name, .. },
+            ParameterKind::KeywordOnly { .. },
+        ) => Parameter::keyword_only(name.clone()),
+        (
+            ParameterKind::KeywordVariadic { name },
+            ParameterKind::KeywordVariadic { .. },
+        ) => Parameter::keyword_variadic(name.clone()),
+        _ => entry.clone(),
+    }
+    .with_annotated_type(annotated_type)
+    .with_optional_default_type(default_type)
+}
+
+fn combine_constructor_partial_return_types<'db>(
+    db: &'db dyn Db,
+    entry: Type<'db>,
+    downstream: Type<'db>,
+) -> Type<'db> {
+    if entry.is_subtype_of(db, downstream) {
+        entry
+    } else if downstream.is_subtype_of(db, entry) {
+        downstream
+    } else {
+        IntersectionType::from_two_elements(db, entry, downstream)
+    }
+}
+
+fn constructor_partial_signature_has_possible_call(signature: &Signature<'_>) -> bool {
+    signature.parameters().iter().all(|parameter| {
+        !(parameter.annotated_type().is_never()
+            && parameter.default_type().is_none()
+            && matches!(
+                parameter.kind(),
+                ParameterKind::PositionalOnly { .. }
+                    | ParameterKind::PositionalOrKeyword { .. }
+                    | ParameterKind::KeywordOnly { .. }
+            ))
+    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -213,6 +213,10 @@ impl<'db> Type<'db> {
             | Type::TypeGuard(_)
             | Type::TypedDict(_) => None,
 
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(callable)) => {
+                Some(CallableTypes::one(callable))
+            }
+
             // TODO
             Type::DataclassDecorator(_)
             | Type::ModuleLiteral(_)

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -213,8 +213,8 @@ impl<'db> Type<'db> {
             | Type::TypeGuard(_)
             | Type::TypedDict(_) => None,
 
-            Type::KnownInstance(KnownInstanceType::FunctoolsPartial { partial, .. }) => {
-                Some(CallableTypes::one(partial))
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
+                Some(CallableTypes::one(partial.partial(db)))
             }
 
             // TODO

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -213,8 +213,8 @@ impl<'db> Type<'db> {
             | Type::TypeGuard(_)
             | Type::TypedDict(_) => None,
 
-            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(callable)) => {
-                Some(CallableTypes::one(callable))
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial { partial, .. }) => {
+                Some(CallableTypes::one(partial))
             }
 
             // TODO

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -7,9 +7,9 @@ use crate::{
     semantic_index::definition::Definition,
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarInstance, ClassType, FindLegacyTypeVarsVisitor,
-        KnownInstanceType, LiteralValueTypeKind, MemberLookupPolicy, Parameter, Parameters,
-        Signature, SubclassOfInner, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
-        UnionType,
+        KnownClass, KnownInstanceType, LiteralValueTypeKind, MemberLookupPolicy, Parameter,
+        Parameters, Signature, SubclassOfInner, Type, TypeContext, TypeMapping,
+        TypeVarBoundOrConstraints, UnionType,
         constraints::{ConstraintSet, IteratorConstraintsExtension},
         relation::{TypeRelation, TypeRelationChecker},
         signatures::CallableSignature,
@@ -370,6 +370,11 @@ impl<'db> CallableType<'db> {
 
     pub(crate) fn into_regular(self, db: &'db dyn Db) -> CallableType<'db> {
         CallableType::new(db, self.signatures(db), CallableTypeKind::Regular)
+    }
+
+    pub(crate) fn into_functools_partial_instance(self, db: &'db dyn Db) -> Type<'db> {
+        let return_ty = self.signatures(db).overload_return_type_or_unknown(db);
+        KnownClass::FunctoolsPartial.to_specialized_instance(db, &[return_ty])
     }
 
     pub(crate) fn bind_self(

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -136,6 +136,8 @@ pub enum KnownClass {
     Template,
     // pathlib
     Path,
+    // functools
+    FunctoolsPartial,
     // ty_extensions
     ConstraintSet,
     GenericContext,
@@ -254,6 +256,7 @@ impl KnownClass {
             | Self::GenericContext
             | Self::Specialization
             | Self::ProtocolMeta
+            | Self::FunctoolsPartial
             | Self::TypedDictFallback => Some(Truthiness::Ambiguous),
 
             Self::Tuple => None,
@@ -350,7 +353,8 @@ impl KnownClass {
             | KnownClass::BuiltinFunctionType
             | KnownClass::ProtocolMeta
             | KnownClass::Template
-            | KnownClass::Path => false,
+            | KnownClass::Path
+            | KnownClass::FunctoolsPartial => false,
         }
     }
 
@@ -443,7 +447,8 @@ impl KnownClass {
             | KnownClass::BuiltinFunctionType
             | KnownClass::ProtocolMeta
             | KnownClass::Template
-            | KnownClass::Path => false,
+            | KnownClass::Path
+            | KnownClass::FunctoolsPartial => false,
         }
     }
 
@@ -535,7 +540,8 @@ impl KnownClass {
             | KnownClass::BuiltinFunctionType
             | KnownClass::ProtocolMeta
             | KnownClass::Template
-            | KnownClass::Path => false,
+            | KnownClass::Path
+            | KnownClass::FunctoolsPartial => false,
         }
     }
 
@@ -639,6 +645,7 @@ impl KnownClass {
             | Self::ProtocolMeta
             | Self::Template
             | Self::Path
+            | Self::FunctoolsPartial
             | Self::Mapping
             | Self::Sequence => false,
         }
@@ -733,6 +740,7 @@ impl KnownClass {
             | KnownClass::NamedTupleLike
             | KnownClass::Template
             | KnownClass::Path
+            | KnownClass::FunctoolsPartial
             | KnownClass::ConstraintSet
             | KnownClass::GenericContext
             | KnownClass::Specialization => false,
@@ -856,6 +864,7 @@ impl KnownClass {
             Self::TypedDictFallback => "TypedDictFallback",
             Self::Template => "Template",
             Self::Path => "Path",
+            Self::FunctoolsPartial => "partial",
             Self::ProtocolMeta => "_ProtocolMeta",
         }
     }
@@ -1239,6 +1248,7 @@ impl KnownClass {
             | Self::Specialization => KnownModule::TyExtensions,
             Self::Template => KnownModule::Templatelib,
             Self::Path => KnownModule::Pathlib,
+            Self::FunctoolsPartial => KnownModule::Functools,
         }
     }
 
@@ -1333,7 +1343,8 @@ impl KnownClass {
             | Self::BuiltinFunctionType
             | Self::ProtocolMeta
             | Self::Template
-            | Self::Path => Some(false),
+            | Self::Path
+            | Self::FunctoolsPartial => Some(false),
 
             Self::Tuple => None,
         }
@@ -1431,7 +1442,8 @@ impl KnownClass {
             | Self::BuiltinFunctionType
             | Self::ProtocolMeta
             | Self::Template
-            | Self::Path => false,
+            | Self::Path
+            | Self::FunctoolsPartial => false,
         }
     }
 
@@ -1542,6 +1554,7 @@ impl KnownClass {
             "TypedDictFallback" => &[Self::TypedDictFallback],
             "Template" => &[Self::Template],
             "Path" => &[Self::Path],
+            "partial" => &[Self::FunctoolsPartial],
             "_ProtocolMeta" => &[Self::ProtocolMeta],
             _ => return None,
         };
@@ -1627,7 +1640,8 @@ impl KnownClass {
             | Self::Generator
             | Self::AsyncGenerator
             | Self::Template
-            | Self::Path => module == self.canonical_module(db),
+            | Self::Path
+            | Self::FunctoolsPartial => module == self.canonical_module(db),
             Self::NoneType => matches!(module, KnownModule::Typeshed | KnownModule::Types),
             Self::SpecialForm
             | Self::TypeAliasType

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -194,7 +194,8 @@ impl<'db> ClassBase<'db> {
                 // A class inheriting from a newtype would make intuitive sense, but newtype
                 // wrappers are just identity callables at runtime, so this sort of inheritance
                 // doesn't work and isn't allowed.
-                | KnownInstanceType::NewType(_) => None,
+                | KnownInstanceType::NewType(_)
+                | KnownInstanceType::FunctoolsPartial(_) => None,
                 KnownInstanceType::TypeGenericAlias(_) => {
                     Self::try_from_type(db, KnownClass::Type.to_class_literal(db), subclass)
                 }

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -195,7 +195,7 @@ impl<'db> ClassBase<'db> {
                 // wrappers are just identity callables at runtime, so this sort of inheritance
                 // doesn't work and isn't allowed.
                 | KnownInstanceType::NewType(_)
-                | KnownInstanceType::FunctoolsPartial(_) => None,
+                | KnownInstanceType::FunctoolsPartial { .. } => None,
                 KnownInstanceType::TypeGenericAlias(_) => {
                     Self::try_from_type(db, KnownClass::Type.to_class_literal(db), subclass)
                 }

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -195,7 +195,7 @@ impl<'db> ClassBase<'db> {
                 // wrappers are just identity callables at runtime, so this sort of inheritance
                 // doesn't work and isn't allowed.
                 | KnownInstanceType::NewType(_)
-                | KnownInstanceType::FunctoolsPartial { .. } => None,
+                | KnownInstanceType::FunctoolsPartial(_) => None,
                 KnownInstanceType::TypeGenericAlias(_) => {
                     Self::try_from_type(db, KnownClass::Type.to_class_literal(db), subclass)
                 }

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -3105,9 +3105,9 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
                 f.write_str("'>")
             }
             KnownInstanceType::NamedTupleSpec(_) => f.write_str("NamedTupleSpec"),
-            KnownInstanceType::FunctoolsPartial { partial, .. } => {
+            KnownInstanceType::FunctoolsPartial(partial) => {
                 f.write_str("partial[")?;
-                Type::Callable(partial)
+                Type::Callable(partial.partial(self.db))
                     .display_with(self.db, DisplaySettings::default().singleline())
                     .fmt_detailed(f)?;
                 f.write_str("]")

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -3105,9 +3105,9 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
                 f.write_str("'>")
             }
             KnownInstanceType::NamedTupleSpec(_) => f.write_str("NamedTupleSpec"),
-            KnownInstanceType::FunctoolsPartial(callable) => {
+            KnownInstanceType::FunctoolsPartial { partial, .. } => {
                 f.write_str("partial[")?;
-                Type::Callable(callable)
+                Type::Callable(partial)
                     .display_with(self.db, DisplaySettings::default().singleline())
                     .fmt_detailed(f)?;
                 f.write_str("]")

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -3105,6 +3105,13 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
                 f.write_str("'>")
             }
             KnownInstanceType::NamedTupleSpec(_) => f.write_str("NamedTupleSpec"),
+            KnownInstanceType::FunctoolsPartial(callable) => {
+                f.write_str("partial[")?;
+                Type::Callable(callable)
+                    .display_with(self.db, DisplaySettings::default().singleline())
+                    .fmt_detailed(f)?;
+                f.write_str("]")
+            }
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1721,28 +1721,31 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         generic_context.specialize_recursive(self.db, types)
     }
 
-    /// Build a specialization that preserves uninferred type variables as themselves.
+    /// Build a specialization that preserves selected uninferred type variables as themselves.
     ///
     /// This is useful for constructing reusable callables like `functools.partial(...)`, where
-    /// unresolved type variables should remain generic over future calls instead of defaulting to
-    /// `Unknown`.
+    /// type variables that can still be inferred by future calls should remain generic, while
+    /// uninferred type variables that can no longer be inferred should still resolve via defaults.
     pub(crate) fn build_preserving_unmapped_with(
         &mut self,
         generic_context: GenericContext<'db>,
+        mut preserve_unmapped: impl FnMut(BoundTypeVarInstance<'db>) -> bool,
         mut choose: impl FnMut(BoundTypeVarInstance<'db>, Type<'db>, Type<'db>) -> Option<Type<'db>>,
     ) -> Specialization<'db> {
-        let types: Box<[_]> = generic_context
+        let types = generic_context
             .variables_inner(self.db)
             .iter()
             .map(
                 |(identity, variable)| match self.types.get(identity).copied() {
-                    Some(mapped_ty) => choose(*variable, mapped_ty, mapped_ty).unwrap_or(mapped_ty),
-                    None => Type::TypeVar(*variable),
+                    Some(mapped_ty) => {
+                        Some(choose(*variable, mapped_ty, mapped_ty).unwrap_or(mapped_ty))
+                    }
+                    None if preserve_unmapped(*variable) => Some(Type::TypeVar(*variable)),
+                    None => None,
                 },
-            )
-            .collect();
+            );
 
-        generic_context.specialize_from_types_recursive(self.db, types)
+        generic_context.specialize_recursive(self.db, types)
     }
 
     /// Insert a type mapping for a bound typevar.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -845,46 +845,52 @@ impl<'db> GenericContext<'db> {
         I: IntoIterator<Item = Option<Type<'db>>>,
         I::IntoIter: ExactSizeIterator,
     {
-        fn specialize_recursive_impl<'db>(
-            db: &'db dyn Db,
-            context: GenericContext<'db>,
-            mut types: Box<[Type<'db>]>,
-        ) -> Specialization<'db> {
-            let len = types.len();
-            loop {
-                let mut any_changed = false;
-                for i in 0..len {
-                    let specialization = ApplySpecialization::Partial {
-                        generic_context: context,
-                        types: &types,
-                        // Don't recursively substitute type[i] in itself. Ideally, we could instead
-                        // check if the result is self-referential after we're done applying the
-                        // partial specialization. But when we apply a paramspec, we don't use the
-                        // callable that it maps to directly; we create a new callable that reuses
-                        // parts of it. That means we can't look for the previous type directly.
-                        // Instead we use this to skip specializing the type in itself in the first
-                        // place.
-                        skip: Some(i),
-                    };
-                    let updated = types[i].apply_type_mapping(
-                        db,
-                        &TypeMapping::ApplySpecialization(specialization),
-                        TypeContext::default(),
-                    );
-                    if updated != types[i] {
-                        types[i] = updated;
-                        any_changed = true;
-                    }
+        let types = self.fill_in_defaults(db, types);
+        self.specialize_from_types_recursive(db, types)
+    }
+
+    fn specialize_from_types_recursive(
+        self,
+        db: &'db dyn Db,
+        mut types: Box<[Type<'db>]>,
+    ) -> Specialization<'db> {
+        let len = types.len();
+        let variables = self.variables(db).collect_vec();
+        loop {
+            let mut any_changed = false;
+            for i in 0..len {
+                // Preserve identity mappings for unresolved type variables.
+                if types[i] == Type::TypeVar(variables[i]) {
+                    continue;
                 }
 
-                if !any_changed {
-                    return Specialization::new(db, context, types, None, None);
+                let specialization = ApplySpecialization::Partial {
+                    generic_context: self,
+                    types: &types,
+                    // Don't recursively substitute type[i] in itself. Ideally, we could instead
+                    // check if the result is self-referential after we're done applying the
+                    // partial specialization. But when we apply a paramspec, we don't use the
+                    // callable that it maps to directly; we create a new callable that reuses
+                    // parts of it. That means we can't look for the previous type directly.
+                    // Instead we use this to skip specializing the type in itself in the first
+                    // place.
+                    skip: Some(i),
+                };
+                let updated = types[i].apply_type_mapping(
+                    db,
+                    &TypeMapping::ApplySpecialization(specialization),
+                    TypeContext::default(),
+                );
+                if updated != types[i] {
+                    types[i] = updated;
+                    any_changed = true;
                 }
             }
-        }
 
-        let types = self.fill_in_defaults(db, types);
-        specialize_recursive_impl(db, self, types)
+            if !any_changed {
+                return Specialization::new(db, self, types, None, None);
+            }
+        }
     }
 
     /// Creates a specialization of this generic context for the `tuple` class.
@@ -1713,6 +1719,30 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             });
 
         generic_context.specialize_recursive(self.db, types)
+    }
+
+    /// Build a specialization that preserves uninferred type variables as themselves.
+    ///
+    /// This is useful for constructing reusable callables like `functools.partial(...)`, where
+    /// unresolved type variables should remain generic over future calls instead of defaulting to
+    /// `Unknown`.
+    pub(crate) fn build_preserving_unmapped_with(
+        &mut self,
+        generic_context: GenericContext<'db>,
+        mut choose: impl FnMut(BoundTypeVarInstance<'db>, Type<'db>, Type<'db>) -> Option<Type<'db>>,
+    ) -> Specialization<'db> {
+        let types: Box<[_]> = generic_context
+            .variables_inner(self.db)
+            .iter()
+            .map(
+                |(identity, variable)| match self.types.get(identity).copied() {
+                    Some(mapped_ty) => choose(*variable, mapped_ty, mapped_ty).unwrap_or(mapped_ty),
+                    None => Type::TypeVar(*variable),
+                },
+            )
+            .collect();
+
+        generic_context.specialize_from_types_recursive(self.db, types)
     }
 
     /// Insert a type mapping for a bound typevar.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use ruff_db::diagnostic::{Annotation, DiagnosticId, Severity};
 use ruff_db::files::File;
 use ruff_db::parsed::ParsedModuleRef;
@@ -54,7 +54,10 @@ use crate::semantic_index::{
 };
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
 use crate::types::call::bind::MatchingOverloadIndex;
-use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorKind};
+use crate::types::call::{
+    ArgumentInferenceRefinement, ArgumentInferenceRefinementBindings, Binding, Bindings,
+    CallArguments, CallError, CallErrorKind,
+};
 use crate::types::callable::CallableTypeKind;
 use crate::types::class::{ClassLiteral, CodeGeneratorKind, MethodDecorator};
 use crate::types::constraints::{ConstraintSetBuilder, PathBounds, Solutions};
@@ -4767,22 +4770,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let mut speculative_builder = self.speculate();
 
             // Attempt to infer the argument types using the narrowed type context.
-            speculative_builder.infer_all_argument_types(
-                ast_arguments.clone(),
-                argument_types,
-                infer_argument_ty,
-                bindings,
-                narrowed_tcx,
-            );
-
-            // Ensure the argument types match their annotated types.
-            if speculative_bindings
-                .check_types_impl(
-                    db,
-                    &constraints,
+            if speculative_builder
+                .infer_and_check_argument_types_with_refinement(
+                    ast_arguments.clone(),
                     argument_types,
+                    infer_argument_ty,
+                    &mut speculative_bindings,
                     narrowed_tcx,
-                    &self.dataclass_field_specifiers,
+                    &constraints,
                 )
                 .is_err()
             {
@@ -4803,13 +4798,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Successfully narrowed to an element of the union.
             self.extend(speculative_builder);
-            Some(bindings.check_types_impl(
-                db,
-                &constraints,
-                argument_types,
-                narrowed_tcx,
-                &self.dataclass_field_specifiers,
-            ))
+            *bindings = speculative_bindings;
+            Some(Ok(()))
         };
 
         // Prefer the declared type of generic classes or callables when narrowing.
@@ -4837,21 +4827,138 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         //
         // TODO: We could also attempt an inference without type context, but this
         // leads to similar performance issues.
-        self.infer_all_argument_types(
+        self.infer_and_check_argument_types_with_refinement(
             ast_arguments,
             argument_types,
             infer_argument_ty,
             bindings,
             call_expression_tcx,
+            &constraints,
+        )
+    }
+
+    fn infer_and_check_argument_types_with_refinement(
+        &mut self,
+        ast_arguments: ArgumentsIter<'_>,
+        argument_types: &mut CallArguments<'_, 'db>,
+        infer_argument_ty: &mut dyn FnMut(&mut Self, ArgExpr<'db, '_>) -> Type<'db>,
+        bindings: &mut Bindings<'db>,
+        call_expression_tcx: TypeContext<'db>,
+        constraints: &ConstraintSetBuilder<'db>,
+    ) -> Result<(), CallErrorKind> {
+        let db = self.db();
+        let may_request_refinement = bindings.may_request_argument_inference_refinement(db);
+        let original_argument_types = may_request_refinement.then(|| argument_types.clone());
+        let original_bindings = may_request_refinement.then(|| bindings.clone());
+
+        self.infer_all_argument_types(
+            ast_arguments.clone(),
+            argument_types,
+            infer_argument_ty,
+            bindings,
+            call_expression_tcx,
+            None,
         );
 
-        bindings.check_types_impl(
+        let mut result = bindings.check_types_impl(
             db,
-            &constraints,
+            constraints,
             argument_types,
             call_expression_tcx,
             &self.dataclass_field_specifiers,
-        )
+        );
+
+        let refinement_request = bindings.argument_inference_refinement_request(db, argument_types);
+        if let (Some(original_bindings), Some(original_argument_types), Some(refinement_request)) = (
+            original_bindings,
+            original_argument_types,
+            refinement_request,
+        ) {
+            *bindings = original_bindings;
+            *argument_types = original_argument_types;
+            let mut refinement_builder = self.speculate();
+            refinement_builder.infer_all_argument_types(
+                ast_arguments,
+                argument_types,
+                infer_argument_ty,
+                bindings,
+                call_expression_tcx,
+                Some(&refinement_request),
+            );
+
+            result = bindings.check_types_impl(
+                db,
+                constraints,
+                argument_types,
+                call_expression_tcx,
+                &self.dataclass_field_specifiers,
+            );
+
+            self.extend(refinement_builder);
+        }
+
+        result
+    }
+
+    fn argument_inference_overloads<'a>(
+        bindings: &'a Bindings<'db>,
+    ) -> Vec<ArgumentInferenceOverload<'a, 'db>> {
+        bindings
+            .iter_type_context_callables()
+            .filter_map(|binding| match binding.matching_overload_index() {
+                MatchingOverloadIndex::Single(_) | MatchingOverloadIndex::Multiple(_) => {
+                    let overloads = binding
+                        .matching_overloads()
+                        .map(move |(_, overload)| (overload, binding));
+
+                    Some(Either::Right(overloads))
+                }
+
+                // If there is a single overload that does not match, we still infer the argument
+                // types for better diagnostics.
+                MatchingOverloadIndex::None => match binding.overloads() {
+                    [overload] => Some(Either::Left(std::iter::once((overload, binding)))),
+                    _ => None,
+                },
+            })
+            .flatten()
+            .collect()
+    }
+
+    fn argument_inference_context<'a>(
+        argument_index: usize,
+        bindings: &'a Bindings<'db>,
+        root_overloads_with_binding: &'a [ArgumentInferenceOverload<'a, 'db>],
+        refinement_bindings: Option<&'a ArgumentInferenceRefinementBindings<'db>>,
+        refinement_overloads_with_binding: Option<&'a [ArgumentInferenceOverload<'a, 'db>]>,
+    ) -> ArgumentInferenceContext<'a, 'db> {
+        if let Some(refinement_bindings) = refinement_bindings
+            && argument_index >= refinement_bindings.argument_start_index()
+            && let Some(refined_argument_index) =
+                argument_index.checked_sub(refinement_bindings.argument_index_offset())
+            && let Some(refinement_overloads_with_binding) = refinement_overloads_with_binding
+        {
+            return ArgumentInferenceContext {
+                overloads_with_binding: refinement_overloads_with_binding,
+                argument_index: refined_argument_index,
+                argument_form: refinement_bindings
+                    .bindings()
+                    .argument_forms()
+                    .get(refined_argument_index)
+                    .copied()
+                    .flatten(),
+            };
+        }
+
+        ArgumentInferenceContext {
+            overloads_with_binding: root_overloads_with_binding,
+            argument_index,
+            argument_form: bindings
+                .argument_forms()
+                .get(argument_index)
+                .copied()
+                .flatten(),
+        }
     }
 
     /// Infer the argument types for all bindings.
@@ -4859,55 +4966,29 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// Note that this method may infer the type of a given argument expression multiple times with
     /// distinct type context. The provided `MultiInferenceState` can be used to dictate multi-inference
     /// behavior.
-    fn infer_all_argument_types<'bindings>(
+    fn infer_all_argument_types(
         &mut self,
         ast_arguments: ArgumentsIter<'_>,
         arguments_types: &mut CallArguments<'_, 'db>,
         infer_argument_ty: &mut dyn FnMut(&mut Self, ArgExpr<'db, '_>) -> Type<'db>,
-        bindings: &'bindings Bindings<'db>,
+        bindings: &Bindings<'db>,
         call_expression_tcx: TypeContext<'db>,
+        argument_inference_refinement: Option<&ArgumentInferenceRefinement<'db>>,
     ) {
-        fn add_overloads_from_binding<'a, 'db>(
-            overloads_with_binding: &mut Vec<(&'a Binding<'db>, &'a CallableBinding<'db>)>,
-            binding: &'a CallableBinding<'db>,
-        ) {
-            match binding.matching_overload_index() {
-                MatchingOverloadIndex::Single(_) | MatchingOverloadIndex::Multiple(_) => {
-                    overloads_with_binding.extend(
-                        binding
-                            .matching_overloads()
-                            .map(|(_, overload)| (overload, binding)),
-                    );
-                }
-
-                // If there is a single overload that does not match, we still infer the argument
-                // types for better diagnostics.
-                MatchingOverloadIndex::None => {
-                    if let [overload] = binding.overloads() {
-                        overloads_with_binding.push((overload, binding));
-                    }
-                }
-            }
-        }
-
         debug_assert_eq!(arguments_types.len(), bindings.argument_forms().len());
 
         let db = self.db();
         let constraints = ConstraintSetBuilder::new();
-        let iter = itertools::izip!(
-            0..,
-            arguments_types.iter_mut(),
-            bindings.argument_forms().iter().copied(),
-            ast_arguments
-        );
+        let root_overloads_with_binding = Self::argument_inference_overloads(bindings);
+        let refinement_bindings =
+            argument_inference_refinement.map(|refinement| match refinement {
+                ArgumentInferenceRefinement::Bindings(bindings) => bindings,
+            });
+        let refinement_overloads_with_binding = refinement_bindings
+            .map(ArgumentInferenceRefinementBindings::bindings)
+            .map(Self::argument_inference_overloads);
 
-        let mut overloads_with_binding: Vec<(&Binding<'db>, &CallableBinding<'db>)> = Vec::new();
-
-        for binding in bindings.iter_type_context_callables() {
-            add_overloads_from_binding(&mut overloads_with_binding, binding);
-        }
-
-        for (argument_index, (_, argument_types), argument_form, ast_argument) in iter {
+        for (argument_index, ast_argument) in ast_arguments.enumerate() {
             let ast_argument = match ast_argument {
                 // Splatted arguments are inferred before parameter matching to
                 // determine their length.
@@ -4920,8 +5001,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ast::ArgOrKeyword::Keyword(ast::Keyword { value, .. }) => value,
             };
 
+            let context = Self::argument_inference_context(
+                argument_index,
+                bindings,
+                &root_overloads_with_binding,
+                refinement_bindings,
+                refinement_overloads_with_binding.as_deref(),
+            );
+
+            let Some(argument_types) = arguments_types.type_at_mut(argument_index) else {
+                continue;
+            };
+
             // Type-form arguments are inferred without type context, so we can infer the argument type directly.
-            if let Some(ParameterForm::Type) = argument_form {
+            if let Some(ParameterForm::Type) = context.argument_form {
                 argument_types.insert(
                     TypeContext::default(),
                     self.infer_type_expression(ast_argument),
@@ -4931,21 +5024,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             // Retrieve the parameter type context for the current argument in a given overload and its binding.
-            let parameter_tcx = |overload: &'bindings Binding<'db>,
-                                 binding: &CallableBinding<'db>| {
-                let argument_index = if binding.bound_type.is_some() {
-                    argument_index + 1
+            //
+            // Returns the annotated (unspecialized) parameter type (used for dedup and as the
+            // storage key in `CallArgumentTypes`) along with the type context to use for inference.
+            let parameter_tcx = |overload: &Binding<'db>,
+                                 binding: &CallableBinding<'db>|
+             -> Option<(Type<'db>, TypeContext<'db>)> {
+                let matched_argument_index = if binding.bound_type.is_some() {
+                    context.argument_index + 1
                 } else {
-                    argument_index
+                    context.argument_index
                 };
 
-                let argument_matches = &overload.argument_matches()[argument_index];
+                let argument_matches = overload.argument_matches().get(matched_argument_index)?;
                 let [parameter_index] = argument_matches.parameters.as_slice() else {
                     return None;
                 };
 
                 let parameter = &overload.signature.parameters()[*parameter_index];
-                let mut parameter_type = parameter.annotated_type();
+                let annotated_type = parameter.annotated_type();
+                let mut parameter_type = annotated_type;
 
                 // If the parameter is a single type variable with an upper bound, e.g., `typing.Self`,
                 // use the upper bound as type context.
@@ -4953,7 +5051,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     && let Some(TypeVarBoundOrConstraints::UpperBound(bound)) =
                         typevar.typevar(db).bound_or_constraints(db)
                 {
-                    return Some((parameter, TypeContext::new(Some(bound))));
+                    return Some((annotated_type, TypeContext::new(Some(bound))));
                 }
 
                 // If this is a generic call, attempt to specialize the parameter type using the
@@ -5014,15 +5112,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     parameter_type = parameter_type.apply_specialization(db, specialization);
                 }
 
-                Some((parameter, TypeContext::new(Some(parameter_type))))
+                Some((annotated_type, TypeContext::new(Some(parameter_type))))
             };
 
             // If there is only a single binding and overload, we can infer the argument directly with
             // the unique parameter type annotation.
-            if let Ok((overload, binding)) = overloads_with_binding.iter().exactly_one() {
-                if let Some((parameter, parameter_tcx)) = parameter_tcx(overload, binding) {
+            if let Ok((overload, binding)) =
+                context.overloads_with_binding.iter().copied().exactly_one()
+            {
+                if let Some((annotated_type, parameter_tcx)) = parameter_tcx(overload, binding) {
                     argument_types.insert(
-                        parameter.annotated_type(),
+                        annotated_type,
                         infer_argument_ty(self, (argument_index, ast_argument, parameter_tcx)),
                     );
                 } else {
@@ -5043,8 +5143,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 );
 
                 // Infer the type of each argument once with each distinct parameter type as type context.
-                let parameter_types = overloads_with_binding
+                let parameter_types = context
+                    .overloads_with_binding
                     .iter()
+                    .copied()
                     .filter_map(|(overload, binding)| parameter_tcx(overload, binding));
 
                 let mut seen = FxHashSet::default();
@@ -5055,8 +5157,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // as inner expressions are repeatedly inferred with the same type context.
                 let teardown = self.setup_expression_cache();
 
-                for (parameter, parameter_tcx) in parameter_types {
-                    if !seen.insert(parameter.annotated_type()) {
+                for (annotated_type, parameter_tcx) in parameter_types {
+                    if !seen.insert(annotated_type) {
                         continue;
                     }
 
@@ -5067,7 +5169,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         &mut self.speculate(),
                         (argument_index, ast_argument, parameter_tcx),
                     );
-                    argument_types.insert(parameter.annotated_type(), inferred_ty);
+                    argument_types.insert(annotated_type, inferred_ty);
                 }
 
                 if teardown {
@@ -9151,6 +9253,13 @@ impl Drop for MultiInferenceGuard<'_, '_, '_> {
 /// An expression representing the function argument at the given index, along with its type
 /// context.
 type ArgExpr<'db, 'ast> = (usize, &'ast ast::Expr, TypeContext<'db>);
+type ArgumentInferenceOverload<'a, 'db> = (&'a Binding<'db>, &'a CallableBinding<'db>);
+
+struct ArgumentInferenceContext<'a, 'db> {
+    overloads_with_binding: &'a [ArgumentInferenceOverload<'a, 'db>],
+    argument_index: usize,
+    argument_form: Option<ParameterForm>,
+}
 
 /// An iterator over arguments to a functional call.
 #[derive(Clone)]

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -55,8 +55,7 @@ use crate::semantic_index::{
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
 use crate::types::call::bind::MatchingOverloadIndex;
 use crate::types::call::{
-    ArgumentInferenceRefinement, ArgumentInferenceRefinementBindings, Binding, Bindings,
-    CallArguments, CallError, CallErrorKind,
+    ArgumentInferenceRefinementBindings, Binding, Bindings, CallArguments, CallError, CallErrorKind,
 };
 use crate::types::callable::CallableTypeKind;
 use crate::types::class::{ClassLiteral, CodeGeneratorKind, MethodDecorator};
@@ -4847,9 +4846,27 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         constraints: &ConstraintSetBuilder<'db>,
     ) -> Result<(), CallErrorKind> {
         let db = self.db();
-        let may_request_refinement = bindings.may_request_argument_inference_refinement(db);
-        let original_argument_types = may_request_refinement.then(|| argument_types.clone());
-        let original_bindings = may_request_refinement.then(|| bindings.clone());
+        if !bindings.may_request_argument_inference_refinement(db) {
+            self.infer_all_argument_types(
+                ast_arguments,
+                argument_types,
+                infer_argument_ty,
+                bindings,
+                call_expression_tcx,
+                None,
+            );
+
+            return bindings.check_types_impl(
+                db,
+                constraints,
+                argument_types,
+                call_expression_tcx,
+                &self.dataclass_field_specifiers,
+            );
+        }
+
+        let original_argument_types = argument_types.clone();
+        let original_bindings = bindings.clone();
 
         self.infer_all_argument_types(
             ast_arguments.clone(),
@@ -4868,34 +4885,33 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             &self.dataclass_field_specifiers,
         );
 
-        let refinement_request = bindings.argument_inference_refinement_request(db, argument_types);
-        if let (Some(original_bindings), Some(original_argument_types), Some(refinement_request)) = (
-            original_bindings,
-            original_argument_types,
-            refinement_request,
-        ) {
-            *bindings = original_bindings;
-            *argument_types = original_argument_types;
-            let mut refinement_builder = self.speculate();
-            refinement_builder.infer_all_argument_types(
-                ast_arguments,
-                argument_types,
-                infer_argument_ty,
-                bindings,
-                call_expression_tcx,
-                Some(&refinement_request),
-            );
+        let Some(refinement_bindings) =
+            bindings.argument_inference_refinement_request(db, argument_types)
+        else {
+            return result;
+        };
 
-            result = bindings.check_types_impl(
-                db,
-                constraints,
-                argument_types,
-                call_expression_tcx,
-                &self.dataclass_field_specifiers,
-            );
+        *bindings = original_bindings;
+        *argument_types = original_argument_types;
+        let mut refinement_builder = self.speculate();
+        refinement_builder.infer_all_argument_types(
+            ast_arguments,
+            argument_types,
+            infer_argument_ty,
+            bindings,
+            call_expression_tcx,
+            Some(&refinement_bindings),
+        );
 
-            self.extend(refinement_builder);
-        }
+        result = bindings.check_types_impl(
+            db,
+            constraints,
+            argument_types,
+            call_expression_tcx,
+            &self.dataclass_field_specifiers,
+        );
+
+        self.extend(refinement_builder);
 
         result
     }
@@ -4973,17 +4989,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         infer_argument_ty: &mut dyn FnMut(&mut Self, ArgExpr<'db, '_>) -> Type<'db>,
         bindings: &Bindings<'db>,
         call_expression_tcx: TypeContext<'db>,
-        argument_inference_refinement: Option<&ArgumentInferenceRefinement<'db>>,
+        refinement_bindings: Option<&ArgumentInferenceRefinementBindings<'db>>,
     ) {
         debug_assert_eq!(arguments_types.len(), bindings.argument_forms().len());
 
         let db = self.db();
         let constraints = ConstraintSetBuilder::new();
         let root_overloads_with_binding = Self::argument_inference_overloads(bindings);
-        let refinement_bindings =
-            argument_inference_refinement.map(|refinement| match refinement {
-                ArgumentInferenceRefinement::Bindings(bindings) => bindings,
-            });
         let refinement_overloads_with_binding = refinement_bindings
             .map(ArgumentInferenceRefinementBindings::bindings)
             .map(Self::argument_inference_overloads);

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1541,6 +1541,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                     Type::unknown()
                 }
+                KnownInstanceType::FunctoolsPartial(_) => {
+                    self.infer_type_expression(&subscript.slice);
+                    if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                        builder.into_diagnostic(format_args!(
+                            "`functools.partial` instances cannot be specialized",
+                        ));
+                    }
+                    Type::unknown()
+                }
             },
             Type::Dynamic(DynamicType::UnknownGeneric(_)) => {
                 self.infer_explicit_type_alias_specialization(subscript, value_ty, true)

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1541,7 +1541,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                     Type::unknown()
                 }
-                KnownInstanceType::FunctoolsPartial { .. } => {
+                KnownInstanceType::FunctoolsPartial(_) => {
                     self.infer_type_expression(&subscript.slice);
                     if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                         builder.into_diagnostic(format_args!(

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1541,7 +1541,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                     Type::unknown()
                 }
-                KnownInstanceType::FunctoolsPartial(_) => {
+                KnownInstanceType::FunctoolsPartial { .. } => {
                     self.infer_type_expression(&subscript.slice);
                     if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                         builder.into_diagnostic(format_args!(

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -107,7 +107,10 @@ pub enum KnownInstanceType<'db> {
 
     /// A `functools.partial(func, ...)` call result where we could determine
     /// the remaining callable signature after binding some arguments.
-    FunctoolsPartial(CallableType<'db>),
+    FunctoolsPartial {
+        wrapped: InternedType<'db>,
+        partial: CallableType<'db>,
+    },
 }
 
 pub(super) fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
@@ -163,8 +166,8 @@ pub(super) fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Size
                 visitor.visit_type(db, field.ty);
             }
         }
-        KnownInstanceType::FunctoolsPartial(callable) => {
-            visitor.visit_callable_type(db, callable);
+        KnownInstanceType::FunctoolsPartial { partial, .. } => {
+            visitor.visit_callable_type(db, partial);
         }
     }
 }
@@ -228,9 +231,15 @@ impl<'db> KnownInstanceType<'db> {
             Self::NamedTupleSpec(spec) => spec
                 .recursive_type_normalized_impl(db, div, true)
                 .map(Self::NamedTupleSpec),
-            Self::FunctoolsPartial(callable) => callable
-                .recursive_type_normalized_impl(db, div, nested)
-                .map(Self::FunctoolsPartial),
+            Self::FunctoolsPartial { wrapped, partial } => Some(Self::FunctoolsPartial {
+                wrapped: InternedType::new(
+                    db,
+                    wrapped
+                        .inner(db)
+                        .recursive_type_normalized_impl(db, div, nested)?,
+                ),
+                partial: partial.recursive_type_normalized_impl(db, div, nested)?,
+            }),
         }
     }
 
@@ -258,7 +267,7 @@ impl<'db> KnownInstanceType<'db> {
             Self::LiteralStringAlias(_) => KnownClass::Str,
             Self::NewType(_) => KnownClass::NewType,
             Self::NamedTupleSpec(_) => KnownClass::Sequence,
-            Self::FunctoolsPartial(_) => KnownClass::FunctoolsPartial,
+            Self::FunctoolsPartial { .. } => KnownClass::FunctoolsPartial,
         }
     }
 
@@ -324,10 +333,16 @@ impl<'db> KnownInstanceType<'db> {
                     callable_type.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 ))
             }
-            KnownInstanceType::FunctoolsPartial(callable_type) => {
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(
-                    callable_type.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-                ))
+            KnownInstanceType::FunctoolsPartial { wrapped, partial } => {
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial {
+                    wrapped: InternedType::new(
+                        db,
+                        wrapped
+                            .inner(db)
+                            .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                    ),
+                    partial: partial.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                })
             }
             KnownInstanceType::TypeGenericAlias(ty) => {
                 Type::KnownInstance(KnownInstanceType::TypeGenericAlias(InternedType::new(

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -32,6 +32,16 @@ pub struct InternedConstraintSet<'db> {
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for InternedConstraintSet<'_> {}
 
+/// A salsa-interned payload for `functools.partial(...)` instances.
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+pub struct FunctoolsPartialInstance<'db> {
+    pub wrapped: InternedType<'db>,
+    pub partial: CallableType<'db>,
+}
+
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for FunctoolsPartialInstance<'_> {}
+
 /// Singleton types that are heavily special-cased by ty. Despite its name,
 /// quite a different type to [`super::NominalInstanceType`].
 ///
@@ -107,10 +117,7 @@ pub enum KnownInstanceType<'db> {
 
     /// A `functools.partial(func, ...)` call result where we could determine
     /// the remaining callable signature after binding some arguments.
-    FunctoolsPartial {
-        wrapped: InternedType<'db>,
-        partial: CallableType<'db>,
-    },
+    FunctoolsPartial(FunctoolsPartialInstance<'db>),
 }
 
 pub(super) fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
@@ -166,8 +173,8 @@ pub(super) fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Size
                 visitor.visit_type(db, field.ty);
             }
         }
-        KnownInstanceType::FunctoolsPartial { partial, .. } => {
-            visitor.visit_callable_type(db, partial);
+        KnownInstanceType::FunctoolsPartial(partial) => {
+            visitor.visit_callable_type(db, partial.partial(db));
         }
     }
 }
@@ -231,15 +238,9 @@ impl<'db> KnownInstanceType<'db> {
             Self::NamedTupleSpec(spec) => spec
                 .recursive_type_normalized_impl(db, div, true)
                 .map(Self::NamedTupleSpec),
-            Self::FunctoolsPartial { wrapped, partial } => Some(Self::FunctoolsPartial {
-                wrapped: InternedType::new(
-                    db,
-                    wrapped
-                        .inner(db)
-                        .recursive_type_normalized_impl(db, div, nested)?,
-                ),
-                partial: partial.recursive_type_normalized_impl(db, div, nested)?,
-            }),
+            Self::FunctoolsPartial(partial) => partial
+                .recursive_type_normalized_impl(db, div, nested)
+                .map(Self::FunctoolsPartial),
         }
     }
 
@@ -267,7 +268,7 @@ impl<'db> KnownInstanceType<'db> {
             Self::LiteralStringAlias(_) => KnownClass::Str,
             Self::NewType(_) => KnownClass::NewType,
             Self::NamedTupleSpec(_) => KnownClass::Sequence,
-            Self::FunctoolsPartial { .. } => KnownClass::FunctoolsPartial,
+            Self::FunctoolsPartial(_) => KnownClass::FunctoolsPartial,
         }
     }
 
@@ -333,16 +334,10 @@ impl<'db> KnownInstanceType<'db> {
                     callable_type.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 ))
             }
-            KnownInstanceType::FunctoolsPartial { wrapped, partial } => {
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartial {
-                    wrapped: InternedType::new(
-                        db,
-                        wrapped
-                            .inner(db)
-                            .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-                    ),
-                    partial: partial.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-                })
+            KnownInstanceType::FunctoolsPartial(partial) => {
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(
+                    partial.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                ))
             }
             KnownInstanceType::TypeGenericAlias(ty) => {
                 Type::KnownInstance(KnownInstanceType::TypeGenericAlias(InternedType::new(
@@ -585,6 +580,47 @@ impl<'db> UnionTypeInstance<'db> {
         };
 
         Some(Self::new(db, value_expr_types, union_type))
+    }
+}
+
+impl<'db> FunctoolsPartialInstance<'db> {
+    fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        Some(Self::new(
+            db,
+            InternedType::new(
+                db,
+                self.wrapped(db)
+                    .inner(db)
+                    .recursive_type_normalized_impl(db, div, nested)?,
+            ),
+            self.partial(db)
+                .recursive_type_normalized_impl(db, div, nested)?,
+        ))
+    }
+
+    fn apply_type_mapping_impl(
+        self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'_, 'db>,
+        tcx: TypeContext<'db>,
+        visitor: &ApplyTypeMappingVisitor<'db>,
+    ) -> Self {
+        Self::new(
+            db,
+            InternedType::new(
+                db,
+                self.wrapped(db)
+                    .inner(db)
+                    .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            ),
+            self.partial(db)
+                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+        )
     }
 }
 

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -104,6 +104,10 @@ pub enum KnownInstanceType<'db> {
 
     /// The inferred spec for a functional `NamedTuple` class.
     NamedTupleSpec(NamedTupleSpec<'db>),
+
+    /// A `functools.partial(func, ...)` call result where we could determine
+    /// the remaining callable signature after binding some arguments.
+    FunctoolsPartial(CallableType<'db>),
 }
 
 pub(super) fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
@@ -158,6 +162,9 @@ pub(super) fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Size
             for field in spec.fields(db) {
                 visitor.visit_type(db, field.ty);
             }
+        }
+        KnownInstanceType::FunctoolsPartial(callable) => {
+            visitor.visit_callable_type(db, callable);
         }
     }
 }
@@ -221,6 +228,9 @@ impl<'db> KnownInstanceType<'db> {
             Self::NamedTupleSpec(spec) => spec
                 .recursive_type_normalized_impl(db, div, true)
                 .map(Self::NamedTupleSpec),
+            Self::FunctoolsPartial(callable) => callable
+                .recursive_type_normalized_impl(db, div, nested)
+                .map(Self::FunctoolsPartial),
         }
     }
 
@@ -248,6 +258,7 @@ impl<'db> KnownInstanceType<'db> {
             Self::LiteralStringAlias(_) => KnownClass::Str,
             Self::NewType(_) => KnownClass::NewType,
             Self::NamedTupleSpec(_) => KnownClass::Sequence,
+            Self::FunctoolsPartial(_) => KnownClass::FunctoolsPartial,
         }
     }
 
@@ -260,7 +271,7 @@ impl<'db> KnownInstanceType<'db> {
     /// For example, an alias created using the `type` statement is an instance of
     /// `typing.TypeAliasType`, so `KnownInstanceType::TypeAliasType(_).instance_fallback(db)`
     /// returns `Type::NominalInstance(NominalInstanceType { class: <typing.TypeAliasType> })`.
-    pub(super) fn instance_fallback(self, db: &dyn Db) -> Type<'_> {
+    pub(super) fn instance_fallback(self, db: &'db dyn Db) -> Type<'db> {
         self.class(db).to_instance(db)
     }
 
@@ -332,7 +343,8 @@ impl<'db> KnownInstanceType<'db> {
             | KnownInstanceType::Literal(_)
             | KnownInstanceType::LiteralStringAlias(_)
             | KnownInstanceType::NamedTupleSpec(_)
-            | KnownInstanceType::NewType(_) => {
+            | KnownInstanceType::NewType(_)
+            | KnownInstanceType::FunctoolsPartial(_) => {
                 // TODO: For some of these, we may need to apply the type mapping to inner types.
                 Type::KnownInstance(self)
             }

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -324,6 +324,11 @@ impl<'db> KnownInstanceType<'db> {
                     callable_type.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 ))
             }
+            KnownInstanceType::FunctoolsPartial(callable_type) => {
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(
+                    callable_type.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                ))
+            }
             KnownInstanceType::TypeGenericAlias(ty) => {
                 Type::KnownInstance(KnownInstanceType::TypeGenericAlias(InternedType::new(
                     db,
@@ -343,8 +348,7 @@ impl<'db> KnownInstanceType<'db> {
             | KnownInstanceType::Literal(_)
             | KnownInstanceType::LiteralStringAlias(_)
             | KnownInstanceType::NamedTupleSpec(_)
-            | KnownInstanceType::NewType(_)
-            | KnownInstanceType::FunctoolsPartial(_) => {
+            | KnownInstanceType::NewType(_) => {
                 // TODO: For some of these, we may need to apply the type mapping to inner types.
                 Type::KnownInstance(self)
             }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -866,30 +866,22 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
 
             (
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartial {
-                    partial: source_callable,
-                    ..
-                }),
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartial {
-                    partial: target_callable,
-                    ..
-                }),
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(source_partial)),
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(target_partial)),
             ) => self.with_recursion_guard(source, target, || {
-                self.check_callable_pair(db, source_callable, target_callable)
+                self.check_callable_pair(db, source_partial.partial(db), target_partial.partial(db))
             }),
 
             // When checking `FunctoolsPartial <: functools.partial[T]`, we need to specialize
             // the nominal instance with the partial's return type so the check is precise.
             (
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartial {
-                    partial: callable, ..
-                }),
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)),
                 Type::NominalInstance(target_instance),
             ) if target_instance
                 .class(db)
                 .is_known(db, KnownClass::FunctoolsPartial) =>
             {
-                let specialized = callable.into_functools_partial_instance(db);
+                let specialized = partial.partial(db).into_functools_partial_instance(db);
                 self.check_type_pair(db, specialized, target)
             }
 
@@ -1257,10 +1249,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.check_function_pair(db, source_function, target_function)
             }
             (
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartial {
-                    partial: source_callable,
-                    ..
-                }),
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(source_partial)),
                 Type::FunctionLiteral(target_function),
             ) if matches!(
                 self.relation,
@@ -1270,7 +1259,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.with_recursion_guard(source, target, || {
                     self.check_callable_signature_pair(
                         db,
-                        source_callable.signatures(db),
+                        source_partial.partial(db).signatures(db),
                         target_function.into_callable_type(db).signatures(db),
                     )
                 })

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -865,6 +865,28 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     })
             }
 
+            (
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(source_callable)),
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(target_callable)),
+            ) => self.with_recursion_guard(source, target, || {
+                self.check_callable_pair(db, source_callable, target_callable)
+            }),
+
+            // When checking `FunctoolsPartial <: functools.partial[T]`, we need to specialize
+            // the nominal instance with the partial's return type so the check is precise.
+            (
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(callable)),
+                Type::NominalInstance(target_instance),
+            ) if target_instance
+                .class(db)
+                .is_known(db, KnownClass::FunctoolsPartial) =>
+            {
+                let return_ty = callable.signatures(db).overload_return_type_or_unknown(db);
+                let specialized =
+                    KnownClass::FunctoolsPartial.to_specialized_instance(db, &[return_ty]);
+                self.check_type_pair(db, specialized, target)
+            }
+
             // Dynamic is only a subtype of `object` and only a supertype of `Never`; both were
             // handled above. It's always assignable, though.
             //
@@ -1227,6 +1249,22 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // only subtypes of each other if they result in the same signature.
             (Type::FunctionLiteral(source_function), Type::FunctionLiteral(target_function)) => {
                 self.check_function_pair(db, source_function, target_function)
+            }
+            (
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(source_callable)),
+                Type::FunctionLiteral(target_function),
+            ) if matches!(
+                self.relation,
+                TypeRelation::Assignability | TypeRelation::ConstraintSetAssignability
+            ) =>
+            {
+                self.with_recursion_guard(source, target, || {
+                    self.check_callable_signature_pair(
+                        db,
+                        source_callable.signatures(db),
+                        target_function.into_callable_type(db).signatures(db),
+                    )
+                })
             }
             (Type::BoundMethod(source_method), Type::BoundMethod(target_method)) => {
                 self.check_bound_method_pair(db, source_method, target_method)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -881,9 +881,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 .class(db)
                 .is_known(db, KnownClass::FunctoolsPartial) =>
             {
-                let return_ty = callable.signatures(db).overload_return_type_or_unknown(db);
-                let specialized =
-                    KnownClass::FunctoolsPartial.to_specialized_instance(db, &[return_ty]);
+                let specialized = callable.into_functools_partial_instance(db);
                 self.check_type_pair(db, specialized, target)
             }
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -866,8 +866,14 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
 
             (
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(source_callable)),
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(target_callable)),
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial {
+                    partial: source_callable,
+                    ..
+                }),
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial {
+                    partial: target_callable,
+                    ..
+                }),
             ) => self.with_recursion_guard(source, target, || {
                 self.check_callable_pair(db, source_callable, target_callable)
             }),
@@ -875,7 +881,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // When checking `FunctoolsPartial <: functools.partial[T]`, we need to specialize
             // the nominal instance with the partial's return type so the check is precise.
             (
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(callable)),
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial {
+                    partial: callable, ..
+                }),
                 Type::NominalInstance(target_instance),
             ) if target_instance
                 .class(db)
@@ -1249,7 +1257,10 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.check_function_pair(db, source_function, target_function)
             }
             (
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(source_callable)),
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial {
+                    partial: source_callable,
+                    ..
+                }),
                 Type::FunctionLiteral(target_function),
             ) if matches!(
                 self.relation,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -16,13 +16,15 @@ use itertools::{EitherOrBoth, Itertools};
 use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec_inline};
 
-use super::{DynamicType, Type, TypeVarVariance, semantic_index};
+use super::{DynamicType, Type, TypeVarVariance, UnionType, semantic_index};
 use crate::semantic_index::definition::Definition;
 use crate::types::callable::CallableTypeKind;
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
 };
-use crate::types::generics::{GenericContext, InferableTypeVars, walk_generic_context};
+use crate::types::generics::{
+    ApplySpecialization, GenericContext, InferableTypeVars, Specialization, walk_generic_context,
+};
 use crate::types::infer::infer_deferred_types;
 use crate::types::relation::{
     HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
@@ -95,6 +97,15 @@ impl<'db> CallableSignature<'db> {
 
     pub(crate) fn iter(&self) -> std::slice::Iter<'_, Signature<'db>> {
         self.overloads.iter()
+    }
+
+    /// Returns the union of all overload return types, or `Unknown` if there are no overloads.
+    pub(crate) fn overload_return_type_or_unknown(&self, db: &'db dyn Db) -> Type<'db> {
+        match self.overloads.as_slice() {
+            [] => Type::unknown(),
+            [signature] => signature.return_ty,
+            overloads => UnionType::from_elements(db, overloads.iter().map(|sig| sig.return_ty)),
+        }
     }
 
     pub(crate) fn with_inherited_generic_context(
@@ -751,6 +762,21 @@ impl<'db> Signature<'db> {
         }
     }
 
+    pub(crate) fn apply_specialization(
+        &self,
+        db: &'db dyn Db,
+        specialization: Specialization<'db>,
+    ) -> Self {
+        let type_mapping =
+            TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(specialization));
+        self.apply_type_mapping_impl(
+            db,
+            &type_mapping,
+            TypeContext::default(),
+            &ApplyTypeMappingVisitor::default(),
+        )
+    }
+
     fn inferable_typevars(&self, db: &'db dyn Db) -> InferableTypeVars<'db> {
         match self.generic_context {
             Some(generic_context) => generic_context.inferable_typevars(db),
@@ -829,6 +855,10 @@ impl<'db> Signature<'db> {
     /// Create a new signature with the given definition.
     pub(crate) fn with_definition(self, definition: Option<Definition<'db>>) -> Self {
         Self { definition, ..self }
+    }
+
+    pub(crate) fn with_parameters(self, parameters: Parameters<'db>) -> Self {
+        Self { parameters, ..self }
     }
 
     /// Create a new signature with the given return type.


### PR DESCRIPTION
## Summary

This is composed of three primary commits:

- The first ("Model functools.partial call results") introduces initial support for partial.
- The second ("Preserve generics through functools.partial") ensures that when a generic callable is wrapped with `functools.partial`, the type variables that aren't yet bound are preserved until the partial is called.
- The third ("Infer functools.partial arguments from wrapped callables") adds inference support so that when calling `functools.partial(fn, x)`, the type of `x` is checked against the wrapped callable's parameter types.

Closes https://github.com/astral-sh/ty/issues/1536.
