### PR TITLE
[pyupgrade] Fix duplicate None in Optional containing union with None (UP045)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP045.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP045.py
@@ -82,3 +82,10 @@ foo: Optional[
     int
     # text
 ] = None
+
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/23429
+# Optional wrapping a union that already contains None should not duplicate None
+foo: None | Optional[None | int] = None
+bar: Optional[None | int] = None
+baz: Optional[int | None] = None

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP045.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP045.py.snap
@@ -311,4 +311,58 @@ help: Convert to `X | None`
    -     # text
    - ] = None
 81 + foo: int | None = None
+82 | 
+83 | 
+84 | # Regression test for: https://github.com/astral-sh/ruff/issues/23429
 note: This is an unsafe fix and may change runtime behavior
+
+UP045 [*] Use `X | None` for type annotations
+  --> UP045.py:89:13
+   |
+87 | # Regression test for: https://github.com/astral-sh/ruff/issues/23429
+88 | # Optional wrapping a union that already contains None should not duplicate None
+89 | foo: None | Optional[None | int] = None
+   |             ^^^^^^^^^^^^^^^^^^^^
+90 | bar: Optional[None | int] = None
+91 | baz: Optional[int | None] = None
+   |
+help: Convert to `X | None`
+86 | 
+87 | # Regression test for: https://github.com/astral-sh/ruff/issues/23429
+88 | # Optional wrapping a union that already contains None should not duplicate None
+   - foo: None | Optional[None | int] = None
+89 + foo: None | None | int = None
+90 | bar: Optional[None | int] = None
+91 | baz: Optional[int | None] = None
+
+UP045 [*] Use `X | None` for type annotations
+  --> UP045.py:90:6
+   |
+88 | # Optional wrapping a union that already contains None should not duplicate None
+89 | foo: None | Optional[None | int] = None
+90 | bar: Optional[None | int] = None
+   |      ^^^^^^^^^^^^^^^^^^^^
+91 | baz: Optional[int | None] = None
+   |
+help: Convert to `X | None`
+87 | # Regression test for: https://github.com/astral-sh/ruff/issues/23429
+88 | # Optional wrapping a union that already contains None should not duplicate None
+89 | foo: None | Optional[None | int] = None
+   - bar: Optional[None | int] = None
+90 + bar: None | int = None
+91 | baz: Optional[int | None] = None
+
+UP045 [*] Use `X | None` for type annotations
+  --> UP045.py:91:6
+   |
+89 | foo: None | Optional[None | int] = None
+90 | bar: Optional[None | int] = None
+91 | baz: Optional[int | None] = None
+   |      ^^^^^^^^^^^^^^^^^^^^
+   |
+help: Convert to `X | None`
+88 | # Optional wrapping a union that already contains None should not duplicate None
+89 | foo: None | Optional[None | int] = None
+90 | bar: Optional[None | int] = None
+   - baz: Optional[int | None] = None
+91 + baz: int | None = None


### PR DESCRIPTION
## Summary

Fixes #23429.

`Optional[None | int]` gets fixed to `None | int | None` — the inner union already contains `None`, so wrapping with `| None` again produces a duplicate. In the reported case, `None | Optional[None | int]` becomes `None | None | int | None`.

The fix adds a `contains_none` check on the inner expression before wrapping. If `None` is already present in the union, the fix outputs the inner expression directly instead of appending `| None`.

## Test Plan

Added three test cases to `UP045.py`:
- `None | Optional[None | int]` → `None | None | int` (no extra trailing `| None`)
- `Optional[None | int]` → `None | int`
- `Optional[int | None]` → `int | None`

All pyupgrade tests pass.