### PR TITLE
[ty] Fix folding ranges for notebooks

### DIFF
--- a/crates/ty_ide/src/folding_range.rs
+++ b/crates/ty_ide/src/folding_range.rs
@@ -2,7 +2,9 @@ use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
 use ruff_python_ast::token::{TokenKind, Tokens};
-use ruff_python_ast::visitor::source_order::{SourceOrderVisitor, TraversalSignal, walk_body};
+use ruff_python_ast::visitor::source_order::{
+    SourceOrderVisitor, TraversalSignal, walk_body, walk_node,
+};
 use ruff_python_ast::{AnyNodeRef, Stmt, StmtClassDef, StmtFunctionDef};
 use ruff_source_file::{Line, UniversalNewlines};
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
@@ -45,7 +47,11 @@ impl From<TextRange> for FoldingRange {
 }
 
 /// Returns a list of folding ranges for the given file.
-pub fn folding_ranges(db: &dyn Db, file: File) -> Vec<FoldingRange> {
+pub fn folding_ranges(
+    db: &dyn Db,
+    file: File,
+    range_filter: Option<TextRange>,
+) -> Vec<FoldingRange> {
     let parsed = parsed_module(db, file).load(db);
     let source = source_text(db, file);
 
@@ -53,11 +59,9 @@ pub fn folding_ranges(db: &dyn Db, file: File) -> Vec<FoldingRange> {
         source: source.as_str(),
         ranges: vec![],
         tokens: parsed.tokens(),
+        range_filter,
     };
-    visitor.visit_body(parsed.suite());
-
-    // Add docstring for module-level (first statement if it's a string literal).
-    visitor.add_docstring_range(parsed.suite());
+    walk_node(&mut visitor, AnyNodeRef::from(parsed.syntax()));
 
     // Add remaining ranges not covered by the AST visitor.
     visitor.add_comment_ranges();
@@ -70,12 +74,26 @@ struct FoldingRangeVisitor<'a> {
     source: &'a str,
     ranges: Vec<FoldingRange>,
     tokens: &'a Tokens,
+    range_filter: Option<TextRange>,
 }
 
 impl<'a> FoldingRangeVisitor<'a> {
+    fn intersects_range_filter(&self, range: TextRange) -> bool {
+        self.range_filter
+            .is_none_or(|range_filter| range_filter.intersect(range).is_some())
+    }
+
+    fn contains_range_filter(&self, range: TextRange) -> bool {
+        self.range_filter
+            .is_none_or(|range_filter| range_filter.contains_range(range))
+    }
+
     /// Add the given folding range if it spans multiple lines.
     fn add_range(&mut self, folding_range: impl Into<FoldingRange>) {
         let folding_range = folding_range.into();
+        if !self.contains_range_filter(folding_range.range) {
+            return;
+        }
         if !self.is_multiline(folding_range.range) {
             return;
         }
@@ -89,6 +107,9 @@ impl<'a> FoldingRangeVisitor<'a> {
     /// or `finally` blocks.
     fn force_add_range(&mut self, folding_range: impl Into<FoldingRange>) {
         let folding_range = folding_range.into();
+        if !self.contains_range_filter(folding_range.range) {
+            return;
+        }
         self.ranges.push(folding_range);
     }
 
@@ -114,6 +135,15 @@ impl<'a> FoldingRangeVisitor<'a> {
         let mut prev_import_end: Option<TextSize> = None;
 
         for stmt in stmts {
+            if !self.intersects_range_filter(stmt.range()) {
+                if let Some(range) = import_range {
+                    self.add_range(FoldingRange::from(range).with_kind(FoldingRangeKind::Imports));
+                }
+                import_range = None;
+                prev_import_end = None;
+                continue;
+            }
+
             if matches!(stmt, Stmt::Import(_) | Stmt::ImportFrom(_)) {
                 // Check if there's a blank line between this import and the previous one.
                 let has_blank_line = prev_import_end
@@ -163,6 +193,9 @@ impl<'a> FoldingRangeVisitor<'a> {
         let mut region_starts: Vec<TextSize> = Vec::new();
 
         for line in self.lines() {
+            if !self.intersects_range_filter(line.full_range()) {
+                continue;
+            }
             let trimmed = line.trim_start();
             if trimmed.starts_with("# region") || trimmed.starts_with("#region") {
                 region_starts.push(line.start());
@@ -183,6 +216,14 @@ impl<'a> FoldingRangeVisitor<'a> {
         let mut comment_range: Option<TextRange> = None;
 
         for line in self.lines() {
+            if !self.intersects_range_filter(line.full_range()) {
+                if let Some(range) = comment_range {
+                    self.add_range(FoldingRange::from(range).with_kind(FoldingRangeKind::Comment));
+                    comment_range = None;
+                }
+                continue;
+            }
+
             let trimmed = line.trim_start();
 
             // Check if this is a comment line (but not a region marker)
@@ -215,6 +256,9 @@ impl<'a> FoldingRangeVisitor<'a> {
         let Some(first_stmt) = body.first() else {
             return;
         };
+        if !self.contains_range_filter(first_stmt.range()) {
+            return;
+        }
         let Stmt::Expr(ref expr_stmt) = *first_stmt else {
             return;
         };
@@ -270,7 +314,14 @@ impl<'a> FoldingRangeVisitor<'a> {
 
 impl SourceOrderVisitor<'_> for FoldingRangeVisitor<'_> {
     fn enter_node(&mut self, node: AnyNodeRef<'_>) -> TraversalSignal {
+        if !self.intersects_range_filter(node.range()) {
+            return TraversalSignal::Skip;
+        }
+
         match node {
+            AnyNodeRef::ModModule(module) => {
+                self.add_docstring_range(&module.body);
+            }
             // Compound statements that create folding regions
             AnyNodeRef::StmtFunctionDef(func) => {
                 self.add_function_def_range(func);
@@ -1711,7 +1762,7 @@ with open("file.txt") as f:
 
     impl CursorTest {
         fn folding_ranges(&self) -> String {
-            let ranges = folding_ranges(&self.db, self.cursor.file);
+            let ranges = folding_ranges(&self.db, self.cursor.file, None);
 
             if ranges.is_empty() {
                 return "No folding ranges found".to_string();

--- a/crates/ty_server/src/server/api/requests/folding_range.rs
+++ b/crates/ty_server/src/server/api/requests/folding_range.rs
@@ -2,9 +2,12 @@ use std::borrow::Cow;
 
 use lsp_types::request::FoldingRangeRequest;
 use lsp_types::{FoldingRange, FoldingRangeKind, FoldingRangeParams, Url};
+use ruff_db::source::source_text;
+use ruff_text_size::TextRange;
 use ty_ide::folding_ranges;
 use ty_project::ProjectDatabase;
 
+use crate::db::Db;
 use crate::document::ToRangeExt;
 use crate::server::api::traits::{
     BackgroundDocumentRequestHandler, RequestHandler, RetriableRequestHandler,
@@ -40,7 +43,20 @@ impl BackgroundDocumentRequestHandler for FoldingRangeRequestHandler {
             return Ok(None);
         };
 
-        let results: Vec<_> = folding_ranges(db, file)
+        // If this document is a notebook cell, only return folding ranges for this cell.
+        // Folding ranges are reported as local ranges, so returning notebook-wide ranges
+        // would produce invalid coordinates for every other cell.
+        let mut cell_range: Option<TextRange> = None;
+
+        if snapshot.document().is_cell()
+            && let Some(notebook_document) = db.notebook_document(file)
+            && let Some(notebook) = source_text(db, file).as_notebook()
+        {
+            let cell_index = notebook_document.cell_index_by_uri(snapshot.url());
+            cell_range = cell_index.and_then(|index| notebook.cell_range(index));
+        }
+
+        let results: Vec<_> = folding_ranges(db, file, cell_range)
             .into_iter()
             .filter_map(|folding_range| {
                 let lsp_range = folding_range

--- a/crates/ty_server/tests/e2e/folding_range.rs
+++ b/crates/ty_server/tests/e2e/folding_range.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use ruff_db::system::SystemPath;
 
 use crate::TestServerBuilder;
+use crate::notebook::NotebookBuilder;
 
 #[test]
 fn folding_range_basic_functionality() -> Result<()> {
@@ -27,6 +28,61 @@ fn folding_range_basic_functionality() -> Result<()> {
     let ranges = server.folding_range_request(&server.file_uri(foo));
 
     insta::assert_json_snapshot!(ranges);
+
+    Ok(())
+}
+
+#[test]
+fn folding_range_notebook_cells_are_filtered_to_the_requested_cell() -> Result<()> {
+    let mut server = TestServerBuilder::new()?
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.initialization_result().unwrap();
+
+    let mut builder = NotebookBuilder::virtual_file("test.ipynb");
+    let first_cell = builder.add_python_cell(
+        r#"import os
+import zipfile
+
+out_dir = "output"
+archive = "archive.zip"
+
+with zipfile.ZipFile(archive, "r") as zip_ref:
+    for file_info in zip_ref.infolist():
+        out_path = os.path.join(out_dir, file_info.filename)
+        if file_info.file_size == 0:
+            pass
+        else:
+            if os.path.exists(out_path):
+                pass
+"#,
+    );
+
+    let second_cell = builder.add_python_cell(
+        r#"x1 = X(
+    p1="X",
+)
+
+x2 = X(
+    p1="X",
+    p2="X",
+    p3="X",
+    p4="X",
+    p5="X",
+    p6="X",
+    p7="X",
+)
+"#,
+    );
+
+    builder.open(&mut server);
+    server.collect_publish_diagnostic_notifications(2);
+
+    let first_cell_ranges = server.folding_range_request(&first_cell);
+    let second_cell_ranges = server.folding_range_request(&second_cell);
+
+    insta::assert_json_snapshot!([first_cell_ranges, second_cell_ranges]);
 
     Ok(())
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__folding_range__folding_range_notebook_cells_are_filtered_to_the_requested_cell.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__folding_range__folding_range_notebook_cells_are_filtered_to_the_requested_cell.snap
@@ -1,0 +1,60 @@
+---
+source: crates/ty_server/tests/e2e/folding_range.rs
+assertion_line: 84
+expression: "[first_cell_ranges, second_cell_ranges]"
+---
+[
+  [
+    {
+      "startLine": 0,
+      "startCharacter": 0,
+      "endLine": 1,
+      "endCharacter": 14,
+      "kind": "imports"
+    },
+    {
+      "startLine": 6,
+      "startCharacter": 0,
+      "endLine": 13,
+      "endCharacter": 20
+    },
+    {
+      "startLine": 7,
+      "startCharacter": 4,
+      "endLine": 13,
+      "endCharacter": 20
+    },
+    {
+      "startLine": 9,
+      "startCharacter": 8,
+      "endLine": 10,
+      "endCharacter": 16
+    },
+    {
+      "startLine": 11,
+      "startCharacter": 8,
+      "endLine": 13,
+      "endCharacter": 20
+    },
+    {
+      "startLine": 12,
+      "startCharacter": 12,
+      "endLine": 13,
+      "endCharacter": 20
+    }
+  ],
+  [
+    {
+      "startLine": 0,
+      "startCharacter": 5,
+      "endLine": 2,
+      "endCharacter": 1
+    },
+    {
+      "startLine": 4,
+      "startCharacter": 5,
+      "endLine": 12,
+      "endCharacter": 1
+    }
+  ]
+]


### PR DESCRIPTION
## Summary

Fixes a bug where folding ranges returned the folding ranges for the entire file
instead of the current cell only.


`folding_ranges` uses `to_local_range` here:

https://github.com/astral-sh/ruff/blob/1425c185b0a47be87112762f65b5bf7e323fb950/crates/ty_server/src/server/api/requests/folding_range.rs#L43-L65

It's only correct to use `to_local_range` if the ranges are all guaranteed to belong to the same text or cell document. This isn't the case here because `folding_ranges` returns all folding ranges for the entire notebook and not just the requested cell. This is incorrect.

The fix here is to limit `folding_ranges` to the cell range if the document is a notebook cell, similar to what we do for semantic tokens:

https://github.com/astral-sh/ruff/blob/12e74ae894f90d0b119fc1b85668ac3380084e8a/crates/ty_server/src/server/api/requests/semantic_tokens.rs#L43-L66

Closes https://github.com/astral-sh/ty/issues/2988

## Test Plan

Added E2E test
