### PR TITLE
[ty] Reject protocol satisfaction when concrete class uses `Self` in non-self parameter

### DIFF
--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -200,6 +200,7 @@ impl<'db> Type<'db> {
                     member.is_satisfied_by(
                         db,
                         self,
+                        Type::ProtocolInstance(protocol),
                         inferable,
                         relation,
                         relation_visitor,


### PR DESCRIPTION
## Summary

When a protocol method uses Self in a parameter position (other than self), a concrete class using Self in the same position should not satisfy the protocol.

Closes https://github.com/astral-sh/ty/issues/2818.
