### PR TITLE
[ty] bytes literal is a sequence of integers

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -2296,6 +2296,28 @@ static_assert(not is_subtype_of(Literal["x"], Sequence[Literal["a", "b"]]))  # '
 static_assert(not is_subtype_of(Literal["aa"], Sequence[Literal[""]]))
 ```
 
+## Bytes literals and Sequence
+
+Bytes literals are sequences of integers.
+
+```py
+from typing import Literal, Sequence, Iterable, Collection, Reversible
+from ty_extensions import is_subtype_of, static_assert
+
+static_assert(is_subtype_of(Literal[b"abba"], Sequence[int]))
+static_assert(is_subtype_of(Literal[b"abba"], Sequence[Literal[97, 98]]))
+static_assert(is_subtype_of(Literal[b"abb"], Iterable[int]))
+static_assert(is_subtype_of(Literal[b"abb"], Iterable[Literal[97, 98]]))
+static_assert(is_subtype_of(Literal[b"abb"], Collection[int]))
+static_assert(is_subtype_of(Literal[b"abb"], Collection[Literal[97, 98]]))
+static_assert(is_subtype_of(Literal[b""], Sequence[int]))
+
+static_assert(not is_subtype_of(Literal[b"abc"], Sequence[Literal[97, 98]]))  # '99' not allowed
+
+# bytes literals are NOT subtypes of non-int element sequences
+static_assert(not is_subtype_of(Literal[b"abc"], Sequence[str]))
+```
+
 [gradual form]: https://typing.python.org/en/latest/spec/glossary.html#term-gradual-form
 [gradual tuple]: https://typing.python.org/en/latest/spec/tuples.html#tuple-type-form
 [special case for float and complex]: https://typing.python.org/en/latest/spec/special-types.html#special-cases-for-float-and-complex


### PR DESCRIPTION
## Summary

Mirror our existing handling for understanding that string literals are a sequence of specific characters -- bytes literals are a sequence of specific integers.

## Test Plan

Added mdtest.