### PR TITLE
[ty] Fix panic on fuzzed slice expression in comprehension

### DIFF
--- a/crates/ty_python_semantic/resources/corpus/ty_2317_fuzzed_slice_expression.py
+++ b/crates/ty_python_semantic/resources/corpus/ty_2317_fuzzed_slice_expression.py
@@ -1,0 +1,3 @@
+# Regression test for https://github.com/astral-sh/ty/issues/2317
+# Parser error recovery for this fuzzed input should not cause a panic.
+arr[::[x for *b in y for (b: _

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -1221,6 +1221,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         // nodes are evaluated in the inner scope.
         let value = self.add_standalone_expression(&generator.iter);
         self.visit_expr(&generator.iter);
+
+        // Clear the assignment stack before entering the comprehension scope.
+        // If the comprehension appears inside an assignment target (e.g., error-recovered
+        // `arr[::[x for *b in y for (b: _` is parsed as `StmtAnnAssign`), the outer
+        // assignment context must not leak into the inner scope.
+        let saved_assignments = std::mem::take(&mut self.current_assignments);
+
         self.push_scope(scope);
 
         self.add_unpackable_assignment(
@@ -1258,6 +1265,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
         visit_outer_elt(self);
         self.pop_scope();
+
+        self.current_assignments = saved_assignments;
     }
 
     fn declare_parameters(&mut self, parameters: &'ast ast::Parameters) {


### PR DESCRIPTION
## Summary

Clear the assignment stack when entering a comprehension scope so that outer assignment context (e.g., an `AnnAssign` from error-recovered AST) cannot leak into the inner scope and create definitions that reference expressions recorded in a different scope's `uses_map`.

Closes https://github.com/astral-sh/ty/issues/2317.
