### PR TITLE
Fix typo in completion.rs comment

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -8788,7 +8788,7 @@ raise <CURSOR>
                 // N.B. We very much want to use the default settings
                 // here, so that our test environment matches the
                 // production environment. If a default changes, the
-                // tests should be fixed to accomodate that change
+                // tests should be fixed to accommodate that change
                 // as well. ---AG
                 settings: CompletionSettings::default(),
                 skip_builtins: false,


### PR DESCRIPTION
## Summary
- fix a typo in a source comment in crates/ty_ide/src/completion.rs
- change "accomodate" to "accommodate"

## Why
- keeps code comments clear and polished