### PR TITLE
ci: declare explicit empty permissions for notify-dependents workflow

### DIFF
--- a/.github/workflows/notify-dependents.yml
+++ b/.github/workflows/notify-dependents.yml
@@ -11,6 +11,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   update-dependents:
     name: Notify dependents


### PR DESCRIPTION
## Summary

- add explicit `permissions: {}` to `.github/workflows/notify-dependents.yml`

## Why

This workflow uses a dedicated PAT secret (`RUFF_PRE_COMMIT_PAT`) to dispatch a workflow in another repository and does not require the default `GITHUB_TOKEN`.

Declaring empty permissions avoids granting unnecessary default scopes and makes the intended auth model explicit.

## Notes
- configuration-only change
- no behavior change to the dispatch logic\n