### PR TITLE
Proof of concept: human readable rule names

### DIFF
--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -452,7 +452,7 @@ pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<Exi
             writer
         };
         if cli.statistics {
-            printer.write_statistics(&diagnostics, &mut summary_writer)?;
+            printer.write_statistics(&diagnostics, &mut summary_writer, preview)?;
         } else {
             printer.write_once(&diagnostics, &mut summary_writer, preview)?;
         }

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -14,7 +14,7 @@ use ruff_linter::fs::relativize_path;
 use ruff_linter::logging::LogLevel;
 use ruff_linter::message::{EmitterContext, render_diagnostics};
 use ruff_linter::notify_user;
-use ruff_linter::preview::is_warning_severity_enabled;
+use ruff_linter::preview::{is_rule_name_output_enabled, is_warning_severity_enabled};
 use ruff_linter::settings::flags::{self};
 use ruff_linter::settings::types::{OutputFormat, PreviewMode, UnsafeFixes};
 
@@ -33,7 +33,7 @@ bitflags! {
 #[derive(Serialize)]
 struct ExpandedStatistics<'a> {
     code: Option<&'a SecondaryCode>,
-    name: &'static str,
+    name: &'a str,
     count: usize,
     #[serde(rename = "fixable")]
     all_fixable: bool,
@@ -48,7 +48,7 @@ impl ExpandedStatistics<'_> {
 
 /// Accumulator type for grouping diagnostics by code.
 /// Format: (`code`, `representative_diagnostic`, `total_count`, `fixable_count`)
-type DiagnosticGroup<'a> = (Option<&'a SecondaryCode>, &'a Diagnostic, usize, usize);
+type DiagnosticGroup<'a> = (&'a str, &'a Diagnostic, usize, usize);
 
 pub(crate) struct Printer {
     format: OutputFormat,
@@ -268,20 +268,21 @@ impl Printer {
         &self,
         diagnostics: &Diagnostics,
         writer: &mut dyn Write,
+        preview: PreviewMode,
     ) -> Result<()> {
         let required_applicability = self.unsafe_fixes.required_applicability();
         let statistics: Vec<ExpandedStatistics> = diagnostics
             .inner
             .iter()
-            .sorted_by_key(|diagnostic| diagnostic.secondary_code())
+            .sorted_by_key(|diagnostic| diagnostic.name())
             .fold(vec![], |mut acc: Vec<DiagnosticGroup>, diagnostic| {
                 let is_fixable = diagnostic
                     .fix()
                     .is_some_and(|fix| fix.applies(required_applicability));
-                let code = diagnostic.secondary_code();
+                let name = diagnostic.name();
 
-                if let Some((prev_code, _prev_message, count, fixable_count)) = acc.last_mut() {
-                    if *prev_code == code {
+                if let Some((prev_name, _prev_message, count, fixable_count)) = acc.last_mut() {
+                    if *prev_name == name {
                         *count += 1;
                         if is_fixable {
                             *fixable_count += 1;
@@ -289,14 +290,14 @@ impl Printer {
                         return acc;
                     }
                 }
-                acc.push((code, diagnostic, 1, usize::from(is_fixable)));
+                acc.push((name, diagnostic, 1, usize::from(is_fixable)));
                 acc
             })
             .iter()
             .map(
-                |&(code, message, count, fixable_count)| ExpandedStatistics {
-                    code,
-                    name: message.name(),
+                |&(name, message, count, fixable_count)| ExpandedStatistics {
+                    code: message.secondary_code(),
+                    name,
                     count,
                     // Backward compatibility: `fixable` is true only when all violations are fixable.
                     // See: https://github.com/astral-sh/ruff/pull/21513
@@ -335,29 +336,49 @@ impl Printer {
 
                 // By default, we mimic Flake8's `--statistics` format.
                 for statistic in &statistics {
-                    writeln!(
-                        writer,
-                        "{:>count_width$}\t{:<code_width$}\t{}{}",
-                        statistic.count.to_string().bold(),
-                        statistic
-                            .code
-                            .map(SecondaryCode::as_str)
-                            .unwrap_or_default()
-                            .red()
-                            .bold(),
-                        if any_fixable {
-                            if statistic.all_fixable {
-                                &all_fixable
-                            } else if statistic.any_fixable() {
-                                &partially_fixable
+                    if is_rule_name_output_enabled(preview) {
+                        writeln!(
+                            writer,
+                            "{:>count_width$}  {}{}",
+                            statistic.count.to_string().bold(),
+                            if any_fixable {
+                                if statistic.all_fixable {
+                                    &all_fixable
+                                } else if statistic.any_fixable() {
+                                    &partially_fixable
+                                } else {
+                                    unfixable
+                                }
                             } else {
-                                unfixable
-                            }
-                        } else {
-                            ""
-                        },
-                        statistic.name,
-                    )?;
+                                ""
+                            },
+                            statistic.name,
+                        )?;
+                    } else {
+                        writeln!(
+                            writer,
+                            "{:>count_width$}\t{:<code_width$}\t{}{}",
+                            statistic.count.to_string().bold(),
+                            statistic
+                                .code
+                                .map(SecondaryCode::as_str)
+                                .unwrap_or_default()
+                                .red()
+                                .bold(),
+                            if any_fixable {
+                                if statistic.all_fixable {
+                                    &all_fixable
+                                } else if statistic.any_fixable() {
+                                    &partially_fixable
+                                } else {
+                                    unfixable
+                                }
+                            } else {
+                                ""
+                            },
+                            statistic.name,
+                        )?;
+                    }
                 }
 
                 self.write_summary_text(writer, diagnostics)?;

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -336,47 +336,36 @@ impl Printer {
 
                 // By default, we mimic Flake8's `--statistics` format.
                 for statistic in &statistics {
+                    let fixable = if any_fixable {
+                        if statistic.all_fixable {
+                            &all_fixable
+                        } else if statistic.any_fixable() {
+                            &partially_fixable
+                        } else {
+                            unfixable
+                        }
+                    } else {
+                        ""
+                    };
                     if is_rule_name_output_enabled(preview) {
                         writeln!(
                             writer,
-                            "{:>count_width$}  {}{}",
-                            statistic.count.to_string().bold(),
-                            if any_fixable {
-                                if statistic.all_fixable {
-                                    &all_fixable
-                                } else if statistic.any_fixable() {
-                                    &partially_fixable
-                                } else {
-                                    unfixable
-                                }
-                            } else {
-                                ""
-                            },
-                            statistic.name,
+                            "{count:>count_width$}\t{fixable}{name}",
+                            count = statistic.count.to_string().bold(),
+                            name = statistic.name,
                         )?;
                     } else {
                         writeln!(
                             writer,
-                            "{:>count_width$}\t{:<code_width$}\t{}{}",
-                            statistic.count.to_string().bold(),
-                            statistic
+                            "{count:>count_width$}\t{code:<code_width$}\t{fixable}{name}",
+                            count = statistic.count.to_string().bold(),
+                            code = statistic
                                 .code
                                 .map(SecondaryCode::as_str)
                                 .unwrap_or_default()
                                 .red()
                                 .bold(),
-                            if any_fixable {
-                                if statistic.all_fixable {
-                                    &all_fixable
-                                } else if statistic.any_fixable() {
-                                    &partially_fixable
-                                } else {
-                                    unfixable
-                                }
-                            } else {
-                                ""
-                            },
-                            statistic.name,
+                            name = statistic.name,
                         )?;
                     }
                 }

--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -2731,7 +2731,7 @@ fn nested_implicit_namespace_package() -> Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    foo/bar/baz/__init__.py:1:1: error[INP001] File `foo/bar/baz/__init__.py` declares a package, but is nested under an implicit namespace package. Add an `__init__.py` to `foo/bar`.
+    foo/bar/baz/__init__.py:1:1: error[implicit-namespace-package] File `foo/bar/baz/__init__.py` declares a package, but is nested under an implicit namespace package. Add an `__init__.py` to `foo/bar`.
     Found 1 error.
 
     ----- stderr -----
@@ -3121,7 +3121,7 @@ class Foo[_T, __T]:
         pass
 
     ----- stderr -----
-    test.py:2:14: error[UP049] Generic class uses private type parameters
+    test.py:2:14: error[private-type-parameter] Generic class uses private type parameters
     Found 2 errors (1 fixed, 1 remaining).
     "
     );
@@ -3267,7 +3267,7 @@ class A(Generic[T]):
     success: false
     exit_code: 1
     ----- stdout -----
-    test.py:6:9: error[UP046] Generic class `A` uses `Generic` subclass instead of type parameters
+    test.py:6:9: error[non-pep695-generic-class] Generic class `A` uses `Generic` subclass instead of type parameters
     Found 1 error.
     No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
@@ -3557,7 +3557,7 @@ fn semantic_syntax_errors() -> Result<()> {
     exit_code: 1
     ----- stdout -----
     main.py:1:3: error[invalid-syntax] assignment expression cannot rebind comprehension variable
-    main.py:1:20: error[F821] Undefined name `foo`
+    main.py:1:20: error[undefined-name] Undefined name `foo`
 
     ----- stderr -----
     "
@@ -3745,7 +3745,7 @@ fn show_fixes_in_full_output_with_preview_enabled() {
     success: false
     exit_code: 1
     ----- stdout -----
-    error[F401][*]: `math` imported but unused
+    error[unused-import][*]: `math` imported but unused
      --> -:1:8
       |
     1 | import math
@@ -3776,12 +3776,12 @@ fn rule_panic_mixed_results_concise() -> Result<()> {
     success: false
     exit_code: 2
     ----- stdout -----
-    normal.py:1:1: error[RUF900] Hey this is a stable test rule.
-    normal.py:1:1: error[RUF901] [*] Hey this is a stable test rule with a safe fix.
-    normal.py:1:1: error[RUF902] Hey this is a stable test rule with an unsafe fix.
-    normal.py:1:1: error[RUF903] Hey this is a stable test rule with a display only fix.
-    normal.py:1:1: error[RUF911] Hey this is a preview test rule.
-    normal.py:1:1: error[RUF950] Hey this is a test rule that was redirected from another.
+    normal.py:1:1: error[stable-test-rule] Hey this is a stable test rule.
+    normal.py:1:1: error[stable-test-rule-safe-fix] [*] Hey this is a stable test rule with a safe fix.
+    normal.py:1:1: error[stable-test-rule-unsafe-fix] Hey this is a stable test rule with an unsafe fix.
+    normal.py:1:1: error[stable-test-rule-display-only-fix] Hey this is a stable test rule with a display only fix.
+    normal.py:1:1: error[preview-test-rule] Hey this is a preview test rule.
+    normal.py:1:1: error[redirected-to-test-rule] Hey this is a test rule that was redirected from another.
     panic.py: fatal[panic] Panicked at <location> when checking `[TMP]/panic.py`: `This is a fake panic for testing.`
     Found 7 errors.
     [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
@@ -3811,24 +3811,24 @@ fn rule_panic_mixed_results_full() -> Result<()> {
     success: false
     exit_code: 2
     ----- stdout -----
-    error[RUF900]: Hey this is a stable test rule.
+    error[stable-test-rule]: Hey this is a stable test rule.
     --> normal.py:1:1
 
-    error[RUF901][*]: Hey this is a stable test rule with a safe fix.
+    error[stable-test-rule-safe-fix][*]: Hey this is a stable test rule with a safe fix.
     --> normal.py:1:1
     1 + # fix from stable-test-rule-safe-fix
     2 | import os
 
-    error[RUF902]: Hey this is a stable test rule with an unsafe fix.
+    error[stable-test-rule-unsafe-fix]: Hey this is a stable test rule with an unsafe fix.
     --> normal.py:1:1
 
-    error[RUF903]: Hey this is a stable test rule with a display only fix.
+    error[stable-test-rule-display-only-fix]: Hey this is a stable test rule with a display only fix.
     --> normal.py:1:1
 
-    error[RUF911]: Hey this is a preview test rule.
+    error[preview-test-rule]: Hey this is a preview test rule.
     --> normal.py:1:1
 
-    error[RUF950]: Hey this is a test rule that was redirected from another.
+    error[redirected-to-test-rule]: Hey this is a test rule that was redirected from another.
     --> normal.py:1:1
 
     error[panic]: Panicked at <location> when checking `[TMP]/panic.py`: `This is a fake panic for testing.`
@@ -4000,10 +4000,10 @@ fn supported_file_extensions_preview_enabled() -> Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    src/thing.ipynb:cell 1:1:8: error[F401] [*] `os` imported but unused
-    src/thing.py:1:8: error[F401] [*] `os` imported but unused
-    src/thing.pyi:1:8: error[F401] [*] `os` imported but unused
-    src/thing.pyw:1:8: error[F401] [*] `os` imported but unused
+    src/thing.ipynb:cell 1:1:8: error[unused-import] [*] `os` imported but unused
+    src/thing.py:1:8: error[unused-import] [*] `os` imported but unused
+    src/thing.pyi:1:8: error[unused-import] [*] `os` imported but unused
+    src/thing.pyw:1:8: error[unused-import] [*] `os` imported but unused
     Found 4 errors.
     [*] 4 fixable with the `--fix` option.
 

--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -3571,7 +3571,7 @@ fn semantic_syntax_errors() -> Result<()> {
     exit_code: 1
     ----- stdout -----
     main.py:1:3: error[invalid-syntax] assignment expression cannot rebind comprehension variable
-    main.py:1:20: error[F821] Undefined name `foo`
+    main.py:1:20: error[undefined-name] Undefined name `foo`
 
     ----- stderr -----
     "

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -1215,7 +1215,7 @@ fn show_statistics_syntax_errors() {
     success: false
     exit_code: 1
     ----- stdout -----
-    1		invalid-syntax
+    1  invalid-syntax
     Found 1 error.
 
     ----- stderr -----
@@ -1228,7 +1228,7 @@ fn show_statistics_syntax_errors() {
     success: false
     exit_code: 1
     ----- stdout -----
-    1		invalid-syntax
+    1  invalid-syntax
     Found 1 error.
 
     ----- stderr -----

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -920,7 +920,7 @@ fn full_output_preview() {
     success: false
     exit_code: 1
     ----- stdout -----
-    error[E741]: Ambiguous variable name: `l`
+    error[ambiguous-variable-name]: Ambiguous variable name: `l`
      --> -:1:1
       |
     1 | l = 1
@@ -949,7 +949,7 @@ preview = true
     success: false
     exit_code: 1
     ----- stdout -----
-    error[E741]: Ambiguous variable name: `l`
+    error[ambiguous-variable-name]: Ambiguous variable name: `l`
      --> -:1:1
       |
     1 | l = 1
@@ -1258,12 +1258,12 @@ fn preview_enabled_prefix() {
     success: false
     exit_code: 1
     ----- stdout -----
-    -:1:1: error[RUF900] Hey this is a stable test rule.
-    -:1:1: error[RUF901] [*] Hey this is a stable test rule with a safe fix.
-    -:1:1: error[RUF902] Hey this is a stable test rule with an unsafe fix.
-    -:1:1: error[RUF903] Hey this is a stable test rule with a display only fix.
-    -:1:1: error[RUF911] Hey this is a preview test rule.
-    -:1:1: error[RUF950] Hey this is a test rule that was redirected from another.
+    -:1:1: error[stable-test-rule] Hey this is a stable test rule.
+    -:1:1: error[stable-test-rule-safe-fix] [*] Hey this is a stable test rule with a safe fix.
+    -:1:1: error[stable-test-rule-unsafe-fix] Hey this is a stable test rule with an unsafe fix.
+    -:1:1: error[stable-test-rule-display-only-fix] Hey this is a stable test rule with a display only fix.
+    -:1:1: error[preview-test-rule] Hey this is a preview test rule.
+    -:1:1: error[redirected-to-test-rule] Hey this is a test rule that was redirected from another.
     Found 6 errors.
     [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
@@ -1280,14 +1280,14 @@ fn preview_enabled_all() {
     success: false
     exit_code: 1
     ----- stdout -----
-    -:1:1: error[D100] Missing docstring in public module
-    -:1:1: error[CPY001] Missing copyright notice at top of file
-    -:1:1: error[RUF900] Hey this is a stable test rule.
-    -:1:1: error[RUF901] [*] Hey this is a stable test rule with a safe fix.
-    -:1:1: error[RUF902] Hey this is a stable test rule with an unsafe fix.
-    -:1:1: error[RUF903] Hey this is a stable test rule with a display only fix.
-    -:1:1: error[RUF911] Hey this is a preview test rule.
-    -:1:1: error[RUF950] Hey this is a test rule that was redirected from another.
+    -:1:1: error[undocumented-public-module] Missing docstring in public module
+    -:1:1: error[missing-copyright-notice] Missing copyright notice at top of file
+    -:1:1: error[stable-test-rule] Hey this is a stable test rule.
+    -:1:1: error[stable-test-rule-safe-fix] [*] Hey this is a stable test rule with a safe fix.
+    -:1:1: error[stable-test-rule-unsafe-fix] Hey this is a stable test rule with an unsafe fix.
+    -:1:1: error[stable-test-rule-display-only-fix] Hey this is a stable test rule with a display only fix.
+    -:1:1: error[preview-test-rule] Hey this is a preview test rule.
+    -:1:1: error[redirected-to-test-rule] Hey this is a test rule that was redirected from another.
     Found 8 errors.
     [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
@@ -1307,7 +1307,7 @@ fn preview_enabled_direct() {
     success: false
     exit_code: 1
     ----- stdout -----
-    -:1:1: error[RUF911] Hey this is a preview test rule.
+    -:1:1: error[preview-test-rule] Hey this is a preview test rule.
     Found 1 error.
 
     ----- stderr -----
@@ -1421,12 +1421,12 @@ fn preview_enabled_group_ignore() {
     success: false
     exit_code: 1
     ----- stdout -----
-    -:1:1: error[RUF900] Hey this is a stable test rule.
-    -:1:1: error[RUF901] [*] Hey this is a stable test rule with a safe fix.
-    -:1:1: error[RUF902] Hey this is a stable test rule with an unsafe fix.
-    -:1:1: error[RUF903] Hey this is a stable test rule with a display only fix.
-    -:1:1: error[RUF911] Hey this is a preview test rule.
-    -:1:1: error[RUF950] Hey this is a test rule that was redirected from another.
+    -:1:1: error[stable-test-rule] Hey this is a stable test rule.
+    -:1:1: error[stable-test-rule-safe-fix] [*] Hey this is a stable test rule with a safe fix.
+    -:1:1: error[stable-test-rule-unsafe-fix] Hey this is a stable test rule with an unsafe fix.
+    -:1:1: error[stable-test-rule-display-only-fix] Hey this is a stable test rule with a display only fix.
+    -:1:1: error[preview-test-rule] Hey this is a preview test rule.
+    -:1:1: error[redirected-to-test-rule] Hey this is a test rule that was redirected from another.
     Found 6 errors.
     [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
@@ -2401,7 +2401,7 @@ select = ["RUF017"]
     success: false
     exit_code: 1
     ----- stdout -----
-    error[RUF017]: Avoid quadratic list summation
+    error[quadratic-list-summation]: Avoid quadratic list summation
      --> -:3:1
       |
     1 | x = [1, 2, 3]
@@ -2442,7 +2442,7 @@ unfixable = ["RUF"]
     success: false
     exit_code: 1
     ----- stdout -----
-    error[RUF017]: Avoid quadratic list summation
+    error[quadratic-list-summation]: Avoid quadratic list summation
      --> -:3:1
       |
     1 | x = [1, 2, 3]

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -1215,7 +1215,7 @@ fn show_statistics_syntax_errors() {
     success: false
     exit_code: 1
     ----- stdout -----
-    1  invalid-syntax
+    1	invalid-syntax
     Found 1 error.
 
     ----- stderr -----
@@ -1228,7 +1228,7 @@ fn show_statistics_syntax_errors() {
     success: false
     exit_code: 1
     ----- stdout -----
-    1  invalid-syntax
+    1	invalid-syntax
     Found 1 error.
 
     ----- stderr -----
@@ -1241,7 +1241,7 @@ fn show_statistics_syntax_errors() {
     success: false
     exit_code: 1
     ----- stdout -----
-    1		invalid-syntax
+    1	invalid-syntax
     Found 1 error.
 
     ----- stderr -----

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -419,9 +419,13 @@ impl Diagnostic {
     /// This is a common pattern for Ruff diagnostics, which want to use the noqa code in general,
     /// but fall back on the `invalid-syntax` identifier for syntax errors, which don't have
     /// secondary codes.
-    pub fn secondary_code_or_id(&self) -> &str {
-        self.secondary_code()
-            .map_or_else(|| self.inner.id.as_str(), SecondaryCode::as_str)
+    pub fn secondary_code_or_id(&self, preview: bool) -> &str {
+        if preview {
+            self.name()
+        } else {
+            self.secondary_code()
+                .map_or_else(|| self.inner.id.as_str(), SecondaryCode::as_str)
+        }
     }
 
     /// Set the secondary code for this diagnostic.

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -424,7 +424,21 @@ impl Diagnostic {
             self.name()
         } else {
             self.secondary_code()
-                .map_or_else(|| self.inner.id.as_str(), SecondaryCode::as_str)
+                .map_or_else(|| self.name(), SecondaryCode::as_str)
+        }
+    }
+
+    /// Render the diagnostic id for display to the user.
+    /// When in preview mode, render the diagnostic name followed by a colon (eg, `rule-name:`).
+    /// Otherwise, render just the secondary code if available (eg, `F401`), or the rule id followed
+    /// by a colon (eg, `invalid-syntax:`).
+    pub fn display_diagnostic_id(&self, preview: bool) -> String {
+        if preview {
+            format!("{name}:", name = self.name())
+        } else if let Some(code) = self.secondary_code() {
+            code.to_string()
+        } else {
+            format!("{id}:", id = self.name())
         }
     }
 
@@ -1526,6 +1540,10 @@ impl DisplayDiagnosticConfig {
         self.cancellation_token
             .as_ref()
             .is_some_and(|token| token.is_cancelled())
+    }
+
+    pub fn is_preview(&self) -> bool {
+        self.preview
     }
 }
 

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -117,7 +117,7 @@ impl std::fmt::Display for DisplayDiagnostics<'_> {
                 FullRenderer::new(self.resolver, self.config).render(f, self.diagnostics)?;
             }
             DiagnosticFormat::Azure => {
-                AzureRenderer::new(self.resolver).render(f, self.diagnostics)?;
+                AzureRenderer::new(self.resolver, self.config).render(f, self.diagnostics)?;
             }
             #[cfg(feature = "serde")]
             DiagnosticFormat::Json => {
@@ -133,20 +133,20 @@ impl std::fmt::Display for DisplayDiagnostics<'_> {
                 rdjson::RdjsonRenderer::new(self.resolver).render(f, self.diagnostics)?;
             }
             DiagnosticFormat::Pylint => {
-                PylintRenderer::new(self.resolver).render(f, self.diagnostics)?;
+                PylintRenderer::new(self.resolver, self.config).render(f, self.diagnostics)?;
             }
             #[cfg(feature = "junit")]
             DiagnosticFormat::Junit => {
-                junit::JunitRenderer::new(self.resolver, self.config.program)
+                junit::JunitRenderer::new(self.resolver, self.config)
                     .render(f, self.diagnostics)?;
             }
             #[cfg(feature = "serde")]
             DiagnosticFormat::Gitlab => {
-                gitlab::GitlabRenderer::new(self.resolver).render(f, self.diagnostics)?;
+                gitlab::GitlabRenderer::new(self.resolver, self.config)
+                    .render(f, self.diagnostics)?;
             }
             DiagnosticFormat::Github => {
-                GithubRenderer::new(self.resolver, self.config.program)
-                    .render(f, self.diagnostics)?;
+                GithubRenderer::new(self.resolver, self.config).render(f, self.diagnostics)?;
             }
         }
 
@@ -237,20 +237,7 @@ impl<'a> ResolvedDiagnostic<'a> {
             })
             .collect();
 
-        let id = if config.hide_severity {
-            // Either the rule code alone (e.g. `F401`), or the lint id with a colon (e.g.
-            // `invalid-syntax:`). When Ruff gets real severities, we should put the colon back in
-            // `DisplaySet::format_annotation` for both cases, but this is a small hack to improve
-            // the formatting of syntax errors for now. This should also be kept consistent with the
-            // concise formatting.
-            diag.secondary_code().map_or_else(
-                || format!("{id}:", id = diag.inner.id),
-                |code| code.to_string(),
-            )
-        } else {
-            diag.secondary_code_or_id().to_string()
-        };
-
+        let id = format!("{id}:", id = diag.secondary_code_or_id(config.preview));
         let level = if config.hide_severity {
             AnnotateLevel::None
         } else {

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -1051,6 +1051,23 @@ fn replace_unprintable<'r>(
     }
 }
 
+/// Render the diagnostic id for display to the user.
+/// When in preview mode, render the diagnostic name followed by a colon (eg, `rule-name:`).
+/// Otherwise, render just the secondary code if available (eg, `F401`), or the rule id followed
+/// by a colon (eg, `invalid-syntax:`).
+fn display_diagnostic_id(diagnostic: &Diagnostic, config: &DisplayDiagnosticConfig) -> String {
+    if config.preview {
+        format!(
+            "{name}:",
+            name = diagnostic.secondary_code_or_id(config.preview)
+        )
+    } else if let Some(code) = diagnostic.secondary_code() {
+        code.to_string()
+    } else {
+        format!("{id}:", id = diagnostic.id())
+    }
+}
+
 struct EscapedSourceCode<'r> {
     text: Cow<'r, str>,
     annotations: Vec<RenderableAnnotation<'r>>,

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -1051,23 +1051,6 @@ fn replace_unprintable<'r>(
     }
 }
 
-/// Render the diagnostic id for display to the user.
-/// When in preview mode, render the diagnostic name followed by a colon (eg, `rule-name:`).
-/// Otherwise, render just the secondary code if available (eg, `F401`), or the rule id followed
-/// by a colon (eg, `invalid-syntax:`).
-fn display_diagnostic_id(diagnostic: &Diagnostic, config: &DisplayDiagnosticConfig) -> String {
-    if config.preview {
-        format!(
-            "{name}:",
-            name = diagnostic.secondary_code_or_id(config.preview)
-        )
-    } else if let Some(code) = diagnostic.secondary_code() {
-        code.to_string()
-    } else {
-        format!("{id}:", id = diagnostic.id())
-    }
-}
-
 struct EscapedSourceCode<'r> {
     text: Cow<'r, str>,
     annotations: Vec<RenderableAnnotation<'r>>,

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -237,7 +237,21 @@ impl<'a> ResolvedDiagnostic<'a> {
             })
             .collect();
 
-        let id = format!("{id}:", id = diag.secondary_code_or_id(config.preview));
+        // TODO(brent) I'm pretty sure this is not the right place for this check, just trying to
+        // get the tests to pass temporarily. It's highly suspicious that this is basically the
+        // opposite of Diagnostic::display_diagnostic_id but with an additional hide_severity check.
+        let id = if config.preview {
+            diag.name().to_string()
+        } else if let Some(code) = diag.secondary_code() {
+            code.to_string()
+        } else {
+            if config.hide_severity {
+                format!("{id}:", id = diag.name())
+            } else {
+                diag.name().to_string()
+            }
+        };
+
         let level = if config.hide_severity {
             AnnotateLevel::None
         } else {

--- a/crates/ruff_db/src/diagnostic/render/azure.rs
+++ b/crates/ruff_db/src/diagnostic/render/azure.rs
@@ -1,16 +1,17 @@
 use ruff_source_file::LineColumn;
 
-use crate::diagnostic::{Diagnostic, Severity};
+use crate::diagnostic::{Diagnostic, DisplayDiagnosticConfig, Severity};
 
 use super::FileResolver;
 
 pub(super) struct AzureRenderer<'a> {
     resolver: &'a dyn FileResolver,
+    config: &'a DisplayDiagnosticConfig,
 }
 
 impl<'a> AzureRenderer<'a> {
-    pub(super) fn new(resolver: &'a dyn FileResolver) -> Self {
-        Self { resolver }
+    pub(super) fn new(resolver: &'a dyn FileResolver, config: &'a DisplayDiagnosticConfig) -> Self {
+        Self { resolver, config }
     }
 }
 
@@ -51,7 +52,7 @@ impl AzureRenderer<'_> {
             writeln!(
                 f,
                 "code={code};]{body}",
-                code = diag.secondary_code_or_id(),
+                code = diag.secondary_code_or_id(self.config.preview),
                 body = diag.concise_message(),
             )?;
         }

--- a/crates/ruff_db/src/diagnostic/render/concise.rs
+++ b/crates/ruff_db/src/diagnostic/render/concise.rs
@@ -1,6 +1,5 @@
 use crate::diagnostic::{
     Diagnostic, DisplayDiagnosticConfig, Severity,
-    render::display_diagnostic_id,
     stylesheet::{DiagnosticStylesheet, fmt_styled, fmt_with_hyperlink},
 };
 
@@ -74,7 +73,7 @@ impl<'a> ConciseRenderer<'a> {
                     "{code} ",
                     code = fmt_styled(
                         fmt_with_hyperlink(
-                            display_diagnostic_id(diag, self.config),
+                            diag.display_diagnostic_id(self.config.preview),
                             diag.documentation_url(),
                             &stylesheet
                         ),

--- a/crates/ruff_db/src/diagnostic/render/concise.rs
+++ b/crates/ruff_db/src/diagnostic/render/concise.rs
@@ -80,12 +80,6 @@ impl<'a> ConciseRenderer<'a> {
                         stylesheet.secondary_code
                     )
                 )?;
-                if self.config.show_fix_status {
-                    // Do not display an indicator for inapplicable fixes
-                    if diag.has_applicable_fix(self.config.fix_applicability()) {
-                        write!(f, "[{fix}] ", fix = fmt_styled("*", stylesheet.separator))?;
-                    }
-                }
             } else {
                 let (severity, severity_style) = match diag.severity() {
                     Severity::Info => ("info", stylesheet.info),

--- a/crates/ruff_db/src/diagnostic/render/concise.rs
+++ b/crates/ruff_db/src/diagnostic/render/concise.rs
@@ -68,28 +68,20 @@ impl<'a> ConciseRenderer<'a> {
             }
 
             if self.config.hide_severity {
-                if let Some(code) = diag.secondary_code() {
-                    write!(
-                        f,
-                        "{code} ",
-                        code = fmt_styled(
-                            fmt_with_hyperlink(&code, diag.documentation_url(), &stylesheet),
-                            stylesheet.secondary_code
-                        )
-                    )?;
-                } else {
-                    write!(
-                        f,
-                        "{id}: ",
-                        id = fmt_styled(
-                            fmt_with_hyperlink(
-                                &diag.inner.id,
-                                diag.documentation_url(),
-                                &stylesheet
-                            ),
-                            stylesheet.secondary_code
-                        )
-                    )?;
+                let id = diag.secondary_code_or_id(self.config.preview);
+                write!(
+                    f,
+                    "{id}: ",
+                    id = fmt_styled(
+                        fmt_with_hyperlink(&id, diag.documentation_url(), &stylesheet),
+                        stylesheet.secondary_code
+                    )
+                )?;
+                if self.config.show_fix_status {
+                    // Do not display an indicator for inapplicable fixes
+                    if diag.has_applicable_fix(self.config.fix_applicability()) {
+                        write!(f, "[{fix}] ", fix = fmt_styled("*", stylesheet.separator))?;
+                    }
                 }
             } else {
                 let (severity, severity_style) = match diag.severity() {
@@ -104,7 +96,7 @@ impl<'a> ConciseRenderer<'a> {
                     severity = fmt_styled(severity, severity_style),
                     id = fmt_styled(
                         fmt_with_hyperlink(
-                            &diag.secondary_code_or_id(),
+                            &diag.secondary_code_or_id(self.config.preview),
                             diag.documentation_url(),
                             &stylesheet
                         ),

--- a/crates/ruff_db/src/diagnostic/render/concise.rs
+++ b/crates/ruff_db/src/diagnostic/render/concise.rs
@@ -1,5 +1,6 @@
 use crate::diagnostic::{
     Diagnostic, DisplayDiagnosticConfig, Severity,
+    render::display_diagnostic_id,
     stylesheet::{DiagnosticStylesheet, fmt_styled, fmt_with_hyperlink},
 };
 
@@ -68,12 +69,15 @@ impl<'a> ConciseRenderer<'a> {
             }
 
             if self.config.hide_severity {
-                let id = diag.secondary_code_or_id(self.config.preview);
                 write!(
                     f,
-                    "{id}: ",
-                    id = fmt_styled(
-                        fmt_with_hyperlink(&id, diag.documentation_url(), &stylesheet),
+                    "{code} ",
+                    code = fmt_styled(
+                        fmt_with_hyperlink(
+                            display_diagnostic_id(diag, self.config),
+                            diag.documentation_url(),
+                            &stylesheet
+                        ),
                         stylesheet.secondary_code
                     )
                 )?;
@@ -163,10 +167,10 @@ mod tests {
         env.fix_applicability(Applicability::DisplayOnly);
         env.preview(true);
         insta::assert_snapshot!(env.render_diagnostics(&diagnostics), @"
-        fib.py:1:8: F401 [*] `os` imported but unused
-        fib.py:6:5: F841 [*] Local variable `x` is assigned to but never used
-        undef.py:1:4: F821 Undefined name `a`
-        fib.py:12:16: F821 Undefined name `fibonaccii`
+        fib.py:1:8: unused-import: [*] `os` imported but unused
+        fib.py:6:5: unused-variable: [*] Local variable `x` is assigned to but never used
+        undef.py:1:4: undefined-name: Undefined name `a`
+        fib.py:12:16: undefined-name: Undefined name `fibonaccii`
         ");
     }
 

--- a/crates/ruff_db/src/diagnostic/render/github.rs
+++ b/crates/ruff_db/src/diagnostic/render/github.rs
@@ -2,7 +2,7 @@ use ruff_text_size::TextRange;
 
 use crate::diagnostic::{
     Annotation, Diagnostic, DisplayDiagnosticConfig, FileResolver, Severity, SubDiagnosticSeverity,
-    UnifiedFile,
+    UnifiedFile, render::display_diagnostic_id,
 };
 
 pub(super) struct GithubRenderer<'a> {
@@ -88,8 +88,8 @@ impl<'a> GithubRenderer<'a> {
 
             write!(
                 f,
-                "{code}:",
-                code = diagnostic.secondary_code_or_id(self.config.preview)
+                "{code}",
+                code = display_diagnostic_id(diagnostic, self.config)
             )?;
             write!(f, " {}", diagnostic.concise_message())?;
 

--- a/crates/ruff_db/src/diagnostic/render/github.rs
+++ b/crates/ruff_db/src/diagnostic/render/github.rs
@@ -1,17 +1,18 @@
 use ruff_text_size::TextRange;
 
 use crate::diagnostic::{
-    Annotation, Diagnostic, FileResolver, Severity, SubDiagnosticSeverity, UnifiedFile,
+    Annotation, Diagnostic, DisplayDiagnosticConfig, FileResolver, Severity, SubDiagnosticSeverity,
+    UnifiedFile,
 };
 
 pub(super) struct GithubRenderer<'a> {
     resolver: &'a dyn FileResolver,
-    program: &'a str,
+    config: &'a DisplayDiagnosticConfig,
 }
 
 impl<'a> GithubRenderer<'a> {
-    pub(super) fn new(resolver: &'a dyn FileResolver, program: &'a str) -> Self {
-        Self { resolver, program }
+    pub(super) fn new(resolver: &'a dyn FileResolver, config: &'a DisplayDiagnosticConfig) -> Self {
+        Self { resolver, config }
     }
 
     pub(super) fn render(
@@ -28,8 +29,8 @@ impl<'a> GithubRenderer<'a> {
             write!(
                 f,
                 "::{severity} title={program} ({code})",
-                program = self.program,
-                code = diagnostic.secondary_code_or_id()
+                program = self.config.program,
+                code = diagnostic.secondary_code_or_id(self.config.preview)
             )?;
 
             if let Some(span) = diagnostic.primary_span() {
@@ -85,12 +86,11 @@ impl<'a> GithubRenderer<'a> {
                 write!(f, "::")?;
             }
 
-            if let Some(code) = diagnostic.secondary_code() {
-                write!(f, "{code}")?;
-            } else {
-                write!(f, "{id}:", id = diagnostic.id())?;
-            }
-
+            write!(
+                f,
+                "{code}:",
+                code = diagnostic.secondary_code_or_id(self.config.preview)
+            )?;
             write!(f, " {}", diagnostic.concise_message())?;
 
             // After rendering the main diagnostic, render its secondary annotations and

--- a/crates/ruff_db/src/diagnostic/render/github.rs
+++ b/crates/ruff_db/src/diagnostic/render/github.rs
@@ -2,7 +2,7 @@ use ruff_text_size::TextRange;
 
 use crate::diagnostic::{
     Annotation, Diagnostic, DisplayDiagnosticConfig, FileResolver, Severity, SubDiagnosticSeverity,
-    UnifiedFile, render::display_diagnostic_id,
+    UnifiedFile,
 };
 
 pub(super) struct GithubRenderer<'a> {
@@ -89,7 +89,7 @@ impl<'a> GithubRenderer<'a> {
             write!(
                 f,
                 "{code}",
-                code = display_diagnostic_id(diagnostic, self.config)
+                code = diagnostic.display_diagnostic_id(self.config.preview)
             )?;
             write!(f, " {}", diagnostic.concise_message())?;
 

--- a/crates/ruff_db/src/diagnostic/render/gitlab.rs
+++ b/crates/ruff_db/src/diagnostic/render/gitlab.rs
@@ -7,17 +7,18 @@ use std::{
 use ruff_source_file::LineColumn;
 use serde::{Serialize, Serializer, ser::SerializeSeq};
 
-use crate::diagnostic::{Diagnostic, Severity};
+use crate::diagnostic::{Diagnostic, DisplayDiagnosticConfig, Severity};
 
 use super::FileResolver;
 
 pub(super) struct GitlabRenderer<'a> {
     resolver: &'a dyn FileResolver,
+    config: &'a DisplayDiagnosticConfig,
 }
 
 impl<'a> GitlabRenderer<'a> {
-    pub(super) fn new(resolver: &'a dyn FileResolver) -> Self {
-        Self { resolver }
+    pub(super) fn new(resolver: &'a dyn FileResolver, config: &'a DisplayDiagnosticConfig) -> Self {
+        Self { resolver, config }
     }
 }
 
@@ -33,6 +34,7 @@ impl GitlabRenderer<'_> {
             serde_json::to_string_pretty(&SerializedMessages {
                 diagnostics,
                 resolver: self.resolver,
+                config: self.config,
                 #[expect(
                     clippy::disallowed_methods,
                     reason = "We don't have access to a `System` here, \
@@ -49,6 +51,7 @@ impl GitlabRenderer<'_> {
 struct SerializedMessages<'a> {
     diagnostics: &'a [Diagnostic],
     resolver: &'a dyn FileResolver,
+    config: &'a DisplayDiagnosticConfig,
     project_dir: Option<&'a str>,
 }
 
@@ -99,7 +102,7 @@ impl Serialize for SerializedMessages<'_> {
             fingerprints.insert(message_fingerprint);
 
             let description = diagnostic.concise_message();
-            let check_name = diagnostic.secondary_code_or_id();
+            let check_name = diagnostic.secondary_code_or_id(self.config.preview);
             let severity = match diagnostic.severity() {
                 Severity::Info => "info",
                 Severity::Warning => "minor",

--- a/crates/ruff_db/src/diagnostic/render/json.rs
+++ b/crates/ruff_db/src/diagnostic/render/json.rs
@@ -102,7 +102,7 @@ pub(super) fn diagnostic_to_json<'a>(
     // and the severity is displayed.
     if config.preview {
         JsonDiagnostic {
-            code: diagnostic.secondary_code_or_id(),
+            code: diagnostic.secondary_code_or_id(config.preview),
             severity: diagnostic.severity(),
             url: diagnostic.documentation_url(),
             message: diagnostic.concise_message(),
@@ -115,7 +115,7 @@ pub(super) fn diagnostic_to_json<'a>(
         }
     } else {
         JsonDiagnostic {
-            code: diagnostic.secondary_code_or_id(),
+            code: diagnostic.secondary_code_or_id(config.preview),
             severity: Severity::Error,
             url: diagnostic.documentation_url(),
             message: diagnostic.concise_message(),

--- a/crates/ruff_db/src/diagnostic/render/junit.rs
+++ b/crates/ruff_db/src/diagnostic/render/junit.rs
@@ -5,7 +5,7 @@ use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite, X
 
 use ruff_source_file::LineColumn;
 
-use crate::diagnostic::{Diagnostic, SecondaryCode, Severity, render::FileResolver};
+use crate::diagnostic::{Diagnostic, DisplayDiagnosticConfig, Severity, render::FileResolver};
 
 /// Print diagnostics as a JUnit-style XML report.
 ///
@@ -17,12 +17,12 @@ use crate::diagnostic::{Diagnostic, SecondaryCode, Severity, render::FileResolve
 /// [`quick_junit`]: https://docs.rs/quick-junit/latest/quick_junit/
 pub(super) struct JunitRenderer<'a> {
     resolver: &'a dyn FileResolver,
-    program: &'a str,
+    config: &'a DisplayDiagnosticConfig,
 }
 
 impl<'a> JunitRenderer<'a> {
-    pub(super) fn new(resolver: &'a dyn FileResolver, program: &'a str) -> Self {
-        Self { resolver, program }
+    pub(super) fn new(resolver: &'a dyn FileResolver, config: &'a DisplayDiagnosticConfig) -> Self {
+        Self { resolver, config }
     }
 
     pub(super) fn render(
@@ -30,16 +30,16 @@ impl<'a> JunitRenderer<'a> {
         f: &mut std::fmt::Formatter,
         diagnostics: &[Diagnostic],
     ) -> std::fmt::Result {
-        let package = format!("org.{}", self.program);
-        let mut report = Report::new(self.program);
+        let package = format!("org.{}", self.config.program);
+        let mut report = Report::new(self.config.program);
 
         if diagnostics.is_empty() {
-            let mut test_suite = TestSuite::new(self.program);
+            let mut test_suite = TestSuite::new(self.config.program);
             test_suite
                 .extra
                 .insert(XmlString::new("package"), XmlString::new(&package));
             let mut case = TestCase::new("No errors found", TestCaseStatus::success());
-            case.set_classname(self.program);
+            case.set_classname(self.config.program);
             test_suite.add_test_case(case);
             report.add_test_suite(test_suite);
         } else {
@@ -58,9 +58,7 @@ impl<'a> JunitRenderer<'a> {
                         start_location: location,
                     } = diagnostic;
 
-                    let code = diagnostic
-                        .secondary_code()
-                        .map_or_else(|| diagnostic.name(), SecondaryCode::as_str);
+                    let code = diagnostic.secondary_code_or_id(self.config.preview);
                     let mut status = TestCaseStatus::non_success(NonSuccessKind::Failure);
                     status.set_message(diagnostic.concise_message().to_str());
 
@@ -76,7 +74,7 @@ impl<'a> JunitRenderer<'a> {
                     }
 
                     let mut case = TestCase::new(
-                        format!("org.{program}.{code}", program = self.program),
+                        format!("org.{program}.{code}", program = self.config.program),
                         status,
                     );
                     case.set_classname(classname.to_str().unwrap_or(filename));

--- a/crates/ruff_db/src/diagnostic/render/pylint.rs
+++ b/crates/ruff_db/src/diagnostic/render/pylint.rs
@@ -1,4 +1,4 @@
-use crate::diagnostic::{Diagnostic, SecondaryCode, render::FileResolver};
+use crate::diagnostic::{Diagnostic, DisplayDiagnosticConfig, render::FileResolver};
 
 /// Generate violations in Pylint format.
 ///
@@ -11,11 +11,12 @@ use crate::diagnostic::{Diagnostic, SecondaryCode, render::FileResolver};
 /// See: [Flake8 documentation](https://flake8.pycqa.org/en/latest/internal/formatters.html#pylint-formatter)
 pub(super) struct PylintRenderer<'a> {
     resolver: &'a dyn FileResolver,
+    config: &'a DisplayDiagnosticConfig,
 }
 
 impl<'a> PylintRenderer<'a> {
-    pub(super) fn new(resolver: &'a dyn FileResolver) -> Self {
-        Self { resolver }
+    pub(super) fn new(resolver: &'a dyn FileResolver, config: &'a DisplayDiagnosticConfig) -> Self {
+        Self { resolver, config }
     }
 }
 
@@ -45,10 +46,7 @@ impl PylintRenderer<'_> {
                 })
                 .unwrap_or_default();
 
-            let code = diagnostic
-                .secondary_code()
-                .map_or_else(|| diagnostic.name(), SecondaryCode::as_str);
-
+            let code = diagnostic.secondary_code_or_id(self.config.preview);
             let row = row.unwrap_or_default();
 
             writeln!(

--- a/crates/ruff_db/src/diagnostic/render/rdjson.rs
+++ b/crates/ruff_db/src/diagnostic/render/rdjson.rs
@@ -79,9 +79,7 @@ fn diagnostic_to_rdjson<'a>(
         message: diagnostic.concise_message(),
         location,
         code: RdjsonCode {
-            value: diagnostic
-                .secondary_code()
-                .map_or_else(|| diagnostic.name(), |code| code.as_str()),
+            value: diagnostic.secondary_code_or_id(false),
             url: diagnostic.documentation_url(),
         },
         suggestions: rdjson_suggestions(

--- a/crates/ruff_linter/src/message/grouped.rs
+++ b/crates/ruff_linter/src/message/grouped.rs
@@ -16,6 +16,7 @@ use crate::message::{Emitter, EmitterContext};
 pub struct GroupedEmitter {
     show_fix_status: bool,
     applicability: Applicability,
+    preview: bool,
 }
 
 impl Default for GroupedEmitter {
@@ -23,6 +24,7 @@ impl Default for GroupedEmitter {
         Self {
             show_fix_status: false,
             applicability: Applicability::Safe,
+            preview: false,
         }
     }
 }
@@ -37,6 +39,12 @@ impl GroupedEmitter {
     #[must_use]
     pub fn with_applicability(mut self, applicability: Applicability) -> Self {
         self.applicability = applicability;
+        self
+    }
+
+    #[must_use]
+    pub fn with_preview(mut self, preview: bool) -> Self {
+        self.preview = preview;
         self
     }
 }
@@ -78,6 +86,7 @@ impl Emitter for GroupedEmitter {
                         applicability: self.applicability,
                         row_length,
                         column_length,
+                        preview: self.preview,
                     }
                 )?;
             }
@@ -126,6 +135,7 @@ struct DisplayGroupedMessage<'a> {
     row_length: NonZeroUsize,
     column_length: NonZeroUsize,
     notebook_index: Option<&'a NotebookIndex>,
+    preview: bool,
 }
 
 impl Display for DisplayGroupedMessage<'_> {
@@ -170,7 +180,8 @@ impl Display for DisplayGroupedMessage<'_> {
             code_and_body = RuleCodeAndBody {
                 message,
                 show_fix_status: self.show_fix_status,
-                applicability: self.applicability
+                applicability: self.applicability,
+                preview: self.preview,
             },
         )?;
 
@@ -182,6 +193,7 @@ pub(super) struct RuleCodeAndBody<'a> {
     pub(crate) message: &'a Diagnostic,
     pub(crate) show_fix_status: bool,
     pub(crate) applicability: Applicability,
+    pub(crate) preview: bool,
 }
 
 impl Display for RuleCodeAndBody<'_> {
@@ -190,9 +202,8 @@ impl Display for RuleCodeAndBody<'_> {
             if let Some(fix) = self.message.fix() {
                 // Do not display an indicator for inapplicable fixes
                 if fix.applies(self.applicability) {
-                    if let Some(code) = self.message.secondary_code() {
-                        write!(f, "{} ", code.red().bold())?;
-                    }
+                    let name = self.message.secondary_code_or_id(self.preview);
+                    write!(f, "{} ", name.red().bold())?;
                     return write!(
                         f,
                         "{fix}{body}",
@@ -203,21 +214,16 @@ impl Display for RuleCodeAndBody<'_> {
             }
         }
 
-        if let Some(code) = self.message.secondary_code() {
-            write!(
-                f,
-                "{code} {body}",
-                code = code.red().bold(),
-                body = self.message.concise_message(),
-            )
-        } else {
-            write!(
-                f,
-                "{code}: {body}",
-                code = self.message.id().as_str().red().bold(),
-                body = self.message.concise_message(),
-            )
-        }
+        write!(
+            f,
+            "{code} {body}",
+            code = self
+                .message
+                .display_diagnostic_id(self.preview)
+                .red()
+                .bold(),
+            body = self.message.concise_message(),
+        )
     }
 }
 

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -212,6 +212,7 @@ pub fn render_diagnostics(
             GroupedEmitter::default()
                 .with_show_fix_status(config.show_fix_status())
                 .with_applicability(config.fix_applicability())
+                .with_preview(config.is_preview())
                 .emit(writer, diagnostics, context)
                 .map_err(std::io::Error::other)?;
         }

--- a/crates/ruff_linter/src/message/sarif.rs
+++ b/crates/ruff_linter/src/message/sarif.rs
@@ -181,10 +181,10 @@ impl Serialize for RuleCode<'_> {
 }
 
 impl<'a> From<&'a Diagnostic> for RuleCode<'a> {
-    fn from(code: &'a Diagnostic) -> Self {
-        match code.secondary_code() {
-            Some(diagnostic) => Self::SecondaryCode(diagnostic),
-            None => Self::LintId(code.id().as_str()),
+    fn from(diag: &'a Diagnostic) -> Self {
+        match diag.secondary_code() {
+            Some(code) => Self::SecondaryCode(code),
+            None => Self::LintId(diag.name()),
         }
     }
 }

--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -348,6 +348,11 @@ pub(crate) const fn is_trailing_pragma_in_line_length_enabled(preview: PreviewMo
     preview.is_enabled()
 }
 
+// https://github.com/astral-sh/ruff/pull/23701
+pub const fn is_rule_name_output_enabled(preview: PreviewMode) -> bool {
+    preview.is_enabled()
+}
+
 // https://github.com/astral-sh/ruff/pull/24371
 pub(crate) const fn is_collapsible_if_fix_safe_enabled(settings: &LinterSettings) -> bool {
     settings.preview.is_enabled()

--- a/crates/ruff_linter/src/registry.rs
+++ b/crates/ruff_linter/src/registry.rs
@@ -37,7 +37,7 @@ impl Rule {
             }
             map
         });
-        dbg!(RULES.get(name).copied().ok_or(FromCodeError::Unknown))
+        RULES.get(name).copied().ok_or(FromCodeError::Unknown)
     }
 }
 

--- a/crates/ruff_linter/src/registry.rs
+++ b/crates/ruff_linter/src/registry.rs
@@ -1,7 +1,11 @@
 //! Remnant of the registry of all [`Rule`] implementations, now it's reexporting from codes.rs
 //! with some helper symbols
 
+use std::sync::LazyLock;
+
 use ruff_db::diagnostic::LintName;
+use rustc_hash::FxHashMap;
+use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
 pub use codes::Rule;
@@ -23,6 +27,17 @@ impl Rule {
             .all_rules()
             .find(|rule| rule.noqa_code().suffix() == code)
             .ok_or(FromCodeError::Unknown)
+    }
+
+    pub fn from_name(name: &str) -> Result<Self, FromCodeError> {
+        static RULES: LazyLock<FxHashMap<&'static str, Rule>> = LazyLock::new(|| {
+            let mut map = FxHashMap::default();
+            for rule in Rule::iter() {
+                map.insert(rule.name().as_str(), rule);
+            }
+            map
+        });
+        dbg!(RULES.get(name).copied().ok_or(FromCodeError::Unknown))
     }
 }
 

--- a/crates/ruff_linter/src/rule_selector.rs
+++ b/crates/ruff_linter/src/rule_selector.rs
@@ -29,15 +29,18 @@ pub enum RuleSelector {
         redirected_from: Option<&'static str>,
     },
     /// Select an individual rule with a given prefix.
-    Rule {
+    RuleCode {
         prefix: RuleCodePrefix,
         redirected_from: Option<&'static str>,
+    },
+    Rule {
+        rule: Rule,
     },
 }
 
 impl RuleSelector {
     pub(crate) const fn rule(prefix: RuleCodePrefix) -> Self {
-        Self::Rule {
+        Self::RuleCode {
             prefix,
             redirected_from: None,
         }
@@ -79,26 +82,29 @@ impl FromStr for RuleSelector {
                     None => (s, None),
                 };
 
-                let (linter, code) =
-                    Linter::parse_code(s).ok_or_else(|| ParseError::Unknown(s.to_string()))?;
+                if let Some((linter, code)) = Linter::parse_code(s) {
+                    if code.is_empty() {
+                        return Ok(Self::Linter(linter));
+                    }
 
-                if code.is_empty() {
-                    return Ok(Self::Linter(linter));
-                }
+                    let prefix = RuleCodePrefix::parse(&linter, code)
+                        .map_err(|_| ParseError::Unknown(s.to_string()))?;
 
-                let prefix = RuleCodePrefix::parse(&linter, code)
-                    .map_err(|_| ParseError::Unknown(s.to_string()))?;
-
-                if is_single_rule_selector(&prefix) {
-                    Ok(Self::Rule {
-                        prefix,
-                        redirected_from,
-                    })
+                    if is_single_rule_selector(&prefix) {
+                        Ok(Self::RuleCode {
+                            prefix,
+                            redirected_from,
+                        })
+                    } else {
+                        Ok(Self::Prefix {
+                            prefix,
+                            redirected_from,
+                        })
+                    }
+                } else if let Ok(rule) = Rule::from_name(s) {
+                    Ok(Self::Rule { rule })
                 } else {
-                    Ok(Self::Prefix {
-                        prefix,
-                        redirected_from,
-                    })
+                    Err(ParseError::Unknown(s.to_string()))
                 }
             }
         }
@@ -136,7 +142,8 @@ impl RuleSelector {
             RuleSelector::All => ("", "ALL"),
             RuleSelector::C => ("", "C"),
             RuleSelector::T => ("", "T"),
-            RuleSelector::Prefix { prefix, .. } | RuleSelector::Rule { prefix, .. } => {
+            RuleSelector::Rule { rule } => ("", rule.name().as_str()),
+            RuleSelector::Prefix { prefix, .. } | RuleSelector::RuleCode { prefix, .. } => {
                 (prefix.linter().common_prefix(), prefix.short_code())
             }
             RuleSelector::Linter(l) => (l.common_prefix(), ""),
@@ -204,9 +211,10 @@ impl RuleSelector {
                     .chain(Linter::Flake8Print.rules()),
             ),
             RuleSelector::Linter(linter) => RuleSelectorIter::Vec(linter.rules()),
-            RuleSelector::Prefix { prefix, .. } | RuleSelector::Rule { prefix, .. } => {
+            RuleSelector::Prefix { prefix, .. } | RuleSelector::RuleCode { prefix, .. } => {
                 RuleSelectorIter::Vec(prefix.clone().rules())
             }
+            RuleSelector::Rule { rule } => RuleSelectorIter::One(std::iter::once(*rule)),
         }
     }
 
@@ -233,7 +241,7 @@ impl RuleSelector {
 
     /// Returns true if this selector is exact i.e. selects a single rule by code
     pub fn is_exact(&self) -> bool {
-        matches!(self, Self::Rule { .. })
+        matches!(self, Self::RuleCode { .. })
     }
 }
 
@@ -241,6 +249,7 @@ pub enum RuleSelectorIter {
     All(RuleIter),
     Chain(std::iter::Chain<std::vec::IntoIter<Rule>, std::vec::IntoIter<Rule>>),
     Vec(std::vec::IntoIter<Rule>),
+    One(std::iter::Once<Rule>),
 }
 
 impl Iterator for RuleSelectorIter {
@@ -251,6 +260,7 @@ impl Iterator for RuleSelectorIter {
             RuleSelectorIter::All(iter) => iter.next(),
             RuleSelectorIter::Chain(iter) => iter.next(),
             RuleSelectorIter::Vec(iter) => iter.next(),
+            RuleSelectorIter::One(iter) => iter.next(),
         }
     }
 }
@@ -306,7 +316,7 @@ mod schema {
             )
             .filter(|p| {
                 // Exclude any prefixes where all of the rules are removed
-                if let Ok(Self::Rule { prefix, .. } | Self::Prefix { prefix, .. }) =
+                if let Ok(Self::RuleCode { prefix, .. } | Self::Prefix { prefix, .. }) =
                     RuleSelector::parse_no_redirect(p)
                 {
                     !prefix.rules().all(|rule| rule.is_removed())
@@ -345,7 +355,7 @@ impl RuleSelector {
             RuleSelector::T => Specificity::LinterGroup,
             RuleSelector::C => Specificity::LinterGroup,
             RuleSelector::Linter(..) => Specificity::Linter,
-            RuleSelector::Rule { .. } => Specificity::Rule,
+            RuleSelector::RuleCode { .. } | RuleSelector::Rule { .. } => Specificity::Rule,
             RuleSelector::Prefix { prefix, .. } => {
                 let prefix: &'static str = prefix.short_code();
                 match prefix.len() {
@@ -380,7 +390,7 @@ impl RuleSelector {
                     .map_err(|_| ParseError::Unknown(s.to_string()))?;
 
                 if is_single_rule_selector(&prefix) {
-                    Ok(Self::Rule {
+                    Ok(Self::RuleCode {
                         prefix,
                         redirected_from: None,
                     })

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_rule_code.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_rule_code.rs
@@ -127,6 +127,7 @@ pub(crate) fn invalid_noqa_code(
 
 pub(crate) fn code_is_valid(code: &str, external: &[String]) -> bool {
     Rule::from_code(get_redirect_target(code).unwrap_or(code)).is_ok()
+        || Rule::from_name(code).is_ok()
         || external.iter().any(|ext| code.starts_with(ext))
 }
 

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -202,7 +202,7 @@ impl Suppressions {
         settings: &LinterSettings,
     ) -> Suppressions {
         let builder = SuppressionsBuilder::new(source, settings);
-        builder.load_from_tokens(tokens, indexer)
+        dbg!(builder.load_from_tokens(tokens, indexer))
     }
 
     pub(crate) fn is_empty(&self) -> bool {
@@ -229,6 +229,7 @@ impl Suppressions {
             let suppression_code =
                 get_redirect_target(suppression.code.as_str()).unwrap_or(suppression.code.as_str());
             if *code == suppression_code && suppression.range.contains_range(range) {
+                dbg!(&suppression);
                 suppression.used.set(true);
                 return true;
             }
@@ -325,7 +326,8 @@ impl Suppressions {
                 // UnusedNOQA
                 let Ok(rule) = Rule::from_code(
                     get_redirect_target(&suppression.code).unwrap_or(&suppression.code),
-                ) else {
+                )
+                .or_else(|_| Rule::from_name(&suppression.code)) else {
                     continue; // "external" lint code, don't treat it as unused
                 };
 

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -202,7 +202,7 @@ impl Suppressions {
         settings: &LinterSettings,
     ) -> Suppressions {
         let builder = SuppressionsBuilder::new(source, settings);
-        dbg!(builder.load_from_tokens(tokens, indexer))
+        builder.load_from_tokens(tokens, indexer)
     }
 
     pub(crate) fn is_empty(&self) -> bool {
@@ -229,7 +229,6 @@ impl Suppressions {
             let suppression_code =
                 get_redirect_target(suppression.code.as_str()).unwrap_or(suppression.code.as_str());
             if *code == suppression_code && suppression.range.contains_range(range) {
-                dbg!(&suppression);
                 suppression.used.set(true);
                 return true;
             }

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -1,7 +1,7 @@
 use compact_str::CompactString;
 use core::fmt;
 use itertools::Itertools;
-use ruff_db::diagnostic::Diagnostic;
+use ruff_db::diagnostic::{Diagnostic, SecondaryCode};
 use ruff_diagnostics::{Edit, Fix};
 use ruff_python_ast::token::{Token, TokenKind, Tokens};
 use ruff_python_index::Indexer;
@@ -215,9 +215,8 @@ impl Suppressions {
             return false;
         }
 
-        let Some(code) = diagnostic.secondary_code() else {
-            return false;
-        };
+        let name = diagnostic.name();
+        let code = diagnostic.secondary_code().map(SecondaryCode::as_str);
         let Some(span) = diagnostic.primary_span() else {
             return false;
         };
@@ -228,7 +227,9 @@ impl Suppressions {
         for suppression in &self.valid {
             let suppression_code =
                 get_redirect_target(suppression.code.as_str()).unwrap_or(suppression.code.as_str());
-            if *code == suppression_code && suppression.range.contains_range(range) {
+            if (name == suppression_code || code.is_some_and(|code| code == suppression_code))
+                && suppression.range.contains_range(range)
+            {
                 suppression.used.set(true);
                 return true;
             }

--- a/crates/ruff_linter/src/test.rs
+++ b/crates/ruff_linter/src/test.rs
@@ -359,9 +359,8 @@ Source with applied fixes:
 
     let messages = messages
         .into_iter()
-        .filter_map(|msg| Some((msg.secondary_code()?.to_string(), msg)))
-        .map(|(code, mut diagnostic)| {
-            let rule = Rule::from_code(&code).unwrap();
+        .filter_map(|mut diagnostic| {
+            let rule = Rule::from_name(diagnostic.name()).ok()?;
             let fixable = diagnostic.fix().is_some_and(|fix| {
                 matches!(
                     fix.applicability(),
@@ -419,7 +418,7 @@ Either ensure you always emit a fix or change `Violation::FIX_AVAILABILITY` to e
                 }
             }
 
-            diagnostic
+            Some(diagnostic)
         })
         .chain(parsed.errors().iter().map(|parse_error| {
             Diagnostic::invalid_syntax(source_code.clone(), &parse_error.error, parse_error)

--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -118,7 +118,7 @@ pub(crate) fn map_codes(func: &ItemFn) -> syn::Result<TokenStream> {
                 fn from(linter: #linter) -> Self {
                     let prefix = RuleCodePrefix::#linter(linter);
                     if is_single_rule_selector(&prefix) {
-                        Self::Rule {
+                        Self::RuleCode {
                             prefix,
                             redirected_from: None,
                         }

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -305,6 +305,8 @@ fn to_lsp_diagnostic(
             ruff_db::diagnostic::Severity::Error => lsp_types::DiagnosticSeverity::ERROR,
             ruff_db::diagnostic::Severity::Fatal => lsp_types::DiagnosticSeverity::ERROR,
         }
+    } else {
+        severity(code)
     };
 
     (

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -19,7 +19,7 @@ use ruff_linter::{
     linter::check_path,
     package::PackageRoot,
     packaging::detect_package_root,
-    settings::flags,
+    settings::{flags, types::PreviewMode},
     source_kind::SourceKind,
     suppression::Suppressions,
 };
@@ -186,6 +186,7 @@ pub(crate) fn check(
                         &source_kind,
                         locator.to_index(),
                         encoding,
+                        settings.linter.preview,
                     ))
                 }
             });
@@ -247,6 +248,7 @@ fn to_lsp_diagnostic(
     source_kind: &SourceKind,
     index: &LineIndex,
     encoding: PositionEncoding,
+    preview: PreviewMode,
 ) -> (usize, lsp_types::Diagnostic) {
     let diagnostic_range = diagnostic.range().unwrap_or_default();
     let name = diagnostic.name();
@@ -296,8 +298,8 @@ fn to_lsp_diagnostic(
         range = diagnostic_range.to_range(source_kind.source_code(), index, encoding);
     }
 
-    let (severity, code) = if let Some(code) = code {
-        (severity(code), code.to_string())
+    let severity = if let Some(code) = diagnostic.secondary_code() {
+        severity(code)
     } else {
         match diagnostic.severity() {
             ruff_db::diagnostic::Severity::Info => lsp_types::DiagnosticSeverity::INFORMATION,
@@ -305,8 +307,6 @@ fn to_lsp_diagnostic(
             ruff_db::diagnostic::Severity::Error => lsp_types::DiagnosticSeverity::ERROR,
             ruff_db::diagnostic::Severity::Fatal => lsp_types::DiagnosticSeverity::ERROR,
         }
-    } else {
-        severity(code)
     };
 
     (

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -253,13 +253,12 @@ fn to_lsp_diagnostic(
     let body = diagnostic.concise_message().to_string();
     let fix = diagnostic.fix();
     let suggestion = diagnostic.first_help_text();
-    let code = diagnostic.secondary_code();
+    let code = diagnostic.secondary_code_or_id(preview.is_enabled());
 
     let fix = fix.and_then(|fix| fix.applies(Applicability::Unsafe).then_some(fix));
 
     let data = (fix.is_some() || noqa_edit.is_some())
         .then(|| {
-            let code = code?.to_string();
             let edits = fix
                 .into_iter()
                 .flat_map(Fix::edits)
@@ -276,7 +275,7 @@ fn to_lsp_diagnostic(
                 title: suggestion.unwrap_or(name).to_string(),
                 noqa_edit,
                 edits,
-                code,
+                code: code.to_string(),
             })
             .ok()
         })
@@ -300,15 +299,12 @@ fn to_lsp_diagnostic(
     let (severity, code) = if let Some(code) = code {
         (severity(code), code.to_string())
     } else {
-        (
-            match diagnostic.severity() {
-                ruff_db::diagnostic::Severity::Info => lsp_types::DiagnosticSeverity::INFORMATION,
-                ruff_db::diagnostic::Severity::Warning => lsp_types::DiagnosticSeverity::WARNING,
-                ruff_db::diagnostic::Severity::Error => lsp_types::DiagnosticSeverity::ERROR,
-                ruff_db::diagnostic::Severity::Fatal => lsp_types::DiagnosticSeverity::ERROR,
-            },
-            diagnostic.secondary_code_or_id().to_string(),
-        )
+        match diagnostic.severity() {
+            ruff_db::diagnostic::Severity::Info => lsp_types::DiagnosticSeverity::INFORMATION,
+            ruff_db::diagnostic::Severity::Warning => lsp_types::DiagnosticSeverity::WARNING,
+            ruff_db::diagnostic::Severity::Error => lsp_types::DiagnosticSeverity::ERROR,
+            ruff_db::diagnostic::Severity::Fatal => lsp_types::DiagnosticSeverity::ERROR,
+        }
     };
 
     (
@@ -317,7 +313,7 @@ fn to_lsp_diagnostic(
             range,
             severity: Some(severity),
             tags: tags(diagnostic),
-            code: Some(lsp_types::NumberOrString::String(code)),
+            code: Some(lsp_types::NumberOrString::String(code.to_string())),
             code_description: diagnostic.documentation_url().and_then(|url| {
                 Some(lsp_types::CodeDescription {
                     href: lsp_types::Url::parse(url).ok()?,

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -275,7 +275,9 @@ impl Workspace {
             .map(|msg| {
                 let range = msg.range().unwrap_or_default();
                 ExpandedMessage {
-                    code: msg.secondary_code_or_id().to_string(),
+                    code: msg
+                        .secondary_code_or_id(self.settings.linter.preview.is_enabled())
+                        .to_string(),
                     message: msg.concise_message().to_string(),
                     start_location: source_code
                         .source_location(range.start(), self.position_encoding)

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -1039,7 +1039,7 @@ impl LintConfiguration {
                     prefix,
                     redirected_from: Some(redirect_from),
                 }
-                | RuleSelector::Rule {
+                | RuleSelector::RuleCode {
                     prefix,
                     redirected_from: Some(redirect_from),
                 } = selector

--- a/python/ruff-ecosystem/ruff_ecosystem/check.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/check.py
@@ -48,8 +48,10 @@ CHECK_DIFF_LINE_RE = re.compile(
 # A little permissive - it allows mismatched brackets around
 # the severity. But should be good enough while we support both
 # the old and new rendering with severities.
+#
+# TODO(brent) re-assess this change before merging. Should we just emit the colon instead?
 CHECK_DIAGNOSTIC_LINE_RE = re.compile(
-    r"^(?P<diff>[+-])? ?(?P<location>.*): (?:(?P<severity>[a-z]+)\[)?(?P<code>[A-Z]{1,4}[0-9]{3,4}|[a-z\-]+:)\]?(?P<fixable> \[\*\])? (?P<message>.*)"
+    r"^(?P<diff>[+-])? ?(?P<location>.*): (?:(?P<severity>[a-z]+)\[)?(?P<code>[A-Z]{1,4}[0-9]{3,4}|[a-z\-]+):?\]?(?P<fixable> \[\*\])? (?P<message>.*)"
 )
 
 PANIC_DIAGNOSTIC_LINE_RE = re.compile(r"^[^:]+: panic: Panicked at ")

--- a/python/ruff-ecosystem/ruff_ecosystem/check.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/check.py
@@ -6,14 +6,16 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import json
 import re
 import time
 from asyncio import create_subprocess_exec
 from collections import Counter
 from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass, field
+from functools import cache
 from pathlib import Path
-from subprocess import PIPE
+from subprocess import PIPE, check_output
 from typing import TYPE_CHECKING, Self
 
 from ruff_ecosystem import logger
@@ -51,7 +53,7 @@ CHECK_DIFF_LINE_RE = re.compile(
 #
 # TODO(brent) re-assess this change before merging. Should we just emit the colon instead?
 CHECK_DIAGNOSTIC_LINE_RE = re.compile(
-    r"^(?P<diff>[+-])? ?(?P<location>.*): (?:(?P<severity>[a-z]+)\[)?(?P<code>[A-Z]{1,4}[0-9]{3,4}|[a-z\-]+):?\]?(?P<fixable> \[\*\])? (?P<message>.*)"
+    r"^(?P<diff>[+-])? ?(?P<location>.*?): (?:(?P<severity>[a-z]+)\[)?(?P<code>[A-Z]{1,4}[0-9]{3,4}|[a-z0-9\-]+):?\]?(?P<fixable> \[\*\])? (?P<message>.*)"
 )
 
 PANIC_DIAGNOSTIC_LINE_RE = re.compile(r"^[^:]+: panic: Panicked at ")
@@ -59,6 +61,26 @@ PANIC_DIAGNOSTIC_LINE_RE = re.compile(r"^[^:]+: panic: Panicked at ")
 CHECK_VIOLATION_FIX_INDICATOR = " [*]"
 
 GITHUB_MAX_COMMENT_LENGTH = 65536  # characters
+
+
+@cache
+def rule_name_to_code(executable: Path) -> dict[str, str]:
+    rules = json.loads(
+        check_output(
+            [executable, "rule", "--all", "--output-format", "json"],
+            encoding="utf8",
+        )
+    )
+    return {rule["name"]: rule["code"] for rule in rules}
+
+
+def normalize_rule_name(line: str, rule_names: dict[str, str]) -> str:
+    match = CHECK_DIAGNOSTIC_LINE_RE.match(line)
+    if match is None or (code := rule_names.get(match["code"])) is None:
+        return line
+
+    start, end = match.span("code")
+    return f"{line[:start]}{code}{line[end:]}"
 
 
 def markdown_check_result(result: Result) -> str:
@@ -536,6 +558,12 @@ async def compare_check(
         baseline_task.result(),
         comparison_task.result(),
     )
+
+    if options.preview:
+        rule_names = rule_name_to_code(ruff_comparison_executable.resolve())
+        comparison_output = [
+            normalize_rule_name(line, rule_names) for line in comparison_output
+        ]
 
     for line in comparison_output:
         if PANIC_DIAGNOSTIC_LINE_RE.match(line):


### PR DESCRIPTION
Adds support for using human readable rule names in:

- range suppressions: `# ruff: disable[unused-async]`
- toml configuration/cli flags: `--select unused-async`

tbd:

- [x] make suppressions actually match rule names
- [x] getting rule names into output formats
- [ ] which pieces to preview gate and how
- [ ] move name->rule mapping into macros?
- [ ] do we want a separate UX for anything, or mix-and-match with rule codes?
- [ ] how to coordinate this with rule categorization and rollout?