### PR TITLE
[ty] Instantiate call-site type variables for generic inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -598,6 +598,11 @@ reveal_type(invoke(identity, 1))  # revealed: Literal[1]
 
 # TODO: this should be `Unknown | int`
 reveal_type(invoke(head, [1, 2, 3]))  # revealed: Unknown
+
+def noop(x: T) -> T:
+    return x
+
+reveal_type(noop(noop))  # revealed: def noop[T](x: T) -> T
 ```
 
 ## Opaque decorators don't affect typevar binding

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -391,6 +391,49 @@ reveal_type(D(1))  # revealed: D[int]
 wrong_innards: D[int] = D("five")
 ```
 
+### Constructor inference can swap type parameters
+
+```py
+class Pair[K, V]:
+    def __init__(self, key: K, value: V) -> None:
+        self.key: K = key
+        self.value: V = value
+
+    def swap(self) -> "Pair[V, K]":
+        swapped = Pair(self.value, self.key)
+        reveal_type(swapped)  # revealed: Pair[V@Pair, K@Pair]
+        return swapped
+
+pair = Pair("foo", 123)
+reveal_type(pair.swap())  # revealed: Pair[int, str]
+```
+
+### `typing.Self` classmethods can specialize generic constructors
+
+```py
+from typing import Self
+
+class Box[T]:
+    value: T
+
+    def __init__(self, value: T) -> None:
+        self.value = value
+
+    @classmethod
+    def from_value(cls, value: T) -> Self:
+        created = cls(value)
+        reveal_type(created)  # revealed: Self@from_value
+        return created
+
+class IntBox(Box[int]):
+    pass
+
+reveal_type(Box.from_value(1))  # revealed: Box[Unknown]
+reveal_type(IntBox.from_value(1))  # revealed: IntBox
+
+IntBox.from_value("x")  # error: [invalid-argument-type]
+```
+
 ### Both present, `__new__` inherited from a generic base class
 
 If either method comes from a generic base class, we don't currently use its inferred specialization

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -530,6 +530,11 @@ reveal_type(invoke(identity, 1))  # revealed: Literal[1]
 
 # TODO: this should be `Unknown | int`
 reveal_type(invoke(head, [1, 2, 3]))  # revealed: Unknown
+
+def noop[T](x: T) -> T:
+    return x
+
+reveal_type(noop(noop))  # revealed: def noop[T](x: T) -> T
 ```
 
 ## Protocols as TypeVar bounds


### PR DESCRIPTION
(paused for now, see : https://github.com/astral-sh/ruff/pull/23369#issuecomment-4110167031)
## Summary

Fixes:

- https://github.com/astral-sh/ty/issues/2817
- https://github.com/astral-sh/ty/issues/2859

Both issues came from solving call specializations against callee-bound type variables. In recursive generic shapes (constructor swapping and generic self-application), that re-used identity can collapse inference.

This change makes inference use call-local type variable identities when needed:

- Add a gate in call binding that detects whether call arguments or the expected type context mention the callee's bound type variables.
- If the gate is false, keep the existing inference path.
- If the gate is true, instantiate the signature generic context to synthetic call-local type variables, run inference in that context, then map solved types and specialization errors back to the original signature context.

This keeps common calls on the existing path, while fixing the aliasing cases that trigger #2817 and #2859.

## Test Plan

- Added `Pair.swap` constructor-inference regression in:
  - `crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md`
  - `crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md`
- Added generic self-application regression (`noop(noop)`) in:
  - `crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md`
  - `crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md`
- Added `typing.Self` classmethod constructor specialization checks in both class mdtests above.
  These exercise the same constructor/synthetic-argument inference path touched by this fix (`cls(value)`), as a targeted side-regression guard