### PR TITLE
Fixes UP032 crash with raw strings containing \N{

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP032_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP032_0.py
@@ -278,3 +278,6 @@ if __name__ == "__main__":
 
 # Unicode escape
 "\N{angle}AOB = {angle}°".format(angle=180)
+
+# Don't convert raw strings with \N{ patterns
+r"\N{angle}AOB = {angle}°".format(angle=180)

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
@@ -274,6 +274,12 @@ impl FStringConversion {
             return Ok(Self::EmptyLiteral);
         }
 
+        // Skip conversion if raw string contains \N{
+        // In raw strings, \N is literal, but f-strings would evaluate {name} as a variable
+        if raw && contents.contains(r"\N{") {
+            anyhow::bail!("Cannot convert raw string with \\N{{}} to f-string");
+        }
+
         // Parse the format string.
         let format_string = FormatString::from_str(contents)?;
 


### PR DESCRIPTION
**Fixes UP032 crash with raw strings containing `\\N{` (#22060)**

Here we are converting raw strings like `r"\\N{angle}".format(angle=180)` to f-strings. Converting to `rf"\\N{angle}"` makes the f-string try to evaluate `{angle}` as a variable instead of keeping it as format syntax, which causes `NameError`.

Let's add a check to skip conversion when raw strings contain `\\N{` patterns.

## Test Plan

Manual testing with the exact code from the issue:
```python
# Before (crashes after ruff fix):
print(r"\\N{angle}AOB = {angle}°".format(angle=180))

# After (left unchanged, works correctly):
print(r"\\N{angle}AOB = {angle}°".format(angle=180))
# Output: \\N180AOB = 180°
```

Added test case to `UP032_0.py` fixture file.