### PR TITLE
Temporarily remove AlexWaygood from reviewbot config

### DIFF
--- a/.github/pr-assignee-pools.toml
+++ b/.github/pr-assignee-pools.toml
@@ -1,12 +1,12 @@
 [[pools]]
 name = "ty-semantic"
 paths = ["/crates/ty_python_semantic/**"]
-reviewers = ["carljm", "AlexWaygood", "sharkdp", "dcreager", "ibraheemdev", "oconnor663"]
+reviewers = ["carljm", "sharkdp", "dcreager", "ibraheemdev", "oconnor663"]
 
 [[pools]]
 name = "ty-module-resolver"
 paths = ["/crates/ty_module_resolver/**", "/crates/ty_site_packages/**"]
-reviewers = ["carljm", "AlexWaygood", "MichaReiser", "BurntSushi"]
+reviewers = ["carljm", "MichaReiser", "BurntSushi"]
 
 [[pools]]
 name = "ty-infra"
@@ -28,7 +28,7 @@ reviewers = ["MichaReiser", "BurntSushi"]
 [[pools]]
 name = "ty-ide"
 paths = ["/crates/ty_ide/**"]
-reviewers = ["MichaReiser", "AlexWaygood", "BurntSushi", "dhruvmanila"]
+reviewers = ["MichaReiser", "BurntSushi", "dhruvmanila"]
 
 [[pools]]
 name = "ty-server"


### PR DESCRIPTION
I'm already assigned to 12 PRs on the Ruff repo, which is too many :-)

For now, I'm trying to work down my existing review queue -- but *right* now I'm also trying to spend slightly less time on reviewing at the moment, and slightly more time finishing off the many half-finished patches I have lying around.

For all these reasons, I'd prefer not to have any more PRs auto-assigned to me for review *right* now.

To be clear here, I'll continue to review ty PRs, and I'm still very happy to have PRs manually assigned to me by humans if they want my feedback specifically. And I do definitely want to be part of the round-robin assignment in the medium/long term. But until my existing review queue is worked down a bit, it doesn't feel practical or useful to automatically add anything more to it.