### PR TITLE
Consider `python-base` language id for text documents

### DIFF
--- a/crates/ty_server/src/document/text_document.rs
+++ b/crates/ty_server/src/document/text_document.rs
@@ -39,7 +39,9 @@ pub enum LanguageId {
 impl From<&str> for LanguageId {
     fn from(language_id: &str) -> Self {
         match language_id {
-            "python" => Self::Python,
+            // `python-base` is sent by Emacs eglot, which derives the language ID from the major
+            // mode name `python-base-mode` by stripping the `-mode` suffix.
+            "python" | "python-base" => Self::Python,
             _ => Self::Other,
         }
     }

--- a/crates/ty_server/tests/e2e/publish_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/publish_diagnostics.rs
@@ -147,6 +147,43 @@ def foo() -> str:
     Ok(())
 }
 
+/// Tests that we get diagnostics when the client sends `python-base` as the language ID.
+///
+/// Emacs eglot derives the language ID from the major mode name `python-base-mode` by stripping the
+/// `-mode` suffix, resulting in `python-base` instead of `python`.
+///
+/// Ref: <https://github.com/astral-sh/ty/issues/2937>
+#[test]
+fn on_did_open_python_base_language_id() -> Result<()> {
+    let workspace_root = SystemPath::new("src");
+    let foo = SystemPath::new("src/foo.py");
+    let foo_content = "\
+def foo() -> str:
+    return 42
+";
+
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(workspace_root, None)?
+        .with_file(foo, foo_content)?
+        .enable_pull_diagnostics(false)
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.send_notification::<DidOpenTextDocument>(DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: server.file_uri(foo),
+            language_id: "python-base".to_string(),
+            version: 1,
+            text: foo_content.to_string(),
+        },
+    });
+    let diagnostics = server.await_notification::<PublishDiagnostics>();
+
+    insta::assert_debug_snapshot!(diagnostics);
+
+    Ok(())
+}
+
 #[test]
 fn on_did_open_diagnostics_off() -> Result<()> {
     let workspace_root = SystemPath::new("src");

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_python_base_language_id.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_python_base_language_id.snap
@@ -1,0 +1,70 @@
+---
+source: crates/ty_server/tests/e2e/publish_diagnostics.rs
+expression: diagnostics
+---
+PublishDiagnosticsParams {
+    uri: Url {
+        scheme: "file",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: None,
+        port: None,
+        path: "<temp_dir>/src/foo.py",
+        query: None,
+        fragment: None,
+    },
+    diagnostics: [
+        Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 11,
+                },
+                end: Position {
+                    line: 1,
+                    character: 13,
+                },
+            },
+            severity: Some(
+                Error,
+            ),
+            code: Some(
+                String(
+                    "invalid-return-type",
+                ),
+            ),
+            code_description: Some(
+                CodeDescription {
+                    href: Url {
+                        scheme: "https",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "ty.dev",
+                            ),
+                        ),
+                        port: None,
+                        path: "/rules",
+                        query: None,
+                        fragment: Some(
+                            "invalid-return-type",
+                        ),
+                    },
+                },
+            ),
+            source: Some(
+                "ty",
+            ),
+            message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
+            related_information: None,
+            tags: None,
+            data: None,
+        },
+    ],
+    version: Some(
+        1,
+    ),
+}


### PR DESCRIPTION
## Summary

fixes: astral-sh/ty#2937

## Test Plan

Add a E2E test case.
