### PR TITLE
isort: Add `sort-strategy` option with new `full-path` strategy

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/isort/import_strategy_full_path.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/import_strategy_full_path.py
@@ -1,0 +1,16 @@
+from collections import OrderedDict
+from collections.abc import Mapping
+from collections import Counter
+from collections.abc import Sequence
+
+import collections.abc
+import collections
+
+# Relative imports
+from . import foo
+from .bar import baz
+from .. import parent
+
+# Star imports
+from xml import *
+from xml.etree import ElementTree

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -1634,7 +1634,7 @@ mod tests {
             Path::new("isort").join(path).as_path(),
             &LinterSettings {
                 isort: super::settings::Settings {
-                    length_sort: true,
+                    import_strategy: super::settings::ImportStrategy::Length,
                     ..super::settings::Settings::default()
                 },
                 src: vec![test_resource_path("fixtures/isort")],
@@ -1654,7 +1654,7 @@ mod tests {
             Path::new("isort").join(path).as_path(),
             &LinterSettings {
                 isort: super::settings::Settings {
-                    length_sort_straight: true,
+                    import_strategy: super::settings::ImportStrategy::LengthStraight,
                     ..super::settings::Settings::default()
                 },
                 src: vec![test_resource_path("fixtures/isort")],

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -1664,4 +1664,22 @@ mod tests {
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())
     }
+
+    #[test_case(Path::new("import_strategy_full_path.py"))]
+    fn full_path(path: &Path) -> Result<()> {
+        let snapshot = format!("full_path__{}", path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("isort").join(path).as_path(),
+            &LinterSettings {
+                isort: super::settings::Settings {
+                    import_strategy: super::settings::ImportStrategy::FullPath,
+                    ..super::settings::Settings::default()
+                },
+                src: vec![test_resource_path("fixtures/isort")],
+                ..LinterSettings::for_rule(Rule::UnsortedImports)
+            },
+        )?;
+        assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
 }

--- a/crates/ruff_linter/src/rules/isort/settings.rs
+++ b/crates/ruff_linter/src/rules/isort/settings.rs
@@ -21,6 +21,33 @@ use super::categorize::ImportSection;
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Default)]
+pub enum ImportStrategy {
+    /// Sort imports by their module path, using the module name for `from` imports (the default).
+    #[default]
+    Path,
+    /// Sort imports by their string length, placing shorter imports before longer ones.
+    ///
+    /// This strategy applies to both straight imports (`import foo`) and `from` imports
+    /// (`from foo import bar`).
+    Length,
+    /// Sort straight imports by their string length, leaving `from` imports sorted by path.
+    LengthStraight,
+}
+
+impl Display for ImportStrategy {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Path => write!(f, "path"),
+            Self::Length => write!(f, "length"),
+            Self::LengthStraight => write!(f, "length_straight"),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, CacheKey)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[derive(Default)]
 pub enum RelativeImportsOrder {
     /// Place "closer" imports (fewer `.` characters, most local) before
     /// "further" imports (more `.` characters, least local).
@@ -68,8 +95,7 @@ pub struct Settings {
     pub default_section: ImportSection,
     pub no_sections: bool,
     pub from_first: bool,
-    pub length_sort: bool,
-    pub length_sort_straight: bool,
+    pub import_strategy: ImportStrategy,
 }
 
 impl Settings {
@@ -123,8 +149,7 @@ impl Default for Settings {
             default_section: ImportSection::Known(ImportType::ThirdParty),
             no_sections: false,
             from_first: false,
-            length_sort: false,
-            length_sort_straight: false,
+            import_strategy: ImportStrategy::default(),
         }
     }
 }
@@ -160,8 +185,7 @@ impl Display for Settings {
                 self.default_section,
                 self.no_sections,
                 self.from_first,
-                self.length_sort,
-                self.length_sort_straight
+                self.import_strategy
             ]
         }
         Ok(())
@@ -176,6 +200,9 @@ pub enum SettingsError {
     InvalidKnownLocalFolder(glob::PatternError),
     InvalidExtraStandardLibrary(glob::PatternError),
     InvalidUserDefinedSection(glob::PatternError),
+    /// The `import-strategy` option conflicts with the deprecated `length-sort` or
+    /// `length-sort-straight` options.
+    ConflictingImportStrategy,
 }
 
 impl Display for SettingsError {
@@ -196,6 +223,12 @@ impl Display for SettingsError {
             SettingsError::InvalidUserDefinedSection(err) => {
                 write!(f, "invalid user-defined section pattern: {err}")
             }
+            SettingsError::ConflictingImportStrategy => {
+                write!(
+                    f,
+                    "`import-strategy` cannot be set alongside the deprecated `length-sort` or `length-sort-straight` options"
+                )
+            }
         }
     }
 }
@@ -208,6 +241,7 @@ impl Error for SettingsError {
             SettingsError::InvalidKnownLocalFolder(err) => Some(err),
             SettingsError::InvalidExtraStandardLibrary(err) => Some(err),
             SettingsError::InvalidUserDefinedSection(err) => Some(err),
+            SettingsError::ConflictingImportStrategy => None,
         }
     }
 }

--- a/crates/ruff_linter/src/rules/isort/settings.rs
+++ b/crates/ruff_linter/src/rules/isort/settings.rs
@@ -25,6 +25,11 @@ pub enum ImportStrategy {
     /// Sort imports by their module path, using the module name for `from` imports (the default).
     #[default]
     Path,
+    /// Sort `from` imports by their fully-qualified name.
+    ///
+    /// For example, `from foo import bar` sorts as `foo.bar` rather than just `foo`. This means
+    /// `from foo import baz` sorts after `from foo.bar import wow`, since `foo.bar.wow < foo.baz`.
+    FullPath,
     /// Sort imports by their string length, placing shorter imports before longer ones.
     ///
     /// This strategy applies to both straight imports (`import foo`) and `from` imports
@@ -38,6 +43,7 @@ impl Display for ImportStrategy {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::Path => write!(f, "path"),
+            Self::FullPath => write!(f, "full_path"),
             Self::Length => write!(f, "length"),
             Self::LengthStraight => write!(f, "length_straight"),
         }

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__full_path__import_strategy_full_path.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__full_path__import_strategy_full_path.py.snap
@@ -1,0 +1,51 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+assertion_line: 1682
+---
+I001 [*] Import block is un-sorted or un-formatted
+  --> import_strategy_full_path.py:1:1
+   |
+ 1 | / from collections import OrderedDict
+ 2 | | from collections.abc import Mapping
+ 3 | | from collections import Counter
+ 4 | | from collections.abc import Sequence
+ 5 | |
+ 6 | | import collections.abc
+ 7 | | import collections
+ 8 | |
+ 9 | | # Relative imports
+10 | | from . import foo
+11 | | from .bar import baz
+12 | | from .. import parent
+13 | |
+14 | | # Star imports
+15 | | from xml import *
+16 | | from xml.etree import ElementTree
+   | |_________________________________^
+   |
+help: Organize imports
+   - from collections import OrderedDict
+   - from collections.abc import Mapping
+   - from collections import Counter
+   - from collections.abc import Sequence
+1  + import collections
+2  + import collections.abc
+3  + from collections.abc import Mapping, Sequence
+4  + from collections import Counter, OrderedDict
+5  + 
+6  + # Star imports
+7  + from xml import *
+8  + from xml.etree import ElementTree
+9  | 
+   - import collections.abc
+   - import collections
+10 + from .. import parent
+11 | 
+12 | # Relative imports
+13 | from . import foo
+14 | from .bar import baz
+   - from .. import parent
+   - 
+   - # Star imports
+   - from xml import *
+   - from xml.etree import ElementTree

--- a/crates/ruff_linter/src/rules/isort/sorting.rs
+++ b/crates/ruff_linter/src/rules/isort/sorting.rs
@@ -87,6 +87,7 @@ pub(crate) struct ModuleKey<'a> {
     force_to_top: bool,
     maybe_length: Option<usize>,
     distance: Distance,
+    qualified_name: Option<NatOrdStr<'a>>,
     maybe_lowercase_name: Option<NatOrdStr<'a>>,
     module_name: Option<NatOrdStr<'a>>,
     first_alias: Option<MemberKey<'a>>,
@@ -107,7 +108,7 @@ impl<'a> ModuleKey<'a> {
         let compute_length = match settings.import_strategy {
             ImportStrategy::Length => true,
             ImportStrategy::LengthStraight => style == ImportStyle::Straight,
-            ImportStrategy::Path => false,
+            ImportStrategy::Path | ImportStrategy::FullPath => false,
         };
         let maybe_length = compute_length.then_some(
             name.map(|name| name.chars().map(|c| c.width().unwrap_or(0)).sum::<usize>())
@@ -127,6 +128,32 @@ impl<'a> ModuleKey<'a> {
             (!settings.case_sensitive).then_some(NatOrdStr(maybe_lowercase(name)))
         });
 
+        // When using the `full-path` strategy, sort `from X import Y` statements by the
+        // fully-qualified name `X.Y` rather than just the module name `X`.
+        let qualified_name =
+            if settings.import_strategy == ImportStrategy::FullPath && style == ImportStyle::From {
+                first_alias.map(|(alias_name, _)| {
+                    let module_part = match (level, name) {
+                        (0, Some(n)) => n.to_string(),
+                        (0, None) => String::new(),
+                        (lvl, Some(n)) => format!("{}{}", ".".repeat(lvl as usize), n),
+                        (lvl, None) => ".".repeat(lvl as usize),
+                    };
+                    let qualified = if module_part.is_empty() {
+                        alias_name.to_string()
+                    } else {
+                        format!("{module_part}.{alias_name}")
+                    };
+                    if settings.case_sensitive {
+                        NatOrdStr::from(qualified)
+                    } else {
+                        NatOrdStr::from(qualified.to_lowercase())
+                    }
+                })
+            } else {
+                None
+            };
+
         let module_name = name.map(NatOrdStr::from);
 
         let asname = asname.map(NatOrdStr::from);
@@ -138,6 +165,7 @@ impl<'a> ModuleKey<'a> {
             force_to_top,
             maybe_length,
             distance,
+            qualified_name,
             maybe_lowercase_name,
             module_name,
             first_alias,

--- a/crates/ruff_linter/src/rules/isort/sorting.rs
+++ b/crates/ruff_linter/src/rules/isort/sorting.rs
@@ -7,7 +7,7 @@ use unicode_width::UnicodeWidthChar;
 
 use ruff_python_stdlib::str;
 
-use super::settings::{RelativeImportsOrder, Settings};
+use super::settings::{ImportStrategy, RelativeImportsOrder, Settings};
 
 #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Copy, Clone)]
 pub(crate) enum MemberType {
@@ -104,13 +104,16 @@ impl<'a> ModuleKey<'a> {
     ) -> Self {
         let force_to_top = !name.is_some_and(|name| settings.force_to_top.contains(name)); // `false` < `true` so we get forced to top first
 
-        let maybe_length = (settings.length_sort
-            || (settings.length_sort_straight && style == ImportStyle::Straight))
-            .then_some(
-                name.map(|name| name.chars().map(|c| c.width().unwrap_or(0)).sum::<usize>())
-                    .unwrap_or_default()
-                    + level as usize,
-            );
+        let compute_length = match settings.import_strategy {
+            ImportStrategy::Length => true,
+            ImportStrategy::LengthStraight => style == ImportStyle::Straight,
+            ImportStrategy::Path => false,
+        };
+        let maybe_length = compute_length.then_some(
+            name.map(|name| name.chars().map(|c| c.width().unwrap_or(0)).sum::<usize>())
+                .unwrap_or_default()
+                + level as usize,
+        );
 
         let distance = match level {
             0 => Distance::None,
@@ -161,8 +164,7 @@ impl<'a> MemberKey<'a> {
         let member_type = settings
             .order_by_type
             .then_some(member_type(name, settings));
-        let maybe_length = settings
-            .length_sort
+        let maybe_length = matches!(settings.import_strategy, ImportStrategy::Length)
             .then(|| name.chars().map(|c| c.width().unwrap_or(0)).sum());
         let maybe_lowercase_name =
             (!settings.case_sensitive).then_some(NatOrdStr(maybe_lowercase(name)));

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2677,15 +2677,18 @@ pub struct IsortOptions {
     ///
     /// - `path`: Sort imports by their module path (the default). For `from` imports, sorts by
     ///   the module name (e.g., `foo` in `from foo import bar`).
+    /// - `full-path`: Sort `from` imports by their fully-qualified name. For example,
+    ///   `from foo import bar` sorts as `foo.bar` rather than `foo`. This means
+    ///   `from foo import baz` sorts after `from foo.bar import wow`, since `foo.bar.wow < foo.baz`.
     /// - `length`: Sort imports by their string length, placing shorter imports before longer ones.
     ///   Applies to both straight imports (`import foo`) and `from` imports (`from foo import bar`).
     /// - `length-straight`: Sort straight imports by their string length, leaving `from` imports
     ///   sorted by path.
     #[option(
         default = r#""path""#,
-        value_type = r#""path" | "length" | "length-straight""#,
+        value_type = r#""path" | "full-path" | "length" | "length-straight""#,
         example = r#"
-            import-strategy = "length"
+            import-strategy = "full-path"
         "#
     )]
     pub import_strategy: Option<ImportStrategy>,

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -20,7 +20,7 @@ use ruff_linter::rules::flake8_pytest_style::settings::SettingsError;
 use ruff_linter::rules::flake8_pytest_style::types;
 use ruff_linter::rules::flake8_quotes::settings::Quote;
 use ruff_linter::rules::flake8_tidy_imports::settings::{ApiBan, Strictness};
-use ruff_linter::rules::isort::settings::RelativeImportsOrder;
+use ruff_linter::rules::isort::settings::{ImportStrategy, RelativeImportsOrder};
 use ruff_linter::rules::isort::{ImportSection, ImportType};
 use ruff_linter::rules::pep8_naming::settings::IgnoreNames;
 use ruff_linter::rules::pydocstyle::settings::Convention;
@@ -2673,6 +2673,23 @@ pub struct IsortOptions {
     )]
     pub from_first: Option<bool>,
 
+    /// The strategy to use when sorting imports.
+    ///
+    /// - `path`: Sort imports by their module path (the default). For `from` imports, sorts by
+    ///   the module name (e.g., `foo` in `from foo import bar`).
+    /// - `length`: Sort imports by their string length, placing shorter imports before longer ones.
+    ///   Applies to both straight imports (`import foo`) and `from` imports (`from foo import bar`).
+    /// - `length-straight`: Sort straight imports by their string length, leaving `from` imports
+    ///   sorted by path.
+    #[option(
+        default = r#""path""#,
+        value_type = r#""path" | "length" | "length-straight""#,
+        example = r#"
+            import-strategy = "length"
+        "#
+    )]
+    pub import_strategy: Option<ImportStrategy>,
+
     /// Sort imports by their string length, such that shorter imports appear
     /// before longer imports. For example, by default, imports will be sorted
     /// alphabetically, as in:
@@ -2687,6 +2704,9 @@ pub struct IsortOptions {
     /// import os
     /// import collections
     /// ```
+    ///
+    /// Deprecated: Use [`import-strategy = "length"`](#lint_isort_import-strategy) instead.
+    #[deprecated(note = "Use `import-strategy = \"length\"` instead.")]
     #[option(
         default = r#"false"#,
         value_type = "bool",
@@ -2698,6 +2718,9 @@ pub struct IsortOptions {
 
     /// Sort straight imports by their string length. Similar to [`length-sort`](#lint_isort_length-sort),
     /// but applies only to straight imports and doesn't affect `from` imports.
+    ///
+    /// Deprecated: Use [`import-strategy = "length-straight"`](#lint_isort_import-strategy) instead.
+    #[deprecated(note = "Use `import-strategy = \"length-straight\"` instead.")]
     #[option(
         default = r#"false"#,
         value_type = "bool",
@@ -2949,8 +2972,31 @@ impl IsortOptions {
             default_section,
             no_sections,
             from_first,
-            length_sort: self.length_sort.unwrap_or(false),
-            length_sort_straight: self.length_sort_straight.unwrap_or(false),
+            import_strategy: {
+                #[expect(deprecated)]
+                let has_length_sort = self.length_sort.is_some_and(|v| v);
+                #[expect(deprecated)]
+                let has_length_sort_straight = self.length_sort_straight.is_some_and(|v| v);
+
+                if let Some(strategy) = self.import_strategy {
+                    if has_length_sort || has_length_sort_straight {
+                        return Err(isort::settings::SettingsError::ConflictingImportStrategy);
+                    }
+                    strategy
+                } else if has_length_sort {
+                    warn_user_once!(
+                        "`length-sort` is deprecated. Use `import-strategy = \"length\"` instead."
+                    );
+                    ImportStrategy::Length
+                } else if has_length_sort_straight {
+                    warn_user_once!(
+                        "`length-sort-straight` is deprecated. Use `import-strategy = \"length-straight\"` instead."
+                    );
+                    ImportStrategy::LengthStraight
+                } else {
+                    ImportStrategy::default()
+                }
+            },
         })
     }
 }
@@ -4169,7 +4215,7 @@ impl From<LintOptionsWire> for LintOptions {
 
 #[cfg(test)]
 mod tests {
-    use crate::options::Flake8SelfOptions;
+    use crate::options::{Flake8SelfOptions, IsortOptions};
     use ruff_linter::rules::flake8_self;
     use ruff_python_ast::name::Name;
 
@@ -4218,5 +4264,46 @@ mod tests {
             settings.ignore_names,
             vec![Name::new_static("_foo"), Name::new_static("_bar")]
         );
+    }
+
+    #[test]
+    fn import_strategy_via_options() {
+        use ruff_linter::rules::isort::settings::ImportStrategy;
+
+        let settings = IsortOptions {
+            import_strategy: Some(ImportStrategy::Length),
+            ..IsortOptions::default()
+        }
+        .try_into_settings()
+        .expect("settings should be valid");
+        assert_eq!(settings.import_strategy, ImportStrategy::Length);
+    }
+
+    #[test]
+    fn import_strategy_conflicts_with_length_sort() {
+        use ruff_linter::rules::isort::settings::ImportStrategy;
+
+        #[expect(deprecated)]
+        let result = IsortOptions {
+            import_strategy: Some(ImportStrategy::Length),
+            length_sort: Some(true),
+            ..IsortOptions::default()
+        }
+        .try_into_settings();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn import_strategy_conflicts_with_length_sort_straight() {
+        use ruff_linter::rules::isort::settings::ImportStrategy;
+
+        #[expect(deprecated)]
+        let result = IsortOptions {
+            import_strategy: Some(ImportStrategy::Path),
+            length_sort_straight: Some(true),
+            ..IsortOptions::default()
+        }
+        .try_into_settings();
+        assert!(result.is_err());
     }
 }

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1631,6 +1631,11 @@
           "const": "path"
         },
         {
+          "description": "Sort `from` imports by their fully-qualified name.\n\nFor example, `from foo import bar` sorts as `foo.bar` rather than just `foo`. This means\n`from foo import baz` sorts after `from foo.bar import wow`, since `foo.bar.wow < foo.baz`.",
+          "type": "string",
+          "const": "full-path"
+        },
+        {
           "description": "Sort imports by their string length, placing shorter imports before longer ones.\n\nThis strategy applies to both straight imports (`import foo`) and `from` imports\n(`from foo import bar`).",
           "type": "string",
           "const": "length"
@@ -1815,7 +1820,7 @@
           }
         },
         "import-strategy": {
-          "description": "The strategy to use when sorting imports.\n\n- `path`: Sort imports by their module path (the default). For `from` imports, sorts by\n  the module name (e.g., `foo` in `from foo import bar`).\n- `length`: Sort imports by their string length, placing shorter imports before longer ones.\n  Applies to both straight imports (`import foo`) and `from` imports (`from foo import bar`).\n- `length-straight`: Sort straight imports by their string length, leaving `from` imports\n  sorted by path.",
+          "description": "The strategy to use when sorting imports.\n\n- `path`: Sort imports by their module path (the default). For `from` imports, sorts by\n  the module name (e.g., `foo` in `from foo import bar`).\n- `full-path`: Sort `from` imports by their fully-qualified name. For example,\n  `from foo import bar` sorts as `foo.bar` rather than `foo`. This means\n  `from foo import baz` sorts after `from foo.bar import wow`, since `foo.bar.wow < foo.baz`.\n- `length`: Sort imports by their string length, placing shorter imports before longer ones.\n  Applies to both straight imports (`import foo`) and `from` imports (`from foo import bar`).\n- `length-straight`: Sort straight imports by their string length, leaving `from` imports\n  sorted by path.",
           "anyOf": [
             {
               "$ref": "#/definitions/ImportStrategy"

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1623,6 +1623,25 @@
         }
       ]
     },
+    "ImportStrategy": {
+      "oneOf": [
+        {
+          "description": "Sort imports by their module path, using the module name for `from` imports (the default).",
+          "type": "string",
+          "const": "path"
+        },
+        {
+          "description": "Sort imports by their string length, placing shorter imports before longer ones.\n\nThis strategy applies to both straight imports (`import foo`) and `from` imports\n(`from foo import bar`).",
+          "type": "string",
+          "const": "length"
+        },
+        {
+          "description": "Sort straight imports by their string length, leaving `from` imports sorted by path.",
+          "type": "string",
+          "const": "length-straight"
+        }
+      ]
+    },
     "ImportType": {
       "type": "string",
       "enum": [
@@ -1795,6 +1814,17 @@
             "type": "string"
           }
         },
+        "import-strategy": {
+          "description": "The strategy to use when sorting imports.\n\n- `path`: Sort imports by their module path (the default). For `from` imports, sorts by\n  the module name (e.g., `foo` in `from foo import bar`).\n- `length`: Sort imports by their string length, placing shorter imports before longer ones.\n  Applies to both straight imports (`import foo`) and `from` imports (`from foo import bar`).\n- `length-straight`: Sort straight imports by their string length, leaving `from` imports\n  sorted by path.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ImportStrategy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "known-first-party": {
           "description": "A list of modules to consider first-party, regardless of whether they\ncan be identified as such via introspection of the local filesystem.\n\nSupports glob patterns. For more information on the glob syntax, refer\nto the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).",
           "type": [
@@ -1826,18 +1856,20 @@
           }
         },
         "length-sort": {
-          "description": "Sort imports by their string length, such that shorter imports appear\nbefore longer imports. For example, by default, imports will be sorted\nalphabetically, as in:\n```python\nimport collections\nimport os\n```\n\nSetting `length-sort = true` will instead sort such that shorter imports\nappear before longer imports, as in:\n```python\nimport os\nimport collections\n```",
+          "description": "Sort imports by their string length, such that shorter imports appear\nbefore longer imports. For example, by default, imports will be sorted\nalphabetically, as in:\n```python\nimport collections\nimport os\n```\n\nSetting `length-sort = true` will instead sort such that shorter imports\nappear before longer imports, as in:\n```python\nimport os\nimport collections\n```\n\nDeprecated: Use [`import-strategy = \"length\"`](#lint_isort_import-strategy) instead.",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "deprecated": true
         },
         "length-sort-straight": {
-          "description": "Sort straight imports by their string length. Similar to [`length-sort`](#lint_isort_length-sort),\nbut applies only to straight imports and doesn't affect `from` imports.",
+          "description": "Sort straight imports by their string length. Similar to [`length-sort`](#lint_isort_length-sort),\nbut applies only to straight imports and doesn't affect `from` imports.\n\nDeprecated: Use [`import-strategy = \"length-straight\"`](#lint_isort_import-strategy) instead.",
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "deprecated": true
         },
         "lines-after-imports": {
           "description": "The number of blank lines to place after imports.\nUse `-1` for automatic determination.\n\nRuff uses at most one blank line after imports in typing stub files (files with `.pyi` extension) in accordance to\nthe typing style recommendations ([source](https://typing.python.org/en/latest/guides/writing_stubs.html#blank-lines)).\n\nWhen using the formatter, only the values `-1`, `1`, and `2` are compatible because\nit enforces at least one empty and at most two empty lines after imports.",


### PR DESCRIPTION
## Summary

> [!NOTE]
> This is an alternative to #22787 based on feedback in same.

Currently, the isort rules sort imports purely based on module path. For example, the following would pass isort with the default configuration:

    from foo import baz
    from foo.bar import wow

since `foo` < `foo.bar`. However, the [hacking][1] plugin for flake8 provides rule `H306`, which expects [that imports are sorted by their fully qualified name][2]. Therefore it would expect the following:

    from foo.bar import wow
    from foo import baz

since `foo.bar.wow` < `foo.baz`.

Add support for this functionality by adding the concept of sort strategies - which gather the existing module path, length sort and length sort straight imports under one option - and adding a new strategy to this list, `full-path`. Users can then configure this like so:

```toml
[tool.ruff.lint.isort]
sort-strategy = "full-path"
```

Existing users of the `length-sort` and `length-sort-straight` option can migrate to this new option like so:

```toml
[tool.ruff.lint.isort]
sort-strategy = "length-sort"
```

## Test Plan

Unit tests included. Change ran against a subset of the many OpenStack projects using ruff for linting.

[1]: https://opendev.org/openstack/hacking/
[2]: https://opendev.org/openstack/hacking/src/commit/235d79d911d55abb0978fcf5ac92e193ebf9efa5/hacking/checks/imports.py#L81-L106
