### PR TITLE
[ty] mdtest.py: auto-rerun mdtests when snapshots are rejected in a separate process

### DIFF
--- a/crates/ty_python_semantic/mdtest.py
+++ b/crates/ty_python_semantic/mdtest.py
@@ -237,7 +237,10 @@ class MDTestRunner:
 
                 # When a pending snapshot (.snap.new) is rejected in a separate
                 # process (e.g. `cargo insta review`), the file is deleted.
-                # Re-run only the tests for the .md file that produced it.
+                # A common reason for rejecting a snapshot is that it was stale
+                # (produced by an earlier test run and now outdated). Re-run the
+                # relevant tests so the snapshot is regenerated from the current
+                # state of the code.
                 if (
                     change == Change.deleted
                     and path.name.endswith(".snap.new")


### PR DESCRIPTION
## Summary

This change improves `mdtest.py` watch mode to automatically re-run tests when snapshot files are rejected during review (e.g., via `cargo insta review` in a separate process). 

When a pending snapshot (`.snap.new` file) is deleted — which happens when a snapshot is rejected — the watch mode now:
1. Detects the deletion of `.snap.new` files in the snapshots directory
2. Maps the snapshot filename back to its source `.md` file using a new `_md_file_for_snapshot()` helper method
3. Re-runs the corresponding mdtest to regenerate the snapshot from the current code state

This is useful because rejected snapshots are often stale (produced by an earlier test run), and re-running the test ensures the snapshot is regenerated with the latest code.

## Test Plan

This PR was Claude-generated (with guidance and iteration by me), but I tested it manually locally and it does what I want it to! To test it manually I:
- Started `mdtest.py` running in an embedded terminal inside VSCode
- Edited an mdtest with `<!-- snapshot-diagnostics -->` enabled so that a new diagnostic was emitted
- In a separate process, ran `cargo insta review`
- Went back to VSCode and changed the `.md` file again so that the diagnostic would change
- Went back to the separate process and rejected the snapshot change (it's now stale, since I edited the `.md` file again)
- Observed that a new pending snapshot was instantly regenerated by mdtest.py after the old (stale) snapshot was rejected. This is different to what happens on `main`, where mdtest.py does not create a new snapshot for you to accept/reject unless you press return (to rerun all tests) or make another edit to the `.md` file