### PR TITLE
[ty] Fix panic on incomplete except handlers

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -5351,6 +5351,26 @@ except <CURSOR># Trigger completion/hover here
         );
     }
 
+    // Ref: https://github.com/astral-sh/ty/issues/2401
+    #[test]
+    fn incomplete_except_handler_uses_enclosing_scope() {
+        completion_test_builder(
+            "\
+def f():
+    sentinel = 1
+    try:
+        print()
+    except <CURSOR>as err:
+        pass
+",
+        )
+        .skip_keywords()
+        .skip_builtins()
+        .skip_auto_import()
+        .build()
+        .contains("sentinel");
+    }
+
     // Ref: https://github.com/astral-sh/ty/issues/572
     #[test]
     fn scope_id_missing_global1() {

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -331,7 +331,7 @@ impl GotoTarget<'_> {
             GotoTarget::ImportSymbolAlias { alias, .. }
             | GotoTarget::ImportModuleAlias { alias, .. }
             | GotoTarget::ImportExportedName { alias, .. } => alias.inferred_type(model),
-            GotoTarget::ExceptVariable(except) => except.inferred_type(model),
+            GotoTarget::ExceptVariable(except) => model.except_handler_type(except),
             GotoTarget::KeywordArgument { keyword, .. } => keyword.value.inferred_type(model),
             // When asking the type of a callable, usually you want the callable itself?
             // (i.e. the type of `MyClass` in `MyClass()` is `<class MyClass>` and not `() -> MyClass`)
@@ -459,15 +459,13 @@ impl GotoTarget<'_> {
                 Some(defs)
             }
 
-            GotoTarget::ClassDef(class) => class
-                .definition(model)
-                .map(ResolvedDefinition::Definition)
-                .map(|definition| vec![definition]),
+            GotoTarget::ClassDef(class) => Some(vec![ResolvedDefinition::Definition(
+                class.definition(model),
+            )]),
 
-            GotoTarget::Parameter(parameter) => parameter
-                .definition(model)
-                .map(ResolvedDefinition::Definition)
-                .map(|definition| vec![definition]),
+            GotoTarget::Parameter(parameter) => Some(vec![ResolvedDefinition::Definition(
+                parameter.definition(model),
+            )]),
 
             // For import aliases (offset within 'y' or 'z' in "from x import y as z")
             GotoTarget::ImportSymbolAlias { asname, .. } => Some(definitions_for_name(
@@ -517,13 +515,9 @@ impl GotoTarget<'_> {
             )),
 
             // For exception variables, they are their own definitions (like parameters)
-            GotoTarget::ExceptVariable(except_handler) => except_handler.name.as_ref().map(|_| {
-                vec![ResolvedDefinition::Definition(
-                    except_handler
-                        .definition(model)
-                        .expect("named except handlers should have a definition"),
-                )]
-            }),
+            GotoTarget::ExceptVariable(except_handler) => model
+                .except_handler_definition(except_handler)
+                .map(|definition| vec![ResolvedDefinition::Definition(definition)]),
 
             // Patterns are glorified assignments but we have to look them up by ident
             // because they're not expressions

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -285,48 +285,36 @@ impl<'db> SemanticModel<'db> {
             // Nodes implementing `HasDefinition`
             ast::AnyNodeRef::StmtFunctionDef(function) => Some(
                 function
-                    .definition(self)?
+                    .definition(self)
                     .scope(self.db)
                     .file_scope_id(self.db),
             ),
-            ast::AnyNodeRef::StmtClassDef(class) => Some(
-                class
-                    .definition(self)?
-                    .scope(self.db)
-                    .file_scope_id(self.db),
-            ),
+            ast::AnyNodeRef::StmtClassDef(class) => {
+                Some(class.definition(self).scope(self.db).file_scope_id(self.db))
+            }
             ast::AnyNodeRef::Parameter(parameter) => Some(
                 parameter
-                    .definition(self)?
+                    .definition(self)
                     .scope(self.db)
                     .file_scope_id(self.db),
             ),
             ast::AnyNodeRef::ParameterWithDefault(parameter) => Some(
                 parameter
-                    .definition(self)?
+                    .definition(self)
                     .scope(self.db)
                     .file_scope_id(self.db),
             ),
-            ast::AnyNodeRef::ExceptHandlerExceptHandler(handler) => {
-                if handler.name.is_some() {
-                    Some(
-                        handler
-                            .definition(self)?
-                            .scope(self.db)
-                            .file_scope_id(self.db),
-                    )
-                } else {
-                    handler
-                        .type_
-                        .as_deref()
-                        .and_then(|handled_exceptions| {
-                            index.try_expression_scope_id(handled_exceptions)
-                        })
-                        .or(Some(FileScopeId::global()))
-                }
-            }
+            ast::AnyNodeRef::ExceptHandlerExceptHandler(handler) => self
+                .except_handler_definition(handler)
+                .map(|definition| definition.scope(self.db).file_scope_id(self.db))
+                .or_else(|| {
+                    handler.type_.as_deref().and_then(|handled_exceptions| {
+                        index.try_expression_scope_id(handled_exceptions)
+                    })
+                })
+                .or(Some(FileScopeId::global())),
             ast::AnyNodeRef::TypeParamTypeVar(var) => {
-                Some(var.definition(self)?.scope(self.db).file_scope_id(self.db))
+                Some(var.definition(self).scope(self.db).file_scope_id(self.db))
             }
 
             // Fallback
@@ -338,6 +326,29 @@ impl<'db> SemanticModel<'db> {
                 Some(expr) => index.try_expression_scope_id(&expr),
             },
         }
+    }
+
+    /// Returns the definition for an exception-handler variable.
+    ///
+    /// Exception handlers only have a definition when they bind a name (`except E as name:`).
+    pub fn except_handler_definition(
+        &self,
+        handler: &ast::ExceptHandlerExceptHandler,
+    ) -> Option<Definition<'db>> {
+        handler.name.as_ref()?;
+        let index = semantic_index(self.db, self.file);
+        Some(index.expect_single_definition(handler))
+    }
+
+    /// Returns the inferred type of an exception-handler variable.
+    ///
+    /// Exception handlers only bind a variable when they have a name (`except E as name:`).
+    pub fn except_handler_type(
+        &self,
+        handler: &ast::ExceptHandlerExceptHandler,
+    ) -> Option<Type<'db>> {
+        let definition = self.except_handler_definition(handler)?;
+        Some(binding_type(self.db, definition))
     }
 
     /// Get a "safe" [`ast::AnyNodeRef`] to use for referring to the given (sub-)AST node.
@@ -529,7 +540,7 @@ pub trait HasDefinition {
     ///
     /// ## Panics
     /// May panic if `self` is from another file than `model`.
-    fn definition<'db>(&self, model: &SemanticModel<'db>) -> Option<Definition<'db>>;
+    fn definition<'db>(&self, model: &SemanticModel<'db>) -> Definition<'db>;
 }
 
 impl HasType for ast::ExprRef<'_> {
@@ -636,16 +647,16 @@ macro_rules! impl_binding_has_ty_def {
     ($ty: ty) => {
         impl HasDefinition for $ty {
             #[inline]
-            fn definition<'db>(&self, model: &SemanticModel<'db>) -> Option<Definition<'db>> {
+            fn definition<'db>(&self, model: &SemanticModel<'db>) -> Definition<'db> {
                 let index = semantic_index(model.db, model.file);
-                Some(index.expect_single_definition(self))
+                index.expect_single_definition(self)
             }
         }
 
         impl HasType for $ty {
             #[inline]
             fn inferred_type<'db>(&self, model: &SemanticModel<'db>) -> Option<Type<'db>> {
-                let binding = HasDefinition::definition(self, model)?;
+                let binding = HasDefinition::definition(self, model);
                 Some(binding_type(model.db, binding))
             }
         }
@@ -657,23 +668,6 @@ impl_binding_has_ty_def!(ast::StmtClassDef);
 impl_binding_has_ty_def!(ast::Parameter);
 impl_binding_has_ty_def!(ast::ParameterWithDefault);
 impl_binding_has_ty_def!(ast::TypeParamTypeVar);
-
-impl HasDefinition for ast::ExceptHandlerExceptHandler {
-    #[inline]
-    fn definition<'db>(&self, model: &SemanticModel<'db>) -> Option<Definition<'db>> {
-        self.name.as_ref()?;
-        let index = semantic_index(model.db, model.file);
-        Some(index.expect_single_definition(self))
-    }
-}
-
-impl HasType for ast::ExceptHandlerExceptHandler {
-    #[inline]
-    fn inferred_type<'db>(&self, model: &SemanticModel<'db>) -> Option<Type<'db>> {
-        let binding = HasDefinition::definition(self, model)?;
-        Some(binding_type(model.db, binding))
-    }
-}
 
 impl HasType for ast::Alias {
     fn inferred_type<'db>(&self, model: &SemanticModel<'db>) -> Option<Type<'db>> {

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -554,11 +554,7 @@ pub fn definitions_and_overloads_for_function<'db>(
             .map(ResolvedDefinition::Definition)
             .collect()
     } else {
-        function
-            .definition(model)
-            .map(ResolvedDefinition::Definition)
-            .into_iter()
-            .collect()
+        vec![ResolvedDefinition::Definition(function.definition(model))]
     }
 }
 


### PR DESCRIPTION
## Summary

We no longer assume that `ExceptHandlerExceptHandler` always has a definition.

Closes https://github.com/astral-sh/ty/issues/2401.
