### PR TITLE
[parser] Fix stack overflow in complex type annotations with nested string literals

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_annotations/annotation_presence.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_annotations/annotation_presence.py
@@ -153,6 +153,10 @@ def f(a: Optional[Any]) -> None: ...
 def f(a: Annotated[Any, ...]) -> None: ...
 def f(a: "Union[str, bytes, Any]") -> None: ...
 
+# Regression test for stack overflow with nested quoted annotations containing
+# escape sequences (https://github.com/astral-sh/ruff/issues/14695)
+def f(x: "'in\x74'"): pass
+
 
 class Foo:
     @decorator()

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__defaults.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__defaults.snap
@@ -281,42 +281,63 @@ ANN401 Dynamically typed expressions (typing.Any) are disallowed in `a`
 153 | def f(a: Annotated[Any, ...]) -> None: ...
 154 | def f(a: "Union[str, bytes, Any]") -> None: ...
     |          ^^^^^^^^^^^^^^^^^^^^^^^^
+155 |
+156 | # Regression test for stack overflow with nested quoted annotations containing
     |
 
-ANN204 [*] Missing return type annotation for special method `__init__`
-   --> annotation_presence.py:159:9
+ANN201 [*] Missing return type annotation for public function `f`
+   --> annotation_presence.py:158:5
     |
-157 | class Foo:
-158 |     @decorator()
-159 |     def __init__(self: "Foo", foo: int):
-    |         ^^^^^^^^
-160 |        ...
+156 | # Regression test for stack overflow with nested quoted annotations containing
+157 | # escape sequences (https://github.com/astral-sh/ruff/issues/14695)
+158 | def f(x: "'in\x74'"): pass
+    |     ^
     |
 help: Add return type annotation: `None`
-156 | 
-157 | class Foo:
-158 |     @decorator()
-    -     def __init__(self: "Foo", foo: int):
-159 +     def __init__(self: "Foo", foo: int) -> None:
-160 |        ...
-161 | 
-162 | 
+155 | 
+156 | # Regression test for stack overflow with nested quoted annotations containing
+157 | # escape sequences (https://github.com/astral-sh/ruff/issues/14695)
+    - def f(x: "'in\x74'"): pass
+158 + def f(x: "'in\x74'") -> None: pass
+159 | 
+160 | 
+161 | class Foo:
 note: This is an unsafe fix and may change runtime behavior
 
 ANN204 [*] Missing return type annotation for special method `__init__`
-   --> annotation_presence.py:165:9
+   --> annotation_presence.py:163:9
     |
-163 | # Regression test for: https://github.com/astral-sh/ruff/issues/7711
-164 | class Class:
-165 |     def __init__(self):
+161 | class Foo:
+162 |     @decorator()
+163 |     def __init__(self: "Foo", foo: int):
     |         ^^^^^^^^
-166 |         print(f"{self.attr=}")
+164 |        ...
     |
 help: Add return type annotation: `None`
-162 | 
-163 | # Regression test for: https://github.com/astral-sh/ruff/issues/7711
-164 | class Class:
+160 | 
+161 | class Foo:
+162 |     @decorator()
+    -     def __init__(self: "Foo", foo: int):
+163 +     def __init__(self: "Foo", foo: int) -> None:
+164 |        ...
+165 | 
+166 | 
+note: This is an unsafe fix and may change runtime behavior
+
+ANN204 [*] Missing return type annotation for special method `__init__`
+   --> annotation_presence.py:169:9
+    |
+167 | # Regression test for: https://github.com/astral-sh/ruff/issues/7711
+168 | class Class:
+169 |     def __init__(self):
+    |         ^^^^^^^^
+170 |         print(f"{self.attr=}")
+    |
+help: Add return type annotation: `None`
+166 | 
+167 | # Regression test for: https://github.com/astral-sh/ruff/issues/7711
+168 | class Class:
     -     def __init__(self):
-165 +     def __init__(self) -> None:
-166 |         print(f"{self.attr=}")
+169 +     def __init__(self) -> None:
+170 |         print(f"{self.attr=}")
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__preview_PYI041_PYI041_3.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__preview_PYI041_PYI041_3.py.snap
@@ -392,76 +392,76 @@ note: This is an unsafe fix and may change runtime behavior
 
 
 PYI041 Use `complex` instead of `int | float | complex`
-   --> PYI041_3.py:119:24
+   --> PYI041_3.py:119:25
     |
 117 |         ...
 118 |
 119 |     def bad(self, arg: "int " "| float | com" "plex") -> "None":
-    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 120 |         ...
     |
 help: Remove redundant type
 
 
 PYI041 Use `complex` instead of `int | float | complex`
-   --> PYI041_3.py:122:25
+   --> PYI041_3.py:122:26
     |
 120 |         ...
 121 |
 122 |     def bad2(self, arg: "int | Union[flo" "at, complex]") -> "None":
-    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 123 |         ...
     |
 help: Remove redundant type
 
 
 PYI041 Use `complex` instead of `int | float | complex`
-   --> PYI041_3.py:125:25
+   --> PYI041_3.py:125:26
     |
 123 |         ...
 124 |
 125 |     def bad3(self, arg: "Union[Union[float, com" "plex], int]") -> "None":
-    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 126 |         ...
     |
 help: Remove redundant type
 
 
 PYI041 Use `complex` instead of `int | float | complex`
-   --> PYI041_3.py:128:25
+   --> PYI041_3.py:128:26
     |
 126 |         ...
 127 |
 128 |     def bad4(self, arg: "Union[float | complex, in" "t ]") -> "None":
-    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 129 |         ...
     |
 help: Remove redundant type
 
 
 PYI041 Use `complex` instead of `int | float | complex`
-   --> PYI041_3.py:131:25
+   --> PYI041_3.py:131:26
     |
 129 |           ...
 130 |
 131 |       def bad5(self, arg: "int | "
-    |  _________________________^
+    |  __________________________^
 132 | |                         "(float | complex)") -> "None":
-    | |___________________________________________^
+    | |__________________________________________^
 133 |           ...
     |
 help: Remove redundant type
 
 
 PYI041 Use `complex` instead of `int | float | complex`
-   --> PYI041_3.py:135:25
+   --> PYI041_3.py:135:26
     |
 133 |           ...
 134 |
 135 |       def bad6(self, arg: "in\
-    |  _________________________^
+    |  __________________________^
 136 | | t | (float | compl" "ex)") -> "None":
-    | |_________________________^
+    | |________________________^
 137 |           ...
     |
 help: Remove redundant type

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__preview_PYI041_PYI041_4.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__preview_PYI041_PYI041_4.py.snap
@@ -11,10 +11,10 @@ Added: 4
 
 --- Added ---
 PYI041 Use `float` instead of `int | float`
- --> PYI041_4.py:4:11
+ --> PYI041_4.py:4:12
   |
 4 | def f1(a: "U" "no[int, fl" "oat, Foo]") -> "None": ...
-  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
 5 | def f2(a: "Uno[int, float, Foo]") -> "None": ...
 6 | def f3(a: """Uno[int, float, Foo]""") -> "None": ...
   |
@@ -64,13 +64,13 @@ note: This is an unsafe fix and may change runtime behavior
 
 
 PYI041 Use `float` instead of `int | float`
- --> PYI041_4.py:7:11
+ --> PYI041_4.py:7:12
   |
 5 |   def f2(a: "Uno[int, float, Foo]") -> "None": ...
 6 |   def f3(a: """Uno[int, float, Foo]""") -> "None": ...
 7 |   def f4(a: "Uno[in\
-  |  ___________^
+  |  ____________^
 8 | | t, float, Foo]") -> "None": ...
-  | |_______________^
+  | |______________^
   |
 help: Remove redundant type

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP006_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP006_0.py.snap
@@ -138,10 +138,10 @@ help: Replace with `list`
 44 | 
 
 UP006 Use `list` instead of `List` for type annotation
-  --> UP006_0.py:45:10
+  --> UP006_0.py:45:11
    |
 45 | def f(x: "Li" "st[str]") -> None:
-   |          ^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^
 46 |     ...
    |
 help: Replace with `list`
@@ -198,28 +198,28 @@ help: Replace with `list`
 56 | 
 
 UP006 Use `list` instead of `List` for type annotation
-  --> UP006_0.py:53:16
+  --> UP006_0.py:53:17
    |
 53 | def f(x: "List['Li' 'st[str]']") -> None:
-   |                ^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^
 54 |     ...
    |
 help: Replace with `list`
 
 UP006 Use `list` instead of `List` for type annotation
-  --> UP006_0.py:57:10
+  --> UP006_0.py:57:11
    |
 57 | def f(x: "Li" "st['List[str]']") -> None:
-   |          ^^^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^^^^^
 58 |     ...
    |
 help: Replace with `list`
 
 UP006 Use `list` instead of `List` for type annotation
-  --> UP006_0.py:57:10
+  --> UP006_0.py:57:12
    |
 57 | def f(x: "Li" "st['List[str]']") -> None:
-   |          ^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^^
 58 |     ...
    |
 help: Replace with `list`

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP049_1.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP049_1.py.snap
@@ -281,7 +281,7 @@ help: Rename type parameter to remove leading underscores
 71 + class C[T]:
 72 +     v1 = cast(T, ...)
 73 +     v2 = cast('T', ...)
-74 +     v3 = cast(T, ...)
+74 +     v3 = cast("T", ...)
 75 | 
 76 |     def _(self):
    -         v1 = cast(_T, ...)
@@ -289,7 +289,7 @@ help: Rename type parameter to remove leading underscores
    -         v3 = cast("\u005fT", ...)
 77 +         v1 = cast(T, ...)
 78 +         v2 = cast('T', ...)
-79 +         v3 = cast(T, ...)
+79 +         v3 = cast("T", ...)
 80 | 
 81 | 
 82 | class C[_T]:
@@ -309,7 +309,7 @@ help: Rename type parameter to remove leading underscores
    - class C[_T]:
    -     v = cast('Literal[\'foo\'] | _T', ...)
 82 + class C[T]:
-83 +     v = cast(T, ...)
+83 +     v = cast('T', ...)
 84 | 
 85 | 
 86 | ## Name collision

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__PY39_RUF013_RUF013_0.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__PY39_RUF013_RUF013_0.py.snap
@@ -334,10 +334,10 @@ help: Convert to `Optional[T]`
 note: This is an unsafe fix and may change runtime behavior
 
 RUF013 PEP 484 prohibits implicit `Optional`
-   --> RUF013_0.py:196:12
+   --> RUF013_0.py:196:13
     |
 196 | def f(arg: "st" "r" = None):  # RUF013
-    |            ^^^^^^^^
+    |             ^^^^^^
 197 |     pass
     |
 help: Convert to `Optional[T]`

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF013_RUF013_0.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF013_RUF013_0.py.snap
@@ -334,10 +334,10 @@ help: Convert to `T | None`
 note: This is an unsafe fix and may change runtime behavior
 
 RUF013 PEP 484 prohibits implicit `Optional`
-   --> RUF013_0.py:196:12
+   --> RUF013_0.py:196:13
     |
 196 | def f(arg: "st" "r" = None):  # RUF013
-    |            ^^^^^^^^
+    |             ^^^^^^
 197 |     pass
     |
 help: Convert to `T | None`

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__add_future_import_RUF013_0.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__add_future_import_RUF013_0.py.snap
@@ -414,10 +414,10 @@ help: Convert to `Optional[T]`
 note: This is an unsafe fix and may change runtime behavior
 
 RUF013 PEP 484 prohibits implicit `Optional`
-   --> RUF013_0.py:196:12
+   --> RUF013_0.py:196:13
     |
 196 | def f(arg: "st" "r" = None):  # RUF013
-    |            ^^^^^^^^
+    |             ^^^^^^
 197 |     pass
     |
 help: Convert to `Optional[T]`

--- a/crates/ruff_python_ast/src/relocate.rs
+++ b/crates/ruff_python_ast/src/relocate.rs
@@ -75,8 +75,11 @@ impl Transformer for Relocator {
             Expr::TString(ast::ExprTString { range, .. }) => {
                 *range = self.range;
             }
-            Expr::StringLiteral(ast::ExprStringLiteral { range, .. }) => {
+            Expr::StringLiteral(ast::ExprStringLiteral { range, value, .. }) => {
                 *range = self.range;
+                for part in value.iter_mut() {
+                    part.range = self.range;
+                }
             }
             Expr::BytesLiteral(ast::ExprBytesLiteral { range, .. }) => {
                 *range = self.range;


### PR DESCRIPTION
## Summary

Fixes #14695.

When a type annotation contains a string literal with an inner quoted string and escape sequences (e.g., `"'in\x74'"`), the annotation parser enters infinite recursion, overflowing the stack. The root cause is in `parse_complex_type_annotation`: it calls `relocate_expr` with `string_expr.range()` (including quotes), which gives the inner parsed expression the same start offset as the outer annotation. Since `ParsedAnnotationsCache` is keyed by start offset, this creates a cache-key collision that produces an unbounded cycle.

This PR makes two targeted changes:

1. **`parse_complex_type_annotation`** (`typing.rs`): Use the content range (excluding quotes and prefixes) for `relocate_expr` instead of the full `string_expr.range()`. This ensures the inner parsed expression gets a distinct start offset from the outer annotation, breaking the cache-key collision.

2. **`relocate_expr`** (`relocate.rs`): Also update the ranges of individual `StringLiteral` parts within `ExprStringLiteral.value`. Previously, only the outer `ExprStringLiteral.range` was updated, leaving parts with stale local parse offsets. This caused incorrect diagnostic ranges for nested forward references in complex annotations (e.g., `"List['List[str]']"`).

### Prior art

PR #14700 added a guard in `TypingTarget::try_from_expr` to return `Unknown` when the parsed annotation is itself a string literal. As noted in review, the better fix is to address the root cause in `parse_complex_type_annotation` by using `range_excluding_quotes` and fixing `relocate_expr` to transform the entire parsed tree accordingly. This PR implements that approach.

### Snapshot changes

5 snapshots are updated with column-position shifts for complex string annotations. These reflect the corrected diagnostic ranges now pointing at content rather than quotes:

- **RUF013** (×3): Column shift at `"st" "r"` concatenated annotation (196:12 → 196:13)
- **UP006**: Column shifts for 4 concatenated annotations (e.g., 45:10 → 45:11)
- **UP049**: Fix suggestions for string annotations now preserve quotes (e.g., `cast("T", ...)` instead of `cast(T, ...)`)

## Test plan

- Reproduction case: `ruff check --isolated --select ANN401` no longer overflows the stack
- `cargo test -p ruff_python_parser` — all tests pass
- `cargo test -p ruff_linter` — all 2640 tests pass (5 snapshots updated)