### PR TITLE
[ty] Fix return type of `assert_never`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/directives/assert_never.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/assert_never.md
@@ -46,6 +46,22 @@ def _(unknown: Unknown):
     assert_never(unknown)  # error: [type-assertion-failure]
 ```
 
+### Return type of `assert_never`
+
+The return type of `assert_never` is always `Never`, despite the type of the argument:
+
+```py
+from typing_extensions import Never, assert_never
+
+def _(never: Never):
+    # revealed: Never
+    reveal_type(assert_never(never))
+
+def _():
+    # revealed: Never
+    reveal_type(assert_never(0))  # error: [type-assertion-failure]
+```
+
 ## Use case: Type narrowing and exhaustiveness checking
 
 ```toml

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4137,7 +4137,7 @@ impl<'db> Type<'db> {
                                     // errors instead of `type-assertion-failure` errors.
                                     .with_annotated_type(Type::any())],
                             ),
-                            Type::none(db),
+                            Type::Never,
                         ),
                     )
                     .into()


### PR DESCRIPTION
## Summary

The return type of `assert_never` [should be `Never`](https://github.com/python/typeshed/blob/2b2a93d6322ad68726321ba3351676b1fd4761c6/stdlib/typing.pyi#L996).

## Test Plan

New Markdown tests.