### PR TITLE
[ty] Respect `Never` return type in `__new__`

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -171,7 +171,7 @@ static PANDAS: Benchmark = Benchmark::new(
         max_dep_date: "2025-06-17",
         python_version: PythonVersion::PY312,
     },
-    4500,
+    5000,
 );
 
 static PYDANTIC: Benchmark = Benchmark::new(

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -580,3 +580,24 @@ reveal_type(C())  # revealed: C
 # Meta.__lt__ is implicitly called here:
 reveal_type(C < C)  # revealed: Literal[True]
 ```
+
+## `__new__` returning `Never`
+
+If `__new__` returns `Never`, the constructor call should also return `Never`, since the constructor
+can never complete successfully.
+
+```py
+from typing_extensions import Never, NoReturn
+
+class AlwaysRaises:
+    def __new__(cls) -> Never:
+        raise RuntimeError("cannot instantiate")
+
+reveal_type(AlwaysRaises())  # revealed: Never
+
+class AlwaysRaisesNoReturn:
+    def __new__(cls) -> NoReturn:
+        raise RuntimeError("cannot instantiate")
+
+reveal_type(AlwaysRaisesNoReturn())  # revealed: Never
+```

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -24,7 +24,6 @@ Since every class has `object` in its MRO, the default implementations are `obje
 As of today there are a number of behaviors that we do not support:
 
 - `__new__` is assumed to return an instance of the class on which it is called
-- User defined `__call__` on metaclass is ignored
 
 ## Creating an instance of the `object` class itself
 
@@ -258,6 +257,27 @@ class Box(Generic[T]):
     def __init__(self, x: T) -> None: ...
 
 reveal_type(Box(1))  # revealed: Box[int]
+```
+
+## `__new__` with method-level type variables mapping to class specialization
+
+When `__new__` has its own type parameters that map to the class's type parameter through the return
+type, we should correctly infer the class specialization.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+class C[T]:
+    x: T
+
+    def __new__[S](cls, x: S) -> "C[tuple[S, S]]":
+        return object.__new__(cls)
+
+reveal_type(C(1))  # revealed: C[tuple[int, int]]
+reveal_type(C("hello"))  # revealed: C[tuple[str, str]]
 ```
 
 ## Constructor calls through `type[T]` with a bound TypeVar

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -21,10 +21,6 @@ Since every class has `object` in its MRO, the default implementations are `obje
     `object`), no arguments are accepted and `TypeError` is raised if any are passed.
 - If `__new__` is defined but `__init__` is not, `object.__init__` will allow arbitrary arguments!
 
-As of today there are a number of behaviors that we do not support:
-
-- `__new__` is assumed to return an instance of the class on which it is called
-
 ## Creating an instance of the `object` class itself
 
 Test the behavior of the `object` class itself. As implementation has to ignore `object` own methods
@@ -278,6 +274,31 @@ class C[T]:
 
 reveal_type(C(1))  # revealed: C[tuple[int, int]]
 reveal_type(C("hello"))  # revealed: C[tuple[str, str]]
+```
+
+## Overloaded `__new__` with generic return types
+
+Overloaded `__new__` methods should correctly resolve to the matching overload and infer the class
+specialization from the overload's return type.
+
+```py
+from typing import Generic, Iterable, TypeVar, overload
+
+T = TypeVar("T")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+
+class MyZip(Generic[T]):
+    @overload
+    def __new__(cls) -> "MyZip[object]": ...
+    @overload
+    def __new__(cls, iter1: Iterable[T1], iter2: Iterable[T2]) -> "MyZip[tuple[T1, T2]]": ...
+    def __new__(cls, *args, **kwargs) -> "MyZip[object]":
+        raise NotImplementedError
+
+def check(a: tuple[int, ...], b: tuple[str, ...]) -> None:
+    reveal_type(MyZip(a, b))  # revealed: MyZip[tuple[int, str]]
+    reveal_type(MyZip())  # revealed: MyZip[object]
 ```
 
 ## Constructor calls through `type[T]` with a bound TypeVar

--- a/crates/ty_python_semantic/resources/mdtest/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/classes.md
@@ -1,5 +1,63 @@
 # Class definitions
 
+## `__new__` return type
+
+Python's `__new__` method can return any type, not just an instance of the class. When `__new__`
+returns a type that is not assignable to the class instance type, we use that return type directly.
+
+### `__new__` returning a different type
+
+```py
+class ReturnsInt:
+    def __new__(cls) -> int:
+        return 42
+
+reveal_type(ReturnsInt())  # revealed: int
+
+x: int = ReturnsInt()  # OK
+y: ReturnsInt = ReturnsInt()  # error: [invalid-assignment]
+```
+
+### `__new__` returning a union type
+
+```py
+class MaybeInt:
+    def __new__(cls, value: str) -> "int | MaybeInt":
+        try:
+            return int(value)
+        except ValueError:
+            return object.__new__(cls)
+
+reveal_type(MaybeInt("42"))  # revealed: int | MaybeInt
+
+a: int | MaybeInt = MaybeInt("42")  # OK
+b: int = MaybeInt("42")  # error: [invalid-assignment]
+```
+
+### `__new__` returning the class type
+
+When `__new__` returns the class type (or `Self`), the normal instance type is used.
+
+```py
+class Normal:
+    def __new__(cls) -> "Normal":
+        return object.__new__(cls)
+
+reveal_type(Normal())  # revealed: Normal
+```
+
+### `__new__` with no return type annotation
+
+When `__new__` has no return type annotation, we fall back to the instance type.
+
+```py
+class NoAnnotation:
+    def __new__(cls):
+        return object.__new__(cls)
+
+reveal_type(NoAnnotation())  # revealed: NoAnnotation
+```
+
 ## Deferred resolution of bases
 
 ### Only the stringified name is deferred

--- a/crates/ty_python_semantic/resources/mdtest/external/sqlmodel.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/sqlmodel.md
@@ -28,6 +28,7 @@ reveal_type(user.name)  # revealed: Any
 
 reveal_type(User.__init__)  # revealed: (self: User, *, id: int, name: str) -> None
 
-# error: [missing-argument]
+# No `missing-argument` error here: `SQLModel.__new__` returns `Any`, so per the spec
+# `__init__` is not evaluated and any arguments are accepted via `__new__`.
 User()
 ```

--- a/crates/ty_python_semantic/resources/mdtest/external/sqlmodel.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/sqlmodel.md
@@ -19,8 +19,12 @@ class User(SQLModel):
     name: str
 
 user = User(id=1, name="John Doe")
-reveal_type(user.id)  # revealed: int
-reveal_type(user.name)  # revealed: str
+# TODO: these should be `int` and `str` once we add pydantic model synthesis.
+# Currently `Any` because `SQLModel.__new__` is annotated as `-> Any`, and the spec says
+# "an explicit return type of `Any` should be treated as a type that is not an instance of
+# the class being constructed."
+reveal_type(user.id)  # revealed: Any
+reveal_type(user.name)  # revealed: Any
 
 reveal_type(User.__init__)  # revealed: (self: User, *, id: int, name: str) -> None
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -414,7 +414,7 @@ If either method comes from a generic base class, we don't currently use its inf
 to specialize the class.
 
 ```py
-from typing_extensions import Generic, TypeVar
+from typing_extensions import Generic, TypeVar, Self
 from ty_extensions import generic_context, into_callable
 
 T = TypeVar("T")
@@ -422,7 +422,7 @@ U = TypeVar("U")
 V = TypeVar("V")
 
 class C(Generic[T, U]):
-    def __new__(cls, *args, **kwargs) -> "C[T, U]":
+    def __new__(cls, *args, **kwargs) -> Self:
         return object.__new__(cls)
 
 class D(C[V, int]):

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -91,6 +91,30 @@ Foo()  # error: [missing-argument]
 reveal_type(Foo(1))  # revealed: Foo
 ```
 
+### Metaclass `__call__` with specific parameters
+
+When the metaclass `__call__` has specific parameters (not just `*args, **kwargs`), we should check
+the metaclass `__call__` signature, even if the return type is the instance type.
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T")
+
+class Meta(type):
+    def __call__(cls: type[T], x: int) -> T:
+        return object.__new__(cls)
+
+class Foo(metaclass=Meta):
+    def __init__(self, x: int) -> None:
+        pass
+
+# The metaclass __call__ has specific parameters, so we check them.
+Foo("wrong")  # error: [invalid-argument-type]
+Foo()  # error: [missing-argument]
+reveal_type(Foo(1))  # revealed: Foo
+```
+
 ## Default
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -117,9 +117,8 @@ reveal_type(Foo(1))  # revealed: Foo
 
 ### Metaclass `__call__` returning bare `type`
 
-When the metaclass `__call__` is annotated as returning `type`, this is typically a mistake in
-singleton patterns where the programmer intended to return an instance. Both mypy and pyright handle
-this specially by ignoring the `type` return annotation and using the instance type instead.
+When the metaclass `__call__` is annotated as returning `type`, we use that return type. This is
+stricter than mypy and pyright, which ignore the `-> type` annotation in this case.
 
 ```py
 from typing import Any
@@ -140,12 +139,11 @@ class MyConfig(metaclass=Singleton):
     def get(self, key: str) -> str:
         return key
 
-# Despite the `-> type` annotation, we treat this as returning an instance.
-# This matches mypy and pyright behavior for this common pattern.
-MyConfig()  # error: [missing-argument]
-reveal_type(MyConfig(1))  # revealed: MyConfig
+# The metaclass `__call__` returns `type`, so that's what we infer.
+reveal_type(MyConfig(1))  # revealed: type
 
-# Instance methods work correctly.
+# Instance methods are not available on `type`.
+# error: [unresolved-attribute]
 MyConfig(1).get("key")
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -115,6 +115,26 @@ Foo()  # error: [missing-argument]
 reveal_type(Foo(1))  # revealed: Foo
 ```
 
+### Metaclass `__call__` returning the class instance type
+
+When the metaclass `__call__` returns the constructed class type (or a subclass), it's not
+overriding normal construction. Per the spec, `__new__`/`__init__` should still be evaluated.
+
+```py
+class Meta(type):
+    def __call__(cls, *args, **kwargs) -> "Foo":
+        return super().__call__(*args, **kwargs)
+
+class Foo(metaclass=Meta):
+    def __init__(self, x: int) -> None:
+        pass
+
+# The metaclass __call__ returns Foo, so we fall through to check __init__.
+Foo()  # error: [missing-argument]
+Foo("wrong")  # error: [invalid-argument-type]
+reveal_type(Foo(1))  # revealed: Foo
+```
+
 ### Metaclass `__call__` returning bare `type`
 
 When the metaclass `__call__` is annotated as returning `type`, we use that return type. This is

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -94,8 +94,8 @@ reveal_type(Foo(1))  # revealed: Foo
 ### Metaclass `__call__` with specific parameters
 
 When the metaclass `__call__` has specific parameters (not just `*args, **kwargs`), we validate them
-even when the return type is an instance type. Here `__init__` accepts anything, so the errors must
-come from the metaclass `__call__`.
+even when the return type is an instance type. Here both `__new__` and `__init__` accept anything,
+so the errors must come from the metaclass `__call__`.
 
 ```py
 from typing import Any, TypeVar
@@ -107,6 +107,9 @@ class Meta(type):
         return object.__new__(cls)
 
 class Foo(metaclass=Meta):
+    def __new__(cls, *args: Any, **kwargs: Any) -> "Foo":
+        return object.__new__(cls)
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         pass
 

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -111,8 +111,12 @@ class Foo(metaclass=Meta):
         pass
 
 # The metaclass `__call__` requires exactly one `int` argument.
-Foo("wrong")  # error: [invalid-argument-type]
-Foo()  # error: [missing-argument]
+# error: [invalid-argument-type]
+reveal_type(Foo("wrong"))  # revealed: Foo
+# error: [missing-argument]
+reveal_type(Foo())  # revealed: Foo
+# error: [too-many-positional-arguments]
+reveal_type(Foo(1, 2))  # revealed: Foo
 reveal_type(Foo(1))  # revealed: Foo
 ```
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7314,7 +7314,11 @@ impl ConstructorReturnDisposition {
             Type::Dynamic(_) | Type::TypeVar(_) => Self::Uncertain,
             Type::Never => Self::Instance,
             Type::NominalInstance(instance) => {
-                if instance.class(db).is_subclass_of(db, constructor_class) {
+                // Check origin class identity first, since `is_subclass_of` returns false
+                // for Generic vs NonGeneric variants of the same class.
+                if instance.class(db).class_literal(db) == constructor_class.class_literal(db)
+                    || instance.class(db).is_subclass_of(db, constructor_class)
+                {
                     Self::Instance
                 } else {
                     Self::NotInstance

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7312,7 +7312,7 @@ impl ConstructorReturnDisposition {
             }
             Type::Dynamic(DynamicType::Any) => Self::NotInstance,
             Type::Dynamic(_) | Type::TypeVar(_) => Self::Uncertain,
-            Type::Never => Self::Instance,
+            Type::Never => Self::NotInstance,
             Type::NominalInstance(instance) => {
                 // Check origin class identity first, since `is_subclass_of` returns false
                 // for Generic vs NonGeneric variants of the same class.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4857,12 +4857,11 @@ impl<'db> Type<'db> {
 
             // All overloads must return a non-instance type for us to treat the metaclass
             // `__call__` as fully overriding `type.__call__`. If any overload returns the
-            // class instance type (or is dynamic/contains typevars), fall through to
+            // class instance type (or contains typevars), fall through to
             // evaluate `__new__`/`__init__`.
             let all_overloads_return_non_instance = !signature.overloads.is_empty()
                 && signature.overloads.iter().all(|sig| {
-                    !sig.return_ty.is_dynamic()
-                        && !sig.return_ty.has_typevar(db)
+                    !sig.return_ty.has_typevar(db)
                         && ConstructorReturnDisposition::of(db, sig.return_ty, class)
                             .is_not_instance()
                 });

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5760,25 +5760,27 @@ impl<'db> Type<'db> {
         );
 
         // Extract metaclass `__call__` info if it exists and has a declared return type.
-        let metaclass_call_info =
-            if let Place::Defined(Type::BoundMethod(metaclass_dunder_call), _, boundness, _) =
-                metaclass_dunder_call.place
-            {
-                let signature = metaclass_dunder_call.function(db).signature(db);
-                // Only use metaclass `__call__` if it has a declared return type.
-                // If return type is unannotated, fall through to `__new__`/`__init__`.
-                let has_declared_return = signature
-                    .overloads
-                    .iter()
-                    .any(|sig| sig.return_ty.is_some());
-                if has_declared_return {
-                    Some((metaclass_dunder_call, boundness))
-                } else {
-                    None
-                }
+        let metaclass_call_info = if let Place::Defined(DefinedPlace {
+            ty: Type::BoundMethod(metaclass_dunder_call),
+            definedness: boundness,
+            ..
+        }) = metaclass_dunder_call.place
+        {
+            let signature = metaclass_dunder_call.function(db).signature(db);
+            // Only use metaclass `__call__` if it has a declared return type.
+            // If return type is unannotated (unknown), fall through to `__new__`/`__init__`.
+            let has_declared_return = signature
+                .overloads
+                .iter()
+                .any(|sig| !sig.return_ty.is_unknown());
+            if has_declared_return {
+                Some((metaclass_dunder_call, boundness))
             } else {
                 None
-            };
+            }
+        } else {
+            None
+        };
 
         // The code below deals with interplay between `__new__` and `__init__` methods.
         // The logic is roughly as follows:
@@ -5892,23 +5894,11 @@ impl<'db> Type<'db> {
                 .to_instance(db)
                 .expect("type should be convertible to instance type");
 
-            // Special case: if the return type is exactly `type`, treat it as returning the
-            // instance type. This is a common pattern in singleton metaclasses where `__call__`
-            // is annotated as `-> type` but actually returns an instance. Both mypy and pyright
-            // handle this specially to avoid false positives.
-            // Note: `-> type` in annotations becomes `NominalInstance(type)`.
-            let returns_bare_type = matches!(
-                metaclass_return_type,
-                Type::NominalInstance(instance) if instance.class(db).is_known(db, KnownClass::Type)
-            );
-
             // Check if we should skip `__new__`/`__init__` evaluation.
             // Skip if: return type is not assignable to instance, is Never, or contains Any.
-            // But don't skip if the return type is exactly `type` (common singleton pattern).
-            let skip_new_init = !returns_bare_type
-                && (!metaclass_return_type.is_assignable_to(db, instance_ty)
-                    || metaclass_return_type.is_never()
-                    || matches!(metaclass_return_type, Type::Dynamic(DynamicType::Any)));
+            let skip_new_init = !metaclass_return_type.is_assignable_to(db, instance_ty)
+                || metaclass_return_type.is_never()
+                || matches!(metaclass_return_type, Type::Dynamic(DynamicType::Any));
 
             // If there are argument errors or we should skip `__new__`/`__init__`, return metaclass result.
             if call_result.is_err() || skip_new_init {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4963,11 +4963,11 @@ impl<'db> Type<'db> {
                 if return_ty.has_typevar(db) {
                     return false;
                 }
-                // Use `is_assignable_to` (matching `into_callable` in class.rs) so that
-                // `-> Any` is treated as assignable to the instance type. This ensures
-                // `__init__` is still checked for libraries like pydantic/SQLModel that
-                // annotate `__new__` as `-> Any`.
-                !return_ty.is_assignable_to(db, constructor_instance_ty)
+                // Per the spec: "an explicit return type of `Any` should be treated as
+                // a type that is not an instance of the class being constructed." We use
+                // `is_subtype_of` so that dynamic types like `Any` are correctly treated
+                // as non-instance returns.
+                !return_ty.is_subtype_of(db, constructor_instance_ty)
             });
 
             if returns_non_instance {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -3347,22 +3347,9 @@ impl<'db> StaticClassLiteral<'db> {
                         )
                     })
             }
-            (CodeGeneratorKind::NamedTuple, "__new__") => {
-                let cls_parameter = Parameter::positional_or_keyword(Name::new_static("cls"))
-                    .with_annotated_type(KnownClass::Type.to_instance(db));
-                // Use `Self` type variable as return type so that subclasses get the correct
-                // return type when calling `__new__`. For example, if `IntBox` inherits from
-                // `Box[int]` (a NamedTuple), then `IntBox(1)` should return `IntBox`, not `Box[int]`.
-                let self_ty = Type::TypeVar(BoundTypeVarInstance::synthetic_self(
-                    db,
-                    instance_ty,
-                    BindingContext::Synthetic,
-                ));
-                signature_from_fields(vec![cls_parameter], self_ty)
-            }
             (
                 CodeGeneratorKind::NamedTuple,
-                "_replace" | "__replace__" | "_fields" | "__slots__",
+                "__new__" | "_replace" | "__replace__" | "_fields" | "__slots__",
             ) => {
                 let fields = self.fields(db, specialization, field_policy);
                 let fields_iter = fields.iter().map(|(name, field)| {

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -383,7 +383,7 @@ async def main(
     errors = 0
 
     for diff in diffs.values():
-        if isinstance(diff, Exception):
+        if isinstance(diff, BaseException):
             errors += 1
         else:
             total_removed += len(diff.removed)
@@ -399,7 +399,7 @@ async def main(
         print()
 
         for (org, repo), diff in diffs.items():
-            if isinstance(diff, Exception):
+            if isinstance(diff, BaseException):
                 changes = "error"
                 print(f"<details><summary>{repo} ({changes})</summary>")
                 repo = repositories[(org, repo)]


### PR DESCRIPTION
## Summary

If a class's `__new__` method returns `Never` or `NoReturn`, the constructor call should infer the return type as `Never` rather than an instance of the class.
