### PR TITLE
[ty] Limit fixed-length tuple expansion in overload matching

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -918,6 +918,33 @@ def _(a: int | None):
     )
 ```
 
+### Optimization: Limit tuple element expansion size
+
+To prevent combinatorial explosion, ty limits the Cartesian product size when expanding tuple
+elements. A tuple like `tuple[A | B, A | B, ..., A | B]` with many union-typed elements would
+otherwise produce an exponential number of expanded types.
+
+`overloaded.pyi`:
+
+```pyi
+from typing import overload
+
+@overload
+def f(x: tuple[int, ...]) -> int: ...
+@overload
+def f(x: tuple[str, ...]) -> str: ...
+```
+
+```py
+from overloaded import f
+
+def _(a: int | str) -> None:
+    # This tuple has too many expandable elements for the Cartesian product to be computed.
+    # ty skips the tuple expansion and falls through to the error case.
+    # error: [no-matching-overload]
+    f((a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a))
+```
+
 ### Retry from parameter matching
 
 As per the spec, the argument type expansion should retry evaluating the expanded argument list from

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Argument_type_expans…_-_Optimization___Limit_…_(cd61048adbc17331).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Argument_type_expans…_-_Optimization___Limit_…_(cd61048adbc17331).snap
@@ -119,7 +119,7 @@ error[no-matching-overload]: No overload of function `f` matches arguments
    | |_________^
 41 |       )
    |
-info: Limit of argument type expansion reached at argument 10
+info: Limit of argument type expansion reached at argument 9
 info: First overload defined here
   --> src/overloaded.pyi:8:5
    |

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -11,6 +11,22 @@ use crate::types::tuple::{Tuple, TupleType};
 
 use super::Type;
 
+/// Maximum number of expanded types that can be generated from a single tuple's
+/// Cartesian product in [`expand_type`].
+///
+/// See: [pyright's `maxSingleOverloadArgTypeExpansionCount`][pyright]
+///
+/// [pyright]: https://github.com/microsoft/pyright/blob/7781cb072382eb1df498eb8fb0a8d6a32d25e5c7/packages/pyright-internal/src/common/consts.ts#L21
+const MAX_TUPLE_EXPANSION: usize = 64;
+
+/// Maximum total number of expanded argument type combinations across all arguments
+/// in [`CallArguments::expand`].
+///
+/// See: [pyright's `maxTotalOverloadArgTypeExpansionCount`][pyright]
+///
+/// [pyright]: https://github.com/microsoft/pyright/blob/7781cb072382eb1df498eb8fb0a8d6a32d25e5c7/packages/pyright-internal/src/common/consts.ts#L24
+const MAX_TOTAL_EXPANSION: usize = 256;
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum Argument<'a> {
     /// The synthetic `self` or `cls` argument, which doesn't appear explicitly at the call site.
@@ -166,9 +182,6 @@ impl<'a, 'db> CallArguments<'a, 'db> {
     ///
     /// [argument type expansion]: https://typing.python.org/en/latest/spec/overload.html#argument-type-expansion
     pub(super) fn expand(&self, db: &'db dyn Db) -> impl Iterator<Item = Expansion<'a, 'db>> + '_ {
-        /// Maximum number of argument lists that can be generated in a single expansion step.
-        static MAX_EXPANSIONS: usize = 512;
-
         /// Represents the state of the expansion process.
         enum State<'a, 'b, 'db> {
             LimitReached(usize),
@@ -226,10 +239,10 @@ impl<'a, 'db> CallArguments<'a, 'db> {
                 };
 
                 let expansion_size = expanded_types.len() * state.len();
-                if expansion_size > MAX_EXPANSIONS {
+                if expansion_size > MAX_TOTAL_EXPANSION {
                     tracing::debug!(
                         "Skipping argument type expansion as it would exceed the \
-                            maximum number of expansions ({MAX_EXPANSIONS})"
+                            maximum number of expansions ({MAX_TOTAL_EXPANSION})"
                     );
                     return Some(State::LimitReached(index));
                 }
@@ -380,23 +393,30 @@ fn expand_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
             if let Some(spec) = instance.tuple_spec(db) {
                 return match &*spec {
                     Tuple::Fixed(fixed_length_tuple) => {
-                        let expanded = fixed_length_tuple
+                        // Pre-expand each element and compute the total Cartesian product size.
+                        // Bail out early if the product would exceed `MAX_TUPLE_EXPANSION` to
+                        // avoid exponential blowup (e.g. a 37-element tuple with 2-element
+                        // unions would produce 2^37 types).
+                        let per_element: Vec<_> = fixed_length_tuple
                             .iter_all_elements()
                             .map(|element| {
-                                if let Some(expanded) = expand_type(db, element) {
-                                    Either::Left(expanded.into_iter())
-                                } else {
-                                    Either::Right(std::iter::once(element))
-                                }
+                                expand_type(db, element).unwrap_or_else(|| vec![element])
                             })
-                            .multi_cartesian_product()
-                            .map(|types| Type::tuple(TupleType::heterogeneous(db, types)))
-                            .collect::<Vec<_>>();
+                            .collect();
 
-                        if expanded.len() == 1 {
-                            // There are no elements in the tuple type that can be expanded.
+                        let product_size: usize = per_element
+                            .iter()
+                            .try_fold(1usize, |acc, v| acc.checked_mul(v.len()))
+                            .unwrap_or(usize::MAX);
+
+                        if product_size <= 1 || product_size > MAX_TUPLE_EXPANSION {
                             None
                         } else {
+                            let expanded = per_element
+                                .into_iter()
+                                .multi_cartesian_product()
+                                .map(|types| Type::tuple(TupleType::heterogeneous(db, types)))
+                                .collect::<Vec<_>>();
                             Some(expanded)
                         }
                     }


### PR DESCRIPTION
## Summary

When resolving overloaded calls, ty expands tuple arguments via Cartesian product as required by the [spec](https://typing.python.org/en/latest/spec/overload.html#argument-type-expansion). This PR adjusts our behavior to match [pyright](https://github.com/microsoft/pyright/blob/5a325e4874e775436671eed65ad696787a1ef74b/packages/pyright-internal/src/analyzer/typeEvaluator.ts#L570), which limits to 64 types for a single tuple and 256 across. (As-is, we only applied a 512 limit _after_ expanding.)

Closes https://github.com/astral-sh/ty/issues/1870.
