### PR TITLE
Update isort action comments heading

### DIFF
--- a/docs/linter.md
+++ b/docs/linter.md
@@ -460,7 +460,7 @@ relevant lines (with the appropriate rule codes), run Ruff with `--add-noqa`, li
 $ ruff check /path/to/file.py --add-noqa
 ```
 
-### Action comments
+### isort action comments
 
 Ruff respects isort's [action comments](https://pycqa.github.io/isort/docs/configuration/action_comments.html)
 (`# isort: skip_file`, `# isort: on`, `# isort: off`, `# isort: skip`, and `# isort: split`), which


### PR DESCRIPTION
Summary
--

Closes #23450 by renaming the `Action comments` heading to `isort action
comments`. I agree with the issue author that this should make it easier to find.

Test Plan
--
