### PR TITLE
[ty] Reject `type[Callable]` special form

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_of/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/basic.md
@@ -165,6 +165,23 @@ class B: ...
 _: type[A, B]
 ```
 
+## Callable types are not valid parameters
+
+```py
+from collections.abc import Callable
+
+def f(
+    x: type[Callable],  # error: [invalid-type-form]
+    y: type[Callable[[int], str]],  # error: [invalid-type-form]
+    # error: [invalid-type-form] "Special form `typing.Callable` expected exactly two arguments"
+    # error: [invalid-type-form] "The first argument to `Callable` must be either a list of types, ParamSpec, Concatenate, or `...`"
+    z: type[Callable[int]],  # error: [invalid-type-form] "The argument to `type[]` must be a class object type"
+):
+    reveal_type(x)  # revealed: type[Unknown]
+    reveal_type(y)  # revealed: type[Unknown]
+    reveal_type(z)  # revealed: type[Unknown]
+```
+
 ## As a base class
 
 ```py

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -777,11 +777,26 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
     /// Given the slice of a `type[]` annotation, return the type that the annotation represents
     fn infer_subclass_of_type_expression(&mut self, slice: &ast::Expr) -> Type<'db> {
+        let invalid_type_argument = |builder: &Self, slice: &ast::Expr| {
+            builder.report_invalid_type_expression(
+                slice,
+                "The argument to `type[]` must be a class object type",
+            );
+            SubclassOfType::subclass_of_unknown()
+        };
+
+        let infer_type_argument = |builder: &mut Self, slice: &ast::Expr| {
+            let slice_ty = builder.infer_type_expression(slice);
+            SubclassOfType::try_from_instance(builder.db(), slice_ty).unwrap_or_else(|| {
+                match slice_ty {
+                    Type::Callable(_) => invalid_type_argument(builder, slice),
+                    _ => todo_type!("unsupported type[X] special form"),
+                }
+            })
+        };
+
         match slice {
-            ast::Expr::Name(_) | ast::Expr::Attribute(_) => {
-                SubclassOfType::try_from_instance(self.db(), self.infer_type_expression(slice))
-                    .unwrap_or(todo_type!("unsupported type[X] special form"))
-            }
+            ast::Expr::Name(_) | ast::Expr::Attribute(_) => infer_type_argument(self, slice),
             ast::Expr::BinOp(binary) if binary.op == ast::Operator::BitOr => {
                 let union_ty = UnionType::from_elements_leave_aliases(
                     self.db(),
@@ -865,6 +880,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 }
                             }
                         }
+                    }
+                    Type::SpecialForm(special_form @ SpecialFormType::Callable) => {
+                        self.infer_parameterized_special_form_type_expression(
+                            subscript,
+                            special_form,
+                        );
+                        invalid_type_argument(self, slice)
                     }
                     _ => {
                         self.infer_type_expression(parameters);


### PR DESCRIPTION
## Summary

The [typing spec](https://typing.python.org/en/latest/spec/special-types.html) says:

> Any other [special forms](https://typing.python.org/en/latest/spec/glossary.html#term-special-form) like Callable are not allowed as an argument to type.

We already reject `Generic` and `TypedDict`. We should probably also reject `Literal`. But this PR adds `Callable`.

Closes https://github.com/astral-sh/ty/issues/2964.
