### PR TITLE
[ty] Fix inappropriate display of `import ...` hint in ty playground completions

### DIFF
--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -342,7 +342,8 @@ class PlaygroundServer
         label: {
           label: completion.name,
           detail:
-            completion.module_name == null
+            completion.module_name == null ||
+            completion.additional_text_edits == null
               ? undefined
               : ` (import ${completion.module_name})`,
           description: completion.detail ?? undefined,


### PR DESCRIPTION
At some point in the past, the labeling for completions was improved so
that an import hint would only be shown if an actual import edit was
associated with the completion. But the improvement only applied to the
display logic for `ty server`. It didn't find its way into the display
logic for the playground, which uses a distinct code path.

Fixes https://github.com/astral-sh/ty/issues/2820