### PR TITLE
[ty] Reject generic metaclasses parameterized by type variables

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -278,7 +278,7 @@ T = TypeVar("T")
 
 class GenericMeta(type, Generic[T]): ...
 
-# error: [invalid-metaclass]
+# error: [invalid-metaclass] "Generic metaclasses are not supported"
 class GenericMetaInstance(metaclass=GenericMeta[T]): ...
 ```
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2887,7 +2887,7 @@ impl<'db> StaticClassLiteral<'db> {
         // Generic metaclasses parameterized by type variables are not supported.
         // `metaclass=Meta[int]` is fine, but `metaclass=Meta[T]` is not.
         // See: https://typing.python.org/en/latest/spec/generics.html#generic-metaclasses
-        if let Some(ty @ Type::GenericAlias(alias)) = explicit_metaclass {
+        if let Some(Type::GenericAlias(alias)) = explicit_metaclass {
             let specialization_has_typevars = alias
                 .specialization(db)
                 .types(db)
@@ -2895,7 +2895,7 @@ impl<'db> StaticClassLiteral<'db> {
                 .any(|ty| ty.has_typevar_or_typevar_instance(db));
             if specialization_has_typevars {
                 return Err(MetaclassError {
-                    kind: MetaclassErrorKind::GenericMetaclass(ty),
+                    kind: MetaclassErrorKind::GenericMetaclass,
                 });
             }
         }
@@ -8294,7 +8294,7 @@ pub(super) enum MetaclassErrorKind<'db> {
         candidate1_is_base_class: bool,
     },
     /// The metaclass is a parameterized generic class, which is not supported.
-    GenericMetaclass(Type<'db>),
+    GenericMetaclass,
     /// The metaclass is not callable
     NotCallable(Type<'db>),
     /// The metaclass is of a union type whose some members are not callable

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1222,14 +1222,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             ));
                         }
                     }
-                    MetaclassErrorKind::GenericMetaclass(ty) => {
+                    MetaclassErrorKind::GenericMetaclass => {
                         if let Some(builder) =
                             self.context.report_lint(&INVALID_METACLASS, class_node)
                         {
-                            builder.into_diagnostic(format_args!(
-                                "Cannot use a parameterized generic class `{}` as a metaclass",
-                                ty.display(self.db())
-                            ));
+                            builder.into_diagnostic("Generic metaclasses are not supported");
                         }
                     }
                     MetaclassErrorKind::NotCallable(ty) => {


### PR DESCRIPTION
## Summary

Add validation to reject generic metaclasses that are parameterized by type variables, as these are banned by the typing spec.

## Test Plan

mdtests