### PR TITLE
[ty] Increase timeout for ecosystem report to 40 min

### DIFF
--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -23,7 +23,7 @@ jobs:
   ty-ecosystem-report:
     name: Create ecosystem report
     runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-22.04-32' || 'ubuntu-latest' }}
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary

Due to the new flakiness runs, the job now times out with the previous limit: https://github.com/astral-sh/ruff/actions/runs/22059891348/job/63737184385

## Test Plan

Run on this branch: https://github.com/astral-sh/ruff/actions/runs/22060979308