### PR TITLE
[`numpydoc`] wrong-section-order (`NPD007`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/numpydoc/NPD007.py
+++ b/crates/ruff_linter/resources/test/fixtures/numpydoc/NPD007.py
@@ -1,0 +1,257 @@
+"""Test cases for NPD007 (numpydoc GL07) - section ordering."""
+
+
+def correct_order():
+    """Calculate something.
+
+    Parameters
+    ----------
+    x : int
+        Input value.
+
+    Returns
+    -------
+    int
+        Output value.
+
+    Examples
+    --------
+    >>> correct_order()
+    42
+    """
+    return 42
+
+
+def wrong_order_returns_before_parameters():  # NPD007
+    """Calculate something.
+
+    Returns
+    -------
+    int
+        Output value.
+
+    Parameters
+    ----------
+    x : int
+        Input value.
+    """
+    return 42
+
+
+def wrong_order_examples_before_returns():  # NPD007
+    """Calculate something.
+
+    Parameters
+    ----------
+    x : int
+        Input value.
+
+    Examples
+    --------
+    >>> wrong_order_examples_before_returns()
+    42
+
+    Returns
+    -------
+    int
+        Output value.
+    """
+    return 42
+
+
+def wrong_order_notes_before_see_also():  # NPD007
+    """Calculate something.
+
+    Parameters
+    ----------
+    x : int
+        Input value.
+
+    Notes
+    -----
+    Some notes here.
+
+    See Also
+    --------
+    other_function : Related function.
+
+    Returns
+    -------
+    int
+        Output value.
+    """
+    return 42
+
+
+def correct_order_with_raises():
+    """Calculate something.
+
+    Parameters
+    ----------
+    x : int
+        Input value.
+
+    Returns
+    -------
+    int
+        Output value.
+
+    Raises
+    ------
+    ValueError
+        If x is negative.
+
+    See Also
+    --------
+    other_function : Related function.
+
+    Notes
+    -----
+    Some notes here.
+
+    Examples
+    --------
+    >>> correct_order_with_raises()
+    42
+    """
+    return 42
+
+
+def correct_order_minimal():
+    """Calculate something.
+
+    Returns
+    -------
+    int
+        Output value.
+    """
+    return 42
+
+
+def wrong_order_see_also_before_raises():  # NPD007
+    """Calculate something.
+
+    Parameters
+    ----------
+    x : int
+        Input value.
+
+    Returns
+    -------
+    int
+        Output value.
+
+    See Also
+    --------
+    other_function : Related function.
+
+    Raises
+    ------
+    ValueError
+        If x is negative.
+    """
+    return 42
+
+
+def wrong_order_multiple():  # NPD007
+    """Calculate something.
+
+    Raises
+    ------
+    ValueError
+        If x is negative.
+
+    See Also
+    --------
+    other_function : Related function.
+
+    Returns
+    -------
+    int
+        Output value.
+
+    Parameters
+    ----------
+    x : int
+        Input value.
+
+    """
+    return 42
+
+
+def google_style_wrong_order():
+    """Calculate something.
+
+    Returns:
+        int: Output value.
+
+    Args:
+        x (int): Input value.
+    """
+    return 42
+
+
+def single_section_only():
+    """Calculate something.
+
+    Returns
+    -------
+    int
+        Output value.
+    """
+    return 42
+
+
+def no_sections():
+    """Just a simple docstring with no sections at all."""
+    return 42
+
+
+def complex_content_wrong_order():  # NPD007
+    """Calculate something complex.
+
+    Examples
+    --------
+    Here's how to use it:
+
+    >>> result = complex_content_wrong_order(5)
+    >>> print(result)
+    10
+
+    You can also do:
+    >>> complex_content_wrong_order(-1)
+    0
+
+    Parameters
+    ----------
+    x : int
+        The input value.
+        Can be positive or negative.
+        Multiple lines of description here.
+
+    Returns
+    -------
+    int
+        The output value.
+        This is also multi-line.
+    """
+    return max(0, x * 2)
+
+
+def extra_text_between_sections():  # NPD007
+    """Calculate something.
+
+    Returns
+    -------
+    int
+        Output value.
+
+    This is some random text that appears between sections.
+    It's not part of any official section.
+
+    Parameters
+    ----------
+    x : int
+        Input value.
+    """
+    return 42

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -986,6 +986,9 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Numpy, "003") => rules::numpy::rules::NumpyDeprecatedFunction,
         (Numpy, "201") => rules::numpy::rules::Numpy2Deprecation,
 
+        // numpydoc
+        (Numpydoc, "007") => rules::numpydoc::rules::WrongSectionOrder,
+
         // fastapi
         (FastApi, "001") => rules::fastapi::rules::FastApiRedundantResponseModel,
         (FastApi, "002") => rules::fastapi::rules::FastApiNonAnnotatedDependency,

--- a/crates/ruff_linter/src/registry.rs
+++ b/crates/ruff_linter/src/registry.rs
@@ -172,6 +172,9 @@ pub enum Linter {
     /// NumPy-specific rules
     #[prefix = "NPY"]
     Numpy,
+    /// [numpydoc](https://numpydoc.readthedocs.io/)
+    #[prefix = "NPD"]
+    Numpydoc,
     /// [pandas-vet](https://pypi.org/project/pandas-vet/)
     #[prefix = "PD"]
     PandasVet,

--- a/crates/ruff_linter/src/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/mod.rs
@@ -44,6 +44,7 @@ pub mod flynt;
 pub mod isort;
 pub mod mccabe;
 pub mod numpy;
+pub mod numpydoc;
 pub mod pandas_vet;
 pub mod pep8_naming;
 pub mod perflint;

--- a/crates/ruff_linter/src/rules/numpydoc/mod.rs
+++ b/crates/ruff_linter/src/rules/numpydoc/mod.rs
@@ -1,0 +1,25 @@
+//! Numpydoc docstring validation rules.
+pub(crate) mod rules;
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use anyhow::Result;
+    use test_case::test_case;
+
+    use crate::registry::Rule;
+    use crate::test::test_path;
+    use crate::{assert_diagnostics, settings};
+
+    #[test_case(Rule::WrongSectionOrder, Path::new("NPD007.py"))]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!("{}_{}", rule_code.name(), path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("numpydoc").join(path).as_path(),
+            &settings::LinterSettings::for_rule(rule_code),
+        )?;
+        assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
+}

--- a/crates/ruff_linter/src/rules/numpydoc/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/numpydoc/rules/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) use wrong_section_order::*;
+
+mod wrong_section_order;

--- a/crates/ruff_linter/src/rules/numpydoc/rules/wrong_section_order.rs
+++ b/crates/ruff_linter/src/rules/numpydoc/rules/wrong_section_order.rs
@@ -1,0 +1,186 @@
+use itertools::Itertools;
+use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_text_size::Ranged;
+
+use crate::checkers::ast::Checker;
+use crate::docstrings::sections::{SectionContext, SectionContexts, SectionKind};
+use crate::docstrings::Docstring;
+use crate::{AlwaysFixableViolation, Edit, Fix};
+
+/// ## What it does
+/// Checks that sections in a numpydoc docstring are in the correct order.
+///
+/// ## Why is this bad?
+/// Numpydoc style guidelines require that docstring sections appear in a specific
+/// order to maintain consistency across documentation. Out-of-order sections can
+/// make documentation harder to read and maintain.
+///
+/// ## Example
+/// ```python
+/// def foo(a: float) -> float:
+///     """Calculate b.
+///
+///     Returns
+///     -------
+///     float
+///         Speed as distance divided by time.
+///
+///     Parameters
+///     ----------
+///     distance : float
+///         Distance traveled.
+///     time : float
+///         Time spent traveling.
+///     """
+///     return distance / time
+/// ```
+///
+/// Use instead:
+/// ```python
+/// def calculate_speed(distance: float, time: float) -> float:
+///     """Calculate speed as distance divided by time.
+///
+///     Parameters
+///     ----------
+///     distance : float
+///         Distance traveled.
+///     time : float
+///         Time spent traveling.
+///
+///     Returns
+///     -------
+///     float
+///         Speed as distance divided by time.
+///     """
+///     return distance / time
+/// ```
+///
+/// ## References
+/// - [Numpydoc Style Guide](https://numpydoc.readthedocs.io/en/latest/format.html)
+/// - [Numpydoc Validation](https://numpydoc.readthedocs.io/en/latest/validation.html#built-in-validation-checks)
+#[derive(ViolationMetadata)]
+#[violation_metadata(preview_since = "1.0.0")]
+pub(crate) struct WrongSectionOrder {
+    section_name: String,
+    expected_order: Vec<String>,
+}
+
+impl AlwaysFixableViolation for WrongSectionOrder {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let WrongSectionOrder { section_name, expected_order } = self;
+        let expected_sections = expected_order.join(", ");
+        format!(
+            "Sections are in the wrong order (\"{section_name}\" out of place). Correct order is: {expected_sections}"
+        )
+    }
+
+    fn fix_title(&self) -> String {
+        "Reorder sections to match numpydoc convention".to_string()
+    }
+}
+
+/// Returns the expected position of a section kind in numpydoc order.
+fn expected_position(kind: SectionKind) -> Option<usize> {
+    match kind {
+        SectionKind::ShortSummary => Some(0),
+        // Note: DeprecationWarning is not a SectionKind yet, it would be position 1
+        SectionKind::ExtendedSummary => Some(2),
+        SectionKind::Parameters => Some(3),
+        SectionKind::Returns => Some(4),
+        SectionKind::Yields => Some(5),
+        SectionKind::Receives => Some(6),
+        SectionKind::OtherParameters | SectionKind::OtherParams => Some(7),
+        SectionKind::Raises => Some(8),
+        SectionKind::Warns => Some(9),
+        SectionKind::Warnings => Some(10),
+        SectionKind::SeeAlso => Some(11),
+        SectionKind::Notes => Some(12),
+        SectionKind::References => Some(13),
+        SectionKind::Examples => Some(14),
+        _ => None,
+    }
+}
+
+/// NPD007
+pub(crate) fn wrong_section_order(
+    checker: &Checker,
+    docstring: &Docstring,
+    section_contexts: &SectionContexts,
+) {
+    let sections: Vec<(SectionContext, usize)> = section_contexts
+        .iter()
+        .filter_map(|context| {
+            expected_position(context.kind()).map(|pos| (context, pos))
+        })
+        .collect();
+
+    // Find the first out-of-order section
+    let Some(window) = sections
+        .windows(2)
+        .find(|window| window[0].1 > window[1].1)
+    else {
+        return; // All sections are in correct order
+    };
+
+    let out_of_order_section = &window[0].0;
+
+    let expected_order: Vec<String> = sections
+        .iter()
+        .map(|(ctx, _)| ctx.kind().as_str().to_string())
+        .sorted_by_key(|name| {
+            SectionKind::from_str(name)
+                .and_then(expected_position)
+                .unwrap_or(usize::MAX)
+        })
+        .collect();
+
+    let mut diagnostic = checker.report_diagnostic(
+        WrongSectionOrder {
+            section_name: out_of_order_section.section_name().to_string(),
+            expected_order,
+        },
+        out_of_order_section.section_name_range(),
+    );
+
+    if let Some(fix) = generate_fix(docstring, &sections) {
+        diagnostic.set_fix(fix);
+    }
+}
+
+/// Generate a fix that reorders the sections in the correct order.
+fn generate_fix(
+    docstring: &Docstring,
+    sections: &[(SectionContext, usize)],
+) -> Option<Fix> {
+    let body = docstring.body();
+    let section_text = |ctx: &SectionContext| {
+        let start = (ctx.range().start() - body.start()).to_usize();
+        let end = (ctx.range().end() - body.start()).to_usize();
+        &body.as_str()[start..end]
+    };
+
+    let (last_section_idx, trailing_whitespace) = {
+        let (idx, (ctx, _)) = sections
+            .iter()
+            .enumerate()
+            .max_by_key(|(_, (ctx, _))| ctx.range().end())?;
+
+        let text = section_text(ctx);
+        (idx, &text[text.trim_end().len()..])
+    };
+
+    let replacement = sections
+        .iter()
+        .map(|(ctx, expected_pos)| (section_text(ctx).trim_end(), *expected_pos))
+        .sorted_by_key(|(_, pos)| *pos)
+        .map(|(text, _)| text)
+        .join("\n\n")
+        + trailing_whitespace;
+
+    Some(Fix::safe_edit(Edit::replacement(
+        replacement,
+        sections[0].0.range().start(),
+        sections[last_section_idx].0.range().end(),
+    )))
+}

--- a/crates/ruff_linter/src/rules/numpydoc/snapshots/ruff_linter__rules__numpydoc__tests__wrong-section-order_NPD007.py.snap
+++ b/crates/ruff_linter/src/rules/numpydoc/snapshots/ruff_linter__rules__numpydoc__tests__wrong-section-order_NPD007.py.snap
@@ -1,0 +1,261 @@
+---
+source: crates/ruff_linter/src/rules/numpydoc/mod.rs
+---
+NPD007 [*] Sections are in the wrong order ("Returns" out of place). Correct order is: Parameters, Returns
+  --> NPD007.py:28:5
+   |
+26 |     """Calculate something.
+27 |
+28 |     Returns
+   |     ^^^^^^^
+29 |     -------
+30 |     int
+   |
+help: Reorder sections to match numpydoc convention
+25 | def wrong_order_returns_before_parameters():  # NPD007
+26 |     """Calculate something.
+27 | 
+28 +     Parameters
+29 +     ----------
+30 +     x : int
+31 +         Input value.
+32 + 
+33 |     Returns
+34 |     -------
+35 |     int
+36 |         Output value.
+   - 
+   -     Parameters
+   -     ----------
+   -     x : int
+   -         Input value.
+37 |     """
+38 |     return 42
+39 | 
+
+NPD007 [*] Sections are in the wrong order ("Examples" out of place). Correct order is: Parameters, Returns, Examples
+  --> NPD007.py:49:5
+   |
+47 |         Input value.
+48 |
+49 |     Examples
+   |     ^^^^^^^^
+50 |     --------
+51 |     >>> wrong_order_examples_before_returns()
+   |
+help: Reorder sections to match numpydoc convention
+46 |     x : int
+47 |         Input value.
+48 | 
+49 +     Returns
+50 +     -------
+51 +     int
+52 +         Output value.
+53 + 
+54 |     Examples
+55 |     --------
+56 |     >>> wrong_order_examples_before_returns()
+57 |     42
+   - 
+   -     Returns
+   -     -------
+   -     int
+   -         Output value.
+58 |     """
+59 |     return 42
+60 | 
+
+NPD007 [*] Sections are in the wrong order ("Notes" out of place). Correct order is: Parameters, Returns, See Also, Notes
+  --> NPD007.py:70:5
+   |
+68 |         Input value.
+69 |
+70 |     Notes
+   |     ^^^^^
+71 |     -----
+72 |     Some notes here.
+   |
+help: Reorder sections to match numpydoc convention
+67 |     x : int
+68 |         Input value.
+69 | 
+   -     Notes
+   -     -----
+   -     Some notes here.
+70 +     Returns
+71 +     -------
+72 +     int
+73 +         Output value.
+74 | 
+75 |     See Also
+76 |     --------
+77 |     other_function : Related function.
+78 | 
+   -     Returns
+   -     -------
+   -     int
+   -         Output value.
+79 +     Notes
+80 +     -----
+81 +     Some notes here.
+82 |     """
+83 |     return 42
+84 | 
+
+NPD007 [*] Sections are in the wrong order ("See Also" out of place). Correct order is: Parameters, Returns, Raises, See Also
+   --> NPD007.py:144:5
+    |
+142 |         Output value.
+143 |
+144 |     See Also
+    |     ^^^^^^^^
+145 |     --------
+146 |     other_function : Related function.
+    |
+help: Reorder sections to match numpydoc convention
+141 |     int
+142 |         Output value.
+143 | 
+    -     See Also
+    -     --------
+    -     other_function : Related function.
+    - 
+144 |     Raises
+145 |     ------
+146 |     ValueError
+147 |         If x is negative.
+148 + 
+149 +     See Also
+150 +     --------
+151 +     other_function : Related function.
+152 |     """
+153 |     return 42
+154 | 
+
+NPD007 [*] Sections are in the wrong order ("See Also" out of place). Correct order is: Parameters, Returns, Raises, See Also
+   --> NPD007.py:164:5
+    |
+162 |         If x is negative.
+163 |
+164 |     See Also
+    |     ^^^^^^^^
+165 |     --------
+166 |     other_function : Related function.
+    |
+help: Reorder sections to match numpydoc convention
+156 | def wrong_order_multiple():  # NPD007
+157 |     """Calculate something.
+158 | 
+159 +     Parameters
+160 +     ----------
+161 +     x : int
+162 +         Input value.
+163 + 
+164 +     Returns
+165 +     -------
+166 +     int
+167 +         Output value.
+168 + 
+169 |     Raises
+170 |     ------
+171 |     ValueError
+--------------------------------------------------------------------------------
+174 |     See Also
+175 |     --------
+176 |     other_function : Related function.
+    - 
+    -     Returns
+    -     -------
+    -     int
+    -         Output value.
+    - 
+    -     Parameters
+    -     ----------
+    -     x : int
+    -         Input value.
+177 | 
+178 |     """
+179 |     return 42
+
+NPD007 [*] Sections are in the wrong order ("Examples" out of place). Correct order is: Parameters, Returns, Examples
+   --> NPD007.py:213:5
+    |
+211 |     """Calculate something complex.
+212 |
+213 |     Examples
+    |     ^^^^^^^^
+214 |     --------
+215 |     Here's how to use it:
+    |
+help: Reorder sections to match numpydoc convention
+210 | def complex_content_wrong_order():  # NPD007
+211 |     """Calculate something complex.
+212 | 
+    -     Examples
+    -     --------
+    -     Here's how to use it:
+    - 
+    -     >>> result = complex_content_wrong_order(5)
+    -     >>> print(result)
+    -     10
+    - 
+    -     You can also do:
+    -     >>> complex_content_wrong_order(-1)
+    -     0
+    - 
+213 |     Parameters
+214 |     ----------
+215 |     x : int
+--------------------------------------------------------------------------------
+222 |     int
+223 |         The output value.
+224 |         This is also multi-line.
+225 + 
+226 +     Examples
+227 +     --------
+228 +     Here's how to use it:
+229 + 
+230 +     >>> result = complex_content_wrong_order(5)
+231 +     >>> print(result)
+232 +     10
+233 + 
+234 +     You can also do:
+235 +     >>> complex_content_wrong_order(-1)
+236 +     0
+237 |     """
+238 |     return max(0, x * 2)
+239 | 
+
+NPD007 [*] Sections are in the wrong order ("Returns" out of place). Correct order is: Parameters, Returns
+   --> NPD007.py:244:5
+    |
+242 |     """Calculate something.
+243 |
+244 |     Returns
+    |     ^^^^^^^
+245 |     -------
+246 |     int
+    |
+help: Reorder sections to match numpydoc convention
+241 | def extra_text_between_sections():  # NPD007
+242 |     """Calculate something.
+243 | 
+244 +     Parameters
+245 +     ----------
+246 +     x : int
+247 +         Input value.
+248 + 
+249 |     Returns
+250 |     -------
+251 |     int
+--------------------------------------------------------------------------------
+253 | 
+254 |     This is some random text that appears between sections.
+255 |     It's not part of any official section.
+    - 
+    -     Parameters
+    -     ----------
+    -     x : int
+    -         Input value.
+256 |     """
+257 |     return 42


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

- Sets up new ruleset for numpydoc-derived rules, with code `NPD`
- Implements rule `NPD007`, derived from numpydoc's GL07 rule (see https://numpydoc.readthedocs.io/en/latest/validation.html)
- Implements fixing for the rule

Addresses part of https://github.com/astral-sh/ruff/issues/8425

## Test Plan

<!-- How was it tested? -->
Tested manually on a few simple examples. Wrote unit tests, including for corner cases:
- [x] multiple misplaced sections
- [x] No sections
- [x] 1 section
- [x] wrong-order but google-style convention
- [x] extra text between sections
- [ ] Unknown section kind
  - Tested manually: the unrecognized section is treated like extra text (see "extra text" case)
- [ ] In a class
  - Tested manually
- [ ] Malformed docstring
  - Tested manually with part of the docstring over-indented: ruff correctly re-indents *and* reorders the sections
- ?

## AI Disclosure

I used Claude Code to write the feature, with special care to make the code as clear as possible.