### PR TITLE
Bump 0.15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.15.4
+
+Released on 2026-02-26.
+
+This is a follow-up release to 0.15.3 that resolves a panic when the new rule `PLR1712` was enabled with any rule that analyzes definitions, such as many of the `ANN` or `D` rules.
+
+### Bug fixes
+
+- Fix panic on access to definitions after analyzing definitions ([#23588](https://github.com/astral-sh/ruff/pull/23588))
+- \[`pyflakes`\] Suppress false positive in `F821` for names used before `del` in stub files ([#23550](https://github.com/astral-sh/ruff/pull/23550))
+
+### Documentation
+
+- Clarify first-party import detection in Ruff ([#23591](https://github.com/astral-sh/ruff/pull/23591))
+- Fix incorrect `import-heading` example ([#23568](https://github.com/astral-sh/ruff/pull/23568))
+
+### Contributors
+
+- [@stakeswky](https://github.com/stakeswky)
+- [@ntBre](https://github.com/ntBre)
+- [@thejcannon](https://github.com/thejcannon)
+- [@GeObts](https://github.com/GeObts)
+
 ## 0.15.3
 
 Released on 2026-02-26.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3026,7 +3026,7 @@ dependencies = [
 
 [[package]]
 name = "ruff"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "argfile",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_linter"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -3663,7 +3663,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_wasm"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ curl -LsSf https://astral.sh/ruff/install.sh | sh
 powershell -c "irm https://astral.sh/ruff/install.ps1 | iex"
 
 # For a specific version.
-curl -LsSf https://astral.sh/ruff/0.15.3/install.sh | sh
-powershell -c "irm https://astral.sh/ruff/0.15.3/install.ps1 | iex"
+curl -LsSf https://astral.sh/ruff/0.15.4/install.sh | sh
+powershell -c "irm https://astral.sh/ruff/0.15.4/install.ps1 | iex"
 ```
 
 You can also install Ruff via [Homebrew](https://formulae.brew.sh/formula/ruff), [Conda](https://anaconda.org/conda-forge/ruff),
@@ -186,7 +186,7 @@ Ruff can also be used as a [pre-commit](https://pre-commit.com/) hook via [`ruff
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.15.3
+  rev: v0.15.4
   hooks:
     # Run the linter.
     - id: ruff-check

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff"
-version = "0.15.3"
+version = "0.15.4"
 publish = true
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_linter"
-version = "0.15.3"
+version = "0.15.4"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_wasm/Cargo.toml
+++ b/crates/ruff_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_wasm"
-version = "0.15.3"
+version = "0.15.4"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -328,7 +328,7 @@ support needs to be explicitly included by adding it to `types_or`:
 ```yaml title=".pre-commit-config.yaml"
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.3
+    rev: v0.15.4
     hooks:
       - id: ruff-format
         types_or: [python, pyi, jupyter, markdown]

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -80,7 +80,7 @@ You can add the following configuration to `.gitlab-ci.yml` to run a `ruff forma
   stage: build
   interruptible: true
   image:
-    name: ghcr.io/astral-sh/ruff:0.15.3-alpine
+    name: ghcr.io/astral-sh/ruff:0.15.4-alpine
   before_script:
     - cd $CI_PROJECT_DIR
     - ruff --version
@@ -106,7 +106,7 @@ Ruff can be used as a [pre-commit](https://pre-commit.com) hook via [`ruff-pre-c
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.15.3
+  rev: v0.15.4
   hooks:
     # Run the linter.
     - id: ruff-check
@@ -119,7 +119,7 @@ To enable lint fixes, add the `--fix` argument to the lint hook:
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.15.3
+  rev: v0.15.4
   hooks:
     # Run the linter.
     - id: ruff-check
@@ -133,7 +133,7 @@ To avoid running on Jupyter Notebooks, remove `jupyter` from the list of allowed
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.15.3
+  rev: v0.15.4
   hooks:
     # Run the linter.
     - id: ruff-check

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -369,7 +369,7 @@ This tutorial has focused on Ruff's command-line interface, but Ruff can also be
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.15.3
+  rev: v0.15.4
   hooks:
     # Run the linter.
     - id: ruff-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ruff"
-version = "0.15.3"
+version = "0.15.4"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 authors = [{ name = "Astral Software Inc.", email = "hey@astral.sh" }]
 readme = "README.md"

--- a/scripts/benchmarks/pyproject.toml
+++ b/scripts/benchmarks/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scripts"
-version = "0.15.3"
+version = "0.15.4"
 description = ""
 authors = ["Charles Marsh <charlie.r.marsh@gmail.com>"]
 


### PR DESCRIPTION
Just to be sure, I ran the example from #23587 again on this branch:

```console
~/astral/ruff on  brent/0.15.4 [$] is 📦 v0.15.4 via 🐍 v3.14.2 via 🦀 v1.93.0
❯ echo 'x = id' | uvx ruff@latest --isolated check - --preview --select ANN003,PLR1712

error: Ruff crashed. If you could open an issue at:

    https://github.com/astral-sh/ruff/issues/new?title=%5BPanic%5D

...quoting the executed command, along with the relevant file contents and `pyproject.toml` settings, we'd be very appreciative!


thread 'main' (1681253) panicked at crates/ruff_python_semantic/src/definition.rs:285:26:
index out of bounds: the len is 0 but the index is 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

~/astral/ruff on  brent/0.15.4 [$] is 📦 v0.15.4 via 🐍 v3.14.2 via 🦀 v1.93.0
❯ echo 'x = id' | just run --isolated check - --preview --select ANN003,PLR1712
cargo run -p ruff -- --isolated check - --preview --select ANN003,PLR1712
   Compiling ruff_python_semantic v0.0.0 (/home/brent/astral/ruff/crates/ruff_python_semantic)
   Compiling ruff v0.15.4 (/home/brent/astral/ruff/crates/ruff)
   Compiling ruff_linter v0.15.4 (/home/brent/astral/ruff/crates/ruff_linter)
   Compiling ruff_graph v0.1.0 (/home/brent/astral/ruff/crates/ruff_graph)
   Compiling ruff_workspace v0.0.0 (/home/brent/astral/ruff/crates/ruff_workspace)
   Compiling ruff_markdown v0.0.0 (/home/brent/astral/ruff/crates/ruff_markdown)
   Compiling ruff_server v0.2.2 (/home/brent/astral/ruff/crates/ruff_server)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 23.14s
     Running `target/debug/ruff --isolated check - --preview --select ANN003,PLR1712`
warning: Detected debug build without --no-cache.
All checks passed!
```