### PR TITLE
Fix `future-annotations` causing TC001/TC002/TC003 to act like strict mode

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
@@ -78,6 +78,7 @@ mod tests {
     )]
     #[test_case(&[Rule::TypingOnlyFirstPartyImport], Path::new("TC001_future.py"))]
     #[test_case(&[Rule::TypingOnlyFirstPartyImport], Path::new("TC001_future_present.py"))]
+    #[test_case(&[Rule::TypingOnlyThirdPartyImport], Path::new("strict.py"))]
     fn add_future_import(rules: &[Rule], path: &Path) -> Result<()> {
         let name = rules.iter().map(Rule::noqa_code).join("-");
         let snapshot = format!("add_future_import__{}_{}", name, path.to_string_lossy());

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -283,10 +283,9 @@ pub(crate) fn typing_only_runtime_import(
     for binding_id in scope.binding_ids() {
         let binding = checker.semantic().binding(binding_id);
 
-        // If we can't add a `__future__` import and in un-strict mode, don't flag typing-only
-        // imports that are implicitly loaded by way of a valid runtime import.
-        if !checker.settings().future_annotations
-            && !checker.settings().flake8_type_checking.strict
+        // In non-strict mode, don't flag typing-only imports that are implicitly loaded
+        // by way of a valid runtime import from the same module.
+        if !checker.settings().flake8_type_checking.strict
             && runtime_imports
                 .iter()
                 .any(|import| is_implicit_import(binding, import))

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__add_future_import__TC002_strict.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__add_future_import__TC002_strict.py.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
+---
+TC002 [*] Move third-party import `pkg.bar.A` into a type-checking block
+  --> strict.py:54:25
+   |
+52 |     # In un-strict mode, this _should_ raise an error, since `pkg.bar` isn't used at runtime
+53 |     import pkg
+54 |     from pkg.bar import A
+   |                         ^
+55 |
+56 |     def test(value: A):
+   |
+help: Move into type-checking block
+1  | from __future__ import annotations
+2  + from typing import TYPE_CHECKING
+3  + 
+4  + if TYPE_CHECKING:
+5  +     from pkg.bar import A
+6  | 
+7  | 
+8  | def f():
+--------------------------------------------------------------------------------
+55 | def f():
+56 |     # In un-strict mode, this _should_ raise an error, since `pkg.bar` isn't used at runtime
+57 |     import pkg
+   -     from pkg.bar import A
+58 | 
+59 |     def test(value: A):
+60 |         return pkg.B()
+note: This is an unsafe fix and may change runtime behavior
+
+TC002 [*] Move third-party import `pkg` into a type-checking block
+  --> strict.py:91:12
+   |
+89 |     # Note that `pkg` is a prefix of `pkgfoo` which are both different modules. This is
+90 |     # testing the implementation.
+91 |     import pkg
+   |            ^^^
+92 |     import pkgfoo.bar as B
+   |
+help: Move into type-checking block
+1  | from __future__ import annotations
+2  + from typing import TYPE_CHECKING
+3  + 
+4  + if TYPE_CHECKING:
+5  +     import pkg
+6  | 
+7  | 
+8  | def f():
+--------------------------------------------------------------------------------
+92 |     # In un-strict mode, this _should_ raise an error, since `pkg` isn't used at runtime.
+93 |     # Note that `pkg` is a prefix of `pkgfoo` which are both different modules. This is
+94 |     # testing the implementation.
+   -     import pkg
+95 |     import pkgfoo.bar as B
+96 | 
+97 |     def test(value: pkg.A):
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

Fixes #23185

When `lint.future-annotations = true` was set, the TC001/TC002/TC003 rules would flag typing-only imports even when a valid runtime import from the same module existed, regardless of the `lint.flake8-type-checking.strict` setting.

The root cause was in the skip condition for implicit imports:

```rust
if !checker.settings().future_annotations
    && !checker.settings().flake8_type_checking.strict
    && runtime_imports.iter().any(|import| is_implicit_import(binding, import))
{
    continue;
}
```

This requires **both** `!future_annotations` and `!strict` to be true (logical AND). When `future_annotations = true`, the first condition is false, so the entire skip is bypassed — making TC001/TC002/TC003 act like strict mode regardless of the `strict` setting.

The fix removes the `future_annotations` check from this condition, so the `strict` setting alone controls whether implicit runtime imports are respected. The `future_annotations` setting should only control whether `from __future__ import annotations` is added as a fix, not whether to flag imports that have valid runtime uses from the same module.

## Test plan

- Added `strict.py` fixture to the `add_future_import` test (which runs with `future_annotations: true, strict: false`) to verify implicit imports are correctly skipped
- New snapshot confirms only 2 diagnostics are emitted (for cases where the module ISN'T implicitly imported), matching the non-strict default behavior
- All 91 existing `flake8_type_checking` tests continue to pass
- Manually verified the exact reproduction case from the issue:

```python
from collections.abc import Set, Iterable
def foo(a: Iterable):
    return Set(a)
```

With `future-annotations = true` and `strict = false`: no diagnostic (correct)  
With `future-annotations = true` and `strict = true`: TC003 diagnostic (correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)