### PR TITLE
[ty] Avoid dictionary key narrowing for multi-target assignments

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
@@ -116,4 +116,9 @@ reveal_type(x5["a"])  # revealed: Literal[1]
 reveal_type(x5["b"])  # revealed: dict[str, int | TD]
 reveal_type(x5["b"]["c"])  # revealed: Literal[2]
 reveal_type(x5["b"]["d"])  # revealed: TD
+
+x6 = x7 = {"a": 1}
+# TODO: This should reveal `Literal[1]`.
+reveal_type(x6["a"])  # revealed: Unknown | int
+reveal_type(x7["a"])  # revealed: Unknown | int
 ```


### PR DESCRIPTION
The example below currently panics.
```py
x = y = { "a": 1 }
```

We attempt to synthesize places for `x["a"]` and `y["a"]` and associate them with a definition for the key-value assignment. However, the definition is uniquely identified by the AST node for `"a"`, causing a panic.

This PR avoids narrowing for multi-target assignments. However, it looks like we do have internal support for associating multiple definitions with a single AST node, but we currently panic if it ever happens. I'm not sure if the assert is just enforcing our current behavior, or there's some other reason we avoid this?

Resolves https://github.com/astral-sh/ty/issues/2866.