### PR TITLE
[ty] Add public `class_name` and `class_module_name` methods to `NominalInstanceType`

### DIFF
--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -3,6 +3,9 @@
 use std::borrow::Cow;
 use std::marker::PhantomData;
 
+use ruff_python_ast::name::Name;
+use ty_module_resolver::{ModuleName, file_to_module};
+
 use super::protocol_class::ProtocolInterface;
 use super::{BoundTypeVarInstance, ClassType, KnownClass, SubclassOfType, Type, TypeVarVariance};
 use crate::place::PlaceAndQualifiers;
@@ -232,6 +235,24 @@ pub(super) fn walk_nominal_instance_type<'db, V: super::visitor::TypeVisitor<'db
 }
 
 impl<'db> NominalInstanceType<'db> {
+    /// Returns the name of the class this is an instance of.
+    ///
+    /// For example, for an instance of `builtins.str`, this returns `"str"`.
+    pub fn class_name(&self, db: &'db dyn Db) -> &'db Name {
+        self.class(db).name(db)
+    }
+
+    /// Returns the fully qualified module name of the module in which the class
+    /// is defined, if it can be resolved.
+    ///
+    /// For example, for an instance of `pathlib.Path`, this returns
+    /// `Some("pathlib")`. Returns `None` if the class's file cannot be resolved
+    /// to a known module (e.g. for classes defined in scripts or notebooks).
+    pub fn class_module_name(&self, db: &'db dyn Db) -> Option<&'db ModuleName> {
+        let file = self.class(db).class_literal(db).file(db);
+        file_to_module(db, file).map(|module| module.name(db))
+    }
+
     pub(super) fn class(&self, db: &'db dyn Db) -> ClassType<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => tuple.to_class_type(db),


### PR DESCRIPTION
Add two public convenience methods to `NominalInstanceType` so that external crates can retrieve the class name and defining module of an instance type without needing access to the `pub(super)` `class()` method or `pub(crate)` types like `ClassType` and `ClassLiteral`:

- `class_name(&self, db) -> &Name`: Returns the class name (e.g. `"str"`)
- `class_module_name(&self, db) -> Option<&ModuleName>`: Returns the fully qualified module name where the class is defined (e.g. `"pathlib"` for `pathlib.Path`), or `None` for scripts/notebooks.

This enables tools that use `ty_python_semantic` as a library to extract structured type information from instance types for use cases like type attribution in code transformation tools.
