### PR TITLE
[ty] Update tests `reveal_type` and `Never`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/never.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/never.md
@@ -22,27 +22,31 @@ reveal_type(stop())
 from typing_extensions import NoReturn, Never, Any
 
 # error: [invalid-type-form] "Type `typing.Never` expected no type parameter"
-x: Never[int]
-a1: NoReturn
-a2: Never
-b1: Any
-b2: int
+invalid: Never[int]
 
-def f():
+def _(never: Never):
     # revealed: Never
-    reveal_type(a1)
-    # revealed: Never
-    reveal_type(a2)
+    reveal_type(never)
 
-    # Never is assignable to all types.
-    v1: int = a1
-    v2: str = a1
-    # Other types are not assignable to Never except for Never (and Any).
-    v3: Never = b1
-    v4: Never = a2
-    v5: Any = b2
-    # error: [invalid-assignment] "Object of type `Literal[1]` is not assignable to `Never`"
-    v6: Never = 1
+def _(noreturn: NoReturn):
+    # revealed: Never
+    reveal_type(noreturn)
+
+# Never is assignable to all types:
+def _(never: Never):
+    v1: int = never
+    v2: str = never
+    v3: Never = never
+    v4: Any = never
+
+# No type is assignable to Never except for Never (and Any):
+def _(never: Never, noreturn: NoReturn, any: Any):
+    v1: Never = 1  # error: [invalid-assignment]
+    v2: Never = "a"  # error: [invalid-assignment]
+
+    v3: Never = any
+    v4: Never = noreturn
+    v4: NoReturn = never
 ```
 
 ## `typing.Never`

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2125,11 +2125,12 @@ of type `Never`):
 ```py
 from typing_extensions import Never, Any
 
-def _(n: Never):
-    reveal_type(n.__setattr__)  # revealed: Never
+def _(never: Never):
+    reveal_type(never.__setattr__)  # revealed: Never
 
+def _(never: Never):
     # No error:
-    n.non_existing = 1
+    never.non_existing = 1
 ```
 
 And similarly for `Any`:

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -471,7 +471,6 @@ def i[T: (int, str)](x: T) -> T:
         case str():
             pass
         case _:
-            reveal_type(x)  # revealed: Never
             assert_never(x)
 
     return x

--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -313,24 +313,29 @@ class P: ...
 class Q: ...
 class R(Generic[T_co]): ...
 
-def _(
-    i1: Intersection[P, Not[P]],
-    i2: Intersection[Not[P], P],
-    i3: Intersection[P, Q, Not[P]],
-    i4: Intersection[Not[P], Q, P],
-    i5: Intersection[P, Any, Not[P]],
-    i6: Intersection[Not[P], Any, P],
-    i7: Intersection[R[P], Not[R[P]]],
-    i8: Intersection[R[P], Not[R[Q]]],
-) -> None:
-    reveal_type(i1)  # revealed: Never
-    reveal_type(i2)  # revealed: Never
-    reveal_type(i3)  # revealed: Never
-    reveal_type(i4)  # revealed: Never
-    reveal_type(i5)  # revealed: Never
-    reveal_type(i6)  # revealed: Never
-    reveal_type(i7)  # revealed: Never
-    reveal_type(i8)  # revealed: R[P] & ~R[Q]
+def _(i: Intersection[P, Not[P]]) -> None:
+    reveal_type(i)  # revealed: Never
+
+def _(i: Intersection[Not[P], P]) -> None:
+    reveal_type(i)  # revealed: Never
+
+def _(i: Intersection[P, Q, Not[P]]) -> None:
+    reveal_type(i)  # revealed: Never
+
+def _(i: Intersection[Not[P], Q, P]) -> None:
+    reveal_type(i)  # revealed: Never
+
+def _(i: Intersection[P, Any, Not[P]]) -> None:
+    reveal_type(i)  # revealed: Never
+
+def _(i: Intersection[Not[P], Any, P]) -> None:
+    reveal_type(i)  # revealed: Never
+
+def _(i: Intersection[R[P], Not[R[P]]]) -> None:
+    reveal_type(i)  # revealed: Never
+
+def _(i: Intersection[R[P], Not[R[Q]]]) -> None:
+    reveal_type(i)  # revealed: R[P] & ~R[Q]
 ```
 
 ### Union of a type and its negation
@@ -784,41 +789,49 @@ type Red = Literal[Color.RED]
 type Green = Literal[Color.GREEN]
 type Blue = Literal[Color.BLUE]
 
-def f(
-    a: Intersection[Color, Red],
-    b: Intersection[Color, Not[Red]],
-    c: Intersection[Color, Not[Red | Green]],
-    d: Intersection[Color, Not[Red | Green | Blue]],
-    e: Intersection[Red, Not[Color]],
-    f: Intersection[Red | Green, Not[Color]],
-    g: Intersection[Not[Red], Color],
-    h: Intersection[Red, Green],
-    i: Intersection[Red | Green, Green | Blue],
-):
+def _(a: Intersection[Color, Red]) -> None:
     reveal_type(a)  # revealed: Literal[Color.RED]
+
+def _(b: Intersection[Color, Not[Red]]) -> None:
     reveal_type(b)  # revealed: Literal[Color.GREEN, Color.BLUE]
+
+def _(c: Intersection[Color, Not[Red | Green]]) -> None:
     reveal_type(c)  # revealed: Literal[Color.BLUE]
+
+def _(d: Intersection[Color, Not[Red | Green | Blue]]) -> None:
     reveal_type(d)  # revealed: Never
+
+def _(e: Intersection[Red, Not[Color]]) -> None:
     reveal_type(e)  # revealed: Never
+
+def _(f: Intersection[Red | Green, Not[Color]]) -> None:
     reveal_type(f)  # revealed: Never
+
+def _(g: Intersection[Not[Red], Color]) -> None:
     reveal_type(g)  # revealed: Literal[Color.GREEN, Color.BLUE]
+
+def _(h: Intersection[Red, Green]) -> None:
     reveal_type(h)  # revealed: Never
+
+def _(i: Intersection[Red | Green, Green | Blue]) -> None:
     reveal_type(i)  # revealed: Literal[Color.GREEN]
 
 class Single(Enum):
     VALUE = 0
 
-def g(
-    a: Intersection[Single, Literal[Single.VALUE]],
-    b: Intersection[Single, Not[Literal[Single.VALUE]]],
-    c: Intersection[Not[Literal[Single.VALUE]], Single],
-    d: Intersection[Single, Not[Single]],
-    e: Intersection[Single | int, Not[Single]],
-):
+def _(a: Intersection[Single, Literal[Single.VALUE]]) -> None:
     reveal_type(a)  # revealed: Single
+
+def _(b: Intersection[Single, Not[Literal[Single.VALUE]]]) -> None:
     reveal_type(b)  # revealed: Never
+
+def _(c: Intersection[Not[Literal[Single.VALUE]], Single]) -> None:
     reveal_type(c)  # revealed: Never
+
+def _(d: Intersection[Single, Not[Single]]) -> None:
     reveal_type(d)  # revealed: Never
+
+def _(e: Intersection[Single | int, Not[Single]]) -> None:
     reveal_type(e)  # revealed: int
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -228,12 +228,14 @@ def _(x: A | B | C):
         case _:
             reveal_type(x)  # revealed: Never
 
+def _(x: A | B | C):
     match x:
         case A() | B() | C():
             reveal_type(x)  # revealed: A | B | C
         case _:
             reveal_type(x)  # revealed: Never
 
+def _(x: A | B | C):
     match x:
         case A():
             reveal_type(x)  # revealed: A


### PR DESCRIPTION
## Summary

`reveal_type(something_of_type_never)` is a call to a function that returns `Never`, since `reveal_type` returns the type of its argument. So it is conceivable that we treat it just like any other call to a terminal function in terms of control flow analysis. This change to our tests prepares us for that scenario in that it splits tests into multiple functions, so that assertions following a `reveal_type(something_of_type_never)` call can no longer be considered unreachable.

