### PR TITLE
[ty] Use type context when inferring constructor argument types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/literal_promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal_promotion.md
@@ -261,7 +261,7 @@ Explicitly annotated `Literal` types will prevent literal promotion:
 
 ```py
 from enum import Enum
-from typing_extensions import Literal, LiteralString
+from typing import Sequence, Literal, LiteralString
 
 class Color(Enum):
     RED = "red"
@@ -270,10 +270,9 @@ type Y[T] = list[T]
 
 class X[T]:
     value: T
+    def __init__(self, value: list[T]): ...
 
-    def __init__(self, value: T): ...
-
-def x[T](x: T) -> X[T]:
+def x[T](x: list[T]) -> X[T]:
     return X(x)
 
 x1: list[Literal[1]] = [1]
@@ -294,13 +293,13 @@ reveal_type(x5)  # revealed: list[list[Literal[1]]]
 x6: dict[list[Literal[1]], list[Literal[Color.RED]]] = {[1]: [Color.RED, Color.RED]}
 reveal_type(x6)  # revealed: dict[list[Literal[1]], list[Color]]
 
-x7: X[Literal[1]] = X(1)
+x7: X[Literal[1]] = X([1])
 reveal_type(x7)  # revealed: X[Literal[1]]
 
-x8: X[int] = X(1)
+x8: X[int] = X([1])
 reveal_type(x8)  # revealed: X[int]
 
-x9: dict[list[X[Literal[1]]], set[Literal[b"a"]]] = {[X(1)]: {b"a"}}
+x9: dict[list[X[Literal[1]]], set[Literal[b"a"]]] = {[X([1])]: {b"a"}}
 reveal_type(x9)  # revealed: dict[list[X[Literal[1]]], set[Literal[b"a"]]]
 
 x10: list[Literal[1, 2, 3]] = [1, 2, 3]
@@ -341,10 +340,10 @@ reveal_type(x19)  # revealed: list[Literal[1]]
 x20: list[Literal[1]] | None = [1]
 reveal_type(x20)  # revealed: list[Literal[1]]
 
-x21: X[Literal[1]] | None = X(1)
+x21: X[Literal[1]] | None = X([1])
 reveal_type(x21)  # revealed: X[Literal[1]]
 
-x22: X[Literal[1]] | None = x(1)
+x22: X[Literal[1]] | None = x([1])
 reveal_type(x22)  # revealed: X[Literal[1]]
 ```
 
@@ -362,6 +361,12 @@ reveal_type(x2)  # revealed: list[Literal[1, 2, 3]]
 x3: Iterable[Literal[1, 2, 3]] = [1, 2, 3]
 reveal_type(x3)  # revealed: list[Literal[1, 2, 3]]
 
+x4: Iterable[Literal[1, 2, 3]] = list([1, 2, 3])
+reveal_type(x4)  # revealed: list[Literal[1, 2, 3]]
+
+x5: frozenset[Literal[1]] = frozenset([1])
+reveal_type(x5)  # revealed: frozenset[Literal[1]]
+
 class Sup1[T]:
     value: T
 
@@ -370,17 +375,17 @@ class Sub1[T](Sup1[T]): ...
 def sub1[T](value: T) -> Sub1[T]:
     return Sub1()
 
-x4: Sub1[Literal[1]] = sub1(1)
-reveal_type(x4)  # revealed: Sub1[Literal[1]]
-
-x5: Sup1[Literal[1]] = sub1(1)
-reveal_type(x5)  # revealed: Sub1[Literal[1]]
-
-x6: Sup1[Literal[1]] | None = sub1(1)
+x6: Sub1[Literal[1]] = sub1(1)
 reveal_type(x6)  # revealed: Sub1[Literal[1]]
 
-x7: Sup1[Literal[1]] | None = sub1(1)
+x7: Sup1[Literal[1]] = sub1(1)
 reveal_type(x7)  # revealed: Sub1[Literal[1]]
+
+x8: Sup1[Literal[1]] | None = sub1(1)
+reveal_type(x8)  # revealed: Sub1[Literal[1]]
+
+x9: Sup1[Literal[1]] | None = sub1(1)
+reveal_type(x9)  # revealed: Sub1[Literal[1]]
 
 class Sup2A[T, U]:
     value: tuple[T, U]
@@ -393,12 +398,12 @@ class Sub2[T, U](Sup2A[T, Any], Sup2B[Any, U]): ...
 def sub2[T, U](x: T, y: U) -> Sub2[T, U]:
     return Sub2()
 
-x8 = sub2(1, 2)
-reveal_type(x8)  # revealed: Sub2[int, int]
+x10 = sub2(1, 2)
+reveal_type(x10)  # revealed: Sub2[int, int]
 
-x9: Sup2A[Literal[1], Literal[2]] = sub2(1, 2)
-reveal_type(x9)  # revealed: Sub2[Literal[1], int]
+x11: Sup2A[Literal[1], Literal[2]] = sub2(1, 2)
+reveal_type(x11)  # revealed: Sub2[Literal[1], int]
 
-x10: Sup2B[Literal[1], Literal[2]] = sub2(1, 2)
-reveal_type(x10)  # revealed: Sub2[int, Literal[2]]
+x12: Sup2B[Literal[1], Literal[2]] = sub2(1, 2)
+reveal_type(x12)  # revealed: Sub2[int, Literal[2]]
 ```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5462,7 +5462,8 @@ impl<'db> Type<'db> {
             (Some(Place::Defined(DefinedPlace { ty: new_method, .. })), Place::Undefined) => Some(
                 new_method
                     .bindings(db)
-                    .map(|binding| binding.with_bound_type(self_type)),
+                    .map(|binding| binding.with_bound_type(self_type))
+                    .with_constructor_instance_type(init_ty),
             ),
 
             (
@@ -5470,7 +5471,11 @@ impl<'db> Type<'db> {
                 Place::Defined(DefinedPlace {
                     ty: init_method, ..
                 }),
-            ) => Some(init_method.bindings(db)),
+            ) => Some(
+                init_method
+                    .bindings(db)
+                    .with_constructor_instance_type(init_ty),
+            ),
 
             (
                 Some(Place::Defined(DefinedPlace { ty: new_method, .. })),
@@ -5484,10 +5489,10 @@ impl<'db> Type<'db> {
                     .bindings(db)
                     .map(|binding| binding.with_bound_type(self_type));
 
-                Some(Bindings::from_union(
-                    callable,
-                    [new_method_bindings, init_method.bindings(db)],
-                ))
+                Some(
+                    Bindings::from_union(callable, [new_method_bindings, init_method.bindings(db)])
+                        .with_constructor_instance_type(init_ty),
+                )
             }
 
             _ => None,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9988,7 +9988,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         SpecializationBuilder::new(db, generic_context.inferable_typevars(db));
 
                     if let Some(declared_return_ty) = call_expression_tcx.annotation {
-                        let _ = builder.infer(overload.signature.return_ty, declared_return_ty);
+                        let _ = builder.infer_reverse(
+                            declared_return_ty,
+                            overload
+                                .constructor_instance_type
+                                .unwrap_or(overload.signature.return_ty),
+                        );
                     }
 
                     let specialization = builder


### PR DESCRIPTION
Pointed out in https://github.com/astral-sh/ty/issues/2280#issuecomment-3861648557. This doesn't fix the issue with `MappingProxyType`, as that one relies on generic protocols.