### PR TITLE
[ty] support complex format chars for `struct.unpack`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/struct_unpack.md
+++ b/crates/ty_python_semantic/resources/mdtest/struct_unpack.md
@@ -35,6 +35,21 @@ def _(buf: bytes):
     reveal_type(unpack("@P4x", buf))  # revealed: tuple[int]
 ```
 
+Support for format characters for complex numbers was added in Python 3.14:
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+from struct import *
+
+def _(buf: bytes):
+    reveal_type(unpack("2F", buf))  # revealed: tuple[complex, complex]
+    reveal_type(unpack("3D", buf))  # revealed: tuple[complex, complex, complex]
+```
+
 ## Escape Large Repetition Counts
 
 ```py

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5019,6 +5019,9 @@ fn parse_struct_format<'db>(db: &'db dyn Db, format_string: &str) -> Option<Vec<
             }
             '?' => (KnownClass::Bool.to_instance(db), count),
             'e' | 'f' | 'd' => (KnownClass::Float.to_instance(db), count),
+            'F' | 'D' if Program::get(db).python_version(db) >= PythonVersion::PY314 => {
+                (KnownClass::Complex.to_instance(db), count)
+            }
             _ => return None,
         };
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Recently the `D` and `F` format characters for complex types were added to `struct.unpack()`.

See the following links for details:

- https://docs.python.org/3/whatsnew/3.14.html#struct
- https://docs.python.org/3/library/struct.html#format-characters

This adds support for these new formats when using Python 3.14+

Refs https://github.com/astral-sh/ty/issues/2437
Refs https://github.com/astral-sh/ruff/pull/22562

## Test Plan

Update to existing mdtest.
