### PR TITLE
[ty] Fix overriding `all` selector

### DIFF
--- a/crates/ty/tests/cli/rule_selection.rs
+++ b/crates/ty/tests/cli/rule_selection.rs
@@ -969,7 +969,7 @@ fn cli_all_rules_warn() -> anyhow::Result<()> {
 
 /// The "all" keyword can be overridden by subsequent specific rule settings
 #[test]
-fn cli_all_rules_with_override() -> anyhow::Result<()> {
+fn cli_all_rules_precedence() -> anyhow::Result<()> {
     let case = CliTest::with_file(
         "test.py",
         r#"
@@ -1212,6 +1212,93 @@ fn overrides_all_rules_with_rule_sorting_before_all() -> anyhow::Result<()> {
     info: rule `abstract-method-in-final-class` was selected in the configuration file
 
     Found 1 diagnostic
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+/// Tests the `all` selector in an `overrides` section
+#[test]
+fn all_overrides() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "pyproject.toml",
+            r#"
+            [tool.ty.rules]
+            all = "error"
+
+            [[tool.ty.overrides]]
+            include = ["tests/**"]
+
+            [tool.ty.overrides.rules]
+            unresolved-reference = "warn"
+            "#,
+        ),
+        (
+            "main.py",
+            r#"
+            y = 4 / 0  # division-by-zero: error (global)
+            x = 1
+            prin(x)    # unresolved-reference: error (global)
+            "#,
+        ),
+        (
+            "tests/test_main.py",
+            r#"
+            y = 4 / 0  # division-by-zero: error (global)
+            x = 1
+            prin(x)    # unresolved-reference: warn (override)
+            "#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(case.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
+     --> main.py:2:5
+      |
+    2 | y = 4 / 0  # division-by-zero: error (global)
+      |     ^^^^^
+    3 | x = 1
+    4 | prin(x)    # unresolved-reference: error (global)
+      |
+    info: rule `division-by-zero` was selected in the configuration file
+
+    error[unresolved-reference]: Name `prin` used when not defined
+     --> main.py:4:1
+      |
+    2 | y = 4 / 0  # division-by-zero: error (global)
+    3 | x = 1
+    4 | prin(x)    # unresolved-reference: error (global)
+      | ^^^^
+      |
+    info: rule `unresolved-reference` was selected in the configuration file
+
+    error[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
+     --> tests/test_main.py:2:5
+      |
+    2 | y = 4 / 0  # division-by-zero: error (global)
+      |     ^^^^^
+    3 | x = 1
+    4 | prin(x)    # unresolved-reference: warn (override)
+      |
+    info: rule `division-by-zero` was selected in the configuration file
+
+    warning[unresolved-reference]: Name `prin` used when not defined
+     --> tests/test_main.py:4:1
+      |
+    2 | y = 4 / 0  # division-by-zero: error (global)
+    3 | x = 1
+    4 | prin(x)    # unresolved-reference: warn (override)
+      | ^^^^
+      |
+    info: rule `unresolved-reference` was selected in the configuration file
+
+    Found 4 diagnostics
 
     ----- stderr -----
     ");

--- a/crates/ty_combine/src/lib.rs
+++ b/crates/ty_combine/src/lib.rs
@@ -3,11 +3,10 @@
     reason = "Prefer System trait methods over std methods in ty crates"
 )]
 
-use std::{collections::HashMap, hash::BuildHasher};
-
 use ordermap::OrderMap;
 use ruff_db::system::SystemPathBuf;
 use ruff_python_ast::PythonVersion;
+use std::{collections::HashMap, hash::BuildHasher};
 
 /// Combine two values, preferring the values in `self`.
 ///
@@ -121,9 +120,18 @@ where
     K: Eq + std::hash::Hash,
     S: BuildHasher,
 {
-    fn combine_with(&mut self, other: Self) {
+    fn combine_with(&mut self, mut other: Self) {
+        // `self` takes precedence over `other` but values with higher precedence must be placed after.
+        // Swap the vectors so that `other` is the one that gets extended, so that the values of `self` come after.
+        std::mem::swap(self, &mut other);
+
         for (k, v) in other {
-            self.entry(k).or_insert(v);
+            // If there's an existing entry, remove it to ensure `k` (previously self)
+            // comes after any item in `self`.
+            self.remove(&k);
+
+            // Append `k` at the end.
+            self.insert(k, v);
         }
     }
 }
@@ -208,21 +216,15 @@ mod tests {
 
     #[test]
     fn combine_order_map() {
-        let a: OrderMap<u32, _> = OrderMap::from_iter([(1, "a"), (2, "a"), (3, "a")]);
-        let b: OrderMap<u32, _> = OrderMap::from_iter([(0, "b"), (2, "b"), (5, "b")]);
+        let a: OrderMap<_, _> = OrderMap::from_iter([(1, "a"), (2, "a"), (3, "a")]);
+        let b: OrderMap<_, _> = OrderMap::from_iter([(0, "b"), (2, "b"), (5, "b")]);
 
         assert_eq!(None.combine(Some(b.clone())), Some(b.clone()));
         assert_eq!(Some(a.clone()).combine(None), Some(a.clone()));
         assert_eq!(
-            Some(a).combine(Some(b)),
+            a.combine(b),
             // The value from `a` takes precedence
-            Some(OrderMap::from_iter([
-                (1, "a"),
-                (2, "a"),
-                (3, "a"),
-                (0, "b"),
-                (5, "b")
-            ]))
+            OrderMap::<_, _>::from_iter([(0, "b"), (5, "b"), (1, "a"), (2, "a"), (3, "a"),])
         );
     }
 }

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -918,6 +918,10 @@ impl SrcOptions {
 )]
 #[serde(rename_all = "kebab-case", transparent)]
 pub struct Rules {
+    /// The rules with their severity. Entries coming later in the map take precedence over
+    /// earlier entries (e.g. a `all` selector earlier in the hash map will be overridden
+    /// by a specific rule selector coming after it but if `all` is the last selector, then it
+    /// overrides even specific rule codes).
     inner: OrderMap<RangedValue<String>, RangedValue<Level>, BuildHasherDefault<FxHasher>>,
 }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/2961

The principle of our configuration merging is that higher precedence entries come later. 
The bug here was that we didn't uphold this property when merging ordered maps. In fact, the 
ordering was just the opposite with lower precedence values coming later, unless the key was in both maps. 

This PR ensures that entries for `x` in `x.combine(y)` always come after `y`'s entries, regardless whether the key is present in just one or both maps. 

## Test Plan

Updated unit test, added integration test
