### PR TITLE
[`pydocstyle`] Fix numpy section ordering (`D420`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydocstyle/D420_numpy.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydocstyle/D420_numpy.py
@@ -13,6 +13,14 @@ def correct_order():
     x : int
         Description.
 
+    Attributes
+    ----------
+    attr : int
+
+    Methods
+    -------
+    method
+
     Returns
     -------
     int
@@ -57,14 +65,6 @@ def correct_order():
     Examples
     --------
     >>> correct_order()
-
-    Attributes
-    ----------
-    attr : int
-
-    Methods
-    -------
-    method
     """
 
 

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/sections.rs
@@ -2177,6 +2177,8 @@ enum NumpySectionOrder {
     ShortSummary,
     ExtendedSummary,
     Parameters,
+    Attributes,
+    Methods,
     Returns,
     Yields,
     Receives,
@@ -2188,8 +2190,6 @@ enum NumpySectionOrder {
     Notes,
     References,
     Examples,
-    Attributes,
-    Methods,
 }
 
 fn numpy_section_order(kind: SectionKind) -> Option<NumpySectionOrder> {
@@ -2197,6 +2197,8 @@ fn numpy_section_order(kind: SectionKind) -> Option<NumpySectionOrder> {
         SectionKind::ShortSummary => Some(NumpySectionOrder::ShortSummary),
         SectionKind::ExtendedSummary => Some(NumpySectionOrder::ExtendedSummary),
         SectionKind::Parameters => Some(NumpySectionOrder::Parameters),
+        SectionKind::Attributes => Some(NumpySectionOrder::Attributes),
+        SectionKind::Methods => Some(NumpySectionOrder::Methods),
         SectionKind::Returns => Some(NumpySectionOrder::Returns),
         SectionKind::Yields => Some(NumpySectionOrder::Yields),
         SectionKind::Receives => Some(NumpySectionOrder::Receives),
@@ -2210,8 +2212,6 @@ fn numpy_section_order(kind: SectionKind) -> Option<NumpySectionOrder> {
         SectionKind::Notes => Some(NumpySectionOrder::Notes),
         SectionKind::References => Some(NumpySectionOrder::References),
         SectionKind::Examples => Some(NumpySectionOrder::Examples),
-        SectionKind::Attributes => Some(NumpySectionOrder::Attributes),
-        SectionKind::Methods => Some(NumpySectionOrder::Methods),
         _ => None,
     }
 }


### PR DESCRIPTION
Matches numpydoc section ordering

Fixes #23682
