### PR TITLE
[`pyupgrade`] Fix false positive for `TypeVar` default before 3.12 (`UP046`)

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_class.rs
@@ -159,7 +159,7 @@ pub(crate) fn non_pep695_generic_class(checker: &Checker, class_def: &StmtClassD
     //
     // because `find_generic` also finds the *first* Generic argument, this has the additional
     // benefit of bailing out with a diagnostic if multiple Generic arguments are present
-    if generic_idx != arguments.len() - 1 {
+    if generic_idx != arguments.args.len() - 1 {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP046_2.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP046_2.py.snap
@@ -1,11 +1,4 @@
 ---
 source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
 ---
-UP046 Generic class `KeywordArguments` uses `Generic` subclass instead of type parameters
-  --> UP046_2.py:16:24
-   |
-16 | class KeywordArguments(Generic[T], metaclass=type):
-   |                        ^^^^^^^^^^
-17 |     var: T
-   |
-help: Use type parameters
+


### PR DESCRIPTION
## Summary

This was reported on [Discord](https://discord.com/channels/1039017663004942429/1070132471699607623/1475883727782674585):

```py
import abc
import typing
from typing import Generic

import typing_extensions

_Caps = typing_extensions.TypeVar("_Caps", bound=int | str, contravariant=True, default=int | str)


class CameraConnection(typing.Generic[_Caps]):  # okay
    pass


class Camera(Generic[_Caps], metaclass=abc.ABCMeta):  # UP046 false positive
    pass
```

In short, `UP046` was suggesting to use PEP-695 type parameters in the second class on Python versions before 3.13 despite `_Caps` using a `default`, which is only supported in PEP-695 type parameters on 3.13 and later.

The fix looks unrelated at first glance, but this early return was preventing the diagnostic from being defused later for having a `default`.

## Test Plan

New test derived from the report
