### PR TITLE
[ty] Fix type checking for multi-member enums within in a function block

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -990,8 +990,8 @@ reveal_type(Color.RED._name_)  # revealed: Literal["RED"]
 def _(red_or_blue: Literal[Color.RED, Color.BLUE]):
     reveal_type(red_or_blue.name)  # revealed: Literal["RED", "BLUE"]
 
-def _(any_color: Color):
-    reveal_type(any_color.name)  # revealed: Literal["RED", "GREEN", "BLUE"]
+def _(color: Color):
+    reveal_type(color.name)  # revealed: Literal["RED", "GREEN", "BLUE"]
 ```
 
 ### `value` and `_value_`
@@ -1016,6 +1016,9 @@ reveal_type(Color.RED._value_)  # revealed: Literal[1]
 reveal_type(Color.GREEN.value)  # revealed: Literal[2]
 reveal_type(Color.GREEN._value_)  # revealed: Literal[2]
 
+def _(color: Color):
+    reveal_type(color.value)  # revealed: Literal[1, 2, 3]
+
 class Answer(StrEnum):
     YES = "yes"
     NO = "no"
@@ -1025,6 +1028,9 @@ reveal_type(Answer.YES._value_)  # revealed: Literal["yes"]
 
 reveal_type(Answer.NO.value)  # revealed: Literal["no"]
 reveal_type(Answer.NO._value_)  # revealed: Literal["no"]
+
+def _(answer: Answer):
+    reveal_type(answer.value)  # revealed: Literal["yes", "no"]
 ```
 
 ## Properties of enum types
@@ -1139,6 +1145,9 @@ python-version = "3.9"
 from enum import Enum, EnumMeta
 
 class EnumWithEnumMetaMetaclass(metaclass=EnumMeta):
+    # Using `EnumMeta` as a metaclass without inheriting `Enum` requires an `__init__`
+    # method that will accept member values (TODO we could catch the lack of this):
+    def __init__(self, val): ...
     NO = 0
     YES = 1
 
@@ -1147,23 +1156,36 @@ reveal_type(EnumWithEnumMetaMetaclass.NO)  # revealed: Literal[EnumWithEnumMetaM
 class SubclassOfEnumMeta(EnumMeta): ...
 
 class EnumWithSubclassOfEnumMetaMetaclass(metaclass=SubclassOfEnumMeta):
+    def __init__(self, val): ...
     NO = 0
     YES = 1
 
 reveal_type(EnumWithSubclassOfEnumMetaMetaclass.NO)  # revealed: Literal[EnumWithSubclassOfEnumMetaMetaclass.NO]
 
-# Attributes like `.value` can *not* be accessed on members of these enums:
+# Attributes `.value` and `.name` can *not* be accessed on members of these enums:
+
 # error: [unresolved-attribute]
 EnumWithSubclassOfEnumMetaMetaclass.NO.value
 # error: [unresolved-attribute]
-EnumWithSubclassOfEnumMetaMetaclass.NO._value_
-# error: [unresolved-attribute]
 EnumWithSubclassOfEnumMetaMetaclass.NO.name
-# error: [unresolved-attribute]
-EnumWithSubclassOfEnumMetaMetaclass.NO._name_
+
+# But the internal underscore attributes are available:
+
+reveal_type(EnumWithSubclassOfEnumMetaMetaclass.NO._value_)  # revealed: Any
+reveal_type(EnumWithSubclassOfEnumMetaMetaclass.NO._name_)  # revealed: Literal["NO"]
+
+def _(x: EnumWithSubclassOfEnumMetaMetaclass):
+    # error: [unresolved-attribute]
+    x.value
+    # error: [unresolved-attribute]
+    x.name
+    reveal_type(x._value_)  # revealed: Any
+    reveal_type(x._name_)  # revealed: Literal["NO", "YES"]
 ```
 
 ### Enums with (subclasses of) `EnumType` as metaclass
+
+In Python 3.11, the meta-type was renamed to `EnumType`.
 
 ```toml
 [environment]
@@ -1174,6 +1196,7 @@ python-version = "3.11"
 from enum import Enum, EnumType
 
 class EnumWithEnumMetaMetaclass(metaclass=EnumType):
+    def __init__(self, val): ...
     NO = 0
     YES = 1
 
@@ -1182,68 +1205,36 @@ reveal_type(EnumWithEnumMetaMetaclass.NO)  # revealed: Literal[EnumWithEnumMetaM
 class SubclassOfEnumMeta(EnumType): ...
 
 class EnumWithSubclassOfEnumMetaMetaclass(metaclass=SubclassOfEnumMeta):
+    def __init__(self, val): ...
     NO = 0
     YES = 1
 
 reveal_type(EnumWithSubclassOfEnumMetaMetaclass.NO)  # revealed: Literal[EnumWithSubclassOfEnumMetaMetaclass.NO]
 
+# Attributes `.value` and `.name` can *not* be accessed on members of these enums:
+
 # error: [unresolved-attribute]
 EnumWithSubclassOfEnumMetaMetaclass.NO.value
+# error: [unresolved-attribute]
+EnumWithSubclassOfEnumMetaMetaclass.NO.name
+
+# But the internal underscore attributes are available:
+
+reveal_type(EnumWithSubclassOfEnumMetaMetaclass.NO._value_)  # revealed: Any
+reveal_type(EnumWithSubclassOfEnumMetaMetaclass.NO._name_)  # revealed: Literal["NO"]
+
+def _(x: EnumWithSubclassOfEnumMetaMetaclass):
+    # error: [unresolved-attribute]
+    x.value
+    # error: [unresolved-attribute]
+    x.name
+    reveal_type(x._value_)  # revealed: Any
+    reveal_type(x._name_)  # revealed: Literal["NO", "YES"]
 ```
 
 ## Function syntax
 
 To do: <https://typing.python.org/en/latest/spec/enums.html#enum-definition>
-
-### `value` and `_value_`
-
-```toml
-[environment]
-python-version = "3.11"
-```
-
-```py
-from enum import Enum, StrEnum
-from typing import Literal
-
-class Color(Enum):
-    RED = 1
-    GREEN = 2
-    BLUE = 3
-
-reveal_type(Color.RED.value)  # revealed: Literal[1]
-reveal_type(Color.RED._value_)  # revealed: Literal[1]
-
-reveal_type(Color.GREEN.value)  # revealed: Literal[2]
-reveal_type(Color.GREEN._value_)  # revealed: Literal[2]
-
-class Answer(StrEnum):
-    YES = "yes"
-    NO = "no"
-
-reveal_type(Answer.YES.value)  # revealed: Literal["yes"]
-reveal_type(Answer.YES._value_)  # revealed: Literal["yes"]
-
-reveal_type(Answer.NO.value)  # revealed: Literal["no"]
-reveal_type(Answer.NO._value_)  # revealed: Literal["no"]
-
-def _(any_color: Color):
-    reveal_type(any_color.value)  # revealed: Literal[1, 2, 3]
-
-def _(any_answer: Answer):
-    reveal_type(any_answer.value)  # revealed: Literal["yes", "no"]
-
-def f(x: Answer) -> None:
-    pass
-
-def g(x: Answer) -> None:
-    # error: [invalid-argument-type]
-    f(x.value)
-
-def h(x: Answer) -> None:
-    # error: [invalid-argument-type]
-    f(x._value_)
-```
 
 ## Exhaustiveness checking
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3353,26 +3353,22 @@ impl<'db> Type<'db> {
                 .member_lookup_with_policy(db, name, policy),
 
             Type::LiteralValue(literal)
-                if literal.as_enum().is_some_and(|enum_literal| {
-                    matches!(name_str, "name" | "_name_")
-                        && Type::ClassLiteral(enum_literal.enum_class(db))
-                            .is_subtype_of(db, KnownClass::Enum.to_subclass_of(db))
-                }) =>
+                if literal.as_enum().is_some()
+                    && matches!(name_str, "name" | "_name_" | "value" | "_value_") =>
             {
                 let enum_literal = literal.as_enum().unwrap();
-                Place::bound(Type::string_literal(db, enum_literal.name(db))).into()
-            }
+                let enum_class = enum_literal.enum_class(db);
+                let is_enum_subclass = Type::ClassLiteral(enum_class)
+                    .is_subtype_of(db, KnownClass::Enum.to_subclass_of(db));
 
-            Type::LiteralValue(literal)
-                if literal.as_enum().is_some_and(|enum_literal| {
-                    matches!(name_str, "value" | "_value_")
-                        && Type::ClassLiteral(enum_literal.enum_class(db))
-                            .is_subtype_of(db, KnownClass::Enum.to_subclass_of(db))
-                }) =>
-            {
-                let enum_literal = literal.as_enum().unwrap();
-                enum_metadata(db, enum_literal.enum_class(db))
-                    .and_then(|metadata| metadata.value_type(enum_literal.name(db)))
+                enum_metadata(db, enum_class)
+                    .and_then(|metadata| match name_str {
+                        "name" if is_enum_subclass => metadata.name_type(db, enum_literal.name(db)),
+                        "_name_" => metadata.name_type(db, enum_literal.name(db)),
+                        "value" if is_enum_subclass => metadata.value_type(enum_literal.name(db)),
+                        "_value_" => metadata.value_type(enum_literal.name(db)),
+                        _ => None,
+                    })
                     .map_or_else(|| Place::Undefined, Place::bound)
                     .into()
             }
@@ -3391,21 +3387,21 @@ impl<'db> Type<'db> {
             }
 
             Type::NominalInstance(instance)
-                if matches!(name_str, "name" | "_name_")
+                if matches!(name_str, "name" | "_name_" | "value" | "_value_")
                     && enum_metadata(db, instance.class_literal(db)).is_some() =>
             {
-                enum_metadata(db, instance.class_literal(db))
-                    .and_then(|metadata| metadata.instance_name_type(db))
-                    .map_or_else(Place::default, Place::bound)
-                    .into()
-            }
+                let class_literal = instance.class_literal(db);
+                let is_enum_subclass = Type::ClassLiteral(class_literal)
+                    .is_subtype_of(db, KnownClass::Enum.to_subclass_of(db));
 
-            Type::NominalInstance(instance)
-                if matches!(name_str, "value" | "_value_")
-                    && enum_metadata(db, instance.class_literal(db)).is_some() =>
-            {
-                enum_metadata(db, instance.class_literal(db))
-                    .and_then(|metadata| metadata.instance_value_type(db))
+                enum_metadata(db, class_literal)
+                    .and_then(|metadata| match name_str {
+                        "name" if is_enum_subclass => metadata.instance_name_type(db),
+                        "_name_" => metadata.instance_name_type(db),
+                        "value" if is_enum_subclass => metadata.instance_value_type(db),
+                        "_value_" => metadata.instance_value_type(db),
+                        _ => None,
+                    })
                     .map_or_else(Place::default, Place::bound)
                     .into()
             }

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -63,6 +63,15 @@ impl<'db> EnumMetadata<'db> {
         }
     }
 
+    /// Returns the type of `.name`/`._name_` for a given enum member.
+    ///
+    /// This is always a string literal of the member name.
+    pub(crate) fn name_type(&self, db: &'db dyn Db, member_name: &Name) -> Option<Type<'db>> {
+        self.members
+            .contains_key(member_name)
+            .then(|| Type::string_literal(db, member_name.as_str()))
+    }
+
     /// Returns the type of `.value`/`._value_` for an enum instance that is not
     /// narrowed to a specific member (e.g. `x: MyEnum` where `MyEnum` has multiple members).
     ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
`TypeError`s between an enum member's `value` attribute and the enum itself are silently suppressed
when inside a function due to resolution as `Any`

Minimal example:
```py
from enum import Enum

class MyEnum(Enum):
    up = 'up'
    down = 'down'

def zero(x: MyEnum):
    return 0

def fun1(x: MyEnum):
    return zero(x.value)

myfun(MyEnum.up) # ok
myfun(MyEnum.up.value) # error (expect: MyEnum, found Literal)
fun1(MyEnum.up) # should error as the previous line due on fun1's call to zero
```

## Test Plan

<!-- How was it tested? -->
1. Added an example test in `crates/ty_python_semantic/resources/mdtest/enums.md` under the Function Syntax heading
1. Verified test failure
1. Implemented a fix
1. Verified green