### PR TITLE
[ty] Avoid the mandatory "ecosystem-analyzer workflow run cancelled" notification every time you make a PR

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: ty-ecosystem-analyzer-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ecosystem-analyzer') }}
 
 env:
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
## Summary

Currently I get an "ecosystem-analyzer workflow cancelled" notification every time I make a PR, regardless of whether the ecosystem-analyzer label is present on the PR when the PR is initially made. Claude's analysis is:

> The problem is the `cancel-in-progress: true` concurrency setting on line 17. Here's what happens:
>
> 1. You push to a PR (no `ecosystem-analyzer` label) → workflow triggers → job is immediately **skipped** (line 32 condition is false)
> 2. You push again → new workflow run starts → concurrency group **cancels** the previous run → you get a "cancelled" notification
>
> Even though the previous run's job was already skipped/done, the concurrency mechanism still sends a cancellation signal, which generates the notification.
>
> The fix is to only cancel in-progress runs when the label is actually present — for unlabeled PRs, the runs are harmlessly skipped in milliseconds and don't need cancellation:

Which seems plausible?