### PR TITLE
[ty] Improve type context support for `__setitem__` dunder calls

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -209,9 +209,6 @@ class DataDescriptor:
     def __set__(self, instance: object, value: list[Literal[1]]) -> None:
         pass
 
-def lst[T](x: T) -> list[T]:
-    return [x]
-
 def _(flag: bool):
     class Meta(type):
         if flag:
@@ -221,11 +218,11 @@ def _(flag: bool):
         x: list[int | None]
 
     def _(c: C):
-        c.x = lst(1)
+        c.x = reveal_type([1])  # revealed: list[int]
 
         # TODO: Use the parameter type of `__set__` as type context to avoid this error.
         # error: [invalid-assignment]
-        C.x = lst(1)
+        C.x = [1]
 ```
 
 For union targets, each element of the union is considered as a separate type context:
@@ -239,11 +236,8 @@ class X:
 class Y:
     x: list[int | None]
 
-def lst[T](x: T) -> list[T]:
-    return [x]
-
 def _(xy: X | Y):
-    xy.x = lst(1)
+    xy.x = reveal_type([1])  # revealed: list[int]
 ```
 
 ## Class constructor parameters
@@ -307,50 +301,88 @@ The key and value parameters types are used as type context for `__setitem__` du
 from typing import TypedDict
 
 class Bar(TypedDict):
-    baz: float
+    bar: list[int | str]
+
+class Baz(TypedDict):
+    bar: list[int | None]
 
 def _(x: dict[str, Bar]):
-    x["foo"] = reveal_type({"baz": 2})  # revealed: Bar
+    x["foo"] = reveal_type({"bar": [2]})  # revealed: Bar
 
 class X:
     def __setitem__(self, key: Bar, value: Bar): ...
 
 def _(x: X):
     # revealed: Bar
-    x[reveal_type({"baz": 1})] = reveal_type({"baz": 2})  # revealed: Bar
-
-# TODO: Support type context with union subscripting.
-def _(x: X | dict[Bar, Bar]):
-    # error: [invalid-assignment]
-    # error: [invalid-assignment]
-    x[{"baz": 1}] = {"baz": 2}
+    x[reveal_type({"bar": [1]})] = reveal_type({"bar": [2]})  # revealed: Bar
 ```
 
-Similarly, the value type for augmented assignment dunder calls is inferred with type context:
+If the target is a union or intersection type, the key and value expressions may be inferred
+multiple times for each applicable type context:
+
+```py
+from ty_extensions import Intersection
+
+def _(x: X | dict[Baz, Baz]):
+    # revealed: dict[str, list[int]]
+    x[reveal_type({"bar": [1]})] = reveal_type({"bar": [2]})  # revealed: dict[str, list[int]]
+
+class Y:
+    def __setitem__(self, key: Baz, value: Baz): ...
+
+def _(x: Intersection[X, Y]):
+    # revealed: Bar
+    x[reveal_type({"bar": [1, "2"]})] = reveal_type({"bar": [3, "4"]})  # revealed: Bar
+
+    # revealed: Baz
+    x[reveal_type({"bar": [1, None]})] = reveal_type({"bar": [2, None]})  # revealed: Baz
+```
+
+Similarly, the declared type of a `TypedDict` key is used as type context:
+
+```py
+from typing import Literal
+
+class TD(TypedDict):
+    foo: list[int | None]
+    bar: list[int | str]
+
+def _(x: TD, foo_or_bar: Literal["foo", "bar"]):
+    x["foo"] = reveal_type([1])  # revealed: list[int | None]
+    x["bar"] = reveal_type([2])  # revealed: list[int | str]
+    x[foo_or_bar] = reveal_type([3])  # revealed: list[int]
+
+def _(x: TD | dict[str, list[int | float]]):
+    x["foo"] = reveal_type([4])  # revealed: list[int]
+
+def _(x: Bar | Baz | dict[str, list[int | float]]):
+    x["bar"] = reveal_type([4])  # revealed: list[int]
+```
+
+As well as the value parameter type of augmented assignment dunder calls:
 
 ```py
 from typing import TypedDict
 
-def lst[T](x: T) -> list[T]:
-    return [x]
-
-class Bar(TypedDict, closed=False):
-    bar: list[int]
-
 def _(bar: Bar):
-    bar |= reveal_type({"bar": lst(1)})  # revealed: Bar
-
-class Bar2(TypedDict):
-    bar: list[int | None]
+    bar |= reveal_type({"bar": [1]})  # revealed: Bar
 
 class X:
-    def __ior__(self, other: Bar2): ...
+    def __ior__(self, other: Baz): ...
 
 def _(x: X):
-    x |= reveal_type({"bar": lst(1)})  # revealed: Bar2
+    x |= reveal_type({"bar": [1]})  # revealed: Baz
 
 def _(x: X | Bar):
-    x |= {"bar": lst(1)}
+    x |= reveal_type({"bar": [1]})  # revealed: dict[str, list[int]]
+
+class Y:
+    def __ior__(self, other: Bar): ...
+
+def _(x: Intersection[X, Y]):
+    # TODO: Reveal `Bar` and `Baz` here.
+    x |= reveal_type({"bar": [1, "2"]})  # revealed: dict[str, list[int | str]]
+    x |= reveal_type({"bar": [1, None]})  # revealed: dict[str, list[int | None]]
 ```
 
 ## Multi-inference diagnostics
@@ -362,33 +394,33 @@ python-version = "3.12"
 
 Diagnostics unrelated to the type-context are only reported once:
 
-`call.py`:
-
 ```py
 from typing import TypedDict
 
-def f[T](x: T) -> list[T]:
+def lst[T](x: T) -> list[T]:
     return [x]
 
-def a(x: list[bool], y: list[bool]): ...
-def b(x: list[int], y: list[int]): ...
-def c(x: list[int], y: list[int]): ...
+def takes_list_of_bool(x: list[bool], y: list[bool]): ...
+def takes_list_of_int(x: list[int], y: list[int]): ...
+def takes_list_of_int2(x: list[int], y: list[int]): ...
 def _(x: int):
     if x == 0:
-        y = a
+        y = takes_list_of_bool
     elif x == 1:
-        y = b
+        y = takes_list_of_int
     else:
-        y = c
+        y = takes_list_of_int2
 
     if x == 0:
         z = True
 
-    y(f(True), [True])
+    y(lst(True), [True])
 
     # error: [possibly-unresolved-reference] "Name `z` used when possibly not defined"
-    y(f(True), [z])
+    y(lst(True), [z])
+```
 
+```py
 class Bar(TypedDict):
     bar: int
 
@@ -404,38 +436,50 @@ def _(flag: bool, bar: Bar | Bar2 | Bar3):
 
     # error: [possibly-unresolved-reference]
     bar |= {"bar": y}
+
+def _(flag: bool, x: dict[Bar, Bar] | dict[Bar2, Bar2] | dict[Bar3, Bar3]):
+    if flag:
+        y = 1
+
+    # error: [possibly-unresolved-reference]
+    x[{"bar": y}] = {"bar": 1}
+    # error: [possibly-unresolved-reference]
+    x[{"bar": 1}] = {"bar": y}
+
+class TD(TypedDict):
+    foo: Bar
+
+def _(flag: bool, x: TD | dict[str, Bar2] | dict[str, Bar3]):
+    if flag:
+        y = 1
+
+    # error: [possibly-unresolved-reference]
+    x["foo"] = {"bar": y}
 ```
 
-`call_standalone_expression.py`:
-
 ```py
-def f(_: str): ...
-def g(_: str): ...
+def takes_str(_: str): ...
+def takes_str2(_: str): ...
 def _(a: object, b: object, flag: bool):
     if flag:
-        x = f
+        x = takes_str
     else:
-        x = g
+        x = takes_str2
 
     # error: [unsupported-operator] "Operator `>` is not supported between two objects of type `object`"
     x(f"{'a' if a > b else 'b'}")
 ```
 
-`attribute_assignment.py`:
-
 ```py
 from typing import TypedDict
 
-class TD(TypedDict):
-    y: int
+class HasTD:
+    td: Bar
 
-class X:
-    td: TD
-
-def _(x: X, flag: bool):
+def _(has_td: HasTD, flag: bool):
     if flag:
         y = 1
 
     # error: [possibly-unresolved-reference] "Name `y` used when possibly not defined"
-    x.td = {"y": y}
+    has_td.td = {"bar": y}
 ```

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -142,6 +142,9 @@ plot3: Plot = {"y": homogeneous_list(1, 2, 3), "x": homogeneous_list(1, 2, 3)}
 reveal_type(plot3["y"])  # revealed: list[int | None]
 reveal_type(plot3["x"])  # revealed: list[int | None]
 
+plot3["y"] = homogeneous_list(1, 2, 3)
+reveal_type(plot3["y"])  # revealed: list[int | None]
+
 Y = "y"
 X = "x"
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1988,39 +1988,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> bool {
         let db = self.db();
 
-        let mut first_tcx = None;
-
-        // A wrapper over `infer_value_ty` that allows inferring the value type multiple times
-        // during attribute resolution.
-        let pure_infer_value_ty = infer_value_ty;
-        let mut infer_value_ty = |builder: &mut Self, tcx: TypeContext<'db>| -> Type<'db> {
-            // Overwrite the previously inferred value, preferring later inferences, which are
-            // likely more precise. Note that we still ensure each inference is assignable to
-            // its declared type, so this mainly affects the IDE hover type.
-            let prev_multi_inference_state =
-                builder.set_multi_inference_state(MultiInferenceState::Overwrite);
-
-            // If we are inferring the argument multiple times, silence diagnostics to avoid duplicated warnings.
-            let was_in_multi_inference = if let Some(first_tcx) = first_tcx {
-                // The first time we infer an argument during multi-inference must be without type context,
-                // to avoid leaking diagnostics for bidirectional inference attempts.
-                debug_assert_eq!(first_tcx, TypeContext::default());
-
-                builder.context.set_multi_inference(true)
-            } else {
-                builder.context.is_in_multi_inference()
-            };
-
-            let value_ty = pure_infer_value_ty(builder, tcx);
-
-            // Reset the multi-inference state.
-            first_tcx.get_or_insert(tcx);
-            builder.multi_inference_state = prev_multi_inference_state;
-            builder.context.set_multi_inference(was_in_multi_inference);
-
-            value_ty
-        };
-
         // This closure should only be called if `value_ty` was inferred with `attr_ty` as type context.
         let ensure_assignable_to =
             |builder: &Self, value_ty: Type<'db>, attr_ty: Type<'db>| -> bool {
@@ -2111,16 +2078,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         match object_ty {
             Type::Union(union) => {
-                // First infer the value without type context, and then again for each union element.
-                let value_ty = infer_value_ty(self, TypeContext::default());
+                let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
+
+                // Perform loud inference without type context, as there may be multiple
+                // equally applicable type contexts for each union member.
+                let value_ty = infer_value_ty.infer_loud(self, TypeContext::default());
 
                 if union.elements(self.db()).iter().all(|elem| {
                     self.validate_attribute_assignment(
                         target,
                         *elem,
                         attribute,
-                        // Note that `infer_value_ty` silences diagnostics after the first inference.
-                        &mut infer_value_ty,
+                        &mut |builder, tcx| infer_value_ty.infer_silent(builder, tcx),
                         false,
                     )
                 }) {
@@ -2144,8 +2113,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             Type::Intersection(intersection) => {
-                // First infer the value without type context, and then again for each union element.
-                let value_ty = infer_value_ty(self, TypeContext::default());
+                let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
 
                 // TODO: Handle negative intersection elements
                 if intersection.positive(db).iter().any(|elem| {
@@ -2153,13 +2121,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         target,
                         *elem,
                         attribute,
-                        // Note that `infer_value_ty` silences diagnostics after the first inference.
-                        &mut infer_value_ty,
+                        &mut |builder, tcx| infer_value_ty.infer_silent(builder, tcx),
                         false,
                     )
                 }) {
+                    // Perform loud inference using the narrowed type context.
+                    infer_value_ty.infer_loud(self, infer_value_ty.last_tcx());
                     true
                 } else {
+                    // Otherwise, perform loud inference without type context, as we failed to
+                    // narrow to any given intersection element.
+                    let value_ty = infer_value_ty.infer_loud(self, TypeContext::default());
+
                     if emit_diagnostics
                         && let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target)
                     {
@@ -2180,7 +2153,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 target,
                 alias.value_type(self.db()),
                 attribute,
-                pure_infer_value_ty,
+                infer_value_ty,
                 emit_diagnostics,
             ),
 
@@ -2238,13 +2211,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             | Type::TypeGuard(_)
             | Type::TypedDict(_)
             | Type::NewTypeInstance(_) => {
-                // TODO: We could use the annotated parameter type of `__setattr__` as type context here.
-                // However, we would still have to perform the first inference without type context.
-                let value_ty = infer_value_ty(self, TypeContext::default());
+                // We may infer the value type multiple times with distinct type context during
+                // attribute resolution.
+                let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
+
+                // Perform loud inference without type context, as we may encounter multiple equally
+                // applicable type contexts during attribute resolution.
+                let value_ty = infer_value_ty.infer_loud(self, TypeContext::default());
 
                 // Infer `__setattr__` once upfront. We use this result for:
                 // 1. Checking if it returns `Never` (indicating an immutable class)
                 // 2. As a fallback when no explicit attribute is found
+                //
+                // TODO: We could re-infer `value_ty` with type context here.
                 let setattr_dunder_call_result = object_ty.try_call_dunder_with_policy(
                     db,
                     "__setattr__",
@@ -2363,8 +2342,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                             dunder_set_result.is_ok()
                         } else {
-                            let value_ty =
-                                infer_value_ty(self, TypeContext::new(Some(meta_attr_ty)));
+                            let value_ty = infer_value_ty
+                                .infer_silent(self, TypeContext::new(Some(meta_attr_ty)));
 
                             ensure_assignable_to(self, value_ty, meta_attr_ty)
                         };
@@ -2386,8 +2365,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 // Bind `Self` via MRO matching.
                                 let instance_attr_ty =
                                     instance_attr_ty.bind_self_typevars(db, object_ty);
-                                let value_ty =
-                                    infer_value_ty(self, TypeContext::new(Some(instance_attr_ty)));
+                                let value_ty = infer_value_ty
+                                    .infer_silent(self, TypeContext::new(Some(instance_attr_ty)));
                                 if invalid_assignment_to_final(self, qualifiers) {
                                     return false;
                                 }
@@ -2434,8 +2413,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             // Bind `Self` via MRO matching.
                             let instance_attr_ty =
                                 instance_attr_ty.bind_self_typevars(db, object_ty);
-                            let value_ty =
-                                infer_value_ty(self, TypeContext::new(Some(instance_attr_ty)));
+                            let value_ty = infer_value_ty
+                                .infer_silent(self, TypeContext::new(Some(instance_attr_ty)));
                             if invalid_assignment_to_final(self, qualifiers) {
                                 return false;
                             }
@@ -2501,13 +2480,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             }),
                         qualifiers,
                     } => {
-                        // We may have to perform multi-inference if the meta attribute is possibly unbound.
-                        // However, we are required to perform the first inference without type context.
-                        let value_ty = infer_value_ty(self, TypeContext::default());
-
                         if invalid_assignment_to_final(self, qualifiers) {
+                            infer_value_ty(self, TypeContext::default());
                             return false;
                         }
+
+                        // We may infer the value type multiple times with distinct type context during
+                        // attribute resolution.
+                        let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
+
+                        // Perform loud inference without type context, as we may encounter multiple equally
+                        // applicable type contexts during attribute resolution.
+                        let value_ty = infer_value_ty.infer_loud(self, TypeContext::default());
 
                         let assignable_to_meta_attr = if let Place::Defined(DefinedPlace {
                             ty: meta_dunder_set,
@@ -2536,8 +2520,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                             dunder_set_result.is_ok()
                         } else {
-                            let value_ty =
-                                infer_value_ty(self, TypeContext::new(Some(meta_attr_ty)));
+                            let value_ty = infer_value_ty
+                                .infer_silent(self, TypeContext::new(Some(meta_attr_ty)));
                             ensure_assignable_to(self, value_ty, meta_attr_ty)
                         };
 
@@ -2553,8 +2537,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 .expect("called on Type::ClassLiteral or Type::SubclassOf")
                                 .place
                             {
-                                let value_ty =
-                                    infer_value_ty(self, TypeContext::new(Some(class_attr_ty)));
+                                let value_ty = infer_value_ty
+                                    .infer_silent(self, TypeContext::new(Some(class_attr_ty)));
                                 (
                                     ensure_assignable_to(self, value_ty, class_attr_ty),
                                     class_attr_boundness,
@@ -4343,33 +4327,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         match target_type {
             Type::Union(union) => {
-                // The first time we infer an argument during multi-inference must be without type context,
-                // to avoid leaking diagnostics for bidirectional inference attempts.
-                let old_multi_inference_state =
-                    self.set_multi_inference_state(MultiInferenceState::Ignore);
-                infer_value_ty(self, TypeContext::default());
-                self.set_multi_inference_state(old_multi_inference_state);
+                let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
 
-                let infer_value_ty = &mut |builder: &mut Self, tcx| {
-                    // Disable diagnostics for subsequent multi-inference attempts.
-                    let was_in_multi_inference = builder.context.set_multi_inference(true);
-
-                    // We may infer the value multiple times with distinct type context, and so take
-                    // the intersection of every inferred type.
-                    let old_multi_inference_state =
-                        builder.set_multi_inference_state(MultiInferenceState::Intersect);
-
-                    let inferred_ty = infer_value_ty(builder, tcx);
-
-                    // Restore the multi-inference state.
-                    builder.context.set_multi_inference(was_in_multi_inference);
-                    builder.set_multi_inference_state(old_multi_inference_state);
-
-                    inferred_ty
-                };
+                // Perform loud inference without type context, as there may be multiple
+                // equally applicable type contexts for each union member.
+                infer_value_ty.infer_loud(self, TypeContext::default());
 
                 union.map(db, |&elem_type| {
-                    self.infer_augmented_op(assignment, elem_type, value_expr, infer_value_ty)
+                    self.infer_augmented_op(
+                        assignment,
+                        elem_type,
+                        value_expr,
+                        &mut |builder, tcx| infer_value_ty.infer_silent(builder, tcx),
+                    )
                 })
             }
 
@@ -5486,10 +5456,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             MultiInferenceState::Panic => {
                 let previous = self.expressions.insert(expression.into(), ty);
                 assert_eq!(previous, None);
-            }
-
-            MultiInferenceState::Overwrite => {
-                self.expressions.insert(expression.into(), ty);
             }
 
             MultiInferenceState::Intersect => {
@@ -8808,6 +8774,82 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 }
 
+/// Manages the inference of a given expression.
+struct MultiInferenceGuard<'db, 'ast, 'infer> {
+    infer_expr:
+        &'infer mut dyn FnMut(&mut TypeInferenceBuilder<'db, 'ast>, TypeContext<'db>) -> Type<'db>,
+    last_tcx: Option<TypeContext<'db>>,
+    finalized: bool,
+}
+
+impl<'db, 'ast, 'infer> MultiInferenceGuard<'db, 'ast, 'infer> {
+    /// Creates a [`MultiInferenceGuard`] for the given expression.
+    fn new(
+        infer_expr: &'infer mut dyn FnMut(
+            &mut TypeInferenceBuilder<'db, 'ast>,
+            TypeContext<'db>,
+        ) -> Type<'db>,
+    ) -> Self {
+        Self {
+            infer_expr,
+            last_tcx: None,
+            finalized: false,
+        }
+    }
+
+    /// Infer the expression with diagnostics enabled.
+    ///
+    /// This method must be called exactly once in the lifetime of the [`MultiInferenceGuard`].
+    fn infer_loud(
+        &mut self,
+        builder: &mut TypeInferenceBuilder<'db, 'ast>,
+        tcx: TypeContext<'db>,
+    ) -> Type<'db> {
+        debug_assert!(
+            !self.finalized,
+            "called `infer_loud` multiple times on a `MultiInferenceGuard`"
+        );
+
+        self.finalized = true;
+        (self.infer_expr)(builder, tcx)
+    }
+
+    /// Infer the expression silently, with diagnostics disabled.
+    ///
+    /// This method may be called an unlimited number of times.
+    fn infer_silent(
+        &mut self,
+        builder: &mut TypeInferenceBuilder<'db, 'ast>,
+        tcx: TypeContext<'db>,
+    ) -> Type<'db> {
+        let prev_multi_inference_state =
+            builder.set_multi_inference_state(MultiInferenceState::Ignore);
+        let was_in_multi_inference = builder.context.set_multi_inference(true);
+
+        let value_ty = (self.infer_expr)(builder, tcx);
+        self.last_tcx = Some(tcx);
+
+        // Reset the multi-inference state.
+        builder.set_multi_inference_state(prev_multi_inference_state);
+        builder.context.set_multi_inference(was_in_multi_inference);
+
+        value_ty
+    }
+
+    fn last_tcx(&self) -> TypeContext<'db> {
+        self.last_tcx.unwrap_or_default()
+    }
+}
+
+impl Drop for MultiInferenceGuard<'_, '_, '_> {
+    fn drop(&mut self) {
+        debug_assert!(
+            self.finalized,
+            "dropped `MultiInferenceGuard` without calling `infer_loud`"
+        );
+    }
+}
+
 /// An expression representing the function argument at the given index, along with its type
 /// context.
 type ArgExpr<'db, 'ast> = (usize, &'ast ast::Expr, TypeContext<'db>);
@@ -8846,12 +8888,6 @@ enum MultiInferenceState {
     /// Panic if the expression has already been inferred.
     #[default]
     Panic,
-
-    /// Overwrite the previously inferred value.
-    ///
-    /// Note that `Overwrite` does not interact well with nested inferences:
-    /// it overwrites values that were written with `MultiInferenceState::Intersect`.
-    Overwrite,
 
     /// Ignore the newly inferred value.
     Ignore,

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -1,7 +1,7 @@
 use itertools::{Either, EitherOrBoth, Itertools};
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span};
 use ruff_db::parsed::parsed_module;
-use ruff_python_ast::{self as ast, ExprContext};
+use ruff_python_ast::{self as ast, ArgOrKeyword, ExprContext};
 use ruff_text_size::Ranged;
 use ty_module_resolver::file_to_module;
 
@@ -18,11 +18,12 @@ use crate::types::diagnostic::{
     CALL_NON_CALLABLE, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, INVALID_KEY,
     INVALID_TYPE_ARGUMENTS, INVALID_TYPE_FORM, NOT_SUBSCRIPTABLE, POSSIBLY_MISSING_IMPLICIT_CALL,
     TypedDictDeleteErrorKind, report_cannot_delete_typed_dict_key,
-    report_invalid_arguments_to_annotated, report_not_subscriptable,
+    report_invalid_arguments_to_annotated, report_invalid_key_on_typed_dict,
+    report_not_subscriptable,
 };
 use crate::types::generics::{GenericContext, InferableTypeVars, bind_typevar};
 use crate::types::infer::InferenceFlags;
-use crate::types::infer::builder::{ArgExpr, ArgumentsIter};
+use crate::types::infer::builder::{ArgExpr, ArgumentsIter, MultiInferenceGuard};
 use crate::types::special_form::AliasSpec;
 use crate::types::subscript::{LegacyGenericOrigin, SubscriptError, SubscriptErrorKind};
 use crate::types::tuple::{Tuple, TupleType};
@@ -1167,9 +1168,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         match object_ty {
             Type::Union(union) => {
-                // TODO: Perform multi-inference here.
-                let slice_ty = infer_slice_ty(self, TypeContext::default());
-                let rhs_value_ty = infer_rhs_value(self, TypeContext::default());
+                let mut infer_slice_ty = MultiInferenceGuard::new(infer_slice_ty);
+                let mut infer_rhs_value = MultiInferenceGuard::new(infer_rhs_value);
+
+                // Perform loud inference without type context, as there may be multiple
+                // equally applicable type contexts for each union member.
+                infer_slice_ty.infer_loud(self, TypeContext::default());
+                infer_rhs_value.infer_loud(self, TypeContext::default());
 
                 // Note that we use a loop here instead of .all(…) to avoid short-circuiting.
                 // We need to keep iterating to emit all diagnostics.
@@ -1179,19 +1184,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         target,
                         full_object_ty.or(Some(object_ty)),
                         *element_ty,
-                        &mut |_, _| slice_ty,
+                        &mut |builder, tcx| infer_slice_ty.infer_silent(builder, tcx),
                         rhs_value_node,
-                        &mut |_, _| rhs_value_ty,
+                        &mut |builder, tcx| infer_rhs_value.infer_silent(builder, tcx),
                         emit_diagnostic,
                     );
                 }
+
                 valid
             }
 
             Type::Intersection(intersection) => {
-                // TODO: Perform multi-inference here.
-                let slice_ty = infer_slice_ty(self, TypeContext::default());
-                let rhs_value_ty = infer_rhs_value(self, TypeContext::default());
+                let mut infer_slice_ty = MultiInferenceGuard::new(infer_slice_ty);
+                let mut infer_rhs_value = MultiInferenceGuard::new(infer_rhs_value);
 
                 let mut check_positive_elements = |emit_diagnostic_and_short_circuit| {
                     let mut valid = false;
@@ -1200,13 +1205,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             target,
                             full_object_ty.or(Some(object_ty)),
                             *element_ty,
-                            &mut |_, _| slice_ty,
+                            &mut |builder, tcx| infer_slice_ty.infer_silent(builder, tcx),
                             rhs_value_node,
-                            &mut |_, _| rhs_value_ty,
+                            &mut |builder, tcx| infer_rhs_value.infer_silent(builder, tcx),
                             emit_diagnostic_and_short_circuit,
                         );
 
-                        if !valid && emit_diagnostic_and_short_circuit {
+                        if valid || emit_diagnostic_and_short_circuit {
+                            // Otherwise, perform loud inference with the narrowed type context, or the
+                            // type context of the first failing element.
+                            infer_slice_ty.infer_loud(self, infer_slice_ty.last_tcx());
+                            infer_rhs_value.infer_loud(self, infer_rhs_value.last_tcx());
                             break;
                         }
                     }
@@ -1218,7 +1227,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // for at least one element, we do not emit any diagnostics. Otherwise,
                 // we re-run the check and emit a diagnostic on the first failing element.
                 let valid = check_positive_elements(false);
-
                 if !valid {
                     check_positive_elements(true);
                 }
@@ -1230,12 +1238,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // As an optimization, prevent calling `__setitem__` on (unions of) large `TypedDict`s, and
                 // validate the assignment ourselves. This also allows us to emit better diagnostics.
 
-                // TODO: Use type context here.
-                let slice_ty = infer_slice_ty(self, TypeContext::default());
-                let rhs_value_ty = infer_rhs_value(self, TypeContext::default());
-
                 let mut valid = true;
+                let slice_ty = infer_slice_ty(self, TypeContext::default());
                 let Some(keys) = key_literals(db, slice_ty) else {
+                    let rhs_value_ty = infer_rhs_value(self, TypeContext::default());
+
                     // Check if the key has a valid type. We only allow string literals, a union of string literals,
                     // or a dynamic type like `Any`. We can do this by checking assignability to `LiteralString`,
                     // but we need to exclude `LiteralString` itself. This check would technically allow weird key
@@ -1278,13 +1285,42 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     return false;
                 };
 
+                // We may need to infer the value multiple times for distinct keys.
+                let mut key_count = 0;
+                let mut infer_rhs_value = MultiInferenceGuard::new(infer_rhs_value);
+
                 for key in keys {
+                    let items = typed_dict.items(db);
+
+                    // Check if the key exists on the `TypedDict`
+                    let Some((_, item)) = items.iter().find(|(name, _)| *name == key) else {
+                        if emit_diagnostic {
+                            report_invalid_key_on_typed_dict(
+                                &self.context,
+                                target.value.as_ref().into(),
+                                target.slice.as_ref().into(),
+                                object_ty,
+                                full_object_ty,
+                                Type::string_literal(db, key),
+                                items,
+                            );
+                        }
+
+                        valid = false;
+                        continue;
+                    };
+
+                    // Infer the value with type context.
+                    let value_ty = infer_rhs_value
+                        .infer_silent(self, TypeContext::new(Some(item.declared_ty)));
+
+                    key_count += 1;
                     valid &= TypedDictKeyAssignment {
                         context: &self.context,
                         typed_dict,
                         full_object_ty,
                         key,
-                        value_ty: rhs_value_ty,
+                        value_ty,
                         typed_dict_node: target.value.as_ref().into(),
                         key_node: target.slice.as_ref().into(),
                         value_node: rhs_value_node.into(),
@@ -1294,13 +1330,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .validate();
                 }
 
+                // Perform loud inference with type context if there is a single key.
+                if key_count == 1 {
+                    infer_rhs_value.infer_loud(self, infer_rhs_value.last_tcx());
+                } else {
+                    infer_rhs_value.infer_loud(self, TypeContext::default());
+                }
+
                 valid
             }
 
             _ => {
                 let ast_arguments = [
-                    ast::ArgOrKeyword::Arg(&target.slice),
-                    ast::ArgOrKeyword::Arg(rhs_value_node),
+                    ArgOrKeyword::Arg(&target.slice),
+                    ArgOrKeyword::Arg(rhs_value_node),
                 ];
 
                 let mut call_arguments =


### PR DESCRIPTION
Resolves https://github.com/astral-sh/ty/issues/2986. I also ended up refactoring some things here, see https://github.com/astral-sh/ty/issues/3001 for details.