### PR TITLE
Limit RUF036 to typing contexts; make it unsafe for non-typing-only

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF036.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF036.py
@@ -66,9 +66,13 @@ def func14(arg: None | int | str | bytes):
     ...
 
 
-# Preserve token boundaries when fixing non-annotation expressions.
-print(None | (int)and 2)
-print(2 or(None) | int)
+# Preserve token boundaries when fixing annotations.
+def func15(arg: None | (int)and 2):
+    ...
+
+
+def func16(arg: 2 or(None) | int):
+    ...
 
 
 # Ok

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -22,7 +22,7 @@ mod tests {
     use crate::rules::pydocstyle::settings::Settings as PydocstyleSettings;
     use crate::settings::LinterSettings;
     use crate::settings::types::{CompiledPerFileIgnoreList, PerFileIgnore, PreviewMode};
-    use crate::test::{test_path, test_resource_path};
+    use crate::test::{test_path, test_resource_path, test_snippet};
     use crate::{assert_diagnostics, assert_diagnostics_diff, settings};
 
     #[test_case(Rule::CollectionLiteralConcatenation, Path::new("RUF005.py"))]
@@ -226,6 +226,23 @@ mod tests {
         )?;
         assert_diagnostics!(diagnostics);
         Ok(())
+    }
+
+    #[test]
+    fn none_not_at_end_of_union_py313() {
+        let diagnostics = test_snippet(
+            r"
+            def func(arg: None | int):
+                ...
+
+            print(None | (int)and 2)
+            ",
+            &settings::LinterSettings {
+                unresolved_target_version: PythonVersion::PY313.into(),
+                ..settings::LinterSettings::for_rule(Rule::NoneNotAtEndOfUnion)
+            },
+        );
+        assert_diagnostics!("PY313_RUF036_runtime_evaluated", diagnostics);
     }
 
     #[test]

--- a/crates/ruff_linter/src/rules/ruff/rules/none_not_at_end_of_union.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/none_not_at_end_of_union.rs
@@ -91,6 +91,11 @@ fn is_union_expr(semantic: &SemanticModel, expr: &Expr) -> bool {
 /// RUF036
 pub(crate) fn none_not_at_end_of_union<'a>(checker: &Checker, union: &'a Expr) {
     let semantic = checker.semantic();
+
+    if !semantic.in_type_definition() {
+        return;
+    }
+
     let mut none_exprs: Vec<&Expr> = Vec::new();
     let mut other_exprs: Vec<&Expr> = Vec::new();
 
@@ -150,10 +155,12 @@ fn generate_fix(
     annotation: &Expr,
     is_pep604: bool,
 ) -> Option<Fix> {
-    let applicability = if checker.comment_ranges().intersects(annotation.range()) {
-        Applicability::Unsafe
-    } else {
+    let applicability = if checker.semantic().in_typing_only_annotation()
+        && !checker.comment_ranges().intersects(annotation.range())
+    {
         Applicability::Safe
+    } else {
+        Applicability::Unsafe
     };
 
     let reordered: Vec<Expr> = other_exprs

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__PY313_RUF036_runtime_evaluated.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__PY313_RUF036_runtime_evaluated.snap
@@ -1,0 +1,18 @@
+---
+source: crates/ruff_linter/src/rules/ruff/mod.rs
+---
+RUF036 [*] `None` not at the end of the type union.
+ --> <filename>:2:15
+  |
+2 | def func(arg: None | int):
+  |               ^^^^^^^^^^
+3 |     ...
+  |
+help: Move `None` to the end of the type union
+1 | 
+  - def func(arg: None | int):
+2 + def func(arg: int | None):
+3 |     ...
+4 | 
+5 | print(None | (int)and 2)
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF036_RUF036.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF036_RUF036.py.snap
@@ -241,37 +241,36 @@ help: Move `None` to the end of the type union
 68 | 
 
 RUF036 [*] `None` not at the end of the type union.
-  --> RUF036.py:70:7
+  --> RUF036.py:70:17
    |
-69 | # Preserve token boundaries when fixing non-annotation expressions.
-70 | print(None | (int)and 2)
-   |       ^^^^^^^^^^^^
-71 | print(2 or(None) | int)
+69 | # Preserve token boundaries when fixing annotations.
+70 | def func15(arg: None | (int)and 2):
+   |                 ^^^^^^^^^^^^
+71 |     ...
    |
 help: Move `None` to the end of the type union
 67 | 
 68 | 
-69 | # Preserve token boundaries when fixing non-annotation expressions.
-   - print(None | (int)and 2)
-70 + print(int | None and 2)
-71 | print(2 or(None) | int)
+69 | # Preserve token boundaries when fixing annotations.
+   - def func15(arg: None | (int)and 2):
+70 + def func15(arg: int | None and 2):
+71 |     ...
 72 | 
 73 | 
 
 RUF036 [*] `None` not at the end of the type union.
-  --> RUF036.py:71:11
+  --> RUF036.py:74:21
    |
-69 | # Preserve token boundaries when fixing non-annotation expressions.
-70 | print(None | (int)and 2)
-71 | print(2 or(None) | int)
-   |           ^^^^^^^^^^^^
+74 | def func16(arg: 2 or(None) | int):
+   |                     ^^^^^^^^^^^^
+75 |     ...
    |
 help: Move `None` to the end of the type union
-68 | 
-69 | # Preserve token boundaries when fixing non-annotation expressions.
-70 | print(None | (int)and 2)
-   - print(2 or(None) | int)
-71 + print(2 or int | None)
+71 |     ...
 72 | 
 73 | 
-74 | # Ok
+   - def func16(arg: 2 or(None) | int):
+74 + def func16(arg: 2 or int | None):
+75 |     ...
+76 | 
+77 |


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/23763.
