### PR TITLE
[flake8-bandit] Fix S103 mask analysis and add exhaustive tests

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S103.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S103.py
@@ -5,11 +5,11 @@ keyfile = "foo"
 
 os.chmod("/etc/passwd", 0o227)  # Error
 os.chmod("/etc/passwd", 0o7)  # Error
-os.chmod("/etc/passwd", 0o664)  # OK
+os.chmod("/etc/passwd", 0o664)  # Error
 os.chmod("/etc/passwd", 0o777)  # Error
 os.chmod("/etc/passwd", 0o770)  # Error
 os.chmod("/etc/passwd", 0o776)  # Error
-os.chmod("/etc/passwd", 0o760)  # OK
+os.chmod("/etc/passwd", 0o760)  # Error
 os.chmod("~/.bashrc", 511)  # Error
 os.chmod("/etc/hosts", 0o777)  # Error
 os.chmod("/tmp/oh_hai", 0x1FF)  # Error
@@ -18,6 +18,15 @@ os.chmod(keyfile, 0o777)  # Error
 os.chmod(keyfile, 0o7 | 0o70 | 0o700)  # Error
 os.chmod(keyfile, stat.S_IRWXO | stat.S_IRWXG | stat.S_IRWXU)  # Error
 os.chmod("~/hidden_exec", stat.S_IXGRP)  # Error
-os.chmod("~/hidden_exec", stat.S_IXOTH)  # OK
+os.chmod("~/hidden_exec", stat.S_IXOTH)  # Error
 os.chmod("/etc/passwd", stat.S_IWOTH)  # Error
+os.chmod("/etc/passwd", stat.S_IWGRP)  # Error
+os.chmod("/etc/passwd", 0o1000)  # OK
+os.chmod("/etc/passwd", 0o777777)  # Error
 os.chmod("/etc/passwd", 0o100000000)  # Error
+os.chmod("/etc/secrets.txt", 0o21)  # Error
+
+mode = 0o700
+os.chmod("/etc/passwd", mode | 0o777)  # Error
+os.chmod("/etc/passwd", 0o777777 & 0o700)  # OK
+os.chmod("/etc/passwd", 0o777777 & 0o777)  # Error

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S103_S103.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S103_S103.py.snap
@@ -9,7 +9,7 @@ S103 `os.chmod` setting a permissive mask `0o227` on file or directory
 6 | os.chmod("/etc/passwd", 0o227)  # Error
   |                         ^^^^^
 7 | os.chmod("/etc/passwd", 0o7)  # Error
-8 | os.chmod("/etc/passwd", 0o664)  # OK
+8 | os.chmod("/etc/passwd", 0o664)  # Error
   |
 
 S103 `os.chmod` setting a permissive mask `0o7` on file or directory
@@ -18,15 +18,26 @@ S103 `os.chmod` setting a permissive mask `0o7` on file or directory
 6 | os.chmod("/etc/passwd", 0o227)  # Error
 7 | os.chmod("/etc/passwd", 0o7)  # Error
   |                         ^^^
-8 | os.chmod("/etc/passwd", 0o664)  # OK
+8 | os.chmod("/etc/passwd", 0o664)  # Error
 9 | os.chmod("/etc/passwd", 0o777)  # Error
   |
+
+S103 `os.chmod` setting a permissive mask `0o664` on file or directory
+  --> S103.py:8:25
+   |
+ 6 | os.chmod("/etc/passwd", 0o227)  # Error
+ 7 | os.chmod("/etc/passwd", 0o7)  # Error
+ 8 | os.chmod("/etc/passwd", 0o664)  # Error
+   |                         ^^^^^
+ 9 | os.chmod("/etc/passwd", 0o777)  # Error
+10 | os.chmod("/etc/passwd", 0o770)  # Error
+   |
 
 S103 `os.chmod` setting a permissive mask `0o777` on file or directory
   --> S103.py:9:25
    |
  7 | os.chmod("/etc/passwd", 0o7)  # Error
- 8 | os.chmod("/etc/passwd", 0o664)  # OK
+ 8 | os.chmod("/etc/passwd", 0o664)  # Error
  9 | os.chmod("/etc/passwd", 0o777)  # Error
    |                         ^^^^^
 10 | os.chmod("/etc/passwd", 0o770)  # Error
@@ -36,12 +47,12 @@ S103 `os.chmod` setting a permissive mask `0o777` on file or directory
 S103 `os.chmod` setting a permissive mask `0o770` on file or directory
   --> S103.py:10:25
    |
- 8 | os.chmod("/etc/passwd", 0o664)  # OK
+ 8 | os.chmod("/etc/passwd", 0o664)  # Error
  9 | os.chmod("/etc/passwd", 0o777)  # Error
 10 | os.chmod("/etc/passwd", 0o770)  # Error
    |                         ^^^^^
 11 | os.chmod("/etc/passwd", 0o776)  # Error
-12 | os.chmod("/etc/passwd", 0o760)  # OK
+12 | os.chmod("/etc/passwd", 0o760)  # Error
    |
 
 S103 `os.chmod` setting a permissive mask `0o776` on file or directory
@@ -51,15 +62,26 @@ S103 `os.chmod` setting a permissive mask `0o776` on file or directory
 10 | os.chmod("/etc/passwd", 0o770)  # Error
 11 | os.chmod("/etc/passwd", 0o776)  # Error
    |                         ^^^^^
-12 | os.chmod("/etc/passwd", 0o760)  # OK
+12 | os.chmod("/etc/passwd", 0o760)  # Error
 13 | os.chmod("~/.bashrc", 511)  # Error
+   |
+
+S103 `os.chmod` setting a permissive mask `0o760` on file or directory
+  --> S103.py:12:25
+   |
+10 | os.chmod("/etc/passwd", 0o770)  # Error
+11 | os.chmod("/etc/passwd", 0o776)  # Error
+12 | os.chmod("/etc/passwd", 0o760)  # Error
+   |                         ^^^^^
+13 | os.chmod("~/.bashrc", 511)  # Error
+14 | os.chmod("/etc/hosts", 0o777)  # Error
    |
 
 S103 `os.chmod` setting a permissive mask `0o777` on file or directory
   --> S103.py:13:23
    |
 11 | os.chmod("/etc/passwd", 0o776)  # Error
-12 | os.chmod("/etc/passwd", 0o760)  # OK
+12 | os.chmod("/etc/passwd", 0o760)  # Error
 13 | os.chmod("~/.bashrc", 511)  # Error
    |                       ^^^
 14 | os.chmod("/etc/hosts", 0o777)  # Error
@@ -69,7 +91,7 @@ S103 `os.chmod` setting a permissive mask `0o777` on file or directory
 S103 `os.chmod` setting a permissive mask `0o777` on file or directory
   --> S103.py:14:24
    |
-12 | os.chmod("/etc/passwd", 0o760)  # OK
+12 | os.chmod("/etc/passwd", 0o760)  # Error
 13 | os.chmod("~/.bashrc", 511)  # Error
 14 | os.chmod("/etc/hosts", 0o777)  # Error
    |                        ^^^^^
@@ -118,7 +140,7 @@ S103 `os.chmod` setting a permissive mask `0o777` on file or directory
 19 | os.chmod(keyfile, stat.S_IRWXO | stat.S_IRWXG | stat.S_IRWXU)  # Error
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 20 | os.chmod("~/hidden_exec", stat.S_IXGRP)  # Error
-21 | os.chmod("~/hidden_exec", stat.S_IXOTH)  # OK
+21 | os.chmod("~/hidden_exec", stat.S_IXOTH)  # Error
    |
 
 S103 `os.chmod` setting a permissive mask `0o10` on file or directory
@@ -128,25 +150,90 @@ S103 `os.chmod` setting a permissive mask `0o10` on file or directory
 19 | os.chmod(keyfile, stat.S_IRWXO | stat.S_IRWXG | stat.S_IRWXU)  # Error
 20 | os.chmod("~/hidden_exec", stat.S_IXGRP)  # Error
    |                           ^^^^^^^^^^^^
-21 | os.chmod("~/hidden_exec", stat.S_IXOTH)  # OK
+21 | os.chmod("~/hidden_exec", stat.S_IXOTH)  # Error
 22 | os.chmod("/etc/passwd", stat.S_IWOTH)  # Error
+   |
+
+S103 `os.chmod` setting a permissive mask `0o1` on file or directory
+  --> S103.py:21:27
+   |
+19 | os.chmod(keyfile, stat.S_IRWXO | stat.S_IRWXG | stat.S_IRWXU)  # Error
+20 | os.chmod("~/hidden_exec", stat.S_IXGRP)  # Error
+21 | os.chmod("~/hidden_exec", stat.S_IXOTH)  # Error
+   |                           ^^^^^^^^^^^^
+22 | os.chmod("/etc/passwd", stat.S_IWOTH)  # Error
+23 | os.chmod("/etc/passwd", stat.S_IWGRP)  # Error
    |
 
 S103 `os.chmod` setting a permissive mask `0o2` on file or directory
   --> S103.py:22:25
    |
 20 | os.chmod("~/hidden_exec", stat.S_IXGRP)  # Error
-21 | os.chmod("~/hidden_exec", stat.S_IXOTH)  # OK
+21 | os.chmod("~/hidden_exec", stat.S_IXOTH)  # Error
 22 | os.chmod("/etc/passwd", stat.S_IWOTH)  # Error
    |                         ^^^^^^^^^^^^
-23 | os.chmod("/etc/passwd", 0o100000000)  # Error
+23 | os.chmod("/etc/passwd", stat.S_IWGRP)  # Error
+24 | os.chmod("/etc/passwd", 0o1000)  # OK
+   |
+
+S103 `os.chmod` setting a permissive mask `0o20` on file or directory
+  --> S103.py:23:25
+   |
+21 | os.chmod("~/hidden_exec", stat.S_IXOTH)  # Error
+22 | os.chmod("/etc/passwd", stat.S_IWOTH)  # Error
+23 | os.chmod("/etc/passwd", stat.S_IWGRP)  # Error
+   |                         ^^^^^^^^^^^^
+24 | os.chmod("/etc/passwd", 0o1000)  # OK
+25 | os.chmod("/etc/passwd", 0o777777)  # Error
+   |
+
+S103 `os.chmod` setting a permissive mask `0o777777` on file or directory
+  --> S103.py:25:25
+   |
+23 | os.chmod("/etc/passwd", stat.S_IWGRP)  # Error
+24 | os.chmod("/etc/passwd", 0o1000)  # OK
+25 | os.chmod("/etc/passwd", 0o777777)  # Error
+   |                         ^^^^^^^^
+26 | os.chmod("/etc/passwd", 0o100000000)  # Error
+27 | os.chmod("/etc/secrets.txt", 0o21)  # Error
    |
 
 S103 `os.chmod` setting an invalid mask on file or directory
-  --> S103.py:23:25
+  --> S103.py:26:25
    |
-21 | os.chmod("~/hidden_exec", stat.S_IXOTH)  # OK
-22 | os.chmod("/etc/passwd", stat.S_IWOTH)  # Error
-23 | os.chmod("/etc/passwd", 0o100000000)  # Error
+24 | os.chmod("/etc/passwd", 0o1000)  # OK
+25 | os.chmod("/etc/passwd", 0o777777)  # Error
+26 | os.chmod("/etc/passwd", 0o100000000)  # Error
    |                         ^^^^^^^^^^^
+27 | os.chmod("/etc/secrets.txt", 0o21)  # Error
+   |
+
+S103 `os.chmod` setting a permissive mask `0o21` on file or directory
+  --> S103.py:27:30
+   |
+25 | os.chmod("/etc/passwd", 0o777777)  # Error
+26 | os.chmod("/etc/passwd", 0o100000000)  # Error
+27 | os.chmod("/etc/secrets.txt", 0o21)  # Error
+   |                              ^^^^
+28 |
+29 | mode = 0o700
+   |
+
+S103 `os.chmod` setting a permissive mask `0o777` on file or directory
+  --> S103.py:30:25
+   |
+29 | mode = 0o700
+30 | os.chmod("/etc/passwd", mode | 0o777)  # Error
+   |                         ^^^^^^^^^^^^
+31 | os.chmod("/etc/passwd", 0o777777 & 0o700)  # OK
+32 | os.chmod("/etc/passwd", 0o777777 & 0o777)  # Error
+   |
+
+S103 `os.chmod` setting a permissive mask `0o777` on file or directory
+  --> S103.py:32:25
+   |
+30 | os.chmod("/etc/passwd", mode | 0o777)  # Error
+31 | os.chmod("/etc/passwd", 0o777777 & 0o700)  # OK
+32 | os.chmod("/etc/passwd", 0o777777 & 0o777)  # Error
+   |                         ^^^^^^^^^^^^^^^^
    |


### PR DESCRIPTION
Fixes #18863
## Summary
- Align S103 dangerous-bit checks with Bandit (`0o33`: `S_IWOTH`, `S_IWGRP`, `S_IXGRP`, `S_IXOTH`).
- Move mask analysis to `u64`.
- Add partial bitwise analysis for `|`, `&`, `^`.
- Keep `0o1000` valid and keep invalid-mask checks for known final values above `0o7777`.
- Add repro + edge-case fixture coverage.

## Test Plan
- `cargo test -p ruff_linter s103_exhaustive_literal_matrix -- --nocapture`
- `cargo test -p ruff_linter s103_exhaustive_bitwise_matrix -- --nocapture`
- `cargo test -p ruff_linter rules::flake8_bandit::tests:: -- --nocapture`

