### PR TITLE
[ty] Consider synthesized methods and `ClassVar`-qualified declarations when determining whether an abstract method has been overridden in a subclass

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/final.md
@@ -1018,6 +1018,31 @@ class Final(DynamicMiddle):  # No error; `foo` is implemented by `DynamicMiddle`
     pass
 ```
 
+### Abstract method implemented via a synthesized method
+
+```py
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from functools import total_ordering
+from typing import final
+
+class AbstractOrdered(ABC):
+    @abstractmethod
+    def __lt__(self, other): ...
+
+@final
+@dataclass(order=True)
+class ConcreteOrdered(AbstractOrdered): ...  # fine
+
+# total_ordering does not override a comparison method
+# if it already exists in the MRO, even if the one that
+# exists in the MRO is abstract!
+@final
+@total_ordering
+class AlsoConreteOrdered(AbstractOrdered):  # error: [abstract-method-in-final-class]
+    def __gt__(self, other): ...
+```
+
 ### Non-final class with unimplemented abstract methods is fine
 
 Non-final classes are allowed to have unimplemented abstract methods, as they can be implemented by
@@ -1206,9 +1231,8 @@ dynamically patch the attribute onto the class (e.g., using a metaclass):
 ```py
 from typing import ClassVar
 
-# TODO: this should not emit an error
 @final
-class GoodChild(Base):  # error: [abstract-method-in-final-class]
+class GoodChild(Base):  # fine
     f: ClassVar[int]
 ```
 


### PR DESCRIPTION
## Summary

This is another standalone PR pulled out of #22898, to reduce the diff on that PR.

Currently we emit a false-positive `abstract-method-in-final-class` diagnostic on this class, because we do not see that the synthesized `__lt__` method created by `@dataclass(order=True)` has overridden the abstract `__lt__` method from the class's superclass:

```py
from abc import ABC, abstractmethod
from dataclasses import dataclass
from typing import final

class AbstractOrdered(ABC):
    @abstractmethod
    def __lt__(self, other): ...

@final
@dataclass(order=True)
class ConcreteOrdered(AbstractOrdered): ...
```

We also currently do not recognise `ClassVar` declarations in a subclass as overriding an abstract method/property on a base class. While an annotation without a binding is not sufficient at runtime as an abstract method override, the `ClassVar` qualifier serves as an explicit declaration from the user to the type checker that the attribute will be accessible on the class object itself (not simply instances of the class) at runtime. We therefore choose to treat `ClassVar` declarations as overrides of abstract methods from superclasses.

## Test Plan

mdtests updated/extended
