### PR TITLE
[ty] Fix GitHub-annotations mdtest output format

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -25,8 +25,8 @@ class C:
 
 c_instance = C(1)
 
-reveal_type(c_instance.inferred_from_value)  # revealed: int
-reveal_type(c_instance.inferred_from_other_attribute)  # revealed: str
+reveal_type(c_instance.inferred_from_value)  # revealed: Unknown | Literal[1, "a"]
+reveal_type(c_instance.inferred_from_other_attribute)  # revealed: Unknown | Literal[1, "a"]
 
 # There is no special handling of attributes that are (directly) assigned to a declared parameter,
 # which means we union with `Unknown` here, since the attribute itself is not declared. This is


### PR DESCRIPTION
## Summary

https://github.com/astral-sh/ruff/pull/22081 fixed one regression but introduced a new one. It fixed the way mdtest failures are reported for local use, so `mdtest.py` works well, but it broke the GitHub-annotations mdtest format that I added way back in https://github.com/astral-sh/ruff/pull/17150. In order for GitHub annotations to work, errors must be printed to stdout. This PR fixes the regression, restoring the feature where mdtest failures would be beautifully rendered by GitHub annotations on the "files changed" tab.

</details>

## Test plan

An earlier commit on this PR branch broke some mdtests deliberately to test the feature. Screenshot of the "files changed" tab before that commit was reverted:

<details>
<summary>Screenshot</summary>

<img width="1586" height="1234" alt="image" src="https://github.com/user-attachments/assets/bdcb9090-eede-4632-bb6b-f06d1ec4f77e" />

</details>

I also manually ran `mdtest.py` locally to check that the format there was still good.