### PR TITLE
[ty] support narrowing from Callable returning type guard

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -391,6 +391,18 @@ def _(a: Foo):
         reveal_type(a)  # revealed: Foo & Bar
 ```
 
+Type guard narrowing also works when the callee has a `Callable` type:
+
+```py
+from typing import Callable
+
+def _(x: Foo | Bar, is_bar: Callable[[object], TypeIs[Bar]]):
+    if is_bar(x):
+        reveal_type(x)  # revealed: Bar
+    else:
+        reveal_type(x)  # revealed: Foo & ~Bar
+```
+
 For generics, we transform the argument passed into `TypeIs[]` from `X` to `Top[X]`. This helps
 especially when using various functions from typeshed that are annotated as returning
 `TypeIs[SomeCovariantGeneric[Any]]` to avoid false positives in other type checkers. For ty's


### PR DESCRIPTION
## Summary

We only narrowed from TypeIs/TypeGuard if the callable was a FunctionLiteral or BoundMethod type. We should be willing to do this narrowing for any TypeIs/TypeGuard type returned from any call expression.

## Test Plan

Added mdtest.
