### PR TITLE
[ty] add reviewbot config

### DIFF
--- a/.github/pr-assignee-pools.toml
+++ b/.github/pr-assignee-pools.toml
@@ -1,5 +1,3 @@
-state_variable = "PR_ASSIGNEE_ROUND_ROBIN_STATE"
-
 [[pools]]
 name = "ty-semantic"
 paths = ["/crates/ty_python_semantic/**"]


### PR DESCRIPTION
## Summary

Adds reviewer pools config for reviewer assignment bot. Implementation lives in astral-bot.

## Test Plan

...no good way to test other than merge and try it, if the config looks good.
