### PR TITLE
[ty] Extract helper closures for literal-to-Sequence relation checks

### DIFF
--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -387,7 +387,8 @@ impl<'db> Type<'db> {
             }
         };
 
-        // Determine if `Sequence[<union of literals>]` has the given type relation to `class`.
+        // Optimized routine to determine if `<instance of class>` has the given type relation
+        // to `Sequence[<union of literals>]`.
         let literal_sequence_relation = |class: ClassType<'db>, literal_types: Box<[Type<'db>]>| {
             let spec = match literal_types.len() {
                 0 => Type::Never,


### PR DESCRIPTION
## Summary

reduce duplicated `has_relation_to_impl` branches for bytes-literals and string-literals

## Test Plan

existing tests
