### PR TITLE
TD003: allow Jira-style issue keys on TODO line

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -102,6 +102,8 @@ impl Violation for MissingTodoAuthor {
 ///
 /// # TODO(charlie): this comment has an issue code (matches the regex `[A-Z]+\-?\d+`)
 /// # SIXCHR-003
+///
+/// # TODO(charlie): SIXCHR-003 this comment has an issue code inline
 /// ```
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.269")]
@@ -242,15 +244,16 @@ static ISSUE_LINK_OWN_LINE_REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     RegexSet::new([
         r"^#\s*(http|https)://.*", // issue link
         r"^#\s*\d+$",              // issue code - like "003"
-        r"^#\s*[A-Z]+\-?\d+$",     // issue code - like "TD003"
+        r"^#\s*[A-Z]+\-?\d+$",     // issue code - like "TD003" or "SIXCHR-003"
     ])
     .unwrap()
 });
 
 static ISSUE_LINK_TODO_LINE_REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     RegexSet::new([
-        r"\s*(http|https)://.*", // issue link
-        r"\s*#\d+.*",            // issue code - like "#003"
+        r"\s*(http|https)://.*",            // issue link
+        r"\s*#\d+.*",                       // issue code - like "#003"
+        r"\b[A-Z][A-Z0-9]+-\d+\b.*",        // issue code - like "RFFU-6877" (Jira-style) inline
     ])
     .unwrap()
 });


### PR DESCRIPTION
Extend TD003 (MissingTodoLink) to treat Jira-style issue keys (e.g., `RFFU-6877`) on the TODO line as a valid issue reference.

Resolves #20809.