### PR TITLE
docs: fix incorrect import-heading example

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2530,14 +2530,13 @@ pub struct IsortOptions {
     #[option(
         default = r#"{}"#,
         value_type = r#"dict["future" | "standard-library" | "third-party" | "first-party" | "local-folder" | str, str]"#,
+        scope = "import-heading",
         example = r#"
-            import-heading = {
-                future = "Future imports",
-                standard-library = "Standard library imports",
-                third-party = "Third party imports",
-                first-party = "First party imports",
-                local-folder = "Local folder imports",
-            }
+            future = "Future imports"
+            standard-library = "Standard library imports"
+            third-party = "Third party imports"
+            first-party = "First party imports"
+            local-folder = "Local folder imports"
         "#
     )]
     pub import_heading: Option<FxHashMap<ImportSection, String>>,


### PR DESCRIPTION
Fixes incorrect TOML example for import-heading configuration.

Closes #23420