### PR TITLE
[ty] Fix incorrect types inferred when unpacking mixed tuples

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/ty_python_semantic/resources/mdtest/unpacking.md
@@ -489,19 +489,13 @@ def f(x: MixedTupleSubclass):
 
     [n, o, *p] = x
     reveal_type(n)  # revealed: I0
-
-    # TODO: `I1 | I2` might be better here? (https://github.com/astral-sh/ty/issues/947)
-    reveal_type(o)  # revealed: I1
-
+    reveal_type(o)  # revealed: I1 | I2
     reveal_type(p)  # revealed: list[I1 | I2]
 
     [o, p, q, *r] = x
     reveal_type(o)  # revealed: I0
-
-    # TODO: `I1 | I2` might be better for both of these? (https://github.com/astral-sh/ty/issues/947)
-    reveal_type(p)  # revealed: I1
-    reveal_type(q)  # revealed: I1
-
+    reveal_type(p)  # revealed: I1 | I2
+    reveal_type(q)  # revealed: I1 | I2
     reveal_type(r)  # revealed: list[I1 | I2]
 
     s, *t, u = x


### PR DESCRIPTION
## Summary

When unpacking a "mixed tuple" like `tuple[I0, *tuple[I1, ...], I2]` with a starred expression (e.g., `[a, b, *c] = x`), ty incorrectly inferred `I1` for `b` instead of `I1 | I2`. The variable-length part can materialize to 0 elements, causing `I2` to shift into the `b` position, so the correct type is the union `I1 | I2`.

Closes: https://github.com/astral-sh/ty/issues/947.
