### PR TITLE
Add Q004 to the list of conflicting rules

### DIFF
--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -440,6 +440,7 @@ When using Ruff as a formatter, we recommend avoiding the following lint rules:
 - [`bad-quotes-multiline-string`](rules/bad-quotes-multiline-string.md) (`Q001`)
 - [`bad-quotes-docstring`](rules/bad-quotes-docstring.md) (`Q002`)
 - [`avoidable-escaped-quote`](rules/avoidable-escaped-quote.md) (`Q003`)
+- [`unnecessary-escaped-quote`](rules/unnecessary-escaped-quote.md) (`Q004`)
 - [`missing-trailing-comma`](rules/missing-trailing-comma.md) (`COM812`)
 - [`prohibited-trailing-comma`](rules/prohibited-trailing-comma.md) (`COM819`)
 - [`multi-line-implicit-string-concatenation`](rules/multi-line-implicit-string-concatenation.md) (`ISC002`) if used without `ISC001` and `flake8-implicit-str-concat.allow-multiline = false`


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

The page of unnecessary-escaped-quote (Q004) says it's redundant with the formatter.
https://docs.astral.sh/ruff/rules/unnecessary-escaped-quote/#formatter-compatibility
But the list of the [conflicting lint rules](https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules) missed it.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
