### PR TITLE
[`perflint`] Fix comment duplication in fixes (`PERF401`, `PERF403`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/perflint/PERF401.py
+++ b/crates/ruff_linter/resources/test/fixtures/perflint/PERF401.py
@@ -305,3 +305,24 @@ def f():
         result = []
         for NL_INDEX in range(3):
             result.append(NL_INDEX)
+
+def f():
+    # comment duplication in if test (https://github.com/astral-sh/ruff/issues/18787)
+    original = list(range(10000))
+    filtered = []
+    for i in original:
+        if (
+            i
+            # comment
+        ):
+            filtered.append(i)
+
+def f():
+    # comment duplication in target (https://github.com/astral-sh/ruff/issues/18787)
+    original = list(range(10000))
+    filtered = []
+    for (
+        i  # comment
+    ) in original:
+        if i > 0:
+            filtered.append(i)

--- a/crates/ruff_linter/resources/test/fixtures/perflint/PERF403.py
+++ b/crates/ruff_linter/resources/test/fixtures/perflint/PERF403.py
@@ -210,6 +210,24 @@ def issue_19153_2():
 
 def issue_19153_3():
     v = {}
-    for o, (x,) in ["ox"]: 
-        v[(x,)] = o 
+    for o, (x,) in ["ox"]:
+        v[(x,)] = o
     return v
+
+def f():
+    # comment duplication in if test (https://github.com/astral-sh/ruff/issues/18787)
+    result = {}
+    for k in ["a", "b", "c"]:
+        if (
+            k
+            # comment
+        ):
+            result[k] = k
+
+def f():
+    # comment duplication in target (https://github.com/astral-sh/ruff/issues/18787)
+    result = {}
+    for (
+        k  # comment
+    ) in ["a", "b", "c"]:
+        result[k] = k

--- a/crates/ruff_linter/src/rules/perflint/rules/manual_dict_comprehension.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_dict_comprehension.rs
@@ -387,11 +387,17 @@ fn convert_to_dict_comprehension(
     let comprehension_str =
         format!("{{{key_str}: {value_str} {for_type} {target_str} in {iter_str}{if_str}}}");
 
-    let for_loop_inline_comments = comment_strings_in_range(
-        checker,
-        for_stmt.range,
-        &[key.range(), value.range(), for_stmt.iter.range()],
-    );
+    let mut ranges_to_ignore = vec![
+        key.range(),
+        value.range(),
+        for_stmt.iter.range(),
+        for_stmt.target.range(),
+    ];
+    if let Some(test) = if_test {
+        ranges_to_ignore.push(test.range());
+    }
+    let for_loop_inline_comments =
+        comment_strings_in_range(checker, for_stmt.range, &ranges_to_ignore);
 
     let newline = checker.stylist().line_ending().as_str();
 

--- a/crates/ruff_linter/src/rules/perflint/rules/manual_list_comprehension.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_list_comprehension.rs
@@ -422,11 +422,16 @@ fn convert_to_list_extend(
     };
 
     let variable_name = locator.slice(binding);
-    let for_loop_inline_comments = comment_strings_in_range(
-        checker,
-        for_stmt.range,
-        &[to_append.range(), for_stmt.iter.range()],
-    );
+    let mut ranges_to_ignore = vec![
+        to_append.range(),
+        for_stmt.iter.range(),
+        for_stmt.target.range(),
+    ];
+    if let Some(test) = if_test {
+        ranges_to_ignore.push(test.range());
+    }
+    let for_loop_inline_comments =
+        comment_strings_in_range(checker, for_stmt.range, &ranges_to_ignore);
 
     let newline = checker.stylist().line_ending().as_str();
 

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF401_PERF401.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF401_PERF401.py.snap
@@ -294,3 +294,25 @@ PERF401 Use a list comprehension to create a transformed list
 294 | G_INDEX = None
     |
 help: Replace for loop with list comprehension
+
+PERF401 Use a list comprehension to create a transformed list
+   --> PERF401.py:318:13
+    |
+316 |             # comment
+317 |         ):
+318 |             filtered.append(i)
+    |             ^^^^^^^^^^^^^^^^^^
+319 |
+320 | def f():
+    |
+help: Replace for loop with list comprehension
+
+PERF401 Use a list comprehension to create a transformed list
+   --> PERF401.py:328:13
+    |
+326 |     ) in original:
+327 |         if i > 0:
+328 |             filtered.append(i)
+    |             ^^^^^^^^^^^^^^^^^^
+    |
+help: Replace for loop with list comprehension

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF403_PERF403.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF403_PERF403.py.snap
@@ -203,9 +203,31 @@ PERF403 Use a dictionary comprehension instead of a for-loop
    --> PERF403.py:214:9
     |
 212 |     v = {}
-213 |     for o, (x,) in ["ox"]: 
-214 |         v[(x,)] = o 
+213 |     for o, (x,) in ["ox"]:
+214 |         v[(x,)] = o
     |         ^^^^^^^^^^^
 215 |     return v
+    |
+help: Replace for loop with dict comprehension
+
+PERF403 Use a dictionary comprehension instead of a for-loop
+   --> PERF403.py:225:13
+    |
+223 |             # comment
+224 |         ):
+225 |             result[k] = k
+    |             ^^^^^^^^^^^^^
+226 |
+227 | def f():
+    |
+help: Replace for loop with dict comprehension
+
+PERF403 Use a dictionary comprehension instead of a for-loop
+   --> PERF403.py:233:9
+    |
+231 |         k  # comment
+232 |     ) in ["a", "b", "c"]:
+233 |         result[k] = k
+    |         ^^^^^^^^^^^^^
     |
 help: Replace for loop with dict comprehension

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__preview__PERF401_PERF401.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__preview__PERF401_PERF401.py.snap
@@ -628,3 +628,53 @@ help: Replace for loop with list comprehension
 292 | G_INDEX = None
 293 | def f():
 note: This is an unsafe fix and may change runtime behavior
+
+PERF401 [*] Use a list comprehension to create a transformed list
+   --> PERF401.py:318:13
+    |
+316 |             # comment
+317 |         ):
+318 |             filtered.append(i)
+    |             ^^^^^^^^^^^^^^^^^^
+319 |
+320 | def f():
+    |
+help: Replace for loop with list comprehension
+309 | def f():
+310 |     # comment duplication in if test (https://github.com/astral-sh/ruff/issues/18787)
+311 |     original = list(range(10000))
+    -     filtered = []
+    -     for i in original:
+    -         if (
+    -             i
+    -             # comment
+    -         ):
+    -             filtered.append(i)
+312 +     # comment
+313 +     filtered = [i for i in original if i]
+314 | 
+315 | def f():
+316 |     # comment duplication in target (https://github.com/astral-sh/ruff/issues/18787)
+note: This is an unsafe fix and may change runtime behavior
+
+PERF401 [*] Use a list comprehension to create a transformed list
+   --> PERF401.py:328:13
+    |
+326 |     ) in original:
+327 |         if i > 0:
+328 |             filtered.append(i)
+    |             ^^^^^^^^^^^^^^^^^^
+    |
+help: Replace for loop with list comprehension
+320 | def f():
+321 |     # comment duplication in target (https://github.com/astral-sh/ruff/issues/18787)
+322 |     original = list(range(10000))
+    -     filtered = []
+    -     for (
+    -         i  # comment
+    -     ) in original:
+    -         if i > 0:
+    -             filtered.append(i)
+323 +     # comment
+324 +     filtered = [i for i in original if i > 0]
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__preview__PERF403_PERF403.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__preview__PERF403_PERF403.py.snap
@@ -426,8 +426,8 @@ PERF403 [*] Use a dictionary comprehension instead of a for-loop
    --> PERF403.py:214:9
     |
 212 |     v = {}
-213 |     for o, (x,) in ["ox"]: 
-214 |         v[(x,)] = o 
+213 |     for o, (x,) in ["ox"]:
+214 |         v[(x,)] = o
     |         ^^^^^^^^^^^
 215 |     return v
     |
@@ -436,8 +436,59 @@ help: Replace for loop with dict comprehension
 210 | 
 211 | def issue_19153_3():
     -     v = {}
-    -     for o, (x,) in ["ox"]: 
-    -         v[(x,)] = o 
-212 +     v = {(x,): o for o, (x,) in ["ox"]} 
+    -     for o, (x,) in ["ox"]:
+    -         v[(x,)] = o
+212 +     v = {(x,): o for o, (x,) in ["ox"]}
 213 |     return v
+214 | 
+215 | def f():
+note: This is an unsafe fix and may change runtime behavior
+
+PERF403 [*] Use a dictionary comprehension instead of a for-loop
+   --> PERF403.py:225:13
+    |
+223 |             # comment
+224 |         ):
+225 |             result[k] = k
+    |             ^^^^^^^^^^^^^
+226 |
+227 | def f():
+    |
+help: Replace for loop with dict comprehension
+216 | 
+217 | def f():
+218 |     # comment duplication in if test (https://github.com/astral-sh/ruff/issues/18787)
+    -     result = {}
+    -     for k in ["a", "b", "c"]:
+    -         if (
+    -             k
+    -             # comment
+    -         ):
+    -             result[k] = k
+219 +     # comment
+220 +     result = {k: k for k in ["a", "b", "c"] if k}
+221 | 
+222 | def f():
+223 |     # comment duplication in target (https://github.com/astral-sh/ruff/issues/18787)
+note: This is an unsafe fix and may change runtime behavior
+
+PERF403 [*] Use a dictionary comprehension instead of a for-loop
+   --> PERF403.py:233:9
+    |
+231 |         k  # comment
+232 |     ) in ["a", "b", "c"]:
+233 |         result[k] = k
+    |         ^^^^^^^^^^^^^
+    |
+help: Replace for loop with dict comprehension
+226 | 
+227 | def f():
+228 |     # comment duplication in target (https://github.com/astral-sh/ruff/issues/18787)
+    -     result = {}
+    -     for (
+    -         k  # comment
+    -     ) in ["a", "b", "c"]:
+    -         result[k] = k
+229 +     # comment
+230 +     result = {k: k for k in ["a", "b", "c"]}
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

- Fix comments inside if test and for target being duplicated when transforming a for-loop into a comprehension

## Test Plan

 - Added test cases for both PERF401 and PERF403
 - Verified comments appear exactly once in preview snapshot fixes

## Closes: [#18787](https://github.com/astral-sh/ruff/issues/18787)


<!-- How was it tested? -->
