### PR TITLE
[ty] Fix false call-non-callable in unreachable deferred annotations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/unreachable.md
+++ b/crates/ty_python_semantic/resources/mdtest/unreachable.md
@@ -489,6 +489,23 @@ if sys.version_info >= (3, 11):
             return self
 ```
 
+For Python 3.14+, deferred annotation lookups in unreachable blocks should also stay
+unreachable-aware:
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+class NonCallable:
+    pass
+
+if False:
+    def _(non_callable: NonCallable):
+        non_callable()
+```
+
 ### Use of unreachable symbols in type annotations, or as class bases
 
 We should not show any diagnostics in type annotations inside unreachable sections.


### PR DESCRIPTION
## Summary

Previously, deferred name resolution (Python 3.14 annotations) used end-of-scope reachable bindings, which could pull in types that are not reachable at the annotation’s actual use site. This change keeps deferred lookup behavior for reachable code, but switches unreachable deferred expressions to use use-site bindings so dead-code suppression is preserved.

Closes https://github.com/astral-sh/ty/issues/2891.
