### PR TITLE
[`airflow`] Extract common utilities for use in new rules

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_context.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR301_context.py
@@ -205,3 +205,37 @@ def test_inlet_events_dataset_subscript_ok(**context):
 
     print(context["inlet_events"][Dataset("this://is-url")])
     print(context["inlet_events"][Asset("this://is-url")])
+
+
+# Same context checks with airflow.sdk import
+from airflow.sdk import task as sdk_task
+
+
+@sdk_task
+def sdk_access_deprecated_context_key(**context):
+    execution_date = context["execution_date"]
+    next_ds = context["next_ds"]
+
+
+@sdk_task
+def sdk_access_valid_context_key(**context):
+    logical_date = context["logical_date"]
+
+
+# Test variant decorator forms like @task.branch and @task.short_circuit
+@task.branch
+def branch_task_with_deprecated_context(**context):
+    execution_date = context["execution_date"]
+    return "some_task"
+
+
+@task.short_circuit
+def short_circuit_task_with_deprecated_context(**context):
+    next_ds = context["next_ds"]
+    return True
+
+
+@task.branch()
+def branch_task_with_call_and_deprecated_context(**context):
+    tomorrow_ds = context["tomorrow_ds"]
+    return "some_task"

--- a/crates/ruff_linter/src/rules/airflow/helpers.rs
+++ b/crates/ruff_linter/src/rules/airflow/helpers.rs
@@ -3,6 +3,7 @@ use crate::fix::edits::remove_unused_imports;
 use crate::importer::ImportRequest;
 use crate::rules::numpy::helpers::{AttributeSearcher, ImportSearcher};
 use ruff_diagnostics::{Edit, Fix};
+use ruff_python_ast::helpers::map_callable;
 use ruff_python_ast::name::{QualifiedName, QualifiedNameBuilder};
 use ruff_python_ast::statement_visitor::StatementVisitor;
 use ruff_python_ast::visitor::Visitor;
@@ -289,4 +290,39 @@ where
     };
 
     any_qualified_base_class(class_def, semantic, &is_base_class)
+}
+
+/// Returns `true` if the current statement hierarchy has a function that's decorated with
+/// `@airflow.decorators.task` or `@airflow.sdk.task`.
+pub(crate) fn in_airflow_task_function(semantic: &SemanticModel) -> bool {
+    semantic
+        .current_statements()
+        .find_map(|stmt| stmt.as_function_def_stmt())
+        .is_some_and(|function_def| is_airflow_task(function_def, semantic))
+}
+
+/// Returns `true` if the given function is decorated with `@airflow.decorators.task`
+/// (or `@airflow.sdk.task`), including variant forms like `@task.branch` and
+/// `@task.short_circuit`.
+pub(crate) fn is_airflow_task(function_def: &StmtFunctionDef, semantic: &SemanticModel) -> bool {
+    function_def.decorator_list.iter().any(|decorator| {
+        let expr = map_callable(&decorator.expression);
+
+        // Match `@task` and `@task()` directly.
+        if semantic
+            .resolve_qualified_name(expr)
+            .is_some_and(|qn| matches!(qn.segments(), ["airflow", "decorators" | "sdk", "task"]))
+        {
+            return true;
+        }
+
+        // Match `@task.<variant>` (e.g., `@task.branch`, `@task.short_circuit`).
+        if let Expr::Attribute(ExprAttribute { value, .. }) = expr {
+            return semantic.resolve_qualified_name(value).is_some_and(|qn| {
+                matches!(qn.segments(), ["airflow", "decorators" | "sdk", "task"])
+            });
+        }
+
+        false
+    })
 }

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_context.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR301_AIR301_context.py.snap
@@ -521,3 +521,52 @@ AIR301 `inlet_events["<uri>"]` is removed in Airflow 3.0
     |                            ^^^^^^^^^^^^^^^
     |
 help: Accessing `inlet_events` via a string key is deprecated; use `context["inlet_events"][Asset(uri="this://is-url")]` instead of `context["inlet_events"]["this://is-url"]`.
+
+AIR301 `execution_date` is removed in Airflow 3.0
+   --> AIR301_context.py:216:30
+    |
+214 | @sdk_task
+215 | def sdk_access_deprecated_context_key(**context):
+216 |     execution_date = context["execution_date"]
+    |                              ^^^^^^^^^^^^^^^^
+217 |     next_ds = context["next_ds"]
+    |
+
+AIR301 `next_ds` is removed in Airflow 3.0
+   --> AIR301_context.py:217:23
+    |
+215 | def sdk_access_deprecated_context_key(**context):
+216 |     execution_date = context["execution_date"]
+217 |     next_ds = context["next_ds"]
+    |                       ^^^^^^^^^
+    |
+
+AIR301 `execution_date` is removed in Airflow 3.0
+   --> AIR301_context.py:228:30
+    |
+226 | @task.branch
+227 | def branch_task_with_deprecated_context(**context):
+228 |     execution_date = context["execution_date"]
+    |                              ^^^^^^^^^^^^^^^^
+229 |     return "some_task"
+    |
+
+AIR301 `next_ds` is removed in Airflow 3.0
+   --> AIR301_context.py:234:23
+    |
+232 | @task.short_circuit
+233 | def short_circuit_task_with_deprecated_context(**context):
+234 |     next_ds = context["next_ds"]
+    |                       ^^^^^^^^^
+235 |     return True
+    |
+
+AIR301 `tomorrow_ds` is removed in Airflow 3.0
+   --> AIR301_context.py:240:27
+    |
+238 | @task.branch()
+239 | def branch_task_with_call_and_deprecated_context(**context):
+240 |     tomorrow_ds = context["tomorrow_ds"]
+    |                           ^^^^^^^^^^^^^
+241 |     return "some_task"
+    |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Extract `is_airflow_task` and `in_airflow_task_function` from `removal_in_3.rs` (AIR301) into the shared `helpers.rs` module so they can be reused by other airflow rules.

The shared versions include two enhancements over the original private implementations:
- Match both `airflow.decorators.task` and `airflow.sdk.task` import paths, supporting Airflow 2 and 3 decorator imports.
- Handle `@task.<variant>` decorator forms (e.g., `@task.branch`, `@task.short_circuit`), not just `@task` and `@task()`.

## Test Plan

Added `airflow.sdk` test cases to `AIR301_context.py` confirming that deprecated context key detection works under both `@task` (from `airflow.decorators`) and `@sdk_task` (from `airflow.sdk`). Existing AIR301 tests continue to pass.

```sh
RUFF_UPDATE_SCHEMA=1 cargo nextest run -p ruff_linter -- "airflow::tests"
cargo clippy -p ruff_linter --all-targets --all-features -- -D warnings
```

Related: #23579 #23584 