### PR TITLE
[ty] Fix bug where diagnostics could disappear after opening an external file

### DIFF
--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -365,10 +365,7 @@ impl Project {
 
         let mut open_files = self.take_open_files(db);
         let removed = open_files.remove(&file);
-
-        if removed {
-            self.set_open_files(db, open_files);
-        }
+        self.set_open_files(db, open_files);
 
         removed
     }
@@ -453,14 +450,34 @@ impl Project {
     pub fn should_check_file(self, db: &dyn Db, file: File) -> bool {
         let path = file.path(db);
 
+        // NOTE: The tracing messages below were added because
+        // whether a file should be checked or not can sometimes
+        // be at the root of confusing UX like "diagnostics all
+        // of a sudden stopped working." Having a trace message
+        // indicating *why* a particular file isn't being checked
+        // can be quite helpful for narrowing down the issue.
+        //
+        // The problem is that it's incredibly noisy. Which is why
+        // we set them to the TRACE level.
+
         // Try to return early to avoid adding a dependency on `open_files` or `file_set` which
         // both have a durability of `LOW`.
         if path.is_vendored_path() {
+            tracing::trace!("Not checking {path} because it is a vendored path");
             return false;
         }
 
         match self.check_mode(db) {
-            CheckMode::OpenFiles => self.open_files(db).contains(&file),
+            CheckMode::OpenFiles => {
+                let should_check = self.open_files(db).contains(&file);
+                if !should_check {
+                    tracing::trace!(
+                        "Not checking {path} because check mode is `OpenFiles` \
+                         and it is not in the open file set"
+                    );
+                }
+                should_check
+            }
             CheckMode::AllFiles => {
                 // Virtual files are always checked.
                 //
@@ -476,9 +493,17 @@ impl Project {
                 // neovim uses `file://...` even for an open buffer
                 // that does not correspond to a file saved to disk
                 // yet.
-                path.is_system_virtual_path()
+                let should_check = path.is_system_virtual_path()
                     || self.files(db).contains(&file)
-                    || self.open_files(db).contains(&file)
+                    || self.open_files(db).contains(&file);
+                if !should_check {
+                    tracing::trace!(
+                        "Not checking {path} because check mode is `AllFiles` \
+                         and it is not a virtual path, in the project files \
+                         or in the open file set"
+                    );
+                }
+                should_check
             }
         }
     }

--- a/crates/ty_server/tests/e2e/workspace_folders.rs
+++ b/crates/ty_server/tests/e2e/workspace_folders.rs
@@ -649,7 +649,9 @@ fn condensed_workspace_diagnostic_snapshot(report: WorkspaceDiagnosticReportResu
         .join("\n")
 }
 
-fn condensed_document_diagnostic_snapshot(report: DocumentDiagnosticReportResult) -> String {
+pub(crate) fn condensed_document_diagnostic_snapshot(
+    report: DocumentDiagnosticReportResult,
+) -> String {
     match report {
         DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(full)) => {
             condensed_full_document_diagnostic_report(full.full_document_diagnostic_report)


### PR DESCRIPTION
This happened whenever:

* Diagnostic mode was set to `openFilesOnly`
* One opened and then closed an external file (or caused the
  LSP client to send notifications that a file was closed, which
  may happen even when the end user doesn't actually open or close
  a file)

When this happened, the entire open file set was cleared. This in turn
resulted in `should_check_file` returning `false` for any file
previously in the open file set. And thus, we'd never get any
diagnostics.

Looking at our revision history, it seems like this bug has been
present for a long time? I'm not sure. However, this bug doesn't apply
when the diagnostic mode is set to `workspace`, which might explain
why it defied reproduction.

I've also included a regression test and some extra TRACE level logs
that might help diagnose these sorts of problems in the future.

Fixes https://github.com/astral-sh/ty-vscode/issues/342
