### PR TITLE
[ty] Resolve TypeVars in `call_signature_details` parameter types

### DIFF
--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4474,6 +4474,10 @@ impl<'db> Binding<'db> {
         &self.argument_matches
     }
 
+    pub(crate) fn specialization(&self) -> Option<Specialization<'db>> {
+        self.specialization
+    }
+
     pub(crate) fn errors(&self) -> &[BindingError<'db>] {
         &self.errors
     }

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -582,12 +582,22 @@ pub struct CallSignatureDetails<'db> {
 impl<'db> CallSignatureDetails<'db> {
     fn from_binding(db: &'db dyn Db, binding: &crate::types::call::Binding<'db>) -> Self {
         let argument_to_parameter_mapping = binding.argument_matches().to_vec();
+        let specialization = binding.specialization();
         let signature = binding.signature.clone();
         let display_details = signature.display(db).to_string_parts();
         let (parameter_kinds, parameter_types): (Vec<ParameterKind>, Vec<Type>) = signature
             .parameters()
             .iter()
-            .map(|param| (param.kind().clone(), param.annotated_type()))
+            .map(|param| {
+                // Apply the inferred specialization (if any) to resolve TypeVars
+                // in the annotated type. For example, if `_KT` was inferred as
+                // `str` from the call arguments, this turns `_KT` into `str`.
+                let mut ty = param.annotated_type();
+                if let Some(spec) = specialization {
+                    ty = ty.apply_specialization(db, spec);
+                }
+                (param.kind().clone(), ty)
+            })
             .unzip();
 
         CallSignatureDetails {
@@ -636,15 +646,23 @@ pub fn call_signature_details<'db>(
         .try_upcast_to_callable(db)
         .map(|callables| callables.into_type(db))
     {
+        // Use from_arguments_typed so that check_types can infer TypeVar
+        // specializations from the actual argument types at this call site.
         let call_arguments =
-            CallArguments::from_arguments(&call_expr.arguments, |_, splatted_value| {
+            CallArguments::from_arguments_typed(&call_expr.arguments, |splatted_value| {
                 splatted_value
                     .inferred_type(model)
                     .unwrap_or(Type::unknown())
             });
-        let bindings = callable_type
+        let mut bindings = callable_type
             .bindings(db)
             .match_parameters(db, &call_arguments);
+
+        // Run type checking to resolve TypeVar bindings from argument types.
+        // For example, calling `dict[str, int].get("a")` resolves the `_KT`
+        // TypeVar to `str`. We ignore errors since we still want signature
+        // details even if the call has type errors.
+        let _ = bindings.check_types_impl(db, &call_arguments, TypeContext::default(), &[]);
 
         // Extract signature details from all callable bindings
         bindings


### PR DESCRIPTION
Previously, `call_signature_details` populated `parameter_types` from raw `param.annotated_type()`, which left function-level TypeVars unresolved. For example, calling a generic function `pair[T](a: T, b: T)` with a `str` argument would report both parameters as type `T` instead of `str`.

This change adds a `check_types` pass after `match_parameters` to infer TypeVar specializations from the actual argument types at the call site. The inferred specialization is then applied to each parameter's annotated type via `apply_specialization`, which resolves TypeVars while preserving non-TypeVar annotations unchanged.

Two changes are needed:
- Switch from `from_arguments` to `from_arguments_typed` so argument types are available for TypeVar inference
- Call `check_types_impl` and use `binding.specialization()` to apply the inferred specialization to annotated types

An alternative would be to add a separate `call_signature_details_with_resolved_types` function to avoid changing the existing behavior, but since resolved types are strictly more useful for consumers (signature help, completions, IDE tooling), updating the existing function seems preferable.