### PR TITLE
Make `unnecessary-key-check` fix unsafe when side effects are uncertain (`RUF019`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF019.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF019.py
@@ -23,6 +23,26 @@ v = "k" in d and d["k"]
 if f() in d and d[f()]:
     pass
 
+# RUF019 (f-string side-effect matrix)
+class C:
+    def __str__(self):
+        return "k"
+
+
+c = C()
+
+# side_effect -> Yes: definite side effect in interpolation; rule should not trigger.
+if f"{f()}" in d and d[f"{f()}"]:
+    pass
+
+# side_effect -> Maybe: formatting may call user code; unsafe fix.
+if f"{c}" in d and d[f"{c}"]:
+    pass
+
+# side_effect -> No: literal-only interpolation; safe fix.
+if f"{1}" in d and d[f"{1}"]:
+    pass
+
 
 if (
         "key" in d

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_key_check.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_key_check.rs
@@ -1,9 +1,9 @@
 use ruff_diagnostics::Applicability;
 use ruff_python_ast::comparable::ComparableExpr;
+use ruff_python_ast::helpers::side_effect;
 use ruff_python_ast::{self as ast, BoolOp, CmpOp, Expr};
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::helpers::contains_effect;
 use ruff_python_ast::token::parenthesized_range;
 use ruff_text_size::Ranged;
 
@@ -31,7 +31,8 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as safe, unless the expression contains comments.
+/// This rule's fix is marked as safe, unless the expression contains comments or
+/// may have side effects.
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.2.0")]
 pub(crate) struct UnnecessaryKeyCheck;
@@ -101,19 +102,23 @@ pub(crate) fn unnecessary_key_check(checker: &Checker, expr: &Expr) {
         return;
     }
 
-    if contains_effect(obj_left, |id| checker.semantic().has_builtin_binding(id))
-        || contains_effect(key_left, |id| checker.semantic().has_builtin_binding(id))
-    {
+    let side_effect =
+        side_effect(obj_left, |id| checker.semantic().has_builtin_binding(id))
+            .merge(side_effect(key_left, |id| {
+                checker.semantic().has_builtin_binding(id)
+            }));
+    if side_effect.is_yes() {
         return;
     }
 
     let mut diagnostic = checker.report_diagnostic(UnnecessaryKeyCheck, expr.range());
 
-    let applicability = if checker.comment_ranges().intersects(expr.range()) {
-        Applicability::Unsafe
-    } else {
-        Applicability::Safe
-    };
+    let applicability =
+        if checker.comment_ranges().intersects(expr.range()) || side_effect.is_maybe() {
+            Applicability::Unsafe
+        } else {
+            Applicability::Safe
+        };
 
     diagnostic.set_fix(Fix::applicable_edit(
         Edit::range_replacement(

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF019_RUF019.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF019_RUF019.py.snap
@@ -116,24 +116,61 @@ help: Replace with `dict.get`
 21 | v = "k" in d and d["k"]
 
 RUF019 [*] Unnecessary key check before dictionary access
-  --> RUF019.py:28:9
+  --> RUF019.py:39:4
    |
-27 |   if (
-28 | /         "key" in d
-29 | |         and  # text
-30 | |         d ["key"]
-   | |_________________^
-31 |   ):
-32 |       ...
+38 | # side_effect -> Maybe: formatting may call user code; unsafe fix.
+39 | if f"{c}" in d and d[f"{c}"]:
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+40 |     pass
    |
 help: Replace with `dict.get`
-25 | 
-26 | 
-27 | if (
+36 |     pass
+37 | 
+38 | # side_effect -> Maybe: formatting may call user code; unsafe fix.
+   - if f"{c}" in d and d[f"{c}"]:
+39 + if d.get(f"{c}"):
+40 |     pass
+41 | 
+42 | # side_effect -> No: literal-only interpolation; safe fix.
+note: This is an unsafe fix and may change runtime behavior
+
+RUF019 [*] Unnecessary key check before dictionary access
+  --> RUF019.py:43:4
+   |
+42 | # side_effect -> No: literal-only interpolation; safe fix.
+43 | if f"{1}" in d and d[f"{1}"]:
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+44 |     pass
+   |
+help: Replace with `dict.get`
+40 |     pass
+41 | 
+42 | # side_effect -> No: literal-only interpolation; safe fix.
+   - if f"{1}" in d and d[f"{1}"]:
+43 + if d.get(f"{1}"):
+44 |     pass
+45 | 
+46 | 
+
+RUF019 [*] Unnecessary key check before dictionary access
+  --> RUF019.py:48:9
+   |
+47 |   if (
+48 | /         "key" in d
+49 | |         and  # text
+50 | |         d ["key"]
+   | |_________________^
+51 |   ):
+52 |       ...
+   |
+help: Replace with `dict.get`
+45 | 
+46 | 
+47 | if (
    -         "key" in d
    -         and  # text
    -         d ["key"]
-28 +         d.get("key")
-29 | ):
-30 |     ...
+48 +         d.get("key")
+49 | ):
+50 |     ...
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -40,6 +40,49 @@ where
     matches!(id, "list" | "tuple" | "set" | "dict" | "frozenset") && is_builtin(id)
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, is_macro::Is)]
+pub enum SideEffect {
+    No,
+    Maybe,
+    Yes,
+}
+
+impl SideEffect {
+    #[must_use]
+    pub const fn merge(self, other: SideEffect) -> SideEffect {
+        match (self, other) {
+            (SideEffect::Yes, _) | (_, SideEffect::Yes) => SideEffect::Yes,
+            (SideEffect::Maybe, _) | (_, SideEffect::Maybe) => SideEffect::Maybe,
+            _ => SideEffect::No,
+        }
+    }
+}
+
+fn is_definitely_side_effect_free_interpolation_expr(expr: &Expr) -> bool {
+    match expr {
+        Expr::StringLiteral(_)
+        | Expr::BytesLiteral(_)
+        | Expr::NumberLiteral(_)
+        | Expr::BooleanLiteral(_)
+        | Expr::NoneLiteral(_)
+        | Expr::EllipsisLiteral(_) => true,
+        Expr::UnaryOp(ast::ExprUnaryOp { operand, .. }) => {
+            is_definitely_side_effect_free_interpolation_expr(operand)
+        }
+        Expr::Tuple(ast::ExprTuple { elts, .. })
+        | Expr::List(ast::ExprList { elts, .. })
+        | Expr::Set(ast::ExprSet { elts, .. }) => elts
+            .iter()
+            .all(is_definitely_side_effect_free_interpolation_expr),
+        Expr::Dict(ast::ExprDict { items, .. }) => items.iter().all(|DictItem { key, value }| {
+            key.as_ref()
+                .is_none_or(is_definitely_side_effect_free_interpolation_expr)
+                && is_definitely_side_effect_free_interpolation_expr(value)
+        }),
+        _ => false,
+    }
+}
+
 /// Return `true` if the `Expr` contains an expression that appears to include a
 /// side-effect (like a function call).
 ///
@@ -48,7 +91,22 @@ pub fn contains_effect<F>(expr: &Expr, is_builtin: F) -> bool
 where
     F: Fn(&str) -> bool,
 {
-    any_over_expr(expr, &|expr| {
+    side_effect(expr, is_builtin).is_yes()
+}
+
+/// Return whether `expr` has no side effects, maybe has side effects, or definitely
+/// has side effects.
+///
+/// Unlike [`contains_effect`], which returns a simple `bool`, this function distinguishes
+/// between expressions that are definitely side-effect-free, definitely side-effectful,
+/// and those that may invoke user-defined code (e.g., formatting a non-literal f-string
+/// interpolation can call `__format__` or `__str__`).
+pub fn side_effect<F>(expr: &Expr, is_builtin: F) -> SideEffect
+where
+    F: Fn(&str) -> bool,
+{
+    let mut effect = SideEffect::No;
+    any_over_expr_mut(expr, &mut |expr| {
         // Accept empty initializers.
         if let Expr::Call(ast::ExprCall {
             func,
@@ -57,10 +115,10 @@ where
             node_index: _,
         }) = expr
         {
-            // Ex) `list()`
             if arguments.is_empty() {
                 if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
                     if !is_iterable_initializer(id.as_str(), |id| is_builtin(id)) {
+                        effect = SideEffect::Yes;
                         return true;
                     }
                     return false;
@@ -87,6 +145,7 @@ where
                     | Expr::SetComp(_)
                     | Expr::DictComp(_)
             ) {
+                effect = SideEffect::Yes;
                 return true;
             }
             if !matches!(
@@ -106,13 +165,29 @@ where
                     | Expr::SetComp(_)
                     | Expr::DictComp(_)
             ) {
+                effect = SideEffect::Yes;
                 return true;
             }
             return false;
         }
 
+        // FString/TString: non-literal interpolation may invoke `__format__`/`__str__`.
+        // Return `false` to let the traversal descend and detect any `Yes` effects inside.
+        if let Expr::FString(ast::ExprFString { value, .. }) = expr {
+            if value.elements().any(has_uncertain_interpolation) {
+                effect = effect.merge(SideEffect::Maybe);
+            }
+            return false;
+        }
+        if let Expr::TString(ast::ExprTString { value, .. }) = expr {
+            if value.elements().any(has_uncertain_interpolation) {
+                effect = effect.merge(SideEffect::Maybe);
+            }
+            return false;
+        }
+
         // Otherwise, avoid all complex expressions.
-        matches!(
+        if matches!(
             expr,
             Expr::Await(_)
                 | Expr::Call(_)
@@ -124,50 +199,82 @@ where
                 | Expr::Yield(_)
                 | Expr::YieldFrom(_)
                 | Expr::IpyEscapeCommand(_)
-        )
-    })
+        ) {
+            effect = SideEffect::Yes;
+            return true;
+        }
+
+        false
+    });
+    effect
+}
+
+/// Returns `true` if the interpolated string element may invoke user-defined code
+/// when formatted (i.e., the interpolation expression is not a known-safe literal).
+fn has_uncertain_interpolation(element: &InterpolatedStringElement) -> bool {
+    match element {
+        InterpolatedStringElement::Literal(_) => false,
+        InterpolatedStringElement::Interpolation(interp) => {
+            !is_definitely_side_effect_free_interpolation_expr(&interp.expression)
+                || interp
+                    .format_spec
+                    .as_ref()
+                    .is_some_and(|spec| spec.elements.iter().any(has_uncertain_interpolation))
+        }
+    }
 }
 
 /// Call `func` over every `Expr` in `expr`, returning `true` if any expression
-/// returns `true`..
+/// returns `true`.
 pub fn any_over_expr(expr: &Expr, func: &dyn Fn(&Expr) -> bool) -> bool {
+    any_over_expr_mut(expr, &mut |e| func(e))
+}
+
+/// Like [`any_over_expr`], but accepts an [`FnMut`] closure, allowing the caller
+/// to accumulate state across the traversal via captured mutable variables.
+pub fn any_over_expr_mut(expr: &Expr, func: &mut dyn FnMut(&Expr) -> bool) -> bool {
     if func(expr) {
         return true;
     }
     match expr {
         Expr::BoolOp(ast::ExprBoolOp { values, .. }) => {
-            values.iter().any(|expr| any_over_expr(expr, func))
+            values.iter().any(|expr| any_over_expr_mut(expr, func))
         }
         Expr::FString(ast::ExprFString { value, .. }) => value
             .elements()
-            .any(|expr| any_over_interpolated_string_element(expr, func)),
+            .any(|expr| any_over_interpolated_string_element_mut(expr, func)),
         Expr::TString(ast::ExprTString { value, .. }) => value
             .elements()
-            .any(|expr| any_over_interpolated_string_element(expr, func)),
+            .any(|expr| any_over_interpolated_string_element_mut(expr, func)),
         Expr::Named(ast::ExprNamed {
             target,
             value,
             range: _,
             node_index: _,
-        }) => any_over_expr(target, func) || any_over_expr(value, func),
+        }) => any_over_expr_mut(target, func) || any_over_expr_mut(value, func),
         Expr::BinOp(ast::ExprBinOp { left, right, .. }) => {
-            any_over_expr(left, func) || any_over_expr(right, func)
+            any_over_expr_mut(left, func) || any_over_expr_mut(right, func)
         }
-        Expr::UnaryOp(ast::ExprUnaryOp { operand, .. }) => any_over_expr(operand, func),
-        Expr::Lambda(ast::ExprLambda { body, .. }) => any_over_expr(body, func),
+        Expr::UnaryOp(ast::ExprUnaryOp { operand, .. }) => any_over_expr_mut(operand, func),
+        Expr::Lambda(ast::ExprLambda { body, .. }) => any_over_expr_mut(body, func),
         Expr::If(ast::ExprIf {
             test,
             body,
             orelse,
             range: _,
             node_index: _,
-        }) => any_over_expr(test, func) || any_over_expr(body, func) || any_over_expr(orelse, func),
+        }) => {
+            any_over_expr_mut(test, func)
+                || any_over_expr_mut(body, func)
+                || any_over_expr_mut(orelse, func)
+        }
         Expr::Dict(ast::ExprDict {
             items,
             range: _,
             node_index: _,
         }) => items.iter().any(|ast::DictItem { key, value }| {
-            any_over_expr(value, func) || key.as_ref().is_some_and(|key| any_over_expr(key, func))
+            any_over_expr_mut(value, func)
+                || key.as_ref().is_some_and(|key| any_over_expr_mut(key, func))
         }),
         Expr::Set(ast::ExprSet {
             elts,
@@ -185,7 +292,7 @@ pub fn any_over_expr(expr: &Expr, func: &dyn Fn(&Expr) -> bool) -> bool {
             range: _,
             node_index: _,
             ..
-        }) => elts.iter().any(|expr| any_over_expr(expr, func)),
+        }) => elts.iter().any(|expr| any_over_expr_mut(expr, func)),
         Expr::ListComp(ast::ExprListComp {
             elt,
             generators,
@@ -205,11 +312,14 @@ pub fn any_over_expr(expr: &Expr, func: &dyn Fn(&Expr) -> bool) -> bool {
             node_index: _,
             parenthesized: _,
         }) => {
-            any_over_expr(elt, func)
+            any_over_expr_mut(elt, func)
                 || generators.iter().any(|generator| {
-                    any_over_expr(&generator.target, func)
-                        || any_over_expr(&generator.iter, func)
-                        || generator.ifs.iter().any(|expr| any_over_expr(expr, func))
+                    any_over_expr_mut(&generator.target, func)
+                        || any_over_expr_mut(&generator.iter, func)
+                        || generator
+                            .ifs
+                            .iter()
+                            .any(|expr| any_over_expr_mut(expr, func))
                 })
         }
         Expr::DictComp(ast::ExprDictComp {
@@ -219,12 +329,15 @@ pub fn any_over_expr(expr: &Expr, func: &dyn Fn(&Expr) -> bool) -> bool {
             range: _,
             node_index: _,
         }) => {
-            any_over_expr(key, func)
-                || any_over_expr(value, func)
+            any_over_expr_mut(key, func)
+                || any_over_expr_mut(value, func)
                 || generators.iter().any(|generator| {
-                    any_over_expr(&generator.target, func)
-                        || any_over_expr(&generator.iter, func)
-                        || generator.ifs.iter().any(|expr| any_over_expr(expr, func))
+                    any_over_expr_mut(&generator.target, func)
+                        || any_over_expr_mut(&generator.iter, func)
+                        || generator
+                            .ifs
+                            .iter()
+                            .any(|expr| any_over_expr_mut(expr, func))
                 })
         }
         Expr::Await(ast::ExprAwait {
@@ -248,33 +361,40 @@ pub fn any_over_expr(expr: &Expr, func: &dyn Fn(&Expr) -> bool) -> bool {
             range: _,
             node_index: _,
             ..
-        }) => any_over_expr(value, func),
+        }) => any_over_expr_mut(value, func),
         Expr::Yield(ast::ExprYield {
             value,
             range: _,
             node_index: _,
         }) => value
             .as_ref()
-            .is_some_and(|value| any_over_expr(value, func)),
+            .is_some_and(|value| any_over_expr_mut(value, func)),
         Expr::Compare(ast::ExprCompare {
             left, comparators, ..
-        }) => any_over_expr(left, func) || comparators.iter().any(|expr| any_over_expr(expr, func)),
+        }) => {
+            any_over_expr_mut(left, func)
+                || comparators.iter().any(|expr| any_over_expr_mut(expr, func))
+        }
         Expr::Call(ast::ExprCall {
             func: call_func,
             arguments,
             range: _,
             node_index: _,
         }) => {
-            any_over_expr(call_func, func)
+            any_over_expr_mut(call_func, func)
                 // Note that this is the evaluation order but not necessarily the declaration order
                 // (e.g. for `f(*args, a=2, *args2, **kwargs)` it's not)
-                || arguments.args.iter().any(|expr| any_over_expr(expr, func))
-                || arguments.keywords
+                || arguments
+                    .args
                     .iter()
-                    .any(|keyword| any_over_expr(&keyword.value, func))
+                    .any(|expr| any_over_expr_mut(expr, func))
+                || arguments
+                    .keywords
+                    .iter()
+                    .any(|keyword| any_over_expr_mut(&keyword.value, func))
         }
         Expr::Subscript(ast::ExprSubscript { value, slice, .. }) => {
-            any_over_expr(value, func) || any_over_expr(slice, func)
+            any_over_expr_mut(value, func) || any_over_expr_mut(slice, func)
         }
         Expr::Slice(ast::ExprSlice {
             lower,
@@ -285,13 +405,13 @@ pub fn any_over_expr(expr: &Expr, func: &dyn Fn(&Expr) -> bool) -> bool {
         }) => {
             lower
                 .as_ref()
-                .is_some_and(|value| any_over_expr(value, func))
+                .is_some_and(|value| any_over_expr_mut(value, func))
                 || upper
                     .as_ref()
-                    .is_some_and(|value| any_over_expr(value, func))
+                    .is_some_and(|value| any_over_expr_mut(value, func))
                 || step
                     .as_ref()
-                    .is_some_and(|value| any_over_expr(value, func))
+                    .is_some_and(|value| any_over_expr_mut(value, func))
         }
         Expr::Name(_)
         | Expr::StringLiteral(_)
@@ -373,6 +493,14 @@ pub fn any_over_interpolated_string_element(
     element: &ast::InterpolatedStringElement,
     func: &dyn Fn(&Expr) -> bool,
 ) -> bool {
+    any_over_interpolated_string_element_mut(element, &mut |e| func(e))
+}
+
+/// Like [`any_over_interpolated_string_element`], but accepts an [`FnMut`] closure.
+pub fn any_over_interpolated_string_element_mut(
+    element: &ast::InterpolatedStringElement,
+    func: &mut dyn FnMut(&Expr) -> bool,
+) -> bool {
     match element {
         ast::InterpolatedStringElement::Literal(_) => false,
         ast::InterpolatedStringElement::Interpolation(ast::InterpolatedElement {
@@ -380,10 +508,10 @@ pub fn any_over_interpolated_string_element(
             format_spec,
             ..
         }) => {
-            any_over_expr(expression, func)
+            any_over_expr_mut(expression, func)
                 || format_spec.as_ref().is_some_and(|spec| {
                     spec.elements.iter().any(|spec_element| {
-                        any_over_interpolated_string_element(spec_element, func)
+                        any_over_interpolated_string_element_mut(spec_element, func)
                     })
                 })
         }
@@ -1665,7 +1793,6 @@ pub fn comment_indentation_after(
 mod tests {
     use std::borrow::Cow;
     use std::cell::RefCell;
-    use std::vec;
 
     use ruff_text_size::TextRange;
 


### PR DESCRIPTION
## Summary

Fixes #12953

### Problem:

`RUF019` could apply a safe fix in cases like `f"{c}"` where formatting can call user-defined `__str__` / `__repr__` and change runtime behavior.

### Solution:

keeps the `RUF019` diagnostic unchanged and adjusts fix safety only:
- `No` side effect: safe fix
- `Maybe` side effect: unsafe fix
- `Yes` side effect: no fix

### Implementation:

- Added tri-state side-effect analysis in `ruff_python_ast::helpers` (`SideEffect`, `side_effect(...)`).
- Kept `contains_effect(...)` for existing callsites.
- Applied the tri-state result only to `RUF019` (`unnecessary_key_check`) in this PR.

## Test Plan

- Added unit tests for `side_effect(...)`.
- Updated `RUF019` fixture and snapshot coverage for safe vs unsafe fix cases.
- Manual check:
  - `cargo run -p ruff -- check ./tmp/ruf12953_repro.py --no-cache --select RUF019 --fix`
  - `cargo run -p ruff -- check ./tmp/ruf12953_repro.py --no-cache --select RUF019 --fix --unsafe-fixes`