### PR TITLE
[ty] Emit diagnostic when `ClassVar` and `Final` are combined

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -747,9 +747,13 @@ If a class variable is additionally qualified as `Final`, we do not union with `
 from typing import Final
 
 class D:
+    # error: [invalid-type-form] "`ClassVar` and `Final` cannot be combined"
     final1: Final[ClassVar] = 1
+    # error: [invalid-type-form] "`ClassVar` and `Final` cannot be combined"
     final2: ClassVar[Final] = 1
+    # error: [invalid-type-form] "`ClassVar` and `Final` cannot be combined"
     final3: ClassVar[Final[int]] = 1
+    # error: [invalid-type-form] "`ClassVar` and `Final` cannot be combined"
     final4: Final[ClassVar[int]] = 1
 
 reveal_type(D.final1)  # revealed: Literal[1]

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -201,6 +201,35 @@ class Sub(Base): ...
 reveal_type(Sub.all_instances)  # revealed: list[Sub]
 ```
 
+## `ClassVar` cannot be combined with `Final`
+
+Per the typing spec, `ClassVar` and `Final` cannot be used together.
+
+```py
+from typing import ClassVar, Final
+
+class C:
+    # error: [invalid-type-form] "`ClassVar` and `Final` cannot be combined"
+    a: ClassVar[Final[int]] = 1
+    # error: [invalid-type-form] "`ClassVar` and `Final` cannot be combined"
+    b: Final[ClassVar[int]] = 1
+```
+
+## `ClassVar[Final[...]]` is allowed in dataclasses
+
+`ClassVar[Final[...]]` is allowed in dataclasses to mark a class variable as both a class variable
+(not a dataclass field) and final.
+
+```py
+from dataclasses import dataclass
+from typing import ClassVar, Final
+
+@dataclass
+class D:
+    # No error: ClassVar[Final[...]] is allowed in dataclasses
+    final_classvar: ClassVar[Final[int]] = 4
+```
+
 ## Illegal `ClassVar` in type expression
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -460,6 +460,7 @@ class C(B):
 from typing import Final, ClassVar, Annotated
 
 class Base:
+    # error: [invalid-type-form] "`ClassVar` and `Final` cannot be combined"
     X: ClassVar[Final[int]] = 1
     Y: Annotated[Final[int], "metadata"] = 2
 
@@ -581,9 +582,12 @@ LEGAL_D: Final
 LEGAL_D = 1
 
 class C:
-    LEGAL_E: ClassVar[Final[int]] = 1
-    LEGAL_F: Final[ClassVar[int]] = 1
-    LEGAL_G: Annotated[Final[ClassVar[int]], "metadata"] = 1
+    # error: [invalid-type-form] "`ClassVar` and `Final` cannot be combined"
+    ILLEGAL_E: ClassVar[Final[int]] = 1
+    # error: [invalid-type-form] "`ClassVar` and `Final` cannot be combined"
+    ILLEGAL_F: Final[ClassVar[int]] = 1
+    # error: [invalid-type-form] "`ClassVar` and `Final` cannot be combined"
+    ILLEGAL_G: Annotated[Final[ClassVar[int]], "metadata"] = 1
 
     def __init__(self):
         self.LEGAL_H: Final[int] = 1


### PR DESCRIPTION
## Summary

We now emit `invalid-type-form` when `ClassVar` and `Final` are nested in either order, per: https://typing.readthedocs.io/en/latest/spec/qualifiers.html#classvar.

I couldn't find an issue for this, but I found it in the conformance suite.