### PR TITLE
[ty] Skip corpus and snapshot files in workflow triggers

### DIFF
--- a/.github/workflows/memory_report.yaml
+++ b/.github/workflows/memory_report.yaml
@@ -19,7 +19,9 @@ on:
       - "Cargo.lock"
       - "!**.md"
       - "!**.snap"
-      # Don't skip all .py/.pyi files: ty_vendored stubs are load-bearing.
+      # It's tempting to skip all Python files in every directory,
+      # but changes to Python files in `ty_vendored` can affect the output of mypy_primer,
+      # so we apply a narrow exemption for all files in the corpus directory instead.
       - "!crates/ty_python_semantic/resources/corpus/**"
 
 concurrency:

--- a/.github/workflows/mypy_primer.yaml
+++ b/.github/workflows/mypy_primer.yaml
@@ -19,7 +19,9 @@ on:
       - "Cargo.lock"
       - "!**.md"
       - "!**.snap"
-      # Don't skip all .py/.pyi files: ty_vendored stubs are load-bearing.
+      # It's tempting to skip all Python files in every directory,
+      # but changes to Python files in `ty_vendored` can affect the output of mypy_primer,
+      # so we apply a narrow exemption for all files in the corpus directory instead.
       - "!crates/ty_python_semantic/resources/corpus/**"
 
 concurrency:

--- a/.github/workflows/typing_conformance.yaml
+++ b/.github/workflows/typing_conformance.yaml
@@ -19,7 +19,9 @@ on:
       - "Cargo.lock"
       - "!**.md"
       - "!**.snap"
-      # Don't skip all .py/.pyi files: ty_vendored stubs are load-bearing.
+      # It's tempting to skip all Python files in every directory,
+      # but changes to Python files in `ty_vendored` can affect the output of mypy_primer,
+      # so we apply a narrow exemption for all files in the corpus directory instead.
       - "!crates/ty_python_semantic/resources/corpus/**"
 
 concurrency:


### PR DESCRIPTION
## Summary

Update three GitHub Actions workflows (`memory_report.yaml`, `mypy_primer.yaml`, and `typing_conformance.yaml`) to exclude the `corpus` directory (which only contains non-load-bearing Python files), and snapshot files, from triggering workflow runs.