### PR TITLE
[ty] filter out pre-loop bindings from loop headers

### DIFF
--- a/crates/ty_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/ty_python_semantic/src/semantic_index/use_def.rs
@@ -990,6 +990,10 @@ impl<'db> UseDefMapBuilder<'db> {
         }
     }
 
+    pub(super) fn next_definition_id(&self) -> ScopedDefinitionId {
+        self.all_definitions.next_index()
+    }
+
     pub(super) fn record_binding(
         &mut self,
         place: ScopedPlaceId,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5218,11 +5218,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     /// Infer the type for a loop header definition.
     ///
-    /// The loop header sees all bindings that loop-back, either by reaching the end of the loop
-    /// body or a `continue` statement. This can include bindings from before the loop too, though
-    /// that's technically redundant, since the loop header definition itself doesn't shadow those
-    /// bindings. See `struct LoopHeader` in the semantic index for more on how all this fits
-    /// together.
+    /// The loop header sees all the bindings that originate in the loop and are visible at a
+    /// loop-back edge (either the end of the loop body or a `continue` statement). See `struct
+    /// LoopHeader` in the semantic index for more on how all this fits together.
     fn infer_loop_header_definition(
         &mut self,
         loop_header_kind: &LoopHeaderDefinitionKind<'db>,


### PR DESCRIPTION
Reading through @mtshiba's https://github.com/astral-sh/ruff/pull/23520 (specifically [`if def != definition` here](https://github.com/astral-sh/ruff/pull/23520/changes#diff-2724ea88306946c952ab0c866665ab64cbe37a15fe8430fa3e2bd9195acf04ddR1212)) made it clear that the way I included pre-loop bindings in loop headers in https://github.com/astral-sh/ruff/pull/22794 is kind of gross. Apart from being fully redundant (loop headers don't shadow pre-existing bindings), it also means that loop headers tracks _themselves_, which presumably creates pointless cycles that need to be resolved. Since definition IDs are issued in source code order, it's relatively easy to filter out all the definitions that existed before the loop began, including the loop headers. Anecdotally this seems to give a ~10% speedup in `isort`, which is the repo that motivated https://github.com/astral-sh/ruff/pull/23520. I'll be curious to see if the ecosystem report shows changed diagnostics, but I'm not sure it will.

Before landing this:
- [x] Rebase on top of https://github.com/astral-sh/ruff/pull/23520 and remove [redundant checks here](https://github.com/astral-sh/ruff/pull/23520#discussion_r2845011453).