### PR TITLE
[ty] improve constant folding in semantic index building

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/binary/integers.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/integers.md
@@ -1,5 +1,11 @@
 # Binary operations on integers
 
+> Developer's note: This is mainly a test for the behavior of the type inferer. The constant
+> evaluator (`resolve_to_literal`) of `SemanticIndexBuilder` is implemented separately from the type
+> inferer, so if you modify the contents of this file or the type inferer, please also modify the
+> implementation of `resolve_to_literal` and the unit tests (semantic_index/tests/const_eval\_\*) at
+> the same time.
+
 ## Basic Arithmetic
 
 ```py


### PR DESCRIPTION
## Summary

From #23201

This PR expands the kinds of expressions that `SemanticIndexBuilder::build_predicate` can constant fold.
This partially copies the implementation in `TypeInferenceBuilder`. I think it would be difficult to integrate the two and put the constant folding implementation in one place without a major overhaul of the current project structure.
Instead, I have commented in various places that the constant folding implementations of `SemanticIndexBuilder` and `TypeInferenceBuilder` are linked and should be improved and fixed simultaneously.

## Test Plan

New unit tests in `semantic_index.rs`
