### PR TITLE
[ty] Make `all` selector case sensitive

### DIFF
--- a/crates/ty/tests/cli/rule_selection.rs
+++ b/crates/ty/tests/cli/rule_selection.rs
@@ -1013,35 +1013,6 @@ fn cli_all_rules_with_override() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// The "all" keyword is case-insensitive
-#[test]
-fn cli_all_rules_case_insensitive() -> anyhow::Result<()> {
-    let case = CliTest::with_file(
-        "test.py",
-        r#"
-        prin(x)  # unresolved-reference
-        "#,
-    )?;
-
-    // Using --ignore ALL (uppercase) should work the same as --ignore all
-    assert_cmd_snapshot!(
-        case
-            .command()
-            .arg("--ignore")
-            .arg("ALL"),
-        @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    All checks passed!
-
-    ----- stderr -----
-    "
-    );
-
-    Ok(())
-}
-
 /// A specific rule can be set first and then overridden by "all"
 #[test]
 fn cli_specific_then_all() -> anyhow::Result<()> {

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -927,7 +927,7 @@ impl Rules {
             };
 
             // Handle "all" as a special case - apply the level to all rules
-            if rule_name.eq_ignore_ascii_case("all") {
+            if rule_name.as_str() == "all" {
                 for lint in registry.lints() {
                     set_lint_level(*lint);
                 }


### PR DESCRIPTION
## Summary

All other rule codes are case sensitive. It's not clear to me what's different about `all` for it to be case insensitive. 

This PR makes `all` case-sensitive the same as all other rule codes.

## Test Plan

Verified that the case insensitive test failed with an unknown rule diagnostic before removing it.
