### PR TITLE
[ty] Infer `LiteralString` for `f"{literal_str_a} {literal_str_b}"`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/literal_string.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/literal_string.md
@@ -89,8 +89,7 @@ def _(literal_a: LiteralString, literal_b: LiteralString, a_str: str):
     reveal_type("{}, {}".format(literal_a, a_str))  # revealed: str
 
     # f-string
-    # TODO: could be `LiteralString` if all components are `LiteralString`
-    reveal_type(f"{literal_a} {literal_b}")  # revealed: str
+    reveal_type(f"{literal_a} {literal_b}")  # revealed: LiteralString
     reveal_type(f"{literal_a} {a_str}")  # revealed: str
 
     # Repetition


### PR DESCRIPTION
## Summary

* The first commit modernizes the `LiteralString` test suite.
* The second commit adds more precise type inference for `f"{literal_str_a} {literal_str_b}"` to make a conformance test pass.

~~This should have a better impact on conformance results once https://github.com/python/typing/pull/2179 lands.~~ (this was merged now)

## Test Plan

Updated and new Markdown tests
