### PR TITLE
[ty] Fixup restoration of multi-inference state in `type_expression.rs`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/string.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/string.md
@@ -103,6 +103,9 @@ def f(
     # error: [unresolved-reference] "SomethingUndefined"
     # error: [unresolved-reference] "SomethingAlsoUndefined"
     i: SomethingUndefined | SomethingAlsoUndefined,
+    # error: [unsupported-operator]
+    # error: [unsupported-operator]
+    j: list["int" | None] | "bytes",
 ):
     reveal_type(a)  # revealed: int | Foo
     reveal_type(b)  # revealed: int | memoryview[int] | bytes

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/string.md_-_String_annotations_-_Partially_deferred_a…_-_Python_less_than_3.1…_(5e6477d05ddea33f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/string.md_-_String_annotations_-_Partially_deferred_a…_-_Python_less_than_3.1…_(5e6477d05ddea33f).snap
@@ -49,38 +49,41 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/string.md
 34 |     # error: [unresolved-reference] "SomethingUndefined"
 35 |     # error: [unresolved-reference] "SomethingAlsoUndefined"
 36 |     i: SomethingUndefined | SomethingAlsoUndefined,
-37 | ):
-38 |     reveal_type(a)  # revealed: int | Foo
-39 |     reveal_type(b)  # revealed: int | memoryview[int] | bytes
-40 |     reveal_type(c)  # revealed: TD | None
-41 |     reveal_type(d)  # revealed: P | None
-42 |     reveal_type(e)  # revealed: T@f | Foo
-43 |     reveal_type(f)  # revealed: Foo | ((...) -> None)
-44 |     reveal_type(g)  # revealed: UsesMeta | Foo
-45 |     reveal_type(h)  # revealed: None
-46 |     reveal_type(i)  # revealed: Unknown
-47 | 
-48 | # fmt: on
-49 | 
-50 | class Foo: ...
-51 | 
-52 | # error: [unsupported-operator]
-53 | X = list["int" | None]
+37 |     # error: [unsupported-operator]
+38 |     # error: [unsupported-operator]
+39 |     j: list["int" | None] | "bytes",
+40 | ):
+41 |     reveal_type(a)  # revealed: int | Foo
+42 |     reveal_type(b)  # revealed: int | memoryview[int] | bytes
+43 |     reveal_type(c)  # revealed: TD | None
+44 |     reveal_type(d)  # revealed: P | None
+45 |     reveal_type(e)  # revealed: T@f | Foo
+46 |     reveal_type(f)  # revealed: Foo | ((...) -> None)
+47 |     reveal_type(g)  # revealed: UsesMeta | Foo
+48 |     reveal_type(h)  # revealed: None
+49 |     reveal_type(i)  # revealed: Unknown
+50 | 
+51 | # fmt: on
+52 | 
+53 | class Foo: ...
 54 | 
-55 | if TYPE_CHECKING:
-56 |     # TODO: ideally we would not error here, since `if TYPE_CHECKING`
-57 |     # blocks are not executed at runtime. Requires
-58 |     # https://github.com/astral-sh/ty/issues/1553.
-59 |     bar: "int" | "None"  # error: [unsupported-operator]
-60 | 
-61 |     # TODO: same as above
-62 |     # error: [unsupported-operator]
-63 |     def foo(x: "int" | "None"): ...
-64 | 
-65 |     class Bar:
-66 |         # no error because this annotation is resolved inside a scope
-67 |         # fully defined inside an `if TYPE_CHECKING` block
-68 |         def f(x: "int" | "None"): ...
+55 | # error: [unsupported-operator]
+56 | X = list["int" | None]
+57 | 
+58 | if TYPE_CHECKING:
+59 |     # TODO: ideally we would not error here, since `if TYPE_CHECKING`
+60 |     # blocks are not executed at runtime. Requires
+61 |     # https://github.com/astral-sh/ty/issues/1553.
+62 |     bar: "int" | "None"  # error: [unsupported-operator]
+63 | 
+64 |     # TODO: same as above
+65 |     # error: [unsupported-operator]
+66 |     def foo(x: "int" | "None"): ...
+67 | 
+68 |     class Bar:
+69 |         # no error because this annotation is resolved inside a scope
+70 |         # fully defined inside an `if TYPE_CHECKING` block
+71 |         def f(x: "int" | "None"): ...
 ```
 
 # Diagnostics
@@ -194,8 +197,8 @@ error[unresolved-reference]: Name `SomethingUndefined` used when not defined
 35 |     # error: [unresolved-reference] "SomethingAlsoUndefined"
 36 |     i: SomethingUndefined | SomethingAlsoUndefined,
    |        ^^^^^^^^^^^^^^^^^^
-37 | ):
-38 |     reveal_type(a)  # revealed: int | Foo
+37 |     # error: [unsupported-operator]
+38 |     # error: [unsupported-operator]
    |
 info: rule `unresolved-reference` is enabled by default
 
@@ -209,8 +212,8 @@ error[unresolved-reference]: Name `SomethingAlsoUndefined` used when not defined
 35 |     # error: [unresolved-reference] "SomethingAlsoUndefined"
 36 |     i: SomethingUndefined | SomethingAlsoUndefined,
    |                             ^^^^^^^^^^^^^^^^^^^^^^
-37 | ):
-38 |     reveal_type(a)  # revealed: int | Foo
+37 |     # error: [unsupported-operator]
+38 |     # error: [unsupported-operator]
    |
 info: rule `unresolved-reference` is enabled by default
 
@@ -218,16 +221,58 @@ info: rule `unresolved-reference` is enabled by default
 
 ```
 error[unsupported-operator]: Unsupported `|` operation
-  --> src/mdtest_snippet.py:53:10
+  --> src/mdtest_snippet.py:39:8
    |
-52 | # error: [unsupported-operator]
-53 | X = list["int" | None]
+37 |     # error: [unsupported-operator]
+38 |     # error: [unsupported-operator]
+39 |     j: list["int" | None] | "bytes",
+   |        ------------------^^^-------
+   |        |                    |
+   |        |                    Has type `Literal["bytes"]`
+   |        Has type `<class 'list[int | None]'>`
+40 | ):
+41 |     reveal_type(a)  # revealed: int | Foo
+   |
+info: All type expressions are evaluated at runtime by default on Python <3.14
+info: Python 3.13 was assumed when inferring types because it was specified on the command line
+help: Put quotes around the whole union rather than just certain elements
+info: rule `unsupported-operator` is enabled by default
+
+```
+
+```
+error[unsupported-operator]: Unsupported `|` operation
+  --> src/mdtest_snippet.py:39:13
+   |
+37 |     # error: [unsupported-operator]
+38 |     # error: [unsupported-operator]
+39 |     j: list["int" | None] | "bytes",
+   |             -----^^^----
+   |             |       |
+   |             |       Has type `None`
+   |             Has type `Literal["int"]`
+40 | ):
+41 |     reveal_type(a)  # revealed: int | Foo
+   |
+info: All type expressions are evaluated at runtime by default on Python <3.14
+info: Python 3.13 was assumed when inferring types because it was specified on the command line
+help: Put quotes around the whole union rather than just certain elements
+info: rule `unsupported-operator` is enabled by default
+
+```
+
+```
+error[unsupported-operator]: Unsupported `|` operation
+  --> src/mdtest_snippet.py:56:10
+   |
+55 | # error: [unsupported-operator]
+56 | X = list["int" | None]
    |          -----^^^----
    |          |       |
    |          |       Has type `None`
    |          Has type `Literal["int"]`
-54 |
-55 | if TYPE_CHECKING:
+57 |
+58 | if TYPE_CHECKING:
    |
 info: All type expressions are evaluated at runtime by default on Python <3.14
 info: Python 3.13 was assumed when inferring types because it was specified on the command line
@@ -238,17 +283,17 @@ info: rule `unsupported-operator` is enabled by default
 
 ```
 error[unsupported-operator]: Unsupported `|` operation
-  --> src/mdtest_snippet.py:59:10
+  --> src/mdtest_snippet.py:62:10
    |
-57 |     # blocks are not executed at runtime. Requires
-58 |     # https://github.com/astral-sh/ty/issues/1553.
-59 |     bar: "int" | "None"  # error: [unsupported-operator]
+60 |     # blocks are not executed at runtime. Requires
+61 |     # https://github.com/astral-sh/ty/issues/1553.
+62 |     bar: "int" | "None"  # error: [unsupported-operator]
    |          -----^^^------
    |          |       |
    |          |       Has type `Literal["None"]`
    |          Has type `Literal["int"]`
-60 |
-61 |     # TODO: same as above
+63 |
+64 |     # TODO: same as above
    |
 info: All type expressions are evaluated at runtime by default on Python <3.14
 info: Python 3.13 was assumed when inferring types because it was specified on the command line
@@ -259,17 +304,17 @@ info: rule `unsupported-operator` is enabled by default
 
 ```
 error[unsupported-operator]: Unsupported `|` operation
-  --> src/mdtest_snippet.py:63:16
+  --> src/mdtest_snippet.py:66:16
    |
-61 |     # TODO: same as above
-62 |     # error: [unsupported-operator]
-63 |     def foo(x: "int" | "None"): ...
+64 |     # TODO: same as above
+65 |     # error: [unsupported-operator]
+66 |     def foo(x: "int" | "None"): ...
    |                -----^^^------
    |                |       |
    |                |       Has type `Literal["None"]`
    |                Has type `Literal["int"]`
-64 |
-65 |     class Bar:
+67 |
+68 |     class Bar:
    |
 info: All type expressions are evaluated at runtime by default on Python <3.14
 info: Python 3.13 was assumed when inferring types because it was specified on the command line

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -162,7 +162,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         {
                             let previous_state =
                                 self.set_multi_inference_state(MultiInferenceState::Ignore);
-                            self.context.set_multi_inference(true);
+                            let was_in_multi_inference = self.context.set_multi_inference(true);
                             // If the left-hand side of the union is itself a PEP-604 union,
                             // we'll already have checked whether it can be used with `|` in a previous inference step
                             // and emitted a diagnostic if it was appropriate. We should skip inferring it here to
@@ -173,7 +173,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             let right_type_value =
                                 self.infer_expression(&binary.right, TypeContext::default());
                             self.multi_inference_state = previous_state;
-                            self.context.set_multi_inference(false);
+                            self.context.set_multi_inference(was_in_multi_inference);
 
                             let dunder_fails = Type::try_call_bin_op(
                                 self.db(),
@@ -185,18 +185,27 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                             // As well as trying the normal dunder lookup,
                             // we also check for the case where one of the operands is a class-literal type
-                            // and the other is a string literal. The normal dunder lookup fails to catch
-                            // this error, since typeshed annotates `type.__(r)or__` as accepting `Any`.
-                            let should_emit_error = dunder_fails
-                                || matches!(
-                                    (left_type_value, right_type_value),
-                                    (
-                                        Type::ClassLiteral(class), Type::LiteralValue(literal))
-                                        | (Type::LiteralValue(literal), Type::ClassLiteral(class)
-                                    )
-                                    if class.metaclass(self.db()) == KnownClass::Type.to_class_literal(self.db())
-                                    && !literal.is_enum()
-                                );
+                            // or generic-alias type and the other is a string literal. The normal dunder lookup
+                            // fails to catch this error, since typeshed annotates `type.__(r)or__` as accepting `Any`.
+                            let should_emit_error = if dunder_fails {
+                                true
+                            } else {
+                                let literal = match (left_type_value, right_type_value) {
+                                    (Type::ClassLiteral(class), Type::LiteralValue(literal))
+                                    | (Type::LiteralValue(literal), Type::ClassLiteral(class))
+                                        if class.metaclass(self.db())
+                                            == KnownClass::Type.to_class_literal(self.db()) =>
+                                    {
+                                        Some(literal)
+                                    }
+                                    (Type::GenericAlias(_), Type::LiteralValue(literal))
+                                    | (Type::LiteralValue(literal), Type::GenericAlias(_)) => {
+                                        Some(literal)
+                                    }
+                                    _ => None,
+                                };
+                                literal.is_some_and(|literal| !literal.is_enum())
+                            };
 
                             if should_emit_error
                                 && let Some(builder) =


### PR DESCRIPTION
## Summary

Two small followups to d9daf6d430623a8a5dd25cb52a3b6f2af961b9cb:
- A minor fix for a bug I introduced in that commit. We should reset `context.multi_inference` to the state it was previously in rather than hardcoding `false` here. This has real-world impact on `altair` (see the mypy_primer report)
- Also detect invalid PEP-604 unions involving `types.GenericAlias` instances and objects that don't have `__or__` methods at runtime. These need to be special-cased in the same way as class-literal types, because of typeshed's very forgiving `types.GenericAlias.__or__` annotation: https://github.com/python/typeshed/blob/07ffb67b924d5f532f8b8b72a4902f58faae6aca/stdlib/types.pyi#L700-L702

## Test Plan

mdtests extended
