### PR TITLE
[ty] Add `Download` button to ty playground which creates a zip export

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -61,7 +61,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3789,7 +3788,6 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3856,7 +3854,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -4104,7 +4101,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4462,7 +4458,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5137,7 +5132,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7028,7 +7022,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -7473,7 +7466,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7578,7 +7570,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -8285,7 +8276,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8443,7 +8433,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8561,7 +8550,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8675,7 +8663,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8866,7 +8853,6 @@
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -8909,6 +8895,7 @@
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "classnames": "^2.3.2",
+        "fflate": "^0.8.2",
         "react": "^19.0.0",
         "react-aria-components": "^1.16.0",
         "react-resizable-panels": "^4.0.0"
@@ -8920,7 +8907,6 @@
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "classnames": "^2.5.1",
-        "fflate": "^0.8.2",
         "lz-string": "^1.5.0",
         "monaco-editor": "^0.55.0",
         "pyodide": "^0.29.0",

--- a/playground/ruff/src/Editor/Chrome.tsx
+++ b/playground/ruff/src/Editor/Chrome.tsx
@@ -1,6 +1,6 @@
 import ruffSchema from "../../../../ruff.schema.json";
 import { useCallback, useMemo, useRef, useState } from "react";
-import { Header, useTheme, setupMonaco } from "shared";
+import { Header, useTheme, setupMonaco, downloadZip } from "shared";
 import {
   copyAsMarkdown,
   copyAsMarkdownLink,
@@ -42,6 +42,24 @@ export default function Chrome() {
       return;
     }
     await copyAsMarkdown(settings, pythonSource);
+  }, [pythonSource, settings]);
+
+  const handleDownload = useCallback(async () => {
+    if (settings == null || pythonSource == null) {
+      return;
+    }
+
+    const toml = await import("smol-toml");
+
+    const files: { [name: string]: string } = { "main.py": pythonSource };
+
+    try {
+      files["ruff.toml"] = toml.stringify(JSON.parse(settings));
+    } catch {
+      files["ruff.json"] = settings;
+    }
+
+    await downloadZip(files, "ruff-playground");
   }, [pythonSource, settings]);
 
   if (initPromise.current == null) {
@@ -110,6 +128,7 @@ export default function Chrome() {
         onShare={handleShare}
         onCopyMarkdownLink={handleCopyMarkdownLink}
         onCopyMarkdown={handleCopyMarkdown}
+        onDownload={handleDownload}
         onReset={handleResetClicked}
       />
 

--- a/playground/shared/package.json
+++ b/playground/shared/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
     "classnames": "^2.3.2",
+    "fflate": "^0.8.2",
     "react-aria-components": "^1.16.0",
     "react": "^19.0.0",
     "react-resizable-panels": "^4.0.0"

--- a/playground/shared/src/Header.tsx
+++ b/playground/shared/src/Header.tsx
@@ -27,7 +27,7 @@ export default function Header({
   onShare: () => Promise<void>;
   onCopyMarkdownLink: () => Promise<void>;
   onCopyMarkdown: () => Promise<void>;
-  onDownload?(): void;
+  onDownload(): void;
 }) {
   return (
     <div
@@ -63,13 +63,9 @@ export default function Header({
             onShare={onShare}
             onCopyMarkdownLink={onCopyMarkdownLink}
             onCopyMarkdown={onCopyMarkdown}
+            onDownload={onDownload}
           />
         </div>
-        {onDownload != null && (
-          <div className="max-sm:hidden flex">
-            <DownloadButton onClicked={onDownload} />
-          </div>
-        )}
         <Divider />
 
         <ThemeButton theme={theme} onChange={onChangeTheme} />
@@ -153,18 +149,6 @@ function ResetButton({ onClicked }: { onClicked?: () => void }) {
       onClick={onClicked}
     >
       Reset
-    </AstralButton>
-  );
-}
-
-function DownloadButton({ onClicked }: { onClicked: () => void }) {
-  return (
-    <AstralButton
-      type="button"
-      className="relative flex-none leading-6 py-1.5 px-3 shadow-xs"
-      onClick={onClicked}
-    >
-      Download
     </AstralButton>
   );
 }

--- a/playground/shared/src/ShareButton.tsx
+++ b/playground/shared/src/ShareButton.tsx
@@ -7,6 +7,7 @@ import {
   MenuTrigger,
   Popover,
   Pressable,
+  Separator,
 } from "react-aria-components";
 import AstralButton from "./AstralButton";
 
@@ -17,10 +18,12 @@ export default function ShareButton({
   onShare,
   onCopyMarkdownLink,
   onCopyMarkdown,
+  onDownload,
 }: {
   onShare: () => Promise<void>;
   onCopyMarkdownLink: () => Promise<void>;
   onCopyMarkdown: () => Promise<void>;
+  onDownload(): void;
 }) {
   const [status, dispatch, isPending] = useActionState(
     async (_previousStatus: ShareStatus, action: ShareAction) => {
@@ -101,6 +104,8 @@ export default function ShareButton({
           >
             Markdown
           </ShareMenuItem>
+          <Separator className="my-1 border-t border-gray-200 dark:border-gray-700" />
+          <ShareMenuItem onAction={onDownload}>Download ZIP</ShareMenuItem>
         </Menu>
       </Popover>
     </MenuTrigger>

--- a/playground/shared/src/downloadZip.ts
+++ b/playground/shared/src/downloadZip.ts
@@ -4,9 +4,10 @@ import { strToU8, zipSync } from "fflate";
  * Creates a ZIP archive from the given files and triggers a browser download.
  * The filename includes a short content hash for uniqueness.
  */
-export async function downloadZip(files: {
-  [name: string]: string;
-}): Promise<void> {
+export async function downloadZip(
+  files: { [name: string]: string },
+  prefix = "playground",
+): Promise<void> {
   const data: { [name: string]: Uint8Array } = {};
 
   for (const [name, content] of Object.entries(files)) {
@@ -24,7 +25,7 @@ export async function downloadZip(files: {
 
   const a = document.createElement("a");
   a.href = url;
-  a.download = `ty-playground-${hash}.zip`;
+  a.download = `${prefix}-${hash}.zip`;
   a.click();
 
   URL.revokeObjectURL(url);

--- a/playground/shared/src/index.ts
+++ b/playground/shared/src/index.ts
@@ -6,6 +6,7 @@ export * as Icons from "./Icons";
 export { type Theme, useTheme } from "./theme";
 export { HorizontalResizeHandle, VerticalResizeHandle } from "./ResizeHandle";
 export { setupMonaco } from "./setupMonaco";
+export { downloadZip } from "./downloadZip";
 export {
   default as SideBar,
   SideBarEntry,

--- a/playground/ty/package.json
+++ b/playground/ty/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
     "classnames": "^2.5.1",
-    "fflate": "^0.8.2",
     "lz-string": "^1.5.0",
     "monaco-editor": "^0.55.0",
     "pyodide": "^0.29.0",

--- a/playground/ty/src/Playground.tsx
+++ b/playground/ty/src/Playground.tsx
@@ -9,7 +9,13 @@ import {
   useRef,
   useState,
 } from "react";
-import { ErrorMessage, Header, setupMonaco, useTheme } from "shared";
+import {
+  ErrorMessage,
+  Header,
+  setupMonaco,
+  useTheme,
+  downloadZip,
+} from "shared";
 import { FileHandle, PositionEncoding, Workspace } from "ty_wasm";
 import {
   copyAsMarkdown,
@@ -18,7 +24,6 @@ import {
   persistLocal,
   restore,
 } from "./Editor/persist";
-import { downloadZip } from "./Editor/downloadZip";
 import { loader } from "@monaco-editor/react";
 import tySchema from "../../../ty.schema.json";
 import Chrome, { formatError } from "./Editor/Chrome";
@@ -85,7 +90,22 @@ export default function Playground() {
     const serialized = serializeFiles(files);
 
     if (serialized != null) {
-      await downloadZip(serialized.files);
+      const downloadFiles = { ...serialized.files };
+
+      if (SETTINGS_FILE_NAME in downloadFiles) {
+        try {
+          const toml = await import("smol-toml");
+          const tomlContent = toml.stringify(
+            JSON.parse(downloadFiles[SETTINGS_FILE_NAME]),
+          );
+          delete downloadFiles[SETTINGS_FILE_NAME];
+          downloadFiles["ty.toml"] = tomlContent;
+        } catch {
+          // Keep the original JSON file if conversion fails.
+        }
+      }
+
+      await downloadZip(downloadFiles, "ty-playground");
     }
   }, [files]);
   const handleFileAdded = useCallback((workspace: Workspace, name: string) => {


### PR DESCRIPTION
Closes: https://github.com/astral-sh/ty/issues/418

## Summary

Add a `Download` button which zips up the current state of the editor and triggers a browser download.

- Adds new dependency `fflate` chosen due to it's size/simplicity/speed
- Adds new `Download` button beside `Share`
- Generates a hash of the content for use in the zip files name. I did consider coupling this to the `Share` and use the uuid it generates to include in the zip name instead but for now not requiring a network call makes it a bit simpler to test/verify.


<img width="816" height="480" alt="Screenshot 2026-02-22 at 15 45 33" src="https://github.com/user-attachments/assets/cbae5e83-9906-4bf7-83eb-6f94d9a4d05e" />

<img width="764" height="156" alt="Screenshot 2026-02-22 at 15 47 00" src="https://github.com/user-attachments/assets/4b0a8076-1e95-4e48-987e-feaab533c74f" />

Sample zip export: [ty-playground-89bb077f.zip](https://github.com/user-attachments/files/25470166/ty-playground-89bb077f.zip)


## Test Plan
<!-- How was it tested? -->
- Create some files in editors
- Click `Download`
- See browser download starter
- Open file / verify content
