### PR TITLE
Implement `#ruff:file-ignore` file-level suppressions

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/suppressions.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/suppressions.py
@@ -163,6 +163,7 @@ def f(
 
 
 class Foo:
+    # ruff: ignore[ARG002]  should be unused due to ignore-all below
     def bar(self, arg1, arg2):
         print("hello")
 

--- a/crates/ruff_linter/resources/test/fixtures/ruff/suppressions.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/suppressions.py
@@ -162,6 +162,13 @@ def f(
     pass
 
 
+class Foo:
+    def bar(self, arg1, arg2):
+        print("hello")
+
+# ruff: ignore-all[ARG002]  should cover the class method above!
+
+
 # Ensure LAST suppression in file is reported.
 # https://github.com/astral-sh/ruff/issues/23235
 # ruff:disable[F401]

--- a/crates/ruff_linter/resources/test/fixtures/ruff/suppressions.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/suppressions.py
@@ -163,11 +163,11 @@ def f(
 
 
 class Foo:
-    # ruff: ignore[ARG002]  should be unused due to ignore-all below
+    # ruff: ignore[ARG002]  should be unused due to file-ignore below
     def bar(self, arg1, arg2):
         print("hello")
 
-# ruff: ignore-all[ARG002]  should cover the class method above!
+# ruff: file-ignore[ARG002]  should cover the class method above!
 
 
 # Ensure LAST suppression in file is reported.

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -490,6 +490,7 @@ mod tests {
             &settings::LinterSettings::for_rules(vec![
                 Rule::UnusedVariable,
                 Rule::UnusedFunctionArgument,
+                Rule::UnusedMethodArgument,
                 Rule::AmbiguousVariableName,
                 Rule::UnusedNOQA,
                 Rule::InvalidRuleCode,

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_suppression_comment.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_suppression_comment.rs
@@ -38,10 +38,13 @@ impl AlwaysFixableViolation for InvalidSuppressionComment {
                 "unexpected indentation".to_string()
             }
             InvalidSuppressionCommentKind::Invalid(InvalidSuppressionKind::Trailing) => {
-                "trailing comments are not supported".to_string()
+                "trailing comments are not supported for this suppression type".to_string()
             }
             InvalidSuppressionCommentKind::Invalid(InvalidSuppressionKind::Unmatched) => {
                 "no matching 'disable' comment".to_string()
+            }
+            InvalidSuppressionCommentKind::Invalid(InvalidSuppressionKind::NotModuleScope) => {
+                "this suppression type must be at global module scope".to_string()
             }
             InvalidSuppressionCommentKind::Error(error) => format!("{error}"),
         };

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_suppression_comment.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_suppression_comment.rs
@@ -38,13 +38,13 @@ impl AlwaysFixableViolation for InvalidSuppressionComment {
                 "unexpected indentation".to_string()
             }
             InvalidSuppressionCommentKind::Invalid(InvalidSuppressionKind::Trailing) => {
-                "trailing comments are not supported for this suppression type".to_string()
+                "trailing comments are only support for ruff:ignore suppressions".to_string()
             }
             InvalidSuppressionCommentKind::Invalid(InvalidSuppressionKind::Unmatched) => {
                 "no matching 'disable' comment".to_string()
             }
             InvalidSuppressionCommentKind::Invalid(InvalidSuppressionKind::NotModuleScope) => {
-                "this suppression type must be at global module scope".to_string()
+                "file-level suppressions must be at global module scope".to_string()
             }
             InvalidSuppressionCommentKind::Error(error) => format!("{error}"),
         };

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__range_suppressions.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__range_suppressions.snap
@@ -501,21 +501,39 @@ help: Remove unused suppression
 163 |
 164 |
 
-RUF100 [*] Unused suppression (non-enabled: `F401`)
-   --> suppressions.py:174:1
+RUF100 [*] Unused suppression (unused: `ARG002`)
+   --> suppressions.py:166:5
     |
-172 | # Ensure LAST suppression in file is reported.
-173 | # https://github.com/astral-sh/ruff/issues/23235
-174 | # ruff:disable[F401]
+165 | class Foo:
+166 |     # ruff: ignore[ARG002]  should be unused due to ignore-all below
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+167 |     def bar(self, arg1, arg2):
+168 |         print("hello")
+    |
+help: Remove unused suppression
+163 |
+164 |
+165 | class Foo:
+    -     # ruff: ignore[ARG002]  should be unused due to ignore-all below
+166 |     def bar(self, arg1, arg2):
+167 |         print("hello")
+168 |
+
+RUF100 [*] Unused suppression (non-enabled: `F401`)
+   --> suppressions.py:175:1
+    |
+173 | # Ensure LAST suppression in file is reported.
+174 | # https://github.com/astral-sh/ruff/issues/23235
+175 | # ruff:disable[F401]
     | ^^^^^^^^^^^^^^^^^^^^
-175 | print("goodbye")
-176 | # ruff:enable[F401]
+176 | print("goodbye")
+177 | # ruff:enable[F401]
     | -------------------
     |
 help: Remove unused suppression
-171 |
-172 | # Ensure LAST suppression in file is reported.
-173 | # https://github.com/astral-sh/ruff/issues/23235
+172 |
+173 | # Ensure LAST suppression in file is reported.
+174 | # https://github.com/astral-sh/ruff/issues/23235
     - # ruff:disable[F401]
-174 | print("goodbye")
+175 | print("goodbye")
     - # ruff:enable[F401]

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__range_suppressions.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__range_suppressions.snap
@@ -502,20 +502,20 @@ help: Remove unused suppression
 164 |
 
 RUF100 [*] Unused suppression (non-enabled: `F401`)
-   --> suppressions.py:167:1
+   --> suppressions.py:174:1
     |
-165 | # Ensure LAST suppression in file is reported.
-166 | # https://github.com/astral-sh/ruff/issues/23235
-167 | # ruff:disable[F401]
+172 | # Ensure LAST suppression in file is reported.
+173 | # https://github.com/astral-sh/ruff/issues/23235
+174 | # ruff:disable[F401]
     | ^^^^^^^^^^^^^^^^^^^^
-168 | print("goodbye")
-169 | # ruff:enable[F401]
+175 | print("goodbye")
+176 | # ruff:enable[F401]
     | -------------------
     |
 help: Remove unused suppression
-164 |
-165 | # Ensure LAST suppression in file is reported.
-166 | # https://github.com/astral-sh/ruff/issues/23235
+171 |
+172 | # Ensure LAST suppression in file is reported.
+173 | # https://github.com/astral-sh/ruff/issues/23235
     - # ruff:disable[F401]
-167 | print("goodbye")
+174 | print("goodbye")
     - # ruff:enable[F401]

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__range_suppressions.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__range_suppressions.snap
@@ -505,8 +505,8 @@ RUF100 [*] Unused suppression (unused: `ARG002`)
    --> suppressions.py:166:5
     |
 165 | class Foo:
-166 |     # ruff: ignore[ARG002]  should be unused due to ignore-all below
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+166 |     # ruff: ignore[ARG002]  should be unused due to file-ignore below
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 167 |     def bar(self, arg1, arg2):
 168 |         print("hello")
     |
@@ -514,7 +514,7 @@ help: Remove unused suppression
 163 |
 164 |
 165 | class Foo:
-    -     # ruff: ignore[ARG002]  should be unused due to ignore-all below
+    -     # ruff: ignore[ARG002]  should be unused due to file-ignore below
 166 |     def bar(self, arg1, arg2):
 167 |         print("hello")
 168 |

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -589,6 +589,10 @@ impl<'a> SuppressionsBuilder<'a> {
                             });
                         }
                     }
+                } else {
+                    warn_user_once!(
+                        "#ruff:ignore-all comment found but not active, enable preview mode"
+                    );
                 }
                 suppressions.next();
                 continue;

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -35,6 +35,7 @@ enum SuppressionAction {
     Enable,
     /// # ruff:ignore[...] ignore a single line or multi-line statement
     Ignore,
+    IgnoreAll,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -136,6 +137,9 @@ pub(crate) enum InvalidSuppressionKind {
 
     /// Suppression does not match surrounding indentation
     Indentation,
+
+    /// Suppression must be at global module scope
+    NotModuleScope,
 }
 
 #[allow(unused)]
@@ -555,6 +559,39 @@ impl<'a> SuppressionsBuilder<'a> {
                 }
                 suppressions.next();
                 continue;
+            } else if suppression.action == SuppressionAction::IgnoreAll {
+                if is_ruff_ignore_enabled(self.settings) {
+                    match indentation_at_offset(suppression.range.start(), self.source) {
+                        // Module scope
+                        Some("") => {
+                            let range = TextRange::up_to(self.source.text_len());
+                            for code in suppression.codes_as_str(self.source) {
+                                self.valid.push(Suppression {
+                                    code: code.into(),
+                                    range,
+                                    used: false.into(),
+                                    comments: SuppressionComments::Single(suppression.clone()),
+                                });
+                            }
+                        }
+                        // Indented/inside block
+                        Some(_) => {
+                            self.invalid.push(InvalidSuppression {
+                                kind: InvalidSuppressionKind::NotModuleScope,
+                                comment: suppression.clone(),
+                            });
+                        }
+                        // Trailing
+                        None => {
+                            self.invalid.push(InvalidSuppression {
+                                kind: InvalidSuppressionKind::Trailing,
+                                comment: suppression.clone(),
+                            });
+                        }
+                    }
+                }
+                suppressions.next();
+                continue;
             }
 
             // Matched suppression comments
@@ -954,6 +991,9 @@ impl<'src> SuppressionParser<'src> {
         } else if self.cursor.as_str().starts_with("enable") {
             self.cursor.skip_bytes("enable".len());
             Ok(SuppressionAction::Enable)
+        } else if self.cursor.as_str().starts_with("ignore-all") {
+            self.cursor.skip_bytes("ignore-all".len());
+            Ok(SuppressionAction::IgnoreAll)
         } else if self.cursor.as_str().starts_with("ignore") {
             self.cursor.skip_bytes("ignore".len());
             Ok(SuppressionAction::Ignore)
@@ -2138,6 +2178,161 @@ bar = [
     }
 
     #[test]
+    fn ignore_all_suppression_single() {
+        let source = r#"
+print("start")
+# ruff:ignore-all[code]
+print("end")
+        "#;
+        assert_debug_snapshot!(
+            Suppressions::debug(source),
+            @r##"
+        Suppressions {
+            valid: [
+                Suppression {
+                    covered_source: "\nprint(\"start\")\n# ruff:ignore-all[code]\nprint(\"end\")\n        ",
+                    code: "code",
+                    disable_comment: SuppressionComment {
+                        text: "# ruff:ignore-all[code]",
+                        action: IgnoreAll,
+                        codes: [
+                            "code",
+                        ],
+                        reason: "",
+                    },
+                    enable_comment: None,
+                },
+            ],
+            invalid: [],
+            errors: [],
+        }
+        "##,
+        );
+    }
+
+    #[test]
+    fn ignore_all_suppression_multiple() {
+        let source = r#"
+print("start")
+# ruff:ignore-all[alpha, beta]
+# ruff:ignore-all[gamma]
+print("end")
+        "#;
+        assert_debug_snapshot!(
+            Suppressions::debug(source),
+            @r##"
+        Suppressions {
+            valid: [
+                Suppression {
+                    covered_source: "\nprint(\"start\")\n# ruff:ignore-all[alpha, beta]\n# ruff:ignore-all[gamma]\nprint(\"end\")\n        ",
+                    code: "alpha",
+                    disable_comment: SuppressionComment {
+                        text: "# ruff:ignore-all[alpha, beta]",
+                        action: IgnoreAll,
+                        codes: [
+                            "alpha",
+                            "beta",
+                        ],
+                        reason: "",
+                    },
+                    enable_comment: None,
+                },
+                Suppression {
+                    covered_source: "\nprint(\"start\")\n# ruff:ignore-all[alpha, beta]\n# ruff:ignore-all[gamma]\nprint(\"end\")\n        ",
+                    code: "beta",
+                    disable_comment: SuppressionComment {
+                        text: "# ruff:ignore-all[alpha, beta]",
+                        action: IgnoreAll,
+                        codes: [
+                            "alpha",
+                            "beta",
+                        ],
+                        reason: "",
+                    },
+                    enable_comment: None,
+                },
+                Suppression {
+                    covered_source: "\nprint(\"start\")\n# ruff:ignore-all[alpha, beta]\n# ruff:ignore-all[gamma]\nprint(\"end\")\n        ",
+                    code: "gamma",
+                    disable_comment: SuppressionComment {
+                        text: "# ruff:ignore-all[gamma]",
+                        action: IgnoreAll,
+                        codes: [
+                            "gamma",
+                        ],
+                        reason: "",
+                    },
+                    enable_comment: None,
+                },
+            ],
+            invalid: [],
+            errors: [],
+        }
+        "##,
+        );
+    }
+
+    #[test]
+    fn ignore_all_suppression_trailing() {
+        let source = r#"
+print("hello")  # ruff:ignore-all[code]
+        "#;
+        assert_debug_snapshot!(
+            Suppressions::debug(source),
+            @r##"
+        Suppressions {
+            valid: [],
+            invalid: [
+                InvalidSuppression {
+                    kind: Trailing,
+                    comment: SuppressionComment {
+                        text: "# ruff:ignore-all[code]",
+                        action: IgnoreAll,
+                        codes: [
+                            "code",
+                        ],
+                        reason: "",
+                    },
+                },
+            ],
+            errors: [],
+        }
+        "##,
+        );
+    }
+
+    #[test]
+    fn ignore_all_suppression_indented() {
+        let source = r#"
+def foo():
+    # ruff:ignore-all[code]
+    pass
+        "#;
+        assert_debug_snapshot!(
+            Suppressions::debug(source),
+            @r##"
+        Suppressions {
+            valid: [],
+            invalid: [
+                InvalidSuppression {
+                    kind: NotModuleScope,
+                    comment: SuppressionComment {
+                        text: "# ruff:ignore-all[code]",
+                        action: IgnoreAll,
+                        codes: [
+                            "code",
+                        ],
+                        reason: "",
+                    },
+                },
+            ],
+            errors: [],
+        }
+        "##,
+        );
+    }
+
+    #[test]
     fn parse_unrelated_comment() {
         assert_debug_snapshot!(
             parse_suppression_comment("# hello world"),
@@ -2313,6 +2508,25 @@ bar = [
             SuppressionComment {
                 text: "# ruff: ignore[code]",
                 action: Ignore,
+                codes: [
+                    "code",
+                ],
+                reason: "",
+            },
+        )
+        "##,
+        );
+    }
+
+    #[test]
+    fn ignore_all_single_code() {
+        assert_debug_snapshot!(
+            parse_suppression_comment("# ruff: ignore-all[code]"),
+            @r##"
+        Ok(
+            SuppressionComment {
+                text: "# ruff: ignore-all[code]",
+                action: IgnoreAll,
                 codes: [
                     "code",
                 ],

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -27,15 +27,16 @@ use crate::rules::ruff::rules::{
 use crate::settings::LinterSettings;
 use crate::{Locator, Violation, warn_user_once};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 enum SuppressionAction {
+    /// # ruff:ignore-all[...] file level suppression
+    IgnoreAll,
     /// # ruff:disable[...] start of a block suppression
     Disable,
     /// # ruff:enable[...] end of a block suppression
     Enable,
     /// # ruff:ignore[...] ignore a single line or multi-line statement
     Ignore,
-    IgnoreAll,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -680,6 +681,19 @@ impl<'a> SuppressionsBuilder<'a> {
 
         self.match_comments("", TextRange::up_to(self.source.text_len()));
 
+        self.valid.sort_by(|a, b| {
+            (
+                a.comments.first().action,
+                a.comments.first().range.start(),
+                &a.code,
+            )
+                .cmp(&(
+                    b.comments.first().action,
+                    b.comments.first().range.start(),
+                    &b.code,
+                ))
+        });
+
         Suppressions {
             valid: self.valid,
             invalid: self.invalid,
@@ -1261,19 +1275,6 @@ def foo():
         Suppressions {
             valid: [
                 Suppression {
-                    covered_source: "# ruff: disable[bar]\n    print('hello')\n\n",
-                    code: "bar",
-                    disable_comment: SuppressionComment {
-                        text: "# ruff: disable[bar]",
-                        action: Disable,
-                        codes: [
-                            "bar",
-                        ],
-                        reason: "",
-                    },
-                    enable_comment: None,
-                },
-                Suppression {
                     covered_source: "# ruff: disable[foo]\nprint('hello')\n\ndef foo():\n    # ruff: disable[bar]\n    print('hello')\n\n",
                     code: "foo",
                     disable_comment: SuppressionComment {
@@ -1281,6 +1282,19 @@ def foo():
                         action: Disable,
                         codes: [
                             "foo",
+                        ],
+                        reason: "",
+                    },
+                    enable_comment: None,
+                },
+                Suppression {
+                    covered_source: "# ruff: disable[bar]\n    print('hello')\n\n",
+                    code: "bar",
+                    disable_comment: SuppressionComment {
+                        text: "# ruff: disable[bar]",
+                        action: Disable,
+                        codes: [
+                            "bar",
                         ],
                         reason: "",
                     },
@@ -1311,26 +1325,6 @@ class Foo:
         Suppressions {
             valid: [
                 Suppression {
-                    covered_source: "# ruff: disable[bar]\n        print('hello')\n        # ruff: enable[bar]",
-                    code: "bar",
-                    disable_comment: SuppressionComment {
-                        text: "# ruff: disable[bar]",
-                        action: Disable,
-                        codes: [
-                            "bar",
-                        ],
-                        reason: "",
-                    },
-                    enable_comment: SuppressionComment {
-                        text: "# ruff: enable[bar]",
-                        action: Enable,
-                        codes: [
-                            "bar",
-                        ],
-                        reason: "",
-                    },
-                },
-                Suppression {
                     covered_source: "# ruff: disable[foo]\n    def bar(self):\n        # ruff: disable[bar]\n        print('hello')\n        # ruff: enable[bar]\n    # ruff: enable[foo]",
                     code: "foo",
                     disable_comment: SuppressionComment {
@@ -1346,6 +1340,26 @@ class Foo:
                         action: Enable,
                         codes: [
                             "foo",
+                        ],
+                        reason: "",
+                    },
+                },
+                Suppression {
+                    covered_source: "# ruff: disable[bar]\n        print('hello')\n        # ruff: enable[bar]",
+                    code: "bar",
+                    disable_comment: SuppressionComment {
+                        text: "# ruff: disable[bar]",
+                        action: Disable,
+                        codes: [
+                            "bar",
+                        ],
+                        reason: "",
+                    },
+                    enable_comment: SuppressionComment {
+                        text: "# ruff: enable[bar]",
+                        action: Enable,
+                        codes: [
+                            "bar",
                         ],
                         reason: "",
                     },
@@ -1437,7 +1451,7 @@ print('hello')
             valid: [
                 Suppression {
                     covered_source: "# ruff: disable[foo, bar]\nprint('hello')\n# ruff: enable[foo, bar]",
-                    code: "foo",
+                    code: "bar",
                     disable_comment: SuppressionComment {
                         text: "# ruff: disable[foo, bar]",
                         action: Disable,
@@ -1459,7 +1473,7 @@ print('hello')
                 },
                 Suppression {
                     covered_source: "# ruff: disable[foo, bar]\nprint('hello')\n# ruff: enable[foo, bar]",
-                    code: "bar",
+                    code: "foo",
                     disable_comment: SuppressionComment {
                         text: "# ruff: disable[foo, bar]",
                         action: Disable,
@@ -1547,7 +1561,7 @@ print('hello')
             valid: [
                 Suppression {
                     covered_source: "# ruff: disable[foo, bar]\nprint('hello')\n# ruff: enable[bar, foo]\n",
-                    code: "foo",
+                    code: "bar",
                     disable_comment: SuppressionComment {
                         text: "# ruff: disable[foo, bar]",
                         action: Disable,
@@ -1561,7 +1575,7 @@ print('hello')
                 },
                 Suppression {
                     covered_source: "# ruff: disable[foo, bar]\nprint('hello')\n# ruff: enable[bar, foo]\n",
-                    code: "bar",
+                    code: "foo",
                     disable_comment: SuppressionComment {
                         text: "# ruff: disable[foo, bar]",
                         action: Disable,
@@ -1679,17 +1693,24 @@ def bar():
         Suppressions {
             valid: [
                 Suppression {
-                    covered_source: "# ruff: disable[delta] unmatched\n        pass\n    # ruff: enable[beta,gamma]\n# ruff: enable[alpha]\n\n# ruff: disable  # parse error!\n",
-                    code: "delta",
+                    covered_source: "# ruff: disable[alpha]\ndef foo():\n    # ruff: disable[beta,gamma]\n    if True:\n        # ruff: disable[delta] unmatched\n        pass\n    # ruff: enable[beta,gamma]\n# ruff: enable[alpha]",
+                    code: "alpha",
                     disable_comment: SuppressionComment {
-                        text: "# ruff: disable[delta] unmatched",
+                        text: "# ruff: disable[alpha]",
                         action: Disable,
                         codes: [
-                            "delta",
+                            "alpha",
                         ],
-                        reason: "unmatched",
+                        reason: "",
                     },
-                    enable_comment: None,
+                    enable_comment: SuppressionComment {
+                        text: "# ruff: enable[alpha]",
+                        action: Enable,
+                        codes: [
+                            "alpha",
+                        ],
+                        reason: "",
+                    },
                 },
                 Suppression {
                     covered_source: "# ruff: disable[beta,gamma]\n    if True:\n        # ruff: disable[delta] unmatched\n        pass\n    # ruff: enable[beta,gamma]",
@@ -1736,6 +1757,19 @@ def bar():
                     },
                 },
                 Suppression {
+                    covered_source: "# ruff: disable[delta] unmatched\n        pass\n    # ruff: enable[beta,gamma]\n# ruff: enable[alpha]\n\n# ruff: disable  # parse error!\n",
+                    code: "delta",
+                    disable_comment: SuppressionComment {
+                        text: "# ruff: disable[delta] unmatched",
+                        action: Disable,
+                        codes: [
+                            "delta",
+                        ],
+                        reason: "unmatched",
+                    },
+                    enable_comment: None,
+                },
+                Suppression {
                     covered_source: "# ruff: disable[zeta] unmatched\n    pass\n# ruff: enable[zeta] underindented\n    pass\n",
                     code: "zeta",
                     disable_comment: SuppressionComment {
@@ -1747,26 +1781,6 @@ def bar():
                         reason: "unmatched",
                     },
                     enable_comment: None,
-                },
-                Suppression {
-                    covered_source: "# ruff: disable[alpha]\ndef foo():\n    # ruff: disable[beta,gamma]\n    if True:\n        # ruff: disable[delta] unmatched\n        pass\n    # ruff: enable[beta,gamma]\n# ruff: enable[alpha]",
-                    code: "alpha",
-                    disable_comment: SuppressionComment {
-                        text: "# ruff: disable[alpha]",
-                        action: Disable,
-                        codes: [
-                            "alpha",
-                        ],
-                        reason: "",
-                    },
-                    enable_comment: SuppressionComment {
-                        text: "# ruff: enable[alpha]",
-                        action: Enable,
-                        codes: [
-                            "alpha",
-                        ],
-                        reason: "",
-                    },
                 },
             ],
             invalid: [

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -29,8 +29,8 @@ use crate::{Locator, Violation, warn_user_once};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 enum SuppressionAction {
-    /// # ruff:ignore-all[...] file level suppression
-    IgnoreAll,
+    /// # ruff:file-ignore[...] file level suppression
+    FileIgnore,
     /// # ruff:disable[...] start of a block suppression
     Disable,
     /// # ruff:enable[...] end of a block suppression
@@ -560,7 +560,7 @@ impl<'a> SuppressionsBuilder<'a> {
                 }
                 suppressions.next();
                 continue;
-            } else if suppression.action == SuppressionAction::IgnoreAll {
+            } else if suppression.action == SuppressionAction::FileIgnore {
                 if is_ruff_ignore_enabled(self.settings) {
                     match indentation_at_offset(suppression.range.start(), self.source) {
                         // Module scope
@@ -592,7 +592,7 @@ impl<'a> SuppressionsBuilder<'a> {
                     }
                 } else {
                     warn_user_once!(
-                        "#ruff:ignore-all comment found but not active, enable preview mode"
+                        "#ruff:file-ignore comment found but not active, enable preview mode"
                     );
                 }
                 suppressions.next();
@@ -1009,9 +1009,9 @@ impl<'src> SuppressionParser<'src> {
         } else if self.cursor.as_str().starts_with("enable") {
             self.cursor.skip_bytes("enable".len());
             Ok(SuppressionAction::Enable)
-        } else if self.cursor.as_str().starts_with("ignore-all") {
-            self.cursor.skip_bytes("ignore-all".len());
-            Ok(SuppressionAction::IgnoreAll)
+        } else if self.cursor.as_str().starts_with("file-ignore") {
+            self.cursor.skip_bytes("file-ignore".len());
+            Ok(SuppressionAction::FileIgnore)
         } else if self.cursor.as_str().starts_with("ignore") {
             self.cursor.skip_bytes("ignore".len());
             Ok(SuppressionAction::Ignore)
@@ -2196,10 +2196,10 @@ bar = [
     }
 
     #[test]
-    fn ignore_all_suppression_single() {
+    fn file_disable_suppression_single() {
         let source = r#"
 print("start")
-# ruff:ignore-all[code]
+# ruff:file-ignore[code]
 print("end")
         "#;
         assert_debug_snapshot!(
@@ -2208,11 +2208,11 @@ print("end")
         Suppressions {
             valid: [
                 Suppression {
-                    covered_source: "\nprint(\"start\")\n# ruff:ignore-all[code]\nprint(\"end\")\n        ",
+                    covered_source: "\nprint(\"start\")\n# ruff:file-ignore[code]\nprint(\"end\")\n        ",
                     code: "code",
                     disable_comment: SuppressionComment {
-                        text: "# ruff:ignore-all[code]",
-                        action: IgnoreAll,
+                        text: "# ruff:file-ignore[code]",
+                        action: FileIgnore,
                         codes: [
                             "code",
                         ],
@@ -2229,11 +2229,11 @@ print("end")
     }
 
     #[test]
-    fn ignore_all_suppression_multiple() {
+    fn file_disable_suppression_multiple() {
         let source = r#"
 print("start")
-# ruff:ignore-all[alpha, beta]
-# ruff:ignore-all[gamma]
+# ruff:file-ignore[alpha, beta]
+# ruff:file-ignore[gamma]
 print("end")
         "#;
         assert_debug_snapshot!(
@@ -2242,11 +2242,11 @@ print("end")
         Suppressions {
             valid: [
                 Suppression {
-                    covered_source: "\nprint(\"start\")\n# ruff:ignore-all[alpha, beta]\n# ruff:ignore-all[gamma]\nprint(\"end\")\n        ",
+                    covered_source: "\nprint(\"start\")\n# ruff:file-ignore[alpha, beta]\n# ruff:file-ignore[gamma]\nprint(\"end\")\n        ",
                     code: "alpha",
                     disable_comment: SuppressionComment {
-                        text: "# ruff:ignore-all[alpha, beta]",
-                        action: IgnoreAll,
+                        text: "# ruff:file-ignore[alpha, beta]",
+                        action: FileIgnore,
                         codes: [
                             "alpha",
                             "beta",
@@ -2256,11 +2256,11 @@ print("end")
                     enable_comment: None,
                 },
                 Suppression {
-                    covered_source: "\nprint(\"start\")\n# ruff:ignore-all[alpha, beta]\n# ruff:ignore-all[gamma]\nprint(\"end\")\n        ",
+                    covered_source: "\nprint(\"start\")\n# ruff:file-ignore[alpha, beta]\n# ruff:file-ignore[gamma]\nprint(\"end\")\n        ",
                     code: "beta",
                     disable_comment: SuppressionComment {
-                        text: "# ruff:ignore-all[alpha, beta]",
-                        action: IgnoreAll,
+                        text: "# ruff:file-ignore[alpha, beta]",
+                        action: FileIgnore,
                         codes: [
                             "alpha",
                             "beta",
@@ -2270,11 +2270,11 @@ print("end")
                     enable_comment: None,
                 },
                 Suppression {
-                    covered_source: "\nprint(\"start\")\n# ruff:ignore-all[alpha, beta]\n# ruff:ignore-all[gamma]\nprint(\"end\")\n        ",
+                    covered_source: "\nprint(\"start\")\n# ruff:file-ignore[alpha, beta]\n# ruff:file-ignore[gamma]\nprint(\"end\")\n        ",
                     code: "gamma",
                     disable_comment: SuppressionComment {
-                        text: "# ruff:ignore-all[gamma]",
-                        action: IgnoreAll,
+                        text: "# ruff:file-ignore[gamma]",
+                        action: FileIgnore,
                         codes: [
                             "gamma",
                         ],
@@ -2291,9 +2291,9 @@ print("end")
     }
 
     #[test]
-    fn ignore_all_suppression_trailing() {
+    fn file_disable_suppression_trailing() {
         let source = r#"
-print("hello")  # ruff:ignore-all[code]
+print("hello")  # ruff:file-ignore[code]
         "#;
         assert_debug_snapshot!(
             Suppressions::debug(source),
@@ -2304,8 +2304,8 @@ print("hello")  # ruff:ignore-all[code]
                 InvalidSuppression {
                     kind: Trailing,
                     comment: SuppressionComment {
-                        text: "# ruff:ignore-all[code]",
-                        action: IgnoreAll,
+                        text: "# ruff:file-ignore[code]",
+                        action: FileIgnore,
                         codes: [
                             "code",
                         ],
@@ -2320,10 +2320,10 @@ print("hello")  # ruff:ignore-all[code]
     }
 
     #[test]
-    fn ignore_all_suppression_indented() {
+    fn file_disable_suppression_indented() {
         let source = r#"
 def foo():
-    # ruff:ignore-all[code]
+    # ruff:file-ignore[code]
     pass
         "#;
         assert_debug_snapshot!(
@@ -2335,8 +2335,8 @@ def foo():
                 InvalidSuppression {
                     kind: NotModuleScope,
                     comment: SuppressionComment {
-                        text: "# ruff:ignore-all[code]",
-                        action: IgnoreAll,
+                        text: "# ruff:file-ignore[code]",
+                        action: FileIgnore,
                         codes: [
                             "code",
                         ],
@@ -2537,14 +2537,14 @@ def foo():
     }
 
     #[test]
-    fn ignore_all_single_code() {
+    fn file_disable_single_code() {
         assert_debug_snapshot!(
-            parse_suppression_comment("# ruff: ignore-all[code]"),
+            parse_suppression_comment("# ruff: file-ignore[code]"),
             @r##"
         Ok(
             SuppressionComment {
-                text: "# ruff: ignore-all[code]",
-                action: IgnoreAll,
+                text: "# ruff: file-ignore[code]",
+                action: FileIgnore,
                 codes: [
                     "code",
                 ],

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -681,7 +681,7 @@ impl<'a> SuppressionsBuilder<'a> {
 
         self.match_comments("", TextRange::up_to(self.source.text_len()));
 
-        self.valid.sort_by(|a, b| {
+        self.valid.sort_unstable_by(|a, b| {
             (
                 a.comments.first().action,
                 a.comments.first().range.start(),
@@ -2196,7 +2196,7 @@ bar = [
     }
 
     #[test]
-    fn file_disable_suppression_single() {
+    fn file_ignore_suppression_single() {
         let source = r#"
 print("start")
 # ruff:file-ignore[code]
@@ -2229,7 +2229,7 @@ print("end")
     }
 
     #[test]
-    fn file_disable_suppression_multiple() {
+    fn file_ignore_suppression_multiple() {
         let source = r#"
 print("start")
 # ruff:file-ignore[alpha, beta]
@@ -2291,7 +2291,7 @@ print("end")
     }
 
     #[test]
-    fn file_disable_suppression_trailing() {
+    fn file_ignore_suppression_trailing() {
         let source = r#"
 print("hello")  # ruff:file-ignore[code]
         "#;
@@ -2320,7 +2320,7 @@ print("hello")  # ruff:file-ignore[code]
     }
 
     #[test]
-    fn file_disable_suppression_indented() {
+    fn file_ignore_suppression_indented() {
         let source = r#"
 def foo():
     # ruff:file-ignore[code]
@@ -2537,7 +2537,7 @@ def foo():
     }
 
     #[test]
-    fn file_disable_single_code() {
+    fn file_ignore_single_code() {
         assert_debug_snapshot!(
             parse_suppression_comment("# ruff: file-ignore[code]"),
             @r##"

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -490,6 +490,23 @@ The file-level suppression comment specification is as follows:
   optional whitespace and a case-insensitive match for `noqa`. After this, the
   specification is as in the inline `noqa` suppressions above.
 
+In [`preview`](preview.md) mode, one or more rules can be ignored across an
+entire file with an "ignore-all" comment on its own line, at global module scope,
+and preferably near the top of the file:
+
+```python
+# ruff: ignore-all[F401, ARG001]
+```
+
+The full-level suppression comment specification is as follows:
+
+- An own-line comment starting with case sensitive `#ruff:`, with optional whitespace
+  after the `#` symbol and `:` symbol, followed by `ignore-all[`, any codes to
+  be suppressed, and ending with `]`.
+- Codes to be suppressed must be separated by commas, with optional whitespace
+  before or after each code, and may be followed by an optional trailing comma
+  after the last code.
+
 ### Detecting unused suppressions
 
 Ruff implements a special rule, [`unused-noqa`](https://docs.astral.sh/ruff/rules/unused-noqa/),

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -491,17 +491,17 @@ The file-level suppression comment specification is as follows:
   specification is as in the inline `noqa` suppressions above.
 
 In [`preview`](preview.md) mode, one or more rules can be ignored across an
-entire file with an "ignore-all" comment on its own line, at global module scope,
+entire file with a `file-ignore` comment on its own line, at global module scope,
 and preferably near the top of the file:
 
 ```python
-# ruff: ignore-all[F401, ARG001]
+# ruff: file-ignore[F401, ARG001]
 ```
 
 The full-level suppression comment specification is as follows:
 
 - An own-line comment starting with case sensitive `#ruff:`, with optional whitespace
-  after the `#` symbol and `:` symbol, followed by `ignore-all[`, any codes to
+  after the `#` symbol and `:` symbol, followed by `file-ignore[`, any codes to
   be suppressed, and ending with `]`.
 - Codes to be suppressed must be separated by commas, with optional whitespace
   before or after each code, and may be followed by an optional trailing comma


### PR DESCRIPTION
Follow-up to #23404

Add support for `#ruff:file-ignore[code]` style file-level suppressions
as own-line comments at global module scope. The range covered by these
suppressions is always the entirety of the file:

```py
# ruff:file-ignore[ARG001]

def foo(
	arg1,
	arg2,
):
	pass

def bar(
	arg1,
	arg2,
):
	pass
```

This currently requires having preview mode enabled. Without preview mode,
the comments are parsed and processed, but not materialized into active
suppressions at runtime.