### PR TITLE
Add attestations for release artifacts and Docker images

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -117,6 +117,10 @@ jobs:
     needs:
       - docker-build
     if: ${{ inputs.plan != '' && !fromJson(inputs.plan).announcement_tag_is_implicit }}
+    permissions:
+      attestations: write
+      id-token: write
+      packages: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -155,6 +159,26 @@ jobs:
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf "${RUFF_BASE_IMG}@sha256:%s " *)
 
+      - name: Export manifest digest
+        id: manifest-digest
+        env:
+          IMAGE: ${{ env.RUFF_BASE_IMG }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          digest="$(
+            docker buildx imagetools inspect \
+              "${IMAGE}:${VERSION}" \
+              --format '{{json .Manifest}}' \
+            | jq -r '.digest'
+          )"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8 # v3.1.0
+        with:
+          subject-name: ${{ env.RUFF_BASE_IMG }}
+          subject-digest: ${{ steps.manifest-digest.outputs.digest }}
+
   docker-publish-extra:
     name: Publish additional Docker image based on ${{ matrix.image-mapping }}
     runs-on: ubuntu-latest
@@ -163,6 +187,10 @@ jobs:
     needs:
       - docker-publish
     if: ${{ inputs.plan != '' && !fromJson(inputs.plan).announcement_tag_is_implicit }}
+    permissions:
+      attestations: write
+      id-token: write
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -237,6 +265,7 @@ jobs:
             ${{ env.TAG_PATTERNS }}
 
       - name: Build and push
+        id: build-and-push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
@@ -249,6 +278,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8 # v3.1.0
+        with:
+          subject-name: ${{ env.RUFF_BASE_IMG }}
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
+
   # This is effectively a duplicate of `docker-publish` to make https://github.com/astral-sh/ruff/pkgs/container/ruff
   # show the ruff base image first since GitHub always shows the last updated image digests
   # This works by annotating the original digests (previously non-annotated) which triggers an update to ghcr.io
@@ -260,6 +295,10 @@ jobs:
     needs:
       - docker-publish-extra
     if: ${{ inputs.plan != '' && !fromJson(inputs.plan).announcement_tag_is_implicit }}
+    permissions:
+      attestations: write
+      id-token: write
+      packages: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -303,3 +342,23 @@ jobs:
             "${annotations[@]}" \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf "${RUFF_BASE_IMG}@sha256:%s " *)
+
+      - name: Export manifest digest
+        id: manifest-digest
+        env:
+          IMAGE: ${{ env.RUFF_BASE_IMG }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          digest="$(
+            docker buildx imagetools inspect \
+              "${IMAGE}:${VERSION}" \
+              --format '{{json .Manifest}}' \
+            | jq -r '.digest'
+          )"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8 # v3.1.0
+        with:
+          subject-name: ${{ env.RUFF_BASE_IMG }}
+          subject-digest: ${{ steps.manifest-digest.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,9 @@ jobs:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
     permissions:
+      "attestations": "write"
       "contents": "read"
+      "id-token": "write"
       "packages": "write"
 
   custom-build-wasm:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -62,7 +62,7 @@ publish-jobs = ["./publish-pypi", "./publish-wasm"]
 # Post-announce jobs to run in CI
 post-announce-jobs = ["./notify-dependents", "./publish-docs", "./publish-playground"]
 # Custom permissions for GitHub Jobs
-github-custom-job-permissions = { "build-docker" = { packages = "write", contents = "read" }, "publish-wasm" = { contents = "read", id-token = "write", packages = "write" } }
+github-custom-job-permissions = { "build-docker" = { packages = "write", contents = "read", id-token = "write", attestations = "write" }, "publish-wasm" = { contents = "read", id-token = "write", packages = "write" } }
 # Whether to install an updater program
 install-updater = false
 # Path that installers should place binaries in


### PR DESCRIPTION
## Summary

Adds GitHub artifact attestations (SLSA provenance) for release artifacts and Docker images.

Users will be able to verify artifacts with:
```bash
# Release artifacts
gh attestation verify ruff-x86_64-unknown-linux-gnu.tar.gz --repo astral-sh/ruff

# Docker images
gh attestation verify oci://ghcr.io/astral-sh/ruff:latest --repo astral-sh/ruff
```

## Test Plan

Tested end-to-end releases and attestation verification on my fork. (Note, some finagling was necessary  to successfully publish without a dedicated depot runner, see a5d98386bb8b14d685164f6464908e84ba4ce91b)

- Workflow run: https://github.com/shaanmajid/ruff/actions/runs/21732754488
- Test release: https://github.com/shaanmajid/ruff/releases/tag/0.15.0

Verify release artifacts:
```bash
gh release download 0.15.0 --repo shaanmajid/ruff --pattern "ruff-x86_64-unknown-linux-gnu.tar.gz" --dir /tmp
gh attestation verify /tmp/ruff-x86_64-unknown-linux-gnu.tar.gz --repo shaanmajid/ruff
```

Verify Docker images:
```bash
gh attestation verify oci://ghcr.io/shaanmajid/ruff:0.15.0 --repo shaanmajid/ruff
gh attestation verify oci://ghcr.io/shaanmajid/ruff:alpine --repo shaanmajid/ruff
gh attestation verify oci://ghcr.io/shaanmajid/ruff:debian --repo shaanmajid/ruff
```

## Notes
- `actions/attest-build-provenance` was preexisting in `dist-workspace.toml` but was unused, so the upgrade across major versions is safe