### PR TITLE
[ty] Infer lambda return types from body expressions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -129,16 +129,16 @@ class C:
         self.c = lambda positional_only=self.c, /: positional_only
         self.d = lambda *, kw_only=self.d: kw_only
 
-        # revealed: (positional=...) -> Unknown
+        # revealed: (positional=...) -> Unknown | ((positional=...) -> Unknown) | ((positional=...) -> Divergent) | ((positional=...) -> Divergent)
         reveal_type(self.a)
 
-        # revealed: (*, kw_only=...) -> Unknown
+        # revealed: (*, kw_only=...) -> Unknown | ((*, kw_only=...) -> Unknown) | ((*, kw_only=...) -> Divergent) | ((*, kw_only=...) -> Divergent)
         reveal_type(self.b)
 
-        # revealed: (positional_only=..., /) -> Unknown
+        # revealed: (positional_only=..., /) -> Unknown | ((positional_only=..., /) -> Unknown) | ((positional_only=..., /) -> Divergent) | ((positional_only=..., /) -> Divergent)
         reveal_type(self.c)
 
-        # revealed: (*, kw_only=...) -> Unknown
+        # revealed: (*, kw_only=...) -> Unknown | ((*, kw_only=...) -> Unknown) | ((*, kw_only=...) -> Divergent) | ((*, kw_only=...) -> Divergent)
         reveal_type(self.d)
 ```
 


### PR DESCRIPTION
Infer the return type of lambda expressions from their body expression, rather than always using `Unknown`.

This can introduce new Salsa cycles when a lambda body references a name involved in a circular definition. Added cycle recovery guards to prevent panics from non-converging cycles, though I'm not confident this is the correct solution.
