### PR TITLE
[ty] intern structs used in `UseDefMap`

### DIFF
--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -877,16 +877,16 @@ pub(crate) fn place_by_id<'db>(
     // on inference from bindings.
 
     let declarations = match considered_definitions {
-        ConsideredDefinitions::EndOfScope => use_def.end_of_scope_declarations(place_id),
-        ConsideredDefinitions::AllReachable => use_def.reachable_declarations(place_id),
+        ConsideredDefinitions::EndOfScope => use_def.end_of_scope_declarations(db, place_id),
+        ConsideredDefinitions::AllReachable => use_def.reachable_declarations(db, place_id),
     };
 
     let declared = place_from_declarations_impl(db, declarations, requires_explicit_reexport)
         .ignore_conflicting_declarations();
 
     let all_considered_bindings = || match considered_definitions {
-        ConsideredDefinitions::EndOfScope => use_def.end_of_scope_bindings(place_id),
-        ConsideredDefinitions::AllReachable => use_def.reachable_bindings(place_id),
+        ConsideredDefinitions::EndOfScope => use_def.end_of_scope_bindings(db, place_id),
+        ConsideredDefinitions::AllReachable => use_def.reachable_bindings(db, place_id),
     };
 
     // If a symbol is undeclared, but qualified with `typing.Final`, we use the right-hand side
@@ -1685,7 +1685,7 @@ pub(crate) mod implicit_globals {
         };
         place_from_declarations(
             db,
-            use_def_map(db, module_type_scope).end_of_scope_symbol_declarations(symbol_id),
+            use_def_map(db, module_type_scope).end_of_scope_symbol_declarations(db, symbol_id),
         )
         .ignore_conflicting_declarations()
     }

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -1516,7 +1516,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let mut use_def_maps: IndexVec<_, _> = self
             .use_def_maps
             .into_iter()
-            .map(|builder| Arc::new(builder.finish()))
+            .map(|builder| Arc::new(builder.finish(self.db)))
             .collect();
 
         let mut ast_ids: IndexVec<_, _> = self

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4953,7 +4953,7 @@ pub(super) fn report_invalid_method_override<'db>(
         MethodKind::NotSynthesized => {
             if let Some(superclass_symbol) = place_table(db, superclass_scope).symbol_id(member)
                 && let Some(binding) = use_def_map(db, superclass_scope)
-                    .end_of_scope_bindings(ScopedPlaceId::Symbol(superclass_symbol))
+                    .end_of_scope_bindings(db, ScopedPlaceId::Symbol(superclass_symbol))
                     .next()
                 && let Some(definition) = binding.binding.definition()
             {

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -83,7 +83,7 @@ pub(crate) fn enum_metadata<'db>(
     let mut auto_counter = 0;
 
     let ignored_names: Option<Vec<&str>> = if let Some(ignore) = table.symbol_id("_ignore_") {
-        let ignore_bindings = use_def_map.reachable_symbol_bindings(ignore);
+        let ignore_bindings = use_def_map.reachable_symbol_bindings(db, ignore);
         let ignore_place = place_from_bindings(db, ignore_bindings).place;
 
         match ignore_place {
@@ -101,7 +101,7 @@ pub(crate) fn enum_metadata<'db>(
     let mut aliases = FxHashMap::default();
 
     let members = use_def_map
-        .all_end_of_scope_symbol_bindings()
+        .all_end_of_scope_symbol_bindings(db)
         .filter_map(|(symbol_id, bindings)| {
             let name = table.symbol(symbol_id).name();
 
@@ -241,7 +241,7 @@ pub(crate) fn enum_metadata<'db>(
                 enum_values.insert(value_ty, name.clone());
             }
 
-            let declarations = use_def_map.end_of_scope_symbol_declarations(symbol_id);
+            let declarations = use_def_map.end_of_scope_symbol_declarations(db, symbol_id);
             let declared =
                 place_from_declarations(db, declarations).ignore_conflicting_declarations();
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -384,7 +384,7 @@ impl<'db> OverloadLiteral<'db> {
             ty: Type::FunctionLiteral(previous_type),
             definedness: Definedness::AlwaysDefined,
             ..
-        }) = place_from_bindings(db, use_def.bindings_at_use(use_id)).place
+        }) = place_from_bindings(db, use_def.bindings_at_use(db, use_id)).place
         else {
             return None;
         };

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -89,9 +89,9 @@ pub fn definitions_for_name<'db>(
             if let Some(global_symbol_id) = global_place_table.symbol_id(name_str) {
                 let global_use_def_map = crate::semantic_index::use_def_map(db, global_scope_id);
                 let global_bindings =
-                    global_use_def_map.reachable_symbol_bindings(global_symbol_id);
+                    global_use_def_map.reachable_symbol_bindings(db, global_symbol_id);
                 let global_declarations =
-                    global_use_def_map.reachable_symbol_declarations(global_symbol_id);
+                    global_use_def_map.reachable_symbol_declarations(db, global_symbol_id);
 
                 for binding in global_bindings {
                     if let Some(def) = binding.binding.definition() {
@@ -117,8 +117,8 @@ pub fn definitions_for_name<'db>(
         let use_def_map = index.use_def_map(scope_id);
 
         // Get all definitions (both bindings and declarations) for this place
-        let bindings = use_def_map.reachable_symbol_bindings(symbol_id);
-        let declarations = use_def_map.reachable_symbol_declarations(symbol_id);
+        let bindings = use_def_map.reachable_symbol_bindings(db, symbol_id);
+        let declarations = use_def_map.reachable_symbol_declarations(db, symbol_id);
 
         for binding in bindings {
             if let Some(def) = binding.binding.definition() {
@@ -335,7 +335,7 @@ fn definitions_for_attribute_in_class_hierarchy<'db>(
             let use_def = use_def_map(db, class_scope);
 
             // Check declarations first
-            for decl in use_def.reachable_symbol_declarations(place_id) {
+            for decl in use_def.reachable_symbol_declarations(db, place_id) {
                 if let Some(def) = decl.declaration.definition() {
                     resolved.extend(resolve_definition(
                         db,
@@ -348,7 +348,7 @@ fn definitions_for_attribute_in_class_hierarchy<'db>(
             }
 
             // If no declarations found, check bindings
-            for binding in use_def.reachable_symbol_bindings(place_id) {
+            for binding in use_def.reachable_symbol_bindings(db, place_id) {
                 if let Some(def) = binding.binding.definition() {
                     resolved.extend(resolve_definition(
                         db,
@@ -373,7 +373,7 @@ fn definitions_for_attribute_in_class_hierarchy<'db>(
                 let use_def = index.use_def_map(function_scope_id);
 
                 // Check declarations first
-                for decl in use_def.reachable_member_declarations(place_id) {
+                for decl in use_def.reachable_member_declarations(db, place_id) {
                     if let Some(def) = decl.declaration.definition() {
                         resolved.extend(resolve_definition(
                             db,
@@ -386,7 +386,7 @@ fn definitions_for_attribute_in_class_hierarchy<'db>(
                 }
 
                 // If no declarations found, check bindings
-                for binding in use_def.reachable_member_bindings(place_id) {
+                for binding in use_def.reachable_member_bindings(db, place_id) {
                     if let Some(def) = binding.binding.definition() {
                         resolved.extend(resolve_definition(
                             db,
@@ -1278,8 +1278,8 @@ mod resolve_definition {
         let mut definitions = IndexSet::new();
 
         // Get all definitions (both bindings and declarations) for this place
-        let bindings = use_def_map.reachable_symbol_bindings(symbol_id);
-        let declarations = use_def_map.reachable_symbol_declarations(symbol_id);
+        let bindings = use_def_map.reachable_symbol_bindings(db, symbol_id);
+        let declarations = use_def_map.reachable_symbol_declarations(db, symbol_id);
 
         for binding in bindings {
             if let Some(def) = binding.binding.definition() {

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -289,7 +289,7 @@ fn unbound_symbol_no_reachability_constraint_check() {
 fn first_public_binding<'db>(db: &'db TestDb, file: File, name: &str) -> Definition<'db> {
     let scope = global_scope(db, file);
     use_def_map(db, scope)
-        .end_of_scope_symbol_bindings(place_table(db, scope).symbol_id(name).unwrap())
+        .end_of_scope_symbol_bindings(db, place_table(db, scope).symbol_id(name).unwrap())
         .find_map(|b| b.binding.definition())
         .expect("no binding found")
 }

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -37,7 +37,7 @@ pub(crate) fn all_end_of_scope_members<'db>(
     let table = place_table(db, scope_id);
 
     use_def_map
-        .all_end_of_scope_symbol_declarations()
+        .all_end_of_scope_symbol_declarations(db)
         .filter_map(move |(symbol_id, declarations)| {
             let place_result = place_from_declarations(db, declarations);
             let first_reachable_definition = place_result.first_declaration?;
@@ -55,7 +55,7 @@ pub(crate) fn all_end_of_scope_members<'db>(
                 first_reachable_definition,
             })
         })
-        .chain(use_def_map.all_end_of_scope_symbol_bindings().filter_map(
+        .chain(use_def_map.all_end_of_scope_symbol_bindings(db).filter_map(
             move |(symbol_id, bindings)| {
                 let PlaceWithDefinition {
                     place,
@@ -88,7 +88,7 @@ pub(crate) fn all_reachable_members<'db>(
     let table = place_table(db, scope_id);
 
     use_def_map
-        .all_reachable_symbols()
+        .all_reachable_symbols(db)
         .flat_map(move |(symbol_id, declarations, bindings)| {
             let symbol = table.symbol(symbol_id);
 
@@ -387,7 +387,7 @@ impl<'db> AllMembers<'db> {
                 let use_def_map = use_def_map(db, module_scope);
                 let place_table = place_table(db, module_scope);
 
-                for (symbol_id, _) in use_def_map.all_end_of_scope_symbol_declarations() {
+                for (symbol_id, _) in use_def_map.all_end_of_scope_symbol_declarations(db) {
                     let symbol_name = place_table.symbol(symbol_id).name();
                     let Place::Defined(DefinedPlace { ty, .. }) =
                         imported_symbol(db, Some(file), symbol_name, None).place

--- a/crates/ty_python_semantic/src/types/member.rs
+++ b/crates/ty_python_semantic/src/types/member.rs
@@ -79,7 +79,7 @@ pub(super) fn class_member<'db>(db: &'db dyn Db, scope: ScopeId<'db>, name: &str
             {
                 // Otherwise, we need to check if the symbol has bindings
                 let use_def = use_def_map(db, scope);
-                let bindings = use_def.end_of_scope_symbol_bindings(symbol_id);
+                let bindings = use_def.end_of_scope_symbol_bindings(db, symbol_id);
                 let inferred = place_from_bindings(db, bindings).place;
 
                 // TODO: we should not need to calculate inferred type second time. This is a temporary

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -109,7 +109,7 @@ fn check_class_declaration<'db>(
         symbol: ScopedSymbolId,
     ) -> bool {
         use_def_map(db, scope)
-            .end_of_scope_symbol_bindings(symbol)
+            .end_of_scope_symbol_bindings(db, symbol)
             .filter_map(|binding| binding.binding.definition())
             .any(|definition| definition.kind(db).is_function_def())
     }
@@ -147,7 +147,7 @@ fn check_class_declaration<'db>(
                 && PROHIBITED_NAMEDTUPLE_ATTRS.contains(&member.name.as_str())
                 && let Some(symbol_id) = place_table(db, class_scope).symbol_id(&member.name)
                 && let Some(bad_definition) = use_def_map(db, class_scope)
-                    .reachable_bindings(ScopedPlaceId::Symbol(symbol_id))
+                    .reachable_bindings(db, ScopedPlaceId::Symbol(symbol_id))
                     .filter_map(|binding| binding.binding.definition())
                     .find(|def| !matches!(def.kind(db), DefinitionKind::AnnotatedAssignment(_)))
                 && let Some(builder) = context.report_lint(
@@ -295,7 +295,7 @@ fn check_class_declaration<'db>(
                         // annotation.
                         let superclass_definition = superclass_symbol_id.and_then(|id| {
                             use_def_map(db, superclass_scope)
-                                .end_of_scope_symbol_declarations(id)
+                                .end_of_scope_symbol_declarations(db, id)
                                 .find_map(|decl| decl.declaration.definition())
                         });
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -97,7 +97,7 @@ impl<'db> ProtocolClass<'db> {
         let class_place_table = place_table(db, body_scope);
 
         for (symbol_id, mut bindings_iterator) in
-            use_def_map(db, body_scope).all_end_of_scope_symbol_bindings()
+            use_def_map(db, body_scope).all_end_of_scope_symbol_bindings(db)
         {
             let symbol_name = class_place_table.symbol(symbol_id).name();
 
@@ -121,8 +121,10 @@ impl<'db> ProtocolClass<'db> {
                         };
                         !place_from_declarations(
                             db,
-                            use_def_map(db, superclass_scope)
-                                .end_of_scope_declarations(ScopedPlaceId::Symbol(scoped_symbol_id)),
+                            use_def_map(db, superclass_scope).end_of_scope_declarations(
+                                db,
+                                ScopedPlaceId::Symbol(scoped_symbol_id),
+                            ),
                         )
                         .into_place_and_conflicting_declarations()
                         .0
@@ -949,7 +951,7 @@ fn cached_protocol_interface<'db>(
         // members at runtime, and it's important that we accurately understand
         // type narrowing that uses `isinstance()` or `issubclass()` with
         // runtime-checkable protocols.
-        for (symbol_id, bindings) in use_def_map.all_end_of_scope_symbol_bindings() {
+        for (symbol_id, bindings) in use_def_map.all_end_of_scope_symbol_bindings(db) {
             let place_and_definition = place_from_bindings(db, bindings);
             let Some(ty) = place_and_definition.place.ignore_possibly_undefined() else {
                 continue;
@@ -965,7 +967,7 @@ fn cached_protocol_interface<'db>(
             );
         }
 
-        for (symbol_id, declarations) in use_def_map.all_end_of_scope_symbol_declarations() {
+        for (symbol_id, declarations) in use_def_map.all_end_of_scope_symbol_declarations(db) {
             let place_result = place_from_declarations(db, declarations);
             let first_declaration = place_result.first_declaration;
             let place = place_result.ignore_conflicting_declarations();

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -548,7 +548,7 @@ impl SpecialFormType {
                 let symbol_id = place_table(db, scope).symbol_id(self.name())?;
 
                 use_def_map(db, scope)
-                    .end_of_scope_bindings(ScopedPlaceId::Symbol(symbol_id))
+                    .end_of_scope_bindings(db, ScopedPlaceId::Symbol(symbol_id))
                     .next()?
                     .binding
                     .definition()


### PR DESCRIPTION
## Summary

While working on https://github.com/astral-sh/ruff/pull/23283, I thought that perhaps we could achieve better memory usage by interning `Bindings` itself. I'll give it a try.

## Test Plan

N/A
