### PR TITLE
[ty] Add `Final` mdtests for loops and redeclaration

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -666,9 +666,9 @@ from typing import Final
 k = ""
 
 for i in range(10):
+    # TODO: This should be an error; it's a reassignment
     k += " "
 
-    # TODO: This should be an error
     k: Final[str] = ""
 ```
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/2689

Update `Final` mdtests to reflect current policy for loop usage and same-scope redeclaration, and document a known TODO loop limitation.

## Test Plan

- Module-level `Final` reassignment in a loop errors
- `Final` declarations in loop bodies are accepted
- Same-scope `Final` redeclaration is accepted
- Known `Final`-in-loop limitation is documented via TODO mdtest