### PR TITLE
Drop explicit support for `.qmd` file extension

### DIFF
--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -51,7 +51,7 @@ impl SourceType {
     pub fn from_extension(ext: &str) -> Self {
         match ext {
             "toml" => Self::Toml(TomlSourceType::Unrecognized),
-            "md" | "qmd" => Self::Markdown,
+            "md" => Self::Markdown,
             _ => Self::Python(PySourceType::from_extension(ext)),
         }
     }


### PR DESCRIPTION
Users can now map their preferred markdown extensions in configuration
via #23218 and #23384.

Issue #3792, #23204
