### PR TITLE
CLAUDE.md: run `cargo dev generate-all`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,3 +87,4 @@ When working on ty, PR titles should start with `[ty]` and be tagged with the `t
 - If you *have* to suppress a Clippy lint, prefer to use `#[expect()]` over `[allow()]`, where possible.
 - Use comments purposefully. Don't use comments to narrate code, but do use them to explain invariants and why something unusual was done a particular way.
 - **Salsa incrementality (ty):** Any method that accesses `.node()` must be `#[salsa::tracked]`, or it will break incrementality. Prefer higher-level semantic APIs over raw AST access.
+- Run `cargo dev generate-all` after changing configuration options, CLI arguments, lint rules, or environment variable definitions, as these changes require regeneration of schemas, docs, and CLI references.


### PR DESCRIPTION
## Summary

Instruct agents to run `cargo dev generate-all` when changing certain parts of the code base.