### PR TITLE
Remove unused loops in deferred checks

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/deferred_comprehensions.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/deferred_comprehensions.rs
@@ -6,8 +6,6 @@ use crate::rules::perflint;
 
 /// Run lint rules over all deferred comprehensions in the [`SemanticModel`].
 pub(crate) fn deferred_comprehensions(checker: &mut Checker) {
-    // Note that we'll need to check for new statements in a loop if any of the rules below receive
-    // a `&mut Checker` again.
     let comprehensions = std::mem::take(&mut checker.analyze.comprehensions);
     for snapshot in comprehensions {
         checker.semantic.restore(snapshot);

--- a/crates/ruff_linter/src/checkers/ast/analyze/deferred_for_loops.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/deferred_for_loops.rs
@@ -6,8 +6,6 @@ use crate::rules::{flake8_bugbear, flake8_simplify, perflint, pylint, pyupgrade,
 
 /// Run lint rules over all deferred for-loops in the [`SemanticModel`].
 pub(crate) fn deferred_for_loops(checker: &mut Checker) {
-    // Note that we'll need to check for new statements in a loop if any of the rules below receive
-    // a `&mut Checker` again.
     let for_loops = std::mem::take(&mut checker.analyze.for_loops);
     for snapshot in for_loops {
         checker.semantic.restore(snapshot);

--- a/crates/ruff_linter/src/checkers/ast/analyze/deferred_lambdas.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/deferred_lambdas.rs
@@ -6,8 +6,6 @@ use crate::rules::{flake8_builtins, flake8_pie, pylint};
 
 /// Run lint rules over all deferred lambdas in the [`SemanticModel`].
 pub(crate) fn deferred_lambdas(checker: &mut Checker) {
-    // Note that we'll need to check for new statements in a loop if any of the rules below receive
-    // a `&mut Checker` again.
     let lambdas = std::mem::take(&mut checker.analyze.lambdas);
     for snapshot in lambdas {
         checker.semantic.restore(snapshot);

--- a/crates/ruff_linter/src/checkers/ast/analyze/deferred_with_statements.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/deferred_with_statements.rs
@@ -4,8 +4,6 @@ use crate::{checkers::ast::Checker, codes::Rule, rules::refurb};
 
 /// Run lint rules over all deferred with-statements in the [`SemanticModel`].
 pub(crate) fn deferred_with_statements(checker: &mut Checker) {
-    // Note that we'll need to check for new statements in a loop if any of the rules below receive
-    // a `&mut Checker` again.
     let with_statements = std::mem::take(&mut checker.analyze.with_statements);
     for snapshot in with_statements {
         checker.semantic.restore(snapshot);


### PR DESCRIPTION
Summary
--

While reviewing #23473, I noticed that the `while` loops in our deferred checks
for `for` loops and lambdas would only be used if we pushed additional deferred
scopes to the `Checker` while running lint rule code. This should actually be
impossible given that the rules only receive a `&Checker` (as shown by the
immutable re-borrow), and none of our tests fail when removing the loops.

I guess it doesn't hurt to have the loops either since they only run once, but
it did serve to confuse me today.

I assume, but didn't fully confirm, that this used to be interleaved with the
visiting phase, at which point additional deferred scopes could have still been
added in the middle of this.

Test Plan
--

Existing tests
