### PR TITLE
docs: link to mypy error codes from PGH003

### DIFF
--- a/crates/ruff_linter/src/rules/pygrep_hooks/rules/blanket_type_ignore.rs
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/rules/blanket_type_ignore.rs
@@ -41,6 +41,10 @@ use crate::checkers::ast::LintContext;
 /// [tool.mypy]
 /// enable_error_code = ["ignore-without-code"]
 /// ```
+///
+/// For the list of possible error codes, see:
+/// - <https://mypy.readthedocs.io/en/stable/error_codes.html>
+/// - <https://mypy.readthedocs.io/en/stable/error_code_list.html>
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.187")]
 pub(crate) struct BlanketTypeIgnore;


### PR DESCRIPTION
Fixes #10821.

PGH003 recommends using `type: ignore[code]`, but the rule documentation did not link to a reference list of valid Mypy error codes.

This PR adds links to the Mypy error code documentation and error code list in the PGH003 "References" section.