### PR TITLE
installers: Download releases from Astral's mirror first

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -67,6 +67,9 @@ github-custom-job-permissions = { "build-docker" = { packages = "write", content
 install-updater = false
 # Path that installers should place binaries in
 install-path = ["$XDG_BIN_HOME/", "$XDG_DATA_HOME/../bin", "~/.local/bin"]
+# Prefer simple hosting for downloads, falling back to GitHub releases
+hosting = ["simple", "github"]
+simple-download-url = "https://releases.astral.sh/github/ruff/releases/download/{tag}"
 
 [dist.github-custom-runners]
 global = "depot-ubuntu-latest-4"


### PR DESCRIPTION
This is like https://github.com/astral-sh/uv/pull/18191 but for Ruff.

> [!NOTE]
> We should only merge this once https://github.com/astral-sh/ruff/pull/23616 is merged and released.

This makes the installer shell scripts download releases from Astral's mirror first, falling back to GitHub releases if the mirror is not available.

## Test plan

```
❯ cargo dist build --tag 0.15.5 -a global
[...]
❯ sh target/distrib/ruff-installer.sh -v
downloading ruff 0.15.5 aarch64-apple-darwin
  from https://releases.astral.sh/github/ruff/releases/download/0.15.5/ruff-aarch64-apple-darwin.tar.gz
  to /var/folders/2p/zyzvnr4j5016wx4h0pdgbjb00000gn/T/tmp.i1na6JQumh/input.tar.gz
no checksums to verify
installing to /Users/zsol/.local/bin
  ruff
everything's installed!
```
