### PR TITLE
Add a rule to enforce lazy imports

### DIFF
--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_extend_from_shared_config.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_extend_from_shared_config.snap
@@ -182,6 +182,7 @@ linter.flake8_self.ignore_names = [
 linter.flake8_tidy_imports.ban_relative_imports = "parents"
 linter.flake8_tidy_imports.banned_api = {}
 linter.flake8_tidy_imports.banned_module_level_imports = []
+linter.flake8_tidy_imports.banned_eager_imports = []
 linter.flake8_type_checking.strict = false
 linter.flake8_type_checking.exempt_modules = [
 	typing,

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool.snap
@@ -184,6 +184,7 @@ linter.flake8_self.ignore_names = [
 linter.flake8_tidy_imports.ban_relative_imports = "parents"
 linter.flake8_tidy_imports.banned_api = {}
 linter.flake8_tidy_imports.banned_module_level_imports = []
+linter.flake8_tidy_imports.banned_eager_imports = []
 linter.flake8_type_checking.strict = false
 linter.flake8_type_checking.exempt_modules = [
 	typing,

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_preview_enabled.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_preview_enabled.snap
@@ -191,6 +191,7 @@ linter.flake8_self.ignore_names = [
 linter.flake8_tidy_imports.ban_relative_imports = "parents"
 linter.flake8_tidy_imports.banned_api = {}
 linter.flake8_tidy_imports.banned_module_level_imports = []
+linter.flake8_tidy_imports.banned_eager_imports = []
 linter.flake8_type_checking.strict = false
 linter.flake8_type_checking.exempt_modules = [
 	typing,

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_target_version_override.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_target_version_override.snap
@@ -186,6 +186,7 @@ linter.flake8_self.ignore_names = [
 linter.flake8_tidy_imports.ban_relative_imports = "parents"
 linter.flake8_tidy_imports.banned_api = {}
 linter.flake8_tidy_imports.banned_module_level_imports = []
+linter.flake8_tidy_imports.banned_eager_imports = []
 linter.flake8_type_checking.strict = false
 linter.flake8_type_checking.exempt_modules = [
 	typing,

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above.snap
@@ -183,6 +183,7 @@ linter.flake8_self.ignore_names = [
 linter.flake8_tidy_imports.ban_relative_imports = "parents"
 linter.flake8_tidy_imports.banned_api = {}
 linter.flake8_tidy_imports.banned_module_level_imports = []
+linter.flake8_tidy_imports.banned_eager_imports = []
 linter.flake8_type_checking.strict = false
 linter.flake8_type_checking.exempt_modules = [
 	typing,

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above_with_tool.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above_with_tool.snap
@@ -184,6 +184,7 @@ linter.flake8_self.ignore_names = [
 linter.flake8_tidy_imports.ban_relative_imports = "parents"
 linter.flake8_tidy_imports.banned_api = {}
 linter.flake8_tidy_imports.banned_module_level_imports = []
+linter.flake8_tidy_imports.banned_eager_imports = []
 linter.flake8_type_checking.strict = false
 linter.flake8_type_checking.exempt_modules = [
 	typing,

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above-2.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above-2.snap
@@ -182,6 +182,7 @@ linter.flake8_self.ignore_names = [
 linter.flake8_tidy_imports.ban_relative_imports = "parents"
 linter.flake8_tidy_imports.banned_api = {}
 linter.flake8_tidy_imports.banned_module_level_imports = []
+linter.flake8_tidy_imports.banned_eager_imports = []
 linter.flake8_type_checking.strict = false
 linter.flake8_type_checking.exempt_modules = [
 	typing,

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above.snap
@@ -182,6 +182,7 @@ linter.flake8_self.ignore_names = [
 linter.flake8_tidy_imports.ban_relative_imports = "parents"
 linter.flake8_tidy_imports.banned_api = {}
 linter.flake8_tidy_imports.banned_module_level_imports = []
+linter.flake8_tidy_imports.banned_eager_imports = []
 linter.flake8_type_checking.strict = false
 linter.flake8_type_checking.exempt_modules = [
 	typing,

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_no_target_fallback.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_no_target_fallback.snap
@@ -182,6 +182,7 @@ linter.flake8_self.ignore_names = [
 linter.flake8_tidy_imports.ban_relative_imports = "parents"
 linter.flake8_tidy_imports.banned_api = {}
 linter.flake8_tidy_imports.banned_module_level_imports = []
+linter.flake8_tidy_imports.banned_eager_imports = []
 linter.flake8_type_checking.strict = false
 linter.flake8_type_checking.exempt_modules = [
 	typing,

--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -295,6 +295,7 @@ linter.flake8_self.ignore_names = [
 linter.flake8_tidy_imports.ban_relative_imports = "parents"
 linter.flake8_tidy_imports.banned_api = {}
 linter.flake8_tidy_imports.banned_module_level_imports = []
+linter.flake8_tidy_imports.banned_eager_imports = []
 linter.flake8_type_checking.strict = false
 linter.flake8_type_checking.exempt_modules = [
 	typing,

--- a/crates/ruff/tests/snapshots/show_settings__display_settings_from_nested_directory.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_settings_from_nested_directory.snap
@@ -303,6 +303,7 @@ linter.flake8_self.ignore_names = [
 linter.flake8_tidy_imports.ban_relative_imports = "parents"
 linter.flake8_tidy_imports.banned_api = {}
 linter.flake8_tidy_imports.banned_module_level_imports = []
+linter.flake8_tidy_imports.banned_eager_imports = []
 linter.flake8_type_checking.strict = false
 linter.flake8_type_checking.exempt_modules = [
 	typing,

--- a/crates/ruff_linter/resources/test/fixtures/flake8_tidy_imports/TID254.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_tidy_imports/TID254.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+import typing as t
+lazy import pathlib
+
+from foo import bar
+lazy from foo import baz
+from starry import *
+
+with manager():
+    import email
+
+if True:
+    from bar import qux
+
+try:
+    import collections
+except Exception:
+    pass
+
+def func():
+    import fractions
+
+class Example:
+    import decimal
+
+x = 1; import pkg.submodule

--- a/crates/ruff_linter/resources/test/fixtures/flake8_tidy_imports/TID254_py314.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_tidy_imports/TID254_py314.py
@@ -1,0 +1,2 @@
+import os
+from foo import bar

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -582,6 +582,9 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             if checker.is_rule_enabled(Rule::BannedModuleLevelImports) {
                 flake8_tidy_imports::rules::banned_module_level_imports(checker, stmt);
             }
+            if checker.is_rule_enabled(Rule::BannedEagerImports) {
+                flake8_tidy_imports::rules::banned_eager_imports(checker, stmt);
+            }
 
             for alias in names {
                 if checker.is_rule_enabled(Rule::NonAsciiImportName) {
@@ -785,6 +788,9 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             }
             if checker.is_rule_enabled(Rule::BannedModuleLevelImports) {
                 flake8_tidy_imports::rules::banned_module_level_imports(checker, stmt);
+            }
+            if checker.is_rule_enabled(Rule::BannedEagerImports) {
+                flake8_tidy_imports::rules::banned_eager_imports(checker, stmt);
             }
 
             if checker.is_rule_enabled(Rule::PytestIncorrectPytestImport) {

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -332,6 +332,29 @@ impl<'a> Checker<'a> {
         Generator::new(self.stylist.indentation(), self.stylist.line_ending())
     }
 
+    pub(crate) fn lazy_import_context(&self) -> Option<LazyImportContext> {
+        match self.semantic.current_scope().kind {
+            // Possible, but invalid positions.
+            ScopeKind::Function(_) => return Some(LazyImportContext::Function),
+            ScopeKind::Class(_) => return Some(LazyImportContext::Class),
+            // Valid position.
+            ScopeKind::Module => {}
+            // Impossible positions because lambdas and comprehensions can't contain statements.
+            ScopeKind::Lambda(_)
+            | ScopeKind::Generator { .. }
+            | ScopeKind::Type
+            | ScopeKind::DunderClassCell => {}
+        }
+
+        for statement in self.semantic.current_statements().skip(1) {
+            if matches!(statement, Stmt::Try(_)) {
+                return Some(LazyImportContext::TryExceptBlocks);
+            }
+        }
+
+        None
+    }
+
     /// Return the preferred quote for a generated `StringLiteral` node, given where we are in the
     /// AST.
     fn preferred_quote(&self) -> Quote {
@@ -803,26 +826,7 @@ impl SemanticSyntaxContext for Checker<'_> {
     }
 
     fn lazy_import_context(&self) -> Option<LazyImportContext> {
-        match self.semantic.current_scope().kind {
-            // Possible, but invalid positions.
-            ScopeKind::Function(_) => return Some(LazyImportContext::Function),
-            ScopeKind::Class(_) => return Some(LazyImportContext::Class),
-            // Valid position.
-            ScopeKind::Module => {}
-            // Impossible positions because lambdas and comprehensions can't contain statements.
-            ScopeKind::Lambda(_)
-            | ScopeKind::Generator { .. }
-            | ScopeKind::Type
-            | ScopeKind::DunderClassCell => {}
-        }
-
-        for statement in self.semantic.current_statements().skip(1) {
-            if matches!(statement, Stmt::Try(_)) {
-                return Some(LazyImportContext::TryExceptBlocks);
-            }
-        }
-
-        None
+        self.lazy_import_context()
     }
 
     fn in_async_context(&self) -> bool {

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -435,6 +435,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Flake8TidyImports, "251") => rules::flake8_tidy_imports::rules::BannedApi,
         (Flake8TidyImports, "252") => rules::flake8_tidy_imports::rules::RelativeImports,
         (Flake8TidyImports, "253") => rules::flake8_tidy_imports::rules::BannedModuleLevelImports,
+        (Flake8TidyImports, "254") => rules::flake8_tidy_imports::rules::BannedEagerImports,
 
         // flake8-return
         (Flake8Return, "501") => rules::flake8_return::rules::UnnecessaryReturnNone,

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/mod.rs
@@ -8,14 +8,19 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
+    use ruff_python_ast::PythonVersion;
+    use ruff_python_trivia::textwrap::dedent;
     use rustc_hash::FxHashMap;
 
     use crate::assert_diagnostics;
     use crate::registry::Rule;
     use crate::rules::flake8_tidy_imports;
-    use crate::rules::flake8_tidy_imports::settings::{ApiBan, Strictness};
+    use crate::rules::flake8_tidy_imports::settings::{
+        AllImports, ApiBan, BannedEagerImports, Strictness,
+    };
     use crate::settings::LinterSettings;
-    use crate::test::test_path;
+    use crate::source_kind::SourceKind;
+    use crate::test::{test_contents, test_path};
 
     #[test]
     fn banned_api() -> Result<()> {
@@ -142,5 +147,189 @@ mod tests {
         )?;
         assert_diagnostics!(diagnostics);
         Ok(())
+    }
+
+    #[test]
+    fn preview_banned_eager_imports() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("flake8_tidy_imports/TID254.py"),
+            &LinterSettings {
+                flake8_tidy_imports: flake8_tidy_imports::settings::Settings {
+                    banned_eager_imports: BannedEagerImports::Imports(vec![
+                        "typing".to_string(),
+                        "foo".to_string(),
+                        "email".to_string(),
+                        "bar".to_string(),
+                        "starry".to_string(),
+                        "collections".to_string(),
+                        "pkg".to_string(),
+                    ]),
+                    ..Default::default()
+                },
+                ..LinterSettings::for_rule(Rule::BannedEagerImports)
+                    .with_preview_mode()
+                    .with_target_version(PythonVersion::PY315)
+            },
+        )?;
+        assert_diagnostics!(diagnostics);
+        Ok(())
+    }
+
+    #[test]
+    fn preview_banned_eager_imports_all() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("flake8_tidy_imports/TID254.py"),
+            &LinterSettings {
+                flake8_tidy_imports: flake8_tidy_imports::settings::Settings {
+                    banned_eager_imports: BannedEagerImports::All(AllImports::All),
+                    ..Default::default()
+                },
+                ..LinterSettings::for_rule(Rule::BannedEagerImports)
+                    .with_preview_mode()
+                    .with_target_version(PythonVersion::PY315)
+            },
+        )?;
+        assert_diagnostics!(diagnostics);
+        Ok(())
+    }
+
+    #[test]
+    fn preview_banned_eager_imports_pre_py315() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("flake8_tidy_imports/TID254_py314.py"),
+            &LinterSettings {
+                flake8_tidy_imports: flake8_tidy_imports::settings::Settings {
+                    banned_eager_imports: BannedEagerImports::All(AllImports::All),
+                    ..Default::default()
+                },
+                ..LinterSettings::for_rule(Rule::BannedEagerImports)
+                    .with_preview_mode()
+                    .with_target_version(PythonVersion::PY314)
+            },
+        )?;
+        assert!(diagnostics.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn preview_banned_eager_imports_fix() {
+        let source = dedent(
+            r#"
+            from __future__ import annotations
+
+            import os
+
+            if True:
+                import email
+
+            with manager():
+                from foo import bar
+
+            try:
+                import collections
+            except Exception:
+                pass
+
+            from starry import *
+
+            def func():
+                import fractions
+
+            class Example:
+                import decimal
+            "#,
+        );
+        let expected = dedent(
+            r#"
+            from __future__ import annotations
+
+            lazy import os
+
+            if True:
+                lazy import email
+
+            with manager():
+                lazy from foo import bar
+
+            try:
+                import collections
+            except Exception:
+                pass
+
+            from starry import *
+
+            def func():
+                import fractions
+
+            class Example:
+                import decimal
+            "#,
+        );
+
+        let source_kind = SourceKind::Python {
+            code: source.to_string(),
+            is_stub: false,
+        };
+
+        let (diagnostics, fixed) = test_contents(
+            &source_kind,
+            Path::new("flake8_tidy_imports/TID254_fix.py"),
+            &LinterSettings {
+                flake8_tidy_imports: flake8_tidy_imports::settings::Settings {
+                    banned_eager_imports: BannedEagerImports::All(AllImports::All),
+                    ..Default::default()
+                },
+                ..LinterSettings::for_rule(Rule::BannedEagerImports)
+                    .with_preview_mode()
+                    .with_target_version(PythonVersion::PY315)
+            },
+        );
+
+        assert_eq!(diagnostics.len(), 3);
+        assert_eq!(fixed.source_code(), expected);
+    }
+
+    #[test]
+    fn preview_banned_eager_imports_dotted_module() {
+        let source = dedent(
+            r#"
+            import foo
+            import foo.bar
+
+            from foo import bar
+            from foo import baz
+            "#,
+        );
+        let expected = dedent(
+            r#"
+            import foo
+            lazy import foo.bar
+
+            lazy from foo import bar
+            from foo import baz
+            "#,
+        );
+
+        let source_kind = SourceKind::Python {
+            code: source.to_string(),
+            is_stub: false,
+        };
+
+        let (diagnostics, fixed) = test_contents(
+            &source_kind,
+            Path::new("flake8_tidy_imports/TID254_dotted.py"),
+            &LinterSettings {
+                flake8_tidy_imports: flake8_tidy_imports::settings::Settings {
+                    banned_eager_imports: BannedEagerImports::Imports(vec!["foo.bar".to_string()]),
+                    ..Default::default()
+                },
+                ..LinterSettings::for_rule(Rule::BannedEagerImports)
+                    .with_preview_mode()
+                    .with_target_version(PythonVersion::PY315)
+            },
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(fixed.source_code(), expected);
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/banned_eager_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/banned_eager_imports.rs
@@ -1,0 +1,134 @@
+use ruff_macros::{ViolationMetadata, derive_message_formats};
+use ruff_python_ast::{PythonVersion, Stmt, StmtImport, StmtImportFrom};
+use ruff_text_size::Ranged;
+
+use crate::checkers::ast::Checker;
+use crate::rules::flake8_tidy_imports::rules::BannedModuleImportPolicies;
+use crate::rules::flake8_tidy_imports::settings::{
+    AllImports, BannedEagerImports as BannedEagerImportsSetting,
+};
+use crate::{Edit, Fix, FixAvailability, Violation};
+
+/// ## What it does
+/// Checks for eager imports in contexts where `lazy import` is legal.
+///
+/// ## Why is this bad?
+/// Python 3.15 adds support for `lazy import` and `lazy from ... import ...`,
+/// which defer the actual import work until the imported name is first used.
+///
+/// When a module should be loaded lazily, using an eager import defeats that
+/// intent by importing it immediately instead.
+///
+/// This rule ignores contexts in which `lazy import` is invalid, such as
+/// functions, classes, `try`/`except` blocks, `__future__` imports, and
+/// `from ... import *` statements.
+///
+/// ## Example
+/// ```python
+/// import typing
+/// ```
+///
+/// Use instead:
+/// ```python
+/// lazy import typing
+/// ```
+///
+/// ## Options
+/// - `lint.flake8-tidy-imports.banned-eager-imports`
+#[derive(ViolationMetadata)]
+#[violation_metadata(preview_since = "NEXT_RUFF_VERSION")]
+pub(crate) struct BannedEagerImports {
+    name: Option<String>,
+}
+
+impl Violation for BannedEagerImports {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let BannedEagerImports { name } = self;
+        match name {
+            Some(name) => format!("`{name}` should be imported lazily"),
+            None => "Use a `lazy` import instead of an eager import".to_string(),
+        }
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Convert to a lazy import".to_string())
+    }
+}
+
+/// TID254
+pub(crate) fn banned_eager_imports(checker: &Checker, stmt: &Stmt) {
+    if !is_convertible_to_lazy_import(checker, stmt) {
+        return;
+    }
+
+    match &checker.settings().flake8_tidy_imports.banned_eager_imports {
+        BannedEagerImportsSetting::All(AllImports::All) => report_all_banned_imports(checker, stmt),
+        BannedEagerImportsSetting::Imports(imports) => {
+            if imports.is_empty() {
+                return;
+            }
+
+            for (policy, node) in &BannedModuleImportPolicies::new(stmt, checker) {
+                if let Some(banned_import) = policy.find(imports.iter().map(String::as_str)) {
+                    report_banned_eager_import(checker, stmt, node.range(), Some(banned_import));
+                }
+            }
+        }
+    }
+}
+
+fn is_convertible_to_lazy_import(checker: &Checker, stmt: &Stmt) -> bool {
+    if checker.target_version() < PythonVersion::PY315 || checker.lazy_import_context().is_some() {
+        return false;
+    }
+
+    match stmt {
+        Stmt::Import(StmtImport { is_lazy, .. }) => !*is_lazy,
+        Stmt::ImportFrom(StmtImportFrom {
+            module,
+            names,
+            is_lazy,
+            ..
+        }) => {
+            !*is_lazy
+                && !matches!(module.as_deref(), Some("__future__"))
+                && !names.iter().any(|alias| alias.name.as_str() == "*")
+        }
+        _ => false,
+    }
+}
+
+fn report_all_banned_imports(checker: &Checker, stmt: &Stmt) {
+    match stmt {
+        Stmt::Import(_) => {
+            for (_, node) in &BannedModuleImportPolicies::new(stmt, checker) {
+                report_banned_eager_import(checker, stmt, node.range(), None);
+            }
+        }
+        Stmt::ImportFrom(_) => {
+            for (_, node) in &BannedModuleImportPolicies::new(stmt, checker) {
+                if !node.is_alias() {
+                    report_banned_eager_import(checker, stmt, node.range(), None);
+                    break;
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn report_banned_eager_import(
+    checker: &Checker,
+    stmt: &Stmt,
+    range: ruff_text_size::TextRange,
+    name: Option<String>,
+) {
+    let mut diagnostic = checker.report_diagnostic(BannedEagerImports { name }, range);
+    diagnostic.set_fix(Fix::unsafe_edit(Edit::insertion(
+        "lazy ".to_string(),
+        stmt.start(),
+    )));
+}

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/mod.rs
@@ -1,7 +1,9 @@
 pub(crate) use banned_api::*;
+pub(crate) use banned_eager_imports::*;
 pub(crate) use banned_module_level_imports::*;
 pub(crate) use relative_imports::*;
 
 mod banned_api;
+mod banned_eager_imports;
 mod banned_module_level_imports;
 mod relative_imports;

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/settings.rs
@@ -39,11 +39,60 @@ impl Display for Strictness {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, CacheKey)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum AllImports {
+    All,
+}
+
+impl Display for AllImports {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::All => write!(f, "\"all\""),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, CacheKey)]
+#[serde(untagged)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum BannedEagerImports {
+    All(AllImports),
+    Imports(Vec<String>),
+}
+
+impl Default for BannedEagerImports {
+    fn default() -> Self {
+        Self::Imports(Vec::new())
+    }
+}
+
+impl Display for BannedEagerImports {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::All(all) => write!(f, "{all}"),
+            Self::Imports(imports) => {
+                if imports.is_empty() {
+                    write!(f, "[]")
+                } else {
+                    writeln!(f, "[")?;
+                    for import in imports {
+                        writeln!(f, "\t{import},")?;
+                    }
+                    write!(f, "]")
+                }
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, CacheKey, Default)]
 pub struct Settings {
     pub ban_relative_imports: Strictness,
     pub banned_api: FxHashMap<String, ApiBan>,
     pub banned_module_level_imports: Vec<String>,
+    pub banned_eager_imports: BannedEagerImports,
 }
 
 impl Settings {
@@ -61,6 +110,7 @@ impl Display for Settings {
                 self.ban_relative_imports,
                 self.banned_api | map,
                 self.banned_module_level_imports | array,
+                self.banned_eager_imports,
             ]
         }
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/snapshots/ruff_linter__rules__flake8_tidy_imports__tests__preview_banned_eager_imports.snap
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/snapshots/ruff_linter__rules__flake8_tidy_imports__tests__preview_banned_eager_imports.snap
@@ -1,0 +1,98 @@
+---
+source: crates/ruff_linter/src/rules/flake8_tidy_imports/mod.rs
+---
+TID254 [*] `typing` should be imported lazily
+ --> TID254.py:4:8
+  |
+3 | import os
+4 | import typing as t
+  |        ^^^^^^^^^^^
+5 | lazy import pathlib
+  |
+help: Convert to a lazy import
+1 | from __future__ import annotations
+2 | 
+3 | import os
+  - import typing as t
+4 + lazy import typing as t
+5 | lazy import pathlib
+6 | 
+7 | from foo import bar
+note: This is an unsafe fix and may change runtime behavior
+
+TID254 [*] `foo` should be imported lazily
+ --> TID254.py:7:1
+  |
+5 | lazy import pathlib
+6 |
+7 | from foo import bar
+  | ^^^^^^^^^^^^^^^^^^^
+8 | lazy from foo import baz
+9 | from starry import *
+  |
+help: Convert to a lazy import
+4  | import typing as t
+5  | lazy import pathlib
+6  | 
+   - from foo import bar
+7  + lazy from foo import bar
+8  | lazy from foo import baz
+9  | from starry import *
+10 | 
+note: This is an unsafe fix and may change runtime behavior
+
+TID254 [*] `email` should be imported lazily
+  --> TID254.py:12:12
+   |
+11 | with manager():
+12 |     import email
+   |            ^^^^^
+13 |
+14 | if True:
+   |
+help: Convert to a lazy import
+9  | from starry import *
+10 | 
+11 | with manager():
+   -     import email
+12 +     lazy import email
+13 | 
+14 | if True:
+15 |     from bar import qux
+note: This is an unsafe fix and may change runtime behavior
+
+TID254 [*] `bar` should be imported lazily
+  --> TID254.py:15:5
+   |
+14 | if True:
+15 |     from bar import qux
+   |     ^^^^^^^^^^^^^^^^^^^
+16 |
+17 | try:
+   |
+help: Convert to a lazy import
+12 |     import email
+13 | 
+14 | if True:
+   -     from bar import qux
+15 +     lazy from bar import qux
+16 | 
+17 | try:
+18 |     import collections
+note: This is an unsafe fix and may change runtime behavior
+
+TID254 [*] `pkg` should be imported lazily
+  --> TID254.py:28:15
+   |
+26 |     import decimal
+27 |
+28 | x = 1; import pkg.submodule
+   |               ^^^^^^^^^^^^^
+   |
+help: Convert to a lazy import
+25 | class Example:
+26 |     import decimal
+27 | 
+   - x = 1; import pkg.submodule
+28 + x = 1; lazy import pkg.submodule
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/snapshots/ruff_linter__rules__flake8_tidy_imports__tests__preview_banned_eager_imports_all.snap
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/snapshots/ruff_linter__rules__flake8_tidy_imports__tests__preview_banned_eager_imports_all.snap
@@ -1,0 +1,118 @@
+---
+source: crates/ruff_linter/src/rules/flake8_tidy_imports/mod.rs
+---
+TID254 [*] Use a `lazy` import instead of an eager import
+ --> TID254.py:3:8
+  |
+1 | from __future__ import annotations
+2 |
+3 | import os
+  |        ^^
+4 | import typing as t
+5 | lazy import pathlib
+  |
+help: Convert to a lazy import
+1 | from __future__ import annotations
+2 | 
+  - import os
+3 + lazy import os
+4 | import typing as t
+5 | lazy import pathlib
+6 | 
+note: This is an unsafe fix and may change runtime behavior
+
+TID254 [*] Use a `lazy` import instead of an eager import
+ --> TID254.py:4:8
+  |
+3 | import os
+4 | import typing as t
+  |        ^^^^^^^^^^^
+5 | lazy import pathlib
+  |
+help: Convert to a lazy import
+1 | from __future__ import annotations
+2 | 
+3 | import os
+  - import typing as t
+4 + lazy import typing as t
+5 | lazy import pathlib
+6 | 
+7 | from foo import bar
+note: This is an unsafe fix and may change runtime behavior
+
+TID254 [*] Use a `lazy` import instead of an eager import
+ --> TID254.py:7:1
+  |
+5 | lazy import pathlib
+6 |
+7 | from foo import bar
+  | ^^^^^^^^^^^^^^^^^^^
+8 | lazy from foo import baz
+9 | from starry import *
+  |
+help: Convert to a lazy import
+4  | import typing as t
+5  | lazy import pathlib
+6  | 
+   - from foo import bar
+7  + lazy from foo import bar
+8  | lazy from foo import baz
+9  | from starry import *
+10 | 
+note: This is an unsafe fix and may change runtime behavior
+
+TID254 [*] Use a `lazy` import instead of an eager import
+  --> TID254.py:12:12
+   |
+11 | with manager():
+12 |     import email
+   |            ^^^^^
+13 |
+14 | if True:
+   |
+help: Convert to a lazy import
+9  | from starry import *
+10 | 
+11 | with manager():
+   -     import email
+12 +     lazy import email
+13 | 
+14 | if True:
+15 |     from bar import qux
+note: This is an unsafe fix and may change runtime behavior
+
+TID254 [*] Use a `lazy` import instead of an eager import
+  --> TID254.py:15:5
+   |
+14 | if True:
+15 |     from bar import qux
+   |     ^^^^^^^^^^^^^^^^^^^
+16 |
+17 | try:
+   |
+help: Convert to a lazy import
+12 |     import email
+13 | 
+14 | if True:
+   -     from bar import qux
+15 +     lazy from bar import qux
+16 | 
+17 | try:
+18 |     import collections
+note: This is an unsafe fix and may change runtime behavior
+
+TID254 [*] Use a `lazy` import instead of an eager import
+  --> TID254.py:28:15
+   |
+26 |     import decimal
+27 |
+28 | x = 1; import pkg.submodule
+   |               ^^^^^^^^^^^^^
+   |
+help: Convert to a lazy import
+25 | class Example:
+26 |     import decimal
+27 | 
+   - x = 1; import pkg.submodule
+28 + x = 1; lazy import pkg.submodule
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -19,7 +19,7 @@ use ruff_linter::rules::flake8_import_conventions::settings::BannedAliases;
 use ruff_linter::rules::flake8_pytest_style::settings::SettingsError;
 use ruff_linter::rules::flake8_pytest_style::types;
 use ruff_linter::rules::flake8_quotes::settings::Quote;
-use ruff_linter::rules::flake8_tidy_imports::settings::{ApiBan, Strictness};
+use ruff_linter::rules::flake8_tidy_imports::settings::{ApiBan, BannedEagerImports, Strictness};
 use ruff_linter::rules::isort::settings::RelativeImportsOrder;
 use ruff_linter::rules::isort::{ImportSection, ImportType};
 use ruff_linter::rules::pep8_naming::settings::IgnoreNames;
@@ -2081,6 +2081,24 @@ pub struct Flake8TidyImportsOptions {
         "#
     )]
     pub banned_module_level_imports: Option<Vec<String>>,
+
+    /// Specific modules that may not be imported eagerly in contexts where lazy imports are legal,
+    /// or `"all"` to require every lazily-convertible import to use the `lazy` keyword. Ruff
+    /// ignores contexts where `lazy import` is invalid, such as functions, classes,
+    /// `try`/`except` blocks, `__future__` imports, and `from ... import *` statements. This rule
+    /// is only enforced when targeting Python 3.15 or newer.
+    #[option(
+        default = r#"[]"#,
+        value_type = r#""all" | list[str]"#,
+        example = r#"
+            # Require lazy imports for specific modules.
+            banned-eager-imports = ["typing", "foo"]
+
+            # Require every module-level import to be lazy.
+            banned-eager-imports = "all"
+        "#
+    )]
+    pub banned_eager_imports: Option<BannedEagerImports>,
 }
 
 impl Flake8TidyImportsOptions {
@@ -2089,6 +2107,7 @@ impl Flake8TidyImportsOptions {
             ban_relative_imports: self.ban_relative_imports.unwrap_or(Strictness::Parents),
             banned_api: self.banned_api.unwrap_or_default(),
             banned_module_level_imports: self.banned_module_level_imports.unwrap_or_default(),
+            banned_eager_imports: self.banned_eager_imports.unwrap_or_default(),
         }
     }
 }

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -768,6 +768,12 @@
     "Alias": {
       "type": "string"
     },
+    "AllImports": {
+      "type": "string",
+      "enum": [
+        "all"
+      ]
+    },
     "AnalyzeOptions": {
       "description": "Configures Ruff's `analyze` command.",
       "type": "object",
@@ -857,6 +863,19 @@
       "items": {
         "type": "string"
       }
+    },
+    "BannedEagerImports": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/AllImports"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
     },
     "ConstantType": {
       "type": "string",
@@ -1452,6 +1471,17 @@
           "additionalProperties": {
             "$ref": "#/definitions/ApiBan"
           }
+        },
+        "banned-eager-imports": {
+          "description": "Specific modules that may not be imported eagerly in contexts where lazy imports are legal,\nor `\"all\"` to require every lazily-convertible import to use the `lazy` keyword. Ruff\nignores contexts where `lazy import` is invalid, such as functions, classes,\n`try`/`except` blocks, `__future__` imports, and `from ... import *` statements. This rule\nis only enforced when targeting Python 3.15 or newer.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BannedEagerImports"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "banned-module-level-imports": {
           "description": "List of specific modules that may not be imported at module level, and should instead be\nimported lazily (e.g., within a function definition, or an `if TYPE_CHECKING:`\nblock, or some other nested context). This also affects the rule `import-outside-top-level`\nif `banned-module-level-imports` is enabled.",
@@ -4336,6 +4366,7 @@
         "TID251",
         "TID252",
         "TID253",
+        "TID254",
         "TRY",
         "TRY0",
         "TRY00",

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -111,6 +111,7 @@ KNOWN_FORMATTING_VIOLATIONS = [
 
 # For some docs, Ruff is unable to parse the example code.
 KNOWN_PARSE_ERRORS = [
+    "banned-eager-imports",  # requires Python 3.15
     "blank-line-with-whitespace",
     "indented-form-feed",
     "missing-newline-at-end-of-file",


### PR DESCRIPTION
## Summary

`TID254` enforces the use of `lazy` imports. You can specify a set of modules, similar to `banned-module-level-imports`, or `"all"`:

```toml
# Require every module-level import to be lazy.
banned-eager-imports = "all"

# Require lazy imports for specific modules.
banned-eager-imports = [
    "boto3",
    "botocore",
]
```
