### PR TITLE
Retain `lazy` keyword when sorting imports

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/isort/lazy_force_sort_within_sections.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/lazy_force_sort_within_sections.py
@@ -1,0 +1,4 @@
+lazy from math import pi
+from math import pi
+lazy import os
+import os

--- a/crates/ruff_linter/resources/test/fixtures/isort/lazy_from_first.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/lazy_from_first.py
@@ -1,0 +1,4 @@
+lazy from math import pi
+from math import pi
+lazy import os
+import os

--- a/crates/ruff_linter/resources/test/fixtures/isort/lazy_imports.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/lazy_imports.py
@@ -1,0 +1,4 @@
+lazy from math import pi
+from math import pi
+lazy import os
+import os

--- a/crates/ruff_linter/src/rules/isort/annotate.rs
+++ b/crates/ruff_linter/src/rules/isort/annotate.rs
@@ -26,7 +26,7 @@ pub(crate) fn annotate_imports<'a>(
                 Stmt::Import(ast::StmtImport {
                     names,
                     range,
-                    is_lazy: _,
+                    is_lazy,
                     node_index: _,
                 }) => {
                     // Find comments above.
@@ -53,6 +53,7 @@ pub(crate) fn annotate_imports<'a>(
                             .map(|alias| AliasData {
                                 name: locator.slice(&alias.name),
                                 asname: alias.asname.as_ref().map(|asname| locator.slice(asname)),
+                                is_lazy: *is_lazy,
                             })
                             .collect(),
                         atop,
@@ -63,7 +64,7 @@ pub(crate) fn annotate_imports<'a>(
                     module,
                     names,
                     level,
-                    is_lazy: _,
+                    is_lazy,
                     range: _,
                     node_index: _,
                 }) => {
@@ -158,6 +159,7 @@ pub(crate) fn annotate_imports<'a>(
                         module: module.as_ref().map(|module| locator.slice(module)),
                         names: aliases,
                         level: *level,
+                        is_lazy: *is_lazy,
                         trailing_comma: if split_on_trailing_comma {
                             trailing_comma(import, tokens)
                         } else {

--- a/crates/ruff_linter/src/rules/isort/format.rs
+++ b/crates/ruff_linter/src/rules/isort/format.rs
@@ -22,6 +22,9 @@ pub(crate) fn format_import(
         output.push_str(comment);
         output.push_str(&stylist.line_ending());
     }
+    if alias.is_lazy {
+        output.push_str("lazy ");
+    }
     if let Some(asname) = alias.asname {
         output.push_str("import ");
         output.push_str(alias.name);
@@ -124,12 +127,16 @@ fn format_single_line(
     }
 
     let module_name = import_from.module_name();
+    if import_from.is_lazy {
+        output.push_str("lazy ");
+        line_width = line_width.add_width(5);
+    }
     output.push_str("from ");
     output.push_str(&module_name);
     output.push_str(" import ");
     line_width = line_width.add_width(5).add_str(&module_name).add_width(8);
 
-    for (index, (AliasData { name, asname }, _)) in aliases.iter().enumerate() {
+    for (index, (AliasData { name, asname, .. }, _)) in aliases.iter().enumerate() {
         if let Some(asname) = asname {
             output.push_str(name);
             output.push_str(" as ");
@@ -205,6 +212,9 @@ fn format_multi_line(
         output.push_str(&stylist.line_ending());
     }
 
+    if import_from.is_lazy {
+        output.push_str("lazy ");
+    }
     output.push_str("from ");
     output.push_str(&import_from.module_name());
     output.push_str(" import ");
@@ -216,7 +226,7 @@ fn format_multi_line(
     }
     output.push_str(&stylist.line_ending());
 
-    for (AliasData { name, asname }, comments) in aliases {
+    for (AliasData { name, asname, .. }, comments) in aliases {
         for comment in &comments.atop {
             output.push_str(stylist.indentation());
             output.push_str(comment);

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -56,6 +56,7 @@ pub(crate) enum AnnotatedImport<'a> {
         module: Option<&'a str>,
         names: Vec<AnnotatedAliasData<'a>>,
         level: u32,
+        is_lazy: bool,
         atop: Vec<Comment<'a>>,
         inline: Vec<Comment<'a>>,
         trailing: Vec<Comment<'a>>,
@@ -341,6 +342,7 @@ mod tests {
     #[test_case(Path::new("insert_empty_lines.py"))]
     #[test_case(Path::new("insert_empty_lines.pyi"))]
     #[test_case(Path::new("isort_skip_file.py"))]
+    #[test_case(Path::new("lazy_imports.py"))]
     #[test_case(Path::new("leading_prefix.py"))]
     #[test_case(Path::new("magic_trailing_comma.py"))]
     #[test_case(Path::new("match_case.py"))]
@@ -766,6 +768,7 @@ mod tests {
     }
 
     #[test_case(Path::new("force_sort_within_sections.py"))]
+    #[test_case(Path::new("lazy_force_sort_within_sections.py"))]
     #[test_case(Path::new("force_sort_within_sections_with_as_names.py"))]
     #[test_case(Path::new("force_sort_within_sections_future.py"))]
     fn force_sort_within_sections(path: &Path) -> Result<()> {
@@ -1064,6 +1067,7 @@ mod tests {
     }
 
     #[test_case(Path::new("from_first.py"))]
+    #[test_case(Path::new("lazy_from_first.py"))]
     fn from_first(path: &Path) -> Result<()> {
         let snapshot = format!("from_first_{}", path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/ruff_linter/src/rules/isort/normalize.rs
+++ b/crates/ruff_linter/src/rules/isort/normalize.rs
@@ -7,7 +7,7 @@ pub(crate) fn normalize_imports<'a>(
     settings: &Settings,
 ) -> ImportBlock<'a> {
     let mut block = ImportBlock::default();
-    for import in imports {
+    for (index, import) in imports.into_iter().enumerate() {
         match import {
             AnnotatedImport::Import {
                 names,
@@ -21,8 +21,10 @@ pub(crate) fn normalize_imports<'a>(
                         .entry(AliasData {
                             name: name.name,
                             asname: name.asname,
+                            is_lazy: name.is_lazy,
                         })
                         .or_default();
+                    comment_set.first_index.get_or_insert(index);
                     for comment in atop {
                         comment_set.atop.push(comment.value);
                     }
@@ -38,14 +40,18 @@ pub(crate) fn normalize_imports<'a>(
                         .entry(AliasData {
                             name: name.name,
                             asname: name.asname,
+                            is_lazy: name.is_lazy,
                         })
-                        .or_default();
+                        .or_default()
+                        .first_index
+                        .get_or_insert(index);
                 }
             }
             AnnotatedImport::ImportFrom {
                 module,
                 names,
                 level,
+                is_lazy,
                 atop,
                 inline,
                 trailing,
@@ -64,13 +70,19 @@ pub(crate) fn normalize_imports<'a>(
                         let import_from = block
                             .import_from_as
                             .entry((
-                                ImportFromData { module, level },
+                                ImportFromData {
+                                    module,
+                                    level,
+                                    is_lazy,
+                                },
                                 AliasData {
                                     name: alias.name,
                                     asname: alias.asname,
+                                    is_lazy: false,
                                 },
                             ))
                             .or_default();
+                        import_from.first_index.get_or_insert(index);
 
                         // Associate the comments above the import statement with the first alias
                         // (best effort).
@@ -93,25 +105,39 @@ pub(crate) fn normalize_imports<'a>(
                         let import_from = if alias.name == "*" {
                             block
                                 .import_from_star
-                                .entry(ImportFromData { module, level })
+                                .entry(ImportFromData {
+                                    module,
+                                    level,
+                                    is_lazy,
+                                })
                                 .or_default()
                         } else if alias.asname.is_none() || settings.combine_as_imports {
                             block
                                 .import_from
-                                .entry(ImportFromData { module, level })
+                                .entry(ImportFromData {
+                                    module,
+                                    level,
+                                    is_lazy,
+                                })
                                 .or_default()
                         } else {
                             block
                                 .import_from_as
                                 .entry((
-                                    ImportFromData { module, level },
+                                    ImportFromData {
+                                        module,
+                                        level,
+                                        is_lazy,
+                                    },
                                     AliasData {
                                         name: alias.name,
                                         asname: alias.asname,
+                                        is_lazy: false,
                                     },
                                 ))
                                 .or_default()
                         };
+                        import_from.first_index.get_or_insert(index);
 
                         for comment in atop {
                             import_from.comments.atop.push(comment.value);
@@ -130,33 +156,48 @@ pub(crate) fn normalize_imports<'a>(
                     let import_from = if alias.name == "*" {
                         block
                             .import_from_star
-                            .entry(ImportFromData { module, level })
+                            .entry(ImportFromData {
+                                module,
+                                level,
+                                is_lazy,
+                            })
                             .or_default()
                     } else if !isolate_aliases
                         && (alias.asname.is_none() || settings.combine_as_imports)
                     {
                         block
                             .import_from
-                            .entry(ImportFromData { module, level })
+                            .entry(ImportFromData {
+                                module,
+                                level,
+                                is_lazy,
+                            })
                             .or_default()
                     } else {
                         block
                             .import_from_as
                             .entry((
-                                ImportFromData { module, level },
+                                ImportFromData {
+                                    module,
+                                    level,
+                                    is_lazy,
+                                },
                                 AliasData {
                                     name: alias.name,
                                     asname: alias.asname,
+                                    is_lazy: false,
                                 },
                             ))
                             .or_default()
                     };
+                    import_from.first_index.get_or_insert(index);
 
                     let comment_set = import_from
                         .aliases
                         .entry(AliasData {
                             name: alias.name,
                             asname: alias.asname,
+                            is_lazy: false,
                         })
                         .or_default();
 

--- a/crates/ruff_linter/src/rules/isort/order.rs
+++ b/crates/ruff_linter/src/rules/isort/order.rs
@@ -34,6 +34,7 @@ pub(crate) fn order_imports<'a>(
                 |(
                     import_from,
                     ImportFromStatement {
+                        first_index,
                         comments,
                         aliases,
                         trailing_comma,
@@ -42,6 +43,7 @@ pub(crate) fn order_imports<'a>(
                     // Within each `Stmt::ImportFrom`, sort the members.
                     (
                         import_from,
+                        first_index.unwrap_or_default(),
                         comments,
                         trailing_comma,
                         aliases
@@ -55,89 +57,207 @@ pub(crate) fn order_imports<'a>(
             );
 
     if matches!(section, ImportSection::Known(ImportType::Future)) {
-        from_imports
-            .sorted_by_cached_key(|(import_from, _, _, aliases)| {
-                ModuleKey::from_module(
-                    import_from.module,
-                    None,
-                    import_from.level,
-                    aliases.first().map(|(alias, _)| (alias.name, alias.asname)),
-                    ImportStyle::From,
-                    settings,
+        let ordered_from_imports = from_imports
+            .sorted_by_cached_key(|(import_from, first_index, _, _, aliases)| {
+                (
+                    ModuleKey::from_module(
+                        import_from.module,
+                        None,
+                        import_from.level,
+                        aliases.first().map(|(alias, _)| (alias.name, alias.asname)),
+                        ImportStyle::From,
+                        settings,
+                    ),
+                    *first_index,
                 )
             })
-            .map(ImportFrom)
-            .chain(
-                straight_imports
-                    .sorted_by_cached_key(|(alias, _)| {
-                        ModuleKey::from_module(
-                            Some(alias.name),
-                            alias.asname,
-                            0,
-                            None,
-                            ImportStyle::Straight,
-                            settings,
-                        )
-                    })
-                    .map(Import),
-            )
+            .collect::<Vec<_>>();
+        let mut eager_from_imports = vec![];
+        let mut lazy_from_imports = vec![];
+        for import_from in ordered_from_imports {
+            if import_from.0.is_lazy {
+                lazy_from_imports.push(import_from);
+            } else {
+                eager_from_imports.push(import_from);
+            }
+        }
+
+        let ordered_straight_imports = straight_imports
+            .sorted_by_cached_key(|(alias, comments)| {
+                (
+                    ModuleKey::from_module(
+                        Some(alias.name),
+                        alias.asname,
+                        0,
+                        None,
+                        ImportStyle::Straight,
+                        settings,
+                    ),
+                    comments.first_index.unwrap_or_default(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut eager_straight_imports = vec![];
+        let mut lazy_straight_imports = vec![];
+        for import in ordered_straight_imports {
+            if import.0.is_lazy {
+                lazy_straight_imports.push(import);
+            } else {
+                eager_straight_imports.push(import);
+            }
+        }
+
+        eager_from_imports
+            .into_iter()
+            .map(|(import_from, _, comments, trailing_comma, aliases)| {
+                ImportFrom((import_from, comments, trailing_comma, aliases))
+            })
+            .chain(eager_straight_imports.into_iter().map(Import))
+            .chain(lazy_from_imports.into_iter().map(
+                |(import_from, _, comments, trailing_comma, aliases)| {
+                    ImportFrom((import_from, comments, trailing_comma, aliases))
+                },
+            ))
+            .chain(lazy_straight_imports.into_iter().map(Import))
             .collect()
     } else if settings.force_sort_within_sections {
-        straight_imports
-            .map(Import)
-            .chain(from_imports.map(ImportFrom))
-            .sorted_by_cached_key(|import| match import {
-                Import((alias, _)) => ModuleKey::from_module(
-                    Some(alias.name),
-                    alias.asname,
-                    0,
-                    None,
-                    ImportStyle::Straight,
-                    settings,
+        let ordered_imports = straight_imports
+            .map(|(alias, comments)| {
+                let first_index = comments.first_index.unwrap_or_default();
+                (Import((alias, comments)), first_index)
+            })
+            .chain(from_imports.map(
+                |(import_from, first_index, comments, trailing_comma, aliases)| {
+                    (
+                        ImportFrom((import_from, comments, trailing_comma, aliases)),
+                        first_index,
+                    )
+                },
+            ))
+            .sorted_by_cached_key(|(import, first_index)| match import {
+                Import((alias, _)) => (
+                    ModuleKey::from_module(
+                        Some(alias.name),
+                        alias.asname,
+                        0,
+                        None,
+                        ImportStyle::Straight,
+                        settings,
+                    ),
+                    *first_index,
                 ),
-                ImportFrom((import_from, _, _, aliases)) => ModuleKey::from_module(
-                    import_from.module,
-                    None,
-                    import_from.level,
-                    aliases.first().map(|(alias, _)| (alias.name, alias.asname)),
-                    ImportStyle::From,
-                    settings,
+                ImportFrom((import_from, _, _, aliases)) => (
+                    ModuleKey::from_module(
+                        import_from.module,
+                        None,
+                        import_from.level,
+                        aliases.first().map(|(alias, _)| (alias.name, alias.asname)),
+                        ImportStyle::From,
+                        settings,
+                    ),
+                    *first_index,
                 ),
             })
+            .collect::<Vec<_>>();
+
+        let mut eager_imports = vec![];
+        let mut lazy_imports = vec![];
+        for (import, first_index) in ordered_imports {
+            let is_lazy = match &import {
+                Import((alias, _)) => alias.is_lazy,
+                ImportFrom((import_from, _, _, _)) => import_from.is_lazy,
+            };
+            if is_lazy {
+                lazy_imports.push((import, first_index));
+            } else {
+                eager_imports.push((import, first_index));
+            }
+        }
+
+        eager_imports
+            .into_iter()
+            .chain(lazy_imports)
+            .map(|(import, _)| import)
             .collect()
     } else {
-        let ordered_straight_imports = straight_imports.sorted_by_cached_key(|(alias, _)| {
-            ModuleKey::from_module(
-                Some(alias.name),
-                alias.asname,
-                0,
-                None,
-                ImportStyle::Straight,
-                settings,
-            )
-        });
-        let ordered_from_imports =
-            from_imports.sorted_by_cached_key(|(import_from, _, _, aliases)| {
-                ModuleKey::from_module(
-                    import_from.module,
-                    None,
-                    import_from.level,
-                    aliases.first().map(|(alias, _)| (alias.name, alias.asname)),
-                    ImportStyle::From,
-                    settings,
+        let ordered_straight_imports = straight_imports
+            .sorted_by_cached_key(|(alias, comments)| {
+                (
+                    ModuleKey::from_module(
+                        Some(alias.name),
+                        alias.asname,
+                        0,
+                        None,
+                        ImportStyle::Straight,
+                        settings,
+                    ),
+                    comments.first_index.unwrap_or_default(),
                 )
-            });
+            })
+            .collect::<Vec<_>>();
+        let mut eager_straight_imports = vec![];
+        let mut lazy_straight_imports = vec![];
+        for import in ordered_straight_imports {
+            if import.0.is_lazy {
+                lazy_straight_imports.push(import);
+            } else {
+                eager_straight_imports.push(import);
+            }
+        }
+
+        let ordered_from_imports = from_imports
+            .sorted_by_cached_key(|(import_from, first_index, _, _, aliases)| {
+                (
+                    ModuleKey::from_module(
+                        import_from.module,
+                        None,
+                        import_from.level,
+                        aliases.first().map(|(alias, _)| (alias.name, alias.asname)),
+                        ImportStyle::From,
+                        settings,
+                    ),
+                    *first_index,
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut eager_from_imports = vec![];
+        let mut lazy_from_imports = vec![];
+        for import_from in ordered_from_imports {
+            if import_from.0.is_lazy {
+                lazy_from_imports.push(import_from);
+            } else {
+                eager_from_imports.push(import_from);
+            }
+        }
         if settings.from_first {
-            ordered_from_imports
+            eager_from_imports
                 .into_iter()
-                .map(ImportFrom)
-                .chain(ordered_straight_imports.into_iter().map(Import))
+                .map(|(import_from, _, comments, trailing_comma, aliases)| {
+                    ImportFrom((import_from, comments, trailing_comma, aliases))
+                })
+                .chain(eager_straight_imports.into_iter().map(Import))
+                .chain(lazy_from_imports.into_iter().map(
+                    |(import_from, _, comments, trailing_comma, aliases)| {
+                        ImportFrom((import_from, comments, trailing_comma, aliases))
+                    },
+                ))
+                .chain(lazy_straight_imports.into_iter().map(Import))
                 .collect()
         } else {
-            ordered_straight_imports
+            eager_straight_imports
                 .into_iter()
                 .map(Import)
-                .chain(ordered_from_imports.into_iter().map(ImportFrom))
+                .chain(eager_from_imports.into_iter().map(
+                    |(import_from, _, comments, trailing_comma, aliases)| {
+                        ImportFrom((import_from, comments, trailing_comma, aliases))
+                    },
+                ))
+                .chain(lazy_straight_imports.into_iter().map(Import))
+                .chain(lazy_from_imports.into_iter().map(
+                    |(import_from, _, comments, trailing_comma, aliases)| {
+                        ImportFrom((import_from, comments, trailing_comma, aliases))
+                    },
+                ))
                 .collect()
         }
     }

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__force_sort_within_sections_lazy_force_sort_within_sections.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__force_sort_within_sections_lazy_force_sort_within_sections.py.snap
@@ -1,0 +1,19 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+---
+I001 [*] Import block is un-sorted or un-formatted
+ --> lazy_force_sort_within_sections.py:1:1
+  |
+1 | / lazy from math import pi
+2 | | from math import pi
+3 | | lazy import os
+4 | | import os
+  | |_________^
+  |
+help: Organize imports
+1 + from math import pi
+2 + import os
+3 | lazy from math import pi
+  - from math import pi
+4 | lazy import os
+  - import os

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__from_first_lazy_from_first.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__from_first_lazy_from_first.py.snap
@@ -1,0 +1,21 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+---
+I001 [*] Import block is un-sorted or un-formatted
+ --> lazy_from_first.py:1:1
+  |
+1 | / lazy from math import pi
+2 | | from math import pi
+3 | | lazy import os
+4 | | import os
+  | |_________^
+  |
+help: Organize imports
+1 + from math import pi
+2 + 
+3 + import os
+4 | lazy from math import pi
+  - from math import pi
+5 + 
+6 | lazy import os
+  - import os

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__lazy_imports.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__lazy_imports.py.snap
@@ -1,0 +1,19 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+---
+I001 [*] Import block is un-sorted or un-formatted
+ --> lazy_imports.py:1:1
+  |
+1 | / lazy from math import pi
+2 | | from math import pi
+3 | | lazy import os
+4 | | import os
+  | |_________^
+  |
+help: Organize imports
+  - lazy from math import pi
+1 + import os
+2 | from math import pi
+3 | lazy import os
+  - import os
+4 + lazy from math import pi

--- a/crates/ruff_linter/src/rules/isort/types.rs
+++ b/crates/ruff_linter/src/rules/isort/types.rs
@@ -15,16 +15,19 @@ pub(crate) enum TrailingComma {
 pub(crate) struct ImportFromData<'a> {
     pub(crate) module: Option<&'a str>,
     pub(crate) level: u32,
+    pub(crate) is_lazy: bool,
 }
 
 #[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq)]
 pub(crate) struct AliasData<'a> {
     pub(crate) name: &'a str,
     pub(crate) asname: Option<&'a str>,
+    pub(crate) is_lazy: bool,
 }
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct ImportCommentSet<'a> {
+    pub(crate) first_index: Option<usize>,
     pub(crate) atop: Vec<Cow<'a, str>>,
     pub(crate) inline: Vec<Cow<'a, str>>,
 }
@@ -72,6 +75,7 @@ impl<'a> Importable<'a> for ImportFromData<'a> {
 
 #[derive(Debug, Default)]
 pub(crate) struct ImportFromStatement<'a> {
+    pub(crate) first_index: Option<usize>,
     pub(crate) comments: ImportFromCommentSet<'a>,
     pub(crate) aliases: FxHashMap<AliasData<'a>, ImportFromCommentSet<'a>>,
     pub(crate) trailing_comma: TrailingComma,


### PR DESCRIPTION
## Summary

For now, we keep our sections as-is, but within each section, we show all the eager imports followed by all the lazy imports, e.g.:

```python
import json
import os
import subprocess
from collections import defaultdict
from pathlib import Path
from typing import Final
lazy import ast
lazy import shutil
lazy from dataclasses import dataclass
```

We may change this behavior later; it shouldn't be considered stable.

See: https://github.com/astral-sh/ruff/issues/21305.
