### PR TITLE
[ty] Pass `--error=deprecated` when running `conformance.py`

### DIFF
--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -471,6 +471,7 @@ def collect_ty_diagnostics(
             "--output-format=gitlab",
             "--ignore=assert-type-unspellable-subtype",
             "--error=invalid-legacy-positional-parameter",
+            "--error=deprecated",
             "--exit-zero",
             *extra_search_path_args,
             *map(str, test_files),


### PR DESCRIPTION
## Summary

This change bumps the recall score reported by the script from 74.33% to 74.82%
