### PR TITLE
[ty] eliminate negative intersection elements in promotion

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -91,34 +91,25 @@ from typing import overload, Callable
 def list1[T](x: T) -> list[T]:
     return [x]
 
-def get_data() -> dict | None:
-    return {}
+def f() -> list[object]:
+    reveal_type(list1(1))  # revealed: list[int]
+    # `list[int]` and `list[object]` are incompatible, but the return type check passes here
+    # because the type of `list1(res)` is inferred by bidirectional type inference using the
+    # annotated return type, and the type of `res` is not used.
+    return list1(1)
 
-def wrap_data() -> list[dict]:
-    if not (res := get_data()):
-        return list1({})
-    reveal_type(list1(res))  # revealed: list[dict[Unknown, Unknown] & ~AlwaysFalsy]
-    # `list[dict[Unknown, Unknown] & ~AlwaysFalsy]` and `list[dict[Unknown, Unknown]]` are incompatible,
-    # but the return type check passes here because the type of `list1(res)` is inferred
-    # by bidirectional type inference using the annotated return type, and the type of `res` is not used.
-    return list1(res)
-
-def wrap_data2() -> list[dict] | None:
-    if not (res := get_data()):
-        return None
-    reveal_type(list1(res))  # revealed: list[dict[Unknown, Unknown] & ~AlwaysFalsy]
-    return list1(res)
+def f2() -> list[object] | None:
+    reveal_type(list1(1))  # revealed: list[int]
+    return list1(1)
 
 def deco[T](func: Callable[[], T]) -> Callable[[], T]:
     return func
 
-def outer() -> Callable[[], list[dict]]:
+def outer() -> Callable[[], list[object]]:
     @deco
-    def inner() -> list[dict]:
-        if not (res := get_data()):
-            return list1({})
-        reveal_type(list1(res))  # revealed: list[dict[Unknown, Unknown] & ~AlwaysFalsy]
-        return list1(res)
+    def inner() -> list[object]:
+        reveal_type(list1(1))  # revealed: list[int]
+        return list1(1)
     return inner
 
 @overload

--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -1,14 +1,27 @@
-# Literal promotion
+# Type promotion
 
 ```toml
 [environment]
 python-version = "3.12"
 ```
 
-There are certain places where we promote literals to their common supertype.
+There are certain places (usually when inferring a type for a typevar in an invariant position)
+where we "promote" types to a supertype, rather than inferring the most precise possible types. For
+example, we don't want `[1, 2]` to be inferred as `list[Literal[1, 2]]`, since that would prevent
+adding a `3` to the list later; we prefer `list[int]` instead.
 
-We also promote `float` to `int | float` and `complex` to `int | float | complex`, even when not in
-a type annotation.
+This is a heuristic, where we are trying to guess the type the user probably means, in the absence
+of a clarifying annotation, and in place of trying to do global inference that accounts for every
+use up-front.
+
+In addition to promoting literal types to their nominal supertype (e.g. `Literal[1]` to `int`,
+`Literal["foo"]` to `str`, we also promote `float` to `int | float` and `complex` to
+`int | float | complex`.
+
+We also remove negative intersection elements, so that e.g. `A & ~AlwaysFalsy` promotes to simply
+`A`.
+
+We avoid promoting literal types that originate from an explicit annotation.
 
 ## Implicitly inferred literal types are promotable
 
@@ -79,8 +92,8 @@ reveal_type(frozenset((1, 2, 3)))  # revealed: frozenset[Literal[1, 2, 3]]
 
 ## Invariant and contravariant return types are promoted
 
-Literals are promoted if they are in non-covariant position in the return type of a generic
-function, or constructor of a generic class:
+We promote in non-covariant position in the return type of a generic function, or constructor of a
+generic class:
 
 ```py
 class Bivariant[T]:
@@ -133,7 +146,7 @@ reveal_type(f10(1, 1))  # revealed: tuple[Invariant[int], Covariant[Literal[1]]]
 reveal_type(f11(1, 1))  # revealed: tuple[Invariant[Covariant[int] | None], Covariant[Literal[1]]] | None
 ```
 
-## Literals are promoted recursively
+## Promotion is recursive
 
 ```py
 from typing import Literal
@@ -149,16 +162,24 @@ x2 = ([1, 2], [(3,), (4,)], ["5", "6"])
 reveal_type(x2)  # revealed: tuple[list[int], list[tuple[int]], list[str]]
 ```
 
-However, this promotion should not take place if the literal type appears in contravariant position,
-e.g., the negative member of a covariant intersection type:
+However, this promotion should not take place in contravariant position:
 
 ```py
-def in_negated_position(non_zero_number: int):
-    if non_zero_number == 0:
-        raise ValueError()
+from typing import Generic, TypeVar
+from ty_extensions import Intersection, Not, AlwaysFalsy
 
-    reveal_type(non_zero_number)  # revealed: int & ~Literal[0]
-    reveal_type([non_zero_number])  # revealed: list[int & ~Literal[0]]
+T_co = TypeVar("T_co", covariant=True)
+T_contra = TypeVar("T_contra", contravariant=True)
+
+class A: ...
+class Consumer(Generic[T_contra]): ...
+class Producer(Generic[T_co]): ...
+
+def _(c: Consumer[Intersection[A, Not[AlwaysFalsy]]], p: Producer[Intersection[A, Not[AlwaysFalsy]]]):
+    reveal_type(c)  # revealed: Consumer[A & ~AlwaysFalsy]
+    reveal_type(p)  # revealed: Producer[A & ~AlwaysFalsy]
+    reveal_type([c])  # revealed: list[Consumer[A & ~AlwaysFalsy]]
+    reveal_type([p])  # revealed: list[Producer[A]]
 ```
 
 ## Literal annotations are respected
@@ -320,8 +341,8 @@ reveal_type(x12)  # revealed: Sub2[int, Literal[2]]
 
 ## Constrained TypeVars with Literal constraints
 
-Literal promotion should not apply to constrained TypeVars, since the inferred type is already one
-of the constraints. Promoting it would produce a type that doesn't match any constraint.
+Promotion should not apply to constrained TypeVars, since the inferred type is already one of the
+constraints. Promoting it would produce a type that doesn't match any constraint.
 
 ```py
 from typing import TypeVar, Literal, Generic
@@ -465,4 +486,18 @@ type X = Literal[b"bar"]
 def _(x1: X | None, x2: X):
     reveal_type([x1, x2])  # revealed: list[Literal[b"bar"] | None]
     reveal_type([x1 or x2])  # revealed: list[Literal[b"bar"]]
+```
+
+## Negative intersection elements are removed
+
+Truthiness narrowing should not leak into invariant literal container inference:
+
+```py
+class A: ...
+
+def _(a: A | None):
+    if a:
+        d = {"a": a}
+        reveal_type(d)  # revealed: dict[str, A]
+    return {}
 ```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1694,16 +1694,16 @@ impl<'db> Type<'db> {
     /// Note that this function tries to promote literals to a more user-friendly form than their
     /// fallback instance type. For example, `def _() -> int` is promoted to `Callable[[], int]`,
     /// as opposed to `FunctionType`.
-    pub(crate) fn promote_literals(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn promote(self, db: &'db dyn Db) -> Type<'db> {
         self.apply_type_mapping(
             db,
-            &TypeMapping::PromoteLiterals(PromoteLiteralsMode::On),
+            &TypeMapping::Promote(PromotionMode::On),
             TypeContext::default(),
         )
     }
 
-    /// Like [`Type::promote_literals`], but does not recurse into nested types.
-    fn promote_literals_impl(self, db: &'db dyn Db) -> Type<'db> {
+    /// Like [`Type::promote`], but does not recurse into nested types.
+    fn promote_impl(self, db: &'db dyn Db) -> Type<'db> {
         match self {
             Type::LiteralValue(literal) if literal.is_promotable() => literal.fallback_instance(db),
             Type::ModuleLiteral(_) => KnownClass::ModuleType.to_instance(db),
@@ -5207,14 +5207,14 @@ impl<'db> Type<'db> {
                 match type_mapping {
                     // Promote the types within the signature before promoting the signature to its
                     // callable form.
-                    TypeMapping::PromoteLiterals(PromoteLiteralsMode::On) => {
+                    TypeMapping::Promote(PromotionMode::On) => {
                         Type::FunctionLiteral(function.apply_type_mapping_impl(
                             db,
                             type_mapping,
                             tcx,
                             visitor,
                         ))
-                        .promote_literals_impl(db)
+                        .promote_impl(db)
                     }
                     _ => Type::FunctionLiteral(function.apply_type_mapping_impl(
                         db,
@@ -5231,7 +5231,7 @@ impl<'db> Type<'db> {
                 method.self_instance(db).apply_type_mapping_impl(db, type_mapping, tcx, visitor),
             )),
 
-            Type::NominalInstance(instance) if matches!(type_mapping, TypeMapping::PromoteLiterals(PromoteLiteralsMode::On)) => {
+            Type::NominalInstance(instance) if matches!(type_mapping, TypeMapping::Promote(PromotionMode::On)) => {
                 match instance.known_class(db) {
                     Some(KnownClass::Complex) => KnownUnion::Complex.to_type(db),
                     Some(KnownClass::Float) => KnownUnion::Float.to_type(db),
@@ -5311,9 +5311,14 @@ impl<'db> Type<'db> {
                     builder =
                         builder.add_positive(positive.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
                 }
-                for negative in intersection.negative(db) {
-                    builder =
-                        builder.add_negative(negative.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor));
+                // Promotion should remove negative contributions from intersections,
+                // so we don't preserve them here when promotion is enabled.
+                if !matches!(type_mapping, TypeMapping::Promote(PromotionMode::On)) {
+                    for negative in intersection.negative(db) {
+                        builder = builder.add_negative(
+                            negative.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor),
+                        );
+                    }
                 }
                 builder.build()
             }
@@ -5380,8 +5385,8 @@ impl<'db> Type<'db> {
                 TypeMapping::ReplaceParameterDefaults |
                 TypeMapping::EagerExpansion |
                 TypeMapping::RescopeReturnCallables(_) |
-                TypeMapping::PromoteLiterals(PromoteLiteralsMode::Off) => self,
-                TypeMapping::PromoteLiterals(PromoteLiteralsMode::On) => self.promote_literals_impl(db)
+                TypeMapping::Promote(PromotionMode::Off) => self,
+                TypeMapping::Promote(PromotionMode::On) => self.promote_impl(db)
             }
 
             Type::LiteralValue(_) => match type_mapping {
@@ -5395,8 +5400,8 @@ impl<'db> Type<'db> {
                 TypeMapping::ReplaceParameterDefaults |
                 TypeMapping::EagerExpansion |
                 TypeMapping::RescopeReturnCallables(_) |
-                TypeMapping::PromoteLiterals(PromoteLiteralsMode::Off) => self,
-                TypeMapping::PromoteLiterals(PromoteLiteralsMode::On) => self.promote_literals_impl(db),
+                TypeMapping::Promote(PromotionMode::Off) => self,
+                TypeMapping::Promote(PromotionMode::On) => self.promote_impl(db),
             }
 
             Type::Dynamic(_) => match type_mapping {
@@ -5406,7 +5411,7 @@ impl<'db> Type<'db> {
                 TypeMapping::BindLegacyTypevars(_) |
                 TypeMapping::BindSelf(..) |
                 TypeMapping::ReplaceSelf { .. } |
-                TypeMapping::PromoteLiterals(_) |
+                TypeMapping::Promote(_) |
                 TypeMapping::ReplaceParameterDefaults |
                 TypeMapping::EagerExpansion |
                 TypeMapping::RescopeReturnCallables(_) => self,
@@ -6052,16 +6057,16 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize)]
-pub enum PromoteLiteralsMode {
+pub enum PromotionMode {
     On,
     Off,
 }
 
-impl PromoteLiteralsMode {
+impl PromotionMode {
     const fn flip(self) -> Self {
         match self {
-            PromoteLiteralsMode::On => PromoteLiteralsMode::Off,
-            PromoteLiteralsMode::Off => PromoteLiteralsMode::On,
+            PromotionMode::On => PromotionMode::Off,
+            PromotionMode::Off => PromotionMode::On,
         }
     }
 }
@@ -6180,7 +6185,7 @@ pub enum TypeMapping<'a, 'db> {
     },
     /// Replaces any literal types with their corresponding promoted type form (e.g. `Literal["string"]`
     /// to `str`, or `def _() -> int` to `Callable[[], int]`).
-    PromoteLiterals(PromoteLiteralsMode),
+    Promote(PromotionMode),
     /// Binds a legacy typevar with the generic context (class, function, type alias) that it is
     /// being used in.
     BindLegacyTypevars(BindingContext<'db>),
@@ -6230,7 +6235,7 @@ impl<'db> TypeMapping<'_, 'db> {
                 )
             }
             TypeMapping::UniqueSpecialization { .. }
-            | TypeMapping::PromoteLiterals(_)
+            | TypeMapping::Promote(_)
             | TypeMapping::BindLegacyTypevars(_)
             | TypeMapping::Materialize(_)
             | TypeMapping::ReplaceParameterDefaults
@@ -6273,7 +6278,7 @@ impl<'db> TypeMapping<'_, 'db> {
                 specialization: specialization.clone(),
                 materialization_kind: materialization_kind.flip(),
             },
-            TypeMapping::PromoteLiterals(mode) => TypeMapping::PromoteLiterals(mode.flip()),
+            TypeMapping::Promote(mode) => TypeMapping::Promote(mode.flip()),
             TypeMapping::ApplySpecialization(_)
             | TypeMapping::UniqueSpecialization { .. }
             | TypeMapping::BindLegacyTypevars(_)

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3797,7 +3797,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
         self.errors.extend(specialization_errors);
 
-        // Attempt to promote any literal types assigned to the specialization.
+        // Attempt to promote any promotable types assigned to the specialization.
         let maybe_promote = |typevar: BoundTypeVarInstance<'db>, ty: Type<'db>| {
             let bound_or_constraints = typevar.typevar(self.db).bound_or_constraints(self.db);
 
@@ -3831,7 +3831,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 return ty;
             }
 
-            let promoted = ty.promote_literals(self.db);
+            let promoted = ty.promote(self.db);
 
             // If the TypeVar has an upper bound, only use the promoted type if it
             // still satisfies the bound.

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4477,7 +4477,7 @@ pub(crate) fn report_undeclared_protocol_member(
     if definition.kind(db).is_unannotated_assignment() {
         let binding_type = binding_type(db, definition);
 
-        let suggestion = binding_type.promote_literals(db);
+        let suggestion = binding_type.promote(db);
 
         if should_give_hint(db, suggestion) {
             diagnostic.set_primary_message(format_args!(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1830,7 +1830,7 @@ impl<'db> SpecializationBuilder<'db> {
     /// the specialization that this builder is building up.
     ///
     /// `formal` should be the top-level formal parameter type that we are inferring. This is used
-    /// by our literal promotion logic, which needs to know which typevars are affected by each
+    /// by our promotion logic, which needs to know which typevars are affected by each
     /// argument, and the variance of those typevars in the corresponding parameter.
     ///
     /// TODO: This is a stopgap! Eventually, the builder will maintain a single constraint set for

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -769,7 +769,7 @@ pub fn definitions_for_bin_op<'db>(
         return None;
     };
 
-    let callable_type = promote_literals_for_self(model.db(), bindings.callable_type());
+    let callable_type = promote_for_self(model.db(), bindings.callable_type());
 
     let definitions: Vec<_> = bindings
         .iter_flat()
@@ -827,7 +827,7 @@ pub fn definitions_for_unary_op<'db>(
         ) => *bindings,
     };
 
-    let callable_type = promote_literals_for_self(model.db(), bindings.callable_type());
+    let callable_type = promote_for_self(model.db(), bindings.callable_type());
 
     let definitions = bindings
         .iter_flat()
@@ -842,10 +842,10 @@ pub fn definitions_for_unary_op<'db>(
     Some((definitions, callable_type))
 }
 
-/// Promotes literal types in `self` positions to their fallback instance types.
+/// Promotes types in `self` positions.
 ///
 /// This is so that we show e.g. `int.__add__` instead of `Literal[4].__add__`.
-fn promote_literals_for_self<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+fn promote_for_self<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
     match ty {
         Type::BoundMethod(method) => Type::BoundMethod(method.map_self_type(db, |self_ty| {
             self_ty.literal_fallback_instance(db).unwrap_or(self_ty)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9971,7 +9971,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if tuple.len() > MAX_TUPLE_LENGTH_FOR_UNANNOTATED_LITERAL_INFERENCE {
                 // Promote literals for very large unannotated tuples,
                 // to avoid pathological performance issues
-                self.infer_expression(elt, ctx).promote_literals(db)
+                self.infer_expression(elt, ctx).promote(db)
             } else {
                 self.infer_expression(elt, ctx)
             }
@@ -10367,7 +10367,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 // Note that unlike when preferring the declared type, we use covariant type
                 // assignments from the type context to potentially _narrow_ the inferred type,
-                // by avoiding literal promotion.
+                // by avoiding promotion.
                 let elt_ty_identity = elt_ty.identity(self.db());
 
                 // If the element is a starred expression, we want to apply the type context to each element
@@ -10395,9 +10395,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     continue;
                 }
 
-                // Convert any element literals to their promoted type form to avoid excessively large
-                // unions for large nested list literals, which the constraint solver struggles with.
-                let inferred_elt_ty = inferred_elt_ty.promote_literals(self.db());
+                // Promote types to avoid excessively large unions for large nested list literals,
+                // which the constraint solver struggles with.
+                let inferred_elt_ty = inferred_elt_ty.promote(self.db());
 
                 builder
                     .infer(

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -285,7 +285,7 @@ impl<'db> KnownInstanceType<'db> {
                 TypeMapping::ApplySpecialization(_)
                 | TypeMapping::ApplySpecializationWithMaterialization { .. }
                 | TypeMapping::UniqueSpecialization { .. }
-                | TypeMapping::PromoteLiterals(_)
+                | TypeMapping::Promote(_)
                 | TypeMapping::BindSelf(..)
                 | TypeMapping::ReplaceSelf { .. }
                 | TypeMapping::Materialize(_)

--- a/crates/ty_python_semantic/src/types/literal.rs
+++ b/crates/ty_python_semantic/src/types/literal.rs
@@ -55,7 +55,7 @@ impl<'db> LiteralValueType<'db> {
         }
     }
 
-    /// Creates a literal value that may be promoted during literal promotion.
+    /// Creates a literal value that may be promoted.
     pub(crate) fn promotable(kind: impl Into<LiteralValueTypeKind<'db>>) -> LiteralValueType<'db> {
         let repr = match kind.into() {
             LiteralValueTypeKind::Int(int) => LiteralValueTypeInner::PromotableInt(int),
@@ -69,7 +69,7 @@ impl<'db> LiteralValueType<'db> {
         Self(repr)
     }
 
-    /// Creates a literal value that should not be promoted during literal promotion.
+    /// Creates a literal value that should not be promoted.
     pub(crate) fn unpromotable(
         kind: impl Into<LiteralValueTypeKind<'db>>,
     ) -> LiteralValueType<'db> {

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -904,7 +904,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                 }
             }
             TypeMapping::UniqueSpecialization { .. }
-            | TypeMapping::PromoteLiterals(_)
+            | TypeMapping::Promote(_)
             | TypeMapping::ReplaceParameterDefaults
             | TypeMapping::BindLegacyTypevars(_)
             | TypeMapping::EagerExpansion


### PR DESCRIPTION
## Summary

Avoid inferring invariant container types like `list[int & ~AlwaysFalsy]`, preferring `list[int]` instead.

Also generally rename "literal promotion" to just "promotion" -- it already promoted e.g. `float` to `int | float`, so it wasn't restricted to literal types. Now it includes even more non-literal cases.

## Test Plan

Added an mdtest.

Removes ~200 ecosystem hits from https://github.com/astral-sh/ruff/pull/23718
