### PR TITLE
Remove invalid inline `noqa` warning

### DIFF
--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -40,8 +40,7 @@ pub(crate) fn check_noqa(
         FileNoqaDirectives::extract(locator, comment_ranges, &settings.external, path);
 
     // Extract all `noqa` directives.
-    let mut noqa_directives =
-        NoqaDirectives::from_commented_ranges(comment_ranges, &settings.external, path, locator);
+    let mut noqa_directives = NoqaDirectives::from_commented_ranges(comment_ranges, path, locator);
 
     if file_noqa_directives.is_empty() && noqa_directives.is_empty() && suppressions.is_empty() {
         return Vec::new();

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -40,7 +40,7 @@ pub fn generate_noqa_edits(
 ) -> Vec<Option<Edit>> {
     let file_directives = FileNoqaDirectives::extract(locator, comment_ranges, external, path);
     let exemption = FileExemption::from(&file_directives);
-    let directives = NoqaDirectives::from_commented_ranges(comment_ranges, external, path, locator);
+    let directives = NoqaDirectives::from_commented_ranges(comment_ranges, path, locator);
     let comments = find_noqa_comments(
         diagnostics,
         locator,
@@ -771,7 +771,7 @@ fn add_noqa_inner(
     let directives = FileNoqaDirectives::extract(locator, comment_ranges, external, path);
     let exemption = FileExemption::from(&directives);
 
-    let directives = NoqaDirectives::from_commented_ranges(comment_ranges, external, path, locator);
+    let directives = NoqaDirectives::from_commented_ranges(comment_ranges, path, locator);
 
     let comments = find_noqa_comments(
         diagnostics,
@@ -1082,7 +1082,6 @@ pub(crate) struct NoqaDirectives<'a> {
 impl<'a> NoqaDirectives<'a> {
     pub(crate) fn from_commented_ranges(
         comment_ranges: &CommentRanges,
-        external: &[String],
         path: &Path,
         locator: &'a Locator<'a>,
     ) -> Self {
@@ -1104,29 +1103,6 @@ impl<'a> NoqaDirectives<'a> {
                             warn!(
                                 "Missing or joined rule code(s) at {path_display}:{line}: {warning}"
                             );
-                        }
-                    }
-                    if let Directive::Codes(codes) = &directive {
-                        // Warn on invalid rule codes.
-                        for code in &codes.codes {
-                            // Ignore externally-defined rules.
-                            if !external
-                                .iter()
-                                .any(|external| code.as_str().starts_with(external))
-                            {
-                                if Rule::from_code(
-                                    get_redirect_target(code.as_str()).unwrap_or(code.as_str()),
-                                )
-                                .is_err()
-                                {
-                                    #[expect(deprecated)]
-                                    let line = locator.compute_line_index(range.start());
-                                    let path_display = relativize_path(path);
-                                    warn!(
-                                        "Invalid rule code provided to `# noqa` at {path_display}:{line}: {code}"
-                                    );
-                                }
-                            }
                         }
                     }
                     // noqa comments are guaranteed to be single line.


### PR DESCRIPTION
Summary
--

This PR partially addresses #23267. This warning is now implemented as the
RUF102 lint rule, so we can get rid of the warning.

There's actually a second instance of this warning (the only variant with tests)
for file-level `noqa`s. As I noted on the issue, these aren't actually covered
by RUF102, but I think we should make that change and remove that warning
separately.

Test Plan
--

Manual testing:

```console
❯ ruff check --select RUF102 --output-format=concise --no-cache - <<EOF
1 # noqa: X111
EOF
warning: Invalid rule code provided to `# noqa` at -:1: X111
-:1:3: RUF102 [*] Invalid rule code in `# noqa`: X111
Found 1 error.
[*] 1 fixable with the `--fix` option.

❯ cargo run -p ruff -- check --select RUF102 --output-format=concise --no-cache - <<EOF
1 # noqa: X111
EOF
-:1:3: RUF102 [*] Invalid rule code in `# noqa`: X111
Found 1 error.
[*] 1 fixable with the `--fix` option.
```
