### PR TITLE
[ty] Fix some state synchronization problems with nested workspace folders

### DIFF
--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -889,11 +889,21 @@ impl Session {
                 }
             })
             .collect();
-        for doc in documents_to_clear {
+        for doc in &documents_to_clear {
             self.clear_diagnostics(client, doc.url());
         }
 
-        self.bump_revision();
+        // Re-sync file state for open documents that now belong to a
+        // different project. While the file was owned by the removed
+        // project, content changes were only applied to that project's
+        // database. The project that now owns these files needs to be
+        // notified that their content may have changed.
+        for doc in &documents_to_clear {
+            if let AnySystemPath::System(path) = doc.notebook_or_file_path() {
+                let changes = vec![ChangeEvent::file_content_changed(path.clone())];
+                self.apply_changes(&AnySystemPath::System(path.clone()), changes);
+            }
+        }
 
         Ok(())
     }

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -658,6 +658,44 @@ impl Session {
             },
         );
 
+        // When a nested workspace is added, files that were previously
+        // open in a parent project need to also be marked as open in
+        // the new project's database.
+        //
+        // Note that we specifically allow the same file to be in the
+        // open file set of multiple projects.
+        //
+        // (We collect these up-front to work around borrowck.)
+        let open_paths: Vec<SystemPathBuf> = self
+            .text_document_handles()
+            .filter_map(|doc| {
+                // We don't account for virtual paths here since,
+                // at time of writing (2026-03-05), virtual paths
+                // are always tied to the first project.
+                //
+                // Ref: https://github.com/astral-sh/ty/issues/794
+                if let AnySystemPath::System(ref path) = *doc.notebook_or_file_path()
+                    && path.starts_with(&root)
+                {
+                    Some(path.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for path in &open_paths {
+            let db = self.project_db_mut(&AnySystemPath::System(path.clone()));
+            match system_path_to_file(db, path) {
+                Ok(file) => {
+                    let project = db.project();
+                    if project.is_file_included(db, path) {
+                        project.open_file(db, file);
+                    }
+                }
+                Err(err) => tracing::warn!("Failed to open file {path}: {err}"),
+            }
+        }
+
         publish_settings_diagnostics(self, client, root);
     }
 
@@ -837,6 +875,11 @@ impl Session {
         let documents_to_clear: Vec<DocumentHandle> = self
             .text_document_handles()
             .filter_map(|doc| {
+                // We don't account for virtual paths here since,
+                // at time of writing (2026-03-05), virtual paths
+                // are always tied to the first project.
+                //
+                // Ref: https://github.com/astral-sh/ty/issues/794
                 if let AnySystemPath::System(ref path) = *doc.notebook_or_file_path()
                     && path.starts_with(&workspace_path)
                 {

--- a/crates/ty_server/tests/e2e/workspace_folders.rs
+++ b/crates/ty_server/tests/e2e/workspace_folders.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use insta::assert_snapshot;
 use lsp_types::{
     DiagnosticSeverity, DocumentDiagnosticReport, DocumentDiagnosticReportResult,
-    FullDocumentDiagnosticReport, Position, WorkspaceDiagnosticReport,
+    FullDocumentDiagnosticReport, Position, Url, WorkspaceDiagnosticReport,
     WorkspaceDiagnosticReportPartialResult, WorkspaceDiagnosticReportResult,
     WorkspaceDocumentDiagnosticReport, notification::PublishDiagnostics,
 };
@@ -617,6 +617,102 @@ fn global_settings_change() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn open_document_then_add_nested_workspace_folder_open_files_only() -> Result<()> {
+    let root = SystemPath::new("root");
+    let root_main = root.join("main.py");
+    let child = SystemPath::new("root/child");
+    let child_main = child.join("main.py");
+    let child_main_content_v1 = "does_not_exist_child1()\n";
+
+    let mut server = TestServerBuilder::new()?
+        .with_initialization_options(
+            ClientOptions::default().with_diagnostic_mode(DiagnosticMode::OpenFilesOnly),
+        )
+        .with_file(&root_main, "does_not_exist_root()")?
+        .with_file(&child_main, child_main_content_v1)?
+        .with_workspace(root, None)?
+        .enable_pull_diagnostics(true)
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(&child_main, child_main_content_v1, 1);
+    let diagnostics = server.document_diagnostic_request(&child_main, None);
+    assert_snapshot!(
+        condensed_document_diagnostic_snapshot(diagnostics),
+        @"0:0..0:21[ERROR]: Name `does_not_exist_child1` used when not defined",
+    );
+
+    server.add_workspace_folder(child, None)?;
+    server.change_workspace_folders([child], []);
+    server = server.wait_until_workspaces_are_initialized();
+
+    let diagnostics = server.document_diagnostic_request(&child_main, None);
+    assert_snapshot!(
+        condensed_document_diagnostic_snapshot(diagnostics),
+        @"0:0..0:21[ERROR]: Name `does_not_exist_child1` used when not defined",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn open_document_then_add_nested_workspace_folder_workspace() -> Result<()> {
+    let root = SystemPath::new("root");
+    let root_main = root.join("main.py");
+    let child = SystemPath::new("root/child");
+    let child_main = child.join("main.py");
+    let child_main_content_v1 = "does_not_exist_child1()\n";
+
+    let mut server = TestServerBuilder::new()?
+        .with_initialization_options(
+            ClientOptions::default().with_diagnostic_mode(DiagnosticMode::Workspace),
+        )
+        .with_file(&root_main, "does_not_exist_root()")?
+        .with_file(&child_main, child_main_content_v1)?
+        .with_workspace(root, None)?
+        .enable_pull_diagnostics(true)
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(&child_main, child_main_content_v1, 1);
+    let diagnostics = server.workspace_diagnostic_request(None, None);
+    assert_snapshot!(
+        condensed_workspace_diagnostic_snapshot(diagnostics), @r"
+    file://<temp_dir>/root/child/main.py
+    	0:0..0:21[ERROR]: Name `does_not_exist_child1` used when not defined
+    file://<temp_dir>/root/main.py
+    	0:0..0:19[ERROR]: Name `does_not_exist_root` used when not defined
+    "
+    );
+
+    server.add_workspace_folder(child, None)?;
+    server.change_workspace_folders([child], []);
+    server = server.wait_until_workspaces_are_initialized();
+
+    // This specifically asserts that we get duplicate diagnostics
+    // here. VS Code seems to de-duplicate them, but ultimately this
+    // comes from checking `root/child/main.py` twice: once as part
+    // of the `root` workspace folder and another as part of the
+    // `root/child` workspace folder. It seems like this is ultimately
+    // necessary as a result of using a distinct project database for
+    // each workspace folder.
+    server.open_text_document(&child_main, child_main_content_v1, 1);
+    let diagnostics = server.workspace_diagnostic_request(None, None);
+    assert_snapshot!(
+        condensed_workspace_diagnostic_snapshot(diagnostics), @r"
+    file://<temp_dir>/root/child/main.py
+    	0:0..0:21[ERROR]: Name `does_not_exist_child1` used when not defined
+    file://<temp_dir>/root/child/main.py
+    	0:0..0:21[ERROR]: Name `does_not_exist_child1` used when not defined
+    file://<temp_dir>/root/main.py
+    	0:0..0:19[ERROR]: Name `does_not_exist_root` used when not defined
+    "
+    );
+
+    Ok(())
+}
+
 /// A helper routine for creating a snapshot for a collection of
 /// workspace diagnostics.
 ///
@@ -625,12 +721,21 @@ fn global_settings_change() -> Result<()> {
 /// workspace folder. This isn't really meant to test the diagnostics
 /// themselves, hence the condensed output.
 fn condensed_workspace_diagnostic_snapshot(report: WorkspaceDiagnosticReportResult) -> String {
-    let items = match report {
+    let mut items = match report {
         WorkspaceDiagnosticReportResult::Report(WorkspaceDiagnosticReport { items }) => items,
         WorkspaceDiagnosticReportResult::Partial(WorkspaceDiagnosticReportPartialResult {
             items,
         }) => items,
     };
+    items.sort_by(|item1, item2| {
+        fn uri(item: &WorkspaceDocumentDiagnosticReport) -> &Url {
+            match *item {
+                WorkspaceDocumentDiagnosticReport::Full(ref item) => &item.uri,
+                WorkspaceDocumentDiagnosticReport::Unchanged(ref item) => &item.uri,
+            }
+        }
+        uri(item1).cmp(uri(item2))
+    });
     items
         .into_iter()
         .map(|item| match item {

--- a/crates/ty_server/tests/e2e/workspace_folders.rs
+++ b/crates/ty_server/tests/e2e/workspace_folders.rs
@@ -656,6 +656,80 @@ fn open_document_then_add_nested_workspace_folder_open_files_only() -> Result<()
     Ok(())
 }
 
+/// Tests that when a file exists in multiple workspace folders
+/// simultaneousy, then changes to that file are properly captured even
+/// after a workspace folder is removed.
+#[test]
+fn open_document_then_add_nested_workspace_folder_with_change() -> Result<()> {
+    let root = SystemPath::new("root");
+    let root_main = root.join("main.py");
+    let child = SystemPath::new("root/child");
+    let child_main = child.join("main.py");
+    let child_main_content_v1 = "does_not_exist_child1()\n";
+    let child_main_content_v2 = "does_not_exist_child1()\ndoes_not_exist_child2()\n";
+
+    let mut server = TestServerBuilder::new()?
+        .with_initialization_options(
+            ClientOptions::default().with_diagnostic_mode(DiagnosticMode::OpenFilesOnly),
+        )
+        .with_file(&root_main, "does_not_exist_root()")?
+        .with_file(&child_main, child_main_content_v1)?
+        .with_workspace(root, None)?
+        .enable_pull_diagnostics(true)
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(&child_main, child_main_content_v1, 1);
+    let diagnostics = server.document_diagnostic_request(&child_main, None);
+    assert_snapshot!(
+        condensed_document_diagnostic_snapshot(diagnostics),
+        @"0:0..0:21[ERROR]: Name `does_not_exist_child1` used when not defined",
+    );
+
+    server.add_workspace_folder(child, None)?;
+    server.change_workspace_folders([child], []);
+    server = server.wait_until_workspaces_are_initialized();
+
+    server.change_text_document(
+        &child_main,
+        vec![lsp_types::TextDocumentContentChangeEvent {
+            range: None,
+            range_length: None,
+            text: child_main_content_v2.to_string(),
+        }],
+        2,
+    );
+
+    let diagnostics = server.document_diagnostic_request(&child_main, None);
+    assert_snapshot!(
+        condensed_document_diagnostic_snapshot(diagnostics),
+        @r"
+    0:0..0:21[ERROR]: Name `does_not_exist_child1` used when not defined
+    1:0..1:21[ERROR]: Name `does_not_exist_child2` used when not defined
+    ",
+    );
+
+    server.change_workspace_folders([], [&child]);
+    let _ = server.await_notification::<PublishDiagnostics>();
+
+    // Previously, the diagnostics here would be reported for
+    // `child_main_content_v1`. The bug was that after the removal
+    // of the nested workspace, `child` now became part of the root
+    // project. But its state in the root project hadn't been updated
+    // when the file was changed. Only its state in the child project
+    // was updated.
+    let diagnostics = server.document_diagnostic_request(&child_main, None);
+    assert_snapshot!(
+        condensed_document_diagnostic_snapshot(diagnostics),
+        @r"
+    0:0..0:21[ERROR]: Name `does_not_exist_child1` used when not defined
+    1:0..1:21[ERROR]: Name `does_not_exist_child2` used when not defined
+    ",
+    );
+
+    Ok(())
+}
+
 #[test]
 fn open_document_then_add_nested_workspace_folder_workspace() -> Result<()> {
     let root = SystemPath::new("root");


### PR DESCRIPTION
This PR addresses a couple of state synchronization problems with
nested workspaces and the open file sets in projects.

The first change addresses a problem where adding a new workspace
folder when there are open files would mean that the new workspace
folder doesn't know about those open files. When the workspace folders
don't share files, then I believe that's fine. But when they are
nested, some of the open files might need to be in multiple projects
simultaneously. So we fix that by explicitly opening the right files
when a new workspace folder is added.

The second change I'm less sure about. When a workspace folder is
removed, it's possible for an open file's state to now be stale.
Namely, when an open file is part of multiple projects, we currently
only dispatch state change notifications (open, close, change) to its
"owning" project. So if an owning project gets removed and that open
file is still part of another project, then its state could now be
stale.

@MichaReiser [suggested] that we instead dispatch state change
notifications across _all_ projects. I think that's a bigger change
though, so I opted for a smaller fix in the second commit for now.
(Even if we did dispatch state change notifications across all
projects, we'd still need something like the first commit to ensure
newly created projects have the right open file set.)

Note that one thing this specifically does not address are close
notifications. If a file is in two workspace folders, is closed and
then one of the workspace folders is removed, then the remaining
workspace folder I believe will still contain that closed file as open.

One thing worth noting is that I've found it difficult to reproduce
some of these state synchronization bugs in VS Code. When using nested
workspace folders with open files, VS Code is _very_ eager to restart
the LSP server.

[suggested]: https://github.com/astral-sh/ruff/pull/22953#discussion_r2878495879
