### PR TITLE
[ty] Support place narrowing for dictionaries contained within list/tuple literals

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
@@ -138,7 +138,11 @@ x11: dict[str, tuple[dict[str, int | str], ...]] = {"a": ({"a": 1, "b": "2"}, {"
 reveal_type(x11["a"][0]["a"])  # revealed: Literal[1]
 reveal_type(x11["a"][1]["b"])  # revealed: Literal["4"]
 
-x12 = [({"a": 1, "b": "2"}, {"a": 3, "b": "4"})]
-reveal_type(x10[0][0]["a"])  # revealed: Literal[1]
-reveal_type(x10[0][1]["b"])  # revealed: Literal["4"]
+x12 = [({"a": 1, "b": "2"}, {"a": 3, "b": "4"}, *[{"a": 5}], {"a": 6})]
+reveal_type(x12[0][0]["a"])  # revealed: Literal[1]
+reveal_type(x12[0][1]["b"])  # revealed: Literal["4"]
+
+# Starred expressions and any elements that follow them are not narrowed.
+reveal_type(x12[0][2]["a"])  # revealed: int
+reveal_type(x12[0][3]["b"])  # revealed: int
 ```

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -822,7 +822,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             };
 
             // Traverse into nested collections that may contain dictionary literals.
-            for (i, item) in items.iter().enumerate() {
+            for (i, item) in items
+                .iter()
+                // Ignore starred expressions and any elements that follow them, as we cannot
+                // determine the index to narrow on.
+                .take_while(|e| !e.is_starred_expr())
+                .enumerate()
+            {
                 if let Some(target) = MemberExprBuilder::visit_subscript_expr(
                     target.clone(),
                     &ast::Expr::NumberLiteral(ast::ExprNumberLiteral {


### PR DESCRIPTION
Resolves https://github.com/astral-sh/ty/issues/2894 by traversing list (or tuple) literals that may contain nested dictionary literals.