### PR TITLE
[ty] Add `explicit_bases_for_class` for external library consumers

### DIFF
--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1018,16 +1018,21 @@ fn find_parameter_range(parameters: &ast::Parameters, parameter_name: &str) -> O
 /// Used by external tools that embed ty as a library.
 /// Not referenced by production code in this repository.
 /// No backwards compatibility guarantees are made for this API.
-pub fn explicit_bases_for_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
+pub fn explicit_bases_for_class<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+) -> Option<impl IntoIterator<Item = Type<'db>> + 'db> {
     let Type::ClassLiteral(class_literal) = ty else {
         return None;
     };
 
-    match class_literal {
-        ClassLiteral::Static(static_class) => Some(static_class.explicit_bases(db).to_vec()),
-        ClassLiteral::Dynamic(dynamic_class) => Some(dynamic_class.explicit_bases(db).to_vec()),
-        ClassLiteral::DynamicNamedTuple(_) => None,
-    }
+    let bases = match class_literal {
+        ClassLiteral::Static(static_class) => static_class.explicit_bases(db),
+        ClassLiteral::Dynamic(dynamic_class) => dynamic_class.explicit_bases(db),
+        ClassLiteral::DynamicNamedTuple(_) => return None,
+    };
+
+    Some(bases.iter().copied())
 }
 
 mod resolve_definition {


### PR DESCRIPTION
## Summary

Similar to #23396, this adds a small public API surface for external tools that embed ty as a library.

Adds a new `pub fn explicit_bases_for_class(db, ty) -> Option<Vec<Type>>` function to `crates/ty_python_semantic/src/types/ide_support.rs`.

Given a `Type::ClassLiteral`, the function returns the types of the explicitly listed base classes (i.e., what appears in `class Foo(Base1, Base2):` parentheses). It delegates to `StaticClassLiteral::explicit_bases()` and `DynamicClassLiteral::explicit_bases()` internally.

As requested in the review of #23147, all new public items include doc comments stating they are intended for external library consumers and carry no backwards compatibility guarantees.

## Test plan

- `cargo check -p ty_python_semantic` passes
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- `uvx prek run -a` passes
- No production code references the new API (it is consumed by external tools only)