### PR TITLE
[ty] Do not record `ReturnsNever` constraints for symbols with no narrowing applied

### DIFF
--- a/crates/ty_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/ty_python_semantic/src/semantic_index/use_def.rs
@@ -1144,11 +1144,15 @@ impl<'db> UseDefMapBuilder<'db> {
         constraint: ScopedNarrowingConstraint,
     ) {
         for state in &mut self.symbol_states {
-            state.record_narrowing_constraint(&mut self.reachability_constraints, constraint);
+            if state.has_narrowing_constraints() {
+                state.record_narrowing_constraint(&mut self.reachability_constraints, constraint);
+            }
         }
 
         for state in &mut self.member_states {
-            state.record_narrowing_constraint(&mut self.reachability_constraints, constraint);
+            if state.has_narrowing_constraints() {
+                state.record_narrowing_constraint(&mut self.reachability_constraints, constraint);
+            }
         }
     }
 

--- a/crates/ty_python_semantic/src/semantic_index/use_def/place_state.rs
+++ b/crates/ty_python_semantic/src/semantic_index/use_def/place_state.rs
@@ -280,6 +280,13 @@ impl Bindings {
         });
     }
 
+    /// Returns `true` if any live binding has a narrowing constraint applied.
+    pub(super) fn has_narrowing_constraints(&self) -> bool {
+        self.live_bindings
+            .iter()
+            .any(|b| b.narrowing_constraint != ScopedNarrowingConstraint::ALWAYS_TRUE)
+    }
+
     /// Add given constraint to all live bindings.
     pub(super) fn record_narrowing_constraint(
         &mut self,
@@ -389,6 +396,11 @@ impl PlaceState {
             is_place_name,
             PreviousDefinitions::AreShadowed,
         );
+    }
+
+    /// Returns `true` if any live binding has a narrowing constraint applied.
+    pub(super) fn has_narrowing_constraints(&self) -> bool {
+        self.bindings.has_narrowing_constraints()
     }
 
     /// Add given constraint to all live bindings.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
