### PR TITLE
[ty] Fix panic for annotation pointing at leading whitespace

### DIFF
--- a/crates/ruff_annotate_snippets/src/renderer/margin.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/margin.rs
@@ -41,9 +41,15 @@ impl Margin {
         //    |                     ^^^^^^^^^
         // ```
 
+        let whitespace_left = whitespace_left.saturating_sub(ELLIPSIS_PASSING);
+        let span_left = span_left.saturating_sub(ELLIPSIS_PASSING);
+
         let mut m = Margin {
-            whitespace_left: whitespace_left.saturating_sub(ELLIPSIS_PASSING),
-            span_left: span_left.saturating_sub(ELLIPSIS_PASSING),
+            // When an annotation points at leading whitespace (e.g. an indentation error),
+            // `whitespace_left` can exceed `span_left`. Clamp it so that trimming whitespace
+            // never hides the leftmost annotation.
+            whitespace_left: min(whitespace_left, span_left),
+            span_left,
             span_right: span_right + ELLIPSIS_PASSING,
             computed_left: 0,
             computed_right: 0,

--- a/crates/ruff_annotate_snippets/tests/formatter.rs
+++ b/crates/ruff_annotate_snippets/tests/formatter.rs
@@ -1029,3 +1029,19 @@ error
     let renderer = Renderer::plain().term_width(18).cut_indicator("…");
     assert_data_eq!(renderer.render(input).to_string(), expected);
 }
+
+#[test]
+fn leading_nbsp_no_overflow() {
+    // Regression test: an annotation pointing at leading whitespace caused a
+    // subtraction overflow in Margin::compute because `label_right` can be less
+    // than `whitespace_left`. See https://github.com/astral-sh/ty/issues/836
+    let source = " \u{00A0}                                     'betting_env.datastructure.team_lineup.Tamheet.get_latest': ( 'dataStrcuture/team_lineup.htm#teamsheet.getlatest',";
+    let input = Level::Error.title("test").snippet(
+        Snippet::source(source)
+            .line_start(1)
+            .annotation(Level::Error.span(0..1)),
+    );
+    // Should not panic.
+    let renderer = Renderer::plain();
+    let _ = renderer.render(input).to_string();
+}


### PR DESCRIPTION
## Summary

When a diagnostic annotation pointed at indentation (e.g., an "unexpected indentation" error), `whitespace_left` could exceed `span_left`, causing a subtraction overflow in `Margin::compute`.

Closes https://github.com/astral-sh/ty/issues/836.
