### PR TITLE
[ty] Avoid literal promotion for covariant declared types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -449,7 +449,7 @@ x10: list[int | str] | list[int | None] = [1, 2, 3]
 reveal_type(x10)  # revealed: list[int | str]
 
 x11: Sequence[int | str] | Sequence[int | None] = [1, 2, 3]
-reveal_type(x11)  # revealed: list[int]
+reveal_type(x11)  # revealed: list[Literal[1, 2, 3]]
 
 x12: list[int] | list[int | None] | list[str | None] = ["1", "2"]
 reveal_type(x12)  # revealed: list[str | None]
@@ -729,16 +729,16 @@ from collections import defaultdict
 from typing import Any, Iterable, Literal, MutableSequence, Sequence
 
 x1: Sequence[Any] = [1, 2, 3]
-reveal_type(x1)  # revealed: list[int]
+reveal_type(x1)  # revealed: list[Literal[1, 2, 3]]
 
 x2: MutableSequence[Any] = [1, 2, 3]
 reveal_type(x2)  # revealed: list[Any]
 
 x3: Iterable[Any] = [1, 2, 3]
-reveal_type(x3)  # revealed: list[int]
+reveal_type(x3)  # revealed: list[Literal[1, 2, 3]]
 
 x4: Iterable[Iterable[Any]] = [[1, 2, 3]]
-reveal_type(x4)  # revealed: list[list[int]]
+reveal_type(x4)  # revealed: list[list[Literal[1, 2, 3]]]
 
 x5: list[Iterable[Any]] = [[1, 2, 3]]
 reveal_type(x5)  # revealed: list[Iterable[Any]]
@@ -747,16 +747,16 @@ x6: Iterable[list[Any]] = [[1, 2, 3]]
 reveal_type(x6)  # revealed: list[list[Any]]
 
 x7: Sequence[Any] = [i for i in [1, 2, 3]]
-reveal_type(x7)  # revealed: list[int]
+reveal_type(x7)  # revealed: list[Literal[1, 2, 3]]
 
 x8: MutableSequence[Any] = [i for i in [1, 2, 3]]
 reveal_type(x8)  # revealed: list[Any]
 
 x9: Iterable[Any] = [i for i in [1, 2, 3]]
-reveal_type(x9)  # revealed: list[int]
+reveal_type(x9)  # revealed: list[Literal[1, 2, 3]]
 
 x10: Iterable[Iterable[Any]] = [[i] for i in [1, 2, 3]]
-reveal_type(x10)  # revealed: list[list[int]]
+reveal_type(x10)  # revealed: list[list[Literal[1, 2, 3]]]
 
 x11: list[Iterable[Any]] = [[i] for i in [1, 2, 3]]
 reveal_type(x11)  # revealed: list[Iterable[Any]]
@@ -790,7 +790,7 @@ def f[T](x: T) -> list[list[T]]:
     return [[x]]
 
 x17: Sequence[Sequence[Any]] = f(1)
-reveal_type(x17)  # revealed: list[list[int]]
+reveal_type(x17)  # revealed: list[list[Literal[1]]]
 
 x18: Sequence[list[Any]] = f(1)
 reveal_type(x18)  # revealed: list[list[Any]]

--- a/crates/ty_python_semantic/resources/mdtest/comprehensions/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/comprehensions/basic.md
@@ -128,8 +128,7 @@ The type of the expression being iterated over is immutable, and so should not b
 `Unknown` or through literal promotion:
 
 ```py
-# TODO: This should reveal `Literal["a", "b"]`
-# revealed: str
+# revealed: Literal["a", "b"]
 x = [reveal_type(string) for string in ["a", "b"]]
 ```
 
@@ -172,7 +171,7 @@ x1: list[int] = [x for x in [1, 2, 3]]
 reveal_type(x1)  # revealed: list[int]
 
 x2: Sequence[int] = [x for x in [1, 2, 3]]
-reveal_type(x2)  # revealed: list[int]
+reveal_type(x2)  # revealed: list[Literal[1, 2, 3]]
 
 x3: dict[int, str] = {x: str(x) for x in [1, 2, 3]}
 reveal_type(x3)  # revealed: dict[int, str]

--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -90,6 +90,28 @@ reveal_type((1, 2, 3))  # revealed: tuple[Literal[1], Literal[2], Literal[3]]
 reveal_type(frozenset((1, 2, 3)))  # revealed: frozenset[Literal[1, 2, 3]]
 ```
 
+Additionally, invariant collection literals are not promoted if they are in covariant position in
+the declared type:
+
+```py
+from typing import MutableSequence, Sequence, Iterable
+
+x1: MutableSequence[int] = [1, 2, 3]
+reveal_type(x1)  # revealed: list[int]
+
+x2: Sequence[int] = [1, 2, 3]
+reveal_type(x2)  # revealed: list[Literal[1, 2, 3]]
+
+x3: Iterable[int] = [1, 2, 3]
+reveal_type(x3)  # revealed: list[Literal[1, 2, 3]]
+
+x4 = frozenset([1, 2, 3])
+reveal_type(x4)  # revealed: frozenset[Literal[1, 2, 3]]
+
+for x5 in [1, 2, 3]:
+    reveal_type(x5)  # revealed: Literal[1, 2, 3]
+```
+
 ## Invariant and contravariant return types are promoted
 
 We promote in non-covariant position in the return type of a generic function, or constructor of a
@@ -151,6 +173,34 @@ reveal_type(f11(1, 1))  # revealed: tuple[Invariant[Covariant[int] | None], Cova
 
 reveal_type(f12(1))  # revealed: ((int, /) -> bool) | None
 reveal_type(f13(1))  # revealed: ((bool, /) -> Invariant[int]) | None
+```
+
+However, non-covariant generic types are not promoted if they are in covariant position in the
+declared type:
+
+```py
+class CovariantSup[T]:
+    def pop(self) -> T:
+        raise NotImplementedError
+
+class InvariantSub[T](CovariantSup[T]):
+    x: T
+    def __init__(self, value: T): ...
+
+def f12[T](x: T) -> InvariantSub[T]:
+    raise NotImplementedError
+
+def f13[T](x: T) -> CovariantSup[T]:
+    raise NotImplementedError
+
+x1 = f12(1)
+reveal_type(x1)  # revealed: InvariantSub[int]
+
+x2 = f13(1)
+reveal_type(x2)  # revealed: CovariantSup[Literal[1]]
+
+x3: CovariantSup[int] = f12(1)
+reveal_type(x3)  # revealed: InvariantSub[Literal[1]]
 ```
 
 ## Promotion is recursive

--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
@@ -55,10 +55,10 @@ def f(x: Iterable[int], y: list[str], z: Never, aa: list[Never], bb: LiskovUncom
 
 reveal_type(tuple((1, 2)))  # revealed: tuple[Literal[1], Literal[2]]
 
-reveal_type(tuple([1]))  # revealed: tuple[int, ...]
+reveal_type(tuple([1]))  # revealed: tuple[Literal[1], ...]
 
 x1: tuple[int, ...] = tuple([1])
-reveal_type(x1)  # revealed: tuple[int, ...]
+reveal_type(x1)  # revealed: tuple[Literal[1], ...]
 
 # error: [invalid-argument-type]
 reveal_type(tuple[int]([1]))  # revealed: tuple[int]

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -868,6 +868,10 @@ impl<'db> Type<'db> {
         Self::Divergent(DivergentType::new(id))
     }
 
+    pub const fn unspecialized_type_var() -> Self {
+        Self::Dynamic(DynamicType::UnspecializedTypeVar)
+    }
+
     pub(crate) const fn is_divergent(&self) -> bool {
         matches!(self, Type::Divergent(_))
     }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4186,6 +4186,10 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         let mut partially_specialized_declared_type: FxHashSet<BoundTypeVarIdentity<'_>> =
             FxHashSet::default();
 
+        // We keep track of the variance of any assignments to type variables in the type context.
+        let mut tcx_variance: FxHashMap<BoundTypeVarIdentity<'_>, TypeVarVariance> =
+            FxHashMap::default();
+
         // Attempt to solve the specialization while preferring the declared type of non-covariant
         // type parameters from generic classes, or callable types.
         //
@@ -4218,10 +4222,6 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 let tcx = tcx.filter_disjoint_elements(self.db, return_ty, self.inferable_typevars);
                 let set = return_ty.when_constraint_set_assignable_to(self.db, tcx, constraints);
 
-                // Use `solutions_with` to determine per-typevar variance from the raw
-                // lower/upper bounds on each BDD path.
-                let mut variance_map: FxHashMap<BoundTypeVarIdentity<'_>, TypeVarVariance> =
-                    FxHashMap::default();
                 let solutions = set.solutions_with_inferable(
                     self.db,
                     constraints,
@@ -4232,7 +4232,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         }
 
                         let identity = typevar.identity(self.db);
-                        variance_map
+                        tcx_variance
                             .entry(identity)
                             .and_modify(|current| *current = current.join(variance))
                             .or_insert(variance);
@@ -4255,7 +4255,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         // type parameter from the type context, as it can lead to argument
                         // assignability errors if the type variable is constrained by a narrower
                         // parameter type.
-                        if variance_map
+                        if tcx_variance
                             .get(&identity)
                             .is_some_and(|v| v.is_covariant())
                         {
@@ -4370,6 +4370,15 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 // Promotion is only useful if the type variable is in non-covariant position
                 // in the return type.
                 if variance_in_return.is_covariant() {
+                    return None;
+                }
+
+                // Promotion is only useful if the type variable is in non-covariant position
+                // in the declared type.
+                if tcx_variance
+                    .get(&typevar.identity(self.db))
+                    .is_some_and(|v| v.is_covariant())
+                {
                     return None;
                 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4035,12 +4035,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             is_async: _,
         } = for_statement;
 
-        self.infer_target(target, iter, &|builder, tcx| {
+        self.infer_target(target, iter, &|builder, _| {
+            // We pass `Iterable` as type context, allowing us to avoid literal promotion for
+            // collection literal in iterable position.
+            let iterable_tcx = KnownClass::Iterable
+                .to_specialized_instance(builder.db(), &[Type::unspecialized_type_var()]);
+
             // TODO: `infer_for_statement_definition` reports a diagnostic if `iter_ty` isn't iterable
             //  but only if the target is a name. We should report a diagnostic here if the target isn't a name:
             //  `for a.x in not_iterable: ...
             builder
-                .infer_standalone_expression(iter, tcx)
+                .infer_standalone_expression(iter, TypeContext::new(Some(iterable_tcx)))
                 .iterate(builder.db())
                 .homogeneous_element_type(builder.db())
         });
@@ -4067,8 +4072,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 unpacked.expression_type(target)
             }
             TargetKind::Single => {
-                let iterable_type =
-                    self.infer_standalone_expression(iterable, TypeContext::default());
+                // We pass `Iterable` as type context, allowing us to avoid literal promotion for
+                // collection literal in iterable position.
+                let iterable_tcx = KnownClass::Iterable
+                    .to_specialized_instance(self.db(), &[Type::unspecialized_type_var()]);
+
+                let iterable_type = self
+                    .infer_standalone_expression(iterable, TypeContext::new(Some(iterable_tcx)));
 
                 iterable_type
                     .try_iterate_with_mode(
@@ -4816,7 +4826,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 tcx_mappings
                                     .get(&typevar.identity(db))
                                     .copied()
-                                    .unwrap_or(Type::Dynamic(DynamicType::UnspecializedTypeVar)),
+                                    .unwrap_or(Type::unspecialized_type_var()),
                             )
                         }),
                     );
@@ -5583,7 +5593,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         });
 
         // Collect type constraints from the declared element types.
-        //
+        let mut elt_tcx_constraints: FxHashMap<BoundTypeVarIdentity<'_>, Type<'db>> =
+            FxHashMap::default();
+        let mut elt_tcx_variance: FxHashMap<BoundTypeVarIdentity<'_>, TypeVarVariance> =
+            FxHashMap::default();
+
         // We use a forward assignability check (`collection_instance ≤ tcx`) to infer what each
         // typevar maps to in the type context. For example, if the type context is `list[int]` and
         // `collection_instance` is `list[T]`, the check produces `T = int`.
@@ -5593,14 +5607,54 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // bound (`upper = object`) indicates contravariant. This correctly handles cases where the
         // type context is a covariant superclass of the collection (e.g., `Sequence[Any]` as type
         // context for `list[T]`).
-        let (elt_tcx_constraints, elt_tcx_variance) = {
-            let mut elt_tcx_constraints: FxHashMap<BoundTypeVarIdentity<'_>, Type<'db>> =
-                FxHashMap::default();
-            let mut elt_tcx_variance: FxHashMap<BoundTypeVarIdentity<'_>, TypeVarVariance> =
-                FxHashMap::default();
 
-            if let Some(tcx) = tcx.annotation
-                && tcx.class_specialization(self.db()).is_some()
+        if let Some(tcx) = tcx.annotation
+            && tcx.class_specialization(self.db()).is_some()
+        {
+            let db = self.db();
+            let collection_instance = Type::instance(db, ClassType::Generic(collection_alias));
+
+            let set = collection_instance.when_constraint_set_assignable_to(db, tcx, &constraints);
+
+            // Use `solutions_with_inferable` to capture per-typevar variance from the raw
+            // lower/upper bounds on each BDD path. We must use the inferable-aware variant so
+            // that non-inferable typevars from outer scopes (which the assignability check
+            // constrains alongside the collection's own typevars) are excluded from cycle
+            // detection and solution extraction. Without this, a type context like
+            // `list[T@MyClass]` would create mutual constraints between `_T` (list's typevar)
+            // and `T@MyClass`, which `is_cyclic` would flag as a cycle, returning
+            // `Unsatisfiable` and losing the type context information entirely.
+            let solutions = set.solutions_with_inferable(
+                db,
+                &constraints,
+                inferable,
+                |typevar, variance, lower, upper| {
+                    if !typevar.is_inferable(db, inferable) {
+                        return Ok(None);
+                    }
+
+                    let identity = typevar.identity(db);
+                    elt_tcx_variance
+                        .entry(identity)
+                        .and_modify(|current| *current = current.join(variance))
+                        .or_insert(variance);
+
+                    PathBounds::default_solve(db, typevar, lower, upper)
+                },
+            );
+
+            // Skip constraint extraction when the type context contains UnspecializedTypeVar
+            // placeholders (from partially-specialized parameter types during multi-inference
+            // for overloaded calls). The assignability check would walk through protocol
+            // supertypes and produce constraints contaminated by the placeholder, which
+            // collapse to `Any` during solution extraction and bypass downstream filters.
+            //
+            // TODO: UnspecializedTypeVar should be removed entirely once the
+            // SpecializationBuilder uses constraint sets internally, at which point the
+            // typevars that it currently replaces can instead be existentially quantified away
+            // (as is already done for generic callable assignability in
+            // `check_signature_pair`).
+            if !tcx.has_unspecialized_type_var(self.db()) {
                 // Skip constraint extraction when the type context contains UnspecializedTypeVar
                 // placeholders (from partially-specialized parameter types during multi-inference
                 // for overloaded calls). The assignability check would walk through protocol
@@ -5612,40 +5666,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // typevars that it currently replaces can instead be existentially quantified away
                 // (as is already done for generic callable assignability in
                 // `check_signature_pair`).
-                && !tcx.has_unspecialized_type_var(self.db())
-            {
-                let db = self.db();
-                let collection_instance = Type::instance(db, ClassType::Generic(collection_alias));
-
-                let set =
-                    collection_instance.when_constraint_set_assignable_to(db, tcx, &constraints);
-
-                // Use `solutions_with_inferable` to capture per-typevar variance from the raw
-                // lower/upper bounds on each BDD path. We must use the inferable-aware variant so
-                // that non-inferable typevars from outer scopes (which the assignability check
-                // constrains alongside the collection's own typevars) are excluded from cycle
-                // detection and solution extraction. Without this, a type context like
-                // `list[T@MyClass]` would create mutual constraints between `_T` (list's typevar)
-                // and `T@MyClass`, which `is_cyclic` would flag as a cycle, returning
-                // `Unsatisfiable` and losing the type context information entirely.
-                let solutions = set.solutions_with_inferable(
-                    db,
-                    &constraints,
-                    inferable,
-                    |typevar, variance, lower, upper| {
-                        if !typevar.is_inferable(db, inferable) {
-                            return Ok(None);
-                        }
-
-                        let identity = typevar.identity(db);
-                        elt_tcx_variance
-                            .entry(identity)
-                            .and_modify(|current| *current = current.join(variance))
-                            .or_insert(variance);
-                        PathBounds::default_solve(db, typevar, lower, upper)
-                    },
-                );
-
                 match solutions {
                     // If the type context is not compatible with the collection type (e.g., a
                     // `list` literal where a `tuple` is expected), the assignability check
@@ -5689,18 +5709,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     .or_insert(inferred_ty);
                             }
                         }
-
-                        // Remove variance entries for typevars whose solutions were filtered out
-                        // (e.g., due to unspecialized typevars). Variance should only be tracked
-                        // for typevars with actual type context constraints.
-                        elt_tcx_variance
-                            .retain(|identity, _| elt_tcx_constraints.contains_key(identity));
                     }
                 }
             }
-
-            (elt_tcx_constraints, elt_tcx_variance)
-        };
+        }
 
         // Create a set of constraints to infer a precise type for `T`.
         let mut builder = SpecializationBuilder::new(self.db(), &constraints, inferable);
@@ -5715,10 +5727,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .get(&elt_ty_identity)
                 .copied();
 
-            // Avoid unnecessarily widening the return type based on a covariant
-            // type parameter from the type context.
+            // Avoid unnecessarily widening the return type based on a covariant type
+            // parameter from the type context.
             //
-            // Note that we also avoid unioning  the inferred type with `Unknown` in this
+            // Note that we also avoid unioning the inferred type with `Unknown` in this
             // case, which is only necessary for invariant collections.
             if elt_tcx_variance
                 .get(&elt_ty_identity)
@@ -5776,30 +5788,33 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let Some(elt) = elt else { continue };
 
                 // Note that unlike when preferring the declared type, we use covariant type
-                // assignments from the type context to potentially _narrow_ the inferred type,
-                // by avoiding promotion.
+                // assignments from the type context to potentially _narrow_ inferred element
+                // types, e.g., by avoiding promotion.
                 let elt_ty_identity = elt_ty.identity(self.db());
+                let elt_tcx_variance = elt_tcx_variance.get(&elt_ty_identity);
 
-                // If the element is a starred expression, we want to apply the type context to each element
-                // in the unpacked expression (which we will store as a tuple when inferring it). We
-                // therefore wrap the type context in an `tuple[T, ...]` specialization.
                 let elt_tcx = elt_tcx_constraints
                     .get(&elt_ty_identity)
                     .copied()
                     .map(|tcx| {
                         if elt.is_starred_expr() && collection_class != KnownClass::Dict {
+                            // If the element is a starred expression, we want to apply the type context to each
+                            // element in the unpacked expression (which we will store as a tuple when inferring it).
+                            // We therefore wrap the type context in an `tuple[T, ...]` specialization.
                             Type::homogeneous_tuple(self.db(), tcx)
                         } else {
                             tcx
                         }
                     });
 
-                let inferred_elt_ty =
+                let mut inferred_elt_ty =
                     infer_elt_expression(self, (i, elt, TypeContext::new(elt_tcx)));
 
-                // Simplify the inference based on a non-covariant declared type.
-                if let Some(elt_tcx) =
-                    elt_tcx.filter(|_| !elt_tcx_variance[&elt_ty_identity].is_covariant())
+                // Simplify the inference based on a non-covariant declared type, if any.
+                if let Some(elt_tcx) = elt_tcx
+                    && !elt_tcx_variance
+                        .expect("we track the variance of all preferred types")
+                        .is_covariant()
                     && inferred_elt_ty.is_assignable_to(self.db(), elt_tcx)
                 {
                     continue;
@@ -5807,7 +5822,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 // Promote types to avoid excessively large unions for large nested list literals,
                 // which the constraint solver struggles with.
-                let inferred_elt_ty = inferred_elt_ty.promote(self.db());
+                //
+                // Note that this is only relevant for non-covariant collections with non-covariant
+                // declared types.
+                if elt_tcx_variance.is_none_or(|variance| !variance.is_covariant()) {
+                    inferred_elt_ty = inferred_elt_ty.promote(self.db());
+                }
 
                 builder
                     .infer(
@@ -6100,14 +6120,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             is_async: _,
         } = comprehension;
 
-        self.infer_target(target, iter, &|builder, tcx| {
+        self.infer_target(target, iter, &|builder, _| {
+            // We pass `Iterable` as type context, allowing us to avoid literal promotion for
+            // collection literal in iterable position.
+            let iterable_tcx = KnownClass::Iterable
+                .to_specialized_instance(builder.db(), &[Type::unspecialized_type_var()]);
+
             // TODO: `infer_comprehension_definition` reports a diagnostic if `iter_ty` isn't iterable
             //  but only if the target is a name. We should report a diagnostic here if the target isn't a name:
             //  `[... for a.x in not_iterable]
             if is_first {
-                infer_same_file_expression_type(builder.db(), builder.index.expression(iter), tcx)
+                infer_same_file_expression_type(
+                    builder.db(),
+                    builder.index.expression(iter),
+                    TypeContext::new(Some(iterable_tcx)),
+                )
             } else {
-                builder.infer_maybe_standalone_expression(iter, tcx)
+                builder
+                    .infer_maybe_standalone_expression(iter, TypeContext::new(Some(iterable_tcx)))
             }
             .iterate(builder.db())
             .homogeneous_element_type(builder.db())
@@ -6128,7 +6158,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let mut infer_iterable_type = || {
             let expression = self.index.expression(iterable);
-            let result = infer_expression_types(self.db(), expression, TypeContext::default());
+
+            // We pass `Iterable` as type context, allowing us to avoid literal promotion for
+            // collection literal in iterable position.
+            let iterable_tcx = KnownClass::Iterable
+                .to_specialized_instance(self.db(), &[Type::unspecialized_type_var()]);
+            let result =
+                infer_expression_types(self.db(), expression, TypeContext::new(Some(iterable_tcx)));
 
             // Two things are different if it's the first comprehension:
             // (1) We must lookup the `ScopedExpressionId` of the iterable expression in the outer scope,


### PR DESCRIPTION
Avoid literal promotion (and `Unknown` widening) for elements in covariant position in their declared type, e.g.,
```py
_: Iterable[int] = reveal_type([1, 2, 3]) # list[Literal[1, 2, 3]]

for _ in reveal_type([1, 2, 3]): # list[Literal[1, 2, 3]]
    ...

reveal_type(frozenset([1, 2, 3]))  # Revealed type: `frozenset[Literal[1, 2, 3]]`
```

Resolves https://github.com/astral-sh/ty/issues/2280, resolves https://github.com/astral-sh/ty/issues/2441.
