### PR TITLE
[`flake8-pytest-style`] Omit row type from PT007 message for single-parameter `parametrize`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -204,6 +204,7 @@ impl Violation for PytestParametrizeNamesWrongType {
 pub(crate) struct PytestParametrizeValuesWrongType {
     values: types::ParametrizeValuesType,
     row: types::ParametrizeValuesRowType,
+    is_multi_named: bool,
 }
 
 impl Violation for PytestParametrizeValuesWrongType {
@@ -211,13 +212,29 @@ impl Violation for PytestParametrizeValuesWrongType {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let PytestParametrizeValuesWrongType { values, row } = self;
-        format!("Wrong values type in `pytest.mark.parametrize` expected `{values}` of `{row}`")
+        let PytestParametrizeValuesWrongType {
+            values,
+            row,
+            is_multi_named,
+        } = self;
+        if *is_multi_named {
+            format!("Wrong values type in `pytest.mark.parametrize` expected `{values}` of `{row}`")
+        } else {
+            format!("Wrong values type in `pytest.mark.parametrize` expected `{values}`")
+        }
     }
 
     fn fix_title(&self) -> Option<String> {
-        let PytestParametrizeValuesWrongType { values, row } = self;
-        Some(format!("Use `{values}` of `{row}` for parameter values"))
+        let PytestParametrizeValuesWrongType {
+            values,
+            row,
+            is_multi_named,
+        } = self;
+        if *is_multi_named {
+            Some(format!("Use `{values}` of `{row}` for parameter values"))
+        } else {
+            Some(format!("Use `{values}` for parameter values"))
+        }
     }
 }
 
@@ -520,10 +537,18 @@ fn check_values(checker: &Checker, names: &Expr, values: &Expr) {
     match values {
         Expr::List(ast::ExprList { elts, .. }) => {
             if values_type != types::ParametrizeValuesType::List {
+                // Include the row type in the message when the parametrize has
+                // multiple names, or when any element is itself a list/tuple
+                // (i.e., the outer container structurally wraps rows).
+                let has_row_type = is_multi_named
+                    || elts
+                        .iter()
+                        .any(|elt| matches!(elt, Expr::List(_) | Expr::Tuple(_)));
                 let mut diagnostic = checker.report_diagnostic(
                     PytestParametrizeValuesWrongType {
                         values: values_type,
                         row: values_row_type,
+                        is_multi_named: has_row_type,
                     },
                     values.range(),
                 );
@@ -567,10 +592,18 @@ fn check_values(checker: &Checker, names: &Expr, values: &Expr) {
         }
         Expr::Tuple(ast::ExprTuple { elts, .. }) => {
             if values_type != types::ParametrizeValuesType::Tuple {
+                // Include the row type in the message when the parametrize has
+                // multiple names, or when any element is itself a list/tuple
+                // (i.e., the outer container structurally wraps rows).
+                let has_row_type = is_multi_named
+                    || elts
+                        .iter()
+                        .any(|elt| matches!(elt, Expr::List(_) | Expr::Tuple(_)));
                 let mut diagnostic = checker.report_diagnostic(
                     PytestParametrizeValuesWrongType {
                         values: values_type,
                         row: values_row_type,
+                        is_multi_named: has_row_type,
                     },
                     values.range(),
                 );
@@ -775,6 +808,7 @@ fn handle_value_rows(
                         PytestParametrizeValuesWrongType {
                             values: values_type,
                             row: values_row_type,
+                            is_multi_named: true,
                         },
                         elt.range(),
                     );
@@ -817,6 +851,7 @@ fn handle_value_rows(
                         PytestParametrizeValuesWrongType {
                             values: values_type,
                             row: values_row_type,
+                            is_multi_named: true,
                         },
                         elt.range(),
                     );

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_lists.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_lists.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 ---
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
  --> PT007.py:4:35
   |
 4 | @pytest.mark.parametrize("param", (1, 2))
@@ -9,7 +9,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `lis
 5 | def test_tuple(param):
 6 |     ...
   |
-help: Use `list` of `list` for parameter values
+help: Use `list` for parameter values
 1 | import pytest
 2 | 
 3 | 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_tuples.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_tuples.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 ---
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
  --> PT007.py:4:35
   |
 4 | @pytest.mark.parametrize("param", (1, 2))
@@ -9,7 +9,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `tup
 5 | def test_tuple(param):
 6 |     ...
   |
-help: Use `list` of `tuple` for parameter values
+help: Use `list` for parameter values
 1 | import pytest
 2 | 
 3 | 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_lists.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_lists.snap
@@ -43,7 +43,7 @@ help: Use `tuple` of `list` for parameter values
 16 | def test_tuple_of_tuples(param1, param2):
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:31:35
    |
 31 | @pytest.mark.parametrize("param", [1, 2])
@@ -51,7 +51,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `li
 32 | def test_list(param):
 33 |     ...
    |
-help: Use `tuple` of `list` for parameter values
+help: Use `tuple` for parameter values
 28 |     ...
 29 | 
 30 | 
@@ -216,7 +216,7 @@ help: Use `tuple` of `list` for parameter values
 77 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:80:31
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -224,7 +224,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `li
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))
 82 | @pytest.mark.parametrize("d", [3,])
    |
-help: Use `tuple` of `list` for parameter values
+help: Use `tuple` for parameter values
 77 |     ...
 78 | 
 79 | 
@@ -275,7 +275,7 @@ help: Use `tuple` of `list` for parameter values
 84 |     "d",
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:82:31
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -285,7 +285,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `li
 83 | @pytest.mark.parametrize(
 84 |     "d",
    |
-help: Use `tuple` of `list` for parameter values
+help: Use `tuple` for parameter values
 79 | 
 80 | @pytest.mark.parametrize("a", [1, 2])
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_tuples.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_tuples.snap
@@ -43,7 +43,7 @@ help: Use `tuple` of `tuple` for parameter values
 27 | def test_tuple_of_lists(param1, param2):
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:31:35
    |
 31 | @pytest.mark.parametrize("param", [1, 2])
@@ -51,7 +51,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 32 | def test_list(param):
 33 |     ...
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 28 |     ...
 29 | 
 30 | 
@@ -258,7 +258,7 @@ help: Use `tuple` of `tuple` for parameter values
 77 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:80:31
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -266,7 +266,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))
 82 | @pytest.mark.parametrize("d", [3,])
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 77 |     ...
 78 | 
 79 | 
@@ -277,7 +277,7 @@ help: Use `tuple` of `tuple` for parameter values
 83 | @pytest.mark.parametrize(
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:82:31
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -287,7 +287,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 83 | @pytest.mark.parametrize(
 84 |     "d",
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 79 | 
 80 | @pytest.mark.parametrize("a", [1, 2])
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))


### PR DESCRIPTION
Fixes #14743

## Summary

When `@pytest.mark.parametrize` has a single parameter name, the PT007 diagnostic message previously always included the row type (e.g., "expected `tuple` of `tuple`"), which was confusing because the "of `tuple`" part refers to the expected type of each *row* of values — a concept that only applies to multi-parameter cases.

For single parameters, the message now reads "expected `tuple`" (or `list`), while multi-parameter cases retain the full "expected `tuple` of `tuple`" format.

### Before

```
@pytest.mark.parametrize("param", [1, 2])
                                   ^^^^^^ PT007 Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
```

### After

```
@pytest.mark.parametrize("param", [1, 2])
                                   ^^^^^^ PT007 Wrong values type in `pytest.mark.parametrize` expected `tuple`
```

Multi-parameter messages remain unchanged:

```
@pytest.mark.parametrize(("param1", "param2"), [[1, 2], [3, 4]])
                                                ^^^^^^ PT007 Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
```

## Test plan

- Updated all 4 PT007 snapshot tests to reflect the new message format for single-parameter cases
- `cargo test -p ruff_linter -- flake8_pytest_style` — all 47 tests pass
- `cargo clippy -p ruff_linter --all-targets --all-features -- -D warnings` — clean
- `cargo dev generate-all` — all generated files up to date
- `uvx prek run -a` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)