### PR TITLE
[ty] Relax union variadic guard to check only parameters beyond minimum length

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -831,9 +831,15 @@ def f17(x: tuple[int] | tuple[int, int]) -> None:
 
 # Longer union elements must still be rejected when they would contribute
 # extra positional arguments.
-def f20(a: int, b: str) -> None: ...
-def f21(x: tuple[int, str] | tuple[int, str, int]) -> None:
+def f20(a: int, b: int) -> None: ...
+def f21(x: tuple[int, int] | tuple[int, int, int]) -> None:
     f20(*x)  # error: [too-many-positional-arguments]
+
+# Shorter union elements must also be rejected when they cannot provide a required
+# positional argument.
+def f22(a: int, b: int, c: int) -> None: ...
+def f23(x: tuple[int, int] | tuple[int, int, int]) -> None:
+    f22(*x)  # error: [missing-argument]
 ```
 
 ### Mixed argument and parameter containing variadic

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -823,14 +823,11 @@ def f18(x: int = 0, y: int = 0) -> None: ...
 def f19(args: tuple[int, ...] | tuple[int, int]) -> None:
     f18(*args)
 
-# TODO: Union variadic unpacking should also work when the non-defaulted parameters
-# are covered by all union elements, even if not all remaining parameters are defaulted.
-# Currently we only apply per-element iteration when all remaining positional parameters
-# have defaults, so this falls back to `iterate()` which produces `tuple[int, ...]` and
-# greedily matches `c: str` with `int`.
+# Union variadic unpacking also works when the non-defaulted parameters are covered by
+# the shortest union element, even if not all remaining parameters are defaulted.
 def f16(a: int, b: int = 0, c: str = "") -> None: ...
 def f17(x: tuple[int] | tuple[int, int]) -> None:
-    f16(*x)  # error: [invalid-argument-type]  # TODO: false positive
+    f16(*x)
 ```
 
 ### Mixed argument and parameter containing variadic

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -828,6 +828,12 @@ def f19(args: tuple[int, ...] | tuple[int, int]) -> None:
 def f16(a: int, b: int = 0, c: str = "") -> None: ...
 def f17(x: tuple[int] | tuple[int, int]) -> None:
     f16(*x)
+
+# Longer union elements must still be rejected when they would contribute
+# extra positional arguments.
+def f20(a: int, b: str) -> None: ...
+def f21(x: tuple[int, str] | tuple[int, str, int]) -> None:
+    f20(*x)  # error: [too-many-positional-arguments]
 ```
 
 ### Mixed argument and parameter containing variadic
@@ -1569,6 +1575,10 @@ from ty_extensions import Unknown
 def f(a: int = 0, b: int = 0, c: int = 0, fmt: str | None = None) -> None: ...
 def _(args: "Unknown | tuple[int, int, int]"):
     f(*args, fmt="{key}")  # fine
+
+def g(a: int, b: int = 0, c: int = 0) -> None: ...
+def _(args: tuple[int, int] | tuple[int, int, int]):
+    g(*args, c=1)  # error: [parameter-already-assigned]
 ```
 
 ## Variadic unpacking should stop at max known arity

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -840,6 +840,17 @@ def f21(x: tuple[int, int] | tuple[int, int, int]) -> None:
 def f22(a: int, b: int, c: int) -> None: ...
 def f23(x: tuple[int, int] | tuple[int, int, int]) -> None:
     f22(*x)  # error: [missing-argument]
+
+# Later positional arguments must not be allowed to "slide left" when a longer
+# union member would still bind an incompatible tuple element. We currently
+# handle this conservatively, so this still reports the broader iterator-based
+# family of errors.
+def f24(a: int, b: int, c: int = 0) -> None: ...
+def f25(x: tuple[int] | tuple[int, str]) -> None:
+    # error: [invalid-argument-type]
+    # error: [invalid-argument-type]
+    # error: [too-many-positional-arguments]
+    f24(*x, 1)  # error: [invalid-argument-type]
 ```
 
 ### Mixed argument and parameter containing variadic

--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -957,7 +957,7 @@ retries it from the start which includes parameter matching as well.
 from typing import overload
 
 @overload
-def f(x: int, y: int, z: str | None = None) -> None: ...
+def f(x: int, y: int) -> None: ...
 @overload
 def f(x: int, y: str, z: int) -> None: ...
 ```
@@ -984,6 +984,47 @@ def _(t: tuple[int, str] | tuple[int, str, int]) -> None:
     # the first example, while the second list matches the second overload. And, because not all of
     # the expanded argument list evaluates successfully, we produce an error.
     f(*t)  # error: [no-matching-overload]
+
+from typing import Literal, overload
+
+@overload
+def g(x: int, y: str) -> Literal[1]: ...
+@overload
+def g(x: int, y: str, z: int) -> Literal[2]: ...
+def g(*args):
+    return 1
+
+def _(t: tuple[int, str] | tuple[int, str, int]) -> None:
+    # Here both expanded argument lists evaluate successfully, so argument expansion should keep
+    # both overloads and combine their return types.
+    reveal_type(g(*t))  # revealed: Literal[1, 2]
+
+@overload
+def h(x: int, y: str) -> Literal[1]: ...
+@overload
+def h(x: object, y: object, z: object) -> Literal[2]: ...
+def h(*args):
+    return 1
+
+def _(t: tuple[int, str] | tuple[int, str, int]) -> None:
+    # Even though the 3-arg overload can type-check against the unexpanded `*args`, argument
+    # expansion should still revive the 2-arg overload and combine both return types.
+    reveal_type(h(*t))  # revealed: Literal[1, 2]
+
+@overload
+def k(x: int, y: str) -> Literal[1]: ...
+@overload
+def k(x: int | str, y: object, z: object) -> Literal[2]: ...
+@overload
+def k(x: object, y: object, z: object) -> Literal[2]: ...
+def k(*args, **kwargs):
+    return 1
+
+def _(t: tuple[int, str] | tuple[int, str, int]) -> None:
+    # Here argument expansion should run before continuing with the multi-overload logic, because
+    # the 2-arg overload can still match one expansion even though it was pruned provisionally
+    # before expansion.
+    reveal_type(k(*t))  # revealed: Literal[1, 2]
 ```
 
 ## Filtering based on variadic arguments

--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -991,7 +991,7 @@ from typing import Literal, overload
 def g(x: int, y: str) -> Literal[1]: ...
 @overload
 def g(x: int, y: str, z: int) -> Literal[2]: ...
-def g(*args):
+def g(*args, **kwargs) -> int:
     return 1
 
 def _(t: tuple[int, str] | tuple[int, str, int]) -> None:
@@ -1003,12 +1003,10 @@ def _(t: tuple[int, str] | tuple[int, str, int]) -> None:
 def h(x: int, y: str) -> Literal[1]: ...
 @overload
 def h(x: object, y: object, z: object) -> Literal[2]: ...
-def h(*args):
+def h(*args, **kwargs) -> int:
     return 1
 
 def _(t: tuple[int, str] | tuple[int, str, int]) -> None:
-    # Even though the 3-arg overload can type-check against the unexpanded `*args`, argument
-    # expansion should still revive the 2-arg overload and combine both return types.
     reveal_type(h(*t))  # revealed: Literal[1, 2]
 
 @overload
@@ -1017,14 +1015,26 @@ def k(x: int, y: str) -> Literal[1]: ...
 def k(x: int | str, y: object, z: object) -> Literal[2]: ...
 @overload
 def k(x: object, y: object, z: object) -> Literal[2]: ...
-def k(*args, **kwargs):
+def k(*args, **kwargs) -> int:
     return 1
 
 def _(t: tuple[int, str] | tuple[int, str, int]) -> None:
-    # Here argument expansion should run before continuing with the multi-overload logic, because
-    # the 2-arg overload can still match one expansion even though it was pruned provisionally
-    # before expansion.
     reveal_type(k(*t))  # revealed: Literal[1, 2]
+
+# TODO: this case should error with overlapping overloads -- but people do write overlapping
+# overloads, and `Literal[1, 2]` is still a better return type here than `Literal[2]`.
+
+@overload
+def m(x: int, y: str) -> Literal[1]: ...
+@overload
+def m(x: int, y: str, z: int = 0) -> Literal[2]: ...
+def m(*args, **kwargs) -> int:
+    return 1
+
+def _(t: tuple[int, str] | tuple[int, str, int]) -> None:
+    # The defaulted third parameter lets the second overload survive provisional arity checking,
+    # but argument expansion should still revive the 2-arg overload and combine both return types.
+    reveal_type(m(*t))  # revealed: Literal[1, 2]
 ```
 
 ## Filtering based on variadic arguments

--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -957,7 +957,7 @@ retries it from the start which includes parameter matching as well.
 from typing import overload
 
 @overload
-def f(x: int, y: int) -> None: ...
+def f(x: int, y: int, z: str | None = None) -> None: ...
 @overload
 def f(x: int, y: str, z: int) -> None: ...
 ```
@@ -968,21 +968,21 @@ from overloaded import f
 # Test all of the above with a number of different splatted argument types
 
 def _(t: tuple[int, str]) -> None:
-    # This correctly produces an error because the first element of the union has a precise arity of
-    # 2, which matches the first overload, but the second element of the tuple doesn't match the
-    # second parameter type, yielding an `invalid-argument-type` error.
+    # This correctly produces an error because the argument has a precise arity of 2, which
+    # matches the first overload, but the second element of the tuple doesn't match the second
+    # parameter type, yielding an `invalid-argument-type` error.
     f(*t)  # error: [invalid-argument-type]
 
 def _(t: tuple[int, str, int]) -> None:
-    # This correctly produces no error because the first element of the union has a precise arity of
-    # 3, which matches the second overload.
+    # This correctly produces no error because the argument has a precise arity of 3, which
+    # matches the second overload.
     f(*t)
 
 def _(t: tuple[int, str] | tuple[int, str, int]) -> None:
     # This produces an error because the expansion produces two argument lists: `[*tuple[int, str]]`
-    # and `[*tuple[int, str, int]]`. The first list produces produces a type checking error as
-    # described in the first example, while the second list matches the second overload. And,
-    # because not all of the expanded argument list evaluates successfully, we produce an error.
+    # and `[*tuple[int, str, int]]`. The first list produces a type checking error as described in
+    # the first example, while the second list matches the second overload. And, because not all of
+    # the expanded argument list evaluates successfully, we produce an error.
     f(*t)  # error: [no-matching-overload]
 ```
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3305,6 +3305,7 @@ struct ParameterInfo {
 }
 
 struct ArgumentMatcher<'a, 'db> {
+    arguments: &'a CallArguments<'a, 'db>,
     parameters: &'a Parameters<'db>,
     argument_forms: &'a mut ArgumentForms,
     errors: &'a mut Vec<BindingError<'db>>,
@@ -3325,7 +3326,7 @@ struct ArgumentMatcher<'a, 'db> {
 
 impl<'a, 'db> ArgumentMatcher<'a, 'db> {
     fn new(
-        arguments: &CallArguments<'a, 'db>,
+        arguments: &'a CallArguments<'a, 'db>,
         parameters: &'a Parameters<'db>,
         argument_forms: &'a mut ArgumentForms,
         errors: &'a mut Vec<BindingError<'db>>,
@@ -3342,6 +3343,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             .collect();
 
         Self {
+            arguments,
             parameters,
             argument_forms,
             errors,
@@ -3353,6 +3355,18 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             variadic_argument_matched_to_variadic_parameter: false,
             explicit_keyword_parameters,
         }
+    }
+
+    fn has_later_positional_input(&self, argument_index: usize) -> bool {
+        self.arguments
+            .iter()
+            .skip(argument_index + 1)
+            .any(|(argument, _)| {
+                matches!(
+                    argument,
+                    Argument::Synthetic | Argument::Positional | Argument::Variadic
+                )
+            })
     }
 
     fn get_argument_index(&self, argument_index: usize) -> Option<usize> {
@@ -3530,8 +3544,14 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                     // later element types. `match_variadic` accounts for that by treating
                     // positions beyond the guaranteed minimum as only conditionally present: they
                     // can satisfy optional parameters, but any required positional parameter
-                    // beyond the minimum still causes the match to fail provisionally.
-                    Type::Union(union) if self.parameters.variadic().is_none() => {
+                    // beyond the minimum still causes the match to fail provisionally. This is
+                    // only sound when no later argument can still contribute more positional
+                    // slots; otherwise, a later positional argument could shift left differently
+                    // for different union members.
+                    Type::Union(union)
+                        if self.parameters.variadic().is_none()
+                            && !self.has_later_positional_input(argument_index) =>
+                    {
                         let tuple_specs: Vec<_> =
                             union.elements(db).iter().map(|ty| ty.iterate(db)).collect();
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3496,25 +3496,11 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                     // union types, length bounds, and variable element so that the rest of the
                     // matching logic handles unions correctly.
                     //
-                    // We restrict this to cases where all remaining positional parameters are
-                    // defaulted and there is no variadic parameter, because the per-position
-                    // union loses the correlation between element lengths and per-position types.
-                    // For example, given overloads `f(x: int, y: int)` and `f(x: int, y: str, z: int)`
-                    // with `t: tuple[int, str] | tuple[int, str, int]`, the per-position union
-                    // would collapse the two arities, preventing the expansion step from correctly
-                    // splitting the union into separate argument lists per overload.
-                    //
-                    // TODO: This is overly conservative. We could also apply this when all
-                    // non-defaulted parameters are covered by the shortest union element,
-                    // e.g. `f(a: int, b: int = 0)` with `*x` where `x: tuple[int] | tuple[int, int]`.
-                    Type::Union(union)
-                        if self.parameters.variadic().is_none()
-                            && self
-                                .parameters
-                                .positional()
-                                .skip(self.next_positional)
-                                .all(|parameter| parameter.default_type().is_some()) =>
-                    {
+                    // The per-position union loses the correlation between element lengths and
+                    // per-position types, so we can only apply this when all parameters beyond
+                    // the guaranteed minimum length are defaulted. Otherwise we fall back to
+                    // the lossy `iterate()` path.
+                    Type::Union(union) if self.parameters.variadic().is_none() => {
                         let tuple_specs: Vec<_> =
                             union.elements(db).iter().map(|ty| ty.iterate(db)).collect();
 
@@ -3523,49 +3509,65 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                             .map(|s| s.len().minimum())
                             .min()
                             .unwrap_or(0);
-                        let any_variable = tuple_specs.iter().any(|s| s.len().is_variable());
-                        let max_elements = tuple_specs
-                            .iter()
-                            .map(|s| s.all_elements().len())
-                            .max()
-                            .unwrap_or(0);
 
-                        let variable_element = {
-                            let var_types: Vec<_> = tuple_specs
-                                .iter()
-                                .filter_map(|s| s.variable_element().copied())
-                                .collect();
-                            if var_types.is_empty() {
-                                None
-                            } else {
-                                Some(UnionType::from_elements_leave_aliases(db, var_types))
-                            }
-                        };
+                        // Parameters within the guaranteed minimum are always provided
+                        // by every union element. Parameters beyond that are only provided
+                        // by the longer elements, so they must have defaults.
+                        let all_optional_params_defaulted = self
+                            .parameters
+                            .positional()
+                            .skip(self.next_positional + min_len)
+                            .all(|parameter| parameter.default_type().is_some());
 
-                        let max_elements = i32::try_from(max_elements).unwrap_or(i32::MAX);
-                        let mut argument_types_vec = Vec::new();
-                        for index in 0..max_elements {
-                            let positional_types: Vec<_> = tuple_specs
-                                .iter()
-                                .filter_map(|s| s.py_index(db, index).ok())
-                                .collect();
-                            if positional_types.is_empty() {
-                                break;
-                            }
-                            argument_types_vec
-                                .push(UnionType::from_elements_leave_aliases(db, positional_types));
-                        }
-
-                        let length = if any_variable || argument_types_vec.len() > min_len {
-                            TupleLength::Variable(min_len, 0)
+                        if !all_optional_params_defaulted {
+                            VariadicArgumentType::Other(argument_type.iterate(db))
                         } else {
-                            TupleLength::Fixed(min_len)
-                        };
+                            let any_variable = tuple_specs.iter().any(|s| s.len().is_variable());
+                            let max_elements = tuple_specs
+                                .iter()
+                                .map(|s| s.all_elements().len())
+                                .max()
+                                .unwrap_or(0);
 
-                        VariadicArgumentType::Union {
-                            argument_types: argument_types_vec,
-                            length,
-                            variable_element,
+                            let variable_element = {
+                                let var_types: Vec<_> = tuple_specs
+                                    .iter()
+                                    .filter_map(|s| s.variable_element().copied())
+                                    .collect();
+                                if var_types.is_empty() {
+                                    None
+                                } else {
+                                    Some(UnionType::from_elements_leave_aliases(db, var_types))
+                                }
+                            };
+
+                            let max_elements = i32::try_from(max_elements).unwrap_or(i32::MAX);
+                            let mut argument_types_vec = Vec::new();
+                            for index in 0..max_elements {
+                                let positional_types: Vec<_> = tuple_specs
+                                    .iter()
+                                    .filter_map(|s| s.py_index(db, index).ok())
+                                    .collect();
+                                if positional_types.is_empty() {
+                                    break;
+                                }
+                                argument_types_vec.push(UnionType::from_elements_leave_aliases(
+                                    db,
+                                    positional_types,
+                                ));
+                            }
+
+                            let length = if any_variable || argument_types_vec.len() > min_len {
+                                TupleLength::Variable(min_len, 0)
+                            } else {
+                                TupleLength::Fixed(min_len)
+                            };
+
+                            VariadicArgumentType::Union {
+                                argument_types: argument_types_vec,
+                                length,
+                                variable_element,
+                            }
                         }
                     }
                     _ => VariadicArgumentType::Other(argument_type.iterate(db)),

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2287,38 +2287,54 @@ impl<'db> CallableBinding<'db> {
         );
 
         // Step 1: Check the result of the arity check which is done by `match_parameters`
-        let matching_overload_indexes = match self.matching_overload_index() {
-            MatchingOverloadIndex::None => {
-                // If no candidate overloads remain from the arity check, we can stop here. We
-                // still perform type checking for non-overloaded function to provide better user
-                // experience.
-                if let [overload] = self.overloads.as_mut_slice() {
-                    overload.check_types(
-                        db,
-                        constraints,
-                        call_arguments.as_ref(),
-                        call_expression_tcx,
-                    );
+
+        // For overloaded calls with expandable `*args`, any arity-based overload pruning is only
+        // provisional. If we have an arity-2 overload and an arity-3 overload, and the call has
+        // `*arg` where `arg` is a union of a 2-tuple and a 3-tuple, we shouldn't eliminate any
+        // overload for arity reasons before trying argument expansion.
+        let (should_retry_after_provisional_arity, overloads_for_expansion) =
+            if self.overloads.len() > 1
+                && self.matching_overload_index().len() < self.overloads.len()
+                && call_arguments.iter().any(|(argument, argument_types)| {
+                    matches!(argument, Argument::Variadic)
+                        && argument_types
+                            .get_default()
+                            .is_some_and(|argument_type| is_expandable_type(db, argument_type))
+                })
+            {
+                // We will retry all overloads after argument expansion.
+                (true, (0..self.overloads.len()).collect())
+            } else {
+                match self.matching_overload_index() {
+                    MatchingOverloadIndex::None => {
+                        // If no candidate overloads remain from the arity check, we can stop here. We
+                        // still perform type checking for non-overloaded function to provide better
+                        // user experience.
+                        if let [overload] = self.overloads.as_mut_slice() {
+                            overload.check_types(
+                                db,
+                                constraints,
+                                call_arguments.as_ref(),
+                                call_expression_tcx,
+                            );
+                        }
+                        return None;
+                    }
+                    MatchingOverloadIndex::Single(index) => {
+                        // If only one candidate overload remains, it is the winning match. Evaluate
+                        // it as a regular (non-overloaded) call.
+                        self.matching_overload_before_type_checking = Some(index);
+                        self.overloads[index].check_types(
+                            db,
+                            constraints,
+                            call_arguments.as_ref(),
+                            call_expression_tcx,
+                        );
+                        return None;
+                    }
+                    MatchingOverloadIndex::Multiple(indexes) => (false, indexes),
                 }
-                return None;
-            }
-            MatchingOverloadIndex::Single(index) => {
-                // If only one candidate overload remains, it is the winning match. Evaluate it as
-                // a regular (non-overloaded) call.
-                self.matching_overload_before_type_checking = Some(index);
-                self.overloads[index].check_types(
-                    db,
-                    constraints,
-                    call_arguments.as_ref(),
-                    call_expression_tcx,
-                );
-                return None;
-            }
-            MatchingOverloadIndex::Multiple(indexes) => {
-                // If two or more candidate overloads remain, proceed to step 2.
-                indexes
-            }
-        };
+            };
 
         // Step 2: Evaluate each remaining overload as a regular (non-overloaded) call to determine
         // whether it is compatible with the supplied argument list.
@@ -2337,54 +2353,58 @@ impl<'db> CallableBinding<'db> {
             "after step 2",
         );
 
-        match self.matching_overload_index() {
-            MatchingOverloadIndex::None => {
-                // If all overloads result in errors, proceed to step 3.
-            }
-            MatchingOverloadIndex::Single(_) => {
-                // If only one overload evaluates without error, it is the winning match.
-                return None;
-            }
-            MatchingOverloadIndex::Multiple(indexes) => {
-                // If two or more candidate overloads remain, proceed to step 4.
-                self.filter_overloads_containing_variadic(&indexes);
-
-                tracing::trace!(
-                    target: "ty_python_semantic::types::call::bind",
-                    matching_overload_index = ?self.matching_overload_index(),
-                    "after step 4",
-                );
-
-                match self.matching_overload_index() {
-                    MatchingOverloadIndex::None => {
-                        // This shouldn't be possible because step 4 can only filter out overloads
-                        // when there _is_ a matching variadic argument.
-                        tracing::debug!("All overloads have been filtered out in step 4");
-                        return None;
-                    }
-                    MatchingOverloadIndex::Single(_) => {
-                        // If only one candidate overload remains, it is the winning match.
-                        return None;
-                    }
-                    MatchingOverloadIndex::Multiple(indexes) => {
-                        // If two or more candidate overloads remain, proceed to step 5.
-                        self.filter_overloads_using_any_or_unknown(
-                            db,
-                            constraints,
-                            call_arguments.as_ref(),
-                            &indexes,
-                        );
-
-                        tracing::trace!(
-                            target: "ty_python_semantic::types::call::bind",
-                            matching_overload_index = ?self.matching_overload_index(),
-                            "after step 5",
-                        );
-                    }
+        // If we are in the "retry for provisional arity" case, we have to try argument expansion
+        // before deciding we are done or moving on to step 4+.
+        if !should_retry_after_provisional_arity {
+            match self.matching_overload_index() {
+                MatchingOverloadIndex::None => {
+                    // If all overloads result in errors, proceed to step 3.
                 }
+                MatchingOverloadIndex::Single(_) => {
+                    // If only one overload evaluates without error, it is the winning match.
+                    return None;
+                }
+                MatchingOverloadIndex::Multiple(indexes) => {
+                    // If two or more candidate overloads remain, proceed to step 4.
+                    self.filter_overloads_containing_variadic(&indexes);
 
-                // This shouldn't lead to argument type expansion.
-                return None;
+                    tracing::trace!(
+                        target: "ty_python_semantic::types::call::bind",
+                        matching_overload_index = ?self.matching_overload_index(),
+                        "after step 4",
+                    );
+
+                    match self.matching_overload_index() {
+                        MatchingOverloadIndex::None => {
+                            // This shouldn't be possible because step 4 can only filter out overloads
+                            // when there _is_ a matching variadic argument.
+                            tracing::debug!("All overloads have been filtered out in step 4");
+                            return None;
+                        }
+                        MatchingOverloadIndex::Single(_) => {
+                            // If only one candidate overload remains, it is the winning match.
+                            return None;
+                        }
+                        MatchingOverloadIndex::Multiple(indexes) => {
+                            // If two or more candidate overloads remain, proceed to step 5.
+                            self.filter_overloads_using_any_or_unknown(
+                                db,
+                                constraints,
+                                call_arguments.as_ref(),
+                                &indexes,
+                            );
+
+                            tracing::trace!(
+                                target: "ty_python_semantic::types::call::bind",
+                                matching_overload_index = ?self.matching_overload_index(),
+                                "after step 5",
+                            );
+                        }
+                    }
+
+                    // This shouldn't lead to argument type expansion.
+                    return None;
+                }
             }
         }
 
@@ -2443,7 +2463,7 @@ impl<'db> CallableBinding<'db> {
             }
         }
 
-        let snapshotter = CallableBindingSnapshotter::new(matching_overload_indexes);
+        let snapshotter = CallableBindingSnapshotter::new(overloads_for_expansion);
 
         // State of the bindings _after_ evaluating (type checking) the matching overloads using
         // the non-expanded argument types.
@@ -3216,6 +3236,16 @@ pub(crate) enum MatchingOverloadIndex {
 
     /// Multiple matching overloads found at the given indexes.
     Multiple(Vec<usize>),
+}
+
+impl MatchingOverloadIndex {
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            MatchingOverloadIndex::None => 0,
+            MatchingOverloadIndex::Single(_) => 1,
+            MatchingOverloadIndex::Multiple(indexes) => indexes.len(),
+        }
+    }
 }
 
 #[derive(Default, Debug, Clone)]
@@ -4904,10 +4934,11 @@ struct CallableBindingSnapshot<'db> {
 
     /// Represents the snapshot of the matched overload bindings.
     ///
-    /// The reason that this only contains the matched overloads are:
-    /// 1. Avoid creating snapshots for the overloads that have been filtered by the arity check
-    /// 2. Avoid duplicating errors when merging the snapshots on a successful evaluation of all
-    ///    the expanded argument lists
+    /// Usually this contains only the overloads that survived the initial arity check, to avoid
+    /// duplicating errors when merging snapshots after a successful evaluation of all expanded
+    /// argument lists. For provisional arity retries on expandable `*args`, however, it can also
+    /// include overloads that were filtered out in step 1 so those overloads can be reconsidered
+    /// against concrete expanded argument lists.
     matching_overloads: Vec<(usize, BindingSnapshot<'db>)>,
 }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3598,6 +3598,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         // `variable_element.is_some()`) or if we have a union of different fixed-length tuples (in
         // which case `variable_element.is_none()`).
         let is_variable = length.is_variable();
+        let has_fixed_union_tail = is_variable && variable_element.is_none();
 
         // We must be able to match up the fixed-length portion of the argument with positional
         // parameters, so we pass on any errors that occur.
@@ -3613,8 +3614,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         // If the tuple is variable-length, we assume that it will soak up all remaining positional
         // parameters, stopping only when we reach a parameter that has an explicit keyword argument
         // or a parameter that can only be provided via keyword argument, or if we run out of
-        // `argument_types` and have no `variable_element`. (The combination of `is_variable` with
-        // no `variable_element` can only happen with a union of different-fixed-length tuples.)
+        // `argument_types` and have no `variable_element`.
         if is_variable {
             while self
                 .parameters
@@ -3632,6 +3632,19 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                     break;
                 }
                 self.match_positional(argument_index, argument, arg_type, is_variable)?;
+            }
+        }
+
+        // A "variable" length with no `variable_element` only comes from a union of different
+        // fixed-length tuples. Any remaining `argument_types` are therefore still concrete
+        // positions from the longer union members, not an open-ended variadic tail. Feed them back
+        // through normal positional matching so we report the same errors as a concrete longer
+        // tuple would (`too-many-positional-arguments`, or a later
+        // `parameter-already-assigned` when an explicit keyword also targets that parameter)
+        // instead of silently dropping those extra positions.
+        if has_fixed_union_tail {
+            for argument_type in argument_types.by_ref() {
+                self.match_positional(argument_index, argument, Some(argument_type), is_variable)?;
             }
         }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3526,10 +3526,11 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                     // union types, length bounds, and variable element so that the rest of the
                     // matching logic handles unions correctly.
                     //
-                    // The per-position union loses the correlation between element lengths and
-                    // per-position types, so we can only apply this when all parameters beyond
-                    // the guaranteed minimum length are defaulted. Otherwise we fall back to
-                    // the lossy `iterate()` path.
+                    // The per-position union loses the correlation between tuple length and the
+                    // later element types. `match_variadic` accounts for that by treating
+                    // positions beyond the guaranteed minimum as only conditionally present: they
+                    // can satisfy optional parameters, but any required positional parameter
+                    // beyond the minimum still causes the match to fail provisionally.
                     Type::Union(union) if self.parameters.variadic().is_none() => {
                         let tuple_specs: Vec<_> =
                             union.elements(db).iter().map(|ty| ty.iterate(db)).collect();
@@ -3540,64 +3541,49 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                             .min()
                             .unwrap_or(0);
 
-                        // Parameters within the guaranteed minimum are always provided
-                        // by every union element. Parameters beyond that are only provided
-                        // by the longer elements, so they must have defaults.
-                        let all_optional_params_defaulted = self
-                            .parameters
-                            .positional()
-                            .skip(self.next_positional + min_len)
-                            .all(|parameter| parameter.default_type().is_some());
+                        let any_variable = tuple_specs.iter().any(|s| s.len().is_variable());
+                        let max_elements = tuple_specs
+                            .iter()
+                            .map(|s| s.all_elements().len())
+                            .max()
+                            .unwrap_or(0);
 
-                        if !all_optional_params_defaulted {
-                            VariadicArgumentType::Other(argument_type.iterate(db))
-                        } else {
-                            let any_variable = tuple_specs.iter().any(|s| s.len().is_variable());
-                            let max_elements = tuple_specs
+                        let variable_element = {
+                            let var_types: Vec<_> = tuple_specs
                                 .iter()
-                                .map(|s| s.all_elements().len())
-                                .max()
-                                .unwrap_or(0);
-
-                            let variable_element = {
-                                let var_types: Vec<_> = tuple_specs
-                                    .iter()
-                                    .filter_map(|s| s.variable_element().copied())
-                                    .collect();
-                                if var_types.is_empty() {
-                                    None
-                                } else {
-                                    Some(UnionType::from_elements_leave_aliases(db, var_types))
-                                }
-                            };
-
-                            let max_elements = i32::try_from(max_elements).unwrap_or(i32::MAX);
-                            let mut argument_types_vec = Vec::new();
-                            for index in 0..max_elements {
-                                let positional_types: Vec<_> = tuple_specs
-                                    .iter()
-                                    .filter_map(|s| s.py_index(db, index).ok())
-                                    .collect();
-                                if positional_types.is_empty() {
-                                    break;
-                                }
-                                argument_types_vec.push(UnionType::from_elements_leave_aliases(
-                                    db,
-                                    positional_types,
-                                ));
-                            }
-
-                            let length = if any_variable || argument_types_vec.len() > min_len {
-                                TupleLength::Variable(min_len, 0)
+                                .filter_map(|s| s.variable_element().copied())
+                                .collect();
+                            if var_types.is_empty() {
+                                None
                             } else {
-                                TupleLength::Fixed(min_len)
-                            };
-
-                            VariadicArgumentType::Union {
-                                argument_types: argument_types_vec,
-                                length,
-                                variable_element,
+                                Some(UnionType::from_elements_leave_aliases(db, var_types))
                             }
+                        };
+
+                        let max_elements = i32::try_from(max_elements).unwrap_or(i32::MAX);
+                        let mut argument_types_vec = Vec::new();
+                        for index in 0..max_elements {
+                            let positional_types: Vec<_> = tuple_specs
+                                .iter()
+                                .filter_map(|s| s.py_index(db, index).ok())
+                                .collect();
+                            if positional_types.is_empty() {
+                                break;
+                            }
+                            argument_types_vec
+                                .push(UnionType::from_elements_leave_aliases(db, positional_types));
+                        }
+
+                        let length = if any_variable || argument_types_vec.len() > min_len {
+                            TupleLength::Variable(min_len, 0)
+                        } else {
+                            TupleLength::Fixed(min_len)
+                        };
+
+                        VariadicArgumentType::Union {
+                            argument_types: argument_types_vec,
+                            length,
+                            variable_element,
                         }
                     }
                     _ => VariadicArgumentType::Other(argument_type.iterate(db)),
@@ -3641,11 +3627,30 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             )?;
         }
 
-        // If the tuple is variable-length, we assume that it will soak up all remaining positional
-        // parameters, stopping only when we reach a parameter that has an explicit keyword argument
-        // or a parameter that can only be provided via keyword argument, or if we run out of
-        // `argument_types` and have no `variable_element`.
-        if is_variable {
+        // For a union of fixed-length tuples, positions beyond the guaranteed minimum are only
+        // present in the longer union members. They therefore cannot satisfy a required
+        // positional parameter, because the shorter members would still be missing that argument.
+        if has_fixed_union_tail {
+            while let Some(parameter) = self.parameters.get_positional(self.next_positional) {
+                if self
+                    .explicit_keyword_parameters
+                    .contains(&self.next_positional)
+                {
+                    break;
+                }
+                let Some(argument_type) = argument_types.next() else {
+                    break;
+                };
+                if parameter.default_type().is_none() {
+                    return Err(());
+                }
+                self.match_positional(argument_index, argument, Some(argument_type), is_variable)?;
+            }
+        // If the tuple is truly variable-length, we assume that it will soak up all remaining
+        // positional parameters, stopping only when we reach a parameter that has an explicit
+        // keyword argument or a parameter that can only be provided via keyword argument, or if
+        // we run out of `argument_types` and have no `variable_element`.
+        } else if is_variable {
             while self
                 .parameters
                 .get_positional(self.next_positional)


### PR DESCRIPTION
## Summary

The guard condition for per-element union iteration in match_variadic previously required all remaining positional parameters to be defaulted. This was overly conservative. We only need parameters beyond the shortest union element's length to be defaulted, since those positions are guaranteed to be provided by every union element.

See: https://github.com/astral-sh/ruff/pull/23124/changes#r2806496807.