### PR TITLE
[ty] When `# type: ignore` appears in comment it is not unused type ignore

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/suppressions/type_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/type_ignore.md
@@ -242,3 +242,10 @@ ty doesn't report invalid `type: ignore` comments:
 ```py
 a = 10 + 4  # type: ignoreee
 ```
+
+## `# type: ignore` appearing inside other comments should not raise unused ignore
+
+```py
+# A comment discussing # type: ignore should not raise `unused-type-ignore-comment`
+
+```

--- a/crates/ty_python_semantic/src/suppression/parser.rs
+++ b/crates/ty_python_semantic/src/suppression/parser.rs
@@ -9,13 +9,21 @@ use thiserror::Error;
 pub(super) struct SuppressionParser<'src> {
     cursor: Cursor<'src>,
     range: TextRange,
+    /// Whether we are parsing the first `#`-delimited section of the comment.
+    /// When `false`, we are in a "sub-comment" (e.g. the `# type: ignore` in
+    /// `# fmt: off # type: ignore`) and trailing free-form text is not allowed.
+    in_first_pragma: bool,
 }
 
 impl<'src> SuppressionParser<'src> {
     pub(super) fn new(source: &'src str, range: TextRange) -> Self {
         let cursor = Cursor::new(&source[range]);
 
-        Self { cursor, range }
+        Self {
+            cursor,
+            range,
+            in_first_pragma: true,
+        }
     }
 
     fn parse_comment(&mut self) -> Result<SuppressionComment, ParseError> {
@@ -43,7 +51,14 @@ impl<'src> SuppressionParser<'src> {
         //             ^^^^^^
         let codes = self.eat_codes(kind)?;
 
-        if self.cursor.is_eof() || codes.is_some() || has_trailing_whitespace {
+        // For sub-comments (not the first `#` section), only accept trailing text
+        // if followed by EOF or another `#` delimiter. This avoids treating
+        // `# type: ignore` mentions in prose (e.g. `# A comment about # type: ignore should...`)
+        // as actual suppressions.
+        let valid_trailing = has_trailing_whitespace
+            && (self.in_first_pragma || self.cursor.is_eof() || self.cursor.first() == '#');
+
+        if self.cursor.is_eof() || codes.is_some() || valid_trailing {
             // Consume the comment until its end or until the next "sub-comment" starts.
             self.cursor.eat_while(|c| c != '#');
             Ok(SuppressionComment {
@@ -51,6 +66,12 @@ impl<'src> SuppressionParser<'src> {
                 codes,
                 range: TextRange::at(comment_start, self.cursor.token_len()),
             })
+        } else if has_trailing_whitespace {
+            // Sub-comment with trailing non-`#` text; not a real suppression.
+            Err(ParseError::new(
+                ParseErrorKind::NotASuppression,
+                TextRange::new(comment_start, self.offset()),
+            ))
         } else {
             self.syntax_error(ParseErrorKind::NoWhitespaceAfterIgnore(kind))
         }
@@ -168,7 +189,10 @@ impl Iterator for SuppressionParser<'_> {
             return None;
         }
 
-        match self.parse_comment() {
+        let result = self.parse_comment();
+        self.in_first_pragma = false;
+
+        match result {
             Ok(result) => Some(Ok(result)),
             Err(error) => {
                 self.cursor.eat_while(|c| c != '#');
@@ -411,6 +435,18 @@ mod tests {
                 ],
             },
         ]
+        "##
+        );
+    }
+
+    #[test]
+    fn type_ignore_inside_other_comment() {
+        assert_debug_snapshot!(
+            SuppressionComments::new(
+                "# A comment discussing # type: ignore should not raise",
+            ),
+            @r##"
+        []
         "##
         );
     }


### PR DESCRIPTION
## Summary

### Why?
In the conformance tests we have:
- https://github.com/python/typing/blob/main/conformance/tests/directives_type_ignore_file1.py - https://github.com/python/typing/blob/main/conformance/tests/directives_type_ignore_file2.py
each have multi line `# ` comments that contain `# type: ignore` currently these are flagged as `unused-type-ignore-comment` meaning they appear as false positives.

### What?

Update suppression parsing logic to handle ` # type: ignore` appearing in a wider comment

## Test Plan
- New mdtest case in suppression.md
- New unittest `suppression/parser.md`

### Conformance tests

#### Existing 
```
uv tool run ty check conformance/tests/directives_type_ignore* --output-format concise
conformance/tests/directives_type_ignore_file1.py:11:7: warning[[unused-type-ignore-comment](https://ty.dev/rules#unused-type-ignore-comment)] Unused blanket `type: ignore` directive
conformance/tests/directives_type_ignore_file1.py:14:17: warning[[unused-type-ignore-comment](https://ty.dev/rules#unused-type-ignore-comment)] Unused blanket `type: ignore` directive
conformance/tests/directives_type_ignore_file2.py:7:1: warning[[unused-type-ignore-comment](https://ty.dev/rules#unused-type-ignore-comment)] Unused blanket `type: ignore` directive
conformance/tests/directives_type_ignore_file2.py:9:7: warning[[unused-type-ignore-comment](https://ty.dev/rules#unused-type-ignore-comment)] Unused blanket `type: ignore` directive
conformance/tests/directives_type_ignore_file2.py:12:17: warning[[unused-type-ignore-comment](https://ty.dev/rules#unused-type-ignore-comment)] Unused blanket `type: ignore` directive
conformance/tests/directives_type_ignore_file2.py:14:10: error[[invalid-assignment](https://ty.dev/rules#invalid-assignment)] Object of type `Literal[""]` is not assignable to `int`
Found 6 diagnostics
```

#### New

```
~/dev/rust/ruff/target/debug/ty check conformance/tests/directives_type_ignore* --output-format concise
conformance/tests/directives_type_ignore_file2.py:7:1: warning[[unused-type-ignore-comment](https://ty.dev/rules#unused-type-ignore-comment)] Unused blanket `type: ignore` directive
conformance/tests/directives_type_ignore_file2.py:14:10: error[[invalid-assignment](https://ty.dev/rules#invalid-assignment)] Object of type `Literal[""]` is not assignable to `int`
Found 2 diagnostics
```

https://github.com/python/typing/blob/main/conformance/tests/directives_type_ignore_file2.py#L7 is still a false positive, as `ty` flags the misaligned type ignore pragma as unused which I think is a reasonable position and would help a user realise that there file-level suppresion is not working in the case where the file happens to not contain a type error. So maybe something to propose as `E?` in the conformance suite?


