### PR TITLE
[ty] Support shellexpand for configuration paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4644,6 +4644,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "shellexpand",
  "thiserror 2.0.18",
  "toml",
  "tracing",

--- a/crates/ty_project/Cargo.toml
+++ b/crates/ty_project/Cargo.toml
@@ -44,6 +44,7 @@ salsa = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+shellexpand = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }

--- a/crates/ty_project/src/metadata/value.rs
+++ b/crates/ty_project/src/metadata/value.rs
@@ -399,7 +399,11 @@ impl RelativePathBuf {
             ValueSource::Cli | ValueSource::Editor => system.current_directory(),
         };
 
-        SystemPath::absolute(&self.0, relative_to)
+        // Expand tildes and environment variables in the path (e.g. `~/.cache/foo`).
+        let expanded = shellexpand::full(self.0.as_str());
+        let path = expanded.as_deref().unwrap_or(self.0.as_str());
+
+        SystemPath::absolute(SystemPath::new(path), relative_to)
     }
 }
 

--- a/crates/ty_project/src/metadata/value.rs
+++ b/crates/ty_project/src/metadata/value.rs
@@ -400,10 +400,28 @@ impl RelativePathBuf {
         };
 
         // Expand tildes and environment variables in the path (e.g. `~/.cache/foo`).
-        let expanded = shellexpand::full(self.0.as_str());
-        let path = expanded.as_deref().unwrap_or(self.0.as_str());
+        // Use `full_with_context` to route lookups through the `System` trait,
+        // ensuring correct behavior in tests, WASM, and the LSP.
+        let expanded = shellexpand::full_with_context(
+            self.0.as_str(),
+            || system.env_var("HOME").ok(),
+            |var| match system.env_var(var) {
+                Ok(val) => Ok(Some(val)),
+                Err(std::env::VarError::NotPresent) => Ok(None),
+                Err(e) => Err(e),
+            },
+        );
 
-        SystemPath::absolute(SystemPath::new(path), relative_to)
+        match &expanded {
+            Ok(path) => SystemPath::absolute(SystemPath::new(path.as_ref()), relative_to),
+            Err(err) => {
+                tracing::warn!(
+                    "Failed to expand variables in path `{}`: {err}",
+                    self.0.as_str()
+                );
+                SystemPath::absolute(&self.0, relative_to)
+            }
+        }
     }
 }
 
@@ -463,5 +481,80 @@ impl RelativeGlobPattern {
 impl std::fmt::Display for RelativeGlobPattern {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use ruff_db::system::{SystemPath, SystemPathBuf, TestSystem};
+
+    use super::{RelativePathBuf, ValueSource};
+
+    #[test]
+    fn tilde_expansion_uses_system_env() {
+        let system = TestSystem::default();
+        system.set_env_var("HOME", "/test/home");
+
+        let path = RelativePathBuf::new(
+            "~/projects",
+            ValueSource::File(Arc::new(SystemPathBuf::from("/project"))),
+        );
+        let resolved = path.absolute(SystemPath::new("/project"), &system);
+
+        assert_eq!(resolved, SystemPathBuf::from("/test/home/projects"));
+    }
+
+    #[test]
+    fn env_var_expansion_uses_system_env() {
+        let system = TestSystem::default();
+        system.set_env_var("MY_DIR", "/custom/dir");
+
+        let path = RelativePathBuf::new(
+            "$MY_DIR/sub",
+            ValueSource::File(Arc::new(SystemPathBuf::from("/project"))),
+        );
+        let resolved = path.absolute(SystemPath::new("/project"), &system);
+
+        assert_eq!(resolved, SystemPathBuf::from("/custom/dir/sub"));
+    }
+
+    #[test]
+    fn undefined_env_var_falls_back_to_literal() {
+        let system = TestSystem::default();
+
+        let path = RelativePathBuf::new(
+            "$NONEXISTENT/foo",
+            ValueSource::File(Arc::new(SystemPathBuf::from("/project"))),
+        );
+        let resolved = path.absolute(SystemPath::new("/project"), &system);
+
+        // When the variable is not found, the original path is used as a fallback.
+        assert_eq!(resolved, SystemPathBuf::from("/project/$NONEXISTENT/foo"));
+    }
+
+    #[test]
+    fn no_expansion_needed() {
+        let system = TestSystem::default();
+
+        let path = RelativePathBuf::new(
+            "src/lib.rs",
+            ValueSource::File(Arc::new(SystemPathBuf::from("/project"))),
+        );
+        let resolved = path.absolute(SystemPath::new("/project"), &system);
+
+        assert_eq!(resolved, SystemPathBuf::from("/project/src/lib.rs"));
+    }
+
+    #[test]
+    fn cli_source_resolves_relative_to_cwd() {
+        let system = TestSystem::default();
+        system.set_env_var("HOME", "/test/home");
+
+        let path = RelativePathBuf::cli("~/config");
+        let resolved = path.absolute(SystemPath::new("/project"), &system);
+
+        assert_eq!(resolved, SystemPathBuf::from("/test/home/config"));
     }
 }

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -567,7 +567,7 @@ impl Session {
             }
         };
 
-        let settings = options.into_settings(&root, client);
+        let settings = options.into_settings(&root, client, &*self.native_system);
         let Some(workspace) = self.workspaces.workspaces.get_mut(&root) else {
             tracing::debug!("Ignoring workspace `{url}` since it was not registered");
             return;

--- a/crates/ty_server/src/session/options.rs
+++ b/crates/ty_server/src/session/options.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use lsp_types::Url;
-use ruff_db::system::{SystemPath, SystemPathBuf};
+use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use ruff_macros::Combine;
 use ruff_python_ast::PythonVersion;
 use serde::{Deserialize, Serialize};
@@ -201,19 +201,32 @@ pub struct WorkspaceOptions {
 }
 
 impl WorkspaceOptions {
-    pub(crate) fn into_settings(self, root: &SystemPath, client: &Client) -> WorkspaceSettings {
-        let configuration_file =
-            self.configuration_file
-                .and_then(|config_file| match shellexpand::full(&config_file) {
-                    Ok(path) => Some(SystemPath::absolute(&*path, root)),
-                    Err(error) => {
-                        client.show_error_message(format_args!(
-                            "Failed to expand the environment variables \
-                            for the `ty.configuration_file` setting: {error}"
-                        ));
-                        None
-                    }
-                });
+    pub(crate) fn into_settings(
+        self,
+        root: &SystemPath,
+        client: &Client,
+        system: &dyn System,
+    ) -> WorkspaceSettings {
+        let configuration_file = self.configuration_file.and_then(|config_file| {
+            match shellexpand::full_with_context(
+                &config_file,
+                || system.env_var("HOME").ok(),
+                |var| match system.env_var(var) {
+                    Ok(val) => Ok(Some(val)),
+                    Err(std::env::VarError::NotPresent) => Ok(None),
+                    Err(e) => Err(e),
+                },
+            ) {
+                Ok(path) => Some(SystemPath::absolute(&*path, root)),
+                Err(error) => {
+                    client.show_error_message(format_args!(
+                        "Failed to expand the environment variables \
+                                for the `ty.configuration_file` setting: {error}"
+                    ));
+                    None
+                }
+            }
+        });
 
         let options_overrides =
             self.configuration.and_then(|map| {


### PR DESCRIPTION
## Summary

This matches the approach and behavior we use in Ruff.

Closes https://github.com/astral-sh/ty/issues/2811.
