### PR TITLE
[ty] Omit the binding context from the display of a `ParamSpec` when the `ParamSpec` is included in the displayed type parameters of the enclosing signature

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
@@ -54,7 +54,7 @@ reveal_type(generic_context(into_callable(identity)))
 # revealed: Literal[1]
 reveal_type(into_callable(identity)(1))
 
-# revealed: [**P, T](c: (**P@identity2) -> T) -> (**P@identity2) -> T
+# revealed: [**P, T](c: (**P) -> T) -> (**P) -> T
 reveal_type(into_callable(identity2))
 # revealed: ty_extensions.GenericContext[P@identity2, T@identity2]
 reveal_type(generic_context(into_callable(identity2)))
@@ -129,7 +129,7 @@ reveal_type(generic_context(decorator_factory))
 def identity(t: T) -> T:
     return t
 
-# revealed: [**P'return, T'return]((**P'return@decorator_factory) -> T'return, /) -> (**P'return@decorator_factory) -> T'return
+# revealed: [**P'return, T'return]((**P'return) -> T'return, /) -> (**P'return) -> T'return
 reveal_type(decorator_factory())
 # revealed: ty_extensions.GenericContext[P'return@decorator_factory, T'return@decorator_factory]
 reveal_type(generic_context(decorator_factory()))
@@ -215,7 +215,7 @@ reveal_type(generic_context(decorator_factory))
 def identity(t: T) -> T:
     return t
 
-# revealed: [**P'return, T'return]((**P'return@decorator_factory) -> T'return, /) -> (**P'return@decorator_factory) -> T'return
+# revealed: [**P'return, T'return]((**P'return) -> T'return, /) -> (**P'return) -> T'return
 reveal_type(decorator_factory())
 # revealed: ty_extensions.GenericContext[P'return@decorator_factory, T'return@decorator_factory]
 reveal_type(generic_context(decorator_factory()))

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
@@ -56,7 +56,7 @@ reveal_type(generic_context(into_callable(identity)))
 # revealed: Literal[1]
 reveal_type(into_callable(identity)(1))
 
-# revealed: [**P, T](c: (**P@identity2) -> T) -> (**P@identity2) -> T
+# revealed: [**P, T](c: (**P) -> T) -> (**P) -> T
 reveal_type(into_callable(identity2))
 # revealed: ty_extensions.GenericContext[P@identity2, T@identity2]
 reveal_type(generic_context(into_callable(identity2)))
@@ -126,7 +126,7 @@ reveal_type(generic_context(decorator_factory))
 def identity[T](t: T) -> T:
     return t
 
-# revealed: [**P'return, T'return]((**P'return@decorator_factory) -> T'return, /) -> (**P'return@decorator_factory) -> T'return
+# revealed: [**P'return, T'return]((**P'return) -> T'return, /) -> (**P'return) -> T'return
 reveal_type(decorator_factory())
 # revealed: ty_extensions.GenericContext[P'return@decorator_factory, T'return@decorator_factory]
 reveal_type(generic_context(decorator_factory()))
@@ -212,7 +212,7 @@ reveal_type(generic_context(decorator_factory))
 def identity[T](t: T) -> T:
     return t
 
-# revealed: [**P'return, T'return]((**P'return@decorator_factory) -> T'return, /) -> (**P'return@decorator_factory) -> T'return
+# revealed: [**P'return, T'return]((**P'return) -> T'return, /) -> (**P'return) -> T'return
 reveal_type(decorator_factory())
 # revealed: ty_extensions.GenericContext[P'return@decorator_factory, T'return@decorator_factory]
 reveal_type(generic_context(decorator_factory()))

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -2135,8 +2135,12 @@ impl<'db> FmtDetailed<'db> for DisplayParameters<'_, 'db> {
             }
             ParametersKind::ParamSpec(typevar) => {
                 write!(f, "**{}", typevar.name(self.db))?;
-                if let Some(name) = typevar.binding_context(self.db).name(self.db) {
-                    write!(f, "@{name}")?;
+                let binding_context = typevar.binding_context(self.db);
+                if let Some(binding_context_name) = binding_context.name(self.db)
+                    && let Some(definition) = binding_context.definition()
+                    && !self.settings.active_scopes.contains(&definition)
+                {
+                    write!(f, "@{binding_context_name}")?;
                 }
             }
         }


### PR DESCRIPTION
## Summary

In https://github.com/astral-sh/ruff/pull/22435, we changed our display of `Callable` types so that we used PEP-695 type parameters more consistently to indicate the scoping of typevars inside these `Callable` types. As part of that change, we started omitting the binding context from the display of a type variable in a `Callable` signature if the type variable was anyway being displayed as part of a type parameter list, since the appearance of the type variable in a type parameter list makes the scoping of the type variable explicit and means that the binding context just adds unnecessary noise.

However, we forgot to make the same changes to `ParamSpec`s: currently on `main`, we always display the binding context when displaying a `ParamSpec`. That leads to internally inconsistent displays like

```py
[**P, T](c: (**P@identity2) -> T) -> (**P@identity2) -> T
```

This PR updates our logic for displaying `ParamSpec`s so that the binding context is also omitted from the display when the `ParamSpec` is listed in a type parameter list for an active scope:


```py
[**P, T](c: (**P) -> T) -> (**P) -> T
```

## Test Plan

mdtests updated
