### PR TITLE
Fix E302 autofix infinite loop with non-ASCII comments

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30.py
@@ -1010,3 +1010,20 @@ class Bar:
                 return 1
             return 2
 # end
+
+
+# E302
+"""Test that ruff fails"""
+
+
+import pytest
+
+# whatever
+# whatever 2
+
+# whatever 3
+@pytest.mark.skip
+def test_ruff_fails() -> None:
+    """A test case that causes ruff to have an infinite loop"""
+    return
+# end

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
@@ -927,12 +927,10 @@ impl<'a, 'b> BlankLinesChecker<'a, 'b> {
                     )));
                 } else {
                     diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
-                        self.stylist.line_ending().repeat(
-                            (expected_blank_lines_before_definition
-                                - line.preceding_blank_lines.count())
-                                as usize,
-                        ),
-                        self.locator.line_start(state.last_non_comment_line_end),
+                        self.stylist
+                            .line_ending()
+                            .repeat(expected_blank_lines_before_definition as usize),
+                        self.locator.line_start(line.first_token_range.start()),
                     )));
                 }
             }

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E302_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E302_E30.py.snap
@@ -166,13 +166,14 @@ E302 [*] Expected 2 blank lines, found 1
 604 |     pass
     |
 help: Add missing blank line(s)
-598 | def f():
 599 |     pass
 600 | 
-601 + 
-602 | # comment
-603 | @decorator
-604 | def g():
+601 | # comment
+602 + 
+603 + 
+604 | @decorator
+605 | def g():
+606 |     pass
 
 E302 [*] Expected 2 blank lines, found 0
    --> E30.py:624:1
@@ -263,11 +264,30 @@ E302 [*] Expected 2 blank lines, found 0
 964 | # end
     |
 help: Add missing blank line(s)
-958 | # E302
 959 | def test_update():
 960 |     pass
-961 + 
+961 | # comment
 962 + 
-963 | # comment
+963 + 
 964 | def test_clientmodel():
 965 |     pass
+966 | # end
+
+E302 [*] Expected 2 blank lines, found 1
+    --> E30.py:1025:1
+     |
+1024 | # whatever 3
+1025 | @pytest.mark.skip
+     | ^
+1026 | def test_ruff_fails() -> None:
+1027 |     """A test case that causes ruff to have an infinite loop"""
+     |
+help: Add missing blank line(s)
+1022 | # whatever 2
+1023 | 
+1024 | # whatever 3
+1025 + 
+1026 + 
+1027 | @pytest.mark.skip
+1028 | def test_ruff_fails() -> None:
+1029 |     """A test case that causes ruff to have an infinite loop"""


### PR DESCRIPTION
## Summary

Fixes #12611.

The E302 fix for missing blank lines before definitions inserted blank lines at the wrong position (after the previous definition's end) and computed an incorrect count (subtracting existing blank lines from the required count). When combined with I001 (import sorting) and non-ASCII characters in comments, the two fixes conflicted on each iteration, preventing convergence after 500 iterations.

Fix the insertion point to be directly before the current definition's first token and always insert the full expected count of blank lines. This ensures the fix is idempotent regardless of preceding content.

## Test plan

- Reproduction case: `ruff check --select E302,I001 --fix --preview --isolated` now converges
- Snapshot updated for `E302_E30.py` (fix now inserts at the correct position)
- `cargo test -p ruff_linter -- blank_lines` — all 40 tests pass