### PR TITLE
Make `setup_primer_project.py` executable and improve the shebang

### DIFF
--- a/scripts/setup_primer_project.py
+++ b/scripts/setup_primer_project.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+#
 # /// script
 # requires-python = ">=3.10"
 # dependencies = ["mypy-primer"]
@@ -6,6 +7,7 @@
 # [tool.uv.sources]
 # mypy-primer = { git = "https://github.com/hauntsaninja/mypy_primer" }
 # ///
+
 """Clone a mypy-primer project and set up a virtualenv with its dependencies installed.
 
 Usage: uv run scripts/setup_primer_project.py <project-name> [directory]


### PR DESCRIPTION
The shebang on this file was useless because the file didn't actually have the executable bit set. It's also not the recommended shebang for uv scripts: see https://docs.astral.sh/uv/guides/scripts/#using-a-shebang-to-create-an-executable-file