### PR TITLE
[ty] Detect flaky projects during ecosystem CI jobs

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -64,6 +64,7 @@ jobs:
           git checkout -b new_commit "$GITHUB_SHA"
           git rev-list --format=%s --max-count=1 new_commit
           cp crates/ty_python_semantic/resources/primer/good.txt projects_new.txt
+          cp crates/ty_python_semantic/resources/primer/flaky.txt projects_flaky.txt
 
           echo "old commit (merge base)"
           MERGE_BASE="$(git merge-base "$GITHUB_SHA" "origin/$GITHUB_BASE_REF")"
@@ -73,15 +74,16 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@f196cedd062037608340986975b908e04c9fb0a1"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@f26093838326d10b6d90f3a9d08125db7aa369d6"
 
           ecosystem-analyzer \
             --repository ruff \
-            --max-flaky-runs 7 \
+            --flaky-runs 10 \
             diff \
             --profile=profiling \
             --projects-old ruff/projects_old.txt \
             --projects-new ruff/projects_new.txt \
+            --projects-flaky ruff/projects_flaky.txt \
             --old old_commit \
             --new new_commit \
             --output-old diagnostics-old.json \

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -56,12 +56,12 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@f196cedd062037608340986975b908e04c9fb0a1"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@f26093838326d10b6d90f3a9d08125db7aa369d6"
 
           ecosystem-analyzer \
             --verbose \
             --repository ruff \
-            --max-flaky-runs 7 \
+            --flaky-runs 20 \
             analyze \
             --profile=profiling \
             --projects ruff/crates/ty_python_semantic/resources/primer/good.txt \

--- a/crates/ty_python_semantic/resources/primer/flaky.txt
+++ b/crates/ty_python_semantic/resources/primer/flaky.txt
@@ -1,0 +1,8 @@
+Expression
+materialize
+porcupine
+prefect
+pydantic
+scikit-build-core
+setuptools
+sympy


### PR DESCRIPTION
This brings in an `ecosystem-analyzer` update that detects when we produce flaky results for a project.

We do this by running `ty` multiple times against each project, looking for when we produce a different diagnostic at the same file/line/column location. If we do, we consider that diagnostic as flaky. The `diff` and `analyze` HTML reports have been updated to show flakiness information. (A diagnostic changing from "flaky" to "not flaky", or vice versa, is now considered a change, as is a different set of diagnostic codes/messages appearing for a flaky diagnostic.)

Since most projects aren't flaky :crossed_fingers:, in the per-PR CI job, we only run flake detection against the projects that we known are flaky. For the others, we still run `ty` once and don't consider any of the diagnostics flaky. In the weekly background job, we run flake detection more aggressively, and on all projects, so that we can update the flaky project list when needed.