### PR TITLE
Use `DisplayDiagnosticsConfig::program` for Ruff's GitHub output

### DIFF
--- a/crates/ruff/tests/cli/snapshots/cli__format__output_format_github.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__format__output_format_github.snap
@@ -14,6 +14,6 @@ info:
 success: false
 exit_code: 1
 ----- stdout -----
-::error title=Ruff (unformatted),file=[TMP]/input.py,line=1,endLine=2::input.py:1:1: unformatted: File would be reformatted
+::error title=ruff (unformatted),file=[TMP]/input.py,line=1,endLine=2::input.py:1:1: unformatted: File would be reformatted
 
 ----- stderr -----

--- a/crates/ruff/tests/cli/snapshots/cli__lint__output_format_github.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__output_format_github.snap
@@ -16,8 +16,8 @@ info:
 success: false
 exit_code: 1
 ----- stdout -----
-::error title=Ruff (F401),file=[TMP]/input.py,line=1,col=8,endLine=1,endColumn=10::input.py:1:8: F401 `os` imported but unused
-::error title=Ruff (F821),file=[TMP]/input.py,line=2,col=5,endLine=2,endColumn=6::input.py:2:5: F821 Undefined name `y`
-::error title=Ruff (invalid-syntax),file=[TMP]/input.py,line=3,col=1,endLine=3,endColumn=6::input.py:3:1: invalid-syntax: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)
+::error title=ruff (F401),file=[TMP]/input.py,line=1,col=8,endLine=1,endColumn=10::input.py:1:8: F401 `os` imported but unused
+::error title=ruff (F821),file=[TMP]/input.py,line=2,col=5,endLine=2,endColumn=6::input.py:2:5: F821 Undefined name `y`
+::error title=ruff (invalid-syntax),file=[TMP]/input.py,line=3,col=1,endLine=3,endColumn=6::input.py:3:1: invalid-syntax: Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)
 
 ----- stderr -----

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -8,7 +8,6 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 
 pub use self::render::{
     DisplayDiagnostic, DisplayDiagnostics, DummyFileResolver, FileResolver, Input,
-    github::{DisplayGithubDiagnostics, GithubRenderer},
 };
 use crate::cancellation::CancellationToken;
 use crate::{Db, files::File};

--- a/crates/ruff_db/src/diagnostic/render/github.rs
+++ b/crates/ruff_db/src/diagnostic/render/github.rs
@@ -1,12 +1,12 @@
 use crate::diagnostic::{Diagnostic, FileResolver, Severity};
 
-pub struct GithubRenderer<'a> {
+pub(super) struct GithubRenderer<'a> {
     resolver: &'a dyn FileResolver,
     program: &'a str,
 }
 
 impl<'a> GithubRenderer<'a> {
-    pub fn new(resolver: &'a dyn FileResolver, program: &'a str) -> Self {
+    pub(super) fn new(resolver: &'a dyn FileResolver, program: &'a str) -> Self {
         Self { resolver, program }
     }
 
@@ -91,26 +91,6 @@ impl<'a> GithubRenderer<'a> {
         }
 
         Ok(())
-    }
-}
-
-pub struct DisplayGithubDiagnostics<'a> {
-    renderer: &'a GithubRenderer<'a>,
-    diagnostics: &'a [Diagnostic],
-}
-
-impl<'a> DisplayGithubDiagnostics<'a> {
-    pub fn new(renderer: &'a GithubRenderer<'a>, diagnostics: &'a [Diagnostic]) -> Self {
-        Self {
-            renderer,
-            diagnostics,
-        }
-    }
-}
-
-impl std::fmt::Display for DisplayGithubDiagnostics<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.renderer.render(f, self.diagnostics)
     }
 }
 

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -8,8 +8,8 @@ use rustc_hash::FxHashMap;
 
 use ruff_db::diagnostic::{
     Annotation, Diagnostic, DiagnosticFormat, DiagnosticId, DisplayDiagnosticConfig,
-    DisplayDiagnostics, DisplayGithubDiagnostics, FileResolver, GithubRenderer, Input, LintName,
-    SecondaryCode, Severity, Span, SubDiagnostic, SubDiagnosticSeverity, UnifiedFile,
+    DisplayDiagnostics, FileResolver, Input, LintName, SecondaryCode, Severity, Span,
+    SubDiagnostic, SubDiagnosticSeverity, UnifiedFile,
 };
 use ruff_db::files::File;
 
@@ -206,11 +206,6 @@ pub fn render_diagnostics(
         Ok(format) => {
             let config = config.format(format);
             let value = DisplayDiagnostics::new(context, &config, diagnostics);
-            write!(writer, "{value}")?;
-        }
-        Err(RuffOutputFormat::Github) => {
-            let renderer = GithubRenderer::new(context, "Ruff");
-            let value = DisplayGithubDiagnostics::new(&renderer, diagnostics);
             write!(writer, "{value}")?;
         }
         Err(RuffOutputFormat::Grouped) => {

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -597,7 +597,6 @@ impl Display for OutputFormat {
 
 /// The subset of output formats only implemented in Ruff, not in `ruff_db` via `DisplayDiagnostics`.
 pub enum RuffOutputFormat {
-    Github,
     Grouped,
     Sarif,
 }
@@ -616,7 +615,7 @@ impl TryFrom<OutputFormat> for DiagnosticFormat {
             OutputFormat::Pylint => Ok(DiagnosticFormat::Pylint),
             OutputFormat::Rdjson => Ok(DiagnosticFormat::Rdjson),
             OutputFormat::Azure => Ok(DiagnosticFormat::Azure),
-            OutputFormat::Github => Err(RuffOutputFormat::Github),
+            OutputFormat::Github => Ok(DiagnosticFormat::Github),
             OutputFormat::Grouped => Err(RuffOutputFormat::Grouped),
             OutputFormat::Sarif => Err(RuffOutputFormat::Sarif),
         }


### PR DESCRIPTION
Summary
--

This is a follow-up to #22125, which added a `program` field to the shared
`DisplayDiagnosticConfig` type. We can reuse this in the GitHub rendering too to
avoid some of the special casing we had just for Ruff.

The one wrinkle here is that we previously used capital `Ruff` for GitHub
diagnostics, but we use `ruff` in the JUnit diagnostics. I think it's probably
fine to change this in the GitHub diagnostics, but it felt worth calling out.

Test Plan
--

Existing tests with updated snapshots showing the case change
