### PR TITLE
conformance.py: Collapse the summary paragraph when nothing changed

### DIFF
--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -892,9 +892,13 @@ def render_summary(test_cases: list[TestCase], *, force_summary_table: bool) -> 
 
             ### No changes detected ✅
 
-            ---
+            <details>
+            <summary>Current numbers</summary>
 
+            <br>
             {summary_paragraph}
+
+            </details>
             """
         )
 


### PR DESCRIPTION
## Summary

I find it useful to have this information available even when nothing changed, but it's too noisy to have the whole paragraph printed out even on unrelated Ruff PRs like https://github.com/astral-sh/ruff/pull/23743#issuecomment-4007245549

## Test Plan

I ran the script locally and pasted it into a GitHub input box to see how it looked