### PR TITLE
docs(settings): clarify pydocstyle convention selector behavior

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -3165,6 +3165,10 @@ pub struct PydocstyleOptions {
     /// the specified convention. As such, the intended workflow is to enable a
     /// convention and then selectively enable or disable any additional rules
     /// on top of it.
+    /// This applies even when rules are enabled via lint.select or
+    /// lint.extend-select using a prefix (for example, D or D4). Rules
+    /// excluded by the convention must be re-enabled explicitly via their
+    /// fully qualified code (for example, D400).
     ///
     /// For example, to use Google-style conventions but avoid requiring
     /// documentation for every function parameter:


### PR DESCRIPTION
References #15217.

This clarifies in the `lint.pydocstyle.convention` settings docs that convention filtering still applies when rules are enabled via `lint.select` / `lint.extend-select` prefixes (e.g. `D`, `D4`), and that excluded rules must be re-enabled via fully-qualified codes (e.g. `D400`).

I made a proposed change and opened this as a draft PR to keep review/process lightweight. Happy to close this if I should route it differently.