### PR TITLE
Fix missing settings links for several linters

### DIFF
--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -171,12 +171,14 @@ pub(crate) fn generate() -> String {
             table_out.push('\n');
         }
 
-        if Options::metadata().has(&format!("lint.{}", linter.name())) {
+        // The linter names for Ruff and NumPy are suffixed with "-specific rules."
+        let linter_name = linter.name().trim_end_matches("-specific rules");
+        // Several linter names are capitalized, but their settings are not.
+        let linter_name_lower = linter_name.to_lowercase();
+        if Options::metadata().has(&format!("lint.{linter_name_lower}")) {
             let _ = write!(
                 table_out,
-                "For related settings, see [{}](settings.md#lint{}).",
-                linter.name(),
-                linter.name(),
+                "For related settings, see [{linter_name}](settings.md#lint{linter_name_lower}).",
             );
             table_out.push('\n');
             table_out.push('\n');


### PR DESCRIPTION
Summary
--

Fixes #23518 by normalizing the linter names before looking them up in
`Options::metadata()`. Most linters were already lowercase, matching their
corresponding options, but several were not:

```console
❯ ruff linter | awk '$2 ~ /^[A-Z]/'
 AIR Airflow
FAST FastAPI
 NPY NumPy-specific rules
PERF Perflint
   F Pyflakes
  PL Pylint
 RUF Ruff-specific rules
 ```

Of these, only Pyflakes, Pylint, and Ruff have settings.

Test Plan
--

Built the docs locally:

<img width="284" height="130" alt="image" src="https://github.com/user-attachments/assets/08e0fee8-972a-4787-bc2d-2aea450e1a71" />

<img width="248" height="141" alt="image" src="https://github.com/user-attachments/assets/1f800740-8cd5-43e7-9306-85d832c4d627" />

<img width="304" height="89" alt="image" src="https://github.com/user-attachments/assets/21f0bf37-81c5-4230-b17a-6f5e4d545357" />
