### PR TITLE
[ty] Minor improvements to diagnostics for abstract final classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Abstract_method_in_g…_(6d8b024dda7ced11).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Abstract_method_in_g…_(6d8b024dda7ced11).snap
@@ -44,7 +44,7 @@ error[abstract-method-in-final-class]: Final class `Child` does not implement ab
  4 | class GrandParent(ABC):
  5 |     @abstractmethod
  6 |     def method(self) -> int: ...
-   |         ------ `method` defined as abstract on superclass `GrandParent`
+   |         ------ `method` declared as abstract on superclass `GrandParent`
  7 |
  8 | class Parent(GrandParent):
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Basic_case_with_ABC_(21e412599c45972a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Basic_case_with_ABC_(21e412599c45972a).snap
@@ -42,7 +42,7 @@ error[abstract-method-in-final-class]: Final class `Derived` does not implement 
  4 | class Base(ABC):
  5 |     @abstractmethod
  6 |     def foo(self) -> int:
-   |         --- `foo` defined as abstract on superclass `Base`
+   |         --- `foo` declared as abstract on superclass `Base`
  7 |         raise NotImplementedError
    |
 info: rule `abstract-method-in-final-class` is enabled by default

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(f807ff3716d8ab0d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(f807ff3716d8ab0d).snap
@@ -51,7 +51,7 @@ error[abstract-method-in-final-class]: Final class `Abstract` does not implement
   |       ^^^^^^^^
 6 |     @abstractmethod
 7 |     def aaaaaaaaaa(self) -> int: ...
-  |         ---------- `aaaaaaaaaa` defined as abstract on superclass `Abstract`
+  |         ---------- `aaaaaaaaaa` declared as abstract
 8 |     @abstractmethod
 9 |     def bbbbbbbb(self) -> int: ...
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Multiple_abstract_me…_(feafee9a4abbe8d1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Multiple_abstract_me…_(feafee9a4abbe8d1).snap
@@ -53,7 +53,7 @@ error[abstract-method-in-final-class]: Final class `MissingAll` does not impleme
  4 | class Base(ABC):
  5 |     @abstractmethod
  6 |     def foo(self) -> int: ...
-   |         --- `foo` defined as abstract on superclass `Base`
+   |         --- `foo` declared as abstract on superclass `Base`
  7 |     @abstractmethod
  8 |     def bar(self) -> str: ...
    |
@@ -76,7 +76,7 @@ error[abstract-method-in-final-class]: Final class `PartiallyImplemented` does n
  8 |     def bar(self) -> str: ...
  9 |     @abstractmethod
 10 |     def baz(self) -> None: ...
-   |         --- `baz` defined as abstract on superclass `Base`
+   |         --- `baz` declared as abstract on superclass `Base`
 11 |
 12 | @final
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Protocol_with_implic…_(e373f31c7a7d88e7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Protocol_with_implic…_(e373f31c7a7d88e7).snap
@@ -174,7 +174,7 @@ error[abstract-method-in-final-class]: Final class `Q` does not implement abstra
  9 |     # would probably be subtle and surprising to many users. This also matches the
 10 |     # behaviour of all other type checkers
 11 |     def still_abstractmethod(self): ...
-   |         -------------------- `still_abstractmethod` defined as abstract on superclass `P`
+   |         -------------------- `still_abstractmethod` declared as abstract on superclass `P`
 12 |
 13 | @final
 14 | class Q(P): ...  # error: [abstract-method-in-final-class]
@@ -188,7 +188,7 @@ info: `P.still_abstractmethod` is implicitly abstract because `P` is a `Protocol
 1 | from typing_extensions import Protocol, final, Never, overload
 2 |
 3 | class P(Protocol):
-  |       ^^^^^^^^^^^ `P` declared here
+  |       ----------- `P` declared here
 4 |     # There'd be no unsoundness here if a subclass of this
 5 |     # class were to be instantiated without the method having been overridden:
   |
@@ -204,7 +204,7 @@ error[abstract-method-in-final-class]: Final class `S` does not implement abstra
 16 | class R(Protocol):
 17 |     # same here
 18 |     def also_still_abstractmethod(self) -> None: ...
-   |         ------------------------- `also_still_abstractmethod` defined as abstract on superclass `R`
+   |         ------------------------- `also_still_abstractmethod` declared as abstract on superclass `R`
 19 |
 20 | @final
 21 | class S(R): ...  # error: [abstract-method-in-final-class]
@@ -218,7 +218,7 @@ info: `R.also_still_abstractmethod` is implicitly abstract because `R` is a `Pro
 14 | class Q(P): ...  # error: [abstract-method-in-final-class]
 15 |
 16 | class R(Protocol):
-   |       ^^^^^^^^^^^ `R` declared here
+   |       ----------- `R` declared here
 17 |     # same here
 18 |     def also_still_abstractmethod(self) -> None: ...
    |
@@ -241,7 +241,7 @@ error[abstract-method-in-final-class]: Final class `RaisesSub` does not implemen
    |
 23 | class Raises(Protocol):
 24 |     def even_this_is_abstract(self):
-   |         --------------------- `even_this_is_abstract` defined as abstract on superclass `Raises`
+   |         --------------------- `even_this_is_abstract` declared as abstract on superclass `Raises`
 25 |         raise NotImplementedError
    |
 info: `Raises.even_this_is_abstract` is implicitly abstract because `Raises` is a `Protocol` class and `even_this_is_abstract` lacks an implementation
@@ -250,7 +250,7 @@ info: `Raises.even_this_is_abstract` is implicitly abstract because `Raises` is 
 21 | class S(R): ...  # error: [abstract-method-in-final-class]
 22 |
 23 | class Raises(Protocol):
-   |       ^^^^^^^^^^^^^^^^ `Raises` declared here
+   |       ---------------- `Raises` declared here
 24 |     def even_this_is_abstract(self):
 25 |         raise NotImplementedError
    |
@@ -272,7 +272,7 @@ error[abstract-method-in-final-class]: Final class `AlsoRaisesSub` does not impl
    |
 30 | class AlsoRaises(Protocol):
 31 |     def also_abstractmethod(self) -> Never:
-   |         ------------------- `also_abstractmethod` defined as abstract on superclass `AlsoRaises`
+   |         ------------------- `also_abstractmethod` declared as abstract on superclass `AlsoRaises`
 32 |         raise NotImplementedError
    |
 info: `AlsoRaises.also_abstractmethod` is implicitly abstract because `AlsoRaises` is a `Protocol` class and `also_abstractmethod` lacks an implementation
@@ -281,7 +281,7 @@ info: `AlsoRaises.also_abstractmethod` is implicitly abstract because `AlsoRaise
 28 | class RaisesSub(Raises): ...  # error: [abstract-method-in-final-class]
 29 |
 30 | class AlsoRaises(Protocol):
-   |       ^^^^^^^^^^^^^^^^^^^^ `AlsoRaises` declared here
+   |       -------------------- `AlsoRaises` declared here
 31 |     def also_abstractmethod(self) -> Never:
 32 |         raise NotImplementedError
    |
@@ -304,7 +304,7 @@ error[abstract-method-in-final-class]: Final class `StrangeSub` does not impleme
 39 | def _(x: NotImplementedErrorAlias):
 40 |     class Strange(Protocol):
 41 |         def weird_abstractmethod(self):
-   |             -------------------- `weird_abstractmethod` defined as abstract on superclass `Strange`
+   |             -------------------- `weird_abstractmethod` declared as abstract on superclass `Strange`
 42 |             raise x
    |
 info: `Strange.weird_abstractmethod` is implicitly abstract because `Strange` is a `Protocol` class and `weird_abstractmethod` lacks an implementation
@@ -312,7 +312,7 @@ info: `Strange.weird_abstractmethod` is implicitly abstract because `Strange` is
    |
 39 | def _(x: NotImplementedErrorAlias):
 40 |     class Strange(Protocol):
-   |           ^^^^^^^^^^^^^^^^^ `Strange` declared here
+   |           ----------------- `Strange` declared here
 41 |         def weird_abstractmethod(self):
 42 |             raise x
    |
@@ -327,7 +327,7 @@ error[abstract-method-in-final-class]: Final class `HasOverloadSub` does not imp
 49 |     def foo(self) -> int: ...
 50 |     @overload
 51 |     def foo(self, x: int) -> str: ...
-   |         --- `foo` defined as abstract on superclass `HasOverloads`
+   |         --- `foo` declared as abstract on superclass `HasOverloads`
 52 |
 53 | @final
 54 | class HasOverloadSub(HasOverloads): ...  # error: [abstract-method-in-final-class]
@@ -341,7 +341,7 @@ info: `HasOverloads.foo` is implicitly abstract because `HasOverloads` is a `Pro
 45 |     class StrangeSub(Strange): ...  # error: [abstract-method-in-final-class]
 46 |
 47 | class HasOverloads(Protocol):
-   |       ^^^^^^^^^^^^^^^^^^^^^^ `HasOverloads` declared here
+   |       ---------------------- `HasOverloads` declared here
 48 |     @overload
 49 |     def foo(self) -> int: ...
    |
@@ -363,7 +363,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstractSub` does not imp
     |
  71 | class HasAbstract(Protocol):
  72 |     def a(self) -> int: ...
-    |         - `a` defined as abstract on superclass `HasAbstract`
+    |         - `a` declared as abstract on superclass `HasAbstract`
  73 |
  74 | class HasAbstract2(Protocol):
     |
@@ -373,7 +373,7 @@ info: `HasAbstract.a` is implicitly abstract because `HasAbstract` is a `Protoco
 69 | class RaisesMultipleSub(RaisesMultiple): ...
 70 |
 71 | class HasAbstract(Protocol):
-   |       ^^^^^^^^^^^^^^^^^^^^^ `HasAbstract` declared here
+   |       --------------------- `HasAbstract` declared here
 72 |     def a(self) -> int: ...
    |
 info: rule `abstract-method-in-final-class` is enabled by default
@@ -394,7 +394,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract2Sub` does not im
     |
  74 | class HasAbstract2(Protocol):
  75 |     def a(self) -> int:
-    |         - `a` defined as abstract on superclass `HasAbstract2`
+    |         - `a` declared as abstract on superclass `HasAbstract2`
  76 |         pass
     |
 info: `HasAbstract2.a` is implicitly abstract because `HasAbstract2` is a `Protocol` class and `a` lacks an implementation
@@ -403,7 +403,7 @@ info: `HasAbstract2.a` is implicitly abstract because `HasAbstract2` is a `Proto
 72 |     def a(self) -> int: ...
 73 |
 74 | class HasAbstract2(Protocol):
-   |       ^^^^^^^^^^^^^^^^^^^^^^ `HasAbstract2` declared here
+   |       ---------------------- `HasAbstract2` declared here
 75 |     def a(self) -> int:
 76 |         pass
    |
@@ -425,7 +425,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract3Sub` does not im
     |
  82 | class HasAbstract4(Protocol):
  83 |     def a(self) -> int:
-    |         - `a` defined as abstract on superclass `HasAbstract4`
+    |         - `a` declared as abstract on superclass `HasAbstract4`
  84 |         """My awesome docs"""
  85 |         ...
     |
@@ -435,7 +435,7 @@ info: `HasAbstract4.a` is implicitly abstract because `HasAbstract4` is a `Proto
 80 |         """My awesome docs"""
 81 |
 82 | class HasAbstract4(Protocol):
-   |       ^^^^^^^^^^^^^^^^^^^^^^ `HasAbstract4` declared here
+   |       ---------------------- `HasAbstract4` declared here
 83 |     def a(self) -> int:
 84 |         """My awesome docs"""
    |
@@ -457,7 +457,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract4Sub` does not im
     |
  82 | class HasAbstract4(Protocol):
  83 |     def a(self) -> int:
-    |         - `a` defined as abstract on superclass `HasAbstract4`
+    |         - `a` declared as abstract on superclass `HasAbstract4`
  84 |         """My awesome docs"""
  85 |         ...
     |
@@ -467,7 +467,7 @@ info: `HasAbstract4.a` is implicitly abstract because `HasAbstract4` is a `Proto
 80 |         """My awesome docs"""
 81 |
 82 | class HasAbstract4(Protocol):
-   |       ^^^^^^^^^^^^^^^^^^^^^^ `HasAbstract4` declared here
+   |       ---------------------- `HasAbstract4` declared here
 83 |     def a(self) -> int:
 84 |         """My awesome docs"""
    |
@@ -489,7 +489,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract5Sub` does not im
     |
  87 | class HasAbstract5(Protocol):
  88 |     def a(self) -> int:
-    |         - `a` defined as abstract on superclass `HasAbstract5`
+    |         - `a` declared as abstract on superclass `HasAbstract5`
  89 |         """My awesome docs"""
  90 |         pass
     |
@@ -499,7 +499,7 @@ info: `HasAbstract5.a` is implicitly abstract because `HasAbstract5` is a `Proto
 85 |         ...
 86 |
 87 | class HasAbstract5(Protocol):
-   |       ^^^^^^^^^^^^^^^^^^^^^^ `HasAbstract5` declared here
+   |       ---------------------- `HasAbstract5` declared here
 88 |     def a(self) -> int:
 89 |         """My awesome docs"""
    |
@@ -521,7 +521,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract6Sub` does not im
     |
  92 | class HasAbstract6(Protocol):
  93 |     def a(self) -> int:
-    |         - `a` defined as abstract on superclass `HasAbstract6`
+    |         - `a` declared as abstract on superclass `HasAbstract6`
  94 |         """My awesome docs"""
  95 |         pass
     |
@@ -531,7 +531,7 @@ info: `HasAbstract6.a` is implicitly abstract because `HasAbstract6` is a `Proto
 90 |         pass
 91 |
 92 | class HasAbstract6(Protocol):
-   |       ^^^^^^^^^^^^^^^^^^^^^^ `HasAbstract6` declared here
+   |       ---------------------- `HasAbstract6` declared here
 93 |     def a(self) -> int:
 94 |         """My awesome docs"""
    |
@@ -553,7 +553,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract7Sub` does not im
     |
 104 | class HasAbstract7(Protocol):
 105 |     def a(self) -> int:
-    |         - `a` defined as abstract on superclass `HasAbstract7`
+    |         - `a` declared as abstract on superclass `HasAbstract7`
 106 |         raise NotImplementedError
     |
 info: `HasAbstract7.a` is implicitly abstract because `HasAbstract7` is a `Protocol` class and `a` lacks an implementation
@@ -562,7 +562,7 @@ info: `HasAbstract7.a` is implicitly abstract because `HasAbstract7` is a `Proto
 102 |         ...
 103 |
 104 | class HasAbstract7(Protocol):
-    |       ^^^^^^^^^^^^^^^^^^^^^^ `HasAbstract7` declared here
+    |       ---------------------- `HasAbstract7` declared here
 105 |     def a(self) -> int:
 106 |         raise NotImplementedError
     |
@@ -584,7 +584,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract8Sub` does not im
     |
 108 | class HasAbstract8(Protocol):
 109 |     def a(self) -> int:
-    |         - `a` defined as abstract on superclass `HasAbstract8`
+    |         - `a` declared as abstract on superclass `HasAbstract8`
 110 |         raise NotImplementedError()
     |
 info: `HasAbstract8.a` is implicitly abstract because `HasAbstract8` is a `Protocol` class and `a` lacks an implementation
@@ -593,7 +593,7 @@ info: `HasAbstract8.a` is implicitly abstract because `HasAbstract8` is a `Proto
 106 |         raise NotImplementedError
 107 |
 108 | class HasAbstract8(Protocol):
-    |       ^^^^^^^^^^^^^^^^^^^^^^ `HasAbstract8` declared here
+    |       ---------------------- `HasAbstract8` declared here
 109 |     def a(self) -> int:
 110 |         raise NotImplementedError()
     |
@@ -615,7 +615,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract9Sub` does not im
     |
 112 | class HasAbstract9(Protocol):
 113 |     def a(self) -> int:
-    |         - `a` defined as abstract on superclass `HasAbstract9`
+    |         - `a` declared as abstract on superclass `HasAbstract9`
 114 |         """My awesome docs"""
 115 |         raise NotImplementedError
     |
@@ -625,7 +625,7 @@ info: `HasAbstract9.a` is implicitly abstract because `HasAbstract9` is a `Proto
 110 |         raise NotImplementedError()
 111 |
 112 | class HasAbstract9(Protocol):
-    |       ^^^^^^^^^^^^^^^^^^^^^^ `HasAbstract9` declared here
+    |       ---------------------- `HasAbstract9` declared here
 113 |     def a(self) -> int:
 114 |         """My awesome docs"""
     |
@@ -645,7 +645,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract10Sub` does not i
     |
 117 | class HasAbstract10(Protocol):
 118 |     def a(self) -> int:
-    |         - `a` defined as abstract on superclass `HasAbstract10`
+    |         - `a` declared as abstract on superclass `HasAbstract10`
 119 |         """My awesome docs"""
 120 |         raise NotImplementedError()
     |
@@ -655,7 +655,7 @@ info: `HasAbstract10.a` is implicitly abstract because `HasAbstract10` is a `Pro
 115 |         raise NotImplementedError
 116 |
 117 | class HasAbstract10(Protocol):
-    |       ^^^^^^^^^^^^^^^^^^^^^^^ `HasAbstract10` declared here
+    |       ----------------------- `HasAbstract10` declared here
 118 |     def a(self) -> int:
 119 |         """My awesome docs"""
     |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union.md_-_Unions_in_calls_-_Union_of_intersectio…_(db3e1dc3b7caa912).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union.md_-_Unions_in_calls_-_Union_of_intersectio…_(db3e1dc3b7caa912).snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ty_test/src/lib.rs
-assertion_line: 623
 expression: snapshot
 ---
 


### PR DESCRIPTION
## Summary

Another PR split out from #22898, to reduce the diff in that PR. Changes made here:

- Use "declared" rather than "defined" in a diagnostic message
- Use secondary annotations (underlined with `______`) rather than primary annotations (underlined with `^^^^^^^`) for annotations in informational subdiagnostics
- Shorten one diagnostic message in some situations: if the abstract method was defined on the same class that we're emitting a diagnostic on, just say "method X declared here" rather than "method X declared here on superclass Y"

## Test Plan

`cargo insta test -p ty_python_semantic`
