### PR TITLE
[ty] Add comments to clarify the purpose of `NominalInstanceType::class_name` and `NominalInstanceType::class_module_name`

### DIFF
--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -239,6 +239,10 @@ impl<'db> NominalInstanceType<'db> {
     /// Returns the name of the class this is an instance of.
     ///
     /// For example, for an instance of `builtins.str`, this returns `"str"`.
+    ///
+    /// As of 2026-02-16, this method is not used in any crates in the Ruff
+    /// repo, but is exposed as a public API for external users of
+    /// `ty_python_semantic`.
     pub fn class_name(&self, db: &'db dyn Db) -> &'db Name {
         self.class(db).name(db)
     }
@@ -249,6 +253,10 @@ impl<'db> NominalInstanceType<'db> {
     /// For example, for an instance of `pathlib.Path`, this returns
     /// `Some("pathlib")`. Returns `None` if the class's file cannot be resolved
     /// to a known module (e.g. for classes defined in scripts or notebooks).
+    ///
+    /// As of 2026-02-16, this method is not used in any crates in the Ruff
+    /// repo, but is exposed as a public API for external users of
+    /// `ty_python_semantic`.
     pub fn class_module_name(&self, db: &'db dyn Db) -> Option<&'db ModuleName> {
         let file = self.class(db).class_literal(db).file(db);
         file_to_module(db, file).map(|module| module.name(db))


### PR DESCRIPTION
These were added in https://github.com/astral-sh/ruff/pull/23147 for external users who may be using `ty_python_semantic` as a library, but, since they're unused by us I think they're at high risk of being deleted in a cleanup PR without comments to explain why they're there.