### PR TITLE
[ty] Flag illegal special form types in PEP 613 type aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -460,3 +460,27 @@ BadTypeAlias14: TypeAlias = Literal[-3.14]  # error: [invalid-type-form]
 # error: [invalid-type-form]
 BadTypeAlias14: TypeAlias = Literal[3.14]
 ```
+
+## No type qualifiers
+
+The right-hand side of a type alias definition is a [type expression], not an annotation expression.
+Type qualifiers like `ClassVar` and `Final` are only valid in annotation expressions, so they cannot
+appear in type alias definitions:
+
+```py
+from typing_extensions import ClassVar, Final, Required, NotRequired, ReadOnly, TypeAlias, Unpack
+from dataclasses import InitVar
+
+bad1: TypeAlias = ClassVar[str]  # error: [invalid-type-form]
+bad2: TypeAlias = ClassVar  # error: [invalid-type-form]
+bad3: TypeAlias = Final[int]  # error: [invalid-type-form]
+bad4: TypeAlias = Final  # error: [invalid-type-form]
+bad5: TypeAlias = Required[int]  # error: [invalid-type-form]
+bad6: TypeAlias = NotRequired[int]  # error: [invalid-type-form]
+bad7: TypeAlias = ReadOnly[int]  # error: [invalid-type-form]
+bad8: TypeAlias = Unpack[tuple[int, ...]]  # error: [invalid-type-form]
+bad9: TypeAlias = InitVar[int]  # error: [invalid-type-form]
+bad10: TypeAlias = InitVar  # error: [invalid-type-form]
+```
+
+[type expression]: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -331,6 +331,59 @@ impl SpecialFormType {
         }
     }
 
+    /// Return `true` if this special form type is valid in a type-expression context (and not
+    /// just in an *annotation* expression context). See the following section of the typing
+    /// specification for more details:
+    /// <https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions>
+    pub(super) const fn is_valid_in_type_expression(self) -> bool {
+        match self {
+            Self::ClassVar
+            | Self::Final
+            | Self::Required
+            | Self::NotRequired
+            | SpecialFormType::ReadOnly
+            | SpecialFormType::Unpack
+            | SpecialFormType::TypeAlias => false,
+            Self::Annotated
+            | SpecialFormType::Any
+            | SpecialFormType::Literal
+            | SpecialFormType::LiteralString
+            | SpecialFormType::Optional
+            | SpecialFormType::Union
+            | SpecialFormType::NoReturn
+            | SpecialFormType::Never
+            | SpecialFormType::Tuple
+            | SpecialFormType::List
+            | SpecialFormType::Dict
+            | SpecialFormType::Set
+            | SpecialFormType::FrozenSet
+            | SpecialFormType::ChainMap
+            | SpecialFormType::Counter
+            | SpecialFormType::DefaultDict
+            | SpecialFormType::Deque
+            | SpecialFormType::OrderedDict
+            | SpecialFormType::Type
+            | SpecialFormType::Unknown
+            | SpecialFormType::AlwaysTruthy
+            | SpecialFormType::AlwaysFalsy
+            | SpecialFormType::Not
+            | SpecialFormType::Intersection
+            | SpecialFormType::TypeOf
+            | SpecialFormType::CallableTypeOf
+            | SpecialFormType::Top
+            | SpecialFormType::Bottom
+            | SpecialFormType::Callable
+            | SpecialFormType::TypingSelf
+            | SpecialFormType::Concatenate
+            | SpecialFormType::TypeGuard
+            | SpecialFormType::TypedDict
+            | SpecialFormType::TypeIs
+            | SpecialFormType::Protocol
+            | SpecialFormType::Generic
+            | SpecialFormType::NamedTuple => true,
+        }
+    }
+
     /// Return `Some(KnownClass)` if this special form is an alias
     /// to a standard library class.
     pub(super) const fn aliased_stdlib_class(self) -> Option<KnownClass> {


### PR DESCRIPTION
## Summary

What it says in the title

## Test Plan

New Markdown tests