### PR TITLE
Remove AlexWaygood as a flake8-pyi codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,9 +11,6 @@
 /crates/ruff_python_parser/ @MichaReiser @dhruvmanila
 /crates/ruff_annotate_snippets/ @BurntSushi
 
-# flake8-pyi
-/crates/ruff_linter/src/rules/flake8_pyi/ @AlexWaygood
-
 # Script for fuzzing the parser/ty etc.
 /python/py-fuzzer/ @AlexWaygood
 


### PR DESCRIPTION
There's too much going on in ty right now for me to have the bandwidth to keep up with flake8-pyi PRs too -- and I have confidence that the Ruff team will ping me on anything if they want my guidance on why a specific flake8-pyi rule was implemented the way it was :-)
