### PR TITLE
Use structs for SARIF output

### DIFF
--- a/crates/ruff_linter/src/message/sarif.rs
+++ b/crates/ruff_linter/src/message/sarif.rs
@@ -95,6 +95,7 @@ struct SarifRule<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     full_description: Option<SarifMessage<'a>>,
     help: SarifMessage<'a>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     help_uri: Option<String>,
     id: &'a SecondaryCode,
     properties: SarifProperties<'a>,


### PR DESCRIPTION
Summary
--

This PR converts the uses of the `json!` macro in the SARIF output to use
explicit structs instead. This should help with ensuring that there are no
unintentional schema changes in #23173.

There are two intentional schema changes here: we now skip serializing the
`SarifRule::full_description` and the `SarifRule::help_uri` if they are `None`, 
which was not the case before. I verified that our old schema was actually 
incorrect here because a field like:

```json
{
  "fullDescription": {
    "text": null
  }
}
```

is invalid, but `rule.explanation()` is never actually `None` for a Ruff rule.

See https://www.jsonschemavalidator.net/s/FvvrX9hb.

I structured the PR to review commit-by-commit, but the diff didn't end up being
too bad anyway.

Test Plan
--

Existing SARIF tests
