### PR TITLE
[ty] Fix bug passing overloaded callable to generic function

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
@@ -245,3 +245,27 @@ reveal_type(generic_context(outside_callable(int_identity)))
 # error: [invalid-argument-type]
 outside_callable(int_identity)("string")
 ```
+
+## Overloaded callable as generic `Callable` argument
+
+The type variable should be inferred from the first matching overload, rather than unioning
+parameter types across all overloads (which would create an unsatisfiable expected type for
+contravariant type variables).
+
+```py
+from typing import Callable, TypeVar, overload
+
+T = TypeVar("T")
+
+def accepts_callable(converter: Callable[[T], None]) -> None:
+    raise NotImplementedError
+
+@overload
+def f(val: str) -> None: ...
+@overload
+def f(val: bytes) -> None: ...
+def f(val: str | bytes) -> None:
+    pass
+
+accepts_callable(f)  # fine
+```

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
@@ -242,3 +242,25 @@ reveal_type(generic_context(outside_callable(int_identity)))
 # error: [invalid-argument-type]
 outside_callable(int_identity)("string")
 ```
+
+## Overloaded callable as generic `Callable` argument
+
+The type variable should be inferred from the first matching overload, rather than unioning
+parameter types across all overloads (which would create an unsatisfiable expected type for
+contravariant type variables).
+
+```py
+from typing import Callable, overload
+
+def accepts_callable[T](converter: Callable[[T], None]) -> None:
+    raise NotImplementedError
+
+@overload
+def f(val: str) -> None: ...
+@overload
+def f(val: bytes) -> None: ...
+def f(val: str | bytes) -> None:
+    pass
+
+accepts_callable(f)  # fine
+```


### PR DESCRIPTION
## Summary

This is not the right fix, just checking ecosystem impact.

relates to: https://github.com/astral-sh/ty/issues/2546

## Test Plan

<!-- How was it tested? -->
