### PR TITLE
alex/abstract class instantiation 3

### DIFF
--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -8,7 +8,7 @@
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20abstract-method-in-final-class" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2193" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2194" target="_blank">View source</a>
 </small>
 
 
@@ -49,7 +49,7 @@ class Derived(Base):  # Error: `Derived` does not implement `method`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20ambiguous-protocol-member" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L648" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L649" target="_blank">View source</a>
 </small>
 
 
@@ -90,7 +90,7 @@ class SubProto(BaseProto, Protocol):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20assert-type-unspellable-subtype" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2329" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2330" target="_blank">View source</a>
 </small>
 
 
@@ -157,7 +157,7 @@ def test(): -> "int":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Preview (since <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a>) ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20call-abstract-method" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2228" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2229" target="_blank">View source</a>
 </small>
 
 
@@ -206,7 +206,7 @@ Foo.method()  # Error: cannot call abstract classmethod
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20call-non-callable" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L164" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L165" target="_blank">View source</a>
 </small>
 
 
@@ -230,7 +230,7 @@ Calling a non-callable object will raise a `TypeError` at runtime.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.7">0.0.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20call-top-callable" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L182" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L183" target="_blank">View source</a>
 </small>
 
 
@@ -261,7 +261,7 @@ def f(x: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20conflicting-argument-forms" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L233" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L234" target="_blank">View source</a>
 </small>
 
 
@@ -293,7 +293,7 @@ f(int)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20conflicting-declarations" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L259" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L260" target="_blank">View source</a>
 </small>
 
 
@@ -324,7 +324,7 @@ a = 1
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20conflicting-metaclass" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L284" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L285" target="_blank">View source</a>
 </small>
 
 
@@ -356,7 +356,7 @@ class C(A, B): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20cyclic-class-definition" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L310" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L311" target="_blank">View source</a>
 </small>
 
 
@@ -388,7 +388,7 @@ class B(A): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20cyclic-type-alias-definition" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L336" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L337" target="_blank">View source</a>
 </small>
 
 
@@ -416,7 +416,7 @@ type B = A
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Preview (since <a href="https://github.com/astral-sh/ty/releases/tag/1.0.0">1.0.0</a>) ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20dataclass-field-order" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L454" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L455" target="_blank">View source</a>
 </small>
 
 
@@ -448,7 +448,7 @@ class Example:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.16">0.0.1-alpha.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20deprecated" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L380" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L381" target="_blank">View source</a>
 </small>
 
 
@@ -475,7 +475,7 @@ old_func()  # emits [deprecated] diagnostic
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20division-by-zero" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L358" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L359" target="_blank">View source</a>
 </small>
 
 
@@ -504,7 +504,7 @@ false positives it can produce.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20duplicate-base" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L401" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L402" target="_blank">View source</a>
 </small>
 
 
@@ -531,7 +531,7 @@ class B(A, A): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20duplicate-kw-only" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L422" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L423" target="_blank">View source</a>
 </small>
 
 
@@ -569,7 +569,7 @@ class A:  # Crash at runtime
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20empty-body" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L937" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L938" target="_blank">View source</a>
 </small>
 
 
@@ -640,7 +640,7 @@ def foo() -> "intt\b": ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20final-without-value" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2166" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2167" target="_blank">View source</a>
 </small>
 
 
@@ -766,7 +766,7 @@ def test(): -> "Literal[5]":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20inconsistent-mro" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L731" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L732" target="_blank">View source</a>
 </small>
 
 
@@ -796,7 +796,7 @@ class C(A, B): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20index-out-of-bounds" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L755" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L756" target="_blank">View source</a>
 </small>
 
 
@@ -822,7 +822,7 @@ t[3]  # IndexError: tuple index out of range
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.33">0.0.1-alpha.33</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20ineffective-final" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2138" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2139" target="_blank">View source</a>
 </small>
 
 
@@ -856,7 +856,7 @@ class MyClass: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20instance-layout-conflict" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L537" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L538" target="_blank">View source</a>
 </small>
 
 
@@ -945,7 +945,7 @@ an atypical memory layout.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-argument-type" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L893" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L894" target="_blank">View source</a>
 </small>
 
 
@@ -972,7 +972,7 @@ func("foo")  # error: [invalid-argument-type]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-assignment" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L977" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L978" target="_blank">View source</a>
 </small>
 
 
@@ -1000,7 +1000,7 @@ a: int = ''
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-attribute-access" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2631" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2632" target="_blank">View source</a>
 </small>
 
 
@@ -1034,7 +1034,7 @@ C.instance_var = 3  # error: Cannot assign to instance variable
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-await" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L999" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1000" target="_blank">View source</a>
 </small>
 
 
@@ -1070,7 +1070,7 @@ asyncio.run(main())
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-base" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1029" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1030" target="_blank">View source</a>
 </small>
 
 
@@ -1094,7 +1094,7 @@ class A(42): ...  # error: [invalid-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-context-manager" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1114" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1115" target="_blank">View source</a>
 </small>
 
 
@@ -1121,7 +1121,7 @@ with 1:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-dataclass" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L506" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L507" target="_blank">View source</a>
 </small>
 
 
@@ -1158,7 +1158,7 @@ class Foo(NamedTuple):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-dataclass-override" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L480" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L481" target="_blank">View source</a>
 </small>
 
 
@@ -1190,7 +1190,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-declaration" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1135" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1136" target="_blank">View source</a>
 </small>
 
 
@@ -1219,7 +1219,7 @@ a: str
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-exception-caught" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1158" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1159" target="_blank">View source</a>
 </small>
 
 
@@ -1263,7 +1263,7 @@ except ZeroDivisionError:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.28">0.0.1-alpha.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-explicit-override" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2271" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2272" target="_blank">View source</a>
 </small>
 
 
@@ -1305,7 +1305,7 @@ class D(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.35">0.0.1-alpha.35</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-frozen-dataclass-subclass" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2911" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2912" target="_blank">View source</a>
 </small>
 
 
@@ -1349,7 +1349,7 @@ class NonFrozenChild(FrozenBase):  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-generic-class" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1236" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1237" target="_blank">View source</a>
 </small>
 
 
@@ -1387,7 +1387,7 @@ class D(Generic[U, T]): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-generic-enum" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1194" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1195" target="_blank">View source</a>
 </small>
 
 
@@ -1466,7 +1466,7 @@ a = 20 / 0  # type: ignore
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.17">0.0.1-alpha.17</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-key" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L776" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L777" target="_blank">View source</a>
 </small>
 
 
@@ -1505,7 +1505,7 @@ carol = Person(name="Carol", age=25)  # typo!
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-legacy-positional-parameter" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2989" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2990" target="_blank">View source</a>
 </small>
 
 
@@ -1566,7 +1566,7 @@ def f(x, y, /):  # Python 3.8+ syntax
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-legacy-type-variable" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1267" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1268" target="_blank">View source</a>
 </small>
 
 
@@ -1601,7 +1601,7 @@ def f(t: TypeVar("U")): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-match-pattern" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1640" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1641" target="_blank">View source</a>
 </small>
 
 
@@ -1629,7 +1629,7 @@ match x:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-metaclass" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1364" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1365" target="_blank">View source</a>
 </small>
 
 
@@ -1663,7 +1663,7 @@ class B(metaclass=f): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-method-override" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2813" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2814" target="_blank">View source</a>
 </small>
 
 
@@ -1770,7 +1770,7 @@ Correct use of `@override` is enforced by ty's `invalid-explicit-override` rule.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-named-tuple" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L683" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L684" target="_blank">View source</a>
 </small>
 
 
@@ -1824,7 +1824,7 @@ AttributeError: Cannot overwrite NamedTuple attribute _asdict
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.27">0.0.1-alpha.27</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-newtype" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1340" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1341" target="_blank">View source</a>
 </small>
 
 
@@ -1854,7 +1854,7 @@ Baz = NewType("Baz", int | str)  # error: invalid base for `typing.NewType`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-overload" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1391" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1392" target="_blank">View source</a>
 </small>
 
 
@@ -1904,7 +1904,7 @@ def foo(x: int) -> int: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-parameter-default" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1490" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1491" target="_blank">View source</a>
 </small>
 
 
@@ -1930,7 +1930,7 @@ def f(a: int = ''): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-paramspec" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1295" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1296" target="_blank">View source</a>
 </small>
 
 
@@ -1961,7 +1961,7 @@ P2 = ParamSpec("S2")  # error: ParamSpec name must match the variable it's assig
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-protocol" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L619" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L620" target="_blank">View source</a>
 </small>
 
 
@@ -1995,7 +1995,7 @@ TypeError: Protocols can only inherit from other protocols, got <class 'int'>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-raise" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1510" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1511" target="_blank">View source</a>
 </small>
 
 
@@ -2044,7 +2044,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-return-type" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L914" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L915" target="_blank">View source</a>
 </small>
 
 
@@ -2073,7 +2073,7 @@ def func() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-super-argument" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1553" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1554" target="_blank">View source</a>
 </small>
 
 
@@ -2169,7 +2169,7 @@ class C: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.10">0.0.10</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-total-ordering" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2949" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2950" target="_blank">View source</a>
 </small>
 
 
@@ -2215,7 +2215,7 @@ class MyClass:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.6">0.0.1-alpha.6</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-type-alias-type" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1319" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1320" target="_blank">View source</a>
 </small>
 
 
@@ -2242,7 +2242,7 @@ NewAlias = TypeAliasType(get_name(), int)        # error: TypeAliasType name mus
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-type-arguments" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1870" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1871" target="_blank">View source</a>
 </small>
 
 
@@ -2289,7 +2289,7 @@ Bar[int]  # error: too few arguments
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-type-checking-constant" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1592" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1593" target="_blank">View source</a>
 </small>
 
 
@@ -2319,7 +2319,7 @@ TYPE_CHECKING = ''
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-type-form" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1616" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1617" target="_blank">View source</a>
 </small>
 
 
@@ -2349,7 +2349,7 @@ b: Annotated[int]  # `Annotated` expects at least two arguments
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-type-guard-call" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1690" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1691" target="_blank">View source</a>
 </small>
 
 
@@ -2383,7 +2383,7 @@ f(10)  # Error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-type-guard-definition" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1662" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1663" target="_blank">View source</a>
 </small>
 
 
@@ -2417,7 +2417,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-type-variable-bound" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1759" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1760" target="_blank">View source</a>
 </small>
 
 
@@ -2448,7 +2448,7 @@ def g[U, T: U](): ...  # error: [invalid-type-variable-bound]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-type-variable-constraints" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1718" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1719" target="_blank">View source</a>
 </small>
 
 
@@ -2495,7 +2495,7 @@ U = TypeVar('U', list[int], int)  # valid constrained Type
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-type-variable-default" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1784" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1785" target="_blank">View source</a>
 </small>
 
 
@@ -2527,7 +2527,7 @@ U = TypeVar("U", int, str, default=bytes)  # error: [invalid-type-variable-defau
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-typed-dict-header" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2784" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2785" target="_blank">View source</a>
 </small>
 
 
@@ -2562,7 +2562,7 @@ def f(x: dict):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.9">0.0.9</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20invalid-typed-dict-statement" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2759" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2760" target="_blank">View source</a>
 </small>
 
 
@@ -2593,7 +2593,7 @@ class Foo(TypedDict):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20isinstance-against-protocol" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L809" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L810" target="_blank">View source</a>
 </small>
 
 
@@ -2648,7 +2648,7 @@ def h(arg2: type):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20isinstance-against-typed-dict" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L857" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L858" target="_blank">View source</a>
 </small>
 
 
@@ -2691,7 +2691,7 @@ def g(arg: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20missing-argument" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1810" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1811" target="_blank">View source</a>
 </small>
 
 
@@ -2716,7 +2716,7 @@ func()  # TypeError: func() missing 1 required positional argument: 'x'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20missing-typed-dict-key" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2732" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2733" target="_blank">View source</a>
 </small>
 
 
@@ -2749,7 +2749,7 @@ alice["age"]  # KeyError
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20no-matching-overload" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1829" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1830" target="_blank">View source</a>
 </small>
 
 
@@ -2778,7 +2778,7 @@ func("string")  # error: [no-matching-overload]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20not-iterable" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1911" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1912" target="_blank">View source</a>
 </small>
 
 
@@ -2804,7 +2804,7 @@ for i in 34:  # TypeError: 'int' object is not iterable
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20not-subscriptable" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1852" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1853" target="_blank">View source</a>
 </small>
 
 
@@ -2828,7 +2828,7 @@ Subscripting an object that does not support it will raise a `TypeError` at runt
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20override-of-final-method" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2084" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2085" target="_blank">View source</a>
 </small>
 
 
@@ -2861,7 +2861,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20override-of-final-variable" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2111" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2112" target="_blank">View source</a>
 </small>
 
 
@@ -2894,7 +2894,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20parameter-already-assigned" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1962" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1963" target="_blank">View source</a>
 </small>
 
 
@@ -2921,7 +2921,7 @@ f(1, x=2)  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20positional-only-parameter-as-kwarg" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2485" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2486" target="_blank">View source</a>
 </small>
 
 
@@ -2948,7 +2948,7 @@ f(x=1)  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20possibly-missing-attribute" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1983" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1984" target="_blank">View source</a>
 </small>
 
 
@@ -2976,7 +2976,7 @@ A.c  # AttributeError: type object 'A' has no attribute 'c'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20possibly-missing-implicit-call" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L207" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L208" target="_blank">View source</a>
 </small>
 
 
@@ -3008,7 +3008,7 @@ A()[0]  # TypeError: 'A' object is not subscriptable
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20possibly-missing-import" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2005" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2006" target="_blank">View source</a>
 </small>
 
 
@@ -3045,7 +3045,7 @@ from module import a  # ImportError: cannot import name 'a' from 'module'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20possibly-unresolved-reference" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2035" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2036" target="_blank">View source</a>
 </small>
 
 
@@ -3109,7 +3109,7 @@ def test(): -> "int":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20redundant-cast" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2659" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2660" target="_blank">View source</a>
 </small>
 
 
@@ -3136,7 +3136,7 @@ cast(int, f())  # Redundant
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20static-assert-error" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2607" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2608" target="_blank">View source</a>
 </small>
 
 
@@ -3166,7 +3166,7 @@ static_assert(int(2.0 * 3.0) == 6)  # error: does not have a statically known tr
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20subclass-of-final-class" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2061" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2062" target="_blank">View source</a>
 </small>
 
 
@@ -3195,7 +3195,7 @@ class B(A): ...  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.30">0.0.1-alpha.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20super-call-in-named-tuple-method" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2419" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2420" target="_blank">View source</a>
 </small>
 
 
@@ -3229,7 +3229,7 @@ class F(NamedTuple):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20too-many-positional-arguments" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2359" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2360" target="_blank">View source</a>
 </small>
 
 
@@ -3256,7 +3256,7 @@ f("foo")  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20type-assertion-failure" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2307" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2308" target="_blank">View source</a>
 </small>
 
 
@@ -3284,7 +3284,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20unavailable-implicit-super-arguments" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2380" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2381" target="_blank">View source</a>
 </small>
 
 
@@ -3330,7 +3330,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20undefined-reveal" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2446" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2447" target="_blank">View source</a>
 </small>
 
 
@@ -3354,7 +3354,7 @@ reveal_type(1)  # NameError: name 'reveal_type' is not defined
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20unknown-argument" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2464" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2465" target="_blank">View source</a>
 </small>
 
 
@@ -3381,7 +3381,7 @@ f(x=1, y=2)  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20unresolved-attribute" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2506" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2507" target="_blank">View source</a>
 </small>
 
 
@@ -3409,7 +3409,7 @@ A().foo  # AttributeError: 'A' object has no attribute 'foo'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.15">0.0.1-alpha.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20unresolved-global" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2680" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2681" target="_blank">View source</a>
 </small>
 
 
@@ -3467,7 +3467,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20unresolved-import" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2528" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2529" target="_blank">View source</a>
 </small>
 
 
@@ -3492,7 +3492,7 @@ import foo  # ModuleNotFoundError: No module named 'foo'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20unresolved-reference" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2547" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2548" target="_blank">View source</a>
 </small>
 
 
@@ -3517,7 +3517,7 @@ print(x)  # NameError: name 'x' is not defined
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.7">0.0.1-alpha.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20unsupported-base" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1047" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1048" target="_blank">View source</a>
 </small>
 
 
@@ -3556,7 +3556,7 @@ class D(C): ...  # error: [unsupported-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20unsupported-bool-conversion" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1931" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1932" target="_blank">View source</a>
 </small>
 
 
@@ -3593,7 +3593,7 @@ b1 < b2 < b1  # exception raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20unsupported-dynamic-base" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1080" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1081" target="_blank">View source</a>
 </small>
 
 
@@ -3634,7 +3634,7 @@ def factory(base: type[Base]) -> type:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20unsupported-operator" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2566" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2567" target="_blank">View source</a>
 </small>
 
 
@@ -3735,7 +3735,7 @@ to `false`.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20useless-overload-body" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1434" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1435" target="_blank">View source</a>
 </small>
 
 
@@ -3798,7 +3798,7 @@ def foo(x: int | str) -> int | str:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20zero-stepsize-in-slice" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2588" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2589" target="_blank">View source</a>
 </small>
 
 

--- a/crates/ty_python_semantic/resources/mdtest/abstract.md
+++ b/crates/ty_python_semantic/resources/mdtest/abstract.md
@@ -97,6 +97,7 @@ But if the annotation does not use `ClassVar`, we do not see that as overriding 
 ```py
 class StillAbstractDynamic(AbstractDynamic):
     f: int
+    g: Callable[..., str]
 
 StillAbstractDynamic()  # error: [call-non-callable]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/abstract.md_-_Tests_regarding_abst…_-_Diagnostics_for_atte…_(54d27d488f3a31c5).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/abstract.md_-_Tests_regarding_abst…_-_Diagnostics_for_atte…_(54d27d488f3a31c5).snap
@@ -1,0 +1,66 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: abstract.md - Tests regarding abstract classes - Diagnostics for attempted instantiation when `--verbose` is specified
+mdtest path: crates/ty_python_semantic/resources/mdtest/abstract.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | from typing import Protocol
+ 2 | 
+ 3 | class Abstract(Protocol):
+ 4 |     def aaaaaaaaa(self) -> int: ...
+ 5 |     def bbbbbbbb(self) -> int: ...
+ 6 |     def cccccccc(self) -> int: ...
+ 7 |     def dddddddddd(self) -> int: ...
+ 8 |     def eeeeeeee(self) -> int: ...
+ 9 |     def fffffff(self) -> int: ...
+10 |     def ggggggggg(self) -> int: ...
+11 |     def hhhhhhhhh(self) -> int: ...
+12 |     def iiiiiiiiii(self) -> int: ...
+13 |     def kkkkkkkkk(self) -> int: ...
+14 | 
+15 | class StillSadlyAbstract(Abstract): ...
+16 | 
+17 | StillSadlyAbstract()  # error: [call-non-callable]
+```
+
+# Diagnostics
+
+```
+error[call-non-callable]: Cannot instantiate abstract class `StillSadlyAbstract`
+  --> src/mdtest_snippet.py:17:1
+   |
+15 | class StillSadlyAbstract(Abstract): ...
+16 |
+17 | StillSadlyAbstract()  # error: [call-non-callable]
+   | ^^^^^^^^^^^^^^^^^^^^ Abstract methods `aaaaaaaaa`, `bbbbbbbb`, `cccccccc`, `dddddddddd`, `eeeeeeee`, `fffffff`, `ggggggggg`, `hhhhhhhhh`, `iiiiiiiiii` and `kkkkkkkkk` are unimplemented
+   |
+  ::: src/mdtest_snippet.py:4:9
+   |
+ 3 | class Abstract(Protocol):
+ 4 |     def aaaaaaaaa(self) -> int: ...
+   |         --------- `aaaaaaaaa` declared as abstract on superclass `Abstract`
+ 5 |     def bbbbbbbb(self) -> int: ...
+ 6 |     def cccccccc(self) -> int: ...
+   |
+info: `Abstract.aaaaaaaaa` is implicitly abstract because `Abstract` is a `Protocol` class and `aaaaaaaaa` lacks an implementation
+ --> src/mdtest_snippet.py:3:7
+  |
+1 | from typing import Protocol
+2 |
+3 | class Abstract(Protocol):
+  |       ------------------ `Abstract` declared here
+4 |     def aaaaaaaaa(self) -> int: ...
+5 |     def bbbbbbbb(self) -> int: ...
+  |
+info: rule `call-non-callable` is enabled by default
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/abstract.md_-_Tests_regarding_abst…_-_Instantiation_is_for…_(5283f4ece0a77446).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/abstract.md_-_Tests_regarding_abst…_-_Instantiation_is_for…_(5283f4ece0a77446).snap
@@ -85,37 +85,38 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/abstract.md
  70 | ConcreteDynamic()  # no error
  71 | class StillAbstractDynamic(AbstractDynamic):
  72 |     f: int
- 73 | 
- 74 | StillAbstractDynamic()  # error: [call-non-callable]
- 75 | class AbstractMixin(ABC):
- 76 |     @abstractmethod
- 77 |     def bar(self): ...
- 78 | 
- 79 | class ConcreteMixin:
- 80 |     def bar(self): ...
- 81 | 
- 82 | class Sub1(AbstractMixin, ConcreteMixin): ...
- 83 | class Sub2(ConcreteMixin, AbstractMixin): ...
- 84 | 
- 85 | Sub1()  # error: [call-non-callable]
- 86 | Sub2()  # fine
- 87 | from typing import Protocol
- 88 | 
- 89 | class Abstract(Protocol):
- 90 |     def aaaaaaaaa(self) -> int: ...
- 91 |     def bbbbbbbb(self) -> int: ...
- 92 |     def cccccccc(self) -> int: ...
- 93 |     def dddddddddd(self) -> int: ...
- 94 |     def eeeeeeee(self) -> int: ...
- 95 |     def fffffff(self) -> int: ...
- 96 |     def ggggggggg(self) -> int: ...
- 97 |     def hhhhhhhhh(self) -> int: ...
- 98 |     def iiiiiiiiii(self) -> int: ...
- 99 |     def kkkkkkkkk(self) -> int: ...
-100 | 
-101 | class StillSadlyAbstract(Abstract): ...
-102 | 
-103 | StillSadlyAbstract()  # error: [call-non-callable]
+ 73 |     g: Callable[..., str]
+ 74 | 
+ 75 | StillAbstractDynamic()  # error: [call-non-callable]
+ 76 | class AbstractMixin(ABC):
+ 77 |     @abstractmethod
+ 78 |     def bar(self): ...
+ 79 | 
+ 80 | class ConcreteMixin:
+ 81 |     def bar(self): ...
+ 82 | 
+ 83 | class Sub1(AbstractMixin, ConcreteMixin): ...
+ 84 | class Sub2(ConcreteMixin, AbstractMixin): ...
+ 85 | 
+ 86 | Sub1()  # error: [call-non-callable]
+ 87 | Sub2()  # fine
+ 88 | from typing import Protocol
+ 89 | 
+ 90 | class Abstract(Protocol):
+ 91 |     def aaaaaaaaa(self) -> int: ...
+ 92 |     def bbbbbbbb(self) -> int: ...
+ 93 |     def cccccccc(self) -> int: ...
+ 94 |     def dddddddddd(self) -> int: ...
+ 95 |     def eeeeeeee(self) -> int: ...
+ 96 |     def fffffff(self) -> int: ...
+ 97 |     def ggggggggg(self) -> int: ...
+ 98 |     def hhhhhhhhh(self) -> int: ...
+ 99 |     def iiiiiiiiii(self) -> int: ...
+100 |     def kkkkkkkkk(self) -> int: ...
+101 | 
+102 | class StillSadlyAbstract(Abstract): ...
+103 | 
+104 | StillSadlyAbstract()  # error: [call-non-callable]
 ```
 
 # Diagnostics
@@ -246,14 +247,14 @@ info: rule `call-non-callable` is enabled by default
 
 ```
 error[call-non-callable]: Cannot instantiate abstract class `StillAbstractDynamic`
-  --> src/mdtest_snippet.py:74:1
+  --> src/mdtest_snippet.py:75:1
    |
-72 |     f: int
-73 |
-74 | StillAbstractDynamic()  # error: [call-non-callable]
+73 |     g: Callable[..., str]
+74 |
+75 | StillAbstractDynamic()  # error: [call-non-callable]
    | ^^^^^^^^^^^^^^^^^^^^^^ Abstract methods `f` and `g` are unimplemented
-75 | class AbstractMixin(ABC):
-76 |     @abstractmethod
+76 | class AbstractMixin(ABC):
+77 |     @abstractmethod
    |
   ::: src/mdtest_snippet.py:62:9
    |
@@ -264,29 +265,40 @@ error[call-non-callable]: Cannot instantiate abstract class `StillAbstractDynami
 63 |     @abstractmethod
 64 |     def g(self) -> str: ...
    |
+info: `f` is overridden with an instance-attribute annotation,
+info: but this is insufficient to make `StillAbstractDynamic` non-abstract
+help: Either assign a value or add `ClassVar` to this declaration
+  --> src/mdtest_snippet.py:72:5
+   |
+70 | ConcreteDynamic()  # no error
+71 | class StillAbstractDynamic(AbstractDynamic):
+72 |     f: int
+   |     - Instance-attribute declaration on superclass
+73 |     g: Callable[..., str]
+   |
 info: rule `call-non-callable` is enabled by default
 
 ```
 
 ```
 error[call-non-callable]: Cannot instantiate abstract class `Sub1`
-  --> src/mdtest_snippet.py:85:1
+  --> src/mdtest_snippet.py:86:1
    |
-83 | class Sub2(ConcreteMixin, AbstractMixin): ...
-84 |
-85 | Sub1()  # error: [call-non-callable]
+84 | class Sub2(ConcreteMixin, AbstractMixin): ...
+85 |
+86 | Sub1()  # error: [call-non-callable]
    | ^^^^^^ Abstract method `bar` is unimplemented
-86 | Sub2()  # fine
-87 | from typing import Protocol
+87 | Sub2()  # fine
+88 | from typing import Protocol
    |
-  ::: src/mdtest_snippet.py:77:9
+  ::: src/mdtest_snippet.py:78:9
    |
-75 | class AbstractMixin(ABC):
-76 |     @abstractmethod
-77 |     def bar(self): ...
+76 | class AbstractMixin(ABC):
+77 |     @abstractmethod
+78 |     def bar(self): ...
    |         --- `bar` declared as abstract on superclass `AbstractMixin`
-78 |
-79 | class ConcreteMixin:
+79 |
+80 | class ConcreteMixin:
    |
 info: rule `call-non-callable` is enabled by default
 
@@ -294,31 +306,31 @@ info: rule `call-non-callable` is enabled by default
 
 ```
 error[call-non-callable]: Cannot instantiate abstract class `StillSadlyAbstract`
-   --> src/mdtest_snippet.py:103:1
+   --> src/mdtest_snippet.py:104:1
     |
-101 | class StillSadlyAbstract(Abstract): ...
-102 |
-103 | StillSadlyAbstract()  # error: [call-non-callable]
+102 | class StillSadlyAbstract(Abstract): ...
+103 |
+104 | StillSadlyAbstract()  # error: [call-non-callable]
     | ^^^^^^^^^^^^^^^^^^^^ 10 abstract methods are unimplemented, including `aaaaaaaaa`, `bbbbbbbb` and `cccccccc`
     |
-   ::: src/mdtest_snippet.py:90:9
+   ::: src/mdtest_snippet.py:91:9
     |
- 89 | class Abstract(Protocol):
- 90 |     def aaaaaaaaa(self) -> int: ...
+ 90 | class Abstract(Protocol):
+ 91 |     def aaaaaaaaa(self) -> int: ...
     |         --------- `aaaaaaaaa` declared as abstract on superclass `Abstract`
- 91 |     def bbbbbbbb(self) -> int: ...
- 92 |     def cccccccc(self) -> int: ...
+ 92 |     def bbbbbbbb(self) -> int: ...
+ 93 |     def cccccccc(self) -> int: ...
     |
 info: Use `--verbose` to see all 10 unimplemented abstract methods
 info: `Abstract.aaaaaaaaa` is implicitly abstract because `Abstract` is a `Protocol` class and `aaaaaaaaa` lacks an implementation
-  --> src/mdtest_snippet.py:89:7
+  --> src/mdtest_snippet.py:90:7
    |
-87 | from typing import Protocol
-88 |
-89 | class Abstract(Protocol):
+88 | from typing import Protocol
+89 |
+90 | class Abstract(Protocol):
    |       ------------------ `Abstract` declared here
-90 |     def aaaaaaaaa(self) -> int: ...
-91 |     def bbbbbbbb(self) -> int: ...
+91 |     def aaaaaaaaa(self) -> int: ...
+92 |     def bbbbbbbb(self) -> int: ...
    |
 info: rule `call-non-callable` is enabled by default
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/abstract.md_-_Tests_regarding_abst…_-_Instantiation_is_for…_(5283f4ece0a77446).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/abstract.md_-_Tests_regarding_abst…_-_Instantiation_is_for…_(5283f4ece0a77446).snap
@@ -1,0 +1,325 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: abstract.md - Tests regarding abstract classes - Instantiation is forbidden
+mdtest path: crates/ty_python_semantic/resources/mdtest/abstract.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+  1 | import abc
+  2 | from typing import Protocol
+  3 | 
+  4 | class AbstractBase(abc.ABC):
+  5 |     @abc.abstractmethod
+  6 |     def bar(self): ...
+  7 | 
+  8 | class StillAbstract(AbstractBase): ...
+  9 | 
+ 10 | # error: [call-non-callable] "Cannot instantiate `StillAbstract` with unimplemented abstract method `bar`"
+ 11 | StillAbstract()
+ 12 | 
+ 13 | class AbstractBase2(abc.ABC):
+ 14 |     @abc.abstractmethod
+ 15 |     def bar(self): ...
+ 16 |     @abc.abstractmethod
+ 17 |     def bar2(self): ...
+ 18 | 
+ 19 | # error: [call-non-callable] "Cannot instantiate `AbstractBase2` with unimplemented abstract methods `bar` and `bar2`"
+ 20 | AbstractBase2()
+ 21 | 
+ 22 | class StillAbstract2(AbstractBase2): ...
+ 23 | 
+ 24 | # error: [call-non-callable]
+ 25 | StillAbstract2()
+ 26 | 
+ 27 | class AbstractBase3(Protocol):
+ 28 |     def bar(self) -> None: ...
+ 29 | 
+ 30 | class StillAbstract3(AbstractBase3): ...
+ 31 | 
+ 32 | # error: [call-non-callable]
+ 33 | StillAbstract3()
+ 34 | from abc import ABC, abstractmethod
+ 35 | from dataclasses import dataclass
+ 36 | from functools import total_ordering
+ 37 | 
+ 38 | class AbstractOrdered(ABC):
+ 39 |     @abstractmethod
+ 40 |     def __lt__(self, other): ...
+ 41 | 
+ 42 | @dataclass(order=True)
+ 43 | class ConcreteOrdered(AbstractOrdered): ...
+ 44 | 
+ 45 | ConcreteOrdered()  # fine
+ 46 | 
+ 47 | @total_ordering
+ 48 | class AlsoConreteOrdered(AbstractOrdered):
+ 49 |     def __gt__(self, other): ...
+ 50 | 
+ 51 | # total_ordering does not override a comparison method
+ 52 | # if it already exists in the MRO, even if the one that
+ 53 | # exists in the MRO is abstract!
+ 54 | #
+ 55 | # error: [call-non-callable]
+ 56 | AlsoConreteOrdered()
+ 57 | from typing import ClassVar, Callable
+ 58 | 
+ 59 | class AbstractDynamic(ABC):
+ 60 |     @property
+ 61 |     @abstractmethod
+ 62 |     def f(self) -> int: ...
+ 63 |     @abstractmethod
+ 64 |     def g(self) -> str: ...
+ 65 | 
+ 66 | class ConcreteDynamic(AbstractDynamic):
+ 67 |     f: ClassVar[int]
+ 68 |     g: ClassVar[Callable[..., str]]
+ 69 | 
+ 70 | ConcreteDynamic()  # no error
+ 71 | class StillAbstractDynamic(AbstractDynamic):
+ 72 |     f: int
+ 73 | 
+ 74 | StillAbstractDynamic()  # error: [call-non-callable]
+ 75 | class AbstractMixin(ABC):
+ 76 |     @abstractmethod
+ 77 |     def bar(self): ...
+ 78 | 
+ 79 | class ConcreteMixin:
+ 80 |     def bar(self): ...
+ 81 | 
+ 82 | class Sub1(AbstractMixin, ConcreteMixin): ...
+ 83 | class Sub2(ConcreteMixin, AbstractMixin): ...
+ 84 | 
+ 85 | Sub1()  # error: [call-non-callable]
+ 86 | Sub2()  # fine
+ 87 | from typing import Protocol
+ 88 | 
+ 89 | class Abstract(Protocol):
+ 90 |     def aaaaaaaaa(self) -> int: ...
+ 91 |     def bbbbbbbb(self) -> int: ...
+ 92 |     def cccccccc(self) -> int: ...
+ 93 |     def dddddddddd(self) -> int: ...
+ 94 |     def eeeeeeee(self) -> int: ...
+ 95 |     def fffffff(self) -> int: ...
+ 96 |     def ggggggggg(self) -> int: ...
+ 97 |     def hhhhhhhhh(self) -> int: ...
+ 98 |     def iiiiiiiiii(self) -> int: ...
+ 99 |     def kkkkkkkkk(self) -> int: ...
+100 | 
+101 | class StillSadlyAbstract(Abstract): ...
+102 | 
+103 | StillSadlyAbstract()  # error: [call-non-callable]
+```
+
+# Diagnostics
+
+```
+error[call-non-callable]: Cannot instantiate abstract class `StillAbstract`
+  --> src/mdtest_snippet.py:11:1
+   |
+10 | # error: [call-non-callable] "Cannot instantiate `StillAbstract` with unimplemented abstract method `bar`"
+11 | StillAbstract()
+   | ^^^^^^^^^^^^^^^ Abstract method `bar` is unimplemented
+12 |
+13 | class AbstractBase2(abc.ABC):
+   |
+  ::: src/mdtest_snippet.py:6:9
+   |
+ 4 | class AbstractBase(abc.ABC):
+ 5 |     @abc.abstractmethod
+ 6 |     def bar(self): ...
+   |         --- `bar` declared as abstract on superclass `AbstractBase`
+ 7 |
+ 8 | class StillAbstract(AbstractBase): ...
+   |
+info: rule `call-non-callable` is enabled by default
+
+```
+
+```
+error[call-non-callable]: Cannot instantiate abstract class `AbstractBase2`
+  --> src/mdtest_snippet.py:20:1
+   |
+19 | # error: [call-non-callable] "Cannot instantiate `AbstractBase2` with unimplemented abstract methods `bar` and `bar2`"
+20 | AbstractBase2()
+   | ^^^^^^^^^^^^^^^ Abstract methods `bar` and `bar2` are unimplemented
+21 |
+22 | class StillAbstract2(AbstractBase2): ...
+   |
+  ::: src/mdtest_snippet.py:15:9
+   |
+13 | class AbstractBase2(abc.ABC):
+14 |     @abc.abstractmethod
+15 |     def bar(self): ...
+   |         --- `bar` declared as abstract
+16 |     @abc.abstractmethod
+17 |     def bar2(self): ...
+   |
+info: rule `call-non-callable` is enabled by default
+
+```
+
+```
+error[call-non-callable]: Cannot instantiate abstract class `StillAbstract2`
+  --> src/mdtest_snippet.py:25:1
+   |
+24 | # error: [call-non-callable]
+25 | StillAbstract2()
+   | ^^^^^^^^^^^^^^^^ Abstract methods `bar` and `bar2` are unimplemented
+26 |
+27 | class AbstractBase3(Protocol):
+   |
+  ::: src/mdtest_snippet.py:15:9
+   |
+13 | class AbstractBase2(abc.ABC):
+14 |     @abc.abstractmethod
+15 |     def bar(self): ...
+   |         --- `bar` declared as abstract on superclass `AbstractBase2`
+16 |     @abc.abstractmethod
+17 |     def bar2(self): ...
+   |
+info: rule `call-non-callable` is enabled by default
+
+```
+
+```
+error[call-non-callable]: Cannot instantiate abstract class `StillAbstract3`
+  --> src/mdtest_snippet.py:33:1
+   |
+32 | # error: [call-non-callable]
+33 | StillAbstract3()
+   | ^^^^^^^^^^^^^^^^ Abstract method `bar` is unimplemented
+34 | from abc import ABC, abstractmethod
+35 | from dataclasses import dataclass
+   |
+  ::: src/mdtest_snippet.py:28:9
+   |
+27 | class AbstractBase3(Protocol):
+28 |     def bar(self) -> None: ...
+   |         --- `bar` declared as abstract on superclass `AbstractBase3`
+29 |
+30 | class StillAbstract3(AbstractBase3): ...
+   |
+info: `AbstractBase3.bar` is implicitly abstract because `AbstractBase3` is a `Protocol` class and `bar` lacks an implementation
+  --> src/mdtest_snippet.py:27:7
+   |
+25 | StillAbstract2()
+26 |
+27 | class AbstractBase3(Protocol):
+   |       ----------------------- `AbstractBase3` declared here
+28 |     def bar(self) -> None: ...
+   |
+help: Change the body of `bar` to `return` or `return None` if it was not intended to be abstract
+info: rule `call-non-callable` is enabled by default
+
+```
+
+```
+error[call-non-callable]: Cannot instantiate abstract class `AlsoConreteOrdered`
+  --> src/mdtest_snippet.py:56:1
+   |
+54 | #
+55 | # error: [call-non-callable]
+56 | AlsoConreteOrdered()
+   | ^^^^^^^^^^^^^^^^^^^^ Abstract method `__lt__` is unimplemented
+57 | from typing import ClassVar, Callable
+   |
+  ::: src/mdtest_snippet.py:40:9
+   |
+38 | class AbstractOrdered(ABC):
+39 |     @abstractmethod
+40 |     def __lt__(self, other): ...
+   |         ------ `__lt__` declared as abstract on superclass `AbstractOrdered`
+41 |
+42 | @dataclass(order=True)
+   |
+info: rule `call-non-callable` is enabled by default
+
+```
+
+```
+error[call-non-callable]: Cannot instantiate abstract class `StillAbstractDynamic`
+  --> src/mdtest_snippet.py:74:1
+   |
+72 |     f: int
+73 |
+74 | StillAbstractDynamic()  # error: [call-non-callable]
+   | ^^^^^^^^^^^^^^^^^^^^^^ Abstract methods `f` and `g` are unimplemented
+75 | class AbstractMixin(ABC):
+76 |     @abstractmethod
+   |
+  ::: src/mdtest_snippet.py:62:9
+   |
+60 |     @property
+61 |     @abstractmethod
+62 |     def f(self) -> int: ...
+   |         - `f` declared as abstract on superclass `AbstractDynamic`
+63 |     @abstractmethod
+64 |     def g(self) -> str: ...
+   |
+info: rule `call-non-callable` is enabled by default
+
+```
+
+```
+error[call-non-callable]: Cannot instantiate abstract class `Sub1`
+  --> src/mdtest_snippet.py:85:1
+   |
+83 | class Sub2(ConcreteMixin, AbstractMixin): ...
+84 |
+85 | Sub1()  # error: [call-non-callable]
+   | ^^^^^^ Abstract method `bar` is unimplemented
+86 | Sub2()  # fine
+87 | from typing import Protocol
+   |
+  ::: src/mdtest_snippet.py:77:9
+   |
+75 | class AbstractMixin(ABC):
+76 |     @abstractmethod
+77 |     def bar(self): ...
+   |         --- `bar` declared as abstract on superclass `AbstractMixin`
+78 |
+79 | class ConcreteMixin:
+   |
+info: rule `call-non-callable` is enabled by default
+
+```
+
+```
+error[call-non-callable]: Cannot instantiate abstract class `StillSadlyAbstract`
+   --> src/mdtest_snippet.py:103:1
+    |
+101 | class StillSadlyAbstract(Abstract): ...
+102 |
+103 | StillSadlyAbstract()  # error: [call-non-callable]
+    | ^^^^^^^^^^^^^^^^^^^^ 10 abstract methods are unimplemented, including `aaaaaaaaa`, `bbbbbbbb` and `cccccccc`
+    |
+   ::: src/mdtest_snippet.py:90:9
+    |
+ 89 | class Abstract(Protocol):
+ 90 |     def aaaaaaaaa(self) -> int: ...
+    |         --------- `aaaaaaaaa` declared as abstract on superclass `Abstract`
+ 91 |     def bbbbbbbb(self) -> int: ...
+ 92 |     def cccccccc(self) -> int: ...
+    |
+info: Use `--verbose` to see all 10 unimplemented abstract methods
+info: `Abstract.aaaaaaaaa` is implicitly abstract because `Abstract` is a `Protocol` class and `aaaaaaaaa` lacks an implementation
+  --> src/mdtest_snippet.py:89:7
+   |
+87 | from typing import Protocol
+88 |
+89 | class Abstract(Protocol):
+   |       ------------------ `Abstract` declared here
+90 |     def aaaaaaaaa(self) -> int: ...
+91 |     def bbbbbbbb(self) -> int: ...
+   |
+info: rule `call-non-callable` is enabled by default
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Abstract_method_in_g…_(6d8b024dda7ced11).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Abstract_method_in_g…_(6d8b024dda7ced11).snap
@@ -36,7 +36,7 @@ error[abstract-method-in-final-class]: Final class `Child` has unimplemented abs
    |
 11 | @final
 12 | class Child(Parent):  # error: [abstract-method-in-final-class]
-   |       ^^^^^ `method` is unimplemented
+   |       ^^^^^ Abstract method `method` is unimplemented
 13 |     pass
    |
   ::: src/mdtest_snippet.py:6:9

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Basic_case_with_ABC_(21e412599c45972a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Basic_case_with_ABC_(21e412599c45972a).snap
@@ -34,7 +34,7 @@ error[abstract-method-in-final-class]: Final class `Derived` has unimplemented a
    |
  9 | @final
 10 | class Derived(Base):  # error: [abstract-method-in-final-class] "Final class `Derived` has unimplemented abstract method `foo`"
-   |       ^^^^^^^ `foo` is unimplemented
+   |       ^^^^^^^ Abstract method `foo` is unimplemented
 11 |     pass
    |
   ::: src/mdtest_snippet.py:6:9

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Multiple_abstract_me…_(feafee9a4abbe8d1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Multiple_abstract_me…_(feafee9a4abbe8d1).snap
@@ -67,7 +67,7 @@ error[abstract-method-in-final-class]: Final class `PartiallyImplemented` has un
    |
 16 | @final
 17 | class PartiallyImplemented(Base):  # error: [abstract-method-in-final-class]
-   |       ^^^^^^^^^^^^^^^^^^^^ `baz` is unimplemented
+   |       ^^^^^^^^^^^^^^^^^^^^ Abstract method `baz` is unimplemented
 18 |     def foo(self) -> int:
 19 |         return 42
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Protocol_with_implic…_(e373f31c7a7d88e7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Protocol_with_implic…_(e373f31c7a7d88e7).snap
@@ -178,7 +178,7 @@ error[abstract-method-in-final-class]: Final class `Q` has unimplemented abstrac
 12 |
 13 | @final
 14 | class Q(P): ...  # error: [abstract-method-in-final-class]
-   |       ^ `still_abstractmethod` is unimplemented
+   |       ^ Abstract method `still_abstractmethod` is unimplemented
 15 |
 16 | class R(Protocol):
    |
@@ -208,7 +208,7 @@ error[abstract-method-in-final-class]: Final class `S` has unimplemented abstrac
 19 |
 20 | @final
 21 | class S(R): ...  # error: [abstract-method-in-final-class]
-   |       ^ `also_still_abstractmethod` is unimplemented
+   |       ^ Abstract method `also_still_abstractmethod` is unimplemented
 22 |
 23 | class Raises(Protocol):
    |
@@ -233,7 +233,7 @@ error[abstract-method-in-final-class]: Final class `RaisesSub` has unimplemented
    |
 27 | @final
 28 | class RaisesSub(Raises): ...  # error: [abstract-method-in-final-class]
-   |       ^^^^^^^^^ `even_this_is_abstract` is unimplemented
+   |       ^^^^^^^^^ Abstract method `even_this_is_abstract` is unimplemented
 29 |
 30 | class AlsoRaises(Protocol):
    |
@@ -264,7 +264,7 @@ error[abstract-method-in-final-class]: Final class `AlsoRaisesSub` has unimpleme
    |
 34 | @final
 35 | class AlsoRaisesSub(AlsoRaises): ...  # error: [abstract-method-in-final-class]
-   |       ^^^^^^^^^^^^^ `also_abstractmethod` is unimplemented
+   |       ^^^^^^^^^^^^^ Abstract method `also_abstractmethod` is unimplemented
 36 |
 37 | type NotImplementedErrorAlias = NotImplementedError
    |
@@ -295,7 +295,7 @@ error[abstract-method-in-final-class]: Final class `StrangeSub` has unimplemente
    |
 44 |     @final
 45 |     class StrangeSub(Strange): ...  # error: [abstract-method-in-final-class]
-   |           ^^^^^^^^^^ `weird_abstractmethod` is unimplemented
+   |           ^^^^^^^^^^ Abstract method `weird_abstractmethod` is unimplemented
 46 |
 47 | class HasOverloads(Protocol):
    |
@@ -331,7 +331,7 @@ error[abstract-method-in-final-class]: Final class `HasOverloadSub` has unimplem
 52 |
 53 | @final
 54 | class HasOverloadSub(HasOverloads): ...  # error: [abstract-method-in-final-class]
-   |       ^^^^^^^^^^^^^^ `foo` is unimplemented
+   |       ^^^^^^^^^^^^^^ Abstract method `foo` is unimplemented
 55 |
 56 | class RaisesDifferentException(Protocol):
    |
@@ -355,7 +355,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstractSub` has unimplem
     |
 122 | @final
 123 | class HasAbstractSub(HasAbstract): ...  # error: [abstract-method-in-final-class]
-    |       ^^^^^^^^^^^^^^ `a` is unimplemented
+    |       ^^^^^^^^^^^^^^ Abstract method `a` is unimplemented
 124 |
 125 | @final
     |
@@ -386,7 +386,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract2Sub` has unimple
     |
 125 | @final
 126 | class HasAbstract2Sub(HasAbstract2): ...  # error: [abstract-method-in-final-class]
-    |       ^^^^^^^^^^^^^^^ `a` is unimplemented
+    |       ^^^^^^^^^^^^^^^ Abstract method `a` is unimplemented
 127 |
 128 | @final
     |
@@ -417,7 +417,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract3Sub` has unimple
     |
 128 | @final
 129 | class HasAbstract3Sub(HasAbstract4): ...  # error: [abstract-method-in-final-class]
-    |       ^^^^^^^^^^^^^^^ `a` is unimplemented
+    |       ^^^^^^^^^^^^^^^ Abstract method `a` is unimplemented
 130 |
 131 | @final
     |
@@ -449,7 +449,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract4Sub` has unimple
     |
 131 | @final
 132 | class HasAbstract4Sub(HasAbstract4): ...  # error: [abstract-method-in-final-class]
-    |       ^^^^^^^^^^^^^^^ `a` is unimplemented
+    |       ^^^^^^^^^^^^^^^ Abstract method `a` is unimplemented
 133 |
 134 | @final
     |
@@ -481,7 +481,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract5Sub` has unimple
     |
 134 | @final
 135 | class HasAbstract5Sub(HasAbstract5): ...  # error: [abstract-method-in-final-class]
-    |       ^^^^^^^^^^^^^^^ `a` is unimplemented
+    |       ^^^^^^^^^^^^^^^ Abstract method `a` is unimplemented
 136 |
 137 | @final
     |
@@ -513,7 +513,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract6Sub` has unimple
     |
 137 | @final
 138 | class HasAbstract6Sub(HasAbstract6): ...  # error: [abstract-method-in-final-class]
-    |       ^^^^^^^^^^^^^^^ `a` is unimplemented
+    |       ^^^^^^^^^^^^^^^ Abstract method `a` is unimplemented
 139 |
 140 | @final
     |
@@ -545,7 +545,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract7Sub` has unimple
     |
 140 | @final
 141 | class HasAbstract7Sub(HasAbstract7): ...  # error: [abstract-method-in-final-class]
-    |       ^^^^^^^^^^^^^^^ `a` is unimplemented
+    |       ^^^^^^^^^^^^^^^ Abstract method `a` is unimplemented
 142 |
 143 | @final
     |
@@ -576,7 +576,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract8Sub` has unimple
     |
 143 | @final
 144 | class HasAbstract8Sub(HasAbstract8): ...  # error: [abstract-method-in-final-class]
-    |       ^^^^^^^^^^^^^^^ `a` is unimplemented
+    |       ^^^^^^^^^^^^^^^ Abstract method `a` is unimplemented
 145 |
 146 | @final
     |
@@ -607,7 +607,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract9Sub` has unimple
     |
 146 | @final
 147 | class HasAbstract9Sub(HasAbstract9): ...  # error: [abstract-method-in-final-class]
-    |       ^^^^^^^^^^^^^^^ `a` is unimplemented
+    |       ^^^^^^^^^^^^^^^ Abstract method `a` is unimplemented
 148 |
 149 | @final
     |
@@ -639,7 +639,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstract10Sub` has unimpl
     |
 149 | @final
 150 | class HasAbstract10Sub(HasAbstract10): ...  # error: [abstract-method-in-final-class]
-    |       ^^^^^^^^^^^^^^^^ `a` is unimplemented
+    |       ^^^^^^^^^^^^^^^^ Abstract method `a` is unimplemented
     |
    ::: src/mdtest_snippet.py:118:9
     |

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -89,6 +89,7 @@ use instance::Protocol;
 pub use instance::{NominalInstanceType, ProtocolInstanceType};
 pub use special_form::SpecialFormType;
 
+mod abstract_methods;
 mod bound_super;
 mod builder;
 mod call;

--- a/crates/ty_python_semantic/src/types/abstract_methods.rs
+++ b/crates/ty_python_semantic/src/types/abstract_methods.rs
@@ -27,9 +27,14 @@ impl<'db> AbstractMethods<'db> {
     /// Returns a set of methods on this class that were defined as abstract on a superclass
     /// and have not been overridden with a concrete implementation anywhere in the MRO
     pub(super) fn of_class(db: &'db dyn Db, class: ClassType<'db>) -> Self {
+        #[salsa::tracked(heap_size=ruff_memory_usage::heap_size, cycle_initial=|_, _, _| true)]
+        fn abstract_methods_is_empty<'db>(db: &'db dyn Db, class: ClassType<'db>) -> bool {
+            abstract_methods_of_class(db, class).is_empty()
+        }
+
         Self {
             class,
-            is_empty: abstract_methods_of_class(db, class).is_empty(),
+            is_empty: abstract_methods_is_empty(db, class),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/abstract_methods.rs
+++ b/crates/ty_python_semantic/src/types/abstract_methods.rs
@@ -27,14 +27,9 @@ impl<'db> AbstractMethods<'db> {
     /// Returns a set of methods on this class that were defined as abstract on a superclass
     /// and have not been overridden with a concrete implementation anywhere in the MRO
     pub(super) fn of_class(db: &'db dyn Db, class: ClassType<'db>) -> Self {
-        #[salsa::tracked(heap_size=ruff_memory_usage::heap_size, cycle_initial=|_, _, _| true)]
-        fn abstract_methods_is_empty<'db>(db: &'db dyn Db, class: ClassType<'db>) -> bool {
-            abstract_methods_of_class(db, class).is_empty()
-        }
-
         Self {
             class,
-            is_empty: abstract_methods_is_empty(db, class),
+            is_empty: abstract_methods_of_class(db, class).is_empty(),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/abstract_methods.rs
+++ b/crates/ty_python_semantic/src/types/abstract_methods.rs
@@ -1,0 +1,371 @@
+use ruff_db::{
+    diagnostic::{Annotation, Span, SubDiagnostic, SubDiagnosticSeverity},
+    parsed::parsed_module,
+};
+use ruff_python_ast::name::Name;
+use ty_module_resolver::file_to_module;
+
+use crate::{
+    Db, FxIndexMap, TypeQualifiers,
+    diagnostic::format_enumeration,
+    place::{DefinedPlace, Place, place_from_bindings, place_from_declarations},
+    semantic_index::{definition::Definition, place_table, use_def_map},
+    types::{
+        ClassBase, ClassLiteral, ClassType, LintDiagnosticGuard, Parameters, Signature, Type,
+        function::{FunctionBodyKind, FunctionDecorators, FunctionType},
+        infer_definition_types,
+    },
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
+pub(super) struct AbstractMethods<'db> {
+    methods: &'db FxIndexMap<Name, AbstractMethod<'db>>,
+    class: ClassType<'db>,
+}
+
+impl<'db> AbstractMethods<'db> {
+    /// Returns a map of methods on this class that were defined as abstract on a superclass
+    /// and have not been overridden with a concrete implementation anywhere in the MRO
+    ///
+    /// The value of the map is a struct containing information about the abstract method.
+    pub(super) fn of_class(db: &'db dyn Db, class: ClassType<'db>) -> Self {
+        #[salsa::tracked(
+            returns(ref),
+            heap_size=ruff_memory_usage::heap_size,
+            cycle_initial=|_, _, _| FxIndexMap::default()
+        )]
+        fn of_class_inner<'db>(
+            db: &'db dyn Db,
+            class: ClassType<'db>,
+        ) -> FxIndexMap<Name, AbstractMethod<'db>> {
+            let mut abstract_methods: FxIndexMap<Name, _> = FxIndexMap::default();
+
+            // Iterate through the MRO in reverse order,
+            // skipping `object` (we know it doesn't define any abstract methods)
+            for supercls in class.iter_mro(db).rev().skip(1) {
+                let ClassBase::Class(class) = supercls else {
+                    continue;
+                };
+
+                // Currently we do not recognize dynamic classes as being able to define abstract methods,
+                // but we do recognise them as being able to override abstract methods defined in static classes.
+                let ClassLiteral::Static(class_literal) = class.class_literal(db) else {
+                    abstract_methods
+                        .retain(|name, _| class.own_class_member(db, None, name).is_undefined());
+                    continue;
+                };
+
+                let scope = class_literal.body_scope(db);
+                let place_table = place_table(db, scope);
+                let use_def_map = use_def_map(db, class_literal.body_scope(db));
+
+                // Treat abstract methods from superclasses as having been overridden
+                // if this class has a synthesized method by that name,
+                // or this class has a `ClassVar` declaration by that name
+                abstract_methods.retain(|name, _| {
+                    if class_literal
+                        .own_synthesized_member(db, None, None, name)
+                        .is_some()
+                    {
+                        return false;
+                    }
+
+                    place_table.symbol_id(name).is_none_or(|symbol_id| {
+                        let declarations = use_def_map.end_of_scope_symbol_declarations(symbol_id);
+                        !place_from_declarations(db, declarations)
+                            .ignore_conflicting_declarations()
+                            .qualifiers
+                            .contains(TypeQualifiers::CLASS_VAR)
+                    })
+                });
+
+                for (symbol_id, bindings_iterator) in use_def_map.all_end_of_scope_symbol_bindings()
+                {
+                    let name = place_table.symbol(symbol_id).name();
+                    let place_and_definition = place_from_bindings(db, bindings_iterator);
+                    let Place::Defined(DefinedPlace { ty, .. }) = place_and_definition.place else {
+                        continue;
+                    };
+                    let Some(definition) = place_and_definition.first_definition else {
+                        continue;
+                    };
+                    if let Some(kind) = type_as_abstract_method(db, ty, class) {
+                        let abstract_method = AbstractMethod {
+                            defining_class: class,
+                            definition,
+                            kind,
+                        };
+                        abstract_methods.insert(name.clone(), abstract_method);
+                    } else {
+                        // If this method is concrete, remove it from the map of abstract methods.
+                        abstract_methods.shift_remove(name);
+                    }
+                }
+            }
+
+            abstract_methods
+        }
+
+        fn type_as_abstract_method<'db>(
+            db: &'db dyn Db,
+            ty: Type<'db>,
+            defining_class: ClassType<'db>,
+        ) -> Option<AbstractMethodKind> {
+            match ty {
+                Type::FunctionLiteral(function) => {
+                    AbstractMethodKind::of_function(db, function, defining_class)
+                }
+                Type::BoundMethod(method) => {
+                    AbstractMethodKind::of_function(db, method.function(db), defining_class)
+                }
+                Type::PropertyInstance(property) => {
+                    // A property is abstract if either its getter or setter is abstract.
+                    property
+                        .getter(db)
+                        .and_then(|getter| type_as_abstract_method(db, getter, defining_class))
+                        .or_else(|| {
+                            property.setter(db).and_then(|setter| {
+                                type_as_abstract_method(db, setter, defining_class)
+                            })
+                        })
+                }
+                _ => None,
+            }
+        }
+
+        Self {
+            methods: of_class_inner(db, class),
+            class,
+        }
+    }
+
+    /// Attach primary and secondary annotations to a passed in diagnostic that describe
+    /// this set of abstract methods
+    pub(super) fn annotate_diagnostic(
+        &self,
+        db: &'db dyn Db,
+        diagnostic: &mut LintDiagnosticGuard,
+    ) {
+        let (first_name, first_method) = self
+            .methods
+            .first()
+            .expect("`annotate_diagnostic()` should not be called on an empty `AbstractMethods`");
+
+        let secondary_annotation = Annotation::secondary(first_method.span(db));
+
+        if self.len() == 1 {
+            diagnostic.set_primary_message(format_args!(
+                "Abstract method `{first_name}` is unimplemented"
+            ));
+            if first_method.defining_class == self.class {
+                diagnostic.annotate(
+                    secondary_annotation
+                        .message(format_args!("`{first_name}` declared as abstract")),
+                );
+            } else {
+                diagnostic.annotate(secondary_annotation.message(format_args!(
+                    "`{first_name}` declared as abstract on superclass `{}`",
+                    first_method.defining_class.name(db)
+                )));
+            }
+        } else {
+            let num_abstract_methods = self.len();
+            let formatted_methods = self.formatted_names(db);
+
+            if formatted_methods.truncation_occurred {
+                diagnostic.set_primary_message(format_args!(
+                    "{num_abstract_methods} abstract methods are unimplemented, \
+                        including {formatted_methods}",
+                ));
+            } else {
+                diagnostic.set_primary_message(format_args!(
+                    "Abstract methods {formatted_methods} are unimplemented"
+                ));
+            }
+
+            if first_method.defining_class == self.class {
+                diagnostic.annotate(
+                    secondary_annotation
+                        .message(format_args!("`{first_name}` declared as abstract")),
+                );
+            } else {
+                diagnostic.annotate(secondary_annotation.message(format_args!(
+                    "`{first_name}` declared as abstract on superclass `{}`",
+                    first_method.defining_class.name(db)
+                )));
+            }
+            if formatted_methods.truncation_occurred {
+                diagnostic.info(format_args!(
+                    "Use `--verbose` to see all {num_abstract_methods} \
+                    unimplemented abstract methods",
+                ));
+            }
+        }
+
+        // If this method was implicitly abstract (due to being a method with an
+        // empty body in a `Protocol` class), return a vec of subdiagnostics that
+        // explain this feature of the type system.
+        if first_method.kind.is_explicit() {
+            return;
+        }
+        let defining_class_name = first_method.defining_class.name(db);
+        let mut sub = SubDiagnostic::new(
+            SubDiagnosticSeverity::Info,
+            format_args!(
+                "`{defining_class_name}.{first_name}` is implicitly abstract \
+                because `{defining_class_name}` is a `Protocol` class \
+                and `{first_name}` lacks an implementation",
+            ),
+        );
+        sub.annotate(
+            Annotation::secondary(first_method.defining_class.definition_span(db))
+                .message(format_args!("`{defining_class_name}` declared here")),
+        );
+        diagnostic.sub(sub);
+
+        // If the implicitly abstract method is defined in first-party code
+        // and the return type is assignable to `None`, they may not have intended
+        // for it to be implicitly abstract; add a clarificatory note:
+        if first_method.kind.is_implicit_due_to_stub_body()
+            && file_to_module(db, first_method.definition.file(db))
+                .and_then(|module| module.search_path(db))
+                .is_some_and(ty_module_resolver::SearchPath::is_first_party)
+        {
+            let function_type_as_callable = infer_definition_types(db, first_method.definition)
+                .binding_type(first_method.definition)
+                .try_upcast_to_callable(db);
+
+            if let Some(callables) = function_type_as_callable
+                && Type::function_like_callable(
+                    db,
+                    Signature::new(Parameters::gradual_form(), Type::none(db)),
+                )
+                .is_assignable_to(db, callables.into_type(db))
+            {
+                diagnostic.help(format_args!(
+                    "Change the body of `{first_name}` to `return` \
+                        or `return None` if it was not intended to be abstract",
+                ));
+            }
+        }
+    }
+
+    /// Unless `--verbose` was specified on the command line,
+    /// we will only print this number of abstract methods in diagnostics
+    /// complaining about abstract class instantiation (and similar)
+    const DEFAULT_METHOD_NUMBER_TO_PRINT: usize = 3;
+
+    /// Return a string that contains a formatted subset of the abstract methods
+    /// in this map.
+    ///
+    /// This is useful for diagnostics.
+    pub(super) fn formatted_names(&self, db: &'db dyn Db) -> FormattedAbstractMethods {
+        let len = self.methods.len();
+        let max_abstract_methods_to_print = if db.verbose() {
+            len
+        } else {
+            AbstractMethods::DEFAULT_METHOD_NUMBER_TO_PRINT
+        };
+        let truncation_occurred = max_abstract_methods_to_print < len;
+        FormattedAbstractMethods {
+            inner: format_enumeration(self.methods.keys().take(max_abstract_methods_to_print)),
+            truncation_occurred,
+        }
+    }
+
+    pub(super) fn first_name(&self) -> Option<&Name> {
+        self.methods.first().map(|(name, _)| name)
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.methods.len()
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.methods.is_empty()
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct FormattedAbstractMethods {
+    inner: String,
+
+    /// Boolean flag that indicates whether the wrapped string is an exhaustive
+    /// enumeration of *all* abstract methods on a class, or only an enumeration
+    /// of a truncated subset
+    pub(super) truncation_occurred: bool,
+}
+
+impl std::fmt::Display for FormattedAbstractMethods {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize, salsa::Update)]
+struct AbstractMethod<'db> {
+    defining_class: ClassType<'db>,
+    definition: Definition<'db>,
+    kind: AbstractMethodKind,
+}
+
+impl<'db> AbstractMethod<'db> {
+    fn span(&self, db: &'db dyn Db) -> Span {
+        let module = parsed_module(db, self.definition.file(db)).load(db);
+        Span::from(self.definition.focus_range(db, &module))
+    }
+}
+
+/// Indicates whether a method is explicitly or implicitly abstract.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+pub(super) enum AbstractMethodKind {
+    /// The method is explicitly marked as abstract using `@abstractmethod`.
+    Explicit,
+    /// The method is implicitly abstract due to being in a `Protocol` class without an
+    /// implementation.
+    ImplicitDueToStubBody,
+    /// The method is implicitly abstract due to being in a `Protocol` class with a body that
+    /// solely consists of `raise NotImplementedError` statements.
+    ImplicitDueToAlwaysRaising,
+}
+
+impl AbstractMethodKind {
+    const fn is_explicit(self) -> bool {
+        matches!(self, AbstractMethodKind::Explicit)
+    }
+
+    const fn is_implicit_due_to_stub_body(self) -> bool {
+        matches!(self, AbstractMethodKind::ImplicitDueToStubBody)
+    }
+
+    /// Return `Some()` if the function passed in is an abstract method.
+    ///
+    /// A method can be abstract if it is explicitly decorated with `@abstractmethod`,
+    /// or if it is an overloaded `Protocol` method without an implementation,
+    /// or if it is a `Protocol` method with a body that solely consists of `pass`/`...`
+    /// statements, or if it is a `Protocol` method that only has a docstring,
+    /// or if it is a `Protocol` method whose body only consists of a single
+    /// `raise NotImplementedError` statement.
+    pub(super) fn of_function<'db>(
+        db: &'db dyn Db,
+        function: FunctionType<'db>,
+        enclosing_class: ClassType<'db>,
+    ) -> Option<Self> {
+        if function.has_known_decorator(db, FunctionDecorators::ABSTRACT_METHOD) {
+            return Some(AbstractMethodKind::Explicit);
+        }
+        if function.definition(db).file(db).is_stub(db) {
+            return None;
+        }
+        if !enclosing_class.is_protocol(db) {
+            return None;
+        }
+        match function.literal(db).body_kind(db) {
+            FunctionBodyKind::Stub => Some(AbstractMethodKind::ImplicitDueToStubBody),
+            FunctionBodyKind::AlwaysRaisesNotImplementedError => {
+                Some(AbstractMethodKind::ImplicitDueToAlwaysRaising)
+            }
+            FunctionBodyKind::Regular => None,
+        }
+    }
+}

--- a/crates/ty_python_semantic/src/types/abstract_methods.rs
+++ b/crates/ty_python_semantic/src/types/abstract_methods.rs
@@ -3,6 +3,7 @@ use ruff_db::{
     parsed::parsed_module,
 };
 use ruff_python_ast::name::Name;
+use smallvec::SmallVec;
 use ty_module_resolver::{SearchPath, file_to_module};
 
 use crate::{
@@ -17,9 +18,15 @@ use crate::{
     },
 };
 
+/// Unless `--verbose` was specified on the command line,
+/// we will only print this number of abstract methods in diagnostics
+/// complaining about abstract class instantiation (and similar)
+const DEFAULT_METHOD_NUMBER_TO_PRINT: usize = 3;
+
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
 pub(super) struct AbstractMethods<'db> {
-    methods: &'db AbstractMethodsInner,
+    methods: &'db SmallVec<[Name; DEFAULT_METHOD_NUMBER_TO_PRINT]>,
+    total_length: usize,
     class: ClassType<'db>,
 }
 
@@ -30,9 +37,12 @@ impl<'db> AbstractMethods<'db> {
         #[salsa::tracked(
             returns(ref),
             heap_size=ruff_memory_usage::heap_size,
-            cycle_initial=|_, _, _| AbstractMethodsInner::default()
+            cycle_initial=|_, _, _| (SmallVec::default(), 0)
         )]
-        fn of_class_inner<'db>(db: &'db dyn Db, class: ClassType<'db>) -> AbstractMethodsInner {
+        fn of_class_inner<'db>(
+            db: &'db dyn Db,
+            class: ClassType<'db>,
+        ) -> (SmallVec<[Name; DEFAULT_METHOD_NUMBER_TO_PRINT]>, usize) {
             let mut abstract_methods: FxIndexSet<&Name> = FxIndexSet::default();
 
             // Iterate through the MRO in reverse order,
@@ -92,34 +102,26 @@ impl<'db> AbstractMethods<'db> {
 
             let total_abstract_methods = abstract_methods.len();
 
-            match total_abstract_methods {
-                0 => AbstractMethodsInner::Empty,
-                1 => AbstractMethodsInner::One(abstract_methods[0].clone()),
-                2 => AbstractMethodsInner::Two([
-                    abstract_methods[0].clone(),
-                    abstract_methods[1].clone(),
-                ]),
-                3 => AbstractMethodsInner::Three([
-                    abstract_methods[0].clone(),
-                    abstract_methods[1].clone(),
-                    abstract_methods[2].clone(),
-                ]),
-                _ if db.verbose() => {
-                    AbstractMethodsInner::Full(abstract_methods.into_iter().cloned().collect())
-                }
-                _ => AbstractMethodsInner::Truncated {
-                    names: [
-                        abstract_methods[0].clone(),
-                        abstract_methods[1].clone(),
-                        abstract_methods[2].clone(),
-                    ],
-                    full_length: total_abstract_methods,
-                },
-            }
+            let truncated = if db.verbose() {
+                abstract_methods.into_iter().cloned().collect()
+            } else {
+                abstract_methods
+                    .into_iter()
+                    .take(DEFAULT_METHOD_NUMBER_TO_PRINT)
+                    .cloned()
+                    .collect()
+            };
+
+            (truncated, total_abstract_methods)
         }
 
-        let methods = of_class_inner(db, class);
-        Self { methods, class }
+        let (methods, total_length) = of_class_inner(db, class);
+
+        Self {
+            methods,
+            class,
+            total_length: *total_length,
+        }
     }
 
     /// Attach primary and secondary annotations to a passed in diagnostic that describe
@@ -129,10 +131,10 @@ impl<'db> AbstractMethods<'db> {
         db: &'db dyn Db,
         diagnostic: &mut LintDiagnosticGuard,
     ) {
-        let first_name =
-            self.methods.iter().next().expect(
-                "`annotate_diagnostic()` should not be called on an empty `AbstractMethods`",
-            );
+        let first_name = self
+            .methods
+            .first()
+            .expect("`annotate_diagnostic()` should not be called on an empty `AbstractMethods`");
 
         let mut annotation_override = None;
 
@@ -314,73 +316,23 @@ impl<'db> AbstractMethods<'db> {
     ///
     /// This is useful for diagnostics.
     pub(super) fn formatted_names(&self) -> FormattedAbstractMethods {
+        let truncation_occurred = self.methods.len() < self.len();
         FormattedAbstractMethods {
             inner: format_enumeration(self.methods),
-            truncation_occurred: self.methods.is_truncated(),
+            truncation_occurred,
         }
     }
 
     pub(super) fn first_name(&self) -> Option<&Name> {
-        self.methods.iter().next()
+        self.methods.first()
     }
 
     pub(super) fn len(&self) -> usize {
-        self.methods.len()
+        self.total_length
     }
 
     pub(super) fn is_empty(&self) -> bool {
-        self.methods.len() == 0
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, salsa::Update, get_size2::GetSize)]
-enum AbstractMethodsInner {
-    #[default]
-    Empty,
-    One(Name),
-    Two([Name; 2]),
-    Three([Name; 3]),
-    Truncated {
-        names: [Name; 3],
-        full_length: usize,
-    },
-    Full(Box<[Name]>),
-}
-
-impl AbstractMethodsInner {
-    const fn is_truncated(&self) -> bool {
-        matches!(self, Self::Truncated { .. })
-    }
-
-    fn len(&self) -> usize {
-        match self {
-            Self::Empty => 0,
-            Self::One(_) => 1,
-            Self::Two(..) => 2,
-            Self::Three(..) => 3,
-            Self::Truncated { full_length, .. } => *full_length,
-            Self::Full(names) => names.len(),
-        }
-    }
-
-    fn iter(&self) -> std::slice::Iter<'_, Name> {
-        match self {
-            AbstractMethodsInner::Empty => [].iter(),
-            AbstractMethodsInner::One(single) => std::slice::from_ref(single).iter(),
-            AbstractMethodsInner::Two(names) => names.iter(),
-            AbstractMethodsInner::Three(names) => names.iter(),
-            AbstractMethodsInner::Truncated { names, .. } => names.iter(),
-            AbstractMethodsInner::Full(names) => names.iter(),
-        }
-    }
-}
-
-impl<'a> IntoIterator for &'a AbstractMethodsInner {
-    type IntoIter = std::slice::Iter<'a, Name>;
-    type Item = &'a Name;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
+        self.methods.is_empty()
     }
 }
 

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4262,18 +4262,18 @@ pub(crate) fn report_attempted_instantiation_of_abstract_class<'db>(
             name = abstract_methods.first_name().unwrap(),
         ));
     } else {
-        let formatted_methods = abstract_methods.formatted_names(db);
+        let formatted_methods = abstract_methods.formatted_names();
         if formatted_methods.truncation_occurred {
             diagnostic.set_concise_message(format_args!(
                 "Cannot instantiate `{class_name}` with {num_abstract_methods} unimplemented \
                 abstract methods, including {formatted_methods}",
-                formatted_methods = abstract_methods.formatted_names(db)
+                formatted_methods = abstract_methods.formatted_names()
             ));
         } else {
             diagnostic.set_concise_message(format_args!(
                 "Cannot instantiate `{class_name}` with unimplemented \
                 abstract methods {formatted_methods}",
-                formatted_methods = abstract_methods.formatted_names(db)
+                formatted_methods = abstract_methods.formatted_names()
             ));
         }
     }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4253,13 +4253,13 @@ pub(crate) fn report_attempted_instantiation_of_abstract_class<'db>(
 
     abstract_methods.annotate_diagnostic(db, &mut diagnostic);
 
-    let num_abstract_methods = abstract_methods.len();
+    let num_abstract_methods = abstract_methods.len(db);
 
     if num_abstract_methods == 1 {
         diagnostic.set_concise_message(format_args!(
             "Cannot instantiate `{class_name}` with unimplemented \
                 abstract method `{name}`",
-            name = abstract_methods.first_name().unwrap(),
+            name = abstract_methods.first_name(db).unwrap(),
         ));
     } else {
         let formatted_methods = abstract_methods.formatted_names(db);

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4262,18 +4262,18 @@ pub(crate) fn report_attempted_instantiation_of_abstract_class<'db>(
             name = abstract_methods.first_name().unwrap(),
         ));
     } else {
-        let formatted_methods = abstract_methods.formatted_names();
+        let formatted_methods = abstract_methods.formatted_names(db);
         if formatted_methods.truncation_occurred {
             diagnostic.set_concise_message(format_args!(
                 "Cannot instantiate `{class_name}` with {num_abstract_methods} unimplemented \
                 abstract methods, including {formatted_methods}",
-                formatted_methods = abstract_methods.formatted_names()
+                formatted_methods = abstract_methods.formatted_names(db)
             ));
         } else {
             diagnostic.set_concise_message(format_args!(
                 "Cannot instantiate `{class_name}` with unimplemented \
                 abstract methods {formatted_methods}",
-                formatted_methods = abstract_methods.formatted_names()
+                formatted_methods = abstract_methods.formatted_names(db)
             ));
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1711,18 +1711,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 `{first_method_name}`",
             ));
         } else {
-            let formatted_names = abstract_methods.formatted_names();
+            let formatted_names = abstract_methods.formatted_names(db);
             if formatted_names.truncation_occurred {
                 diagnostic.set_concise_message(format_args!(
                     "Final class `{class_name}` has {num_abstract_methods} unimplemented \
                     abstract methods, including {formatted_methods}",
-                    formatted_methods = abstract_methods.formatted_names()
+                    formatted_methods = abstract_methods.formatted_names(db)
                 ));
             } else {
                 diagnostic.set_concise_message(format_args!(
                     "Final class `{class_name}` has unimplemented \
                     abstract methods {formatted_methods}",
-                    formatted_methods = abstract_methods.formatted_names()
+                    formatted_methods = abstract_methods.formatted_names(db)
                 ));
             }
         }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1,9 +1,7 @@
 use std::borrow::Cow;
 
 use itertools::{Either, EitherOrBoth, Itertools};
-use ruff_db::diagnostic::{
-    Annotation, Diagnostic, DiagnosticId, Severity, Span, SubDiagnostic, SubDiagnosticSeverity,
-};
+use ruff_db::diagnostic::{Annotation, Diagnostic, DiagnosticId, Severity, Span};
 use ruff_db::files::File;
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_db::source::source_text;
@@ -59,11 +57,12 @@ use crate::semantic_index::{
     ApplicableConstraints, EnclosingSnapshotResult, SemanticIndex, attribute_assignments,
     get_loop_header, place_table,
 };
+use crate::types::abstract_methods::AbstractMethods;
 use crate::types::builder::RecursivelyDefined;
 use crate::types::call::bind::{CallableDescription, MatchingOverloadIndex};
 use crate::types::call::{Argument, Binding, Bindings, CallArguments, CallError, CallErrorKind};
 use crate::types::class::{
-    AbstractMethod, ClassLiteral, CodeGeneratorKind, DynamicClassAnchor, DynamicClassLiteral,
+    ClassLiteral, CodeGeneratorKind, DynamicClassAnchor, DynamicClassLiteral,
     DynamicMetaclassConflict, DynamicNamedTupleAnchor, DynamicNamedTupleLiteral, FieldKind,
     MetaclassErrorKind, MethodDecorator, NamedTupleField, NamedTupleSpec,
 };
@@ -88,7 +87,8 @@ use crate::types::diagnostic::{
     UNRESOLVED_ATTRIBUTE, UNRESOLVED_GLOBAL, UNRESOLVED_IMPORT, UNRESOLVED_REFERENCE,
     UNSUPPORTED_DYNAMIC_BASE, UNSUPPORTED_OPERATOR, USELESS_OVERLOAD_BODY,
     hint_if_stdlib_attribute_exists_on_other_versions,
-    hint_if_stdlib_submodule_exists_on_other_versions, report_attempted_protocol_instantiation,
+    hint_if_stdlib_submodule_exists_on_other_versions,
+    report_attempted_instantiation_of_abstract_class, report_attempted_protocol_instantiation,
     report_bad_dunder_set_call, report_bad_frozen_dataclass_inheritance,
     report_call_to_abstract_method, report_cannot_delete_typed_dict_key,
     report_cannot_pop_required_field_on_typed_dict, report_conflicting_metaclass_from_bases,
@@ -1682,10 +1682,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         let class_type = class.identity_specialization(db);
-        let abstract_methods = class_type.abstract_methods(db);
+        let abstract_methods = AbstractMethods::of_class(db, class_type);
 
         // If there are no abstract methods, we're done.
-        let Some((first_method_name, abstract_method)) = abstract_methods.iter().next() else {
+        let Some(first_method_name) = abstract_methods.first_name() else {
             return;
         };
 
@@ -1702,6 +1702,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             "Final class `{class_name}` has unimplemented abstract methods",
         ));
 
+        abstract_methods.annotate_diagnostic(db, &mut diagnostic);
         let num_abstract_methods = abstract_methods.len();
 
         if num_abstract_methods == 1 {
@@ -1709,92 +1710,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 "Final class `{class_name}` has unimplemented abstract method \
                 `{first_method_name}`",
             ));
-            diagnostic.set_primary_message(format_args!("`{first_method_name}` is unimplemented"));
         } else {
-            let verbose = db.verbose();
-            let max_abstract_methods_to_print = if verbose { num_abstract_methods } else { 3 };
-            let formatted_methods =
-                format_enumeration(abstract_methods.keys().take(max_abstract_methods_to_print));
-
-            if num_abstract_methods > max_abstract_methods_to_print {
-                diagnostic.set_primary_message(format_args!(
-                    "{num_abstract_methods} abstract methods are unimplemented, \
-                        including {formatted_methods}",
-                ));
+            let formatted_names = abstract_methods.formatted_names(db);
+            if formatted_names.truncation_occurred {
                 diagnostic.set_concise_message(format_args!(
                     "Final class `{class_name}` has {num_abstract_methods} unimplemented \
                     abstract methods, including {formatted_methods}",
-                ));
-                diagnostic.info(format_args!(
-                    "Use `--verbose` to see all {num_abstract_methods} \
-                    unimplemented abstract methods",
+                    formatted_methods = abstract_methods.formatted_names(db)
                 ));
             } else {
                 diagnostic.set_concise_message(format_args!(
                     "Final class `{class_name}` has unimplemented \
                     abstract methods {formatted_methods}",
+                    formatted_methods = abstract_methods.formatted_names(db)
                 ));
-                diagnostic.set_primary_message(format_args!(
-                    "Abstract methods {formatted_methods} are unimplemented"
-                ));
-            }
-        }
-
-        let AbstractMethod {
-            defining_class,
-            definition,
-            kind,
-        } = abstract_method;
-
-        let module = parsed_module(db, definition.file(db)).load(db);
-        let span = Span::from(definition.focus_range(db, &module));
-        let defining_class_name = defining_class.name(db);
-
-        let mut secondary_annotation = Annotation::secondary(span);
-        secondary_annotation = if defining_class.class_literal(db) == ClassLiteral::Static(class) {
-            secondary_annotation.message(format_args!("`{first_method_name}` declared as abstract"))
-        } else {
-            secondary_annotation.message(format_args!(
-                "`{first_method_name}` declared as abstract on superclass `{defining_class_name}`",
-            ))
-        };
-        diagnostic.annotate(secondary_annotation);
-
-        if !kind.is_explicit() {
-            let mut sub = SubDiagnostic::new(
-                SubDiagnosticSeverity::Info,
-                format_args!(
-                    "`{defining_class_name}.{first_method_name}` is implicitly abstract \
-                    because `{defining_class_name}` is a `Protocol` class \
-                    and `{first_method_name}` lacks an implementation",
-                ),
-            );
-            sub.annotate(
-                Annotation::secondary(defining_class.definition_span(db))
-                    .message(format_args!("`{defining_class_name}` declared here")),
-            );
-            diagnostic.sub(sub);
-
-            // If the implicitly abstract method is defined in first-party code
-            // and the return type is assignable to `None`, they may not have intended
-            // for it to be implicitly abstract; add a clarificatory note:
-            if kind.is_implicit_due_to_stub_body() && db.should_check_file(definition.file(db)) {
-                let function_type_as_callable = infer_definition_types(db, *definition)
-                    .binding_type(*definition)
-                    .try_upcast_to_callable(db);
-
-                if let Some(callables) = function_type_as_callable
-                    && Type::function_like_callable(
-                        db,
-                        Signature::new(Parameters::gradual_form(), Type::none(db)),
-                    )
-                    .is_assignable_to(db, callables.into_type(db))
-                {
-                    diagnostic.help(format_args!(
-                        "Change the body of `{first_method_name}` to `return` \
-                        or `return None` if it was not intended to be abstract"
-                    ));
-                }
             }
         }
     }
@@ -12414,7 +12343,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .to_class_type(self.db())
                 {
                     if function.is_classmethod(self.db())
-                        && function.as_abstract_method(self.db(), class).is_some()
+                        && function.is_abstract(self.db(), class)
                         && function.has_trivial_body(self.db())
                     {
                         report_call_to_abstract_method(
@@ -12430,7 +12359,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if let ast::Expr::Attribute(ast::ExprAttribute { value, .. }) = func.as_ref() {
                     let value_type = self.expression_type(value);
                     if let Some(class) = value_type.to_class_type(self.db()) {
-                        if function.as_abstract_method(self.db(), class).is_some()
+                        if function.is_abstract(self.db(), class)
                             && function.has_trivial_body(self.db())
                         {
                             report_call_to_abstract_method(
@@ -12461,10 +12390,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // that protocol -- and indeed, according to the spec, type checkers must disallow abstract
             // subclasses of the protocol to be passed to parameters that accept `type[SomeProtocol]`.
             // <https://typing.python.org/en/latest/spec/protocol.html#type-and-class-objects-vs-protocols>.
-            if !callable_type.is_subclass_of()
-                && let Some(protocol) = class.into_protocol_class(self.db())
-            {
-                report_attempted_protocol_instantiation(&self.context, call_expression, protocol);
+            if !callable_type.is_subclass_of() {
+                if let Some(protocol) = class.into_protocol_class(self.db()) {
+                    report_attempted_protocol_instantiation(
+                        &self.context,
+                        call_expression,
+                        protocol,
+                    );
+                } else {
+                    let abstract_methods = AbstractMethods::of_class(self.db(), class);
+                    if !abstract_methods.is_empty() {
+                        report_attempted_instantiation_of_abstract_class(
+                            &self.context,
+                            call_expression,
+                            class,
+                            &abstract_methods,
+                        );
+                    }
+                }
             }
 
             // Inference of correctly-placed `TypeVar`, `ParamSpec`, and `NewType` definitions

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1711,18 +1711,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 `{first_method_name}`",
             ));
         } else {
-            let formatted_names = abstract_methods.formatted_names(db);
+            let formatted_names = abstract_methods.formatted_names();
             if formatted_names.truncation_occurred {
                 diagnostic.set_concise_message(format_args!(
                     "Final class `{class_name}` has {num_abstract_methods} unimplemented \
                     abstract methods, including {formatted_methods}",
-                    formatted_methods = abstract_methods.formatted_names(db)
+                    formatted_methods = abstract_methods.formatted_names()
                 ));
             } else {
                 diagnostic.set_concise_message(format_args!(
                     "Final class `{class_name}` has unimplemented \
                     abstract methods {formatted_methods}",
-                    formatted_methods = abstract_methods.formatted_names(db)
+                    formatted_methods = abstract_methods.formatted_names()
                 ));
             }
         }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1684,8 +1684,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let class_type = class.identity_specialization(db);
         let abstract_methods = AbstractMethods::of_class(db, class_type);
 
+        if abstract_methods.is_empty() {
+            return;
+        }
+
         // If there are no abstract methods, we're done.
-        let Some(first_method_name) = abstract_methods.first_name() else {
+        let Some(first_method_name) = abstract_methods.first_name(db) else {
             return;
         };
 
@@ -1703,7 +1707,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         ));
 
         abstract_methods.annotate_diagnostic(db, &mut diagnostic);
-        let num_abstract_methods = abstract_methods.len();
+        let num_abstract_methods = abstract_methods.len(db);
 
         if num_abstract_methods == 1 {
             diagnostic.set_concise_message(format_args!(


### PR DESCRIPTION
- **[ty] Detect invalid attempts to instantiate abstract classes**
- **reduce memory footprint of `AbstractMethods`**
- **this calls for MOAR subdiagnostics**
- **further attempt to reduce memory footprint of `AbstractMethods`**
- **Further attempts to reduce memory usage**
- **Revert "Further attempts to reduce memory usage"**
- **Revert "further attempt to reduce memory footprint of `AbstractMethods`"**
- **[ty] Detect invalid attempts to instantiate abstract classes (take 3)**

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
