### PR TITLE
[`pyupgrade`] Fix handling of `typing.{io,re}` (`UP035`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
@@ -117,3 +117,18 @@ from typing_extensions import get_type_hints
 from typing_extensions import is_typeddict
 # https://github.com/astral-sh/ruff/pull/15800#pullrequestreview-2580704217
 from typing_extensions import TypedDict
+
+# UP035 on py37+ only
+from typing.io import BinaryIO
+
+# UP035 on py37+ only
+from typing.io import IO
+
+# UP035 on py37+ only
+from typing.io import TextIO
+
+# UP035 on py37+ only
+from typing.re import Match
+
+# UP035 on py37+ only
+from typing.re import Pattern

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
@@ -1163,3 +1163,93 @@ help: Import from `typing`
 115 | 
 116 | # https://github.com/astral-sh/ruff/issues/15780
 117 | from typing_extensions import is_typeddict
+
+UP035 [*] Import from `typing` instead: `BinaryIO`
+   --> UP035.py:122:1
+    |
+121 | # UP035 on py37+ only
+122 | from typing.io import BinaryIO
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+123 |
+124 | # UP035 on py37+ only
+    |
+help: Import from `typing`
+119 | from typing_extensions import TypedDict
+120 | 
+121 | # UP035 on py37+ only
+    - from typing.io import BinaryIO
+122 + from typing import BinaryIO
+123 | 
+124 | # UP035 on py37+ only
+125 | from typing.io import IO
+
+UP035 [*] Import from `typing` instead: `IO`
+   --> UP035.py:125:1
+    |
+124 | # UP035 on py37+ only
+125 | from typing.io import IO
+    | ^^^^^^^^^^^^^^^^^^^^^^^^
+126 |
+127 | # UP035 on py37+ only
+    |
+help: Import from `typing`
+122 | from typing.io import BinaryIO
+123 | 
+124 | # UP035 on py37+ only
+    - from typing.io import IO
+125 + from typing import IO
+126 | 
+127 | # UP035 on py37+ only
+128 | from typing.io import TextIO
+
+UP035 [*] Import from `typing` instead: `TextIO`
+   --> UP035.py:128:1
+    |
+127 | # UP035 on py37+ only
+128 | from typing.io import TextIO
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+129 |
+130 | # UP035 on py37+ only
+    |
+help: Import from `typing`
+125 | from typing.io import IO
+126 | 
+127 | # UP035 on py37+ only
+    - from typing.io import TextIO
+128 + from typing import TextIO
+129 | 
+130 | # UP035 on py37+ only
+131 | from typing.re import Match
+
+UP035 [*] Import from `re` instead: `Match`
+   --> UP035.py:131:1
+    |
+130 | # UP035 on py37+ only
+131 | from typing.re import Match
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+132 |
+133 | # UP035 on py37+ only
+    |
+help: Import from `re`
+128 | from typing.io import TextIO
+129 | 
+130 | # UP035 on py37+ only
+    - from typing.re import Match
+131 + from re import Match
+132 | 
+133 | # UP035 on py37+ only
+134 | from typing.re import Pattern
+
+UP035 [*] Import from `re` instead: `Pattern`
+   --> UP035.py:134:1
+    |
+133 | # UP035 on py37+ only
+134 | from typing.re import Pattern
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+help: Import from `re`
+131 | from typing.re import Match
+132 | 
+133 | # UP035 on py37+ only
+    - from typing.re import Pattern
+134 + from re import Pattern


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Back in Python 3.5, the docs referred to `typing.io` as the primary location for `IO`, `TextIO`, and `BinaryIO` and `typing.re` as the primary location for `Pattern` and `Match`:

- https://docs.python.org/3.5/library/typing.html#typing.io
- https://docs.python.org/3.5/library/typing.html#typing.re

In Python 3.6, reference to `typing.io` and `typing.re` disappeared and these types were importable directly from `typing`:

- https://docs.python.org/3.6/library/typing.html#typing.IO
- https://docs.python.org/3.6/library/typing.html#typing.Pattern

In Python 3.9, the `typing.io` and `typing.re` namespaces were deprecated pending removal in Python 3.12. In addition, `typing.Pattern` and `typing.Match` were deprecated in favour of `re.Pattern` and `re.Match`:

- https://docs.python.org/3.9/library/typing.html#typing.IO
- https://docs.python.org/3.9/library/typing.html#typing.Pattern

Although interestingly it implies that the deprecation of the namespaces was from Python 3.8.

The pending removal version for the namespaces was updated from 3.12 to 3.13 as the deprecation warning was only in place from 3.11 - that update was backported through 3.10:

- https://docs.python.org/3.10/library/typing.html#typing.IO
- https://docs.python.org/3.10/library/typing.html#typing.Pattern

The namespaces were removed in Python 3.13:

- https://docs.python.org/3.13/library/typing.html#typing.IO
- https://docs.python.org/3.13/library/typing.html#typing.Pattern

On this basis, it seems we could update `UP035` for the `typing.io` and `typing.re` namespaces to target as far back as Python 3.6 as they weren't even mentioned in the docs for Python 3.6 to 3.8 and only mentioned again when soft deprecated in Python 3.9. The versions of these types in the main `typing` module have been available the whole time. As ruff only targets 3.7+, let's go for 3.7.

## Test Plan

<!-- How was it tested? -->

Updated snapshots.