### PR TITLE
[parser] Fix re-lexing of unclosed interpolated strings in triple-quoted f-strings

### DIFF
--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__triple_quoted_fstring_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__triple_quoted_fstring_1.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
-input_file: crates/ruff_python_parser/resources/invalid/re_lexing/triple_quoted_fstring_1.py
 ---
 ## AST
 
@@ -64,21 +63,36 @@ Module(
                     ),
                 },
             ),
+            Assign(
+                StmtAssign {
+                    node_index: NodeIndex(None),
+                    range: 193..198,
+                    targets: [
+                        Name(
+                            ExprName {
+                                node_index: NodeIndex(None),
+                                range: 193..194,
+                                id: Name("y"),
+                                ctx: Store,
+                            },
+                        ),
+                    ],
+                    value: NumberLiteral(
+                        ExprNumberLiteral {
+                            node_index: NodeIndex(None),
+                            range: 197..198,
+                            value: Int(
+                                1,
+                            ),
+                        },
+                    ),
+                },
+            ),
         ],
     },
 )
 ```
 ## Errors
-
-  |
-3 |   # https://github.com/astral-sh/ruff/issues/11929
-4 |
-5 |   f"""hello {x # comment    
-  |  ___________________________^
-6 | | y = 1
-  | |_____^ Syntax Error: f-string: unterminated triple-quoted string
-  |
-
 
   |
 5 | f"""hello {x # comment    
@@ -88,17 +102,7 @@ Module(
 
 
   |
-3 |   # https://github.com/astral-sh/ruff/issues/11929
-4 |
-5 |   f"""hello {x # comment    
-  |  ___________________________^
-6 | | y = 1
-  | |_____^ Syntax Error: Expected FStringEnd, found FStringMiddle
-  |
-
-
-  |
 5 | f"""hello {x # comment    
 6 | y = 1
-  |      ^ Syntax Error: Expected a statement
+  |      ^ Syntax Error: f-string: unterminated string
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__ty_1828.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__ty_1828.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
-input_file: crates/ruff_python_parser/resources/invalid/re_lexing/ty_1828.py
 ---
 ## AST
 
@@ -145,6 +144,21 @@ Module(
                     simple: false,
                 },
             ),
+            ClassDef(
+                StmtClassDef {
+                    node_index: NodeIndex(None),
+                    range: 94..102,
+                    decorator_list: [],
+                    name: Identifier {
+                        id: Name("A"),
+                        range: 100..101,
+                        node_index: NodeIndex(None),
+                    },
+                    type_params: None,
+                    arguments: None,
+                    body: [],
+                },
+            ),
         ],
     },
 )
@@ -190,17 +204,6 @@ Module(
 
 
   |
-1 |   # Regression test for https://github.com/astral-sh/ty/issues/1828
-2 |   (c: int = 1,f"""{d=[
-3 |   def a(
-  |  _______^
-4 | | class A:
-5 | |     pass
-  | |_________^ Syntax Error: f-string: unterminated triple-quoted string
-  |
-
-
-  |
 2 | (c: int = 1,f"""{d=[
 3 | def a(
 4 | class A:
@@ -210,13 +213,12 @@ Module(
 
 
   |
-1 |   # Regression test for https://github.com/astral-sh/ty/issues/1828
 2 |   (c: int = 1,f"""{d=[
 3 |   def a(
-  |  _______^
-4 | | class A:
+4 |   class A:
+  |  _________^
 5 | |     pass
-  | |_________^ Syntax Error: Expected a statement
+  | |_________^ Syntax Error: f-string: unterminated triple-quoted string
   |
 
 


### PR DESCRIPTION
## Summary

Fixes #21896.

When the parser's error recovery path (`re_lex_logical_token`) encounters unclosed interpolated strings inside triple-quoted f-strings, it decrements the nesting counter too eagerly, crossing the interpolation boundary. This desynchronizes the lexer's state, producing cascading parse errors and preventing proper recovery.

This PR adds a guard in `re_lex_logical_token` that prevents the nesting decrement from crossing the f-string interpolation boundary for triple-quoted strings. The check uses `is_triple_quoted()` on the interpolated string context, so it covers both f-strings and t-strings. Non-triple-quoted strings intentionally bypass this guard since they use newline-based recovery.

### Prior art

PR #21898 took a different approach (syncing interpolated string state *after* the decrement), but was self-closed by the author as "not the proper fix." This PR instead prevents the problematic decrement from happening in the first place — a preventive guard rather than reactive state restoration. This means there is no need to reason about which conditions require restoring the interpolated string state afterward; the boundary simply cannot be crossed.

### Why the guard is safe

- `self.nesting <= interpolated_string.nesting() + 1` correctly identifies when the next decrement would cross the boundary
- The method returns `false` when the guard fires, which is the same return value as other early-exit paths — the parser continues with alternative recovery strategies
- The condition only activates for triple-quoted strings; single-quoted strings use newline-based recovery and are unaffected

## Test plan

- Existing snapshot tests updated (`re_lexing__triple_quoted_fstring_1`, `re_lexing__ty_1828`)
- Reproduction case from the issue: no longer produces cascading errors
- `cargo test -p ruff_python_parser` — all tests pass