### PR TITLE
Fix RUF027 false negative with escape sequences in format specs

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_0.py
@@ -83,6 +83,7 @@ def in_type_def():
 def escaped_format_spec():
     a = 4
     b = "{a:\x64}"  # RUF027
+    c = "{a:\n}"  # RUF027 - newline in format spec is valid via custom __format__
 
 # Regression test for parser bug
 # https://github.com/astral-sh/ruff/issues/18860

--- a/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
@@ -3,7 +3,6 @@ use rustc_hash::FxHashSet;
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::{self as ast, PythonVersion};
-use ruff_python_literal::format::FormatSpec;
 use ruff_python_parser::parse_expression;
 use ruff_python_semantic::analyze::logging::is_logger_candidate;
 use ruff_python_semantic::{Modules, SemanticModel, TypingOnlyBindingsStatus};
@@ -33,8 +32,7 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 ///    (for example: `"{value}".format(...)`)
 /// 4. The string has no `{...}` expression sections, or uses invalid f-string syntax.
 /// 5. The string references variables that are not in scope, or it doesn't capture variables at all.
-/// 6. Any format specifiers in the potential f-string are invalid.
-/// 7. The string is part of a function call that is known to expect a template string rather than an
+/// 6. The string is part of a function call that is known to expect a template string rather than an
 ///    evaluated f-string: for example, a [`logging`][logging] call, a [`gettext`][gettext] call,
 ///    or a [FastAPI path].
 ///
@@ -252,20 +250,6 @@ fn should_be_fstring(
                     return false;
                 }
                 has_name = true;
-            }
-            if let Some(spec) = &element.format_spec {
-                let spec_text;
-                let spec_str = if spec.elements.interpolations().next().is_none() {
-                    // Use decoded literal values so escape sequences like `\x64`
-                    // are resolved before parsing.
-                    spec_text = spec.elements.literals().map(|lit| &*lit.value).collect::<String>();
-                    &spec_text
-                } else {
-                    &fstring_expr[spec.range()]
-                };
-                if FormatSpec::parse(spec_str).is_err() {
-                    return false;
-                }
             }
         }
         if !has_name {

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF027_RUF027_0.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF027_RUF027_0.py.snap
@@ -328,8 +328,7 @@ RUF027 [*] Possible f-string without an `f` prefix
 84 |     a = 4
 85 |     b = "{a:\x64}"  # RUF027
    |         ^^^^^^^^^^
-86 |
-87 | # Regression test for parser bug
+86 |     c = "{a:\n}"  # RUF027 - newline in format spec is valid via custom __format__
    |
 help: Add `f` prefix
 82 | 
@@ -337,23 +336,44 @@ help: Add `f` prefix
 84 |     a = 4
    -     b = "{a:\x64}"  # RUF027
 85 +     b = f"{a:\x64}"  # RUF027
-86 | 
-87 | # Regression test for parser bug
-88 | # https://github.com/astral-sh/ruff/issues/18860
+86 |     c = "{a:\n}"  # RUF027 - newline in format spec is valid via custom __format__
+87 | 
+88 | # Regression test for parser bug
 note: This is an unsafe fix and may change runtime behavior
 
 RUF027 [*] Possible f-string without an `f` prefix
-  --> RUF027_0.py:96:11
+  --> RUF027_0.py:86:9
    |
-94 | def backslash_test():
-95 |     x = "test"
-96 |     print("Hello {'\\n'}{x}")  # Should not trigger RUF027 for Python < 3.12
+84 |     a = 4
+85 |     b = "{a:\x64}"  # RUF027
+86 |     c = "{a:\n}"  # RUF027 - newline in format spec is valid via custom __format__
+   |         ^^^^^^^^
+87 |
+88 | # Regression test for parser bug
+   |
+help: Add `f` prefix
+83 | def escaped_format_spec():
+84 |     a = 4
+85 |     b = "{a:\x64}"  # RUF027
+   -     c = "{a:\n}"  # RUF027 - newline in format spec is valid via custom __format__
+86 +     c = f"{a:\n}"  # RUF027 - newline in format spec is valid via custom __format__
+87 | 
+88 | # Regression test for parser bug
+89 | # https://github.com/astral-sh/ruff/issues/18860
+note: This is an unsafe fix and may change runtime behavior
+
+RUF027 [*] Possible f-string without an `f` prefix
+  --> RUF027_0.py:97:11
+   |
+95 | def backslash_test():
+96 |     x = "test"
+97 |     print("Hello {'\\n'}{x}")  # Should not trigger RUF027 for Python < 3.12
    |           ^^^^^^^^^^^^^^^^^^
    |
 help: Add `f` prefix
-93 | # Should not trigger RUF027 for Python < 3.12 due to backslashes in interpolations
-94 | def backslash_test():
-95 |     x = "test"
+94 | # Should not trigger RUF027 for Python < 3.12 due to backslashes in interpolations
+95 | def backslash_test():
+96 |     x = "test"
    -     print("Hello {'\\n'}{x}")  # Should not trigger RUF027 for Python < 3.12
-96 +     print(f"Hello {'\\n'}{x}")  # Should not trigger RUF027 for Python < 3.12
+97 +     print(f"Hello {'\\n'}{x}")  # Should not trigger RUF027 for Python < 3.12
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF027_RUF027_1.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF027_RUF027_1.py.snap
@@ -1,4 +1,23 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
-
+RUF027 [*] Possible f-string without an `f` prefix
+  --> RUF027_1.py:23:12
+   |
+21 |     e = "incorrect syntax: {}"
+22 |     f = "uses a builtin: {max}"
+23 |     json = "{ positive: false }"
+   |            ^^^^^^^^^^^^^^^^^^^^^
+24 |     json2 = "{ 'positive': false }"
+25 |     json3 = "{ 'positive': 'false' }"
+   |
+help: Add `f` prefix
+20 |     d = "bad variable: {invalid}"
+21 |     e = "incorrect syntax: {}"
+22 |     f = "uses a builtin: {max}"
+   -     json = "{ positive: false }"
+23 +     json = f"{ positive: false }"
+24 |     json2 = "{ 'positive': false }"
+25 |     json3 = "{ 'positive': 'false' }"
+26 |     alternative_formatter("{a}", a=5)
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__missing_fstring_syntax_backslash_py311.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__missing_fstring_syntax_backslash_py311.snap
@@ -6,7 +6,7 @@ source: crates/ruff_linter/src/rules/ruff/mod.rs
 +linter.unresolved_target_version = 3.11
 
 --- Summary ---
-Removed: 3
+Removed: 4
 Added: 0
 
 --- Removed ---
@@ -40,8 +40,7 @@ RUF027 [*] Possible f-string without an `f` prefix
 84 |     a = 4
 85 |     b = "{a:\x64}"  # RUF027
    |         ^^^^^^^^^^
-86 |
-87 | # Regression test for parser bug
+86 |     c = "{a:\n}"  # RUF027 - newline in format spec is valid via custom __format__
    |
 help: Add `f` prefix
 82 | 
@@ -49,24 +48,46 @@ help: Add `f` prefix
 84 |     a = 4
    -     b = "{a:\x64}"  # RUF027
 85 +     b = f"{a:\x64}"  # RUF027
-86 | 
-87 | # Regression test for parser bug
-88 | # https://github.com/astral-sh/ruff/issues/18860
+86 |     c = "{a:\n}"  # RUF027 - newline in format spec is valid via custom __format__
+87 | 
+88 | # Regression test for parser bug
 note: This is an unsafe fix and may change runtime behavior
 
 
 RUF027 [*] Possible f-string without an `f` prefix
-  --> RUF027_0.py:96:11
+  --> RUF027_0.py:86:9
    |
-94 | def backslash_test():
-95 |     x = "test"
-96 |     print("Hello {'\\n'}{x}")  # Should not trigger RUF027 for Python < 3.12
+84 |     a = 4
+85 |     b = "{a:\x64}"  # RUF027
+86 |     c = "{a:\n}"  # RUF027 - newline in format spec is valid via custom __format__
+   |         ^^^^^^^^
+87 |
+88 | # Regression test for parser bug
+   |
+help: Add `f` prefix
+83 | def escaped_format_spec():
+84 |     a = 4
+85 |     b = "{a:\x64}"  # RUF027
+   -     c = "{a:\n}"  # RUF027 - newline in format spec is valid via custom __format__
+86 +     c = f"{a:\n}"  # RUF027 - newline in format spec is valid via custom __format__
+87 | 
+88 | # Regression test for parser bug
+89 | # https://github.com/astral-sh/ruff/issues/18860
+note: This is an unsafe fix and may change runtime behavior
+
+
+RUF027 [*] Possible f-string without an `f` prefix
+  --> RUF027_0.py:97:11
+   |
+95 | def backslash_test():
+96 |     x = "test"
+97 |     print("Hello {'\\n'}{x}")  # Should not trigger RUF027 for Python < 3.12
    |           ^^^^^^^^^^^^^^^^^^
    |
 help: Add `f` prefix
-93 | # Should not trigger RUF027 for Python < 3.12 due to backslashes in interpolations
-94 | def backslash_test():
-95 |     x = "test"
+94 | # Should not trigger RUF027 for Python < 3.12 due to backslashes in interpolations
+95 | def backslash_test():
+96 |     x = "test"
    -     print("Hello {'\\n'}{x}")  # Should not trigger RUF027 for Python < 3.12
-96 +     print(f"Hello {'\\n'}{x}")  # Should not trigger RUF027 for Python < 3.12
+97 +     print(f"Hello {'\\n'}{x}")  # Should not trigger RUF027 for Python < 3.12
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Fixes #23360

RUF027 was extracting format specs as raw source text, so something like `"{a:\x64}"` would pass `\x64` to `FormatSpec::parse` instead of the decoded `d`. This meant it wouldn't recognize the string as a valid f-string candidate.

The parser already decodes escape sequences in the AST literal elements, so I switched to using those instead of slicing the source directly.

Added a test case covering this.