### PR TITLE
[`flake8-return`] Detect implicit returns in `match` statements (`RET503`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_return/RET503.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_return/RET503.py
@@ -329,6 +329,27 @@ def end_of_file():
     x = 2 \
 
 
+def test_match_non_exhaustive(y):
+    match y:
+        case 0:
+            return 1
+
+
+def test_match_wildcard(y):
+    match y:
+        case 0:
+            return 1
+        case _:
+            return 2
+
+
+def test_match_capture(y):
+    match y:
+        case 0:
+            return 1
+        case val:
+            return val
+
 
 # function return type annotation NoReturn
 def bar_no_return_annotation() -> NoReturn:

--- a/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
@@ -523,11 +523,18 @@ fn has_implicit_return(checker: &Checker, stmt: &Stmt) -> bool {
                 true
             }
         }
-        Stmt::Match(ast::StmtMatch { cases, .. }) => cases.iter().any(|case| {
-            case.body
+        Stmt::Match(ast::StmtMatch { cases, .. }) => {
+            if cases.iter().any(|case| {
+                case.body
+                    .last()
+                    .is_some_and(|last| has_implicit_return(checker, last))
+            }) {
+                return true;
+            }
+            !cases
                 .last()
-                .is_some_and(|last| has_implicit_return(checker, last))
-        }),
+                .is_some_and(|case| case.pattern.is_irrefutable())
+        }
         Stmt::With(ast::StmtWith { body, .. }) => body
             .last()
             .is_some_and(|last_stmt| has_implicit_return(checker, last_stmt)),

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET503_RET503.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET503_RET503.py.snap
@@ -401,49 +401,68 @@ help: Add explicit `return` statement
 330 | 
 331 +     return None
 332 | 
-333 | 
-334 | # function return type annotation NoReturn
+333 | def test_match_non_exhaustive(y):
+334 |     match y:
 note: This is an unsafe fix and may change runtime behavior
 
 RET503 [*] Missing explicit `return` at the end of function able to return non-`None` value
-   --> RET503.py:398:1
+   --> RET503.py:332:1
     |
-398 | / def f():
-399 | |     if a:
-400 | |         return b
-401 | |     else:
-402 | |         with c:
-403 | |             d
+332 | / def test_match_non_exhaustive(y):
+333 | |     match y:
+334 | |         case 0:
+335 | |             return 1
+    | |____________________^
+    |
+help: Add explicit `return` statement
+333 |     match y:
+334 |         case 0:
+335 |             return 1
+336 +     return None
+337 | 
+338 | 
+339 | def test_match_wildcard(y):
+note: This is an unsafe fix and may change runtime behavior
+
+RET503 [*] Missing explicit `return` at the end of function able to return non-`None` value
+   --> RET503.py:419:1
+    |
+419 | / def f():
+420 | |     if a:
+421 | |         return b
+422 | |     else:
+423 | |         with c:
+424 | |             d
     | |_____________^
     |
 help: Add explicit `return` statement
-401 |     else:
-402 |         with c:
-403 |             d
-404 +     return None
-405 | 
-406 | 
-407 | 
+422 |     else:
+423 |         with c:
+424 |             d
+425 +     return None
+426 | 
+427 | 
+428 | 
 note: This is an unsafe fix and may change runtime behavior
 
 RET503 [*] Missing explicit `return` at the end of function able to return non-`None` value
-   --> RET503.py:413:1
+   --> RET503.py:434:1
     |
-411 |   # the semantic model hasn't yet seen `bar`'s declaration.
-412 |   # Supporting nested functions requires making this a deferred rule.
-413 | / def foo(x: int) -> int:
-414 | |     def bar() -> NoReturn:
-415 | |         abort()
-416 | |     if x == 5:
-417 | |         return 5
-418 | |     bar()
+432 |   # the semantic model hasn't yet seen `bar`'s declaration.
+433 |   # Supporting nested functions requires making this a deferred rule.
+434 | / def foo(x: int) -> int:
+435 | |     def bar() -> NoReturn:
+436 | |         abort()
+437 | |     if x == 5:
+438 | |         return 5
+439 | |     bar()
     | |_________^
     |
 help: Add explicit `return` statement
-415 |         abort()
-416 |     if x == 5:
-417 |         return 5
+436 |         abort()
+437 |     if x == 5:
+438 |         return 5
     -     bar()
-418 +     bar()
-419 +     return None
+439 +     bar()
+440 +     return None
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

This PR fixes a false negative in the `RET503` (missing explicit return) rule when using Python 3.10 `match` statements (#23206).

Previously, the `flake8-return` linter only checked for implicit returns *within* the bodies of the individual match cases. 


## Test Plan

1. **Regression Tests**: Added new test cases to `RET503.py`:
    - `test_match_non_exhaustive`: Verified that a `match` without a catch-all now triggers `RET503`.
    - `test_match_wildcard`: Verified that `case _:` correctly satisfies the exhaustiveness check.
    - `test_match_capture`: Verified that a name capture (e.g., `case val:`) correctly satisfies the exhaustiveness check.
