### PR TITLE
Avoid suggesting `InitVar` for `__post_init__` that references PEP 695 type parameters

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF033.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF033.py
@@ -140,3 +140,12 @@ class D:
     def __post_init__(self, x: int = """
     """) -> None:
         self.x = x
+
+
+# https://github.com/astral-sh/ruff/issues/19628
+# No fix: annotation references a type variable scoped to `__post_init__`
+@dataclass
+class E:
+    def __post_init__[T: (str, bytes)](self, a: T | None = None, b: T | None = None) -> None:
+        self.a = str(a)
+        self.b = str(b)

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF033_RUF033.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF033_RUF033.py.snap
@@ -489,4 +489,30 @@ help: Use `dataclasses.InitVar` instead
 141 +     """
 142 +     def __post_init__(self, x: int) -> None:
 143 |         self.x = x
+144 | 
+145 | 
 note: This is an unsafe fix and may change runtime behavior
+
+RUF033 `__post_init__` method with argument defaults
+   --> RUF033.py:149:60
+    |
+147 | @dataclass
+148 | class E:
+149 |     def __post_init__[T: (str, bytes)](self, a: T | None = None, b: T | None = None) -> None:
+    |                                                            ^^^^
+150 |         self.a = str(a)
+151 |         self.b = str(b)
+    |
+help: Use `dataclasses.InitVar` instead
+
+RUF033 `__post_init__` method with argument defaults
+   --> RUF033.py:149:80
+    |
+147 | @dataclass
+148 | class E:
+149 |     def __post_init__[T: (str, bytes)](self, a: T | None = None, b: T | None = None) -> None:
+    |                                                                                ^^^^
+150 |         self.a = str(a)
+151 |         self.b = str(b)
+    |
+help: Use `dataclasses.InitVar` instead


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/19628.