### PR TITLE
[ty] Fix playground crash when renaming file

### DIFF
--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -403,21 +403,13 @@ class PlaygroundServer
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _token: CancellationToken,
   ): languages.ProviderResult<languages.DocumentHighlight[]> {
-    const workspace = this.props.workspace;
-    const selectedFile = this.props.files.selected;
-
-    if (selectedFile == null) {
-      return;
+    const fileHandle = this.getFileHandleForModel(model);
+    if (fileHandle == null) {
+      return undefined;
     }
 
-    const selectedHandle = this.props.files.handles[selectedFile];
-
-    if (selectedHandle == null) {
-      return;
-    }
-
-    const highlights = workspace.documentHighlights(
-      selectedHandle,
+    const highlights = this.props.workspace.documentHighlights(
+      fileHandle,
       new TyPosition(position.lineNumber, position.column),
     );
 
@@ -502,6 +494,14 @@ class PlaygroundServer
     this.inVendoredFileCondition.set(isViewingVendoredFile);
   }
 
+  private getPlaygroundFileIdForUri(uri: Uri): FileId | null {
+    return (
+      this.props.files.index.find((file) => {
+        return Uri.file(file.name).toString() === uri.toString();
+      })?.id ?? null
+    );
+  }
+
   private getOrCreateVendoredFileHandle(vendoredPath: string): FileHandle {
     const cachedHandle = this.vendoredFileHandles.get(vendoredPath);
     // Check if we already have a handle for this vendored file
@@ -524,13 +524,12 @@ class PlaygroundServer
       return this.getOrCreateVendoredFileHandle(vendoredPath);
     }
 
-    // Handle regular user files
-    const selectedFile = this.props.files.selected;
-    if (selectedFile == null) {
+    const fileId = this.getPlaygroundFileIdForUri(model.uri);
+    if (fileId == null) {
       return null;
     }
 
-    return this.props.files.handles[selectedFile];
+    return this.props.files.handles[fileId] ?? null;
   }
 
   private formatSignatureHelp(
@@ -805,9 +804,7 @@ class PlaygroundServer
       this.props.onVendoredFileChange(fileHandle);
     } else {
       // Handle regular files
-      const fileId = files.index.find((file) => {
-        return Uri.file(file.name).toString() === resource.toString();
-      })?.id;
+      const fileId = this.getPlaygroundFileIdForUri(resource);
 
       if (fileId == null) {
         return false;
@@ -837,12 +834,7 @@ class PlaygroundServer
   provideDocumentFormattingEdits(
     model: editor.ITextModel,
   ): languages.ProviderResult<languages.TextEdit[]> {
-    if (this.props.files.selected == null) {
-      return null;
-    }
-
-    const fileHandle = this.props.files.handles[this.props.files.selected];
-
+    const fileHandle = this.getFileHandleForModel(model);
     if (fileHandle == null) {
       return null;
     }
@@ -873,9 +865,7 @@ class PlaygroundServer
         this.monaco.editor.createModel(content, "python", uri);
       } else {
         // Handle regular files
-        const fileId = this.props.files.index.find((file) => {
-          return Uri.file(file.name).toString() === uri.toString();
-        })?.id;
+        const fileId = this.getPlaygroundFileIdForUri(uri);
 
         if (fileId != null) {
           const handle = this.props.files.handles[fileId];


### PR DESCRIPTION
## Summary

The playground implements the rename operation as a `closeFile` + `openFile` calls, and 
the React state is updated after both these operations complete.

This operation isn't atomic, and Monaco has its own event loop. The result is
that Monaco might fetch semantic tokens or other information after the file was closed and opened, but before React's updates are fully propagated to Monaco (or in the middle of Monaco updating its internal state as part of it).

The solution is to avoid using `files.selected` within Monaco when the action should be performed on the current file. Instead, we search for the file matching monaco's current `model`. This has the effect that all operations become no-ops if Monaco's current model still points to the old file (before the rename). 

I don't feel 100% sure about the root cause analysis, but I think this change goes in the right direction.

Closes https://github.com/astral-sh/ty/issues/3000

## Test Plan


https://github.com/user-attachments/assets/9d3109a8-db8a-4912-b929-46a71cbcff0f

