### PR TITLE
[ty] Infer submodule type instead of Unknown for unimported submodule access

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -3151,14 +3151,14 @@ We give special diagnostics for this common case too:
 import foo
 
 # snapshot: possibly-missing-submodule
-reveal_type(foo.bar)  # revealed: Unknown
+reveal_type(foo.bar)  # revealed: <module 'foo.bar'> & Any
 ```
 
 ```snapshot
 warning[possibly-missing-submodule]: Submodule `bar` might not have been imported
  --> src/foo_importer.py:4:13
   |
-4 | reveal_type(foo.bar)  # revealed: Unknown
+4 | reveal_type(foo.bar)  # revealed: <module 'foo.bar'> & Any
   |             ^^^^^^^
   |
 help: Consider explicitly importing `foo.bar`
@@ -3170,14 +3170,14 @@ help: Consider explicitly importing `foo.bar`
 import baz
 
 # snapshot: possibly-missing-submodule
-reveal_type(baz.bar)  # revealed: Unknown
+reveal_type(baz.bar)  # revealed: <module 'baz.bar'> & Any
 ```
 
 ```snapshot
 warning[possibly-missing-submodule]: Submodule `bar` might not have been imported
  --> src/baz_importer.py:4:13
   |
-4 | reveal_type(baz.bar)  # revealed: Unknown
+4 | reveal_type(baz.bar)  # revealed: <module 'baz.bar'> & Any
   |             ^^^^^^^
   |
 help: Consider explicitly importing `baz.bar`

--- a/crates/ty_python_semantic/resources/mdtest/import/nonstandard_conventions.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/nonstandard_conventions.md
@@ -61,7 +61,7 @@ import mypackage
 
 reveal_type(mypackage.imported.X)  # revealed: int
 # error: [possibly-missing-submodule] "Submodule `fails` might not have been imported"
-reveal_type(mypackage.fails.Y)  # revealed: Unknown
+reveal_type(mypackage.fails.Y)  # revealed: int & Any
 ```
 
 ### In Non-Stub
@@ -91,7 +91,7 @@ import mypackage
 
 reveal_type(mypackage.imported.X)  # revealed: int
 # error: [possibly-missing-submodule] "Submodule `fails` might not have been imported"
-reveal_type(mypackage.fails.Y)  # revealed: Unknown
+reveal_type(mypackage.fails.Y)  # revealed: int & Any
 ```
 
 ## Absolute `from` Import of Direct Submodule in `__init__`
@@ -126,7 +126,7 @@ import mypackage
 
 reveal_type(mypackage.imported.X)  # revealed: int
 # error: [possibly-missing-submodule] "Submodule `fails` might not have been imported"
-reveal_type(mypackage.fails.Y)  # revealed: Unknown
+reveal_type(mypackage.fails.Y)  # revealed: int & Any
 ```
 
 ### In Non-Stub
@@ -156,7 +156,7 @@ import mypackage
 
 reveal_type(mypackage.imported.X)  # revealed: int
 # error: [possibly-missing-submodule] "Submodule `fails` might not have been imported"
-reveal_type(mypackage.fails.Y)  # revealed: Unknown
+reveal_type(mypackage.fails.Y)  # revealed: int & Any
 ```
 
 ## Import of Direct Submodule in `__init__`
@@ -185,7 +185,7 @@ import mypackage
 
 # TODO: this could work and would be nice to have?
 # error: [possibly-missing-submodule] "Submodule `imported` might not have been imported"
-reveal_type(mypackage.imported.X)  # revealed: Unknown
+reveal_type(mypackage.imported.X)  # revealed: int & Any
 ```
 
 ### In Non-Stub
@@ -209,7 +209,7 @@ import mypackage
 
 # TODO: this could work and would be nice to have
 # error: [possibly-missing-submodule] "Submodule `imported` might not have been imported"
-reveal_type(mypackage.imported.X)  # revealed: Unknown
+reveal_type(mypackage.imported.X)  # revealed: int & Any
 ```
 
 ## Relative `from` Import of Nested Submodule in `__init__`
@@ -243,9 +243,9 @@ import mypackage
 
 reveal_type(mypackage.submodule)  # revealed: <module 'mypackage.submodule'>
 # error: [possibly-missing-submodule] "Submodule `nested` might not have been imported"
-reveal_type(mypackage.submodule.nested)  # revealed: Unknown
+reveal_type(mypackage.submodule.nested)  # revealed: <module 'mypackage.submodule.nested'> & Any
 # error: [possibly-missing-submodule] "Submodule `nested` might not have been imported"
-reveal_type(mypackage.submodule.nested.X)  # revealed: Unknown
+reveal_type(mypackage.submodule.nested.X)  # revealed: int & Any
 # error: [unresolved-attribute] "has no member `nested`"
 reveal_type(mypackage.nested)  # revealed: Unknown
 # error: [unresolved-attribute] "has no member `nested`"
@@ -281,9 +281,9 @@ import mypackage
 reveal_type(mypackage.submodule)  # revealed: <module 'mypackage.submodule'>
 # TODO: this would be nice to support
 # error: [possibly-missing-submodule] "Submodule `nested` might not have been imported"
-reveal_type(mypackage.submodule.nested)  # revealed: Unknown
+reveal_type(mypackage.submodule.nested)  # revealed: <module 'mypackage.submodule.nested'> & Any
 # error: [possibly-missing-submodule] "Submodule `nested` might not have been imported"
-reveal_type(mypackage.submodule.nested.X)  # revealed: Unknown
+reveal_type(mypackage.submodule.nested.X)  # revealed: int & Any
 reveal_type(mypackage.nested)  # revealed: <module 'mypackage.submodule.nested'>
 reveal_type(mypackage.nested.X)  # revealed: int
 ```
@@ -319,9 +319,9 @@ import mypackage
 
 reveal_type(mypackage.submodule)  # revealed: <module 'mypackage.submodule'>
 # error: [possibly-missing-submodule] "Submodule `nested` might not have been imported"
-reveal_type(mypackage.submodule.nested)  # revealed: Unknown
+reveal_type(mypackage.submodule.nested)  # revealed: <module 'mypackage.submodule.nested'> & Any
 # error: [possibly-missing-submodule] "Submodule `nested` might not have been imported"
-reveal_type(mypackage.submodule.nested.X)  # revealed: Unknown
+reveal_type(mypackage.submodule.nested.X)  # revealed: int & Any
 # error: [unresolved-attribute] "has no member `nested`"
 reveal_type(mypackage.nested)  # revealed: Unknown
 # error: [unresolved-attribute] "has no member `nested`"
@@ -357,9 +357,9 @@ import mypackage
 reveal_type(mypackage.submodule)  # revealed: <module 'mypackage.submodule'>
 # TODO: this would be nice to support
 # error: [possibly-missing-submodule] "Submodule `nested` might not have been imported"
-reveal_type(mypackage.submodule.nested)  # revealed: Unknown
+reveal_type(mypackage.submodule.nested)  # revealed: <module 'mypackage.submodule.nested'> & Any
 # error: [possibly-missing-submodule] "Submodule `nested` might not have been imported"
-reveal_type(mypackage.submodule.nested.X)  # revealed: Unknown
+reveal_type(mypackage.submodule.nested.X)  # revealed: int & Any
 reveal_type(mypackage.nested)  # revealed: <module 'mypackage.submodule.nested'>
 reveal_type(mypackage.nested.X)  # revealed: int
 ```
@@ -394,11 +394,11 @@ X: int = 42
 import mypackage
 
 # error: [possibly-missing-submodule] "Submodule `submodule` might not have been imported"
-reveal_type(mypackage.submodule)  # revealed: Unknown
+reveal_type(mypackage.submodule)  # revealed: <module 'mypackage.submodule'> & Any
 # error: [possibly-missing-submodule] "Submodule `submodule` might not have been imported"
-reveal_type(mypackage.submodule.nested)  # revealed: Unknown
+reveal_type(mypackage.submodule.nested)  # revealed: Any
 # error: [possibly-missing-submodule] "Submodule `submodule` might not have been imported"
-reveal_type(mypackage.submodule.nested.X)  # revealed: Unknown
+reveal_type(mypackage.submodule.nested.X)  # revealed: Any
 ```
 
 ### In Non-Stub
@@ -430,11 +430,11 @@ import mypackage
 
 # TODO: this would be nice to support
 # error: [possibly-missing-submodule] "Submodule `submodule` might not have been imported"
-reveal_type(mypackage.submodule)  # revealed: Unknown
+reveal_type(mypackage.submodule)  # revealed: <module 'mypackage.submodule'> & Any
 # error: [possibly-missing-submodule] "Submodule `submodule` might not have been imported"
-reveal_type(mypackage.submodule.nested)  # revealed: Unknown
+reveal_type(mypackage.submodule.nested)  # revealed: Any
 # error: [possibly-missing-submodule] "Submodule `submodule` might not have been imported"
-reveal_type(mypackage.submodule.nested.X)  # revealed: Unknown
+reveal_type(mypackage.submodule.nested.X)  # revealed: Any
 ```
 
 ## Relative `from` Import of Direct Submodule in `__init__`, Mismatched Alias
@@ -461,7 +461,7 @@ X: int = 42
 import mypackage
 
 # error: [possibly-missing-submodule] "Submodule `imported` might not have been imported"
-reveal_type(mypackage.imported.X)  # revealed: Unknown
+reveal_type(mypackage.imported.X)  # revealed: int & Any
 # error: [unresolved-attribute] "has no member `imported_m`"
 reveal_type(mypackage.imported_m.X)  # revealed: Unknown
 ```
@@ -487,7 +487,7 @@ import mypackage
 
 # TODO: this would be nice to support, as it works at runtime
 # error: [possibly-missing-submodule] "Submodule `imported` might not have been imported"
-reveal_type(mypackage.imported.X)  # revealed: Unknown
+reveal_type(mypackage.imported.X)  # revealed: int & Any
 reveal_type(mypackage.imported_m.X)  # revealed: int
 ```
 
@@ -675,7 +675,7 @@ reveal_type(imported.X)  # revealed: int
 # TODO: this would be nice to support, but it's dangerous with available_submodule_attributes
 # for details, see: https://github.com/astral-sh/ty/issues/1488
 # error: [possibly-missing-submodule] "Submodule `imported` might not have been imported"
-reveal_type(mypackage.imported.X)  # revealed: Unknown
+reveal_type(mypackage.imported.X)  # revealed: int & Any
 ```
 
 ### In Non-Stub
@@ -701,7 +701,7 @@ reveal_type(imported.X)  # revealed: int
 
 # TODO: this would be nice to support, as it works at runtime
 # error: [possibly-missing-submodule] "Submodule `imported` might not have been imported"
-reveal_type(mypackage.imported.X)  # revealed: Unknown
+reveal_type(mypackage.imported.X)  # revealed: int & Any
 ```
 
 ## `from` Import of Sibling Module
@@ -740,7 +740,7 @@ reveal_type(imported.X)  # revealed: int
 # error: [unresolved-attribute] "has no member `fails`"
 reveal_type(imported.fails.Y)  # revealed: Unknown
 # error: [possibly-missing-submodule] "Submodule `fails` might not have been imported"
-reveal_type(mypackage.fails.Y)  # revealed: Unknown
+reveal_type(mypackage.fails.Y)  # revealed: int & Any
 ```
 
 ### In Non-Stub
@@ -773,7 +773,7 @@ from mypackage import imported
 reveal_type(imported.X)  # revealed: int
 reveal_type(imported.fails.Y)  # revealed: int
 # error: [possibly-missing-submodule] "Submodule `fails`"
-reveal_type(mypackage.fails.Y)  # revealed: Unknown
+reveal_type(mypackage.fails.Y)  # revealed: int & Any
 ```
 
 ## Fractal Re-export Nameclash Problems

--- a/crates/ty_python_semantic/resources/mdtest/import/relative.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/relative.md
@@ -248,7 +248,7 @@ from . import foo
 import package
 
 # error: [possibly-missing-submodule]
-reveal_type(package.foo.X)  # revealed: Unknown
+reveal_type(package.foo.X)  # revealed: int & Any
 ```
 
 ## Relative imports at the top of a search path

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -644,7 +644,7 @@ from module2 import imported as other_imported
 from ty_extensions import TypeOf, static_assert, is_equivalent_to
 
 # error: [possibly-missing-submodule]
-reveal_type(imported.abc)  # revealed: Unknown
+reveal_type(imported.abc)  # revealed: <module 'imported.abc'> & Any
 
 reveal_type(other_imported.abc)  # revealed: <module 'imported.abc'>
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8396,7 +8396,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         {
                             let mut maybe_submodule_name = module_name.clone();
                             maybe_submodule_name.extend(&relative_submodule);
-                            if resolve_module(db, self.file(), &maybe_submodule_name).is_some() {
+                            if let Some(submodule) =
+                                resolve_module(db, self.file(), &maybe_submodule_name)
+                            {
                                 if let Some(builder) = self
                                     .context
                                     .report_lint(&POSSIBLY_MISSING_SUBMODULE, attribute)
@@ -8408,7 +8410,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                         "Consider explicitly importing `{maybe_submodule_name}`"
                                     ));
                                 }
-                                return fallback();
+                                let module_type = Type::module_literal(db, self.file(), submodule);
+                                let intersection = IntersectionBuilder::new(db)
+                                    .add_positive(module_type)
+                                    .add_positive(Type::any())
+                                    .build();
+                                return TypeAndQualifiers::new(
+                                    intersection,
+                                    TypeOrigin::Inferred,
+                                    TypeQualifiers::empty(),
+                                );
                             }
                         }
                     }

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1684,6 +1684,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     subscript_ty
                 })
             }
+            Type::Intersection(intersection) => {
+                self.infer_type_expression(slice);
+                intersection.map_positive(self.db(), |element| {
+                    let mut speculative_builder = self.speculate();
+                    let subscript_ty =
+                        speculative_builder.infer_subscript_type_expression(subscript, *element);
+                    self.context.extend(&speculative_builder.context.finish());
+                    subscript_ty
+                })
+            }
             _ => {
                 if !self.in_string_annotation() {
                     self.infer_expression(slice, TypeContext::default());


### PR DESCRIPTION
## Summary

Picks up the stalled work from #21619 and #21654, implementing the `<module> & Any` approach [suggested by @AlexWaygood](https://github.com/astral-sh/ruff/pull/21619#pullrequestreview-2464449082) in his review.

When ty encounters `module.submodule` where the submodule exists but wasn't explicitly imported, it previously inferred `Unknown` as the type. This caused cascading false positives — any downstream attribute access on the result would re-trigger `possibly-missing-attribute` or produce `Unknown` types throughout the chain.

Now we infer `<module 'x.y'> & Any`:
- The **module literal** half resolves known attributes correctly (e.g., `mod.sub.X` where `X: int` → `int & Any`)
- The **`Any`** half absorbs downstream attribute lookups that would otherwise cascade warnings (e.g., `mod.sub.nested.X` → `Any` without additional diagnostics)

### How it works

| Pattern | Before | After |
|---------|--------|-------|
| Direct submodule access (`mod.sub`) | `Unknown` | `<module 'mod.sub'> & Any` |
| Known attr via submodule (`mod.sub.X` where `X: int`) | `Unknown` | `int & Any` |
| Cascading chain (`mod.sub.nested.X`) | `Unknown` (+ cascading warnings) | `Any` (no cascading warnings) |

### Key difference from #21619

PR #21619 returned just `<module>`, which caused `.nested` access to re-enter the same code path and emit additional `possibly-missing-attribute` warnings. The `& Any` intersection prevents this — `Any` always returns a bound result for member lookups, so downstream access doesn't trigger new diagnostics.

### Known limitation

`int & Any` is displayed rather than just `int` for known attributes accessed through the submodule. This is because `IntersectionBuilder` doesn't currently simplify `T & Any → T`. This could be addressed separately by adding that simplification rule to the intersection builder.

Closes https://github.com/astral-sh/ty/issues/1623

## Test plan

- Updated assertions in `attributes.md`, `import/nonstandard_conventions.md`, `import/relative.md`, `type_properties/is_equivalent_to.md`
- Updated snapshot for `attributes.md` diagnostic
- Verified no cascading `possibly-missing-attribute` warnings in nested submodule test cases
- Full `cargo nextest run -p ty_python_semantic` passes (463 tests)
- `cargo clippy` clean
- `uvx prek run -a` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)