### PR TITLE
[ty] Configure check mode for all projects

### DIFF
--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -24,6 +24,7 @@ use crate::system::{AnySystemPath, file_to_url};
 use crate::{DIAGNOSTIC_NAME, Db, DiagnosticMode};
 use crate::{PositionEncoding, Session};
 
+#[derive(Debug)]
 pub(super) struct Diagnostics {
     items: Vec<ruff_db::diagnostic::Diagnostic>,
     encoding: PositionEncoding,

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -24,7 +24,7 @@ use ruff_python_ast::PySourceType;
 use ty_combine::Combine;
 use ty_project::metadata::Options;
 use ty_project::watch::{ChangeEvent, CreatedKind};
-use ty_project::{ChangeResult, CheckMode, Db as _, ProjectDatabase, ProjectMetadata};
+use ty_project::{ChangeResult, Db as _, ProjectDatabase, ProjectMetadata};
 
 use index::DocumentError;
 use ty_python_semantic::MisconfigurationMode;
@@ -530,12 +530,12 @@ impl Session {
 
         if let Some(global_options) = global_options {
             let global_settings = global_options.into_settings();
-            if global_settings.diagnostic_mode().is_workspace() {
-                for project in self.projects.values_mut() {
-                    project.db.set_check_mode(CheckMode::AllFiles);
-                }
-            }
             self.global_settings = Arc::new(global_settings);
+        }
+        if let Some(check_mode) = self.global_settings.diagnostic_mode().to_check_mode() {
+            for project in self.projects.values_mut() {
+                project.db.set_check_mode(check_mode);
+            }
         }
 
         self.register_capabilities(client);

--- a/crates/ty_server/src/session/options.rs
+++ b/crates/ty_server/src/session/options.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use ty_combine::Combine;
 use ty_ide::{CompletionSettings, InlayHintSettings};
+use ty_project::CheckMode;
 use ty_project::metadata::Options as TyOptions;
 use ty_project::metadata::options::ProjectOptionsOverrides;
 use ty_project::metadata::value::{RangedValue, RelativePathBuf, ValueSource};
@@ -367,6 +368,17 @@ impl DiagnosticMode {
     /// Returns `true` if the diagnostic mode is set to check only currently open files.
     pub(crate) const fn is_open_files_only(self) -> bool {
         matches!(self, DiagnosticMode::OpenFilesOnly)
+    }
+
+    /// Returns this diagnostic mode as a check mode.
+    ///
+    /// This returns `None` when diagnostics are disabled.
+    pub(crate) const fn to_check_mode(self) -> Option<CheckMode> {
+        match self {
+            DiagnosticMode::Off => None,
+            DiagnosticMode::OpenFilesOnly => Some(CheckMode::OpenFiles),
+            DiagnosticMode::Workspace => Some(CheckMode::AllFiles),
+        }
     }
 
     pub(crate) const fn is_off(self) -> bool {

--- a/crates/ty_server/tests/e2e/publish_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/publish_diagnostics.rs
@@ -326,8 +326,6 @@ def foo() -> str:
         },
     };
     server.send_notification::<DidOpenTextDocument>(params);
-    let _close_diagnostics = server.await_notification::<PublishDiagnostics>();
-
     let diagnostics = server.await_notification::<PublishDiagnostics>();
 
     insta::assert_debug_snapshot!(diagnostics);

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__changing_language_of_file_without_extension-2.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__changing_language_of_file_without_extension-2.snap
@@ -15,7 +15,5 @@ PublishDiagnosticsParams {
         fragment: None,
     },
     diagnostics: [],
-    version: Some(
-        1,
-    ),
+    version: None,
 }


### PR DESCRIPTION
Previously, we were only setting the check mode on a project if the
diagnostic mode was `workspace`. While the diagnostic mode defaults to
`OpenFilesOnly`, the _check mode_ on a ty project defaults to `AllFiles`
(i.e., workspace).

The result is that projects were always configured in `AllFiles` check
mode, making it impossible to set the check mode to `OpenFilesOnly`.
Confusingly, this is _distinct_ from the global settings diagnostic
mode, which could actually be different thant he check mode on the
individual projects!

This did cause one test failure: an end-to-end test checking that
changing the language of a file resulted in the LSP picking up that
change. e.g., Going from Python to non-Python should result in no
diagnostics. This was added in #21867, but I believe the change was
incomplete: when a `didOpen` notification is received, we were
unconditionally adding the file to the project state without checking
its extension. The test still "worked" precisely because of the
`AllFiles` vs `OpenFilesOnly` confusion. That is, the server defaulted
to `OpenFilesOnly`, but the project defaulted to `AllFiles`. This in
turn made it so the file was an "open file" and not actually picked up
from a directory scan. That in turn led to `should_check_file` returning
false, since the `AllFiles` mode explicitly ignores "open files."

Ref astral-sh/ty#2616
