### PR TITLE
Cache the union of two types as a tracked function

### DIFF
--- a/crates/ty_python_semantic/src/semantic_index/reachability_constraints.rs
+++ b/crates/ty_python_semantic/src/semantic_index/reachability_constraints.rs
@@ -940,7 +940,7 @@ impl ReachabilityConstraints {
                     false_accumulated,
                 );
 
-                UnionType::from_elements(db, [true_ty, false_ty])
+                UnionType::from_two_elements(db, true_ty, false_ty)
             }
         }
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2902,7 +2902,7 @@ impl<'db> Type<'db> {
                     if descr_get_boundness == Definedness::AlwaysDefined {
                         bindings.return_type(db)
                     } else {
-                        UnionType::from_elements(db, [bindings.return_type(db), self])
+                        UnionType::from_two_elements(db, bindings.return_type(db), self)
                     }
                 })
                 // TODO: an error when calling `__get__` will lead to a `TypeError` or similar at runtime;
@@ -3161,7 +3161,7 @@ impl<'db> Type<'db> {
                     widening: fallback_widening,
                 }),
             ) => Place::Defined(DefinedPlace {
-                ty: UnionType::from_elements(db, [meta_attr_ty, fallback_ty]),
+                ty: UnionType::from_two_elements(db, meta_attr_ty, fallback_ty),
                 origin: meta_origin.merge(fallback_origin),
                 definedness: fallback_boundness,
                 widening: fallback_widening,
@@ -3205,7 +3205,7 @@ impl<'db> Type<'db> {
                     widening: fallback_widening,
                 }),
             ) => Place::Defined(DefinedPlace {
-                ty: UnionType::from_elements(db, [meta_attr_ty, fallback_ty]),
+                ty: UnionType::from_two_elements(db, meta_attr_ty, fallback_ty),
                 origin: meta_origin.merge(fallback_origin),
                 definedness: meta_attr_boundness.max(fallback_boundness),
                 widening: fallback_widening,
@@ -4541,12 +4541,10 @@ impl<'db> Type<'db> {
                                             "object",
                                         ))
                                         // TODO: Should be `ReadableBuffer` instead of this union type:
-                                        .with_annotated_type(UnionType::from_elements(
+                                        .with_annotated_type(UnionType::from_two_elements(
                                             db,
-                                            [
-                                                KnownClass::Bytes.to_instance(db),
-                                                KnownClass::Bytearray.to_instance(db),
-                                            ],
+                                            KnownClass::Bytes.to_instance(db),
+                                            KnownClass::Bytearray.to_instance(db),
                                         ))
                                         .with_default_type(Type::bytes_literal(db, b"")),
                                         Parameter::positional_or_keyword(Name::new_static(
@@ -4648,13 +4646,11 @@ impl<'db> Type<'db> {
                                     Parameter::positional_only(Some(Name::new_static("message")))
                                         .with_annotated_type(Type::literal_string()),
                                     Parameter::keyword_only(Name::new_static("category"))
-                                        .with_annotated_type(UnionType::from_elements(
+                                        .with_annotated_type(UnionType::from_two_elements(
                                             db,
-                                            [
-                                                // TODO: should be `type[Warning]`
-                                                Type::any(),
-                                                KnownClass::NoneType.to_instance(db),
-                                            ],
+                                            // TODO: should be `type[Warning]`
+                                            Type::any(),
+                                            KnownClass::NoneType.to_instance(db),
                                         ))
                                         // TODO: should be `type[Warning]`
                                         .with_default_type(Type::any()),
@@ -4748,36 +4744,31 @@ impl<'db> Type<'db> {
                                 db,
                                 [
                                     Parameter::positional_or_keyword(Name::new_static("fget"))
-                                        .with_annotated_type(UnionType::from_elements(
+                                        .with_annotated_type(UnionType::from_two_elements(
                                             db,
-                                            [
-                                                Type::single_callable(db, getter_signature),
-                                                Type::none(db),
-                                            ],
+                                            Type::single_callable(db, getter_signature),
+                                            Type::none(db),
                                         ))
                                         .with_default_type(Type::none(db)),
                                     Parameter::positional_or_keyword(Name::new_static("fset"))
-                                        .with_annotated_type(UnionType::from_elements(
+                                        .with_annotated_type(UnionType::from_two_elements(
                                             db,
-                                            [
-                                                Type::single_callable(db, setter_signature),
-                                                Type::none(db),
-                                            ],
+                                            Type::single_callable(db, setter_signature),
+                                            Type::none(db),
                                         ))
                                         .with_default_type(Type::none(db)),
                                     Parameter::positional_or_keyword(Name::new_static("fdel"))
-                                        .with_annotated_type(UnionType::from_elements(
+                                        .with_annotated_type(UnionType::from_two_elements(
                                             db,
-                                            [
-                                                Type::single_callable(db, deleter_signature),
-                                                Type::none(db),
-                                            ],
+                                            Type::single_callable(db, deleter_signature),
+                                            Type::none(db),
                                         ))
                                         .with_default_type(Type::none(db)),
                                     Parameter::positional_or_keyword(Name::new_static("doc"))
-                                        .with_annotated_type(UnionType::from_elements(
+                                        .with_annotated_type(UnionType::from_two_elements(
                                             db,
-                                            [KnownClass::Str.to_instance(db), Type::none(db)],
+                                            KnownClass::Str.to_instance(db),
+                                            Type::none(db),
                                         ))
                                         .with_default_type(Type::none(db)),
                                 ],
@@ -5657,9 +5648,10 @@ impl<'db> Type<'db> {
                                 // and the type returned by the `__getitem__` method.
                                 //
                                 // No diagnostic is emitted; iteration will always succeed!
-                                Cow::Owned(TupleSpec::homogeneous(UnionType::from_elements(
+                                Cow::Owned(TupleSpec::homogeneous(UnionType::from_two_elements(
                                     db,
-                                    [dunder_next_return, dunder_getitem_return_type],
+                                    dunder_next_return,
+                                    dunder_getitem_return_type,
                                 )))
                             })
                             .map_err(|dunder_getitem_error| {
@@ -9978,9 +9970,10 @@ impl<'db> IterationError<'db> {
             } => match dunder_getitem_error {
                 CallDunderError::MethodNotAvailable => Some(*dunder_next_return),
                 CallDunderError::PossiblyUnbound(dunder_getitem_outcome) => {
-                    Some(UnionType::from_elements(
+                    Some(UnionType::from_two_elements(
                         db,
-                        [*dunder_next_return, dunder_getitem_outcome.return_type(db)],
+                        *dunder_next_return,
+                        dunder_getitem_outcome.return_type(db),
                     ))
                 }
                 CallDunderError::CallError(CallErrorKind::NotCallable, _) => {
@@ -9988,8 +9981,11 @@ impl<'db> IterationError<'db> {
                 }
                 CallDunderError::CallError(_, dunder_getitem_bindings) => {
                     let dunder_getitem_return = dunder_getitem_bindings.return_type(db);
-                    let elements = [*dunder_next_return, dunder_getitem_return];
-                    Some(UnionType::from_elements(db, elements))
+                    Some(UnionType::from_two_elements(
+                        db,
+                        *dunder_next_return,
+                        dunder_getitem_return,
+                    ))
                 }
             },
 
@@ -11434,9 +11430,10 @@ impl<'db> KnownBoundMethodType<'db> {
                                 Parameter::positional_only(Some(Name::new_static("instance")))
                                     .with_annotated_type(Type::object()),
                                 Parameter::positional_only(Some(Name::new_static("owner")))
-                                    .with_annotated_type(UnionType::from_elements(
+                                    .with_annotated_type(UnionType::from_two_elements(
                                         db,
-                                        [KnownClass::Type.to_instance(db), Type::none(db)],
+                                        KnownClass::Type.to_instance(db),
+                                        Type::none(db),
                                     ))
                                     .with_default_type(Type::none(db)),
                             ],
@@ -11469,26 +11466,23 @@ impl<'db> KnownBoundMethodType<'db> {
                         db,
                         [
                             Parameter::positional_only(Some(Name::new_static("prefix")))
-                                .with_annotated_type(UnionType::from_elements(
+                                .with_annotated_type(UnionType::from_two_elements(
                                     db,
-                                    [
-                                        KnownClass::Str.to_instance(db),
-                                        Type::homogeneous_tuple(
-                                            db,
-                                            KnownClass::Str.to_instance(db),
-                                        ),
-                                    ],
+                                    KnownClass::Str.to_instance(db),
+                                    Type::homogeneous_tuple(db, KnownClass::Str.to_instance(db)),
                                 )),
                             Parameter::positional_only(Some(Name::new_static("start")))
-                                .with_annotated_type(UnionType::from_elements(
+                                .with_annotated_type(UnionType::from_two_elements(
                                     db,
-                                    [KnownClass::SupportsIndex.to_instance(db), Type::none(db)],
+                                    KnownClass::SupportsIndex.to_instance(db),
+                                    Type::none(db),
                                 ))
                                 .with_default_type(Type::none(db)),
                             Parameter::positional_only(Some(Name::new_static("end")))
-                                .with_annotated_type(UnionType::from_elements(
+                                .with_annotated_type(UnionType::from_two_elements(
                                     db,
-                                    [KnownClass::SupportsIndex.to_instance(db), Type::none(db)],
+                                    KnownClass::SupportsIndex.to_instance(db),
+                                    Type::none(db),
                                 ))
                                 .with_default_type(Type::none(db)),
                         ],
@@ -11559,9 +11553,10 @@ impl<'db> KnownBoundMethodType<'db> {
                         db,
                         [Parameter::keyword_only(Name::new_static("inferable"))
                             .type_form()
-                            .with_annotated_type(UnionType::from_elements(
+                            .with_annotated_type(UnionType::from_two_elements(
                                 db,
-                                [Type::homogeneous_tuple(db, Type::any()), Type::none(db)],
+                                Type::homogeneous_tuple(db, Type::any()),
+                                Type::none(db),
                             ))
                             .with_default_type(Type::none(db))],
                     ),
@@ -11578,9 +11573,10 @@ impl<'db> KnownBoundMethodType<'db> {
                                 .with_annotated_type(KnownClass::ConstraintSet.to_instance(db)),
                         ],
                     ),
-                    UnionType::from_elements(
+                    UnionType::from_two_elements(
                         db,
-                        [KnownClass::Specialization.to_instance(db), Type::none(db)],
+                        KnownClass::Specialization.to_instance(db),
+                        Type::none(db),
                     ),
                 )))
             }
@@ -11639,9 +11635,10 @@ impl WrapperDescriptorKind {
                             Parameter::positional_only(Some(Name::new_static("instance")))
                                 .with_annotated_type(Type::object()),
                             Parameter::positional_only(Some(Name::new_static("owner")))
-                                .with_annotated_type(UnionType::from_elements(
+                                .with_annotated_type(UnionType::from_two_elements(
                                     db,
-                                    [type_instance, none],
+                                    type_instance,
+                                    none,
                                 ))
                                 .with_default_type(none),
                         ],
@@ -12206,9 +12203,13 @@ pub(crate) fn walk_union<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for UnionType<'_> {}
 
+#[salsa::tracked]
 impl<'db> UnionType<'db> {
     /// Create a union from a list of elements
     /// (which may be eagerly simplified into a different variant of [`Type`] altogether).
+    ///
+    /// For performance reasons, consider using [`UnionType::from_two_elements`] if
+    /// the union is constructed from exactly two elements.
     pub fn from_elements<I, T>(db: &'db dyn Db, elements: I) -> Type<'db>
     where
         I: IntoIterator<Item = T>,
@@ -12220,6 +12221,18 @@ impl<'db> UnionType<'db> {
                 builder.add(element.into())
             })
             .build()
+    }
+
+    /// Create a union type `A | B` from two elements `A` and `B`.
+    #[salsa::tracked(
+        cycle_initial=|_, id, _, _| Type::divergent(id),
+        cycle_fn=|db, cycle, previous: &Type<'db>, result: Type<'db>, _, _| {
+            result.cycle_normalized(db, *previous, cycle)
+        },
+        heap_size=ruff_memory_usage::heap_size
+    )]
+    pub fn from_two_elements(db: &'db dyn Db, a: Type<'db>, b: Type<'db>) -> Type<'db> {
+        UnionBuilder::new(db).add(a).add(b).build()
     }
 
     /// Create a union from a list of elements without unpacking type aliases.
@@ -12571,12 +12584,10 @@ pub(crate) enum KnownUnion {
 impl KnownUnion {
     pub(crate) fn to_type(self, db: &dyn Db) -> Type<'_> {
         match self {
-            KnownUnion::Float => UnionType::from_elements(
+            KnownUnion::Float => UnionType::from_two_elements(
                 db,
-                [
-                    KnownClass::Int.to_instance(db),
-                    KnownClass::Float.to_instance(db),
-                ],
+                KnownClass::Int.to_instance(db),
+                KnownClass::Float.to_instance(db),
             ),
             KnownUnion::Complex => UnionType::from_elements(
                 db,

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1415,7 +1415,7 @@ impl<'db> Bindings<'db> {
                             };
 
                             let union_with_default =
-                                |ty| UnionType::from_elements(db, [ty, default]);
+                                |ty| UnionType::from_two_elements(db, ty, default);
 
                             // TODO: we could emit a diagnostic here (if default is not set)
                             overload.set_return_type(
@@ -3802,7 +3802,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         if let Some(existing) = self.parameter_tys[parameter_index].replace(argument_type) {
             // We already verified in `match_parameters` that we only match multiple arguments
             // with variadic parameters.
-            let union = UnionType::from_elements(self.db, [existing, argument_type]);
+            let union = UnionType::from_two_elements(self.db, existing, argument_type);
             self.parameter_tys[parameter_index] = Some(union);
         }
     }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -3225,7 +3225,7 @@ impl<'db> StaticClassLiteral<'db> {
                         //     def __gt__(self, other): return not (self == other or self < other)
                         // If `__lt__` returns `int`, then `__gt__` could return `int | bool`.
                         let return_ty =
-                            UnionType::from_elements(db, [signature.return_ty, bool_ty]);
+                            UnionType::from_two_elements(db, signature.return_ty, bool_ty);
                         Signature::new_generic(
                             signature.generic_context,
                             signature.parameters().clone(),
@@ -3502,7 +3502,11 @@ impl<'db> StaticClassLiteral<'db> {
 
                 // This could probably be `weakref | None`, but it does not seem important enough to
                 // model it precisely.
-                Some(UnionType::from_elements(db, [Type::any(), Type::none(db)]))
+                Some(UnionType::from_two_elements(
+                    db,
+                    Type::any(),
+                    Type::none(db),
+                ))
             }
             (CodeGeneratorKind::NamedTuple, name) if name != "__init__" => {
                 KnownClass::NamedTupleFallback
@@ -3736,7 +3740,7 @@ impl<'db> StaticClassLiteral<'db> {
                             if field.is_required() {
                                 field.declared_ty
                             } else {
-                                UnionType::from_elements(db, [field.declared_ty, Type::none(db)])
+                                UnionType::from_two_elements(db, field.declared_ty, Type::none(db))
                             },
                         );
 
@@ -3762,9 +3766,10 @@ impl<'db> StaticClassLiteral<'db> {
                             if field.is_required() {
                                 field.declared_ty
                             } else {
-                                UnionType::from_elements(
+                                UnionType::from_two_elements(
                                     db,
-                                    [field.declared_ty, Type::TypeVar(t_default)],
+                                    field.declared_ty,
+                                    Type::TypeVar(t_default),
                                 )
                             },
                         );
@@ -3783,7 +3788,7 @@ impl<'db> StaticClassLiteral<'db> {
                                         .with_annotated_type(KnownClass::Str.to_instance(db)),
                                 ],
                             ),
-                            UnionType::from_elements(db, [Type::unknown(), Type::none(db)]),
+                            UnionType::from_two_elements(db, Type::unknown(), Type::none(db)),
                         )
                     }))
                     .chain(std::iter::once({
@@ -3806,9 +3811,10 @@ impl<'db> StaticClassLiteral<'db> {
                                         .with_annotated_type(Type::TypeVar(t_default)),
                                 ],
                             ),
-                            UnionType::from_elements(
+                            UnionType::from_two_elements(
                                 db,
-                                [Type::unknown(), Type::TypeVar(t_default)],
+                                Type::unknown(),
+                                Type::TypeVar(t_default),
                             ),
                         )
                     }));
@@ -3866,9 +3872,10 @@ impl<'db> StaticClassLiteral<'db> {
                                         .with_annotated_type(Type::TypeVar(t_default)),
                                 ],
                             ),
-                            UnionType::from_elements(
+                            UnionType::from_two_elements(
                                 db,
-                                [field.declared_ty, Type::TypeVar(t_default)],
+                                field.declared_ty,
+                                Type::TypeVar(t_default),
                             ),
                         );
 
@@ -4704,9 +4711,10 @@ impl<'db> StaticClassLiteral<'db> {
                             } else {
                                 Member {
                                     inner: Place::Defined(DefinedPlace {
-                                        ty: UnionType::from_elements(
+                                        ty: UnionType::from_two_elements(
                                             db,
-                                            [declared_ty, implicit_ty],
+                                            declared_ty,
+                                            implicit_ty,
                                         ),
                                         origin: TypeOrigin::Declared,
                                         definedness: declaredness,
@@ -4766,9 +4774,10 @@ impl<'db> StaticClassLiteral<'db> {
                             {
                                 Member {
                                     inner: Place::Defined(DefinedPlace {
-                                        ty: UnionType::from_elements(
+                                        ty: UnionType::from_two_elements(
                                             db,
-                                            [declared_ty, implicit_ty],
+                                            declared_ty,
+                                            implicit_ty,
                                         ),
                                         origin: TypeOrigin::Declared,
                                         definedness: declaredness,

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -787,7 +787,7 @@ impl<'db> ConstrainedTypeVar<'db> {
         }
 
         // (s₁ ≤ α ≤ t₁) ∧ (s₂ ≤ α ≤ t₂) = (s₁ ∪ s₂) ≤ α ≤ (t₁ ∩ t₂))
-        let lower = UnionType::from_elements(db, [self.lower(db), other.lower(db)]);
+        let lower = UnionType::from_two_elements(db, self.lower(db), other.lower(db));
         let upper = IntersectionType::from_two_elements(db, self_upper, other_upper);
 
         // If `lower ≰ upper`, then the intersection is empty, since there is no type that is both

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1460,12 +1460,10 @@ pub(super) fn function_body_kind<'db>(
         } = raise
         && infer_type(exc).is_subtype_of(
             db,
-            UnionType::from_elements(
+            UnionType::from_two_elements(
                 db,
-                [
-                    KnownClass::NotImplementedError.to_class_literal(db),
-                    KnownClass::NotImplementedError.to_instance(db),
-                ],
+                KnownClass::NotImplementedError.to_class_literal(db),
+                KnownClass::NotImplementedError.to_instance(db),
             ),
         )
     {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1373,7 +1373,7 @@ impl<'db> Specialization<'db> {
             .zip(other.types(db))
             .map(|(self_type, other_type)| match (self_type, other_type) {
                 (unknown, known) | (known, unknown) if unknown.is_unknown() => *known,
-                _ => UnionType::from_elements(db, [self_type, other_type]),
+                _ => UnionType::from_two_elements(db, *self_type, *other_type),
             })
             .collect();
         // TODO: Combine the tuple specs too
@@ -1869,7 +1869,7 @@ impl<'db> SpecializationBuilder<'db> {
                     return;
                 }
 
-                *entry.get_mut() = UnionType::from_elements(self.db, [*entry.get(), ty]);
+                *entry.get_mut() = UnionType::from_two_elements(self.db, *entry.get(), ty);
             }
             Entry::Vacant(entry) => {
                 entry.insert(ty);

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -442,7 +442,7 @@ fn merge_constraints_or<'db>(
                     into_constraint.intersection_disjunct,
                     from_constraint.intersection_disjunct,
                 ) {
-                    (Some(a), Some(b)) => Some(UnionType::from_elements(db, [a, b])),
+                    (Some(a), Some(b)) => Some(UnionType::from_two_elements(db, a, b)),
                     (Some(a), None) => Some(a),
                     (None, Some(b)) => Some(b),
                     (None, None) => None,
@@ -864,7 +864,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 }
             }
             (_, Some(LiteralValueTypeKind::Bool(b))) => Some(
-                UnionType::from_elements(self.db, [rhs_ty, Type::int_literal(i64::from(b))])
+                UnionType::from_two_elements(self.db, rhs_ty, Type::int_literal(i64::from(b)))
                     .negate(self.db),
             ),
             _ if rhs_ty.is_single_valued(self.db) => Some(rhs_ty.negate(self.db)),
@@ -963,7 +963,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 .build();
 
             // Keep order: first literal complement, then broader arms.
-            let result = UnionType::from_elements(self.db, [narrowed_single, rest_union]);
+            let result = UnionType::from_two_elements(self.db, narrowed_single, rest_union);
             Some(result)
         } else {
             None


### PR DESCRIPTION
The same as https://github.com/astral-sh/ruff/pull/23547, but for unions rather than intersections. Similar to #23547, this appears to bring across-the-board performance improvements without significant memory-usage increases.