### PR TITLE
[ty] treat bivariance as covariant

### DIFF
--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -3195,11 +3195,11 @@ def function():
         );
 
         // TODO: Should this be constravariant instead?
-        assert_snapshot!(test.hover(), @"
-        P@Alias (bivariant)
+        assert_snapshot!(test.hover(), @r###"
+        P@Alias (covariant)
         ---------------------------------------------
         ```python
-        P@Alias (bivariant)
+        P@Alias (covariant)
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -3210,7 +3210,7 @@ def function():
           |                                         |
           |                                         source
           |
-        ");
+        "###);
     }
 
     #[test]

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -413,6 +413,7 @@ class GenericShape[T]:
     @classmethod
     def baz[U](cls, u: U) -> "GenericShape[U]":
         reveal_type(cls)  # revealed: type[Self@baz]
+        # error: [invalid-return-type]
         return cls()
 
 class GenericCircle[T](GenericShape[T]): ...
@@ -1076,7 +1077,7 @@ class ExplicitGeneric[T]:
 
 ExplicitGeneric[int]().special()
 
-# TODO: this should be an `invalid-argument-type` error
+# error: [invalid-argument-type] "Argument to bound method `special` is incorrect: Expected `ExplicitGeneric[int]`, found `ExplicitGeneric[str]`"
 ExplicitGeneric[str]().special()
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -280,17 +280,12 @@ If the type of a constructor parameter is a class typevar, we can use that to in
 parameter. The types inferred from a type context and from a constructor parameter must be
 consistent with each other.
 
-We have to add `x: T` to the classes to ensure they're not bivariant in `T` (__new__ and __init__
-signatures don't count towards variance).
-
 ### `__new__` only
 
 ```py
 from ty_extensions import generic_context, into_regular_callable
 
 class C[T]:
-    x: T
-
     def __new__(cls, x: T) -> "C[T]":
         return object.__new__(cls)
 
@@ -299,9 +294,9 @@ reveal_type(generic_context(C))
 # revealed: ty_extensions.GenericContext[T@C]
 reveal_type(generic_context(into_regular_callable(C)))
 
-reveal_type(C(1))  # revealed: C[int]
+reveal_type(C(1))  # revealed: C[Literal[1]]
 
-# error: [invalid-assignment] "Object of type `C[str]` is not assignable to `C[int]`"
+# error: [invalid-assignment] "Object of type `C[Literal["five"]]` is not assignable to `C[int]`"
 wrong_innards: C[int] = C("five")
 ```
 
@@ -311,8 +306,6 @@ wrong_innards: C[int] = C("five")
 from ty_extensions import generic_context, into_regular_callable
 
 class C[T]:
-    x: T
-
     def __init__(self, x: T) -> None: ...
 
 # revealed: ty_extensions.GenericContext[T@C]
@@ -320,9 +313,9 @@ reveal_type(generic_context(C))
 # revealed: ty_extensions.GenericContext[T@C]
 reveal_type(generic_context(into_regular_callable(C)))
 
-reveal_type(C(1))  # revealed: C[int]
+reveal_type(C(1))  # revealed: C[Literal[1]]
 
-# error: [invalid-assignment] "Object of type `C[str]` is not assignable to `C[int]`"
+# error: [invalid-assignment] "Object of type `C[Literal["five"]]` is not assignable to `C[int]`"
 wrong_innards: C[int] = C("five")
 ```
 
@@ -520,10 +513,6 @@ from typing import overload
 from ty_extensions import generic_context, into_regular_callable
 
 class C[T]:
-    # we need to use the type variable or else the class is bivariant in T, and
-    # specializations become meaningless
-    x: T
-
     @overload
     def __init__(self: C[str], x: str) -> None: ...
     @overload
@@ -560,10 +549,6 @@ C[None](b"bytes")  # error: [no-matching-overload]
 C[None](12)
 
 class D[T, U]:
-    # we need to use the type variable or else the class is bivariant in T, and
-    # specializations become meaningless
-    x: T
-
     @overload
     def __init__(self: "D[str, U]", u: U) -> None: ...
     @overload
@@ -577,7 +562,7 @@ reveal_type(generic_context(into_regular_callable(D)))
 
 reveal_type(D("string"))  # revealed: D[str, Literal["string"]]
 reveal_type(D(1))  # revealed: D[str, Literal[1]]
-reveal_type(D(1, "string"))  # revealed: D[int, Literal["string"]]
+reveal_type(D(1, "string"))  # revealed: D[Literal[1], Literal["string"]]
 ```
 
 ### Synthesized methods with dataclasses

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
@@ -7,8 +7,11 @@ python-version = "3.12"
 
 Type variables have a property called _variance_ that affects the subtyping and assignability
 relations. Much more detail can be found in the [spec]. To summarize, each typevar is either
-**covariant**, **contravariant**, **invariant**, or **bivariant**. (Note that bivariance is not
-currently mentioned in the typing spec, but is a fourth case that we must consider.)
+**covariant**, **contravariant**, or **invariant**. Our inference lattice also has an internal
+**bivariant** state; if a PEP 695 type parameter would otherwise infer to bivariance, we fall back
+to covariance instead. (Bivariance is technically correct when a typevar is unused, but it is
+confusing since it makes all specializations equivalent, it's not practically useful, and it's not
+in the spec, so we avoid it.)
 
 For all of the examples below, we will consider typevars `T` and `U`, two generic classes using
 those typevars `C[T]` and `D[U]`, and two types `A` and `B`.
@@ -281,15 +284,10 @@ static_assert(not is_equivalent_to(D[Any], C[Any]))
 static_assert(not is_equivalent_to(D[Any], C[Unknown]))
 ```
 
-## Bivariance
+## Bivariant Fallback
 
-With a bivariant typevar, _all_ specializations of the generic class are assignable to (and in fact,
-gradually equivalent to) each other, and all specializations are subtypes of (and equivalent to)
-each other.
-
-This is a bit of pathological case, which really only happens when the class doesn't use the typevar
-at all. (If it did, it would have to be covariant, contravariant, or invariant, depending on _how_
-the typevar was used.)
+If inference for a PEP 695 type parameter would otherwise conclude bivariance because the type
+parameter is unused, we fall back to covariance instead.
 
 ```py
 from ty_extensions import is_assignable_to, is_equivalent_to, is_subtype_of, static_assert, Unknown
@@ -305,7 +303,7 @@ class D[U](C[U]):
     pass
 
 static_assert(is_assignable_to(C[B], C[A]))
-static_assert(is_assignable_to(C[A], C[B]))
+static_assert(not is_assignable_to(C[A], C[B]))
 static_assert(is_assignable_to(C[A], C[Any]))
 static_assert(is_assignable_to(C[B], C[Any]))
 static_assert(is_assignable_to(C[Any], C[A]))
@@ -313,37 +311,37 @@ static_assert(is_assignable_to(C[Any], C[B]))
 
 static_assert(is_assignable_to(D[B], C[A]))
 static_assert(is_subtype_of(C[A], C[A]))
-static_assert(is_assignable_to(D[A], C[B]))
+static_assert(not is_assignable_to(D[A], C[B]))
 static_assert(is_assignable_to(D[A], C[Any]))
 static_assert(is_assignable_to(D[B], C[Any]))
 static_assert(is_assignable_to(D[Any], C[A]))
 static_assert(is_assignable_to(D[Any], C[B]))
 
 static_assert(is_subtype_of(C[B], C[A]))
-static_assert(is_subtype_of(C[A], C[B]))
-static_assert(is_subtype_of(C[A], C[Any]))
-static_assert(is_subtype_of(C[B], C[Any]))
-static_assert(is_subtype_of(C[Any], C[A]))
-static_assert(is_subtype_of(C[Any], C[B]))
-static_assert(is_subtype_of(C[Any], C[Any]))
-static_assert(is_subtype_of(C[object], C[Any]))
-static_assert(is_subtype_of(C[Any], C[Never]))
+static_assert(not is_subtype_of(C[A], C[B]))
+static_assert(not is_subtype_of(C[A], C[Any]))
+static_assert(not is_subtype_of(C[B], C[Any]))
+static_assert(not is_subtype_of(C[Any], C[A]))
+static_assert(not is_subtype_of(C[Any], C[B]))
+static_assert(not is_subtype_of(C[Any], C[Any]))
+static_assert(not is_subtype_of(C[object], C[Any]))
+static_assert(not is_subtype_of(C[Any], C[Never]))
 
 static_assert(is_subtype_of(D[B], C[A]))
-static_assert(is_subtype_of(D[A], C[B]))
-static_assert(is_subtype_of(D[A], C[Any]))
-static_assert(is_subtype_of(D[B], C[Any]))
-static_assert(is_subtype_of(D[Any], C[A]))
-static_assert(is_subtype_of(D[Any], C[B]))
+static_assert(not is_subtype_of(D[A], C[B]))
+static_assert(not is_subtype_of(D[A], C[Any]))
+static_assert(not is_subtype_of(D[B], C[Any]))
+static_assert(not is_subtype_of(D[Any], C[A]))
+static_assert(not is_subtype_of(D[Any], C[B]))
 
 static_assert(is_equivalent_to(C[A], C[A]))
 static_assert(is_equivalent_to(C[B], C[B]))
-static_assert(is_equivalent_to(C[B], C[A]))
-static_assert(is_equivalent_to(C[A], C[B]))
-static_assert(is_equivalent_to(C[A], C[Any]))
-static_assert(is_equivalent_to(C[B], C[Any]))
-static_assert(is_equivalent_to(C[Any], C[A]))
-static_assert(is_equivalent_to(C[Any], C[B]))
+static_assert(not is_equivalent_to(C[B], C[A]))
+static_assert(not is_equivalent_to(C[A], C[B]))
+static_assert(not is_equivalent_to(C[A], C[Any]))
+static_assert(not is_equivalent_to(C[B], C[Any]))
+static_assert(not is_equivalent_to(C[Any], C[A]))
+static_assert(not is_equivalent_to(C[Any], C[B]))
 
 static_assert(not is_equivalent_to(D[A], C[A]))
 static_assert(not is_equivalent_to(D[B], C[B]))
@@ -704,10 +702,11 @@ class C[T]:
     def __new__(self, x: T): ...
 
 static_assert(is_subtype_of(C[B], C[A]))
-static_assert(is_subtype_of(C[A], C[B]))
+static_assert(not is_subtype_of(C[A], C[B]))
 ```
 
-This example is then bivariant because it doesn't use `T` outside of the two exempted methods.
+This example would otherwise be bivariant because it doesn't use `T` outside of the two exempted
+methods, so we fall back to covariance.
 
 This holds likewise for dataclasses with synthesized `__init__`:
 
@@ -937,17 +936,17 @@ static_assert(not is_subtype_of(InvariantLiteral1, InvariantInt))
 static_assert(not is_subtype_of(MyInvariant[Literal[1]], MyInvariant[int]))
 static_assert(not is_subtype_of(MyInvariant[int], MyInvariant[Literal[1]]))
 
-class Bivariant[T]:
+class WouldBeBivariant[T]:
     pass
 
-type BivariantLiteral1 = Bivariant[Literal[1]]
-type BivariantInt = Bivariant[int]
-type MyBivariant[T] = Bivariant[T]
+type WouldBeBivariantLiteral1 = WouldBeBivariant[Literal[1]]
+type WouldBeBivariantInt = WouldBeBivariant[int]
+type MyWouldBeBivariant[T] = WouldBeBivariant[T]
 
-static_assert(is_subtype_of(BivariantInt, BivariantLiteral1))
-static_assert(is_subtype_of(BivariantLiteral1, BivariantInt))
-static_assert(is_subtype_of(MyBivariant[Literal[1]], MyBivariant[int]))
-static_assert(is_subtype_of(MyBivariant[int], MyBivariant[Literal[1]]))
+static_assert(not is_subtype_of(WouldBeBivariantInt, WouldBeBivariantLiteral1))
+static_assert(is_subtype_of(WouldBeBivariantLiteral1, WouldBeBivariantInt))
+static_assert(is_subtype_of(MyWouldBeBivariant[Literal[1]], MyWouldBeBivariant[int]))
+static_assert(not is_subtype_of(MyWouldBeBivariant[int], MyWouldBeBivariant[Literal[1]]))
 ```
 
 ## Inheriting from generic classes with inferred variance

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type.md
@@ -164,7 +164,7 @@ def f(x: A[int] | B):
         reveal_type(x)  # revealed: A[int] | B
 
     if type(x) is A:
-        reveal_type(x)  # revealed: A[int]
+        reveal_type(x)  # revealed: A[int] | (B & A[object])
     else:
         reveal_type(x)  # revealed: A[int] | B
 
@@ -182,7 +182,7 @@ def f(x: A[int] | B):
     if type(x) is not A:
         reveal_type(x)  # revealed: A[int] | B
     else:
-        reveal_type(x)  # revealed: A[int]
+        reveal_type(x)  # revealed: A[int] | (B & A[object])
 
     if type(x) is not B:
         reveal_type(x)  # revealed: A[int] | B

--- a/crates/ty_python_semantic/resources/mdtest/type_of/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/basic.md
@@ -232,8 +232,6 @@ python-version = "3.12"
 from typing import final, Any
 from ty_extensions import is_assignable_to, is_subtype_of, is_disjoint_from, static_assert
 
-class Biv[T]: ...
-
 class Cov[T]:
     def pop(self) -> T:
         raise NotImplementedError
@@ -246,9 +244,6 @@ class Inv[T]:
     x: T
 
 @final
-class BivSub[T](Biv[T]): ...
-
-@final
 class CovSub[T](Cov[T]): ...
 
 @final
@@ -258,9 +253,6 @@ class ContraSub[T](Contra[T]): ...
 class InvSub[T](Inv[T]): ...
 
 def _[T, U]():
-    static_assert(is_subtype_of(type[BivSub[T]], type[BivSub[U]]))
-    static_assert(not is_disjoint_from(type[BivSub[U]], type[BivSub[T]]))
-
     # `T` and `U` could specialize to the same type.
     static_assert(not is_subtype_of(type[CovSub[T]], type[CovSub[U]]))
     static_assert(not is_disjoint_from(type[CovSub[U]], type[CovSub[T]]))
@@ -272,12 +264,6 @@ def _[T, U]():
     static_assert(not is_disjoint_from(type[InvSub[U]], type[InvSub[T]]))
 
 def _():
-    static_assert(is_subtype_of(type[BivSub[bool]], type[BivSub[int]]))
-    static_assert(is_subtype_of(type[BivSub[int]], type[BivSub[bool]]))
-    static_assert(not is_disjoint_from(type[BivSub[bool]], type[BivSub[int]]))
-    # `BivSub[int]` and `BivSub[str]` are mutual subtypes.
-    static_assert(not is_disjoint_from(type[BivSub[int]], type[BivSub[str]]))
-
     static_assert(is_subtype_of(type[CovSub[bool]], type[CovSub[int]]))
     static_assert(not is_subtype_of(type[CovSub[int]], type[CovSub[bool]]))
     static_assert(not is_disjoint_from(type[CovSub[bool]], type[CovSub[int]]))
@@ -297,12 +283,6 @@ def _():
     static_assert(not is_disjoint_from(type[InvSub[bool]], type[InvSub[int]]))
 
 def _[T]():
-    static_assert(is_subtype_of(type[BivSub[T]], type[BivSub[Any]]))
-    static_assert(is_subtype_of(type[BivSub[Any]], type[BivSub[T]]))
-    static_assert(is_assignable_to(type[BivSub[T]], type[BivSub[Any]]))
-    static_assert(is_assignable_to(type[BivSub[Any]], type[BivSub[T]]))
-    static_assert(not is_disjoint_from(type[BivSub[T]], type[BivSub[Any]]))
-
     static_assert(not is_subtype_of(type[CovSub[T]], type[CovSub[Any]]))
     static_assert(not is_subtype_of(type[CovSub[Any]], type[CovSub[T]]))
     static_assert(is_assignable_to(type[CovSub[T]], type[CovSub[Any]]))
@@ -322,12 +302,6 @@ def _[T]():
     static_assert(not is_disjoint_from(type[InvSub[T]], type[InvSub[Any]]))
 
 def _[T, U]():
-    static_assert(is_subtype_of(type[BivSub[T]], type[Biv[T]]))
-    static_assert(not is_subtype_of(type[Biv[T]], type[BivSub[T]]))
-    static_assert(not is_disjoint_from(type[BivSub[T]], type[Biv[T]]))
-    static_assert(not is_disjoint_from(type[BivSub[U]], type[Biv[T]]))
-    static_assert(not is_disjoint_from(type[BivSub[U]], type[Biv[U]]))
-
     static_assert(is_subtype_of(type[CovSub[T]], type[Cov[T]]))
     static_assert(not is_subtype_of(type[Cov[T]], type[CovSub[T]]))
     static_assert(not is_disjoint_from(type[CovSub[T]], type[Cov[T]]))
@@ -347,11 +321,6 @@ def _[T, U]():
     static_assert(not is_disjoint_from(type[InvSub[U]], type[Inv[U]]))
 
 def _():
-    static_assert(is_subtype_of(type[BivSub[bool]], type[Biv[int]]))
-    static_assert(is_subtype_of(type[BivSub[int]], type[Biv[bool]]))
-    static_assert(not is_disjoint_from(type[BivSub[bool]], type[Biv[int]]))
-    static_assert(not is_disjoint_from(type[BivSub[int]], type[Biv[bool]]))
-
     static_assert(is_subtype_of(type[CovSub[bool]], type[Cov[int]]))
     static_assert(not is_subtype_of(type[CovSub[int]], type[Cov[bool]]))
     static_assert(not is_disjoint_from(type[CovSub[bool]], type[Cov[int]]))
@@ -370,12 +339,6 @@ def _():
     static_assert(not is_disjoint_from(type[InvSub[int]], type[Inv[bool]]))
 
 def _[T]():
-    static_assert(is_subtype_of(type[BivSub[T]], type[Biv[Any]]))
-    static_assert(is_subtype_of(type[BivSub[Any]], type[Biv[T]]))
-    static_assert(is_assignable_to(type[BivSub[T]], type[Biv[Any]]))
-    static_assert(is_assignable_to(type[BivSub[Any]], type[Biv[T]]))
-    static_assert(not is_disjoint_from(type[BivSub[T]], type[Biv[Any]]))
-
     static_assert(not is_subtype_of(type[CovSub[T]], type[Cov[Any]]))
     static_assert(not is_subtype_of(type[CovSub[Any]], type[Cov[T]]))
     static_assert(is_assignable_to(type[CovSub[T]], type[Cov[Any]]))

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -490,9 +490,11 @@ expects_type_c_of_int_and_str(C)
 # Also OK, the specialized `C[int, str]` is assignable to `type[C[int, str]]`
 expects_type_c_of_int_and_str(C[int, str])
 
-# TODO: these should be errors
+# error: [invalid-argument-type]
 expects_type_c_of_int_and_str(C[str])
+# error: [invalid-argument-type]
 expects_type_c_of_int_and_str(C[int, str, bytes])
+# error: [invalid-argument-type]
 expects_type_c_of_int_and_str(C[str, int])
 ```
 
@@ -508,14 +510,17 @@ def expects_type_c_default_of_int_str(f: type[C[int, str]]): ...
 
 expects_type_c_default(C)
 expects_type_c_default(C[int, str])
-expects_type_c_default_of_int(C)
 expects_type_c_default_of_int(C[int])
 expects_type_c_default_of_int_str(C)
 expects_type_c_default_of_int_str(C[int, str])
 
-# TODO: these should be errors
+# error: [invalid-argument-type]
 expects_type_c_default(C[int])
+# error: [invalid-argument-type]
+expects_type_c_default_of_int(C)
+# error: [invalid-argument-type]
 expects_type_c_default_of_int(C[str])
+# error: [invalid-argument-type]
 expects_type_c_default_of_int_str(C[str, int])
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -896,14 +896,6 @@ static_assert(not is_subtype_of(Invariant[Any], Invariant[int]))
 static_assert(not is_subtype_of(Invariant[int], Invariant[Any]))
 static_assert(not is_subtype_of(Invariant[Any], Invariant[object]))
 static_assert(not is_subtype_of(Invariant[object], Invariant[Any]))
-
-class Bivariant[T]: ...
-
-static_assert(is_subtype_of(Bivariant[Any], Bivariant[Any]))
-static_assert(is_subtype_of(Bivariant[Any], Bivariant[int]))
-static_assert(is_subtype_of(Bivariant[int], Bivariant[Any]))
-static_assert(is_subtype_of(Bivariant[Any], Bivariant[object]))
-static_assert(is_subtype_of(Bivariant[object], Bivariant[Any]))
 ```
 
 The same for `Unknown`:

--- a/crates/ty_python_semantic/resources/mdtest/union_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/union_types.md
@@ -347,8 +347,6 @@ python-version = "3.12"
 ```py
 from typing import Any
 
-class Bivariant[T]: ...
-
 class Covariant[T]:
     def get(self) -> T:
         raise NotImplementedError
@@ -360,8 +358,6 @@ class Invariant[T]:
     mutable_attribute: T
 
 def _(
-    a: Bivariant[Any] | Bivariant[Any | str],
-    b: Bivariant[Any | str] | Bivariant[Any],
     c: Covariant[Any] | Covariant[Any | str],
     d: Covariant[Any | str] | Covariant[Any],
     e: Contravariant[Any | str] | Contravariant[Any],
@@ -369,8 +365,6 @@ def _(
     g: Invariant[Any] | Invariant[Any | str],
     h: Invariant[Any | str] | Invariant[Any],
 ):
-    reveal_type(a)  # revealed: Bivariant[Any]
-    reveal_type(b)  # revealed: Bivariant[Any | str]
     reveal_type(c)  # revealed: Covariant[Any | str]
     reveal_type(d)  # revealed: Covariant[Any | str]
     reveal_type(e)  # revealed: Contravariant[Any]

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -301,6 +301,15 @@ fn type_alias_variance() {
         generic_context.variables(db).next().unwrap()
     }
 
+    fn assert_effective_variance<'db>(
+        db: &'db TestDb,
+        type_alias: PEP695TypeAliasType<'db>,
+        expected: TypeVarVariance,
+    ) {
+        let typevar = get_bound_typevar(db, type_alias);
+        assert_eq!(typevar.variance(db), expected);
+    }
+
     let mut db = setup_db();
     db.write_dedented(
         "/src/a.py",
@@ -372,6 +381,19 @@ type RecursiveAlias2[T] = None | list[T] | list[RecursiveAlias2[T]]
         KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(recursive2))
             .variance_of(&db, get_bound_typevar(&db, recursive2)),
         TypeVarVariance::Invariant
+    );
+
+    assert_effective_variance(&db, covariant, TypeVarVariance::Covariant);
+    assert_effective_variance(&db, contravariant, TypeVarVariance::Contravariant);
+    assert_effective_variance(&db, invariant, TypeVarVariance::Invariant);
+    assert_effective_variance(&db, bivariant, TypeVarVariance::Covariant);
+    assert_effective_variance(&db, recursive, TypeVarVariance::Covariant);
+    assert_effective_variance(&db, recursive2, TypeVarVariance::Invariant);
+
+    assert_eq!(
+        get_bound_typevar(&db, bivariant)
+            .variance_with_polarity(&db, TypeVarVariance::Contravariant),
+        TypeVarVariance::Contravariant
     );
 }
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -823,14 +823,24 @@ impl<'db> BoundTypeVarInstance<'db> {
         polarity: TypeVarVariance,
     ) -> TypeVarVariance {
         let _span = tracing::trace_span!("variance_with_polarity").entered();
+
         match self.typevar(db).explicit_variance(db) {
             Some(explicit_variance) => explicit_variance.compose(polarity),
-            None => match self.binding_context(db) {
-                BindingContext::Definition(definition) => binding_type(db, definition)
-                    .with_polarity(polarity)
-                    .variance_of(db, self),
-                BindingContext::Synthetic => TypeVarVariance::Invariant,
-            },
+            None => {
+                let inferred_variance = match self.binding_context(db) {
+                    BindingContext::Definition(definition) => {
+                        binding_type(db, definition).variance_of(db, self)
+                    }
+                    BindingContext::Synthetic => TypeVarVariance::Invariant,
+                };
+
+                match inferred_variance {
+                    // bivariance is confusing and not useful; fall back to covariant
+                    TypeVarVariance::Bivariant => TypeVarVariance::Covariant,
+                    variance => variance,
+                }
+                .compose(polarity)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/1728

Bivariance is confusing, not useful, and not in the spec. Fall back to covariant when we would otherwise infer bivariance.

## Test Plan

Adjusted existing test expectations.
