### PR TITLE
[flake8-bugbear] Fix B023 false positive for immediately-invoked lambdas

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B023.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B023.py
@@ -183,3 +183,12 @@ for val in range(3):
 
 
     funcs.append(make_func())
+
+
+# OK because the lambda is immediately invoked (IIFE pattern).
+# The closure is consumed right away, so late-binding is not a concern.
+for i in range(3):
+    (lambda: i)()
+    (lambda x=i: x)()
+    print((lambda: i)())
+    result = (lambda i=i: i * 2)()

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
@@ -132,6 +132,12 @@ impl<'a> Visitor<'a> for SuspiciousVariablesVisitor<'a> {
                 range: _,
                 node_index: _,
             }) => {
+                // Mark immediately-invoked lambdas as safe — the closure
+                // is consumed right away, so late-binding is not a concern.
+                if func.is_lambda_expr() {
+                    self.safe_functions.push(func);
+                }
+
                 match func.as_ref() {
                     Expr::Name(ast::ExprName { id, .. }) => {
                         if matches!(id.as_str(), "filter" | "reduce" | "map") {


### PR DESCRIPTION
## Summary

Fixes #7847.

B023 (`function-uses-loop-variable`) currently flags lambdas that reference loop variables even when the lambda is immediately invoked (IIFE pattern). Since the closure is consumed right away, late-binding is not a concern and the diagnostic is a false positive.

This PR marks immediately-invoked lambdas as safe by checking `func.is_lambda_expr()` at the call site visitor, pushing the lambda into `safe_functions` so its body is not flagged.

## Test Plan

Added test cases to `B023.py` covering several IIFE patterns:

```python
for i in range(3):
    (lambda: i)()          # OK — immediately invoked
    (lambda x=i: x)()      # OK — default arg + immediately invoked
    print((lambda: i)())   # OK — nested in another call
    result = (lambda i=i: i * 2)()  # OK — default arg shadows
```

All existing B023 tests continue to pass. No snapshot changes needed (the new cases produce no diagnostics, as expected).