### PR TITLE
[ty] Use a smaller diagnostic range for `inconsistent-mro` diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_Unresolvable_MROs_in…_(e2b355c09a967862).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_Unresolvable_MROs_in…_(e2b355c09a967862).snap
@@ -26,12 +26,12 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/mro.md
 
 ```
 error[inconsistent-mro]: Cannot create a consistent method resolution order (MRO) for class `Baz` with bases list `[<special-form 'typing.Protocol[T]'>, <class 'Foo'>, <class 'Bar[T@Baz]'>]`
- --> src/mdtest_snippet.py:7:1
+ --> src/mdtest_snippet.py:7:7
   |
 5 | class Foo(Protocol): ...
 6 | class Bar(Protocol[T]): ...
 7 | class Baz(Protocol[T], Foo, Bar[T]): ...  # error: [inconsistent-mro]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
 info: rule `inconsistent-mro` is enabled by default
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/type.md_-_Calls_to_`type()`_-_`inconsistent-mro`_e…_(839db6a431c3b705).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/type.md_-_Calls_to_`type()`_-_`inconsistent-mro`_e…_(839db6a431c3b705).snap
@@ -49,12 +49,12 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/call/type.md
 
 ```
 error[inconsistent-mro]: Cannot create a consistent method resolution order (MRO) for class `Foo1` with bases list `[<special-form 'typing.Generic[K, V]'>, <class 'dict'>]`
- --> src/mdtest_snippet.py:6:1
+ --> src/mdtest_snippet.py:6:7
   |
 4 | V = TypeVar("V")
 5 |
 6 | class Foo1(Generic[K, V], dict): ...  # error: [inconsistent-mro]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^
 7 |
 8 | # fmt: off
   |
@@ -74,18 +74,19 @@ note: This is an unsafe fix and may change runtime behavior
 
 ```
 error[inconsistent-mro]: Cannot create a consistent method resolution order (MRO) for class `Foo2` with bases list `[<special-form 'typing.Generic[K, V]'>, <class 'dict'>]`
-  --> src/mdtest_snippet.py:10:1
+  --> src/mdtest_snippet.py:10:7
    |
  8 |   # fmt: off
  9 |
-10 | / class Foo2(  # error: [inconsistent-mro]
+10 |   class Foo2(  # error: [inconsistent-mro]
+   |  _______^
 11 | |     # comment1
 12 | |     Generic[K, V],  # comment2
 13 | |     # comment3
 14 | |     dict  # comment4
 15 | |     # comment5
 16 | | ): ...
-   | |______^
+   | |_^
 17 |
 18 |   class Foo3(Generic[K, V], dict, metaclass=type): ...  # error: [inconsistent-mro]
    |
@@ -107,12 +108,12 @@ note: This is an unsafe fix and may change runtime behavior
 
 ```
 error[inconsistent-mro]: Cannot create a consistent method resolution order (MRO) for class `Foo3` with bases list `[<special-form 'typing.Generic[K, V]'>, <class 'dict'>]`
-  --> src/mdtest_snippet.py:18:1
+  --> src/mdtest_snippet.py:18:7
    |
 16 | ): ...
 17 |
 18 | class Foo3(Generic[K, V], dict, metaclass=type): ...  # error: [inconsistent-mro]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 19 |
 20 | class Foo4(  # error: [inconsistent-mro]
    |
@@ -132,11 +133,12 @@ note: This is an unsafe fix and may change runtime behavior
 
 ```
 error[inconsistent-mro]: Cannot create a consistent method resolution order (MRO) for class `Foo4` with bases list `[<special-form 'typing.Generic[K, V]'>, <class 'dict'>]`
-  --> src/mdtest_snippet.py:20:1
+  --> src/mdtest_snippet.py:20:7
    |
 18 |   class Foo3(Generic[K, V], dict, metaclass=type): ...  # error: [inconsistent-mro]
 19 |
-20 | / class Foo4(  # error: [inconsistent-mro]
+20 |   class Foo4(  # error: [inconsistent-mro]
+   |  _______^
 21 | |     # comment1
 22 | |     Generic[K, V],  # comment2
 23 | |     # comment3
@@ -145,7 +147,7 @@ error[inconsistent-mro]: Cannot create a consistent method resolution order (MRO
 26 | |     metaclass=type  # comment6
 27 | |     # comment7
 28 | | ): ...
-   | |______^
+   | |_^
 29 |
 30 |   # fmt: on
    |

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1109,8 +1109,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         bases_list,
                         generic_index,
                     } => {
-                        if let Some(builder) =
-                            self.context.report_lint(&INCONSISTENT_MRO, class_node)
+                        if let Some(builder) = self
+                            .context
+                            .report_lint(&INCONSISTENT_MRO, class.header_range(self.db()))
                         {
                             let mut diagnostic = builder.into_diagnostic(format_args!(
                                 "Cannot create a consistent method resolution order (MRO) \


### PR DESCRIPTION
## Summary

Currently these diagnostics take up the whole range of the class, which could be huge if the class body is bigger than just `...` (admittedly implausible, who ever needs more than that in a class body?).

## Test Plan

snapshots updated
