### PR TITLE
[ty] Render all changed diagnostics in conformance.py

### DIFF
--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -804,12 +804,17 @@ def render_file_stats_table(test_cases: list[TestCase]) -> str:
     )
 
     lines = [
-        "### Files changed",
+        "### Test file breakdown",
+        "",
+        "<details>",
+        f"<summary>{len(changed)} file{'s' if len(changed) != 1 else ''} altered</summary>",
         "",
         "| File | True Positives | False Positives | False Negatives | Status |",
         "|------|----|----|----|--------|",
         *rows,
         totals_row,
+        "",
+        "</details>",
         "",
     ]
     return "\n".join(lines)
@@ -847,6 +852,13 @@ def diff_format(
 
 
 def render_summary(test_cases: list[TestCase], *, force_summary_table: bool) -> str:
+    def format_metric(diff: float, old: float, new: float):
+        if diff > 0:
+            return f"increased from {old:.2%} to {new:.2%}"
+        if diff < 0:
+            return f"decreased from {old:.2%} to {new:.2%}"
+        return f"held steady at {old:.2%}"
+
     old = compute_stats(test_cases, Source.OLD)
     new = compute_stats(test_cases, Source.NEW)
 
@@ -862,6 +874,13 @@ def render_summary(test_cases: list[TestCase], *, force_summary_table: bool) -> 
     false_neg_change = new.false_negatives - old.false_negatives
     total_change = new.total_diagnostics - old.total_diagnostics
 
+    summary_paragraph = (
+        f"The percentage of diagnostics emitted that were expected errors "
+        f"{format_metric(precision_change, old.precision, new.precision)}. "
+        f"The percentage of expected errors that received a diagnostic "
+        f"{format_metric(recall_change, old.recall, new.recall)}."
+    )
+
     base_header = f"[Typing conformance results]({CONFORMANCE_DIR_WITH_README})"
 
     if not force_summary_table and all(
@@ -871,7 +890,11 @@ def render_summary(test_cases: list[TestCase], *, force_summary_table: bool) -> 
             f"""
             ## {base_header}
 
-            No changes detected ✅
+            ### No changes detected ✅
+
+            ---
+
+            {summary_paragraph}
             """
         )
 
@@ -899,10 +922,18 @@ def render_summary(test_cases: list[TestCase], *, force_summary_table: bool) -> 
         f"""
         ## {header}
 
+        {summary_paragraph}
 
         ### Summary
 
-        <details><summary>How are test cases classified?</summary>{summary_note}</details>
+        <details>
+        <summary>How are test cases classified?</summary>
+
+        <br>
+
+        {summary_note}
+
+        </details>
 
         | Metric | Old | New | Diff | Outcome |
         |--------|-----|-----|------|---------|


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This is meant to fix https://github.com/astral-sh/ty/issues/2786. Previously, the conformance.py script would only render changed diagnostics if one of the ty versions raised no diagnostics in the test group. This PR updates the change detection logic and the renderer so that we display both the old and new diagnostics if they are not identical. I've also created separate sections for cases where diagnostics changed without changing the classification as well as a new `Files changed` section that shows how performance at the file level has changed.

## Test Plan

<!-- How was it tested? -->
I'll try cherry-picking #23088 and take a look at the comment. 

I also ran the following command to see how the output would look against 0.0.18:

```
uv run --no-project --python 3.12 scripts/conformance.py --tests-path ./../typing/conformance/ --old-ty uvx ty@0.0.18
```

Which returned the following:

<details>
<summary>conformance.md</summary>

## [Typing conformance results](https://github.com/python/typing/blob/main/conformance/) improved 🎉


### Summary

Each test case represents one expected error annotation or a group of annotations sharing a tag. Counts are per test case, not per diagnostic — multiple diagnostics on the same line count as one. Required annotations (`E`) are true positives when ty flags the expected location and false negatives when it does not. Optional annotations (`E?`) are true positives when flagged but true negatives (not false negatives) when not. Tagged annotations (`E[tag]`) require ty to flag exactly one of the tagged lines; tagged multi-annotations (`E[tag+]`) allow any number up to the tag count. Flagging unexpected locations counts as a false positive.

<div align="center">

| Metric | Old | New | Diff | Outcome |
|--------|-----|-----|------|---------|
| True Positives  | 761 | 763 | +2 | ⏫ (✅) |
| False Positives | 141 | 141 | +0 |  |
| False Negatives | 270 | 269 | -1 | ⏬ (✅) |
| Total Diagnostics | 971 | 973 | +2 | ⏫ |
| Precision | 84.37% | 84.40% | +0.03% | ⏫ (✅) |
| Recall | 73.81% | 73.93% | +0.12% | ⏫ (✅) |

</div>



### Files changed

<div align="center">

| File | True Positives | False Positives | False Negatives | Status |
|------|----|----|----|--------|
| [enums_member_values.py](https://github.com/python/typing/blob/main/conformance/tests/enums_member_values.py) | 6 (+2) ✅ | 0 | 0 (-1) ✅ | ✅ Newly Passing 🎉 |
| [aliases_typealiastype.py](https://github.com/python/typing/blob/main/conformance/tests/aliases_typealiastype.py) | 15 | 0 (-1) ✅ | 7 | ❌ |
| [narrowing_typeis.py](https://github.com/python/typing/blob/main/conformance/tests/narrowing_typeis.py) | 9 | 1 (+1) ❌ | 0 | ❌ Regressed |
| **Total** | **763 (+2) ✅** | **141** | **269 (-1) ✅** | 48/131 |

</div>


### True positives added (1)

<details>
<summary>1 diagnostic</summary>

<table>
<tr><th>Test case</th><th>Δ</th><th>Location</th><th>Name</th><th>Message</th></tr>
<tr><td align="center" valign="middle"><a href="https://github.com/python/typing/blob/main/conformance/tests/enums_member_values.py#L78">enums_member_values.py:78</a></td><td align="center" valign="middle">+</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/enums_member_values.py#L78">78:5</a></td><td>invalid-assignment</td><td>Enum member `GREEN` value is not assignable to expected type</td></tr>
</table>

</details>

### False positives removed (1)

<details>
<summary>1 diagnostic</summary>

<table>
<tr><th>Test case</th><th>Δ</th><th>Location</th><th>Name</th><th>Message</th></tr>
<tr><td align="center" valign="middle"><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_typealiastype.py#L23">aliases_typealiastype.py:23</a></td><td align="center" valign="middle">-</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_typealiastype.py#L23">23:5</a></td><td>invalid-argument-type</td><td>Argument to class `TypeAliasType` is incorrect: Expected `tuple[TypeVar | ParamSpec | typing_extensions.TypeVarTuple, ...]`, found `tuple[TypeVar, TypeVar, ParamSpec, typing.TypeVarTuple]`</td></tr>
</table>

</details>

### True positives changed (6)

<details>
<summary>6 diagnostics</summary>

<table>
<tr><th>Test case</th><th>Δ</th><th>Location</th><th>Name</th><th>Message</th></tr>
<tr><td rowspan="2" align="center" valign="middle"><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_explicit.py#L102">aliases_explicit.py:102</a></td><td align="center" valign="middle">-</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_explicit.py#L102">102:5</a></td><td>not-subscriptable</td><td>Cannot subscript non-generic type</td></tr>
<tr><td align="center" valign="middle">+</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_explicit.py#L102">102:5</a></td><td>not-subscriptable</td><td>Cannot subscript non-generic type `&lt;types.UnionType special-form &#x27;list[Unknown] | set[Unknown]&#x27;&gt;`</td></tr>
<tr><td rowspan="2" align="center" valign="middle"><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_explicit.py#L67">aliases_explicit.py:67</a></td><td align="center" valign="middle">-</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_explicit.py#L67">67:9</a></td><td>not-subscriptable</td><td>Cannot subscript non-generic type</td></tr>
<tr><td align="center" valign="middle">+</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_explicit.py#L67">67:9</a></td><td>not-subscriptable</td><td>Cannot subscript non-generic type `&lt;types.UnionType special-form &#x27;int | None&#x27;&gt;`</td></tr>
<tr><td rowspan="2" align="center" valign="middle"><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_explicit.py#L68">aliases_explicit.py:68</a></td><td align="center" valign="middle">-</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_explicit.py#L68">68:9</a></td><td>not-subscriptable</td><td>Cannot subscript non-generic type: `&lt;class &#x27;list[int | None]&#x27;&gt;` is already specialized</td></tr>
<tr><td align="center" valign="middle">+</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_explicit.py#L68">68:9</a></td><td>not-subscriptable</td><td>Cannot subscript non-generic type `&lt;class &#x27;list[int | None]&#x27;&gt;`</td></tr>
<tr><td rowspan="2" align="center" valign="middle"><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_implicit.py#L135">aliases_implicit.py:135</a></td><td align="center" valign="middle">-</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_implicit.py#L135">135:5</a></td><td>not-subscriptable</td><td>Cannot subscript non-generic type</td></tr>
<tr><td align="center" valign="middle">+</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_implicit.py#L135">135:5</a></td><td>not-subscriptable</td><td>Cannot subscript non-generic type `&lt;types.UnionType special-form &#x27;list[Unknown] | set[Unknown]&#x27;&gt;`</td></tr>
<tr><td rowspan="2" align="center" valign="middle"><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_implicit.py#L76">aliases_implicit.py:76</a></td><td align="center" valign="middle">-</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_implicit.py#L76">76:9</a></td><td>not-subscriptable</td><td>Cannot subscript non-generic type</td></tr>
<tr><td align="center" valign="middle">+</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_implicit.py#L76">76:9</a></td><td>not-subscriptable</td><td>Cannot subscript non-generic type `&lt;types.UnionType special-form &#x27;int | None&#x27;&gt;`</td></tr>
<tr><td rowspan="2" align="center" valign="middle"><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_implicit.py#L77">aliases_implicit.py:77</a></td><td align="center" valign="middle">-</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_implicit.py#L77">77:9</a></td><td>not-subscriptable</td><td>Cannot subscript non-generic type: `&lt;class &#x27;list[int | None]&#x27;&gt;` is already specialized</td></tr>
<tr><td align="center" valign="middle">+</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/aliases_implicit.py#L77">77:9</a></td><td>not-subscriptable</td><td>Cannot subscript non-generic type `&lt;class &#x27;list[int | None]&#x27;&gt;`</td></tr>
</table>

</details>

### False positives changed (1)

<details>
<summary>1 diagnostic</summary>

<table>
<tr><th>Test case</th><th>Δ</th><th>Location</th><th>Name</th><th>Message</th></tr>
<tr><td rowspan="2" align="center" valign="middle"><a href="https://github.com/python/typing/blob/main/conformance/tests/generics_typevartuple_specialization.py#L45">generics_typevartuple_specialization.py:45</a></td><td align="center" valign="middle">-</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/generics_typevartuple_specialization.py#L45">45:40</a></td><td>not-subscriptable</td><td>Cannot subscript non-generic type: `&lt;class &#x27;tuple[str, @Todo]&#x27;&gt;` is already specialized</td></tr>
<tr><td align="center" valign="middle">+</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/generics_typevartuple_specialization.py#L45">45:40</a></td><td>not-subscriptable</td><td>Cannot subscript non-generic type `&lt;class &#x27;tuple[str, @Todo]&#x27;&gt;`</td></tr>
</table>

</details>

### False positives added (1)

<details>
<summary>1 diagnostic</summary>

<table>
<tr><th>Test case</th><th>Δ</th><th>Location</th><th>Name</th><th>Message</th></tr>
<tr><td align="center" valign="middle"><a href="https://github.com/python/typing/blob/main/conformance/tests/narrowing_typeis.py#L35">narrowing_typeis.py:35</a></td><td align="center" valign="middle">+</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/narrowing_typeis.py#L35">35:18</a></td><td>invalid-assignment</td><td>Object of type `object` is not assignable to `int`</td></tr>
</table>

</details>

### Optional Diagnostics Added (2)

<details>
<summary>2 diagnostics</summary>

<table>
<tr><th>Test case</th><th>Δ</th><th>Location</th><th>Name</th><th>Message</th></tr>
<tr><td align="center" valign="middle"><a href="https://github.com/python/typing/blob/main/conformance/tests/enums_member_values.py#L50">enums_member_values.py:50</a></td><td align="center" valign="middle">+</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/enums_member_values.py#L50">50:5</a></td><td>invalid-assignment</td><td>Enum member `MARS` is incompatible with `__init__`</td></tr>
<tr><td align="center" valign="middle"><a href="https://github.com/python/typing/blob/main/conformance/tests/enums_member_values.py#L51">enums_member_values.py:51</a></td><td align="center" valign="middle">+</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/enums_member_values.py#L51">51:5</a></td><td>invalid-assignment</td><td>Enum member `JUPITER` is incompatible with `__init__`</td></tr>
</table>

</details>

### Optional Diagnostics Removed (1)

<details>
<summary>1 diagnostic</summary>

<table>
<tr><th>Test case</th><th>Δ</th><th>Location</th><th>Name</th><th>Message</th></tr>
<tr><td align="center" valign="middle"><a href="https://github.com/python/typing/blob/main/conformance/tests/enums_member_values.py#L96">enums_member_values.py:96</a></td><td align="center" valign="middle">-</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/enums_member_values.py#L96">96:1</a></td><td>type-assertion-failure</td><td>Type `Unknown` does not match asserted type `int`</td></tr>
</table>

</details>

### Optional Diagnostics Changed (1)

<details>
<summary>1 diagnostic</summary>

<table>
<tr><th>Test case</th><th>Δ</th><th>Location</th><th>Name</th><th>Message</th></tr>
<tr><td rowspan="2" align="center" valign="middle"><a href="https://github.com/python/typing/blob/main/conformance/tests/enums_member_values.py#L54">enums_member_values.py:54</a></td><td align="center" valign="middle">-</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/enums_member_values.py#L54">54:1</a></td><td>type-assertion-failure</td><td>Type `tuple[Literal[1], float, float]` does not match asserted type `Literal[1]`</td></tr>
<tr><td align="center" valign="middle">+</td><td><a href="https://github.com/python/typing/blob/main/conformance/tests/enums_member_values.py#L54">54:1</a></td><td>type-assertion-failure</td><td>Type `Any` does not match asserted type `Literal[1]`</td></tr>
</table>

</details>

</details>
