### PR TITLE
fix renovate `actions/*-artifact` updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -55,7 +55,7 @@
       groupName: "Artifact GitHub Actions dependencies",
       matchManagers: ["github-actions"],
       matchDatasources: ["gitea-tags", "github-tags"],
-      matchPackageNames: ["actions/.*-artifact"],
+      matchPackageNames: ["actions/upload-artifact", "actions/download-artifact"],
       description: "Weekly update of artifact-related GitHub Actions dependencies",
     },
     {


### PR DESCRIPTION
## Summary

The intention here is that this should be a regex match. But that evidently is not working (https://github.com/astral-sh/ruff/pull/23656 and https://github.com/astral-sh/ruff/pull/23655 were filed as separate PRs rather than one combined PR). Looking at the renovate docs, it's possible that we need to surround the string with `/` in order for it to be considered a regular expression -- i.e., `/actions/.*-artifact/` rather than `actions/.*-artifact`. But a regex here also just feels like it's overcomplicating things anyway -- the only ones we aare about are `upload-artifact` and `download-artifact`! 

## Test Plan

- `npx --yes --package renovate -- renovate-config-validator`. This eventually passed after I figured out how to upgrade the ancient version of renovate I had installed locally. (IDK how to use npm 😆)
- I'll rerun renovate on the repo after this PR has merged to check it's working correctly now -- it _should_ close both PRs and create a new, combined one