### PR TITLE
Fix import-heading documentation example format

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2508,6 +2508,7 @@ pub struct IsortOptions {
         default = r#"{}"#,
         value_type = r#"dict["future" | "standard-library" | "third-party" | "first-party" | "local-folder" | str, str]"#,
         example = r#"
+            [lint.isort.import-heading]
             future = "Future imports"
             standard-library = "Standard library imports"
             third-party = "Third party imports"


### PR DESCRIPTION
## Summary

The documentation example for `import-heading` setting was missing the proper TOML table header `[lint.isort.import-heading]`.

## Before
```toml
[lint.isort]
future = "Future imports"
standard-library = "Standard library imports"
```

## After
```toml
[lint.isort.import-heading]
future = "Future imports"
standard-library = "Standard library imports"
```

Fixes #23420