### PR TITLE
[ty] Dataclasses: descriptor-typed fields without defaults

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/fields.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/fields.md
@@ -58,10 +58,10 @@ class NoDefaultSpecificClass(SomeClass):
 reveal_type(NoDefaultSpecificClass(SpecificConfiguration()).config)  # revealed: SpecificConfiguration | None
 ```
 
-## Descriptor-typed fields with defaults
+## Descriptor-typed fields
 
 A dataclass field whose declared type is a descriptor should still resolve through the descriptor
-protocol on instance access, even when the field has a default value.
+protocol on instance access, regardless of whether the field has a default value.
 
 `Desc2` has `__get__` but no `__set__`, making it a non-data descriptor.
 
@@ -88,9 +88,13 @@ class DC2:
 dc2 = DC2(Desc2(), Desc2(), Desc2())
 
 # On the class, __get__(None, owner) is called, returning list[T].
+reveal_type(DC2.x)  # revealed: list[int]
+reveal_type(DC2.y)  # revealed: list[str]
 reveal_type(DC2.z)  # revealed: list[str]
 
 # On instances, __get__(instance, owner) is called, returning T.
+reveal_type(dc2.x)  # revealed: int
+reveal_type(dc2.y)  # revealed: str
 # The default value should not cause the declared descriptor type
 # to leak into the instance attribute type.
 reveal_type(dc2.z)  # revealed: str

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -4742,6 +4742,17 @@ impl<'db> StaticClassLiteral<'db> {
 
                             Member::unbound()
                         }
+                    } else if self.is_own_dataclass_instance_field(db, name)
+                        && !declared_ty
+                            .class_member(db, "__get__".into())
+                            .place
+                            .is_undefined()
+                    {
+                        // For dataclass-like classes with descriptor-typed fields
+                        // that have no default value, return unbound so that the
+                        // descriptor protocol in `member_lookup_with_policy` can
+                        // resolve the attribute type through `__get__`.
+                        Member::unbound()
                     } else {
                         // The attribute is declared but not bound in the class body.
                         // We take this as a sign that this is intended to be a pure


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/astral-sh/ruff/pull/22965 that also handles descriptor-typed fields with a default value.

## Test Plan

New Markdown tests based on the typing conformance tests [here](https://shark.fish/typing-conformance-report/dataclasses_descriptors.html#L66).
