### PR TITLE
[ty] Initial test suite for PEP-728 `TypedDict` features

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3098,6 +3098,23 @@ def _(extra: Extra) -> None:
         reveal_type(item)  # revealed: tuple[str, object]
 ```
 
+### A closed `TypedDict` is equivalent to `extra_items=Never`
+
+```py
+from typing_extensions import TypedDict, Never
+from ty_extensions import static_assert, is_equivalent_to, is_subtype_of
+
+class Extra(TypedDict, extra_items=Never):
+    x: int
+
+class Closed(TypedDict, closed=True):
+    x: int
+
+static_assert(is_equivalent_to(Extra, Closed))
+static_assert(is_subtype_of(Extra, Closed))
+static_assert(is_subtype_of(Closed, Extra))
+```
+
 ### Empty closed TypedDict is known to be falsy
 
 An empty `closed=True` TypedDict cannot contain any keys, so it is always empty and always falsy.


### PR DESCRIPTION
## Summary

This PR adds an initial test suite for `closed=True` and `extra_items` TypedDicts, both originally introduced by PEP 728. The spec for TypedDicts is [here](https://typing.python.org/en/latest/spec/typeddict.html), and the conformance-suite tests for PEP 728 features are [here](https://github.com/python/typing/blob/main/conformance/tests/typeddicts_extra_items.py).

Note that we already have _some_ existing tests for the `closed=True` keyword here:

https://github.com/astral-sh/ruff/blob/92a77f2a69639b63306534488355e18de2dd081a/crates/ty_python_semantic/resources/mdtest/typed_dict.md?plain=1#L2927-L2941

## Test Plan

this pr is all tests

Co-authored-by: Carl Meyer <carl@astral.sh>