### PR TITLE
[ty] fix equality and contains narrowing with PEP 695 type aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -168,6 +168,25 @@ def _(flag1: bool, flag2: bool):
         reveal_type(x)  # revealed: Literal[2]
 ```
 
+## `==` with PEP 695 alias to a union of literals
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Literal
+
+type Y = Literal[2, 3]
+
+def _(x: Literal[1, 2], y: Y):
+    if x == y:
+        reveal_type(x)  # revealed: Literal[2]
+    else:
+        reveal_type(x)  # revealed: Literal[1, 2]
+```
+
 ## `!=` for non-single-valued types
 
 Only single-valued types should narrow the type:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -42,6 +42,61 @@ def _(x: Literal["a", "b", "c", 1]):
         reveal_type(x)  # revealed: Literal[1]
 ```
 
+## `in` for PEP 695 aliases
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Literal, assert_never
+
+type Foo = Literal["a", "b", "c", "d"]
+
+def _(x: Foo):
+    if x in ("a", "b"):
+        reveal_type(x)  # revealed: Literal["a", "b"]
+    else:
+        reveal_type(x)  # revealed: Literal["c", "d"]
+
+def _(x: Foo) -> str:
+    if x in ("a", "b"):
+        return "AB"
+    match x:
+        case "c":
+            return "C"
+        case "d":
+            return "D"
+        case _ as never:
+            assert_never(never)
+```
+
+## `in` for mixed PEP 695 aliases
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Literal
+
+type Foo = Literal["a", "b", "c"] | int
+
+def _(x: Foo):
+    if x in ("a", "b"):
+        reveal_type(x)  # revealed: Literal["a", "b"] | int
+    else:
+        reveal_type(x)  # revealed: Literal["c"] | int
+
+def _(x: Foo):
+    if x not in ("a", "c"):
+        reveal_type(x)  # revealed: Literal["b"] | int
+    else:
+        reveal_type(x)  # revealed: Literal["a", "c"] | int
+```
+
 ## `in` for `str` and literal strings
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1542,29 +1542,31 @@ impl<'db> Type<'db> {
     }
 
     pub(crate) fn is_union_of_single_valued(&self, db: &'db dyn Db) -> bool {
-        self.as_union().is_some_and(|union| {
+        let ty = self.resolve_type_alias(db);
+        ty.as_union().is_some_and(|union| {
             union.elements(db).iter().all(|ty| {
                 ty.is_single_valued(db)
                     || ty.is_bool(db)
                     || ty.is_literal_string()
                     || (ty.is_enum(db) && !ty.overrides_equality(db))
             })
-        }) || self.is_bool(db)
-            || self.is_literal_string()
-            || (self.is_enum(db) && !self.overrides_equality(db))
+        }) || ty.is_bool(db)
+            || ty.is_literal_string()
+            || (ty.is_enum(db) && !ty.overrides_equality(db))
     }
 
     pub(crate) fn is_union_with_single_valued(&self, db: &'db dyn Db) -> bool {
-        self.as_union().is_some_and(|union| {
+        let ty = self.resolve_type_alias(db);
+        ty.as_union().is_some_and(|union| {
             union.elements(db).iter().any(|ty| {
                 ty.is_single_valued(db)
                     || ty.is_bool(db)
                     || ty.is_literal_string()
                     || (ty.is_enum(db) && !ty.overrides_equality(db))
             })
-        }) || self.is_bool(db)
-            || self.is_literal_string()
-            || (self.is_enum(db) && !self.overrides_equality(db))
+        }) || ty.is_bool(db)
+            || ty.is_literal_string()
+            || (ty.is_enum(db) && !ty.overrides_equality(db))
     }
 
     /// Create a promotable string literal.

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -763,6 +763,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     }
 
     fn evaluate_expr_eq(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
+        let rhs_ty = rhs_ty.resolve_type_alias(self.db);
+
         // We can only narrow on equality checks against single-valued types.
         if rhs_ty.is_single_valued(self.db) || rhs_ty.is_union_of_single_valued(self.db) {
             // The fully-general (and more efficient) approach here would be to introduce a
@@ -873,6 +875,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     // TODO `expr_in` and `expr_not_in` should perhaps be unified with `expr_eq` and `expr_ne`,
     // since `eq` and `ne` are equivalent to `in` and `not in` with only one element in the RHS.
     fn evaluate_expr_in(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
+        let lhs_ty = lhs_ty.resolve_type_alias(self.db);
+
         if lhs_ty.is_single_valued(self.db) || lhs_ty.is_union_of_single_valued(self.db) {
             rhs_ty
                 .try_iterate(self.db)
@@ -916,6 +920,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     }
 
     fn evaluate_expr_not_in(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
+        let lhs_ty = lhs_ty.resolve_type_alias(self.db);
+
         let rhs_values = rhs_ty
             .try_iterate(self.db)
             .ok()?


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/2903.

We didn't resolve PEP 695 type aliases before deciding if its a narrowable type for `in` or equality narrowing.

## Test Plan

Added mdtests.
