### PR TITLE
[ty] Improve documentation for `expect_single_definition` method

### DIFF
--- a/crates/ty_python_semantic/src/semantic_index.rs
+++ b/crates/ty_python_semantic/src/semantic_index.rs
@@ -469,6 +469,11 @@ impl<'db> SemanticIndex<'db> {
     ///
     /// If the number of definitions associated with the key is not exactly 1 and
     /// the `debug_assertions` feature is enabled, this method will panic.
+    ///
+    /// It is generally safe to use this method for any AST node that does not
+    /// correspond to a `*` (wildcard) import, since `*` imports are the only
+    /// situations that can result in multiple definitions being associated with a
+    /// single AST node.
     #[track_caller]
     pub(crate) fn expect_single_definition(
         &self,


### PR DESCRIPTION
## Summary

It's generally safe to use this method in most places, but that isn't currently obvious from the docs for the method. X-ref https://github.com/astral-sh/ruff/pull/23141#discussion_r2782619551

## Test Plan

`uvx prek run -a`
