### PR TITLE
[ty] Reachability analysis for generic function calls

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2699,7 +2699,7 @@ class ManyCycles2:
 
     def f1(self: "ManyCycles2"):
         # TODO: should be Unknown | list[Unknown | int] | list[Divergent]
-        reveal_type(self.x3)  # revealed: Unknown | list[Unknown | int] | list[Divergent] | list[Divergent]
+        reveal_type(self.x3)  # revealed: Unknown | list[Unknown | int] | list[Unknown] | list[Divergent]
 
         self.x1 = [self.x2] + [self.x3]
         self.x2 = [self.x1] + [self.x3]

--- a/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
+++ b/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
@@ -755,9 +755,36 @@ def _() -> NoReturn:
     f("")
 ```
 
+### Generic functions
+
+If a generic function's return type depends on a type variable, and the argument passed resolves
+that type variable to `Never`, the call should still be treated as terminal.
+
+```py
+from typing import TypeVar, NoReturn
+
+T = TypeVar("T")
+
+def identity(x: T) -> T:
+    return x
+
+# No "implicitly returns `None`" diagnostic
+def _() -> NoReturn:
+    identity(exit())
+
+def _(flag: bool):
+    if flag:
+        x = "test"
+    else:
+        x = "terminal"
+        identity(exit())
+
+    reveal_type(x)  # revealed: Literal["test"]
+```
+
 ### Other callables
 
-If other types of callables are annotated with `NoReturn`, we should still be ablt to infer correct
+If other types of callables are annotated with `NoReturn`, we should still be able to infer correct
 reachability.
 
 ```py

--- a/crates/ty_python_semantic/src/semantic_index/reachability_constraints.rs
+++ b/crates/ty_python_semantic/src/semantic_index/reachability_constraints.rs
@@ -1081,18 +1081,18 @@ impl ReachabilityConstraints {
                     return Truthiness::AlwaysFalse.negate_if(!predicate.is_positive);
                 };
 
-                let (no_overloads_return_never, all_overloads_return_never) = overloads_iterator
-                    .fold((true, true), |(none, all), overload| {
-                        let overload_returns_never =
-                            overload.return_ty.is_equivalent_to(db, Type::Never);
+                let mut no_overloads_return_never = true;
+                let mut all_overloads_return_never = true;
+                let mut any_overload_is_generic = false;
 
-                        (
-                            none && !overload_returns_never,
-                            all && overload_returns_never,
-                        )
-                    });
+                for overload in overloads_iterator {
+                    let returns_never = overload.return_ty.is_equivalent_to(db, Type::Never);
+                    no_overloads_return_never &= !returns_never;
+                    all_overloads_return_never &= returns_never;
+                    any_overload_is_generic |= overload.return_ty.has_typevar(db);
+                }
 
-                if no_overloads_return_never {
+                if no_overloads_return_never && !any_overload_is_generic {
                     Truthiness::AlwaysFalse
                 } else if all_overloads_return_never {
                     Truthiness::AlwaysTrue


### PR DESCRIPTION
## Summary

If a generic function's return type depends on a type variable, and the argument passed resolves that type variable to `Never`, the call should still be treated as terminal:

```py
def identity[T](x: T) -> T:
    return x

def f() -> Never:
    identity(exit())  # should be detected as terminal
```

This is a tiny win for correctness, but unfortunately a small drop in performance and slight increase in memory usage, because we need to infer more call expressions upfront. If we think it's not important enough, I'm also okay to change this to a test-only PR that documents this as a known limitation. If we merge it, I might follow up with an idea to simplify the code in a [slightly larger refactoring PR](https://github.com/astral-sh/ruff/pull/23378).

## Memory usage

Insignificant changes on some large internal projects, a 2% *decrease* in memory usage when running on home-assistant/core.

## Ecosystem

No ecosystem changes, as far as I can tell.

## Test Plan

New Markdown tests