### PR TITLE
[ty] Treat enum attributes with type annotations as members

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -77,12 +77,12 @@ class Answer(Enum):
     YES = 1
     NO = 2
 
-    non_member_1: str = "some value"  # error: [invalid-enum-member-annotation]
+    annotated_member: str = "some value"  # error: [invalid-enum-member-annotation]
 
-# revealed: tuple[Literal["YES"], Literal["NO"], Literal["non_member_1"]]
+# revealed: tuple[Literal["YES"], Literal["NO"], Literal["annotated_member"]]
 reveal_type(enum_members(Answer))
-reveal_type(Answer.non_member_1)  # revealed: Literal[Answer.non_member_1]
-reveal_type(Answer.YES.non_member_1)  # revealed: Literal[Answer.non_member_1]
+reveal_type(Answer.annotated_member)  # revealed: Literal[Answer.annotated_member]
+reveal_type(Answer.YES.annotated_member)  # revealed: Literal[Answer.annotated_member]
 ```
 
 Enum members are allowed to be marked `Final` (without a type), even if unnecessary:
@@ -158,12 +158,9 @@ Pure declarations (annotations without values) are non-members and are fine:
 ```py
 class Pet6(Enum):
     CAT = 1
-    genus: str  # OK: no value, so this is a non-member declaration
     species: str  # OK: no value, so this is a non-member declaration
 
-reveal_type(Pet6.genus)  # revealed: str
 reveal_type(Pet6.species)  # revealed: str
-reveal_type(Pet6.CAT.genus)  # revealed: str
 reveal_type(Pet6.CAT.species)  # revealed: str
 ```
 
@@ -175,13 +172,11 @@ In stubs, these should still be treated as non-member attributes rather than enu
 from enum import Enum
 
 class Pet6Stub(Enum):
-    genus: str
     species: str
 
     CAT = ...
     DOG = ...
 
-reveal_type(Pet6Stub.genus)  # revealed: str
 reveal_type(Pet6Stub.species)  # revealed: str
 ```
 
@@ -235,6 +230,28 @@ class Pet9(Enum):
     A: int = 42  # OK: `A` is listed in `_ignore_`
     B: str = "hello"  # OK: `B` is listed in `_ignore_`
     C: int = 3  # error: [invalid-enum-member-annotation]
+```
+
+### Unreachable declarations do not change membership
+
+Statically unreachable declarations should be ignored when deciding whether a name is an enum
+member:
+
+```py
+from enum import Enum
+from ty_extensions import enum_members
+
+class Pet10(Enum):
+    if False:
+        CAT: int
+
+    CAT = 1
+    DOG = 2
+
+# revealed: tuple[Literal["CAT"], Literal["DOG"]]
+reveal_type(enum_members(Pet10))
+reveal_type(Pet10.CAT)  # revealed: Literal[Pet10.CAT]
+reveal_type(Pet10.DOG)  # revealed: Literal[Pet10.DOG]
 ```
 
 ### Declared `_value_` annotation

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -64,9 +64,10 @@ class ColorInt(IntEnum):
 reveal_type(enum_members(ColorInt))
 ```
 
-### Declared non-member attributes
+### Annotated assignments with values are still members
 
-Attributes on the enum class that are declared are not considered members of the enum:
+If an enum attribute has both an annotation and a value, it is still an enum member at runtime, even
+though the annotation is invalid:
 
 ```py
 from enum import Enum
@@ -76,12 +77,12 @@ class Answer(Enum):
     YES = 1
     NO = 2
 
-    non_member_1: int
-
     non_member_1: str = "some value"  # error: [invalid-enum-member-annotation]
 
-# revealed: tuple[Literal["YES"], Literal["NO"]]
+# revealed: tuple[Literal["YES"], Literal["NO"], Literal["non_member_1"]]
 reveal_type(enum_members(Answer))
+reveal_type(Answer.non_member_1)  # revealed: Literal[Answer.non_member_1]
+reveal_type(Answer.YES.non_member_1)  # revealed: Literal[Answer.non_member_1]
 ```
 
 Enum members are allowed to be marked `Final` (without a type), even if unnecessary:
@@ -157,12 +158,46 @@ Pure declarations (annotations without values) are non-members and are fine:
 ```py
 class Pet6(Enum):
     CAT = 1
+    genus: str  # OK: no value, so this is a non-member declaration
     species: str  # OK: no value, so this is a non-member declaration
+
+reveal_type(Pet6.genus)  # revealed: str
+reveal_type(Pet6.species)  # revealed: str
+reveal_type(Pet6.CAT.genus)  # revealed: str
+reveal_type(Pet6.CAT.species)  # revealed: str
 ```
+
+### Pure declarations in stubs
+
+In stubs, these should still be treated as non-member attributes rather than enum members:
+
+```pyi
+from enum import Enum
+
+class Pet6Stub(Enum):
+    genus: str
+    species: str
+
+    CAT = ...
+    DOG = ...
+
+reveal_type(Pet6Stub.genus)  # revealed: str
+reveal_type(Pet6Stub.species)  # revealed: str
+```
+
+### Callable values and subclasses
 
 Callable values are never enum members at runtime, so annotating them is fine:
 
+```toml
+[environment]
+python-version = "3.11"
+```
+
 ```py
+from enum import Enum, IntEnum, StrEnum
+from typing import Callable
+
 def identity(x: int) -> int:
     return x
 

--- a/crates/ty_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/ty_python_semantic/src/semantic_index/use_def.rs
@@ -862,6 +862,31 @@ pub(crate) struct DeclarationWithConstraint<'db> {
     pub(crate) reachability_constraint: ScopedReachabilityConstraintId,
 }
 
+impl<'db> DeclarationsIterator<'_, 'db> {
+    /// Returns `true` if `predicate` holds for every declaration whose
+    /// reachability constraint is not statically false.
+    pub(crate) fn all_reachable(
+        self,
+        db: &'db dyn crate::Db,
+        mut predicate: impl FnMut(DefinitionState<'db>) -> bool,
+    ) -> bool {
+        let predicates = self.predicates;
+        let reachability_constraints = self.reachability_constraints;
+
+        self.filter(
+            |DeclarationWithConstraint {
+                 reachability_constraint,
+                 ..
+             }| {
+                !reachability_constraints
+                    .evaluate(db, predicates, *reachability_constraint)
+                    .is_always_false()
+            },
+        )
+        .all(|DeclarationWithConstraint { declaration, .. }| predicate(declaration))
+    }
+}
+
 impl<'db> Iterator for DeclarationsIterator<'_, 'db> {
     type Item = DeclarationWithConstraint<'db>;
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -16,7 +16,7 @@ use crate::{
         place_from_bindings, place_from_declarations,
     },
     semantic_index::{
-        DeclarationWithConstraint, attribute_assignments, attribute_declarations, attribute_scopes,
+        attribute_assignments, attribute_declarations, attribute_scopes,
         definition::{Definition, DefinitionKind, DefinitionState, TargetKind},
         place_table,
         scope::{Scope, ScopeId},
@@ -1751,17 +1751,14 @@ impl<'db> StaticClassLiteral<'db> {
             // want to improve this, we could instead pass a definition-kind filter to the use-def map
             // query, or to the `symbol_from_declarations` call below. Doing so would potentially require
             // us to generate a union of `__init__` methods.
-            if !declarations
-                .clone()
-                .all(|DeclarationWithConstraint { declaration, .. }| {
-                    declaration.is_undefined_or(|declaration| {
-                        matches!(
-                            declaration.kind(db),
-                            DefinitionKind::AnnotatedAssignment(..)
-                        )
-                    })
+            if !declarations.clone().all_reachable(db, |declaration| {
+                declaration.is_undefined_or(|declaration| {
+                    matches!(
+                        declaration.kind(db),
+                        DefinitionKind::AnnotatedAssignment(..)
+                    )
                 })
-            {
+            }) {
                 continue;
             }
 

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1,16 +1,18 @@
+use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 
 use crate::{
     Db, FxIndexMap,
-    place::{
-        DefinedPlace, Place, PlaceAndQualifiers, place_from_bindings, place_from_declarations,
+    place::{DefinedPlace, Place, place_from_bindings, place_from_declarations},
+    semantic_index::{
+        DeclarationWithConstraint, definition::DefinitionKind, place_table, scope::ScopeId,
+        use_def_map,
     },
-    semantic_index::{place_table, scope::ScopeId, use_def_map},
     types::{
         ClassBase, ClassLiteral, DynamicType, EnumLiteralType, KnownClass, LiteralValueTypeKind,
-        MemberLookupPolicy, StaticClassLiteral, Type, TypeQualifiers, function::FunctionType,
+        MemberLookupPolicy, StaticClassLiteral, Type, function::FunctionType,
         set_theoretic::builder::UnionBuilder,
     },
 };
@@ -211,12 +213,15 @@ pub(crate) fn enum_metadata<'db>(
                 return None;
             }
 
-            if name == "_ignore_" || ignored_names.contains(name) {
+            if matches!(name.as_str(), "_ignore_" | "_value_" | "_name_")
+                || ignored_names.contains(name)
+            {
                 // Skip ignored attributes
                 return None;
             }
 
             let inferred = place_from_bindings(db, bindings).place;
+            let mut explicit_member_wrapper = false;
 
             let value_ty = match inferred {
                 Place::Undefined => {
@@ -233,12 +238,15 @@ pub(crate) fn enum_metadata<'db>(
                             Some(KnownClass::Nonmember) => return None,
 
                             // enum.member
-                            Some(KnownClass::Member) => Some(
-                                ty.member(db, "value")
-                                    .place
-                                    .ignore_possibly_undefined()
-                                    .unwrap_or(Type::unknown()),
-                            ),
+                            Some(KnownClass::Member) => {
+                                explicit_member_wrapper = true;
+                                Some(
+                                    ty.member(db, "value")
+                                        .place
+                                        .ignore_possibly_undefined()
+                                        .unwrap_or(Type::unknown()),
+                                )
+                            }
 
                             // enum.auto
                             Some(KnownClass::Auto) => {
@@ -342,38 +350,23 @@ pub(crate) fn enum_metadata<'db>(
             }
 
             let declarations = use_def_map.end_of_scope_symbol_declarations(symbol_id);
-            let declared =
-                place_from_declarations(db, declarations).ignore_conflicting_declarations();
 
-            match declared {
-                PlaceAndQualifiers {
-                    place:
-                        Place::Defined(DefinedPlace {
-                            ty: Type::Dynamic(DynamicType::Unknown),
-                            ..
-                        }),
-                    qualifiers,
-                } if qualifiers.contains(TypeQualifiers::FINAL) => {}
-                PlaceAndQualifiers {
-                    place: Place::Undefined,
-                    ..
-                } => {
-                    // Undeclared attributes are considered members
-                }
-                PlaceAndQualifiers {
-                    place:
-                        Place::Defined(DefinedPlace {
-                            ty: Type::NominalInstance(instance),
-                            ..
-                        }),
-                    ..
-                } if instance.has_known_class(db, KnownClass::Member) => {
-                    // If the attribute is specifically declared with `enum.member`, it is considered a member
-                }
-                _ => {
-                    // Declared attributes are considered non-members
-                    return None;
-                }
+            if !explicit_member_wrapper
+                && !declarations
+                    .clone()
+                    .all(|DeclarationWithConstraint { declaration, .. }| {
+                        declaration.is_undefined_or(|declaration| {
+                            matches!(
+                                declaration.kind(db),
+                                DefinitionKind::AnnotatedAssignment(assignment)
+                                    if assignment
+                                        .value(&parsed_module(db, declaration.file(db)).load(db))
+                                        .is_some()
+                            )
+                        })
+                    })
+            {
+                return None;
             }
 
             Some((name.clone(), value_ty))

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -6,10 +6,7 @@ use smallvec::SmallVec;
 use crate::{
     Db, FxIndexMap,
     place::{DefinedPlace, Place, place_from_bindings, place_from_declarations},
-    semantic_index::{
-        DeclarationWithConstraint, definition::DefinitionKind, place_table, scope::ScopeId,
-        use_def_map,
-    },
+    semantic_index::{definition::DefinitionKind, place_table, scope::ScopeId, use_def_map},
     types::{
         ClassBase, ClassLiteral, DynamicType, EnumLiteralType, KnownClass, LiteralValueTypeKind,
         MemberLookupPolicy, StaticClassLiteral, Type, function::FunctionType,
@@ -352,19 +349,17 @@ pub(crate) fn enum_metadata<'db>(
             let declarations = use_def_map.end_of_scope_symbol_declarations(symbol_id);
 
             if !explicit_member_wrapper
-                && !declarations
-                    .clone()
-                    .all(|DeclarationWithConstraint { declaration, .. }| {
-                        declaration.is_undefined_or(|declaration| {
-                            matches!(
-                                declaration.kind(db),
-                                DefinitionKind::AnnotatedAssignment(assignment)
-                                    if assignment
-                                        .value(&parsed_module(db, declaration.file(db)).load(db))
-                                        .is_some()
-                            )
-                        })
+                && !declarations.clone().all_reachable(db, |declaration| {
+                    declaration.is_undefined_or(|declaration| {
+                        matches!(
+                            declaration.kind(db),
+                            DefinitionKind::AnnotatedAssignment(assignment)
+                                if assignment
+                                    .value(&parsed_module(db, declaration.file(db)).load(db))
+                                    .is_some()
+                        )
                     })
+                })
             {
                 return None;
             }


### PR DESCRIPTION
## Summary

Something like `foo: int = 1` inside an enum should trigger `[invalid-enum-member-annotation]`, but should still be considered a member.

See: https://github.com/astral-sh/ruff/pull/23772.