### PR TITLE
[ty] Repro and fix for stack overflow in protocol checking

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/regression/decorated_stream_collect_cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/decorated_stream_collect_cycle.md
@@ -1,0 +1,787 @@
+# Decorated Stream Protocol Regression
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+`streamkit/__init__.py`:
+
+```py
+# package marker
+```
+
+`streamkit/types.py`:
+
+```py
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, AsyncContextManager, ContextManager, TypeGuard
+from collections.abc import AsyncIterable, Awaitable, Callable, Iterable
+
+if TYPE_CHECKING:
+    from .protocol import Streamable
+
+type SyncMapper[T, U] = Callable[[T], U]
+type AsyncMapper[T, U] = Callable[[T], Awaitable[U]]
+type Mapper[T, U] = SyncMapper[T, U] | AsyncMapper[T, U]
+type SyncPredicate[T, U] = Callable[[T], TypeGuard[U] | bool]
+type AsyncPredicate[T, U] = Callable[[T], Awaitable[TypeGuard[U] | bool]]
+type Predicate[T, U] = SyncPredicate[T, U] | AsyncPredicate[T, U]
+type SyncBoolPredicate[T] = Callable[[T], bool]
+type AsyncBoolPredicate[T] = Callable[[T], Awaitable[bool]]
+type BoolPredicate[T] = SyncBoolPredicate[T] | AsyncBoolPredicate[T]
+type SyncTypeGuardPredicate[T, U] = Callable[[T], TypeGuard[U]]
+type AsyncTypeGuardPredicate[T, U] = Callable[[T], Awaitable[TypeGuard[U]]]
+type TypeGuardPredicate[T, U] = SyncTypeGuardPredicate[T, U] | AsyncTypeGuardPredicate[T, U]
+type SyncSelector[T, U] = Callable[[T], StreamLike[U]]
+type AsyncSelector[T, U] = Callable[[T], Awaitable[StreamLike[U]]]
+type Selector[T, U] = SyncSelector[T, U] | AsyncSelector[T, U]
+type StreamTransform[T, U] = Callable[[Streamable[T]], Streamable[U]]
+type StreamLike[T] = Streamable[T] | AsyncIterable[T] | Iterable[T]
+type SyncAccumulator[A, T] = Callable[[A, T], A]
+type AsyncAccumulator[A, T] = Callable[[A, T], Awaitable[A]]
+type Accumulator[A, T] = SyncAccumulator[A, T] | AsyncAccumulator[A, T]
+type SyncCollectAccumulator[T] = Callable[[T], None]
+type AsyncCollectAccumulator[T] = Callable[[T], Awaitable[None]]
+type CollectAccumulator[T] = SyncCollectAccumulator[T] | AsyncCollectAccumulator[T]
+type SyncFinisher[R] = Callable[[], R]
+type AsyncFinisher[R] = Callable[[], Awaitable[R]]
+type Finisher[R] = SyncFinisher[R] | AsyncFinisher[R]
+type Collector[T, R] = tuple[CollectAccumulator[T], Finisher[R]]
+type SyncSideEffect[T] = Callable[[T], None]
+type AsyncSideEffect[T] = Callable[[T], Awaitable[None]]
+type SideEffect[T] = SyncSideEffect[T] | AsyncSideEffect[T]
+type SyncKeySelector[T, K] = Callable[[T], K]
+type AsyncKeySelector[T, K] = Callable[[T], Awaitable[K]]
+type KeySelector[T, K] = SyncKeySelector[T, K] | AsyncKeySelector[T, K]
+type ContextManagerFactory = Callable[[], ContextManager[object] | AsyncContextManager[object]]
+```
+
+`streamkit/_utils.py`:
+
+```py
+from __future__ import annotations
+
+import inspect
+from typing import Awaitable, cast
+
+
+async def _await_if_needed[T](value: T | Awaitable[T]) -> T:
+    if inspect.isawaitable(value):
+        return await cast(Awaitable[T], value)
+    return value
+```
+
+`streamkit/protocol.py`:
+
+```py
+from __future__ import annotations
+
+from collections.abc import AsyncIterable
+from typing import Any, Protocol, overload
+
+from .types import (
+    Accumulator,
+    BoolPredicate,
+    CollectAccumulator,
+    Collector,
+    Finisher,
+    KeySelector,
+    Mapper,
+    Predicate,
+    Selector,
+    StreamLike,
+    StreamTransform,
+    TypeGuardPredicate,
+)
+
+
+class Streamable[T](AsyncIterable[T], Protocol):
+    async def has_any(self) -> bool: ...
+
+    @overload
+    async def has_any_matching[U1](self, predicate: Predicate[T, U1], /) -> bool: ...
+
+    @overload
+    async def has_any_matching[U1, U2](
+        self,
+        predicate1: Predicate[T, U1],
+        predicate2: Predicate[T, U2],
+        /,
+    ) -> tuple[bool, bool]: ...
+
+    @overload
+    async def has_any_matching[U1, U2, U3](
+        self,
+        predicate1: Predicate[T, U1],
+        predicate2: Predicate[T, U2],
+        predicate3: Predicate[T, U3],
+        /,
+    ) -> tuple[bool, bool, bool]: ...
+
+    @overload
+    async def has_any_matching[U1, U2, U3, U4](
+        self,
+        predicate1: Predicate[T, U1],
+        predicate2: Predicate[T, U2],
+        predicate3: Predicate[T, U3],
+        predicate4: Predicate[T, U4],
+        /,
+    ) -> tuple[bool, bool, bool, bool]: ...
+
+    @overload
+    async def has_any_matching[U1, U2, U3, U4, U5](
+        self,
+        predicate1: Predicate[T, U1],
+        predicate2: Predicate[T, U2],
+        predicate3: Predicate[T, U3],
+        predicate4: Predicate[T, U4],
+        predicate5: Predicate[T, U5],
+        /,
+    ) -> tuple[bool, bool, bool, bool, bool]: ...
+
+    @overload
+    async def has_any_matching(self, *predicates: Predicate[T, Any]) -> tuple[bool, ...]: ...
+
+    async def has_any_matching(self, *predicates: Predicate[T, Any]) -> Any: ...
+
+    async def to_list(self) -> list[T]: ...
+
+    @overload
+    async def collect[R](self, accumulator: CollectAccumulator[T], finisher: Finisher[R], /) -> R: ...
+
+    @overload
+    async def collect[R1](self, collector: Collector[T, R1], /) -> R1: ...
+
+    @overload
+    async def collect[R1, R2](
+        self,
+        collector1: Collector[T, R1],
+        collector2: Collector[T, R2],
+        /,
+    ) -> tuple[R1, R2]: ...
+
+    @overload
+    async def collect[R1, R2, R3](
+        self,
+        collector1: Collector[T, R1],
+        collector2: Collector[T, R2],
+        collector3: Collector[T, R3],
+        /,
+    ) -> tuple[R1, R2, R3]: ...
+
+    async def collect(self, *collectors: object) -> Any: ...
+
+    @overload
+    async def first_matching(self, predicate: BoolPredicate[T], /) -> T | None: ...
+
+    @overload
+    async def first_matching(
+        self,
+        predicate1: BoolPredicate[T],
+        predicate2: BoolPredicate[T],
+        /,
+    ) -> tuple[T | None, T | None]: ...
+
+    @overload
+    async def first_matching(
+        self,
+        predicate1: BoolPredicate[T],
+        predicate2: BoolPredicate[T],
+        predicate3: BoolPredicate[T],
+        /,
+    ) -> tuple[T | None, T | None, T | None]: ...
+
+    @overload
+    async def first_matching(
+        self,
+        predicate1: BoolPredicate[T],
+        predicate2: BoolPredicate[T],
+        predicate3: BoolPredicate[T],
+        predicate4: BoolPredicate[T],
+        /,
+    ) -> tuple[T | None, T | None, T | None, T | None]: ...
+
+    @overload
+    async def first_matching(
+        self,
+        predicate1: BoolPredicate[T],
+        predicate2: BoolPredicate[T],
+        predicate3: BoolPredicate[T],
+        predicate4: BoolPredicate[T],
+        predicate5: BoolPredicate[T],
+        /,
+    ) -> tuple[T | None, T | None, T | None, T | None, T | None]: ...
+
+    @overload
+    async def first_matching[U1](self, predicate: TypeGuardPredicate[T, U1], /) -> U1 | None: ...
+
+    @overload
+    async def first_matching[U1, U2](
+        self,
+        predicate1: TypeGuardPredicate[T, U1],
+        predicate2: TypeGuardPredicate[T, U2],
+        /,
+    ) -> tuple[U1 | None, U2 | None]: ...
+
+    @overload
+    async def first_matching[U1, U2, U3](
+        self,
+        predicate1: TypeGuardPredicate[T, U1],
+        predicate2: TypeGuardPredicate[T, U2],
+        predicate3: TypeGuardPredicate[T, U3],
+        /,
+    ) -> tuple[U1 | None, U2 | None, U3 | None]: ...
+
+    @overload
+    async def first_matching[U1, U2, U3, U4](
+        self,
+        predicate1: TypeGuardPredicate[T, U1],
+        predicate2: TypeGuardPredicate[T, U2],
+        predicate3: TypeGuardPredicate[T, U3],
+        predicate4: TypeGuardPredicate[T, U4],
+        /,
+    ) -> tuple[U1 | None, U2 | None, U3 | None, U4 | None]: ...
+
+    @overload
+    async def first_matching[U1, U2, U3, U4, U5](
+        self,
+        predicate1: TypeGuardPredicate[T, U1],
+        predicate2: TypeGuardPredicate[T, U2],
+        predicate3: TypeGuardPredicate[T, U3],
+        predicate4: TypeGuardPredicate[T, U4],
+        predicate5: TypeGuardPredicate[T, U5],
+        /,
+    ) -> tuple[U1 | None, U2 | None, U3 | None, U4 | None, U5 | None]: ...
+
+    @overload
+    async def first_matching(self, *predicates: Predicate[T, Any]) -> tuple[Any, ...]: ...
+
+    async def first_matching(self, *predicates: Predicate[T, Any]) -> Any: ...
+
+    @overload
+    async def last_matching(self, predicate: BoolPredicate[T], /) -> T | None: ...
+
+    @overload
+    async def last_matching(
+        self,
+        predicate1: BoolPredicate[T],
+        predicate2: BoolPredicate[T],
+        /,
+    ) -> tuple[T | None, T | None]: ...
+
+    @overload
+    async def last_matching(
+        self,
+        predicate1: BoolPredicate[T],
+        predicate2: BoolPredicate[T],
+        predicate3: BoolPredicate[T],
+        /,
+    ) -> tuple[T | None, T | None, T | None]: ...
+
+    @overload
+    async def last_matching(
+        self,
+        predicate1: BoolPredicate[T],
+        predicate2: BoolPredicate[T],
+        predicate3: BoolPredicate[T],
+        predicate4: BoolPredicate[T],
+        /,
+    ) -> tuple[T | None, T | None, T | None, T | None]: ...
+
+    @overload
+    async def last_matching(
+        self,
+        predicate1: BoolPredicate[T],
+        predicate2: BoolPredicate[T],
+        predicate3: BoolPredicate[T],
+        predicate4: BoolPredicate[T],
+        predicate5: BoolPredicate[T],
+        /,
+    ) -> tuple[T | None, T | None, T | None, T | None, T | None]: ...
+
+    @overload
+    async def last_matching[U1](self, predicate: TypeGuardPredicate[T, U1], /) -> U1 | None: ...
+
+    @overload
+    async def last_matching[U1, U2](
+        self,
+        predicate1: TypeGuardPredicate[T, U1],
+        predicate2: TypeGuardPredicate[T, U2],
+        /,
+    ) -> tuple[U1 | None, U2 | None]: ...
+
+    @overload
+    async def last_matching[U1, U2, U3](
+        self,
+        predicate1: TypeGuardPredicate[T, U1],
+        predicate2: TypeGuardPredicate[T, U2],
+        predicate3: TypeGuardPredicate[T, U3],
+        /,
+    ) -> tuple[U1 | None, U2 | None, U3 | None]: ...
+
+    @overload
+    async def last_matching[U1, U2, U3, U4](
+        self,
+        predicate1: TypeGuardPredicate[T, U1],
+        predicate2: TypeGuardPredicate[T, U2],
+        predicate3: TypeGuardPredicate[T, U3],
+        predicate4: TypeGuardPredicate[T, U4],
+        /,
+    ) -> tuple[U1 | None, U2 | None, U3 | None, U4 | None]: ...
+
+    @overload
+    async def last_matching[U1, U2, U3, U4, U5](
+        self,
+        predicate1: TypeGuardPredicate[T, U1],
+        predicate2: TypeGuardPredicate[T, U2],
+        predicate3: TypeGuardPredicate[T, U3],
+        predicate4: TypeGuardPredicate[T, U4],
+        predicate5: TypeGuardPredicate[T, U5],
+        /,
+    ) -> tuple[U1 | None, U2 | None, U3 | None, U4 | None, U5 | None]: ...
+
+    @overload
+    async def last_matching(self, *predicates: Predicate[T, Any]) -> tuple[Any, ...]: ...
+
+    async def last_matching(self, *predicates: Predicate[T, Any]) -> Any: ...
+
+    def filter[U](self, predicate: Predicate[T, U], /) -> "Streamable[U]": ...
+
+    def map[U](self, func: Mapper[T, U], /) -> "Streamable[U]": ...
+
+    def flat_map[U](self, selector: Selector[T, U], /) -> "Streamable[U]": ...
+
+    def pipe[U](self, transform: StreamTransform[T, U], /) -> "Streamable[U]": ...
+
+    def index(self) -> "Streamable[tuple[int, T]]": ...
+
+    def scan[A](self, initial: A, accumulator: Accumulator[A, T]) -> "Streamable[A]": ...
+
+    def sort[K](self, key: KeySelector[T, K] | None = None, reverse: bool = False) -> "Streamable[T]": ...
+
+    def distinct[K](self, key: KeySelector[T, K] | None = None) -> "Streamable[T]": ...
+
+    def skip(self, count: int) -> "Streamable[T]": ...
+
+    def skip_last(self, count: int) -> "Streamable[T]": ...
+
+    def skip_until[U](self, predicate: Predicate[T, U], /) -> "Streamable[T]": ...
+
+    def skip_while[U](self, predicate: Predicate[T, U], /) -> "Streamable[T]": ...
+
+    def take(self, count: int) -> "Streamable[T]": ...
+
+    def take_last(self, count: int) -> "Streamable[T]": ...
+
+    def take_until[U](self, predicate: Predicate[T, U], /) -> "Streamable[T]": ...
+
+    def take_while[U](self, predicate: Predicate[T, U], /) -> "Streamable[T]": ...
+
+    def concat(self, *others: StreamLike[T]) -> "Streamable[T]": ...
+
+    def merge(self, *others: StreamLike[T]) -> "Streamable[T]": ...
+```
+
+`streamkit/streamables.py`:
+
+```py
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Iterable
+from typing import Any, cast, overload
+
+from ._utils import _await_if_needed
+from .protocol import Streamable
+from .types import (
+    Accumulator,
+    BoolPredicate,
+    CollectAccumulator,
+    Collector,
+    ContextManagerFactory,
+    Finisher,
+    KeySelector,
+    Mapper,
+    Predicate,
+    Selector,
+    SideEffect,
+    StreamLike,
+    StreamTransform,
+    TypeGuardPredicate,
+)
+
+
+def _ensure_async_iterable[T](iterable: Iterable[T] | AsyncIterable[T]) -> AsyncIterable[T]:
+    if isinstance(iterable, AsyncIterable):
+        return cast(AsyncIterable[T], iterable)
+    return _IterableAsyncIterable(iterable)
+
+
+class _IterableAsyncIterable[T](AsyncIterable[T]):
+    def __init__(self, iterable: Iterable[T]) -> None:
+        self._iterable = iterable
+
+    async def __aiter__(self) -> AsyncIterator[T]:
+        for item in self._iterable:
+            yield item
+
+
+class _StreamableImpl[T](Streamable[T]):
+    def __init__(
+        self,
+        source: AsyncIterable[T] | Iterable[T] | Awaitable[AsyncIterable[T] | Iterable[T]],
+    ) -> None:
+        self._source = source
+
+    def __aiter__(self) -> AsyncIterator[T]:
+        raise NotImplementedError
+
+    @staticmethod
+    def _wrap[U](source: AsyncIterable[U]) -> Streamable[U]:
+        return _StreamableImpl(source)
+
+    async def has_any(self) -> bool:
+        raise NotImplementedError
+
+    @overload
+    async def has_any_matching[U1](self, predicate: Predicate[T, U1], /) -> bool: ...
+
+    @overload
+    async def has_any_matching[U1, U2](
+        self,
+        predicate1: Predicate[T, U1],
+        predicate2: Predicate[T, U2],
+        /,
+    ) -> tuple[bool, bool]: ...
+
+    @overload
+    async def has_any_matching[U1, U2, U3](
+        self,
+        predicate1: Predicate[T, U1],
+        predicate2: Predicate[T, U2],
+        predicate3: Predicate[T, U3],
+        /,
+    ) -> tuple[bool, bool, bool]: ...
+
+    @overload
+    async def has_any_matching[U1, U2, U3, U4](
+        self,
+        predicate1: Predicate[T, U1],
+        predicate2: Predicate[T, U2],
+        predicate3: Predicate[T, U3],
+        predicate4: Predicate[T, U4],
+        /,
+    ) -> tuple[bool, bool, bool, bool]: ...
+
+    @overload
+    async def has_any_matching[U1, U2, U3, U4, U5](
+        self,
+        predicate1: Predicate[T, U1],
+        predicate2: Predicate[T, U2],
+        predicate3: Predicate[T, U3],
+        predicate4: Predicate[T, U4],
+        predicate5: Predicate[T, U5],
+        /,
+    ) -> tuple[bool, bool, bool, bool, bool]: ...
+
+    @overload
+    async def has_any_matching(self, *predicates: Predicate[T, Any]) -> tuple[bool, ...]: ...
+
+    async def has_any_matching(self, *predicates: Predicate[T, Any]) -> Any:
+        raise NotImplementedError
+
+    async def count(self) -> int:
+        raise NotImplementedError
+
+    async def first(self) -> T | None:
+        raise NotImplementedError
+
+    @overload
+    async def first_matching(self, predicate: BoolPredicate[T], /) -> T | None: ...
+
+    @overload
+    async def first_matching(
+        self,
+        predicate1: BoolPredicate[T],
+        predicate2: BoolPredicate[T],
+        /,
+    ) -> tuple[T | None, T | None]: ...
+
+    @overload
+    async def first_matching(
+        self,
+        predicate1: BoolPredicate[T],
+        predicate2: BoolPredicate[T],
+        predicate3: BoolPredicate[T],
+        /,
+    ) -> tuple[T | None, T | None, T | None]: ...
+
+    @overload
+    async def first_matching(
+        self,
+        predicate1: BoolPredicate[T],
+        predicate2: BoolPredicate[T],
+        predicate3: BoolPredicate[T],
+        predicate4: BoolPredicate[T],
+        /,
+    ) -> tuple[T | None, T | None, T | None, T | None]: ...
+
+    @overload
+    async def first_matching(
+        self,
+        predicate1: BoolPredicate[T],
+        predicate2: BoolPredicate[T],
+        predicate3: BoolPredicate[T],
+        predicate4: BoolPredicate[T],
+        predicate5: BoolPredicate[T],
+        /,
+    ) -> tuple[T | None, T | None, T | None, T | None, T | None]: ...
+
+    @overload
+    async def first_matching[U1](self, predicate: TypeGuardPredicate[T, U1], /) -> U1 | None: ...
+
+    @overload
+    async def first_matching[U1, U2](
+        self,
+        predicate1: TypeGuardPredicate[T, U1],
+        predicate2: TypeGuardPredicate[T, U2],
+        /,
+    ) -> tuple[U1 | None, U2 | None]: ...
+
+    @overload
+    async def first_matching[U1, U2, U3](
+        self,
+        predicate1: TypeGuardPredicate[T, U1],
+        predicate2: TypeGuardPredicate[T, U2],
+        predicate3: TypeGuardPredicate[T, U3],
+        /,
+    ) -> tuple[U1 | None, U2 | None, U3 | None]: ...
+
+    @overload
+    async def first_matching[U1, U2, U3, U4](
+        self,
+        predicate1: TypeGuardPredicate[T, U1],
+        predicate2: TypeGuardPredicate[T, U2],
+        predicate3: TypeGuardPredicate[T, U3],
+        predicate4: TypeGuardPredicate[T, U4],
+        /,
+    ) -> tuple[U1 | None, U2 | None, U3 | None, U4 | None]: ...
+
+    @overload
+    async def first_matching[U1, U2, U3, U4, U5](
+        self,
+        predicate1: TypeGuardPredicate[T, U1],
+        predicate2: TypeGuardPredicate[T, U2],
+        predicate3: TypeGuardPredicate[T, U3],
+        predicate4: TypeGuardPredicate[T, U4],
+        predicate5: TypeGuardPredicate[T, U5],
+        /,
+    ) -> tuple[U1 | None, U2 | None, U3 | None, U4 | None, U5 | None]: ...
+
+    @overload
+    async def first_matching(self, *predicates: Predicate[T, Any]) -> tuple[Any, ...]: ...
+
+    async def first_matching(self, *predicates: Predicate[T, Any]) -> Any:
+        raise NotImplementedError
+
+    @overload
+    async def last_matching(self, predicate: BoolPredicate[T], /) -> T | None: ...
+
+    @overload
+    async def last_matching(
+        self,
+        predicate1: BoolPredicate[T],
+        predicate2: BoolPredicate[T],
+        /,
+    ) -> tuple[T | None, T | None]: ...
+
+    @overload
+    async def last_matching(
+        self,
+        predicate1: BoolPredicate[T],
+        predicate2: BoolPredicate[T],
+        predicate3: BoolPredicate[T],
+        /,
+    ) -> tuple[T | None, T | None, T | None]: ...
+
+    @overload
+    async def last_matching(
+        self,
+        predicate1: BoolPredicate[T],
+        predicate2: BoolPredicate[T],
+        predicate3: BoolPredicate[T],
+        predicate4: BoolPredicate[T],
+        /,
+    ) -> tuple[T | None, T | None, T | None, T | None]: ...
+
+    @overload
+    async def last_matching(
+        self,
+        predicate1: BoolPredicate[T],
+        predicate2: BoolPredicate[T],
+        predicate3: BoolPredicate[T],
+        predicate4: BoolPredicate[T],
+        predicate5: BoolPredicate[T],
+        /,
+    ) -> tuple[T | None, T | None, T | None, T | None, T | None]: ...
+
+    @overload
+    async def last_matching[U1](self, predicate: TypeGuardPredicate[T, U1], /) -> U1 | None: ...
+
+    @overload
+    async def last_matching[U1, U2](
+        self,
+        predicate1: TypeGuardPredicate[T, U1],
+        predicate2: TypeGuardPredicate[T, U2],
+        /,
+    ) -> tuple[U1 | None, U2 | None]: ...
+
+    @overload
+    async def last_matching[U1, U2, U3](
+        self,
+        predicate1: TypeGuardPredicate[T, U1],
+        predicate2: TypeGuardPredicate[T, U2],
+        predicate3: TypeGuardPredicate[T, U3],
+        /,
+    ) -> tuple[U1 | None, U2 | None, U3 | None]: ...
+
+    @overload
+    async def last_matching[U1, U2, U3, U4](
+        self,
+        predicate1: TypeGuardPredicate[T, U1],
+        predicate2: TypeGuardPredicate[T, U2],
+        predicate3: TypeGuardPredicate[T, U3],
+        predicate4: TypeGuardPredicate[T, U4],
+        /,
+    ) -> tuple[U1 | None, U2 | None, U3 | None, U4 | None]: ...
+
+    @overload
+    async def last_matching[U1, U2, U3, U4, U5](
+        self,
+        predicate1: TypeGuardPredicate[T, U1],
+        predicate2: TypeGuardPredicate[T, U2],
+        predicate3: TypeGuardPredicate[T, U3],
+        predicate4: TypeGuardPredicate[T, U4],
+        predicate5: TypeGuardPredicate[T, U5],
+        /,
+    ) -> tuple[U1 | None, U2 | None, U3 | None, U4 | None, U5 | None]: ...
+
+    @overload
+    async def last_matching(self, *predicates: Predicate[T, Any]) -> tuple[Any, ...]: ...
+
+    async def last_matching(self, *predicates: Predicate[T, Any]) -> Any:
+        raise NotImplementedError
+
+    async def last(self) -> T | None:
+        raise NotImplementedError
+
+    async def reduce[A](self, initial: A, accumulator: Accumulator[A, T]) -> A:
+        raise NotImplementedError
+
+    async def to_list(self) -> list[T]:
+        raise NotImplementedError
+
+    @overload
+    async def collect[R](
+        self, accumulator: CollectAccumulator[T], finisher: Finisher[R], /
+    ) -> R: ...
+
+    @overload
+    async def collect[R1](self, collector: Collector[T, R1], /) -> R1: ...
+
+    @overload
+    async def collect[R1, R2](
+        self,
+        collector1: Collector[T, R1],
+        collector2: Collector[T, R2],
+        /,
+    ) -> tuple[R1, R2]: ...
+
+    @overload
+    async def collect[R1, R2, R3](
+        self,
+        collector1: Collector[T, R1],
+        collector2: Collector[T, R2],
+        collector3: Collector[T, R3],
+        /,
+    ) -> tuple[R1, R2, R3]: ...
+
+    async def collect(self, *collectors: object) -> Any:
+        raise NotImplementedError
+
+    async def to_map[K](self, key: KeySelector[T, K]) -> dict[K, T]:
+        raise NotImplementedError
+
+    def filter[U](self, predicate: Predicate[T, U], /) -> Streamable[U]:
+        raise NotImplementedError
+
+    def map[U](self, func: Mapper[T, U], /) -> Streamable[U]:
+        raise NotImplementedError
+
+    def flat_map[U](self, selector: Selector[T, U], /) -> Streamable[U]:
+        raise NotImplementedError
+
+    def pipe[U](self, transform: StreamTransform[T, U], /) -> Streamable[U]:
+        raise NotImplementedError
+
+    def index(self) -> Streamable[tuple[int, T]]:
+        raise NotImplementedError
+
+    def on_each(self, effect: SideEffect[T]) -> Streamable[T]:
+        raise NotImplementedError
+
+    def all_in_context(self, factory: ContextManagerFactory) -> Streamable[T]:
+        raise NotImplementedError
+
+    def each_in_context(self, factory: ContextManagerFactory) -> Streamable[T]:
+        raise NotImplementedError
+
+    def scan[A](self, initial: A, accumulator: Accumulator[A, T]) -> Streamable[A]:
+        raise NotImplementedError
+
+    def sort[K](self, key: KeySelector[T, K] | None = None, reverse: bool = False) -> Streamable[T]:
+        raise NotImplementedError
+
+    def distinct[K](self, key: KeySelector[T, K] | None = None) -> Streamable[T]:
+        raise NotImplementedError
+
+    def skip(self, count: int) -> Streamable[T]:
+        raise NotImplementedError
+
+    def skip_last(self, count: int) -> Streamable[T]:
+        raise NotImplementedError
+
+    def skip_until[U](self, predicate: Predicate[T, U], /) -> Streamable[T]:
+        raise NotImplementedError
+
+    def skip_while[U](self, predicate: Predicate[T, U], /) -> Streamable[T]:
+        raise NotImplementedError
+
+    def take(self, count: int) -> Streamable[T]:
+        raise NotImplementedError
+
+    def take_last(self, count: int) -> Streamable[T]:
+        raise NotImplementedError
+
+    def take_until[U](self, predicate: Predicate[T, U], /) -> Streamable[T]:
+        raise NotImplementedError
+
+    def take_while[U](self, predicate: Predicate[T, U], /) -> Streamable[T]:
+        raise NotImplementedError
+
+    def concat(self, *others: StreamLike[T]) -> Streamable[T]:
+        raise NotImplementedError
+
+    def merge(self, *others: StreamLike[T]) -> Streamable[T]:
+        raise NotImplementedError
+
+
+class Streamables:
+    @staticmethod
+    def from_iterable[T](
+        iterable: Iterable[T] | AsyncIterable[T] | Awaitable[Iterable[T] | AsyncIterable[T]],
+    ) -> Streamable[T]:
+        return _StreamableImpl(iterable)
+```

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1278,12 +1278,14 @@ impl<'db> ClassType<'db> {
             .find_map(|base| base.as_disjoint_base(db))
     }
 
-    /// Return `true` if this class could exist in the MRO of `other`.
-    pub(super) fn could_exist_in_mro_of(
+    pub(super) fn could_exist_in_mro_of<'c>(
         self,
         db: &'db dyn Db,
         other: Self,
-        constraints: &ConstraintSetBuilder<'db>,
+        constraints: &'c ConstraintSetBuilder<'db>,
+        inferable: InferableTypeVars<'_, 'db>,
+        relation_visitor: &HasRelationToVisitor<'db, 'c>,
+        disjointness_visitor: &IsDisjointVisitor<'db, 'c>,
     ) -> bool {
         other
             .iter_mro(db)
@@ -1296,11 +1298,13 @@ impl<'db> ClassType<'db> {
                     this_alias.origin(db) == other_alias.origin(db)
                         && !this_alias
                             .specialization(db)
-                            .is_disjoint_from(
+                            .is_disjoint_from_impl(
                                 db,
                                 other_alias.specialization(db),
                                 constraints,
-                                InferableTypeVars::None,
+                                inferable,
+                                disjointness_visitor,
+                                relation_visitor,
                             )
                             .is_always_satisfied(db)
                 }
@@ -1314,22 +1318,39 @@ impl<'db> ClassType<'db> {
     /// For two given classes `A` and `B`, it is often possible to say for sure
     /// that there could never exist any class `C` that inherits from both `A` and `B`.
     /// In these situations, this method returns `false`; in all others, it returns `true`.
-    pub(super) fn could_coexist_in_mro_with(
+    pub(super) fn could_coexist_in_mro_with<'c>(
         self,
         db: &'db dyn Db,
         other: Self,
-        constraints: &ConstraintSetBuilder<'db>,
+        constraints: &'c ConstraintSetBuilder<'db>,
+        inferable: InferableTypeVars<'_, 'db>,
+        relation_visitor: &HasRelationToVisitor<'db, 'c>,
+        disjointness_visitor: &IsDisjointVisitor<'db, 'c>,
     ) -> bool {
         if self == other {
             return true;
         }
 
         if self.is_final(db) {
-            return other.could_exist_in_mro_of(db, self, constraints);
+            return other.could_exist_in_mro_of(
+                db,
+                self,
+                constraints,
+                inferable,
+                relation_visitor,
+                disjointness_visitor,
+            );
         }
 
         if other.is_final(db) {
-            return self.could_exist_in_mro_of(db, other, constraints);
+            return self.could_exist_in_mro_of(
+                db,
+                other,
+                constraints,
+                inferable,
+                relation_visitor,
+                disjointness_visitor,
+            );
         }
 
         // Two disjoint bases can only coexist in an MRO if one is a subclass of the other.
@@ -1339,7 +1360,14 @@ impl<'db> ClassType<'db> {
                 other
                     .nearest_disjoint_base(db)
                     .is_some_and(|disjoint_base_2| {
-                        !disjoint_base_1.could_coexist_in_mro_with(db, &disjoint_base_2)
+                        !disjoint_base_1.could_coexist_in_mro_with(
+                            db,
+                            &disjoint_base_2,
+                            constraints,
+                            inferable,
+                            relation_visitor,
+                            disjointness_visitor,
+                        )
                     })
             })
         {
@@ -1367,11 +1395,13 @@ impl<'db> ClassType<'db> {
             return true;
         };
         if self_metaclass_instance
-            .when_disjoint_from(
+            .is_disjoint_from_impl(
                 db,
                 other_metaclass_instance,
                 constraints,
-                InferableTypeVars::None,
+                inferable,
+                disjointness_visitor,
+                relation_visitor,
             )
             .is_always_satisfied(db)
         {
@@ -6514,17 +6544,42 @@ impl<'db> DisjointBase<'db> {
         }
     }
 
-    /// Two disjoint bases can only coexist in a class's MRO if one is a subclass of the other
-    fn could_coexist_in_mro_with(&self, db: &'db dyn Db, other: &Self) -> bool {
+    fn could_coexist_in_mro_with<'c>(
+        &self,
+        db: &'db dyn Db,
+        other: &Self,
+        constraints: &'c ConstraintSetBuilder<'db>,
+        inferable: InferableTypeVars<'_, 'db>,
+        relation_visitor: &HasRelationToVisitor<'db, 'c>,
+        disjointness_visitor: &IsDisjointVisitor<'db, 'c>,
+    ) -> bool {
         self == other
             || self
                 .class
                 .default_specialization(db)
-                .is_subclass_of(db, other.class.default_specialization(db))
+                .has_relation_to_impl(
+                    db,
+                    other.class.default_specialization(db),
+                    constraints,
+                    inferable,
+                    TypeRelation::Subtyping,
+                    relation_visitor,
+                    disjointness_visitor,
+                )
+                .is_always_satisfied(db)
             || other
                 .class
                 .default_specialization(db)
-                .is_subclass_of(db, self.class.default_specialization(db))
+                .has_relation_to_impl(
+                    db,
+                    self.class.default_specialization(db),
+                    constraints,
+                    inferable,
+                    TypeRelation::Subtyping,
+                    relation_visitor,
+                    disjointness_visitor,
+                )
+                .is_always_satisfied(db)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -66,7 +66,7 @@
 //!
 //! [bdd]: https://en.wikipedia.org/wiki/Binary_decision_diagram
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
@@ -80,12 +80,14 @@ use smallvec::SmallVec;
 
 use crate::types::class::GenericAlias;
 use crate::types::generics::{GenericContext, InferableTypeVars, Specialization};
+use crate::types::protocol_class::walk_protocol_interface;
 use crate::types::visitor::{
     TypeCollector, TypeVisitor, any_over_type, walk_type_with_recursion_guard,
 };
 use crate::types::{
-    BoundTypeVarIdentity, BoundTypeVarInstance, IntersectionType, Type, TypeVarBoundOrConstraints,
-    UnionType, walk_bound_type_var_type,
+    BoundTypeVarIdentity, BoundTypeVarInstance, IntersectionType, NegativeIntersectionElements,
+    ProtocolInstanceType, Type, TypeVarBoundOrConstraints, TypeVarInstance, UnionBuilder,
+    UnionType, walk_bound_type_var_type, walk_type_var_type,
 };
 use crate::{Db, FxIndexMap, FxIndexSet, FxOrderSet};
 
@@ -292,10 +294,16 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     /// neither bound _is_ a typevar. And it's not something we can create a specialization from,
     /// since we would endlessly substitute until we stack overflow.
     pub(crate) fn is_cyclic(self, db: &'db dyn Db) -> bool {
+        const MAX_REACHABILITY_DEPTH: u32 = 64;
+
         #[derive(Default)]
         struct CollectReachability<'db> {
             reachable_typevars: RefCell<FxHashSet<BoundTypeVarIdentity<'db>>>,
+            visited_bound_typevars: RefCell<FxHashSet<BoundTypeVarIdentity<'db>>>,
+            visited_typevars: RefCell<FxHashSet<TypeVarInstance<'db>>>,
             recursion_guard: TypeCollector<'db>,
+            depth: Cell<u32>,
+            hit_depth_limit: Cell<bool>,
         }
 
         impl<'db> TypeVisitor<'db> for CollectReachability<'db> {
@@ -308,10 +316,25 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
                 db: &'db dyn Db,
                 bound_typevar: BoundTypeVarInstance<'db>,
             ) {
-                self.reachable_typevars
-                    .borrow_mut()
-                    .insert(bound_typevar.identity(db));
+                let identity = bound_typevar.identity(db);
+                self.reachable_typevars.borrow_mut().insert(identity);
+
+                // Reachability only depends on which bound typevars are mentioned, not on how
+                // many times we expand the same bound typevar's bounds/defaults. Re-walking the
+                // same bound typevar here can recurse forever through generic callable defaults.
+                if !self.visited_bound_typevars.borrow_mut().insert(identity) {
+                    return;
+                }
+
                 walk_bound_type_var_type(db, bound_typevar, self);
+            }
+
+            fn visit_type_var_type(&self, db: &'db dyn Db, typevar: TypeVarInstance<'db>) {
+                if !self.visited_typevars.borrow_mut().insert(typevar) {
+                    return;
+                }
+
+                walk_type_var_type(db, typevar, self);
             }
 
             fn visit_generic_alias_type(&self, db: &'db dyn Db, alias: GenericAlias<'db>) {
@@ -327,8 +350,34 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
                 }
             }
 
+            fn visit_protocol_instance_type(
+                &self,
+                db: &'db dyn Db,
+                protocol: ProtocolInstanceType<'db>,
+            ) {
+                // Reachability only depends on free typevars that appear in the instantiated
+                // protocol type. For class-based protocols, walking the full lazily-inferred
+                // interface explodes through every member signature and nested protocol, even
+                // though the only free typevars we care about live in the protocol's
+                // specialization. Treat those the same as nominal instances and only fall back
+                // to walking member interfaces for synthesized protocols.
+                if let Some(nominal) = protocol.to_nominal_instance() {
+                    self.visit_nominal_instance_type(db, nominal);
+                } else {
+                    walk_protocol_interface(db, protocol.interface(db), self);
+                }
+            }
+
             fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+                let current_depth = self.depth.get();
+                if current_depth >= MAX_REACHABILITY_DEPTH {
+                    self.hit_depth_limit.set(true);
+                    return;
+                }
+
+                self.depth.set(current_depth + 1);
                 walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+                self.depth.set(current_depth);
             }
         }
 
@@ -363,15 +412,21 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
             BoundTypeVarIdentity<'db>,
             FxHashSet<BoundTypeVarIdentity<'db>>,
         > = FxHashMap::default();
+        let mut hit_depth_limit = false;
         self.node.for_each_constraint(db, &mut |constraint, _| {
             let visitor = CollectReachability::default();
             visitor.visit_type(db, constraint.lower(db));
             visitor.visit_type(db, constraint.upper(db));
+            hit_depth_limit |= visitor.hit_depth_limit.get();
             reachable_typevars
                 .entry(constraint.typevar(db).identity(db))
                 .or_default()
                 .extend(visitor.reachable_typevars.into_inner());
         });
+
+        if hit_depth_limit {
+            return true;
+        }
 
         // Then perform a depth-first search to see if there are any cycles.
         let mut discovered: FxHashSet<BoundTypeVarIdentity<'db>> = FxHashSet::default();
@@ -563,6 +618,55 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     pub(crate) fn display_graph(self, db: &'db dyn Db, prefix: &dyn Display) -> impl Display {
         self.node.display_graph(db, prefix)
     }
+}
+
+fn union_from_elements_cycle_recovery<'db>(
+    db: &'db dyn Db,
+    elements: impl IntoIterator<Item = Type<'db>>,
+) -> Type<'db> {
+    elements
+        .into_iter()
+        .fold(UnionBuilder::new(db).cycle_recovery(true), |builder, ty| {
+            builder.add(ty)
+        })
+        .build()
+}
+
+fn intersection_from_elements_without_simplification<'db>(
+    db: &'db dyn Db,
+    elements: impl IntoIterator<Item = Type<'db>>,
+) -> Type<'db> {
+    let positive: FxOrderSet<_> = elements.into_iter().collect();
+    match positive.len() {
+        0 => Type::object(),
+        1 => positive
+            .iter()
+            .next()
+            .copied()
+            .expect("single-element intersection should have one element"),
+        _ => Type::Intersection(IntersectionType::new(
+            db,
+            positive,
+            NegativeIntersectionElements::Empty,
+        )),
+    }
+}
+
+fn is_assignable_to_all<'db>(
+    db: &'db dyn Db,
+    lhs: Type<'db>,
+    rhs: impl IntoIterator<Item = Type<'db>>,
+) -> bool {
+    rhs.into_iter().all(|upper| lhs.is_assignable_to(db, upper))
+}
+
+fn is_constraint_set_assignable_to_all<'db>(
+    db: &'db dyn Db,
+    lhs: Type<'db>,
+    rhs: impl IntoIterator<Item = Type<'db>>,
+) -> bool {
+    rhs.into_iter()
+        .all(|upper| lhs.is_constraint_set_assignable_to(db, upper))
 }
 
 impl Debug for ConstraintSet<'_, '_> {
@@ -1703,15 +1807,15 @@ impl<'db> Node<'db> {
                 // process. (Here we are just checking assignability, so we don't need to construct
                 // the lower and upper bounds in a consistent order.)
                 debug_assert!({
-                    let greatest_lower_bound = UnionType::from_elements(
+                    let greatest_lower_bound = union_from_elements_cycle_recovery(
                         db,
                         current_bounds.iter().map(|bounds| bounds.lower),
                     );
-                    let least_upper_bound = IntersectionType::from_elements(
+                    is_constraint_set_assignable_to_all(
                         db,
+                        greatest_lower_bound,
                         current_bounds.iter().map(|bounds| bounds.upper),
-                    );
-                    greatest_lower_bound.is_constraint_set_assignable_to(db, least_upper_bound)
+                    )
                 });
 
                 // We've been tracking the lower and upper bound that the types for this path must
@@ -2535,7 +2639,7 @@ impl<'db> InteriorNode<'db> {
                     match bound_typevar.typevar(db).require_bound_or_constraints(db) {
                         TypeVarBoundOrConstraints::UpperBound(bound) => {
                             let bound = bound.top_materialization(db);
-                            let lower = UnionType::from_elements(db, bounds.lower);
+                            let lower = union_from_elements_cycle_recovery(db, bounds.lower);
                             if !lower.is_assignable_to(db, bound) {
                                 // This path does not satisfy the typevar's upper bound, and is
                                 // therefore not a valid specialization.
@@ -2553,7 +2657,7 @@ impl<'db> InteriorNode<'db> {
                                 continue;
                             }
 
-                            let upper = IntersectionType::from_elements(
+                            let upper = intersection_from_elements_without_simplification(
                                 db,
                                 std::iter::chain(bounds.upper, [bound]),
                             );
@@ -2567,14 +2671,17 @@ impl<'db> InteriorNode<'db> {
 
                         TypeVarBoundOrConstraints::Constraints(constraints) => {
                             // Filter out the typevar constraints that aren't satisfied by this path.
-                            let lower = UnionType::from_elements(db, bounds.lower);
-                            let upper = IntersectionType::from_elements(db, bounds.upper);
+                            let lower = union_from_elements_cycle_recovery(db, bounds.lower);
                             let compatible_constraints =
                                 constraints.elements(db).iter().filter(|constraint| {
                                     let constraint_lower = constraint.bottom_materialization(db);
                                     let constraint_upper = constraint.top_materialization(db);
                                     lower.is_assignable_to(db, constraint_lower)
-                                        && constraint_upper.is_assignable_to(db, upper)
+                                        && is_assignable_to_all(
+                                            db,
+                                            constraint_upper,
+                                            bounds.upper.iter().copied(),
+                                        )
                                 });
 
                             // If only one constraint remains, that's our specialization for this path.
@@ -4402,16 +4509,22 @@ impl<'db> GenericContext<'db> {
                 // their source order. This should give us a consistently ordered specialization,
                 // regardless of the variable ordering of the original BDD.
                 representatives.sort_unstable_by_key(|bounds| bounds.source_order);
-                let greatest_lower_bound =
-                    UnionType::from_elements(db, representatives.iter().map(|bounds| bounds.lower));
-                let least_upper_bound = IntersectionType::from_elements(
+                let greatest_lower_bound = union_from_elements_cycle_recovery(
+                    db,
+                    representatives.iter().map(|bounds| bounds.lower),
+                );
+                let least_upper_bound = intersection_from_elements_without_simplification(
                     db,
                     representatives.iter().map(|bounds| bounds.upper),
                 );
 
                 // If `lower ≰ upper`, then there is no type that satisfies all of the paths in the
                 // BDD. That's an ambiguous specialization, as described above.
-                if !greatest_lower_bound.is_constraint_set_assignable_to(db, least_upper_bound) {
+                if !is_constraint_set_assignable_to_all(
+                    db,
+                    greatest_lower_bound,
+                    representatives.iter().map(|bounds| bounds.upper),
+                ) {
                     tracing::trace!(
                         target: "ty_python_semantic::types::constraints::specialize_constrained",
                         bound_typevar = %identity.display(db),

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -113,18 +113,14 @@ impl<Tag, T: Hash + Eq + Clone, R: Clone, Extra> CycleDetector<Tag, T, R, Extra>
             return self.fallback.clone();
         }
 
-        // Check depth limit to prevent stack overflow from recursive generic types
-        // with growing specializations (e.g., C[set[T]] -> C[set[set[T]]] -> ...)
-        let current_depth = self.depth.get();
-        if current_depth >= MAX_RECURSION_DEPTH {
+        let Some(current_depth) = self.enter_depth() else {
             self.seen.borrow_mut().pop();
             return self.fallback.clone();
-        }
-        self.depth.set(current_depth + 1);
+        };
 
         let ret = func();
 
-        self.depth.set(current_depth);
+        self.exit_depth(current_depth);
         self.seen.borrow_mut().pop();
         self.cache.borrow_mut().insert(item, ret.clone());
 
@@ -141,22 +137,48 @@ impl<Tag, T: Hash + Eq + Clone, R: Clone, Extra> CycleDetector<Tag, T, R, Extra>
             return Some(self.fallback.clone());
         }
 
-        // Check depth limit to prevent stack overflow from recursive generic protocols
-        // with growing specializations (e.g., C[set[T]] -> C[set[set[T]]] -> ...)
-        let current_depth = self.depth.get();
-        if current_depth >= MAX_RECURSION_DEPTH {
+        let Some(current_depth) = self.enter_depth() else {
             self.seen.borrow_mut().pop();
             return Some(self.fallback.clone());
-        }
-        self.depth.set(current_depth + 1);
+        };
 
-        let ret = func()?;
+        let ret = func();
 
-        self.depth.set(current_depth);
+        self.exit_depth(current_depth);
         self.seen.borrow_mut().pop();
+        let ret = ret?;
         self.cache.borrow_mut().insert(item, ret.clone());
 
         Some(ret)
+    }
+
+    /// Increment the recursion depth without recording a `seen` key.
+    ///
+    /// This is used for recursive helpers such as callable/signature relations that can recurse
+    /// deeply without passing through the main `Type` relation entrypoint on every step.
+    pub fn guard(&self, func: impl FnOnce() -> R) -> R {
+        let Some(current_depth) = self.enter_depth() else {
+            return self.fallback.clone();
+        };
+
+        let ret = func();
+        self.exit_depth(current_depth);
+        ret
+    }
+
+    fn enter_depth(&self) -> Option<u32> {
+        // Check depth limit to prevent stack overflow from recursive generic types
+        // with growing specializations (e.g., C[set[T]] -> C[set[set[T]]] -> ...)
+        let current_depth = self.depth.get();
+        if current_depth >= MAX_RECURSION_DEPTH {
+            return None;
+        }
+        self.depth.set(current_depth + 1);
+        Some(current_depth)
+    }
+
+    fn exit_depth(&self, previous_depth: u32) {
+        self.depth.set(previous_depth);
     }
 }
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1555,23 +1555,6 @@ impl<'db> Specialization<'db> {
         })
     }
 
-    pub(crate) fn is_disjoint_from<'c>(
-        self,
-        db: &'db dyn Db,
-        other: Self,
-        constraints: &'c ConstraintSetBuilder<'db>,
-        inferable: InferableTypeVars<'_, 'db>,
-    ) -> ConstraintSet<'db, 'c> {
-        self.is_disjoint_from_impl(
-            db,
-            other,
-            constraints,
-            inferable,
-            &IsDisjointVisitor::default(constraints),
-            &HasRelationToVisitor::default(constraints),
-        )
-    }
-
     pub(crate) fn is_disjoint_from_impl<'c>(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -180,6 +180,17 @@ impl<'db> Type<'db> {
             {
                 return result;
             }
+
+            // If both sides are instances of the same class-based protocol, the nominal generic
+            // relation is the full answer. Falling through to structural interface checking here
+            // needlessly re-expands recursive protocol members like
+            // `index() -> Streamable[tuple[int, T]]`, which creates ever-deeper same-shape
+            // protocol comparisons.
+            if let Type::NominalInstance(self_nominal) = type_to_test
+                && self_nominal.class_literal(db) == nominal_instance.class_literal(db)
+            {
+                return result;
+            }
         }
 
         // `Generator` special case: Prior to 3.13, the `_ReturnT_co` type didn't appear in any
@@ -509,9 +520,14 @@ impl<'db> NominalInstanceType<'db> {
         result.or(db, constraints, || {
             ConstraintSet::from_bool(
                 constraints,
-                !self
-                    .class(db)
-                    .could_coexist_in_mro_with(db, other.class(db), constraints),
+                !self.class(db).could_coexist_in_mro_with(
+                    db,
+                    other.class(db),
+                    constraints,
+                    inferable,
+                    relation_visitor,
+                    disjointness_visitor,
+                ),
             )
         })
     }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -354,9 +354,9 @@ impl<'db> ProtocolInterface<'db> {
                         (
                             ProtocolMemberKind::Method(our_method),
                             ProtocolMemberKind::Method(other_method),
-                        ) => our_method.bind_self(db, None).has_relation_to_impl(
+                        ) => Type::Callable(our_method.bind_self(db, None)).has_relation_to_impl(
                             db,
-                            protocol_bind_self(db, other_method, None),
+                            Type::Callable(protocol_bind_self(db, other_method, None)),
                             constraints,
                             inferable,
                             relation,
@@ -785,9 +785,14 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
                     |callables| {
                         callables
                             .map(|callable| callable.apply_self(db, fallback_other))
+                            .into_type(db)
                             .has_relation_to_impl(
                                 db,
-                                protocol_bind_self(db, *method, Some(fallback_other)),
+                                Type::Callable(protocol_bind_self(
+                                    db,
+                                    *method,
+                                    Some(fallback_other),
+                                )),
                                 constraints,
                                 inferable,
                                 relation,

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1054,36 +1054,42 @@ impl<'db> Type<'db> {
             // applied to the signature. Different specializations of the same function literal are
             // only subtypes of each other if they result in the same signature.
             (Type::FunctionLiteral(self_function), Type::FunctionLiteral(target_function)) => {
-                self_function.has_relation_to_impl(
-                    db,
-                    target_function,
-                    constraints,
-                    inferable,
-                    relation,
-                    relation_visitor,
-                    disjointness_visitor,
-                )
+                relation_visitor.visit((self, target, relation), || {
+                    self_function.has_relation_to_impl(
+                        db,
+                        target_function,
+                        constraints,
+                        inferable,
+                        relation,
+                        relation_visitor,
+                        disjointness_visitor,
+                    )
+                })
             }
-            (Type::BoundMethod(self_method), Type::BoundMethod(target_method)) => self_method
-                .has_relation_to_impl(
-                    db,
-                    target_method,
-                    constraints,
-                    inferable,
-                    relation,
-                    relation_visitor,
-                    disjointness_visitor,
-                ),
+            (Type::BoundMethod(self_method), Type::BoundMethod(target_method)) => relation_visitor
+                .visit((self, target, relation), || {
+                    self_method.has_relation_to_impl(
+                        db,
+                        target_method,
+                        constraints,
+                        inferable,
+                        relation,
+                        relation_visitor,
+                        disjointness_visitor,
+                    )
+                }),
             (Type::KnownBoundMethod(self_method), Type::KnownBoundMethod(target_method)) => {
-                self_method.has_relation_to_impl(
-                    db,
-                    target_method,
-                    constraints,
-                    inferable,
-                    relation,
-                    relation_visitor,
-                    disjointness_visitor,
-                )
+                relation_visitor.visit((self, target, relation), || {
+                    self_method.has_relation_to_impl(
+                        db,
+                        target_method,
+                        constraints,
+                        inferable,
+                        relation,
+                        relation_visitor,
+                        disjointness_visitor,
+                    )
+                })
             }
 
             // All `StringLiteral` types are a subtype of `LiteralString`.
@@ -1538,17 +1544,18 @@ impl<'db> Type<'db> {
             }
 
             // For generic aliases, we delegate to the underlying class type.
-            (Type::GenericAlias(self_alias), Type::GenericAlias(target_alias)) => {
-                ClassType::Generic(self_alias).has_relation_to_impl(
-                    db,
-                    ClassType::Generic(target_alias),
-                    constraints,
-                    inferable,
-                    relation,
-                    relation_visitor,
-                    disjointness_visitor,
-                )
-            }
+            (Type::GenericAlias(self_alias), Type::GenericAlias(target_alias)) => relation_visitor
+                .visit((self, target, relation), || {
+                    ClassType::Generic(self_alias).has_relation_to_impl(
+                        db,
+                        ClassType::Generic(target_alias),
+                        constraints,
+                        inferable,
+                        relation,
+                        relation_visitor,
+                        disjointness_visitor,
+                    )
+                }),
 
             (Type::GenericAlias(alias), Type::SubclassOf(target_subclass_ty)) => target_subclass_ty
                 .subclass_of()
@@ -1570,15 +1577,17 @@ impl<'db> Type<'db> {
 
             // This branch asks: given two types `type[T]` and `type[S]`, is `type[T]` a subtype of `type[S]`?
             (Type::SubclassOf(self_subclass_ty), Type::SubclassOf(target_subclass_ty)) => {
-                self_subclass_ty.has_relation_to_impl(
-                    db,
-                    target_subclass_ty,
-                    constraints,
-                    inferable,
-                    relation,
-                    relation_visitor,
-                    disjointness_visitor,
-                )
+                relation_visitor.visit((self, target, relation), || {
+                    self_subclass_ty.has_relation_to_impl(
+                        db,
+                        target_subclass_ty,
+                        constraints,
+                        inferable,
+                        relation,
+                        relation_visitor,
+                        disjointness_visitor,
+                    )
+                })
             }
 
             // `Literal[str]` is a subtype of `type` because the `str` class object is an instance of its metaclass `type`.
@@ -2328,19 +2337,21 @@ impl<'db> Type<'db> {
             }
 
             (Type::GenericAlias(left_alias), Type::GenericAlias(right_alias)) => {
-                ConstraintSet::from_bool(
-                    constraints,
-                    left_alias.origin(db) != right_alias.origin(db),
-                )
-                .or(db, constraints, || {
-                    left_alias.specialization(db).is_disjoint_from_impl(
-                        db,
-                        right_alias.specialization(db),
+                disjointness_visitor.visit((self, other), || {
+                    ConstraintSet::from_bool(
                         constraints,
-                        inferable,
-                        disjointness_visitor,
-                        relation_visitor,
+                        left_alias.origin(db) != right_alias.origin(db),
                     )
+                    .or(db, constraints, || {
+                        left_alias.specialization(db).is_disjoint_from_impl(
+                            db,
+                            right_alias.specialization(db),
+                            constraints,
+                            inferable,
+                            disjointness_visitor,
+                            relation_visitor,
+                        )
+                    })
                 })
             }
 
@@ -2369,6 +2380,9 @@ impl<'db> Type<'db> {
                             db,
                             ClassType::NonGeneric(class_b),
                             constraints,
+                            inferable,
+                            relation_visitor,
+                            disjointness_visitor,
                         ),
                     ),
                     SubclassOfInner::TypeVar(_) => unreachable!(),
@@ -2385,6 +2399,9 @@ impl<'db> Type<'db> {
                             db,
                             ClassType::Generic(alias_b),
                             constraints,
+                            inferable,
+                            relation_visitor,
+                            disjointness_visitor,
                         ),
                     ),
                     SubclassOfInner::TypeVar(_) => unreachable!(),
@@ -2392,7 +2409,16 @@ impl<'db> Type<'db> {
             }
 
             (Type::SubclassOf(left), Type::SubclassOf(right)) => {
-                left.is_disjoint_from_impl(db, right, constraints, inferable, disjointness_visitor)
+                disjointness_visitor.visit((self, other), || {
+                    left.is_disjoint_from_impl(
+                        db,
+                        right,
+                        constraints,
+                        inferable,
+                        disjointness_visitor,
+                        relation_visitor,
+                    )
+                })
             }
 
             // for `type[Any]`/`type[Unknown]`/`type[Todo]`, we know the type cannot be any larger than `type`,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -299,16 +299,18 @@ impl<'db> CallableSignature<'db> {
         relation_visitor: &HasRelationToVisitor<'db, 'c>,
         disjointness_visitor: &IsDisjointVisitor<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
-        Self::has_relation_to_inner(
-            db,
-            &self.overloads,
-            &other.overloads,
-            constraints,
-            inferable,
-            relation,
-            relation_visitor,
-            disjointness_visitor,
-        )
+        relation_visitor.guard(|| {
+            Self::has_relation_to_inner(
+                db,
+                &self.overloads,
+                &other.overloads,
+                constraints,
+                inferable,
+                relation,
+                relation_visitor,
+                disjointness_visitor,
+            )
+        })
     }
 
     pub(crate) fn is_single_paramspec(&self) -> Option<(BoundTypeVarInstance<'db>, Type<'db>)> {
@@ -361,6 +363,8 @@ impl<'db> CallableSignature<'db> {
         other_signature: &Signature<'db>,
         inferable: InferableTypeVars<'_, 'db>,
         relation: TypeRelation,
+        relation_visitor: &HasRelationToVisitor<'db, 'c>,
+        disjointness_visitor: &IsDisjointVisitor<'db, 'c>,
     ) -> Option<ConstraintSet<'db, 'c>> {
         let single_required_positional_parameter_type = |signature: &Signature<'db>| {
             if signature.parameters().len() != 1 {
@@ -410,7 +414,14 @@ impl<'db> CallableSignature<'db> {
                 return None;
             }
             let signatures_are_disjoint = self_parameter_type
-                .when_disjoint_from(db, other_parameter_type, constraints, inferable)
+                .is_disjoint_from_impl(
+                    db,
+                    other_parameter_type,
+                    constraints,
+                    inferable,
+                    disjointness_visitor,
+                    relation_visitor,
+                )
                 .is_always_satisfied(db);
 
             if signatures_are_disjoint {
@@ -427,19 +438,23 @@ impl<'db> CallableSignature<'db> {
         }
 
         // Function assignability here is parameter-contravariant and return-covariant.
-        let parameters_cover_target = other_parameter_type.has_relation_to(
+        let parameters_cover_target = other_parameter_type.has_relation_to_impl(
             db,
             parameter_type_union.build(),
             constraints,
             inferable,
             relation,
+            relation_visitor,
+            disjointness_visitor,
         );
-        let returns_match_target = return_type_union.build().has_relation_to(
+        let returns_match_target = return_type_union.build().has_relation_to_impl(
             db,
             other_signature.return_ty,
             constraints,
             inferable,
             relation,
+            relation_visitor,
+            disjointness_visitor,
         );
         let aggregate_relation =
             parameters_cover_target.and(db, constraints, || returns_match_target);
@@ -597,6 +612,8 @@ impl<'db> CallableSignature<'db> {
                     other_signature,
                     inferable,
                     relation,
+                    relation_visitor,
+                    disjointness_visitor,
                 ) {
                     return aggregate_relation;
                 }
@@ -604,16 +621,18 @@ impl<'db> CallableSignature<'db> {
                 self_signatures
                     .iter()
                     .when_any(db, constraints, |self_signature| {
-                        Self::has_relation_to_inner(
-                            db,
-                            std::slice::from_ref(self_signature),
-                            other_signatures,
-                            constraints,
-                            inferable,
-                            relation,
-                            relation_visitor,
-                            disjointness_visitor,
-                        )
+                        relation_visitor.guard(|| {
+                            Self::has_relation_to_inner(
+                                db,
+                                std::slice::from_ref(self_signature),
+                                other_signatures,
+                                constraints,
+                                inferable,
+                                relation,
+                                relation_visitor,
+                                disjointness_visitor,
+                            )
+                        })
                     })
             }
 
@@ -621,32 +640,36 @@ impl<'db> CallableSignature<'db> {
             ([_], _) => other_signatures
                 .iter()
                 .when_all(db, constraints, |other_signature| {
-                    Self::has_relation_to_inner(
-                        db,
-                        self_signatures,
-                        std::slice::from_ref(other_signature),
-                        constraints,
-                        inferable,
-                        relation,
-                        relation_visitor,
-                        disjointness_visitor,
-                    )
+                    relation_visitor.guard(|| {
+                        Self::has_relation_to_inner(
+                            db,
+                            self_signatures,
+                            std::slice::from_ref(other_signature),
+                            constraints,
+                            inferable,
+                            relation,
+                            relation_visitor,
+                            disjointness_visitor,
+                        )
+                    })
                 }),
 
             // `self` is definitely overloaded while `other` is possibly overloaded.
             (_, _) => other_signatures
                 .iter()
                 .when_all(db, constraints, |other_signature| {
-                    Self::has_relation_to_inner(
-                        db,
-                        self_signatures,
-                        std::slice::from_ref(other_signature),
-                        constraints,
-                        inferable,
-                        relation,
-                        relation_visitor,
-                        disjointness_visitor,
-                    )
+                    relation_visitor.guard(|| {
+                        Self::has_relation_to_inner(
+                            db,
+                            self_signatures,
+                            std::slice::from_ref(other_signature),
+                            constraints,
+                            inferable,
+                            relation,
+                            relation_visitor,
+                            disjointness_visitor,
+                        )
+                    })
                 }),
         }
     }
@@ -1143,15 +1166,17 @@ impl<'db> Signature<'db> {
         let inferable = inferable.merge(&other_inferable);
 
         // `inner` will create a constraint set that references these newly inferable typevars.
-        let when = self.has_relation_to_inner(
-            db,
-            other,
-            constraints,
-            inferable,
-            relation,
-            relation_visitor,
-            disjointness_visitor,
-        );
+        let when = relation_visitor.guard(|| {
+            self.has_relation_to_inner(
+                db,
+                other,
+                constraints,
+                inferable,
+                relation,
+                relation_visitor,
+                disjointness_visitor,
+            )
+        });
 
         // But the caller does not need to consider those extra typevars. Whatever constraint set
         // we produce, we reduce it back down to the inferable set that the caller asked about.

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -265,8 +265,9 @@ impl<'db> SubclassOfType<'db> {
         db: &'db dyn Db,
         other: Self,
         constraints: &'c ConstraintSetBuilder<'db>,
-        _inferable: InferableTypeVars<'_, 'db>,
-        _visitor: &IsDisjointVisitor<'db, 'c>,
+        inferable: InferableTypeVars<'_, 'db>,
+        disjointness_visitor: &IsDisjointVisitor<'db, 'c>,
+        relation_visitor: &HasRelationToVisitor<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
         match (self.subclass_of, other.subclass_of) {
             (SubclassOfInner::Dynamic(_), _) | (_, SubclassOfInner::Dynamic(_)) => {
@@ -275,7 +276,14 @@ impl<'db> SubclassOfType<'db> {
             (SubclassOfInner::Class(self_class), SubclassOfInner::Class(other_class)) => {
                 ConstraintSet::from_bool(
                     constraints,
-                    !self_class.could_coexist_in_mro_with(db, other_class, constraints),
+                    !self_class.could_coexist_in_mro_with(
+                        db,
+                        other_class,
+                        constraints,
+                        inferable,
+                        relation_visitor,
+                        disjointness_visitor,
+                    ),
                 )
             }
             (SubclassOfInner::TypeVar(_), _) | (_, SubclassOfInner::TypeVar(_)) => {


### PR DESCRIPTION
## Summary

This PR includes a  test case, and fix, for a stack overflow running `ty check` on our codebase (both latest release and git main).  Both were produced by codex; I'm not familiar enough with `ty` to say if this is the right solution but at least hope the repro case is useful.

Note it's "minimal" in the sense that it was the smallest example I was able to produce, but is still quite large (~780 LOC).

This is codex's explanation:

A ParamSpec-preserving decorator wrapped around a function that mentions a recursive class-based protocol could send ty into either a stack overflow or practical non-termination. The smallest self-contained shape was a stream-like protocol whose methods returned further specializations of the same protocol, especially index() -> Streamable[tuple[int, T]]. While checking assignability, ty kept rebuilding recursive protocol and constraint shapes instead of recognizing that it was revisiting the same class-based protocol relation.

There were two main causes. First, ConstraintSet::is_cyclic treated class-based protocols like fully structural protocols and walked their entire lazily inferred interfaces when computing reachability. In a callable and ParamSpec-heavy path this pulled in large member graphs and recursive generic returns, which was enough to overflow the stack. Second, even after the nominal protocol relation had already been computed, protocol conformance could still fall through to structural member checking for two instances of the same class-based protocol. Recursive members such as Streamable[T] -> Streamable[tuple[int, T]] then created ever-deeper same-shape comparisons. Aggregate lower and upper-bound construction in the constraint solver compounded the problem by routing cyclic paths back through full smart union and intersection simplification.

Fix this by cutting off those recursive expansions at the right boundaries:

- preserve relation and disjointness visitors through callable and MRO checks so recursive comparisons reuse the same cycle guards;
- make ConstraintSet::is_cyclic collect reachability from the nominal specialization of class-based protocols instead of walking their full interfaces, with extra visited-set and depth guards for typevars;
- use cycle-recovery unions and unsimplified positive intersections in the constraint solver's aggregate-bound hot paths to avoid re-entering expensive smart simplification on cyclic bounds;
- when both sides are instances of the same class-based protocol, treat the nominal generic relation as authoritative and skip the redundant structural interface walk;
- remove the unused Specialization::is_disjoint_from wrapper.

With these changes the decorated protocol regression completes normally again, including the mdtest repro, instead of hanging or overflowing the stack.

## Test Plan

Test cases added in PR, and verified it resolves the overflow in our codebase. 