### PR TITLE
[ty] Fix union ordering in solver

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -2373,7 +2373,13 @@ impl<'db> InteriorNode<'db> {
             let mut sorted_paths = Vec::new();
             Node::Interior(interior).for_each_path(db, |path| {
                 let mut path: Vec<_> = path.positive_constraints().collect();
-                path.sort_by_key(|(_, source_order)| *source_order);
+                path.sort_by(|(a, _), (b, _)| {
+                    super::type_ordering::union_or_intersection_elements_ordering(
+                        db,
+                        &a.lower(db).normalized(db),
+                        &b.lower(db).normalized(db),
+                    )
+                });
                 sorted_paths.push(path);
             });
             sorted_paths.sort_by(|path1, path2| {


### PR DESCRIPTION
## Summary

So this is the fix, now I only need to find the problem.

I am debugging this by running
```bash
for i in {1..10}; do ty check --no-progress --output-format=concise | rg tests/test_tools.py:17:17; done
```
in the `rich` ecosystem project, where I get the following output on `main` (scroll to the right):
```
tests/test_tools.py:17:17: error[invalid-argument-type] Argument to function `next` is incorrect: Expected `SupportsNext[Unknown]`, found `MyIterable[Unknown | str]`
tests/test_tools.py:17:17: error[invalid-argument-type] Argument to function `next` is incorrect: Expected `SupportsNext[Unknown]`, found `MyIterable[Unknown | str]`
tests/test_tools.py:17:17: error[invalid-argument-type] Argument to function `next` is incorrect: Expected `SupportsNext[Unknown]`, found `MyIterable[Unknown | str]`
tests/test_tools.py:17:17: error[invalid-argument-type] Argument to function `next` is incorrect: Expected `SupportsNext[Unknown]`, found `MyIterable[str | Unknown]`
tests/test_tools.py:17:17: error[invalid-argument-type] Argument to function `next` is incorrect: Expected `SupportsNext[Unknown]`, found `MyIterable[str | Unknown]`
tests/test_tools.py:17:17: error[invalid-argument-type] Argument to function `next` is incorrect: Expected `SupportsNext[Unknown]`, found `MyIterable[Unknown | str]`
tests/test_tools.py:17:17: error[invalid-argument-type] Argument to function `next` is incorrect: Expected `SupportsNext[Unknown]`, found `MyIterable[str | Unknown]`
tests/test_tools.py:17:17: error[invalid-argument-type] Argument to function `next` is incorrect: Expected `SupportsNext[Unknown]`, found `MyIterable[Unknown | str]`
tests/test_tools.py:17:17: error[invalid-argument-type] Argument to function `next` is incorrect: Expected `SupportsNext[Unknown]`, found `MyIterable[str | Unknown]`
tests/test_tools.py:17:17: error[invalid-argument-type] Argument to function `next` is incorrect: Expected `SupportsNext[Unknown]`, found `MyIterable[Unknown | str]`
```
… whereas on this branch, I consistently get the `str | Unknown` ordering.

A few findings:
* This only happens in multi-threaded mode
* It seems to depend on the fact that "a lot" of files are being checked, *even if those files do not appear in the import tree of `test_tools.py`*! It seems like when I remove more and more files from the rich project, the "wrong" ordering becomes less likely…
* I was not able to reproduce this in single-threaded runs by permuting the order of checking the files.

Open questions:
* Is the [`source_order`](https://github.com/astral-sh/ruff/pull/21983) field potentially problematic in the context of non-deterministic checking-order of files?

## Test Plan

* [x] mypy_primer/ecosystem-analyzer on this PR is *not* helpful, since the base branch is still non-deterministic.
* [ ] Run ecosystem analyzer locally with `--flaky-runs`
