### PR TITLE
Extend TD003 to accept Jira-style issue IDs on the same line

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
@@ -40,4 +40,10 @@ def foo(x):
 
 # TODO: A todo with a random number, 5431
 
+# TODO: JIRA-123 A todo with a Jira-style issue ID on the same line
+
+# TODO: RFFU-6877 Another Jira-style issue ID
+
+# TODO: FOO-1 Minimum length Jira-style issue ID
+
 # TODO: here's a TODO on the last line with no link

--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -249,8 +249,9 @@ static ISSUE_LINK_OWN_LINE_REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
 
 static ISSUE_LINK_TODO_LINE_REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     RegexSet::new([
-        r"\s*(http|https)://.*", // issue link
-        r"\s*#\d+.*",            // issue code - like "#003"
+        r"\s*(http|https)://.*",  // issue link
+        r"\s*#\d+.*",             // issue code - like "#003"
+        r"\s*[A-Z]+-\d+",         // issue code - like "JIRA-123", "RFFU-6877"
     ])
     .unwrap()
 });

--- a/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__missing-todo-link_TD003.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__missing-todo-link_TD003.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_todos/mod.rs
+assertion_line: 27
 ---
 TD003 Missing issue link for this TODO
   --> TD003.py:15:3
@@ -51,14 +52,14 @@ TD003 Missing issue link for this TODO
 41 | # TODO: A todo with a random number, 5431
    |   ^^^^
 42 |
-43 | # TODO: here's a TODO on the last line with no link
+43 | # TODO: JIRA-123 A todo with a Jira-style issue ID on the same line
    |
 
 TD003 Missing issue link for this TODO
-  --> TD003.py:43:3
+  --> TD003.py:49:3
    |
-41 | # TODO: A todo with a random number, 5431
-42 |
-43 | # TODO: here's a TODO on the last line with no link
+47 | # TODO: FOO-1 Minimum length Jira-style issue ID
+48 |
+49 | # TODO: here's a TODO on the last line with no link
    |   ^^^^
    |


### PR DESCRIPTION
The `ISSUE_LINK_TODO_LINE_REGEX_SET` (used for matching issue references on the same line as a TODO comment) was missing the `[A-Z]+-\d+` pattern that was already present in the own-line regex set (`ISSUE_LINK_OWN_LINE_REGEX_SET`).

This meant that comments like:

```python
# TODO: JIRA-123 fix the widget
# TODO: RFFU-6877 investigate flaky test
```

would incorrectly trigger TD003 (missing-todo-link), even though the issue ID was right there on the same line. The pattern only worked when the issue ID was on a separate comment line below the TODO.

**Changes:**
- Added `[A-Z]+-\d+` pattern to `ISSUE_LINK_TODO_LINE_REGEX_SET`
- Added test cases for Jira-style issue IDs on the same line as TODO comments
- Updated snapshot

Closes #20809