### PR TITLE
Deduplicate type variables in generic functions

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP047_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP047_0.py
@@ -52,6 +52,12 @@ def default_var(v: V) -> V:
     return v
 
 
+# TypeVar used in multiple parameter annotations should still be detected
+def multi_param(t: list[T], c: Callable[[T], None]) -> T:
+    c(t[0])
+    return t[1]
+
+
 # these cases are not handled
 
 def outer():

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs
@@ -1,3 +1,5 @@
+use rustc_hash::FxHashSet;
+
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::StmtFunctionDef;
 use ruff_python_ast::visitor::Visitor;
@@ -158,6 +160,10 @@ pub(crate) fn non_pep695_generic_function(checker: &Checker, function_def: &Stmt
             type_vars.extend(vars);
         }
     }
+
+    // Deduplicate type vars that appear in multiple parameter annotations
+    let mut seen = FxHashSet::default();
+    type_vars.retain(|tv| seen.insert(tv.name));
 
     let Some(type_vars) = check_type_vars(type_vars, checker) else {
         return;

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP047_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP047_0.py.snap
@@ -116,3 +116,23 @@ help: Use type parameters
 45 | 
 46 | 
 note: This is an unsafe fix and may change runtime behavior
+
+UP047 [*] Generic function `multi_param` should use type parameters
+  --> UP047_0.py:56:5
+   |
+55 | # TypeVar used in multiple parameter annotations should still be detected
+56 | def multi_param(t: list[T], c: Callable[[T], None]) -> T:
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+57 |     c(t[0])
+58 |     return t[1]
+   |
+help: Use type parameters
+53 | 
+54 | 
+55 | # TypeVar used in multiple parameter annotations should still be detected
+   - def multi_param(t: list[T], c: Callable[[T], None]) -> T:
+56 + def multi_param[T: float](t: list[T], c: Callable[[T], None]) -> T:
+57 |     c(t[0])
+58 |     return t[1]
+59 | 
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/19863.
