### PR TITLE
Add `home-assistant` to ecosystem projects

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -151,4 +151,5 @@ DEFAULT_TARGETS = [
     ),
     Project(repo=Repository(owner="pdm-project", name="pdm", ref="main")),
     Project(repo=Repository(owner="astropy", name="astropy", ref="main")),
+    Project(repo=Repository(owner="home-assistant", name="core", ref="dev")),
 ]


### PR DESCRIPTION
Summary
--

I think Micha suggested this before, but I couldn't find the message. This also
may have helped to catch #23125.

Test Plan
--

CI on this PR. I think this is a pretty large repo, so I want to make sure it
doesn't cause too much of a slowdown, in addition to the job passing. However,
it only takes ~4 seconds to check locally compared to ~22 for airflow, despite
containing more files (16k vs 6.5k) and more lines of code (3 million vs 1.2
million).
