### PR TITLE
conformance.py: stop escaping `|` characters

### DIFF
--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -184,8 +184,6 @@ class TyDiagnostic:
     def __post_init__(self) -> None:
         # Remove check name prefix from description
         self.description = self.description.replace(f"{self.check_name}: ", "")
-        # Escape pipe characters for GitHub markdown tables
-        self.description = self.description.replace("|", "\\|")
 
     def __str__(self) -> str:
         return (


### PR DESCRIPTION
## Summary

In the latest version of this script, all the diagnostics are enclosed within triple-backtick code blocks, so we no longer need this escaping. And we see spurious backslashes appearing in the output because of it, e.g.

<img width="2372" height="678" alt="image" src="https://github.com/user-attachments/assets/2d7b3eef-7567-4c9f-83a1-87e1e5e62723" />

## Test Plan

I manually copied the raw HTML from https://github.com/astral-sh/ruff/pull/23684#issuecomment-3992935132 into a GitHub input box, removed the backslashes, and previewed what the comment would look like. It looked great.