### PR TITLE
docs: add argfile usage example to `ruff check` docs

### DIFF
--- a/docs/linter.md
+++ b/docs/linter.md
@@ -19,6 +19,14 @@ $ ruff check --watch          # Lint files in the current directory and re-lint 
 $ ruff check path/to/code/    # Lint files in `path/to/code`.
 ```
 
+You can also pass arguments via an argfile by prefixing the filename with `@`:
+
+```console
+$ ruff check @arguments.txt
+```
+
+Each argument in the file should be on its own line. This is useful for long file lists and paths that contain spaces.
+
 For the full list of supported options, run `ruff check --help`.
 
 ## Rule selection


### PR DESCRIPTION
Closes #21894.

## Summary
- Document support for passing CLI arguments via argfiles (for example, `ruff check @arguments.txt`).
- Add a concrete command example to the `ruff check` section.
- Clarify that each argument in the argfile must be on its own line.

## Test Plan
- Docs-only change.
- Verified the rendered markdown in the GitHub diff view.