### PR TITLE
[ty] Visit pattern arguments in source order

### DIFF
--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -2,8 +2,7 @@ use ruff_text_size::Ranged;
 
 use crate::visitor::source_order::SourceOrderVisitor;
 use crate::{
-    self as ast, Alias, AnyNodeRef, AnyParameterRef, ArgOrKeyword, MatchCase, PatternArguments,
-    PatternKeyword,
+    self as ast, Alias, AnyNodeRef, AnyParameterRef, ArgOrKeyword, MatchCase, PatternKeyword,
 };
 
 impl ast::ElifElseClause {
@@ -272,19 +271,13 @@ impl ast::PatternArguments {
     where
         V: SourceOrderVisitor<'a> + ?Sized,
     {
-        let PatternArguments {
-            range: _,
-            node_index: _,
-            patterns,
-            keywords,
-        } = self;
-
-        for pattern in patterns {
-            visitor.visit_pattern(pattern);
-        }
-
-        for keyword in keywords {
-            visitor.visit_pattern_keyword(keyword);
+        for pattern_or_keyword in self.patterns_source_order() {
+            match pattern_or_keyword {
+                crate::PatternOrKeyword::Pattern(pattern) => visitor.visit_pattern(pattern),
+                crate::PatternOrKeyword::Keyword(keyword) => {
+                    visitor.visit_pattern_keyword(keyword);
+                }
+            }
         }
     }
 }

--- a/crates/ruff_python_ast/src/visitor/source_order.rs
+++ b/crates/ruff_python_ast/src/visitor/source_order.rs
@@ -491,12 +491,7 @@ where
 {
     let node = AnyNodeRef::from(pattern_arguments);
     if visitor.enter_node(node).is_traverse() {
-        for pattern in &pattern_arguments.patterns {
-            visitor.visit_pattern(pattern);
-        }
-        for keyword in &pattern_arguments.keywords {
-            visitor.visit_pattern_keyword(keyword);
-        }
+        pattern_arguments.visit_source_order(visitor);
     }
     visitor.leave_node(node);
 }


### PR DESCRIPTION
## Summary

`PatternArguments::visit_source_order()` visited all positional patterns first, then all keyword patterns. But keyword patterns can appear before positional patterns in the source text:

```python
case ast.Attribute(value=ast.Name(id), attr)
```

The visitor would process `attr` first, then `value=ast.Name(id)`.

We now visit in source order using the pattern established via `arguments_source_order`.

Closes https://github.com/astral-sh/ty/issues/2417.
