### PR TITLE
[ty] Add micro benchmarks to review-bot pool

### DIFF
--- a/.github/pr-assignee-pools.toml
+++ b/.github/pr-assignee-pools.toml
@@ -16,6 +16,7 @@ paths = [
   "/crates/ty_project/**",
   "/crates/ty/**",
   "/crates/ty_benchmark/**",
+  "/crates/ruff_benchmark/benches/ty*",
 ]
 reviewers = ["carljm", "MichaReiser", "BurntSushi"]
 


### PR DESCRIPTION
## Summary

… so that we get auto-assigned reviewers on PRs like https://github.com/astral-sh/ruff/pull/23546

