### PR TITLE
Increase the ruleset size to 16 bits

### DIFF
--- a/crates/ruff_linter/src/registry/rule_set.rs
+++ b/crates/ruff_linter/src/registry/rule_set.rs
@@ -5,7 +5,7 @@ use ruff_macros::CacheKey;
 
 use crate::registry::Rule;
 
-const RULESET_SIZE: usize = 15;
+const RULESET_SIZE: usize = 16;
 
 /// A set of [`Rule`]s.
 ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

There are currently 960 rules and no room for more. This raises the limit to 1024.

## Test Plan

Ran the `configuration::tests::select_two_char_prefix` test after adding one extra rule.
