### PR TITLE
[ty] Fix precedence of `all` selector in TOML configurations

### DIFF
--- a/crates/ty/tests/cli/rule_selection.rs
+++ b/crates/ty/tests/cli/rule_selection.rs
@@ -1153,3 +1153,68 @@ fn configuration_all_rules_with_rule_sorting_before_all() -> anyhow::Result<()> 
 
     Ok(())
 }
+
+/// Same TOML key ordering issue, but within an override's `[rules]` table.
+/// `abstract-method-in-final-class` sorts before `all` lexicographically, but
+/// the specific rule should still take precedence over `all`.
+#[test]
+fn overrides_all_rules_with_rule_sorting_before_all() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "pyproject.toml",
+            r#"
+            [[tool.ty.overrides]]
+            include = ["src/**"]
+
+            [tool.ty.overrides.rules]
+            all = "warn"
+            abstract-method-in-final-class = "error"
+            "#,
+        ),
+        (
+            "src/test.py",
+            r#"
+            from typing import final
+            from abc import ABC, abstractmethod
+
+            class Base(ABC):
+                @abstractmethod
+                def foo(self) -> int:
+                    raise NotImplementedError
+
+            @final
+            class Derived(Base):
+                pass
+            "#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(case.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error[abstract-method-in-final-class]: Final class `Derived` has unimplemented abstract methods
+      --> src/test.py:11:7
+       |
+    10 | @final
+    11 | class Derived(Base):
+       |       ^^^^^^^ `foo` is unimplemented
+    12 |     pass
+       |
+      ::: src/test.py:7:9
+       |
+     5 | class Base(ABC):
+     6 |     @abstractmethod
+     7 |     def foo(self) -> int:
+       |         --- `foo` declared as abstract on superclass `Base`
+     8 |         raise NotImplementedError
+       |
+    info: rule `abstract-method-in-final-class` was selected in the configuration file
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -108,8 +108,40 @@ pub struct Options {
 impl Options {
     pub fn from_toml_str(content: &str, source: ValueSource) -> Result<Self, TyTomlError> {
         let _guard = ValueSourceGuard::new(source, true);
-        let options = toml::from_str(content)?;
+        let mut options: Self = toml::from_str(content)?;
+        options.prioritize_all_selectors();
         Ok(options)
+    }
+
+    /// Ensures that the `all` selector is applied before per-rule selectors
+    /// in all rule tables (top-level and overrides).
+    ///
+    /// This must be called after deserializing from TOML and before any
+    /// [`Combine::combine`] calls, because TOML tables are unordered and the
+    /// `toml` crate sorts keys lexicographically.
+    pub(crate) fn prioritize_all_selectors(&mut self) {
+        // Stable sort that moves all `all` selectors before non-`all` selectors
+        // while preserving relative order among non-`all` entries.
+        let sort = |rules: &mut Rules| {
+            rules.inner.sort_by(
+                |key_a, _, key_b, _| match (**key_a == "all", **key_b == "all") {
+                    (true, false) => Ordering::Less,
+                    (false, true) => Ordering::Greater,
+                    _ => Ordering::Equal,
+                },
+            );
+        };
+
+        if let Some(rules) = &mut self.rules {
+            sort(rules);
+        }
+        if let Some(overrides) = &mut self.overrides {
+            for override_option in &mut overrides.0 {
+                if let Some(rules) = &mut override_option.rules {
+                    sort(rules);
+                }
+            }
+        }
     }
 
     pub fn deserialize_with<'de, D>(source: ValueSource, deserializer: D) -> Result<Self, D::Error>
@@ -911,7 +943,7 @@ impl Rules {
         // Initialize the selection with the defaults
         let mut selection = RuleSelection::from_registry(registry);
 
-        let mut apply_rule = |rule_name: &RangedValue<String>, level: &RangedValue<Level>| {
+        for (rule_name, level) in &self.inner {
             let source = rule_name.source();
             let lint_source = match source {
                 ValueSource::File(_) => LintSource::File,
@@ -932,7 +964,7 @@ impl Rules {
                 for lint in registry.lints() {
                     set_lint_level(*lint);
                 }
-                return;
+                continue;
             }
 
             match registry.get(rule_name) {
@@ -960,29 +992,6 @@ impl Rules {
                     diagnostics.push(diagnostic.with_annotation(annotation));
                 }
             }
-        };
-
-        // TOML tables are unordered, so for selectors from the same configuration file we treat
-        // `all` as the base level and apply explicit per-rule selectors afterwards.
-        let mut ordered_rules: Vec<_> = self.inner.iter().collect();
-        ordered_rules.sort_by(|(rule_a, _), (rule_b, _)| {
-            match (rule_a.source(), rule_b.source()) {
-                (ValueSource::File(path_a), ValueSource::File(path_b)) if path_a == path_b => {
-                    match (
-                        rule_a.eq_ignore_ascii_case("all"),
-                        rule_b.eq_ignore_ascii_case("all"),
-                    ) {
-                        (true, false) => Ordering::Less,
-                        (false, true) => Ordering::Greater,
-                        _ => Ordering::Equal,
-                    }
-                }
-                _ => Ordering::Equal,
-            }
-        });
-
-        for (rule_name, level) in ordered_rules {
-            apply_rule(rule_name, level);
         }
 
         selection

--- a/crates/ty_project/src/metadata/pyproject.rs
+++ b/crates/ty_project/src/metadata/pyproject.rs
@@ -35,7 +35,16 @@ impl PyProject {
         source: ValueSource,
     ) -> Result<Self, PyProjectError> {
         let _guard = ValueSourceGuard::new(source, true);
-        toml::from_str(content).map_err(PyProjectError::TomlSyntax)
+        let mut pyproject: Self = toml::from_str(content).map_err(PyProjectError::TomlSyntax)?;
+        // TOML tables are unordered and the `toml` crate sorts keys
+        // lexicographically. Normalize rule order so that the `all` selector
+        // is applied before per-rule selectors.
+        if let Some(tool) = &mut pyproject.tool {
+            if let Some(ty) = &mut tool.ty {
+                ty.prioritize_all_selectors();
+            }
+        }
+        Ok(pyproject)
     }
 }
 


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ty/issues/2952.

TOML tables are unordered — the spec says key/value pairs within tables are not guaranteed to be in any specific order. However, the `toml` crate happens to sort keys lexicographically when deserializing. This means that rules like `abstract-method-in-final-class` sort *before* `all`, so the `all` selector silently overrides the more-specific rule when processed sequentially.

This PR fixes the issue by sorting selectors from the same configuration file so that `all` is always applied first, then specific per-rule selectors are applied afterwards. This ensures that specific rules always take precedence over `all` within a given config file, regardless of lexicographic ordering.

The fix is scoped to file-based configuration only — CLI argument order is still preserved as-is, since users have explicit control over ordering there.

## Test plan

Added a test (`configuration_all_rules_with_rule_sorting_before_all`) that uses `abstract-method-in-final-class` (which sorts before `all`) to verify the specific rule takes precedence.