### PR TITLE
docs: link allow-multiline from ISC003

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/explicit.rs
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/explicit.rs
@@ -38,7 +38,7 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// Setting `lint.flake8-implicit-str-concat.allow-multiline = false` will disable this rule because
 /// it would leave no allowed way to write a multi-line string.
 ///
-/// - `lint.flake8-implicit-str-concat.allow-multiline`
+/// - [`lint.flake8-implicit-str-concat.allow-multiline`](https://docs.astral.sh/ruff/settings/)
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.201")]
 pub(crate) struct ExplicitStringConcatenation;


### PR DESCRIPTION
Fixes #17027.

Link `lint.flake8-implicit-str-concat.allow-multiline` from the ISC003 rule documentation.