### PR TITLE
[`flake8-bugbear`] Tag certain `B007` diagnostics as unnecessary

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -134,6 +134,11 @@ pub(crate) fn unused_loop_control_variable(checker: &Checker, stmt_for: &ast::St
             },
             expr.range(),
         );
+
+        if certainty == Certainty::Certain {
+            diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Unnecessary);
+        }
+
         if let Some(rename) = rename {
             if certainty == Certainty::Certain {
                 // Avoid fixing if the variable, or any future bindings to the variable, are


### PR DESCRIPTION
Closes #23452 

## Summary

Adds `DiagnosticTag::Unnecessary` to B007 diagnostics only when certainty is Certain, so editors can dim definitely-unused loop control variables without dimming uncertain cases.

## Test Plan

Added new test and manually tested in VSCode.

<img width="485" height="227" alt="image" src="https://github.com/user-attachments/assets/b41c85f1-0a2e-4e6d-987c-0cb62ec96513" />
