### PR TITLE
[ty] support for `typing.Concatenate`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -257,8 +257,7 @@ Using `Concatenate` as the first argument to `Callable`:
 from typing_extensions import Callable, Concatenate
 
 def _(c: Callable[Concatenate[int, str, ...], int]):
-    # TODO: Should reveal the correct signature
-    reveal_type(c)  # revealed: (...) -> int
+    reveal_type(c)  # revealed: (int, str, /, *args: Any, **kwargs: Any) -> int
 ```
 
 And, as one of the parameter types:

--- a/crates/ty_python_semantic/resources/mdtest/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/final.md
@@ -1302,7 +1302,9 @@ class Base(ABC):
     @abstractproperty  # error: [deprecated]
     def value(self) -> int:
         return 0
-
+    # TODO: False positive: `Concatenate` in `classmethod.__init__` signature causes spurious
+    # invalid-argument-type when the type variables are not fully resolved.
+    # error: [invalid-argument-type]
     @abstractclassmethod  # error: [deprecated]
     def make(cls) -> "Base":
         raise NotImplementedError

--- a/crates/ty_python_semantic/resources/mdtest/generics/concatenate.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/concatenate.md
@@ -1,0 +1,124 @@
+# `typing.Concatenate`
+
+`Concatenate` is used with `Callable` and `ParamSpec` to describe higher-order functions that add,
+remove, or transform parameters of other callables.
+
+## Basic `Callable[Concatenate[..., ...], ...]` types
+
+### With ellipsis (gradual form)
+
+```py
+from typing_extensions import Callable, Concatenate
+
+def _(c: Callable[Concatenate[int, ...], str]):
+    reveal_type(c)  # revealed: (int, /, *args: Any, **kwargs: Any) -> str
+
+def _(c: Callable[Concatenate[int, str, ...], bool]):
+    reveal_type(c)  # revealed: (int, str, /, *args: Any, **kwargs: Any) -> bool
+```
+
+### With `ParamSpec`
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing_extensions import Callable, Concatenate, ParamSpec
+
+P = ParamSpec("P")
+
+def _(c: Callable[Concatenate[int, P], str]):
+    reveal_type(c)  # revealed: (int, /, *args: P@_.args, **kwargs: P@_.kwargs) -> str
+```
+
+## Decorator that strips a prefix parameter
+
+A common use case is decorators that strip the first parameter from a callable.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, reveal_type
+from typing_extensions import Concatenate, ParamSpec
+
+P = ParamSpec("P")
+
+def with_request[**P, R](f: Callable[Concatenate[int, P], R]) -> Callable[P, R]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        return f(0, *args, **kwargs)
+    return wrapper
+
+@with_request
+def handler(request: int, name: str) -> bool:
+    return True
+
+# The decorator strips the first `int` parameter
+reveal_type(handler)  # revealed: (name: str) -> bool
+
+# Calling without the stripped parameter should work
+handler("test")
+```
+
+## Multiple prefix parameters
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, reveal_type
+from typing_extensions import Concatenate, ParamSpec
+
+P = ParamSpec("P")
+
+def add_two_params[**P, R](
+    f: Callable[Concatenate[int, str, P], R],
+) -> Callable[P, R]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        return f(0, "", *args, **kwargs)
+    return wrapper
+
+@add_two_params
+def process(a: int, b: str, flag: bool) -> None:
+    pass
+
+reveal_type(process)  # revealed: (flag: bool) -> None
+
+process(True)
+```
+
+## Assignability of `Concatenate` gradual forms
+
+When both sides of an assignment use `Concatenate[T, ...]`, the prefix parameters must be
+compatible. The gradual tail (`...`) still allows assignability for the remaining parameters.
+
+```py
+from typing_extensions import Callable, Concatenate
+
+def _(
+    x: Callable[Concatenate[int, ...], None],
+    y: Callable[Concatenate[str, ...], None],
+    same: Callable[Concatenate[int, ...], None],
+    gradual: Callable[..., None],
+    multi_self: Callable[Concatenate[int, str, ...], None],
+    multi_other: Callable[Concatenate[str, int, ...], None],
+):
+    # Same prefix types: assignable
+    x = same
+
+    # Different prefix types: not assignable
+    x = y  # error: [invalid-assignment]
+
+    # Swapped multi-prefix types: not assignable
+    multi_self = multi_other  # error: [invalid-assignment]
+
+    # Pure gradual is assignable to/from Concatenate gradual
+    x = gradual
+    gradual = x
+```

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1081,8 +1081,5 @@ class Factory[**P](Protocol):
 def call_factory[**P](ctr: Factory[P], *args: P.args, **kwargs: P.kwargs) -> int:
     return ctr("", *args, **kwargs)
 
-# TODO: This should be OK - P should be inferred as [] since my_factory only has `arg: str`
-# which matches the prefix. Currently this is a false positive.
-# error: [invalid-argument-type]
 call_factory(my_factory)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -237,8 +237,7 @@ from typing_extensions import Callable, Concatenate, TypeAliasType
 MyAlias4: TypeAlias = Callable[Concatenate[dict[str, T], ...], list[U]]
 
 def _(c: MyAlias4[int, str]):
-    # TODO: should be (int, / ...) -> str
-    reveal_type(c)  # revealed: Unknown
+    reveal_type(c)  # revealed: (dict[str, int], /, *args: Any, **kwargs: Any) -> list[str]
 
 T = TypeVar("T")
 
@@ -270,8 +269,7 @@ def _(x: ListOrDict[int]):
 MyAlias7: TypeAlias = Callable[Concatenate[T, ...], None]
 
 def _(c: MyAlias7[int]):
-    # TODO: should be (int, / ...) -> None
-    reveal_type(c)  # revealed: Unknown
+    reveal_type(c)  # revealed: (int, /, *args: Any, **kwargs: Any) -> None
 ```
 
 ## Imported

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -73,7 +73,7 @@ pub(crate) use crate::types::narrow::{
     infer_narrowing_constraint,
 };
 use crate::types::newtype::NewType;
-pub(crate) use crate::types::signatures::{Parameter, Parameters};
+pub(crate) use crate::types::signatures::{ConcatenateTail, Parameter, Parameters};
 use crate::types::signatures::{ParameterForm, walk_signature};
 use crate::types::tuple::{Tuple, TupleSpec, TupleSpecBuilder};
 use crate::types::typed_dict::TypedDictField;

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -57,7 +57,7 @@ use crate::semantic_index::scope::{
 use crate::semantic_index::symbol::{ScopedSymbolId, Symbol};
 use crate::semantic_index::{
     ApplicableConstraints, EnclosingSnapshotResult, SemanticIndex, attribute_assignments,
-    get_loop_header, place_table,
+    get_loop_header, place_table, semantic_index,
 };
 use crate::types::builder::RecursivelyDefined;
 use crate::types::call::bind::{CallableDescription, MatchingOverloadIndex};
@@ -128,16 +128,16 @@ use crate::types::typed_dict::{
 };
 use crate::types::{
     BoundTypeVarIdentity, BoundTypeVarInstance, CallDunderError, CallableBinding, CallableType,
-    CallableTypeKind, ClassType, DataclassParams, DynamicType, InternedConstraintSet, InternedType,
-    IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, KnownUnion,
-    LintDiagnosticGuard, LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy,
-    MetaclassCandidate, PEP695TypeAliasType, ParamSpecAttrKind, Parameter, ParameterForm,
-    Parameters, Signature, SpecialFormType, StaticClassLiteral, SubclassOfType, Truthiness, Type,
-    TypeAliasType, TypeAndQualifiers, TypeContext, TypeQualifiers, TypeVarBoundOrConstraints,
-    TypeVarBoundOrConstraintsEvaluation, TypeVarConstraints, TypeVarDefaultEvaluation,
-    TypeVarIdentity, TypeVarInstance, TypeVarKind, TypeVarVariance, TypedDictType, UnionBuilder,
-    UnionType, UnionTypeInstance, any_over_type, binding_type, definition_expression_type,
-    infer_complete_scope_types, infer_scope_types, todo_type,
+    CallableTypeKind, ClassType, ConcatenateTail, DataclassParams, DynamicType,
+    InternedConstraintSet, InternedType, IntersectionBuilder, IntersectionType, KnownClass,
+    KnownInstanceType, KnownUnion, LintDiagnosticGuard, LiteralValueType, LiteralValueTypeKind,
+    MemberLookupPolicy, MetaclassCandidate, PEP695TypeAliasType, ParamSpecAttrKind, Parameter,
+    ParameterForm, Parameters, Signature, SpecialFormType, StaticClassLiteral, SubclassOfType,
+    Truthiness, Type, TypeAliasType, TypeAndQualifiers, TypeContext, TypeQualifiers,
+    TypeVarBoundOrConstraints, TypeVarBoundOrConstraintsEvaluation, TypeVarConstraints,
+    TypeVarDefaultEvaluation, TypeVarIdentity, TypeVarInstance, TypeVarKind, TypeVarVariance,
+    TypedDictType, UnionBuilder, UnionType, UnionTypeInstance, any_over_type, binding_type,
+    definition_expression_type, infer_complete_scope_types, infer_scope_types, todo_type,
 };
 use crate::types::{CallableTypes, overrides};
 use crate::types::{ClassBase, add_inferred_python_version_hint_to_diagnostic};
@@ -4874,8 +4874,120 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 return Ok(Type::paramspec_value_callable(db, parameters));
             }
 
-            ast::Expr::Subscript(_) => {
-                // TODO: Support `Concatenate[...]`
+            ast::Expr::Subscript(subscript) => {
+                let value_ty = self.infer_expression(&subscript.value, TypeContext::default());
+
+                if matches!(value_ty, Type::SpecialForm(SpecialFormType::Concatenate)) {
+                    let arguments_slice = &*subscript.slice;
+                    let arguments = if let ast::Expr::Tuple(tuple) = arguments_slice {
+                        &*tuple.elts
+                    } else {
+                        std::slice::from_ref(arguments_slice)
+                    };
+
+                    let num_arguments = arguments.len();
+                    if num_arguments < 2 {
+                        for argument in arguments {
+                            self.infer_type_expression(argument);
+                        }
+                        if arguments_slice.is_tuple_expr() {
+                            self.store_expression_type(arguments_slice, Type::unknown());
+                        }
+                        return Ok(Type::paramspec_value_callable(
+                            db,
+                            Parameters::gradual_form(),
+                        ));
+                    }
+
+                    let (prefix_args, last_arg) = arguments.split_at(arguments.len() - 1);
+                    let last_arg = &last_arg[0];
+
+                    let mut params: Vec<Parameter<'db>> = Vec::with_capacity(num_arguments);
+                    for arg in prefix_args {
+                        let ty = self.infer_type_expression(arg);
+                        params.push(Parameter::positional_only(None).with_annotated_type(ty));
+                    }
+
+                    let result = match last_arg {
+                        ast::Expr::EllipsisLiteral(_) => {
+                            self.infer_type_expression(last_arg);
+                            params.push(
+                                Parameter::variadic(Name::new_static("args"))
+                                    .with_annotated_type(Type::Dynamic(DynamicType::Any)),
+                            );
+                            params.push(
+                                Parameter::keyword_variadic(Name::new_static("kwargs"))
+                                    .with_annotated_type(Type::Dynamic(DynamicType::Any)),
+                            );
+                            Some(
+                                Parameters::new(db, params)
+                                    .into_concatenate(ConcatenateTail::Gradual),
+                            )
+                        }
+                        ast::Expr::Name(name) if !name.is_invalid() => {
+                            let name_ty = self.infer_name_load(name);
+                            if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) =
+                                name_ty
+                                && typevar.is_paramspec(db)
+                            {
+                                let index = semantic_index(db, self.scope().file(db));
+                                if let Some(bound_typevar) = bind_typevar(
+                                    db,
+                                    index,
+                                    self.scope().file_scope_id(db),
+                                    self.typevar_binding_context,
+                                    typevar,
+                                ) {
+                                    params.push(
+                                        Parameter::variadic(Name::new_static("args"))
+                                            .with_annotated_type(Type::TypeVar(
+                                                bound_typevar.with_paramspec_attr(
+                                                    db,
+                                                    ParamSpecAttrKind::Args,
+                                                ),
+                                            )),
+                                    );
+                                    params.push(
+                                        Parameter::keyword_variadic(Name::new_static("kwargs"))
+                                            .with_annotated_type(Type::TypeVar(
+                                                bound_typevar.with_paramspec_attr(
+                                                    db,
+                                                    ParamSpecAttrKind::Kwargs,
+                                                ),
+                                            )),
+                                    );
+                                    Some(Parameters::new(db, params).into_concatenate(
+                                        ConcatenateTail::ParamSpec(bound_typevar),
+                                    ))
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None
+                            }
+                        }
+                        _ => {
+                            self.infer_type_expression(last_arg);
+                            None
+                        }
+                    };
+
+                    if arguments_slice.is_tuple_expr() {
+                        let inferred_type = if result.is_some() {
+                            todo_type!("`Concatenate[]` special form")
+                        } else {
+                            Type::unknown()
+                        };
+                        self.store_expression_type(arguments_slice, inferred_type);
+                    }
+
+                    return Ok(Type::paramspec_value_callable(
+                        db,
+                        result.unwrap_or_else(Parameters::todo),
+                    ));
+                }
+
+                // Non-Concatenate subscript: fall back to todo
                 return Ok(Type::paramspec_value_callable(db, Parameters::todo()));
             }
 
@@ -16033,56 +16145,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ));
             }
             Type::SpecialForm(SpecialFormType::Callable) => {
-                let arguments = if let ast::Expr::Tuple(tuple) = &*subscript.slice {
-                    &*tuple.elts
-                } else {
-                    std::slice::from_ref(&*subscript.slice)
-                };
-
-                // TODO: Remove this once we support Concatenate properly. This is necessary
-                // to avoid a lot of false positives downstream, because we can't represent the typevar-
-                // specialized `Callable` types yet.
-                let num_arguments = arguments.len();
-                if num_arguments == 2 {
-                    let first_arg = &arguments[0];
-                    let second_arg = &arguments[1];
-
-                    if first_arg.is_subscript_expr() {
-                        let first_arg_ty = self.infer_expression(first_arg, TypeContext::default());
-                        if let Type::Dynamic(DynamicType::UnknownGeneric(generic_context)) =
-                            first_arg_ty
-                        {
-                            let mut variables = generic_context
-                                .variables(self.db())
-                                .collect::<FxOrderSet<_>>();
-
-                            let return_ty =
-                                self.infer_expression(second_arg, TypeContext::default());
-                            return_ty.bind_and_find_all_legacy_typevars(
-                                self.db(),
-                                self.typevar_binding_context,
-                                &mut variables,
-                            );
-
-                            let generic_context =
-                                GenericContext::from_typevar_instances(self.db(), variables);
-                            return Type::Dynamic(DynamicType::UnknownGeneric(generic_context));
-                        }
-
-                        if let Some(builder) =
-                            self.context.report_lint(&INVALID_TYPE_FORM, subscript)
-                        {
-                            builder.into_diagnostic(format_args!(
-                                "The first argument to `Callable` must be either a list of types, \
-                                     ParamSpec, Concatenate, or `...`",
-                            ));
-                        }
-                        return Type::KnownInstance(KnownInstanceType::Callable(
-                            CallableType::unknown(self.db()),
-                        ));
-                    }
-                }
-
                 let callable = self
                     .infer_callable_type(subscript)
                     .as_callable()

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1349,12 +1349,36 @@ impl<'db> Signature<'db> {
         // If either of the parameter lists is gradual (`...`), then it is assignable to and from
         // any other parameter list, but not a subtype or supertype of any other parameter list.
         if self.parameters.is_gradual() || other.parameters.is_gradual() {
-            result.intersect(
-                db,
-                ConstraintSet::from(
-                    relation.is_assignability() || relation.is_constraint_set_assignability(),
-                ),
+            if !(relation.is_assignability() || relation.is_constraint_set_assignability()) {
+                return ConstraintSet::from(false);
+            }
+
+            // For Concatenate[T, ...] forms, check that the prefix params are compatible.
+            // The prefix params precede the *args/**kwargs gradual tail, so prefix_len = total_params - 2.
+            let self_is_concat_gradual = matches!(
+                self.parameters.kind(),
+                ParametersKind::Concatenate(ConcatenateTail::Gradual)
             );
+            let other_is_concat_gradual = matches!(
+                other.parameters.kind(),
+                ParametersKind::Concatenate(ConcatenateTail::Gradual)
+            );
+
+            if self_is_concat_gradual && other_is_concat_gradual {
+                let self_prefix_len = self.parameters.len() - 2;
+                let other_prefix_len = other.parameters.len() - 2;
+                let common = self_prefix_len.min(other_prefix_len);
+                for i in 0..common {
+                    // Parameters are contravariant
+                    if !check_types(
+                        other.parameters.as_slice()[i].annotated_type(),
+                        self.parameters.as_slice()[i].annotated_type(),
+                    ) {
+                        return result;
+                    }
+                }
+            }
+
             return result;
         }
 
@@ -1416,7 +1440,100 @@ impl<'db> Signature<'db> {
                     return result;
                 }
 
-                (None, None) => {}
+                (None, None) => {
+                    // Check for Concatenate-style signatures: prefix params followed by
+                    // *P.args, **P.kwargs. These are not detected by as_paramspec() because
+                    // the prefix params change the ParametersKind from ParamSpec to Standard.
+
+                    // Case: `other` has Concatenate pattern, `self` is concrete
+                    if let Some((other_prefix, other_paramspec)) =
+                        other.parameters.find_paramspec_from_args_kwargs(db)
+                        && !other_prefix.is_empty()
+                    {
+                        let self_params = self.parameters.as_slice();
+                        if self_params.len() >= other_prefix.len() {
+                            // Check prefix param types (contravariant)
+                            for (other_param, self_param) in
+                                other_prefix.iter().zip(self_params.iter())
+                            {
+                                result.intersect(
+                                    db,
+                                    other_param.annotated_type().has_relation_to_impl(
+                                        db,
+                                        self_param.annotated_type(),
+                                        inferable,
+                                        relation,
+                                        relation_visitor,
+                                        disjointness_visitor,
+                                    ),
+                                );
+                            }
+
+                            // Bind the ParamSpec to the remaining self params
+                            let remaining_params = &self_params[other_prefix.len()..];
+                            let lower = Type::Callable(CallableType::new(
+                                db,
+                                CallableSignature::single(Signature::new(
+                                    Parameters::new(db, remaining_params.iter().cloned()),
+                                    Type::unknown(),
+                                )),
+                                CallableTypeKind::ParamSpecValue,
+                            ));
+                            let param_spec_matches = ConstraintSet::constrain_typevar(
+                                db,
+                                other_paramspec,
+                                lower,
+                                Type::object(),
+                            );
+                            result.intersect(db, param_spec_matches);
+                            return result;
+                        }
+                    }
+
+                    // Case: `self` has Concatenate pattern, `other` is concrete
+                    if let Some((self_prefix, self_paramspec)) =
+                        self.parameters.find_paramspec_from_args_kwargs(db)
+                        && !self_prefix.is_empty()
+                    {
+                        let other_params = other.parameters.as_slice();
+                        if other_params.len() >= self_prefix.len() {
+                            // Check prefix param types (contravariant)
+                            for (self_param, other_param) in
+                                self_prefix.iter().zip(other_params.iter())
+                            {
+                                result.intersect(
+                                    db,
+                                    self_param.annotated_type().has_relation_to_impl(
+                                        db,
+                                        other_param.annotated_type(),
+                                        inferable,
+                                        relation,
+                                        relation_visitor,
+                                        disjointness_visitor,
+                                    ),
+                                );
+                            }
+
+                            let remaining_params = &other_params[self_prefix.len()..];
+                            let upper = Type::Callable(CallableType::new(
+                                db,
+                                CallableSignature::single(Signature::new(
+                                    Parameters::new(db, remaining_params.iter().cloned()),
+                                    Type::unknown(),
+                                )),
+                                CallableTypeKind::ParamSpecValue,
+                            ));
+                            let param_spec_matches = ConstraintSet::constrain_typevar(
+                                db,
+                                self_paramspec,
+                                Type::Never,
+                                upper,
+                            );
+                            result.intersect(db, param_spec_matches);
+                            return result;
+                        }
+                    }
+                }
             }
         }
 
@@ -1741,9 +1858,14 @@ impl<'db> VarianceInferable<'db> for &Signature<'db> {
     }
 }
 
-// TODO: the spec also allows signatures like `Concatenate[int, ...]` or `Concatenate[int, P]`,
-// which have some number of required positional-only parameters followed by a gradual form or a
-// `ParamSpec`. Our representation will need some adjustments to represent that.
+/// The tail of a `Concatenate[T, ..., tail]` form.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+pub(crate) enum ConcatenateTail<'db> {
+    /// `Concatenate[T, ...]` — prefix params followed by a gradual `*args: Any, **kwargs: Any`.
+    Gradual,
+    /// `Concatenate[T, P]` — prefix params followed by a `ParamSpec`.
+    ParamSpec(BoundTypeVarInstance<'db>),
+}
 
 /// The kind of parameter list represented.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
@@ -1777,6 +1899,10 @@ pub(crate) enum ParametersKind<'db> {
     // TODO: Maybe we should use `find_paramspec_from_args_kwargs` instead of storing the typevar
     // here?
     ParamSpec(BoundTypeVarInstance<'db>),
+
+    /// Represents a `Concatenate[T, ..., tail]` form: some number of required positional-only
+    /// prefix parameters followed by either a gradual form or a `ParamSpec`.
+    Concatenate(ConcatenateTail<'db>),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
@@ -1846,7 +1972,19 @@ impl<'db> Parameters<'db> {
     }
 
     pub(crate) const fn is_gradual(&self) -> bool {
-        matches!(self.kind, ParametersKind::Gradual)
+        matches!(
+            self.kind,
+            ParametersKind::Gradual | ParametersKind::Concatenate(ConcatenateTail::Gradual)
+        )
+    }
+
+    /// Set the kind to `Concatenate(tail)`, used for `Concatenate[T, ..., tail]` forms where
+    /// prefix parameters precede either a gradual or `ParamSpec` suffix.
+    pub(crate) fn into_concatenate(self, tail: ConcatenateTail<'db>) -> Self {
+        Self {
+            kind: ParametersKind::Concatenate(tail),
+            ..self
+        }
     }
 
     pub(crate) const fn is_top(&self) -> bool {
@@ -2116,7 +2254,10 @@ impl<'db> Parameters<'db> {
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         if let TypeMapping::Materialize(materialization_kind) = type_mapping
-            && self.kind == ParametersKind::Gradual
+            && matches!(
+                self.kind,
+                ParametersKind::Gradual | ParametersKind::Concatenate(ConcatenateTail::Gradual)
+            )
         {
             match materialization_kind {
                 MaterializationKind::Bottom => {


### PR DESCRIPTION
## Summary

Implements basic `Concatenate[T, P]` support in ty, replacing three `todo_type!()` / `Parameters::todo()` stubs with real parameter extraction. This eliminates false positive `missing-argument` and `invalid-return-type` errors when decorators use `Concatenate` to strip prefix parameters.

### Changes

- **Parsing** (`type_expression.rs`, `builder.rs`): Extract prefix types from `Concatenate[...]` as positional-only parameters, with the last argument handled as either `...` (gradual form) or a `ParamSpec`. Applied in both `infer_callable_parameter_types` and `infer_paramspec_explicit_specialization_value`.
- **Constraint matching** (`signatures.rs`): Detect Concatenate-style parameter lists (`[prefix..., *P.args, **P.kwargs]`) via `find_paramspec_from_args_kwargs`, match prefix types, and bind the `ParamSpec` to remaining parameters. Added `Parameters::into_gradual()` for the `Concatenate[T, ...]` form.
- **Display** (`display.rs`): Show prefix parameters in gradual Concatenate forms instead of collapsing to `(...)`.
- **Workaround removal** (`builder.rs`): Remove the `Callable[<subscript>, ...]` → `UnknownGeneric` short-circuit.

### Known regression

`abstractclassmethod.__init__` uses `Callable[Concatenate[type[_T], _P], _R_co]` in typeshed. With Concatenate now producing real types, this surfaces a pre-existing false positive (tracked with a TODO in `final.md`).

## Test Plan

- New `generics/concatenate.md` with tests for gradual form, ParamSpec form, decorator stripping, and multiple prefix parameters
- Updated expectations in `callable.md`, `paramspec.md`, `pep613_type_aliases.md`, and `final.md`