### PR TITLE
[ty] Fix overload public type when implementation has a type-changing…

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -895,3 +895,63 @@ def baz(x, y, z=None) -> bytes | list[str]:
 # revealed: Overload[(x, y) -> bytes, (x, y, z) -> list[str]]
 reveal_type(baz)
 ```
+
+## Implementation decorated with untyped decorator (simple)
+
+When the overload implementation is wrapped in a decorator with no typed signature, the overload
+stubs should still govern dispatch.
+
+```py
+from typing import Literal, overload
+
+def untyped_deco(f):
+    return f
+
+class A: ...
+class B: ...
+
+@overload
+def f(x: Literal[True]) -> A: ...
+@overload
+def f(x: Literal[False] = ...) -> B: ...
+@untyped_deco
+def f(x: bool = False) -> A | B:
+    return B()
+
+reveal_type(f)  # revealed: Overload[(x: Literal[True]) -> A, (x: Literal[False] = ...) -> B]
+reveal_type(f())  # revealed: B
+reveal_type(f(True))  # revealed: A
+```
+
+## Implementation decorated with signature-preserving decorator
+
+When the overload implementation is wrapped in a signature-preserving decorator
+(`Callable[P, T] -> Callable[P, T]`), the overload stubs should still govern dispatch. Per PEP 484,
+the implementation should be ignored by type checkers; only the `@overload` stubs are used. This
+matches the behavior of mypy and pyright.
+
+```py
+from typing import Callable, Literal, ParamSpec, TypeVar, overload
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+def preserve(fn: Callable[P, T]) -> Callable[P, T]:
+    return fn
+
+class A: ...
+class B: ...
+
+@overload
+def f(x: Literal[True]) -> A: ...
+@overload
+def f(x: Literal[False] = ...) -> B: ...
+@preserve
+def f(x: bool = False) -> A | B:
+    return B()
+
+reveal_type(f)  # revealed: Overload[(x: Literal[True]) -> A, (x: Literal[False] = ...) -> B]
+reveal_type(f())  # revealed: B
+reveal_type(f(False))  # revealed: B
+reveal_type(f(True))  # revealed: A
+```

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -357,7 +357,7 @@ impl<'db> OverloadLiteral<'db> {
 
     /// Returns the overload immediately before this one in the AST. Returns `None` if there is no
     /// previous overload.
-    fn previous_overload(self, db: &'db dyn Db) -> Option<FunctionLiteral<'db>> {
+    pub(crate) fn previous_overload(self, db: &'db dyn Db) -> Option<FunctionLiteral<'db>> {
         // The semantic model records a use for each function on the name node. This is used
         // here to get the previous function definition with the same name.
         let scope = self.definition(db).scope(db);

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3453,6 +3453,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             inferred_ty = self.apply_decorator(*decorator_ty, inferred_ty, decorator_node);
         }
 
+        // If the implementation of an overloaded function is wrapped in a decorator that
+        // transforms it to a non-`FunctionLiteral` type, restore the pre-decoration
+        // `FunctionLiteral`. Per PEP 484, the implementation "should be ignored by a type
+        // checker" — only the `@overload` stubs govern dispatch. We need a `FunctionLiteral`
+        // here so the overload chain is preserved in the public type.
+        if !matches!(inferred_ty, Type::FunctionLiteral(_))
+            && !overload_literal.is_overload(self.db())
+            && overload_literal.previous_overload(self.db()).is_some()
+        {
+            inferred_ty = self
+                .undecorated_type
+                .expect("undecorated_type is set before the decorator loop");
+        }
+
         self.add_declaration_with_binding(
             function.into(),
             definition,


### PR DESCRIPTION
## Summary

When the implementation of an overloaded function is wrapped in a decorator that returns a non-`FunctionLiteral` type (either a typed `Callable[P, T] -> Callable[P, T]` decorator or an untyped one), ty loses the overload chain. The overload stubs are stored in a linked list through `FunctionLiteral` via `previous_overload`. When a decorator transforms the implementation to a plain `Callable`, that link is severed, and callers see the decorator's return type instead of the overload signatures.

This pattern exists in real-world libraries. For example, [`LazyFrame.collect()` in polars](https://github.com/pola-rs/polars/blob/50a3bfbb4f663939a0868907ef1cc51c4288ce05/py-polars/src/polars/lazyframe/frame.py#L2171-L2211) uses two `@overload` stubs followed by a `@deprecate_streaming_parameter()` + `@forward_old_opt_flags()` decorated implementation.

With the bug, ty infers the wrong type for `.collect()`:

```python
import polars as pl

lf: pl.LazyFrame = pl.LazyFrame({"a": [1, 2, 3]})
reveal_type(lf.collect)
# was:  Overload[(..., background: Literal[True], ...) -> InProcessQuery, (..., background: Literal[False] = ..., ...) -> DataFrame | InProcessQuery, ...]
# now:  Overload[(..., background: Literal[True], ...) -> InProcessQuery, (..., background: Literal[False] = ..., ...) -> DataFrame]
```

The fix: after applying decorators in `infer_definition_types`, if the result is a non-`FunctionLiteral` and the function is the non-`@overload` implementation of an overload chain, restore the pre-decoration `FunctionLiteral`. Per PEP 484, the implementation is ignored by type checkers, only the `@overload` stubs govern dispatch. The pre-decoration `FunctionLiteral` already chains back to the stubs via `previous_overload`, so restoring it gives the correct public type. This matches the behavior of mypy and pyright.

## Test Plan

Added mdtests covering:

- An untyped decorator on the overload implementation
- A typed `Callable[P, T] -> Callable[P, T]` decorator on the overload implementation

```
cargo test -p ty_python_semantic --test mdtest
```

All tests pass.

_Note:_ I prompted Claude to track down this bug and fix it, it produced this patch which fixed the issue I ran into with my polars typecheck.