### PR TITLE
[pydoclint] Fix false positive for exceptions raised via classmethods and chained calls (DOC501, DOC502)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_google.py
@@ -246,3 +246,74 @@ def foo():
         raise TypeError  # no DOC501 here because we already emitted a diagnostic for the earlier `raise TypeError`
     raise ValueError  # DOC501
     return 42
+
+
+# OK - exception raised via classmethod, documented in Raises section
+def validate_classmethod(value):
+    """Validate a value.
+
+    Args:
+        value: the value to validate.
+
+    Raises:
+        ValueError: if the value is invalid.
+    """
+    raise ValueError.from_exception_data(
+        title="Validation",
+        line_errors=[],
+    )
+
+
+# DOC501 - exception raised via classmethod, NOT documented
+def validate_classmethod_missing(value):
+    """Validate a value.
+
+    Args:
+        value: the value to validate.
+    """
+    raise ValueError.from_exception_data(
+        title="Validation",
+        line_errors=[],
+    )
+
+
+# OK - exception raised via classmethod using imported exception
+def validate_imported_classmethod(value):
+    """Validate a value.
+
+    Args:
+        value: the value to validate.
+
+    Raises:
+        AnotherError: if the value is invalid.
+    """
+    raise AnotherError.create(value)
+
+
+# OK - chained method call with .with_traceback(), documented
+def chained_with_traceback(value):
+    """Validate a value.
+
+    Args:
+        value: the value to validate.
+
+    Raises:
+        ValueError: if the value is invalid.
+    """
+    raise ValueError.from_exception_data(
+        title="Validation",
+        line_errors=[],
+    ).with_traceback(None)
+
+
+# DOC501 - chained method call, NOT documented
+def chained_missing(value):
+    """Validate a value.
+
+    Args:
+        value: the value to validate.
+    """
+    raise ValueError.from_exception_data(
+        title="Validation",
+        line_errors=[],
+    ).with_traceback(None)

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_google.py
@@ -1,5 +1,7 @@
 import something
+import urllib.error
 from somewhere import AnotherError
+from urllib import error as url_error
 
 
 class FasterThanLightError(Exception):
@@ -317,3 +319,72 @@ def chained_missing(value):
         title="Validation",
         line_errors=[],
     ).with_traceback(None)
+
+
+# OK - exception raised via module attribute call, documented
+def module_exception_documented(value):
+    """Process a value.
+
+    Args:
+        value: the value to process.
+
+    Raises:
+        something.SomeError: if the value is bad.
+    """
+    raise something.SomeError(value)
+
+
+# DOC501 - exception raised via module attribute call, NOT documented
+def module_exception_missing(value):
+    """Process a value.
+
+    Args:
+        value: the value to process.
+    """
+    raise something.SomeError(value)
+
+
+# OK - exception raised via nested module attribute call, documented
+def nested_module_exception_documented(value):
+    """Process a value.
+
+    Args:
+        value: the value to process.
+
+    Raises:
+        URLError: if the connection fails.
+    """
+    raise urllib.error.URLError(value)
+
+
+# DOC501 - exception raised via nested module attribute call, NOT documented
+def nested_module_exception_missing(value):
+    """Process a value.
+
+    Args:
+        value: the value to process.
+    """
+    raise urllib.error.URLError(value)
+
+
+# OK - exception raised via from-imported module, documented
+def from_import_module_documented(value):
+    """Process a value.
+
+    Args:
+        value: the value to process.
+
+    Raises:
+        URLError: if the connection fails.
+    """
+    raise url_error.URLError(value)
+
+
+# DOC501 - exception raised via from-imported module, NOT documented
+def from_import_module_missing(value):
+    """Process a value.
+
+    Args:
+        value: the value to process.
+    """
+    raise url_error.URLError(value)

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_google.py
@@ -1,7 +1,5 @@
 import something
-import urllib.error
 from somewhere import AnotherError
-from urllib import error as url_error
 
 
 class FasterThanLightError(Exception):
@@ -248,6 +246,10 @@ def foo():
         raise TypeError  # no DOC501 here because we already emitted a diagnostic for the earlier `raise TypeError`
     raise ValueError  # DOC501
     return 42
+
+
+import urllib.error
+from urllib import error as url_error
 
 
 # OK - exception raised via classmethod, documented in Raises section

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC502_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC502_google.py
@@ -164,3 +164,51 @@ def i():
         pass
     except (ValueError, TypeError) as e:
         raise e
+
+
+from somewhere import AnotherError
+
+
+# This should NOT trigger DOC502 because ValueError is explicitly raised via a classmethod
+def validate_classmethod(value):
+    """Validate a value.
+
+    Args:
+        value: The value to validate.
+
+    Raises:
+        ValueError: If the value is invalid.
+    """
+    raise ValueError.from_exception_data(
+        title="Validation",
+        line_errors=[],
+    )
+
+
+# This should NOT trigger DOC502 because AnotherError is explicitly raised via a classmethod
+def validate_imported_classmethod(value):
+    """Validate a value.
+
+    Args:
+        value: The value to validate.
+
+    Raises:
+        AnotherError: If the value is invalid.
+    """
+    raise AnotherError.create(value)
+
+
+# This should NOT trigger DOC502 because ValueError is explicitly raised in a chained call
+def chained_with_traceback(value):
+    """Validate a value.
+
+    Args:
+        value: The value to validate.
+
+    Raises:
+        ValueError: If the value is invalid.
+    """
+    raise ValueError.from_exception_data(
+        title="Validation",
+        line_errors=[],
+    ).with_traceback(None)

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::helpers::{map_callable, map_subscript};
+use ruff_python_ast::helpers::map_subscript;
 use ruff_python_ast::name::QualifiedName;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{self as ast, Expr, Stmt, visitor};

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -980,10 +980,33 @@ impl<'a> Visitor<'a> for BodyVisitor<'a> {
         match stmt {
             Stmt::Raise(ast::StmtRaise { exc, .. }) => {
                 if let Some(exc) = exc.as_ref() {
-                    // First try to resolve the exception directly
-                    if let Some(qualified_name) =
-                        self.semantic.resolve_qualified_name(map_callable(exc))
-                    {
+                    // Unwrap method chain calls to find the exception type:
+                    //   `raise ValueError("bad")` → `ValueError`
+                    //   `raise ValueError.from_exception_data(...)` → `ValueError`
+                    //   `raise Error.create(...).with_traceback(tb)` → `Error`
+                    //   `raise module.SomeError` → `module.SomeError` (bare attr, no unwrap)
+                    let mut current = exc.as_ref();
+                    let qualified_name = loop {
+                        if let ast::Expr::Call(ast::ExprCall { func, .. }) = current {
+                            if let ast::Expr::Attribute(attr) = func.as_ref() {
+                                // `Error.method(...)` — try resolving the object.
+                                if let Some(qn) = self.semantic.resolve_qualified_name(&attr.value)
+                                {
+                                    break Some(qn);
+                                }
+                                // Object is another call — keep peeling.
+                                current = &attr.value;
+                            } else {
+                                // `Error(...)` — resolve the callable directly.
+                                break self.semantic.resolve_qualified_name(func.as_ref());
+                            }
+                        } else {
+                            // Bare `Error` or `module.Error` — resolve as-is.
+                            break self.semantic.resolve_qualified_name(current);
+                        }
+                    };
+
+                    if let Some(qualified_name) = qualified_name {
                         self.raised_exceptions.push(ExceptionEntry {
                             qualified_name,
                             range: exc.range(),

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -1,11 +1,11 @@
 use itertools::Itertools;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::helpers::map_subscript;
+use ruff_python_ast::helpers::{map_callable, map_subscript};
 use ruff_python_ast::name::QualifiedName;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{self as ast, Expr, Stmt, visitor};
 use ruff_python_semantic::analyze::{function_type, visibility};
-use ruff_python_semantic::{Definition, SemanticModel};
+use ruff_python_semantic::{BindingKind, Definition, SemanticModel};
 use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_source_file::{LineRanges, NewlineWithTrailingNewline};
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
@@ -871,7 +871,15 @@ impl Ranged for ReturnEntry {
 /// An individual exception raised in a function body.
 #[derive(Debug)]
 struct ExceptionEntry<'a> {
+    /// Qualified name used for the diagnostic display.
     qualified_name: QualifiedName<'a>,
+    /// Additional qualified name accepted when matching against the docstring's
+    /// `Raises` section. Populated for ambiguous `X.method(...)` forms — without
+    /// type information, the AST cannot distinguish a classmethod constructor
+    /// (`ValueError.from_exception_data(...)`, exception is `ValueError`) from
+    /// a module attribute call (`urllib.error.URLError(...)`, exception is the
+    /// full path). Accepting either form sidesteps the ambiguity.
+    extra_candidate: Option<QualifiedName<'a>>,
     range: TextRange,
 }
 
@@ -951,9 +959,40 @@ impl<'a> BodyVisitor<'a> {
         }
         self.raised_exceptions.push(ExceptionEntry {
             qualified_name,
+            extra_candidate: None,
             range,
         });
     }
+}
+
+/// For chained method calls like `f(...).g(...).h(...)`, walk down to the
+/// inner-most `Call`. This lets the standard `map_callable` + `resolve_qualified_name`
+/// pipeline handle expressions like `Error.create(...).with_traceback(tb)` by
+/// reducing them to a resolvable form before resolution.
+/// Walk down an `Attribute` chain to the leftmost `Name`, if any.
+fn head_name(expr: &Expr) -> Option<&ast::ExprName> {
+    let mut current = expr;
+    loop {
+        match current {
+            Expr::Name(name) => return Some(name),
+            Expr::Attribute(ast::ExprAttribute { value, .. }) => current = value.as_ref(),
+            _ => return None,
+        }
+    }
+}
+
+fn peel_chained_method_calls(expr: &Expr) -> &Expr {
+    let mut current = expr;
+    while let Expr::Call(ast::ExprCall { func, .. }) = current {
+        if let Expr::Attribute(ast::ExprAttribute { value, .. }) = func.as_ref() {
+            if matches!(value.as_ref(), Expr::Call(_)) {
+                current = value.as_ref();
+                continue;
+            }
+        }
+        break;
+    }
+    current
 }
 
 impl<'a> Visitor<'a> for BodyVisitor<'a> {
@@ -980,35 +1019,58 @@ impl<'a> Visitor<'a> for BodyVisitor<'a> {
         match stmt {
             Stmt::Raise(ast::StmtRaise { exc, .. }) => {
                 if let Some(exc) = exc.as_ref() {
-                    // Unwrap method chain calls to find the exception type:
-                    //   `raise ValueError("bad")` → `ValueError`
-                    //   `raise ValueError.from_exception_data(...)` → `ValueError`
-                    //   `raise Error.create(...).with_traceback(tb)` → `Error`
-                    //   `raise module.SomeError` → `module.SomeError` (bare attr, no unwrap)
-                    let mut current = exc.as_ref();
-                    let qualified_name = loop {
-                        if let ast::Expr::Call(ast::ExprCall { func, .. }) = current {
-                            if let ast::Expr::Attribute(attr) = func.as_ref() {
-                                // `Error.method(...)` — try resolving the object.
-                                if let Some(qn) = self.semantic.resolve_qualified_name(&attr.value)
-                                {
-                                    break Some(qn);
-                                }
-                                // Object is another call — keep peeling.
-                                current = &attr.value;
-                            } else {
-                                // `Error(...)` — resolve the callable directly.
-                                break self.semantic.resolve_qualified_name(func.as_ref());
-                            }
-                        } else {
-                            // Bare `Error` or `module.Error` — resolve as-is.
-                            break self.semantic.resolve_qualified_name(current);
-                        }
-                    };
+                    // Reduce chained method calls to their inner-most call so
+                    // `map_callable` + `resolve_qualified_name` can handle them
+                    // (e.g. `Error.create(...).with_traceback(tb)` → `Error.create(...)`).
+                    let inner = peel_chained_method_calls(exc.as_ref());
+                    let callable = map_callable(inner);
+                    let qualified_name = self.semantic.resolve_qualified_name(callable);
 
                     if let Some(qualified_name) = qualified_name {
+                        // For `X.method(...)` (after peeling chains), the AST cannot
+                        // tell us whether `X` is a class (classmethod constructor) or
+                        // a module (attribute call). Compute the trimmed alternative
+                        // and decide which form to display by inspecting what the
+                        // head name binds to: if it's a class/builtin, prefer the
+                        // trimmed form (the class is the exception). Otherwise the
+                        // head is a module and the full name is the exception.
+                        let trimmed = if matches!(callable, Expr::Attribute(_)) {
+                            let segments = qualified_name.segments();
+                            if segments.len() > 1 {
+                                Some(
+                                    segments[..segments.len() - 1]
+                                        .iter()
+                                        .copied()
+                                        .collect::<QualifiedName>(),
+                                )
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        };
+
+                        let head_is_class = trimmed
+                            .as_ref()
+                            .and_then(|_| head_name(callable))
+                            .and_then(|name| self.semantic.resolve_name(name))
+                            .map(|id| self.semantic.binding(id))
+                            .is_some_and(|binding| {
+                                matches!(
+                                    binding.kind,
+                                    BindingKind::ClassDefinition(_) | BindingKind::Builtin
+                                )
+                            });
+
+                        let (display, extra_candidate) = match (trimmed, head_is_class) {
+                            (Some(trimmed), true) => (trimmed, Some(qualified_name)),
+                            (Some(trimmed), false) => (qualified_name, Some(trimmed)),
+                            (None, _) => (qualified_name, None),
+                        };
+
                         self.raised_exceptions.push(ExceptionEntry {
-                            qualified_name,
+                            qualified_name: display,
+                            extra_candidate,
                             range: exc.range(),
                         });
                     } else if let ast::Expr::Name(name) = exc.as_ref() {
@@ -1367,6 +1429,12 @@ pub(crate) fn check_docstring(
                         .qualified_name
                         .segments()
                         .ends_with(exception.segments())
+                        || body_raise
+                            .extra_candidate
+                            .as_ref()
+                            .is_some_and(|candidate| {
+                                candidate.segments().ends_with(exception.segments())
+                            })
                 })
             }) {
                 checker.report_diagnostic(

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -889,6 +889,18 @@ impl Ranged for ExceptionEntry<'_> {
     }
 }
 
+impl ExceptionEntry<'_> {
+    fn matches_docstring_exception(&self, exception: &QualifiedName) -> bool {
+        self.qualified_name
+            .segments()
+            .ends_with(exception.segments())
+            || self
+                .extra_candidate
+                .as_ref()
+                .is_some_and(|candidate| candidate.segments().ends_with(exception.segments()))
+    }
+}
+
 /// A summary of documentable statements from the function body
 #[derive(Debug)]
 struct BodyEntries<'a> {
@@ -965,10 +977,6 @@ impl<'a> BodyVisitor<'a> {
     }
 }
 
-/// For chained method calls like `f(...).g(...).h(...)`, walk down to the
-/// inner-most `Call`. This lets the standard `map_callable` + `resolve_qualified_name`
-/// pipeline handle expressions like `Error.create(...).with_traceback(tb)` by
-/// reducing them to a resolvable form before resolution.
 /// Walk down an `Attribute` chain to the leftmost `Name`, if any.
 fn head_name(expr: &Expr) -> Option<&ast::ExprName> {
     let mut current = expr;
@@ -981,6 +989,10 @@ fn head_name(expr: &Expr) -> Option<&ast::ExprName> {
     }
 }
 
+/// For chained method calls like `f(...).g(...).h(...)`, walk down to the
+/// inner-most `Call`. This lets the standard `map_callable` + `resolve_qualified_name`
+/// pipeline handle expressions like `Error.create(...).with_traceback(tb)` by
+/// reducing them to a resolvable form before resolution.
 fn peel_chained_method_calls(expr: &Expr) -> &Expr {
     let mut current = expr;
     while let Expr::Call(ast::ExprCall { func, .. }) = current {
@@ -1424,18 +1436,10 @@ pub(crate) fn check_docstring(
             }
 
             if !docstring_sections.raises.as_ref().is_some_and(|section| {
-                section.raised_exceptions.iter().any(|exception| {
-                    body_raise
-                        .qualified_name
-                        .segments()
-                        .ends_with(exception.segments())
-                        || body_raise
-                            .extra_candidate
-                            .as_ref()
-                            .is_some_and(|candidate| {
-                                candidate.segments().ends_with(exception.segments())
-                            })
-                })
+                section
+                    .raised_exceptions
+                    .iter()
+                    .any(|exception| body_raise.matches_docstring_exception(exception))
             }) {
                 checker.report_diagnostic(
                     DocstringMissingException {
@@ -1494,12 +1498,11 @@ pub(crate) fn check_docstring(
             if let Some(docstring_raises) = docstring_sections.raises {
                 let mut extraneous_exceptions = Vec::new();
                 for docstring_raise in &docstring_raises.raised_exceptions {
-                    if !body_entries.raised_exceptions.iter().any(|exception| {
-                        exception
-                            .qualified_name
-                            .segments()
-                            .ends_with(docstring_raise.segments())
-                    }) {
+                    if !body_entries
+                        .raised_exceptions
+                        .iter()
+                        .any(|exception| exception.matches_docstring_exception(docstring_raise))
+                    {
                         extraneous_exceptions.push(docstring_raise.to_string());
                     }
                 }

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py.snap
@@ -226,3 +226,35 @@ DOC501 Raised exception `ValueError` missing from docstring
 244 |           raise TypeError  # DOC501
     |
 help: Add `ValueError` to the docstring
+
+DOC501 Raised exception `ValueError` missing from docstring
+   --> DOC501_google.py:269:5
+    |
+267 |   # DOC501 - exception raised via classmethod, NOT documented
+268 |   def validate_classmethod_missing(value):
+269 | /     """Validate a value.
+270 | |
+271 | |     Args:
+272 | |         value: the value to validate.
+273 | |     """
+    | |_______^
+274 |       raise ValueError.from_exception_data(
+275 |           title="Validation",
+    |
+help: Add `ValueError` to the docstring
+
+DOC501 Raised exception `ValueError` missing from docstring
+   --> DOC501_google.py:311:5
+    |
+309 |   # DOC501 - chained method call, NOT documented
+310 |   def chained_missing(value):
+311 | /     """Validate a value.
+312 | |
+313 | |     Args:
+314 | |         value: the value to validate.
+315 | |     """
+    | |_______^
+316 |       raise ValueError.from_exception_data(
+317 |           title="Validation",
+    |
+help: Add `ValueError` to the docstring

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py.snap
@@ -2,259 +2,304 @@
 source: crates/ruff_linter/src/rules/pydoclint/mod.rs
 ---
 DOC501 Raised exception `FasterThanLightError` missing from docstring
-  --> DOC501_google.py:34:5
+  --> DOC501_google.py:36:5
    |
-32 |   # DOC501
-33 |   def calculate_speed(distance: float, time: float) -> float:
-34 | /     """Calculate speed as distance divided by time.
-35 | |
-36 | |     Args:
-37 | |         distance: Distance traveled.
-38 | |         time: Time spent traveling.
-39 | |
-40 | |     Returns:
-41 | |         Speed as distance divided by time.
-42 | |     """
+34 |   # DOC501
+35 |   def calculate_speed(distance: float, time: float) -> float:
+36 | /     """Calculate speed as distance divided by time.
+37 | |
+38 | |     Args:
+39 | |         distance: Distance traveled.
+40 | |         time: Time spent traveling.
+41 | |
+42 | |     Returns:
+43 | |         Speed as distance divided by time.
+44 | |     """
    | |_______^
-43 |       try:
-44 |           return distance / time
+45 |       try:
+46 |           return distance / time
    |
 help: Add `FasterThanLightError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-  --> DOC501_google.py:51:5
+  --> DOC501_google.py:53:5
    |
-49 |   # DOC501
-50 |   def calculate_speed(distance: float, time: float) -> float:
-51 | /     """Calculate speed as distance divided by time.
-52 | |
-53 | |     Args:
-54 | |         distance: Distance traveled.
-55 | |         time: Time spent traveling.
-56 | |
-57 | |     Returns:
-58 | |         Speed as distance divided by time.
-59 | |     """
+51 |   # DOC501
+52 |   def calculate_speed(distance: float, time: float) -> float:
+53 | /     """Calculate speed as distance divided by time.
+54 | |
+55 | |     Args:
+56 | |         distance: Distance traveled.
+57 | |         time: Time spent traveling.
+58 | |
+59 | |     Returns:
+60 | |         Speed as distance divided by time.
+61 | |     """
    | |_______^
-60 |       try:
-61 |           return distance / time
+62 |       try:
+63 |           return distance / time
    |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `FasterThanLightError` missing from docstring
-  --> DOC501_google.py:51:5
+  --> DOC501_google.py:53:5
    |
-49 |   # DOC501
-50 |   def calculate_speed(distance: float, time: float) -> float:
-51 | /     """Calculate speed as distance divided by time.
-52 | |
-53 | |     Args:
-54 | |         distance: Distance traveled.
-55 | |         time: Time spent traveling.
-56 | |
-57 | |     Returns:
-58 | |         Speed as distance divided by time.
-59 | |     """
+51 |   # DOC501
+52 |   def calculate_speed(distance: float, time: float) -> float:
+53 | /     """Calculate speed as distance divided by time.
+54 | |
+55 | |     Args:
+56 | |         distance: Distance traveled.
+57 | |         time: Time spent traveling.
+58 | |
+59 | |     Returns:
+60 | |         Speed as distance divided by time.
+61 | |     """
    | |_______^
-60 |       try:
-61 |           return distance / time
+62 |       try:
+63 |           return distance / time
    |
 help: Add `FasterThanLightError` to the docstring
 
 DOC501 Raised exception `ZeroDivisionError` missing from docstring
-  --> DOC501_google.py:70:5
+  --> DOC501_google.py:72:5
    |
-68 |   # DOC501
-69 |   def calculate_speed(distance: float, time: float) -> float:
-70 | /     """Calculate speed as distance divided by time.
-71 | |
-72 | |     Args:
-73 | |         distance: Distance traveled.
-74 | |         time: Time spent traveling.
-75 | |
-76 | |     Returns:
-77 | |         Speed as distance divided by time.
-78 | |     """
+70 |   # DOC501
+71 |   def calculate_speed(distance: float, time: float) -> float:
+72 | /     """Calculate speed as distance divided by time.
+73 | |
+74 | |     Args:
+75 | |         distance: Distance traveled.
+76 | |         time: Time spent traveling.
+77 | |
+78 | |     Returns:
+79 | |         Speed as distance divided by time.
+80 | |     """
    | |_______^
-79 |       try:
-80 |           return distance / time
+81 |       try:
+82 |           return distance / time
    |
 help: Add `ZeroDivisionError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-  --> DOC501_google.py:88:5
-   |
-86 |   # DOC501
-87 |   def calculate_speed(distance: float, time: float) -> float:
-88 | /     """Calculate speed as distance divided by time.
-89 | |
-90 | |     Args:
-91 | |         distance: Distance traveled.
-92 | |         time: Time spent traveling.
-93 | |
-94 | |     Returns:
-95 | |         Speed as distance divided by time.
-96 | |     """
-   | |_______^
-97 |       try:
-98 |           return distance / time
-   |
+   --> DOC501_google.py:90:5
+    |
+ 88 |   # DOC501
+ 89 |   def calculate_speed(distance: float, time: float) -> float:
+ 90 | /     """Calculate speed as distance divided by time.
+ 91 | |
+ 92 | |     Args:
+ 93 | |         distance: Distance traveled.
+ 94 | |         time: Time spent traveling.
+ 95 | |
+ 96 | |     Returns:
+ 97 | |         Speed as distance divided by time.
+ 98 | |     """
+    | |_______^
+ 99 |       try:
+100 |           return distance / time
+    |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `ZeroDivisionError` missing from docstring
-  --> DOC501_google.py:88:5
-   |
-86 |   # DOC501
-87 |   def calculate_speed(distance: float, time: float) -> float:
-88 | /     """Calculate speed as distance divided by time.
-89 | |
-90 | |     Args:
-91 | |         distance: Distance traveled.
-92 | |         time: Time spent traveling.
-93 | |
-94 | |     Returns:
-95 | |         Speed as distance divided by time.
-96 | |     """
-   | |_______^
-97 |       try:
-98 |           return distance / time
-   |
+   --> DOC501_google.py:90:5
+    |
+ 88 |   # DOC501
+ 89 |   def calculate_speed(distance: float, time: float) -> float:
+ 90 | /     """Calculate speed as distance divided by time.
+ 91 | |
+ 92 | |     Args:
+ 93 | |         distance: Distance traveled.
+ 94 | |         time: Time spent traveling.
+ 95 | |
+ 96 | |     Returns:
+ 97 | |         Speed as distance divided by time.
+ 98 | |     """
+    | |_______^
+ 99 |       try:
+100 |           return distance / time
+    |
 help: Add `ZeroDivisionError` to the docstring
 
 DOC501 Raised exception `AnotherError` missing from docstring
-   --> DOC501_google.py:106:5
+   --> DOC501_google.py:108:5
     |
-104 |   # DOC501
-105 |   def calculate_speed(distance: float, time: float) -> float:
-106 | /     """Calculate speed as distance divided by time.
-107 | |
-108 | |     Args:
-109 | |         distance: Distance traveled.
-110 | |         time: Time spent traveling.
-111 | |
-112 | |     Returns:
-113 | |         Speed as distance divided by time.
-114 | |     """
+106 |   # DOC501
+107 |   def calculate_speed(distance: float, time: float) -> float:
+108 | /     """Calculate speed as distance divided by time.
+109 | |
+110 | |     Args:
+111 | |         distance: Distance traveled.
+112 | |         time: Time spent traveling.
+113 | |
+114 | |     Returns:
+115 | |         Speed as distance divided by time.
+116 | |     """
     | |_______^
-115 |       raise AnotherError
+117 |       raise AnotherError
     |
 help: Add `AnotherError` to the docstring
 
 DOC501 Raised exception `AnotherError` missing from docstring
-   --> DOC501_google.py:120:5
+   --> DOC501_google.py:122:5
     |
-118 |   # DOC501
-119 |   def calculate_speed(distance: float, time: float) -> float:
-120 | /     """Calculate speed as distance divided by time.
-121 | |
-122 | |     Args:
-123 | |         distance: Distance traveled.
-124 | |         time: Time spent traveling.
-125 | |
-126 | |     Returns:
-127 | |         Speed as distance divided by time.
-128 | |     """
+120 |   # DOC501
+121 |   def calculate_speed(distance: float, time: float) -> float:
+122 | /     """Calculate speed as distance divided by time.
+123 | |
+124 | |     Args:
+125 | |         distance: Distance traveled.
+126 | |         time: Time spent traveling.
+127 | |
+128 | |     Returns:
+129 | |         Speed as distance divided by time.
+130 | |     """
     | |_______^
-129 |       raise AnotherError()
+131 |       raise AnotherError()
     |
 help: Add `AnotherError` to the docstring
 
 DOC501 Raised exception `SomeError` missing from docstring
-   --> DOC501_google.py:134:5
+   --> DOC501_google.py:136:5
     |
-132 |   # DOC501
-133 |   def foo(bar: int):
-134 | /     """Foo.
-135 | |
-136 | |     Args:
-137 | |         bar: Bar.
-138 | |     """
+134 |   # DOC501
+135 |   def foo(bar: int):
+136 | /     """Foo.
+137 | |
+138 | |     Args:
+139 | |         bar: Bar.
+140 | |     """
     | |_______^
-139 |       raise something.SomeError
+141 |       raise something.SomeError
     |
 help: Add `SomeError` to the docstring
 
 DOC501 Raised exception `ZeroDivisionError` missing from docstring
-   --> DOC501_google.py:197:5
+   --> DOC501_google.py:199:5
     |
-195 |   # DOC501
-196 |   def calculate_speed(distance: float, time: float) -> float:
-197 | /     """Calculate speed as distance divided by time.
-198 | |
-199 | |     Args:
-200 | |         distance: Distance traveled.
-201 | |         time: Time spent traveling.
-202 | |
-203 | |     Returns:
-204 | |         Speed as distance divided by time.
-205 | |
-206 | |     Raises:
-207 | |         TypeError: if you didn't pass a number for both parameters
-208 | |     """
+197 |   # DOC501
+198 |   def calculate_speed(distance: float, time: float) -> float:
+199 | /     """Calculate speed as distance divided by time.
+200 | |
+201 | |     Args:
+202 | |         distance: Distance traveled.
+203 | |         time: Time spent traveling.
+204 | |
+205 | |     Returns:
+206 | |         Speed as distance divided by time.
+207 | |
+208 | |     Raises:
+209 | |         TypeError: if you didn't pass a number for both parameters
+210 | |     """
     | |_______^
-209 |       try:
-210 |           return distance / time
+211 |       try:
+212 |           return distance / time
     |
 help: Add `ZeroDivisionError` to the docstring
 
 DOC501 Raised exception `TypeError` missing from docstring
-   --> DOC501_google.py:238:5
+   --> DOC501_google.py:240:5
     |
-237 |   def foo():
-238 | /     """Foo.
-239 | |
-240 | |     Returns:
-241 | |         42: int.
-242 | |     """
+239 |   def foo():
+240 | /     """Foo.
+241 | |
+242 | |     Returns:
+243 | |         42: int.
+244 | |     """
     | |_______^
-243 |       if True:
-244 |           raise TypeError  # DOC501
+245 |       if True:
+246 |           raise TypeError  # DOC501
     |
 help: Add `TypeError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-   --> DOC501_google.py:238:5
+   --> DOC501_google.py:240:5
     |
-237 |   def foo():
-238 | /     """Foo.
-239 | |
-240 | |     Returns:
-241 | |         42: int.
-242 | |     """
+239 |   def foo():
+240 | /     """Foo.
+241 | |
+242 | |     Returns:
+243 | |         42: int.
+244 | |     """
     | |_______^
-243 |       if True:
-244 |           raise TypeError  # DOC501
+245 |       if True:
+246 |           raise TypeError  # DOC501
     |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-   --> DOC501_google.py:269:5
+   --> DOC501_google.py:271:5
     |
-267 |   # DOC501 - exception raised via classmethod, NOT documented
-268 |   def validate_classmethod_missing(value):
-269 | /     """Validate a value.
-270 | |
-271 | |     Args:
-272 | |         value: the value to validate.
-273 | |     """
+269 |   # DOC501 - exception raised via classmethod, NOT documented
+270 |   def validate_classmethod_missing(value):
+271 | /     """Validate a value.
+272 | |
+273 | |     Args:
+274 | |         value: the value to validate.
+275 | |     """
     | |_______^
-274 |       raise ValueError.from_exception_data(
-275 |           title="Validation",
+276 |       raise ValueError.from_exception_data(
+277 |           title="Validation",
     |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-   --> DOC501_google.py:311:5
+   --> DOC501_google.py:313:5
     |
-309 |   # DOC501 - chained method call, NOT documented
-310 |   def chained_missing(value):
-311 | /     """Validate a value.
-312 | |
-313 | |     Args:
-314 | |         value: the value to validate.
-315 | |     """
+311 |   # DOC501 - chained method call, NOT documented
+312 |   def chained_missing(value):
+313 | /     """Validate a value.
+314 | |
+315 | |     Args:
+316 | |         value: the value to validate.
+317 | |     """
     | |_______^
-316 |       raise ValueError.from_exception_data(
-317 |           title="Validation",
+318 |       raise ValueError.from_exception_data(
+319 |           title="Validation",
     |
 help: Add `ValueError` to the docstring
+
+DOC501 Raised exception `SomeError` missing from docstring
+   --> DOC501_google.py:339:5
+    |
+337 |   # DOC501 - exception raised via module attribute call, NOT documented
+338 |   def module_exception_missing(value):
+339 | /     """Process a value.
+340 | |
+341 | |     Args:
+342 | |         value: the value to process.
+343 | |     """
+    | |_______^
+344 |       raise something.SomeError(value)
+    |
+help: Add `SomeError` to the docstring
+
+DOC501 Raised exception `URLError` missing from docstring
+   --> DOC501_google.py:362:5
+    |
+360 |   # DOC501 - exception raised via nested module attribute call, NOT documented
+361 |   def nested_module_exception_missing(value):
+362 | /     """Process a value.
+363 | |
+364 | |     Args:
+365 | |         value: the value to process.
+366 | |     """
+    | |_______^
+367 |       raise urllib.error.URLError(value)
+    |
+help: Add `URLError` to the docstring
+
+DOC501 Raised exception `URLError` missing from docstring
+   --> DOC501_google.py:385:5
+    |
+383 |   # DOC501 - exception raised via from-imported module, NOT documented
+384 |   def from_import_module_missing(value):
+385 | /     """Process a value.
+386 | |
+387 | |     Args:
+388 | |         value: the value to process.
+389 | |     """
+    | |_______^
+390 |       raise url_error.URLError(value)
+    |
+help: Add `URLError` to the docstring

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py.snap
@@ -2,304 +2,304 @@
 source: crates/ruff_linter/src/rules/pydoclint/mod.rs
 ---
 DOC501 Raised exception `FasterThanLightError` missing from docstring
-  --> DOC501_google.py:36:5
+  --> DOC501_google.py:34:5
    |
-34 |   # DOC501
-35 |   def calculate_speed(distance: float, time: float) -> float:
-36 | /     """Calculate speed as distance divided by time.
-37 | |
-38 | |     Args:
-39 | |         distance: Distance traveled.
-40 | |         time: Time spent traveling.
-41 | |
-42 | |     Returns:
-43 | |         Speed as distance divided by time.
-44 | |     """
+32 |   # DOC501
+33 |   def calculate_speed(distance: float, time: float) -> float:
+34 | /     """Calculate speed as distance divided by time.
+35 | |
+36 | |     Args:
+37 | |         distance: Distance traveled.
+38 | |         time: Time spent traveling.
+39 | |
+40 | |     Returns:
+41 | |         Speed as distance divided by time.
+42 | |     """
    | |_______^
-45 |       try:
-46 |           return distance / time
+43 |       try:
+44 |           return distance / time
    |
 help: Add `FasterThanLightError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-  --> DOC501_google.py:53:5
+  --> DOC501_google.py:51:5
    |
-51 |   # DOC501
-52 |   def calculate_speed(distance: float, time: float) -> float:
-53 | /     """Calculate speed as distance divided by time.
-54 | |
-55 | |     Args:
-56 | |         distance: Distance traveled.
-57 | |         time: Time spent traveling.
-58 | |
-59 | |     Returns:
-60 | |         Speed as distance divided by time.
-61 | |     """
+49 |   # DOC501
+50 |   def calculate_speed(distance: float, time: float) -> float:
+51 | /     """Calculate speed as distance divided by time.
+52 | |
+53 | |     Args:
+54 | |         distance: Distance traveled.
+55 | |         time: Time spent traveling.
+56 | |
+57 | |     Returns:
+58 | |         Speed as distance divided by time.
+59 | |     """
    | |_______^
-62 |       try:
-63 |           return distance / time
+60 |       try:
+61 |           return distance / time
    |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `FasterThanLightError` missing from docstring
-  --> DOC501_google.py:53:5
+  --> DOC501_google.py:51:5
    |
-51 |   # DOC501
-52 |   def calculate_speed(distance: float, time: float) -> float:
-53 | /     """Calculate speed as distance divided by time.
-54 | |
-55 | |     Args:
-56 | |         distance: Distance traveled.
-57 | |         time: Time spent traveling.
-58 | |
-59 | |     Returns:
-60 | |         Speed as distance divided by time.
-61 | |     """
+49 |   # DOC501
+50 |   def calculate_speed(distance: float, time: float) -> float:
+51 | /     """Calculate speed as distance divided by time.
+52 | |
+53 | |     Args:
+54 | |         distance: Distance traveled.
+55 | |         time: Time spent traveling.
+56 | |
+57 | |     Returns:
+58 | |         Speed as distance divided by time.
+59 | |     """
    | |_______^
-62 |       try:
-63 |           return distance / time
+60 |       try:
+61 |           return distance / time
    |
 help: Add `FasterThanLightError` to the docstring
 
 DOC501 Raised exception `ZeroDivisionError` missing from docstring
-  --> DOC501_google.py:72:5
+  --> DOC501_google.py:70:5
    |
-70 |   # DOC501
-71 |   def calculate_speed(distance: float, time: float) -> float:
-72 | /     """Calculate speed as distance divided by time.
-73 | |
-74 | |     Args:
-75 | |         distance: Distance traveled.
-76 | |         time: Time spent traveling.
-77 | |
-78 | |     Returns:
-79 | |         Speed as distance divided by time.
-80 | |     """
+68 |   # DOC501
+69 |   def calculate_speed(distance: float, time: float) -> float:
+70 | /     """Calculate speed as distance divided by time.
+71 | |
+72 | |     Args:
+73 | |         distance: Distance traveled.
+74 | |         time: Time spent traveling.
+75 | |
+76 | |     Returns:
+77 | |         Speed as distance divided by time.
+78 | |     """
    | |_______^
-81 |       try:
-82 |           return distance / time
+79 |       try:
+80 |           return distance / time
    |
 help: Add `ZeroDivisionError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-   --> DOC501_google.py:90:5
-    |
- 88 |   # DOC501
- 89 |   def calculate_speed(distance: float, time: float) -> float:
- 90 | /     """Calculate speed as distance divided by time.
- 91 | |
- 92 | |     Args:
- 93 | |         distance: Distance traveled.
- 94 | |         time: Time spent traveling.
- 95 | |
- 96 | |     Returns:
- 97 | |         Speed as distance divided by time.
- 98 | |     """
-    | |_______^
- 99 |       try:
-100 |           return distance / time
-    |
+  --> DOC501_google.py:88:5
+   |
+86 |   # DOC501
+87 |   def calculate_speed(distance: float, time: float) -> float:
+88 | /     """Calculate speed as distance divided by time.
+89 | |
+90 | |     Args:
+91 | |         distance: Distance traveled.
+92 | |         time: Time spent traveling.
+93 | |
+94 | |     Returns:
+95 | |         Speed as distance divided by time.
+96 | |     """
+   | |_______^
+97 |       try:
+98 |           return distance / time
+   |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `ZeroDivisionError` missing from docstring
-   --> DOC501_google.py:90:5
-    |
- 88 |   # DOC501
- 89 |   def calculate_speed(distance: float, time: float) -> float:
- 90 | /     """Calculate speed as distance divided by time.
- 91 | |
- 92 | |     Args:
- 93 | |         distance: Distance traveled.
- 94 | |         time: Time spent traveling.
- 95 | |
- 96 | |     Returns:
- 97 | |         Speed as distance divided by time.
- 98 | |     """
-    | |_______^
- 99 |       try:
-100 |           return distance / time
-    |
+  --> DOC501_google.py:88:5
+   |
+86 |   # DOC501
+87 |   def calculate_speed(distance: float, time: float) -> float:
+88 | /     """Calculate speed as distance divided by time.
+89 | |
+90 | |     Args:
+91 | |         distance: Distance traveled.
+92 | |         time: Time spent traveling.
+93 | |
+94 | |     Returns:
+95 | |         Speed as distance divided by time.
+96 | |     """
+   | |_______^
+97 |       try:
+98 |           return distance / time
+   |
 help: Add `ZeroDivisionError` to the docstring
 
 DOC501 Raised exception `AnotherError` missing from docstring
-   --> DOC501_google.py:108:5
+   --> DOC501_google.py:106:5
     |
-106 |   # DOC501
-107 |   def calculate_speed(distance: float, time: float) -> float:
-108 | /     """Calculate speed as distance divided by time.
-109 | |
-110 | |     Args:
-111 | |         distance: Distance traveled.
-112 | |         time: Time spent traveling.
-113 | |
-114 | |     Returns:
-115 | |         Speed as distance divided by time.
-116 | |     """
+104 |   # DOC501
+105 |   def calculate_speed(distance: float, time: float) -> float:
+106 | /     """Calculate speed as distance divided by time.
+107 | |
+108 | |     Args:
+109 | |         distance: Distance traveled.
+110 | |         time: Time spent traveling.
+111 | |
+112 | |     Returns:
+113 | |         Speed as distance divided by time.
+114 | |     """
     | |_______^
-117 |       raise AnotherError
+115 |       raise AnotherError
     |
 help: Add `AnotherError` to the docstring
 
 DOC501 Raised exception `AnotherError` missing from docstring
-   --> DOC501_google.py:122:5
+   --> DOC501_google.py:120:5
     |
-120 |   # DOC501
-121 |   def calculate_speed(distance: float, time: float) -> float:
-122 | /     """Calculate speed as distance divided by time.
-123 | |
-124 | |     Args:
-125 | |         distance: Distance traveled.
-126 | |         time: Time spent traveling.
-127 | |
-128 | |     Returns:
-129 | |         Speed as distance divided by time.
-130 | |     """
+118 |   # DOC501
+119 |   def calculate_speed(distance: float, time: float) -> float:
+120 | /     """Calculate speed as distance divided by time.
+121 | |
+122 | |     Args:
+123 | |         distance: Distance traveled.
+124 | |         time: Time spent traveling.
+125 | |
+126 | |     Returns:
+127 | |         Speed as distance divided by time.
+128 | |     """
     | |_______^
-131 |       raise AnotherError()
+129 |       raise AnotherError()
     |
 help: Add `AnotherError` to the docstring
 
 DOC501 Raised exception `SomeError` missing from docstring
-   --> DOC501_google.py:136:5
+   --> DOC501_google.py:134:5
     |
-134 |   # DOC501
-135 |   def foo(bar: int):
-136 | /     """Foo.
-137 | |
-138 | |     Args:
-139 | |         bar: Bar.
-140 | |     """
+132 |   # DOC501
+133 |   def foo(bar: int):
+134 | /     """Foo.
+135 | |
+136 | |     Args:
+137 | |         bar: Bar.
+138 | |     """
     | |_______^
-141 |       raise something.SomeError
+139 |       raise something.SomeError
     |
 help: Add `SomeError` to the docstring
 
 DOC501 Raised exception `ZeroDivisionError` missing from docstring
-   --> DOC501_google.py:199:5
+   --> DOC501_google.py:197:5
     |
-197 |   # DOC501
-198 |   def calculate_speed(distance: float, time: float) -> float:
-199 | /     """Calculate speed as distance divided by time.
-200 | |
-201 | |     Args:
-202 | |         distance: Distance traveled.
-203 | |         time: Time spent traveling.
-204 | |
-205 | |     Returns:
-206 | |         Speed as distance divided by time.
-207 | |
-208 | |     Raises:
-209 | |         TypeError: if you didn't pass a number for both parameters
-210 | |     """
+195 |   # DOC501
+196 |   def calculate_speed(distance: float, time: float) -> float:
+197 | /     """Calculate speed as distance divided by time.
+198 | |
+199 | |     Args:
+200 | |         distance: Distance traveled.
+201 | |         time: Time spent traveling.
+202 | |
+203 | |     Returns:
+204 | |         Speed as distance divided by time.
+205 | |
+206 | |     Raises:
+207 | |         TypeError: if you didn't pass a number for both parameters
+208 | |     """
     | |_______^
-211 |       try:
-212 |           return distance / time
+209 |       try:
+210 |           return distance / time
     |
 help: Add `ZeroDivisionError` to the docstring
 
 DOC501 Raised exception `TypeError` missing from docstring
-   --> DOC501_google.py:240:5
+   --> DOC501_google.py:238:5
     |
-239 |   def foo():
-240 | /     """Foo.
-241 | |
-242 | |     Returns:
-243 | |         42: int.
-244 | |     """
+237 |   def foo():
+238 | /     """Foo.
+239 | |
+240 | |     Returns:
+241 | |         42: int.
+242 | |     """
     | |_______^
-245 |       if True:
-246 |           raise TypeError  # DOC501
+243 |       if True:
+244 |           raise TypeError  # DOC501
     |
 help: Add `TypeError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-   --> DOC501_google.py:240:5
+   --> DOC501_google.py:238:5
     |
-239 |   def foo():
-240 | /     """Foo.
-241 | |
-242 | |     Returns:
-243 | |         42: int.
-244 | |     """
+237 |   def foo():
+238 | /     """Foo.
+239 | |
+240 | |     Returns:
+241 | |         42: int.
+242 | |     """
     | |_______^
-245 |       if True:
-246 |           raise TypeError  # DOC501
+243 |       if True:
+244 |           raise TypeError  # DOC501
     |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-   --> DOC501_google.py:271:5
+   --> DOC501_google.py:273:5
     |
-269 |   # DOC501 - exception raised via classmethod, NOT documented
-270 |   def validate_classmethod_missing(value):
-271 | /     """Validate a value.
-272 | |
-273 | |     Args:
-274 | |         value: the value to validate.
-275 | |     """
+271 |   # DOC501 - exception raised via classmethod, NOT documented
+272 |   def validate_classmethod_missing(value):
+273 | /     """Validate a value.
+274 | |
+275 | |     Args:
+276 | |         value: the value to validate.
+277 | |     """
     | |_______^
-276 |       raise ValueError.from_exception_data(
-277 |           title="Validation",
+278 |       raise ValueError.from_exception_data(
+279 |           title="Validation",
     |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-   --> DOC501_google.py:313:5
+   --> DOC501_google.py:315:5
     |
-311 |   # DOC501 - chained method call, NOT documented
-312 |   def chained_missing(value):
-313 | /     """Validate a value.
-314 | |
-315 | |     Args:
-316 | |         value: the value to validate.
-317 | |     """
+313 |   # DOC501 - chained method call, NOT documented
+314 |   def chained_missing(value):
+315 | /     """Validate a value.
+316 | |
+317 | |     Args:
+318 | |         value: the value to validate.
+319 | |     """
     | |_______^
-318 |       raise ValueError.from_exception_data(
-319 |           title="Validation",
+320 |       raise ValueError.from_exception_data(
+321 |           title="Validation",
     |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `SomeError` missing from docstring
-   --> DOC501_google.py:339:5
+   --> DOC501_google.py:341:5
     |
-337 |   # DOC501 - exception raised via module attribute call, NOT documented
-338 |   def module_exception_missing(value):
-339 | /     """Process a value.
-340 | |
-341 | |     Args:
-342 | |         value: the value to process.
-343 | |     """
+339 |   # DOC501 - exception raised via module attribute call, NOT documented
+340 |   def module_exception_missing(value):
+341 | /     """Process a value.
+342 | |
+343 | |     Args:
+344 | |         value: the value to process.
+345 | |     """
     | |_______^
-344 |       raise something.SomeError(value)
+346 |       raise something.SomeError(value)
     |
 help: Add `SomeError` to the docstring
 
 DOC501 Raised exception `URLError` missing from docstring
-   --> DOC501_google.py:362:5
+   --> DOC501_google.py:364:5
     |
-360 |   # DOC501 - exception raised via nested module attribute call, NOT documented
-361 |   def nested_module_exception_missing(value):
-362 | /     """Process a value.
-363 | |
-364 | |     Args:
-365 | |         value: the value to process.
-366 | |     """
+362 |   # DOC501 - exception raised via nested module attribute call, NOT documented
+363 |   def nested_module_exception_missing(value):
+364 | /     """Process a value.
+365 | |
+366 | |     Args:
+367 | |         value: the value to process.
+368 | |     """
     | |_______^
-367 |       raise urllib.error.URLError(value)
+369 |       raise urllib.error.URLError(value)
     |
 help: Add `URLError` to the docstring
 
 DOC501 Raised exception `URLError` missing from docstring
-   --> DOC501_google.py:385:5
+   --> DOC501_google.py:387:5
     |
-383 |   # DOC501 - exception raised via from-imported module, NOT documented
-384 |   def from_import_module_missing(value):
-385 | /     """Process a value.
-386 | |
-387 | |     Args:
-388 | |         value: the value to process.
-389 | |     """
+385 |   # DOC501 - exception raised via from-imported module, NOT documented
+386 |   def from_import_module_missing(value):
+387 | /     """Process a value.
+388 | |
+389 | |     Args:
+390 | |         value: the value to process.
+391 | |     """
     | |_______^
-390 |       raise url_error.URLError(value)
+392 |       raise url_error.URLError(value)
     |
 help: Add `URLError` to the docstring

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py_ignore_one_line.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py_ignore_one_line.snap
@@ -226,3 +226,35 @@ DOC501 Raised exception `ValueError` missing from docstring
 244 |           raise TypeError  # DOC501
     |
 help: Add `ValueError` to the docstring
+
+DOC501 Raised exception `ValueError` missing from docstring
+   --> DOC501_google.py:269:5
+    |
+267 |   # DOC501 - exception raised via classmethod, NOT documented
+268 |   def validate_classmethod_missing(value):
+269 | /     """Validate a value.
+270 | |
+271 | |     Args:
+272 | |         value: the value to validate.
+273 | |     """
+    | |_______^
+274 |       raise ValueError.from_exception_data(
+275 |           title="Validation",
+    |
+help: Add `ValueError` to the docstring
+
+DOC501 Raised exception `ValueError` missing from docstring
+   --> DOC501_google.py:311:5
+    |
+309 |   # DOC501 - chained method call, NOT documented
+310 |   def chained_missing(value):
+311 | /     """Validate a value.
+312 | |
+313 | |     Args:
+314 | |         value: the value to validate.
+315 | |     """
+    | |_______^
+316 |       raise ValueError.from_exception_data(
+317 |           title="Validation",
+    |
+help: Add `ValueError` to the docstring

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py_ignore_one_line.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py_ignore_one_line.snap
@@ -2,259 +2,304 @@
 source: crates/ruff_linter/src/rules/pydoclint/mod.rs
 ---
 DOC501 Raised exception `FasterThanLightError` missing from docstring
-  --> DOC501_google.py:34:5
+  --> DOC501_google.py:36:5
    |
-32 |   # DOC501
-33 |   def calculate_speed(distance: float, time: float) -> float:
-34 | /     """Calculate speed as distance divided by time.
-35 | |
-36 | |     Args:
-37 | |         distance: Distance traveled.
-38 | |         time: Time spent traveling.
-39 | |
-40 | |     Returns:
-41 | |         Speed as distance divided by time.
-42 | |     """
+34 |   # DOC501
+35 |   def calculate_speed(distance: float, time: float) -> float:
+36 | /     """Calculate speed as distance divided by time.
+37 | |
+38 | |     Args:
+39 | |         distance: Distance traveled.
+40 | |         time: Time spent traveling.
+41 | |
+42 | |     Returns:
+43 | |         Speed as distance divided by time.
+44 | |     """
    | |_______^
-43 |       try:
-44 |           return distance / time
+45 |       try:
+46 |           return distance / time
    |
 help: Add `FasterThanLightError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-  --> DOC501_google.py:51:5
+  --> DOC501_google.py:53:5
    |
-49 |   # DOC501
-50 |   def calculate_speed(distance: float, time: float) -> float:
-51 | /     """Calculate speed as distance divided by time.
-52 | |
-53 | |     Args:
-54 | |         distance: Distance traveled.
-55 | |         time: Time spent traveling.
-56 | |
-57 | |     Returns:
-58 | |         Speed as distance divided by time.
-59 | |     """
+51 |   # DOC501
+52 |   def calculate_speed(distance: float, time: float) -> float:
+53 | /     """Calculate speed as distance divided by time.
+54 | |
+55 | |     Args:
+56 | |         distance: Distance traveled.
+57 | |         time: Time spent traveling.
+58 | |
+59 | |     Returns:
+60 | |         Speed as distance divided by time.
+61 | |     """
    | |_______^
-60 |       try:
-61 |           return distance / time
+62 |       try:
+63 |           return distance / time
    |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `FasterThanLightError` missing from docstring
-  --> DOC501_google.py:51:5
+  --> DOC501_google.py:53:5
    |
-49 |   # DOC501
-50 |   def calculate_speed(distance: float, time: float) -> float:
-51 | /     """Calculate speed as distance divided by time.
-52 | |
-53 | |     Args:
-54 | |         distance: Distance traveled.
-55 | |         time: Time spent traveling.
-56 | |
-57 | |     Returns:
-58 | |         Speed as distance divided by time.
-59 | |     """
+51 |   # DOC501
+52 |   def calculate_speed(distance: float, time: float) -> float:
+53 | /     """Calculate speed as distance divided by time.
+54 | |
+55 | |     Args:
+56 | |         distance: Distance traveled.
+57 | |         time: Time spent traveling.
+58 | |
+59 | |     Returns:
+60 | |         Speed as distance divided by time.
+61 | |     """
    | |_______^
-60 |       try:
-61 |           return distance / time
+62 |       try:
+63 |           return distance / time
    |
 help: Add `FasterThanLightError` to the docstring
 
 DOC501 Raised exception `ZeroDivisionError` missing from docstring
-  --> DOC501_google.py:70:5
+  --> DOC501_google.py:72:5
    |
-68 |   # DOC501
-69 |   def calculate_speed(distance: float, time: float) -> float:
-70 | /     """Calculate speed as distance divided by time.
-71 | |
-72 | |     Args:
-73 | |         distance: Distance traveled.
-74 | |         time: Time spent traveling.
-75 | |
-76 | |     Returns:
-77 | |         Speed as distance divided by time.
-78 | |     """
+70 |   # DOC501
+71 |   def calculate_speed(distance: float, time: float) -> float:
+72 | /     """Calculate speed as distance divided by time.
+73 | |
+74 | |     Args:
+75 | |         distance: Distance traveled.
+76 | |         time: Time spent traveling.
+77 | |
+78 | |     Returns:
+79 | |         Speed as distance divided by time.
+80 | |     """
    | |_______^
-79 |       try:
-80 |           return distance / time
+81 |       try:
+82 |           return distance / time
    |
 help: Add `ZeroDivisionError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-  --> DOC501_google.py:88:5
-   |
-86 |   # DOC501
-87 |   def calculate_speed(distance: float, time: float) -> float:
-88 | /     """Calculate speed as distance divided by time.
-89 | |
-90 | |     Args:
-91 | |         distance: Distance traveled.
-92 | |         time: Time spent traveling.
-93 | |
-94 | |     Returns:
-95 | |         Speed as distance divided by time.
-96 | |     """
-   | |_______^
-97 |       try:
-98 |           return distance / time
-   |
+   --> DOC501_google.py:90:5
+    |
+ 88 |   # DOC501
+ 89 |   def calculate_speed(distance: float, time: float) -> float:
+ 90 | /     """Calculate speed as distance divided by time.
+ 91 | |
+ 92 | |     Args:
+ 93 | |         distance: Distance traveled.
+ 94 | |         time: Time spent traveling.
+ 95 | |
+ 96 | |     Returns:
+ 97 | |         Speed as distance divided by time.
+ 98 | |     """
+    | |_______^
+ 99 |       try:
+100 |           return distance / time
+    |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `ZeroDivisionError` missing from docstring
-  --> DOC501_google.py:88:5
-   |
-86 |   # DOC501
-87 |   def calculate_speed(distance: float, time: float) -> float:
-88 | /     """Calculate speed as distance divided by time.
-89 | |
-90 | |     Args:
-91 | |         distance: Distance traveled.
-92 | |         time: Time spent traveling.
-93 | |
-94 | |     Returns:
-95 | |         Speed as distance divided by time.
-96 | |     """
-   | |_______^
-97 |       try:
-98 |           return distance / time
-   |
+   --> DOC501_google.py:90:5
+    |
+ 88 |   # DOC501
+ 89 |   def calculate_speed(distance: float, time: float) -> float:
+ 90 | /     """Calculate speed as distance divided by time.
+ 91 | |
+ 92 | |     Args:
+ 93 | |         distance: Distance traveled.
+ 94 | |         time: Time spent traveling.
+ 95 | |
+ 96 | |     Returns:
+ 97 | |         Speed as distance divided by time.
+ 98 | |     """
+    | |_______^
+ 99 |       try:
+100 |           return distance / time
+    |
 help: Add `ZeroDivisionError` to the docstring
 
 DOC501 Raised exception `AnotherError` missing from docstring
-   --> DOC501_google.py:106:5
+   --> DOC501_google.py:108:5
     |
-104 |   # DOC501
-105 |   def calculate_speed(distance: float, time: float) -> float:
-106 | /     """Calculate speed as distance divided by time.
-107 | |
-108 | |     Args:
-109 | |         distance: Distance traveled.
-110 | |         time: Time spent traveling.
-111 | |
-112 | |     Returns:
-113 | |         Speed as distance divided by time.
-114 | |     """
+106 |   # DOC501
+107 |   def calculate_speed(distance: float, time: float) -> float:
+108 | /     """Calculate speed as distance divided by time.
+109 | |
+110 | |     Args:
+111 | |         distance: Distance traveled.
+112 | |         time: Time spent traveling.
+113 | |
+114 | |     Returns:
+115 | |         Speed as distance divided by time.
+116 | |     """
     | |_______^
-115 |       raise AnotherError
+117 |       raise AnotherError
     |
 help: Add `AnotherError` to the docstring
 
 DOC501 Raised exception `AnotherError` missing from docstring
-   --> DOC501_google.py:120:5
+   --> DOC501_google.py:122:5
     |
-118 |   # DOC501
-119 |   def calculate_speed(distance: float, time: float) -> float:
-120 | /     """Calculate speed as distance divided by time.
-121 | |
-122 | |     Args:
-123 | |         distance: Distance traveled.
-124 | |         time: Time spent traveling.
-125 | |
-126 | |     Returns:
-127 | |         Speed as distance divided by time.
-128 | |     """
+120 |   # DOC501
+121 |   def calculate_speed(distance: float, time: float) -> float:
+122 | /     """Calculate speed as distance divided by time.
+123 | |
+124 | |     Args:
+125 | |         distance: Distance traveled.
+126 | |         time: Time spent traveling.
+127 | |
+128 | |     Returns:
+129 | |         Speed as distance divided by time.
+130 | |     """
     | |_______^
-129 |       raise AnotherError()
+131 |       raise AnotherError()
     |
 help: Add `AnotherError` to the docstring
 
 DOC501 Raised exception `SomeError` missing from docstring
-   --> DOC501_google.py:134:5
+   --> DOC501_google.py:136:5
     |
-132 |   # DOC501
-133 |   def foo(bar: int):
-134 | /     """Foo.
-135 | |
-136 | |     Args:
-137 | |         bar: Bar.
-138 | |     """
+134 |   # DOC501
+135 |   def foo(bar: int):
+136 | /     """Foo.
+137 | |
+138 | |     Args:
+139 | |         bar: Bar.
+140 | |     """
     | |_______^
-139 |       raise something.SomeError
+141 |       raise something.SomeError
     |
 help: Add `SomeError` to the docstring
 
 DOC501 Raised exception `ZeroDivisionError` missing from docstring
-   --> DOC501_google.py:197:5
+   --> DOC501_google.py:199:5
     |
-195 |   # DOC501
-196 |   def calculate_speed(distance: float, time: float) -> float:
-197 | /     """Calculate speed as distance divided by time.
-198 | |
-199 | |     Args:
-200 | |         distance: Distance traveled.
-201 | |         time: Time spent traveling.
-202 | |
-203 | |     Returns:
-204 | |         Speed as distance divided by time.
-205 | |
-206 | |     Raises:
-207 | |         TypeError: if you didn't pass a number for both parameters
-208 | |     """
+197 |   # DOC501
+198 |   def calculate_speed(distance: float, time: float) -> float:
+199 | /     """Calculate speed as distance divided by time.
+200 | |
+201 | |     Args:
+202 | |         distance: Distance traveled.
+203 | |         time: Time spent traveling.
+204 | |
+205 | |     Returns:
+206 | |         Speed as distance divided by time.
+207 | |
+208 | |     Raises:
+209 | |         TypeError: if you didn't pass a number for both parameters
+210 | |     """
     | |_______^
-209 |       try:
-210 |           return distance / time
+211 |       try:
+212 |           return distance / time
     |
 help: Add `ZeroDivisionError` to the docstring
 
 DOC501 Raised exception `TypeError` missing from docstring
-   --> DOC501_google.py:238:5
+   --> DOC501_google.py:240:5
     |
-237 |   def foo():
-238 | /     """Foo.
-239 | |
-240 | |     Returns:
-241 | |         42: int.
-242 | |     """
+239 |   def foo():
+240 | /     """Foo.
+241 | |
+242 | |     Returns:
+243 | |         42: int.
+244 | |     """
     | |_______^
-243 |       if True:
-244 |           raise TypeError  # DOC501
+245 |       if True:
+246 |           raise TypeError  # DOC501
     |
 help: Add `TypeError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-   --> DOC501_google.py:238:5
+   --> DOC501_google.py:240:5
     |
-237 |   def foo():
-238 | /     """Foo.
-239 | |
-240 | |     Returns:
-241 | |         42: int.
-242 | |     """
+239 |   def foo():
+240 | /     """Foo.
+241 | |
+242 | |     Returns:
+243 | |         42: int.
+244 | |     """
     | |_______^
-243 |       if True:
-244 |           raise TypeError  # DOC501
+245 |       if True:
+246 |           raise TypeError  # DOC501
     |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-   --> DOC501_google.py:269:5
+   --> DOC501_google.py:271:5
     |
-267 |   # DOC501 - exception raised via classmethod, NOT documented
-268 |   def validate_classmethod_missing(value):
-269 | /     """Validate a value.
-270 | |
-271 | |     Args:
-272 | |         value: the value to validate.
-273 | |     """
+269 |   # DOC501 - exception raised via classmethod, NOT documented
+270 |   def validate_classmethod_missing(value):
+271 | /     """Validate a value.
+272 | |
+273 | |     Args:
+274 | |         value: the value to validate.
+275 | |     """
     | |_______^
-274 |       raise ValueError.from_exception_data(
-275 |           title="Validation",
+276 |       raise ValueError.from_exception_data(
+277 |           title="Validation",
     |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-   --> DOC501_google.py:311:5
+   --> DOC501_google.py:313:5
     |
-309 |   # DOC501 - chained method call, NOT documented
-310 |   def chained_missing(value):
-311 | /     """Validate a value.
-312 | |
-313 | |     Args:
-314 | |         value: the value to validate.
-315 | |     """
+311 |   # DOC501 - chained method call, NOT documented
+312 |   def chained_missing(value):
+313 | /     """Validate a value.
+314 | |
+315 | |     Args:
+316 | |         value: the value to validate.
+317 | |     """
     | |_______^
-316 |       raise ValueError.from_exception_data(
-317 |           title="Validation",
+318 |       raise ValueError.from_exception_data(
+319 |           title="Validation",
     |
 help: Add `ValueError` to the docstring
+
+DOC501 Raised exception `SomeError` missing from docstring
+   --> DOC501_google.py:339:5
+    |
+337 |   # DOC501 - exception raised via module attribute call, NOT documented
+338 |   def module_exception_missing(value):
+339 | /     """Process a value.
+340 | |
+341 | |     Args:
+342 | |         value: the value to process.
+343 | |     """
+    | |_______^
+344 |       raise something.SomeError(value)
+    |
+help: Add `SomeError` to the docstring
+
+DOC501 Raised exception `URLError` missing from docstring
+   --> DOC501_google.py:362:5
+    |
+360 |   # DOC501 - exception raised via nested module attribute call, NOT documented
+361 |   def nested_module_exception_missing(value):
+362 | /     """Process a value.
+363 | |
+364 | |     Args:
+365 | |         value: the value to process.
+366 | |     """
+    | |_______^
+367 |       raise urllib.error.URLError(value)
+    |
+help: Add `URLError` to the docstring
+
+DOC501 Raised exception `URLError` missing from docstring
+   --> DOC501_google.py:385:5
+    |
+383 |   # DOC501 - exception raised via from-imported module, NOT documented
+384 |   def from_import_module_missing(value):
+385 | /     """Process a value.
+386 | |
+387 | |     Args:
+388 | |         value: the value to process.
+389 | |     """
+    | |_______^
+390 |       raise url_error.URLError(value)
+    |
+help: Add `URLError` to the docstring

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py_ignore_one_line.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py_ignore_one_line.snap
@@ -2,304 +2,304 @@
 source: crates/ruff_linter/src/rules/pydoclint/mod.rs
 ---
 DOC501 Raised exception `FasterThanLightError` missing from docstring
-  --> DOC501_google.py:36:5
+  --> DOC501_google.py:34:5
    |
-34 |   # DOC501
-35 |   def calculate_speed(distance: float, time: float) -> float:
-36 | /     """Calculate speed as distance divided by time.
-37 | |
-38 | |     Args:
-39 | |         distance: Distance traveled.
-40 | |         time: Time spent traveling.
-41 | |
-42 | |     Returns:
-43 | |         Speed as distance divided by time.
-44 | |     """
+32 |   # DOC501
+33 |   def calculate_speed(distance: float, time: float) -> float:
+34 | /     """Calculate speed as distance divided by time.
+35 | |
+36 | |     Args:
+37 | |         distance: Distance traveled.
+38 | |         time: Time spent traveling.
+39 | |
+40 | |     Returns:
+41 | |         Speed as distance divided by time.
+42 | |     """
    | |_______^
-45 |       try:
-46 |           return distance / time
+43 |       try:
+44 |           return distance / time
    |
 help: Add `FasterThanLightError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-  --> DOC501_google.py:53:5
+  --> DOC501_google.py:51:5
    |
-51 |   # DOC501
-52 |   def calculate_speed(distance: float, time: float) -> float:
-53 | /     """Calculate speed as distance divided by time.
-54 | |
-55 | |     Args:
-56 | |         distance: Distance traveled.
-57 | |         time: Time spent traveling.
-58 | |
-59 | |     Returns:
-60 | |         Speed as distance divided by time.
-61 | |     """
+49 |   # DOC501
+50 |   def calculate_speed(distance: float, time: float) -> float:
+51 | /     """Calculate speed as distance divided by time.
+52 | |
+53 | |     Args:
+54 | |         distance: Distance traveled.
+55 | |         time: Time spent traveling.
+56 | |
+57 | |     Returns:
+58 | |         Speed as distance divided by time.
+59 | |     """
    | |_______^
-62 |       try:
-63 |           return distance / time
+60 |       try:
+61 |           return distance / time
    |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `FasterThanLightError` missing from docstring
-  --> DOC501_google.py:53:5
+  --> DOC501_google.py:51:5
    |
-51 |   # DOC501
-52 |   def calculate_speed(distance: float, time: float) -> float:
-53 | /     """Calculate speed as distance divided by time.
-54 | |
-55 | |     Args:
-56 | |         distance: Distance traveled.
-57 | |         time: Time spent traveling.
-58 | |
-59 | |     Returns:
-60 | |         Speed as distance divided by time.
-61 | |     """
+49 |   # DOC501
+50 |   def calculate_speed(distance: float, time: float) -> float:
+51 | /     """Calculate speed as distance divided by time.
+52 | |
+53 | |     Args:
+54 | |         distance: Distance traveled.
+55 | |         time: Time spent traveling.
+56 | |
+57 | |     Returns:
+58 | |         Speed as distance divided by time.
+59 | |     """
    | |_______^
-62 |       try:
-63 |           return distance / time
+60 |       try:
+61 |           return distance / time
    |
 help: Add `FasterThanLightError` to the docstring
 
 DOC501 Raised exception `ZeroDivisionError` missing from docstring
-  --> DOC501_google.py:72:5
+  --> DOC501_google.py:70:5
    |
-70 |   # DOC501
-71 |   def calculate_speed(distance: float, time: float) -> float:
-72 | /     """Calculate speed as distance divided by time.
-73 | |
-74 | |     Args:
-75 | |         distance: Distance traveled.
-76 | |         time: Time spent traveling.
-77 | |
-78 | |     Returns:
-79 | |         Speed as distance divided by time.
-80 | |     """
+68 |   # DOC501
+69 |   def calculate_speed(distance: float, time: float) -> float:
+70 | /     """Calculate speed as distance divided by time.
+71 | |
+72 | |     Args:
+73 | |         distance: Distance traveled.
+74 | |         time: Time spent traveling.
+75 | |
+76 | |     Returns:
+77 | |         Speed as distance divided by time.
+78 | |     """
    | |_______^
-81 |       try:
-82 |           return distance / time
+79 |       try:
+80 |           return distance / time
    |
 help: Add `ZeroDivisionError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-   --> DOC501_google.py:90:5
-    |
- 88 |   # DOC501
- 89 |   def calculate_speed(distance: float, time: float) -> float:
- 90 | /     """Calculate speed as distance divided by time.
- 91 | |
- 92 | |     Args:
- 93 | |         distance: Distance traveled.
- 94 | |         time: Time spent traveling.
- 95 | |
- 96 | |     Returns:
- 97 | |         Speed as distance divided by time.
- 98 | |     """
-    | |_______^
- 99 |       try:
-100 |           return distance / time
-    |
+  --> DOC501_google.py:88:5
+   |
+86 |   # DOC501
+87 |   def calculate_speed(distance: float, time: float) -> float:
+88 | /     """Calculate speed as distance divided by time.
+89 | |
+90 | |     Args:
+91 | |         distance: Distance traveled.
+92 | |         time: Time spent traveling.
+93 | |
+94 | |     Returns:
+95 | |         Speed as distance divided by time.
+96 | |     """
+   | |_______^
+97 |       try:
+98 |           return distance / time
+   |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `ZeroDivisionError` missing from docstring
-   --> DOC501_google.py:90:5
-    |
- 88 |   # DOC501
- 89 |   def calculate_speed(distance: float, time: float) -> float:
- 90 | /     """Calculate speed as distance divided by time.
- 91 | |
- 92 | |     Args:
- 93 | |         distance: Distance traveled.
- 94 | |         time: Time spent traveling.
- 95 | |
- 96 | |     Returns:
- 97 | |         Speed as distance divided by time.
- 98 | |     """
-    | |_______^
- 99 |       try:
-100 |           return distance / time
-    |
+  --> DOC501_google.py:88:5
+   |
+86 |   # DOC501
+87 |   def calculate_speed(distance: float, time: float) -> float:
+88 | /     """Calculate speed as distance divided by time.
+89 | |
+90 | |     Args:
+91 | |         distance: Distance traveled.
+92 | |         time: Time spent traveling.
+93 | |
+94 | |     Returns:
+95 | |         Speed as distance divided by time.
+96 | |     """
+   | |_______^
+97 |       try:
+98 |           return distance / time
+   |
 help: Add `ZeroDivisionError` to the docstring
 
 DOC501 Raised exception `AnotherError` missing from docstring
-   --> DOC501_google.py:108:5
+   --> DOC501_google.py:106:5
     |
-106 |   # DOC501
-107 |   def calculate_speed(distance: float, time: float) -> float:
-108 | /     """Calculate speed as distance divided by time.
-109 | |
-110 | |     Args:
-111 | |         distance: Distance traveled.
-112 | |         time: Time spent traveling.
-113 | |
-114 | |     Returns:
-115 | |         Speed as distance divided by time.
-116 | |     """
+104 |   # DOC501
+105 |   def calculate_speed(distance: float, time: float) -> float:
+106 | /     """Calculate speed as distance divided by time.
+107 | |
+108 | |     Args:
+109 | |         distance: Distance traveled.
+110 | |         time: Time spent traveling.
+111 | |
+112 | |     Returns:
+113 | |         Speed as distance divided by time.
+114 | |     """
     | |_______^
-117 |       raise AnotherError
+115 |       raise AnotherError
     |
 help: Add `AnotherError` to the docstring
 
 DOC501 Raised exception `AnotherError` missing from docstring
-   --> DOC501_google.py:122:5
+   --> DOC501_google.py:120:5
     |
-120 |   # DOC501
-121 |   def calculate_speed(distance: float, time: float) -> float:
-122 | /     """Calculate speed as distance divided by time.
-123 | |
-124 | |     Args:
-125 | |         distance: Distance traveled.
-126 | |         time: Time spent traveling.
-127 | |
-128 | |     Returns:
-129 | |         Speed as distance divided by time.
-130 | |     """
+118 |   # DOC501
+119 |   def calculate_speed(distance: float, time: float) -> float:
+120 | /     """Calculate speed as distance divided by time.
+121 | |
+122 | |     Args:
+123 | |         distance: Distance traveled.
+124 | |         time: Time spent traveling.
+125 | |
+126 | |     Returns:
+127 | |         Speed as distance divided by time.
+128 | |     """
     | |_______^
-131 |       raise AnotherError()
+129 |       raise AnotherError()
     |
 help: Add `AnotherError` to the docstring
 
 DOC501 Raised exception `SomeError` missing from docstring
-   --> DOC501_google.py:136:5
+   --> DOC501_google.py:134:5
     |
-134 |   # DOC501
-135 |   def foo(bar: int):
-136 | /     """Foo.
-137 | |
-138 | |     Args:
-139 | |         bar: Bar.
-140 | |     """
+132 |   # DOC501
+133 |   def foo(bar: int):
+134 | /     """Foo.
+135 | |
+136 | |     Args:
+137 | |         bar: Bar.
+138 | |     """
     | |_______^
-141 |       raise something.SomeError
+139 |       raise something.SomeError
     |
 help: Add `SomeError` to the docstring
 
 DOC501 Raised exception `ZeroDivisionError` missing from docstring
-   --> DOC501_google.py:199:5
+   --> DOC501_google.py:197:5
     |
-197 |   # DOC501
-198 |   def calculate_speed(distance: float, time: float) -> float:
-199 | /     """Calculate speed as distance divided by time.
-200 | |
-201 | |     Args:
-202 | |         distance: Distance traveled.
-203 | |         time: Time spent traveling.
-204 | |
-205 | |     Returns:
-206 | |         Speed as distance divided by time.
-207 | |
-208 | |     Raises:
-209 | |         TypeError: if you didn't pass a number for both parameters
-210 | |     """
+195 |   # DOC501
+196 |   def calculate_speed(distance: float, time: float) -> float:
+197 | /     """Calculate speed as distance divided by time.
+198 | |
+199 | |     Args:
+200 | |         distance: Distance traveled.
+201 | |         time: Time spent traveling.
+202 | |
+203 | |     Returns:
+204 | |         Speed as distance divided by time.
+205 | |
+206 | |     Raises:
+207 | |         TypeError: if you didn't pass a number for both parameters
+208 | |     """
     | |_______^
-211 |       try:
-212 |           return distance / time
+209 |       try:
+210 |           return distance / time
     |
 help: Add `ZeroDivisionError` to the docstring
 
 DOC501 Raised exception `TypeError` missing from docstring
-   --> DOC501_google.py:240:5
+   --> DOC501_google.py:238:5
     |
-239 |   def foo():
-240 | /     """Foo.
-241 | |
-242 | |     Returns:
-243 | |         42: int.
-244 | |     """
+237 |   def foo():
+238 | /     """Foo.
+239 | |
+240 | |     Returns:
+241 | |         42: int.
+242 | |     """
     | |_______^
-245 |       if True:
-246 |           raise TypeError  # DOC501
+243 |       if True:
+244 |           raise TypeError  # DOC501
     |
 help: Add `TypeError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-   --> DOC501_google.py:240:5
+   --> DOC501_google.py:238:5
     |
-239 |   def foo():
-240 | /     """Foo.
-241 | |
-242 | |     Returns:
-243 | |         42: int.
-244 | |     """
+237 |   def foo():
+238 | /     """Foo.
+239 | |
+240 | |     Returns:
+241 | |         42: int.
+242 | |     """
     | |_______^
-245 |       if True:
-246 |           raise TypeError  # DOC501
+243 |       if True:
+244 |           raise TypeError  # DOC501
     |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-   --> DOC501_google.py:271:5
+   --> DOC501_google.py:273:5
     |
-269 |   # DOC501 - exception raised via classmethod, NOT documented
-270 |   def validate_classmethod_missing(value):
-271 | /     """Validate a value.
-272 | |
-273 | |     Args:
-274 | |         value: the value to validate.
-275 | |     """
+271 |   # DOC501 - exception raised via classmethod, NOT documented
+272 |   def validate_classmethod_missing(value):
+273 | /     """Validate a value.
+274 | |
+275 | |     Args:
+276 | |         value: the value to validate.
+277 | |     """
     | |_______^
-276 |       raise ValueError.from_exception_data(
-277 |           title="Validation",
+278 |       raise ValueError.from_exception_data(
+279 |           title="Validation",
     |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `ValueError` missing from docstring
-   --> DOC501_google.py:313:5
+   --> DOC501_google.py:315:5
     |
-311 |   # DOC501 - chained method call, NOT documented
-312 |   def chained_missing(value):
-313 | /     """Validate a value.
-314 | |
-315 | |     Args:
-316 | |         value: the value to validate.
-317 | |     """
+313 |   # DOC501 - chained method call, NOT documented
+314 |   def chained_missing(value):
+315 | /     """Validate a value.
+316 | |
+317 | |     Args:
+318 | |         value: the value to validate.
+319 | |     """
     | |_______^
-318 |       raise ValueError.from_exception_data(
-319 |           title="Validation",
+320 |       raise ValueError.from_exception_data(
+321 |           title="Validation",
     |
 help: Add `ValueError` to the docstring
 
 DOC501 Raised exception `SomeError` missing from docstring
-   --> DOC501_google.py:339:5
+   --> DOC501_google.py:341:5
     |
-337 |   # DOC501 - exception raised via module attribute call, NOT documented
-338 |   def module_exception_missing(value):
-339 | /     """Process a value.
-340 | |
-341 | |     Args:
-342 | |         value: the value to process.
-343 | |     """
+339 |   # DOC501 - exception raised via module attribute call, NOT documented
+340 |   def module_exception_missing(value):
+341 | /     """Process a value.
+342 | |
+343 | |     Args:
+344 | |         value: the value to process.
+345 | |     """
     | |_______^
-344 |       raise something.SomeError(value)
+346 |       raise something.SomeError(value)
     |
 help: Add `SomeError` to the docstring
 
 DOC501 Raised exception `URLError` missing from docstring
-   --> DOC501_google.py:362:5
+   --> DOC501_google.py:364:5
     |
-360 |   # DOC501 - exception raised via nested module attribute call, NOT documented
-361 |   def nested_module_exception_missing(value):
-362 | /     """Process a value.
-363 | |
-364 | |     Args:
-365 | |         value: the value to process.
-366 | |     """
+362 |   # DOC501 - exception raised via nested module attribute call, NOT documented
+363 |   def nested_module_exception_missing(value):
+364 | /     """Process a value.
+365 | |
+366 | |     Args:
+367 | |         value: the value to process.
+368 | |     """
     | |_______^
-367 |       raise urllib.error.URLError(value)
+369 |       raise urllib.error.URLError(value)
     |
 help: Add `URLError` to the docstring
 
 DOC501 Raised exception `URLError` missing from docstring
-   --> DOC501_google.py:385:5
+   --> DOC501_google.py:387:5
     |
-383 |   # DOC501 - exception raised via from-imported module, NOT documented
-384 |   def from_import_module_missing(value):
-385 | /     """Process a value.
-386 | |
-387 | |     Args:
-388 | |         value: the value to process.
-389 | |     """
+385 |   # DOC501 - exception raised via from-imported module, NOT documented
+386 |   def from_import_module_missing(value):
+387 | /     """Process a value.
+388 | |
+389 | |     Args:
+390 | |         value: the value to process.
+391 | |     """
     | |_______^
-390 |       raise url_error.URLError(value)
+392 |       raise url_error.URLError(value)
     |
 help: Add `URLError` to the docstring


### PR DESCRIPTION
## Summary

Fixes #23570.

`raise ValueError.from_exception_data(...)` causes DOC501 to report `from_exception_data` as the missing exception instead of `ValueError`, and DOC502 to flag `ValueError` as not raised. Same thing happens with chained calls like `raise Error.create(...).with_traceback(tb)` and module attribute calls like `raise rich_click.ClickException(...)`.

The root cause: `map_callable` unwraps the call, leaving `ValueError.from_exception_data` as an `Expr::Attribute`, and `resolve_qualified_name` resolves the full dotted path including the method name.

The fix uses `map_callable + resolve_qualified_name` (same as other rules) but adds handling for the ambiguity in `X.method(...)` where the AST can't tell whether X is a class (classmethod constructor) or a module (attribute call). Both interpretations are stored as candidates and the docstring matcher accepts either. The display name is picked by checking the head name's `BindingKind`: `Builtin`/`ClassDefinition` means X is the exception class, otherwise the full resolved name is used.

Chained method calls (`Error.create(...).with_traceback(tb)`) are peeled down to the inner-most call before resolution.

## Test plan

Added test cases to `DOC501_google.py` for:
- Classmethod raises (documented + undocumented)
- Imported exceptions via classmethod
- Chained `.with_traceback()` calls
- Module attribute calls (`something.SomeError(...)`, `urllib.error.URLError(...)`)
- From-imported module attribute calls (`from urllib import error as url_error` + `raise url_error.URLError(...)`)

All 18 pydoclint tests pass.