### PR TITLE
Fix DOC501 false positive for classmethod-constructed exceptions

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_google.py
@@ -246,3 +246,29 @@ def foo():
         raise TypeError  # no DOC501 here because we already emitted a diagnostic for the earlier `raise TypeError`
     raise ValueError  # DOC501
     return 42
+
+
+class MyError(Exception):
+    @classmethod
+    def from_code(cls, code: int) -> "MyError":
+        return cls(f"Error code: {code}")
+
+
+# OK: exception raised via classmethod should be recognized (https://github.com/astral-sh/ruff/issues/23570)
+def foo_classmethod():
+    """Foo.
+
+    Raises:
+        MyError: If something goes wrong.
+    """
+    raise MyError.from_code(42)
+
+
+# DOC501: classmethod-constructed exception missing from docstring
+def bar_classmethod():
+    """Bar.
+
+    Raises:
+        ValueError: Some other error.
+    """
+    raise MyError.from_code(42)  # DOC501

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC502_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC502_google.py
@@ -164,3 +164,19 @@ def i():
         pass
     except (ValueError, TypeError) as e:
         raise e
+
+
+class MyError(Exception):
+    @classmethod
+    def from_code(cls, code: int) -> "MyError":
+        return cls(f"Error code: {code}")
+
+
+# OK: exception raised via classmethod should be recognized (https://github.com/astral-sh/ruff/issues/23570)
+def foo_classmethod():
+    """Foo.
+
+    Raises:
+        MyError: If something goes wrong.
+    """
+    raise MyError.from_code(42)

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -980,10 +980,31 @@ impl<'a> Visitor<'a> for BodyVisitor<'a> {
         match stmt {
             Stmt::Raise(ast::StmtRaise { exc, .. }) => {
                 if let Some(exc) = exc.as_ref() {
-                    // First try to resolve the exception directly
-                    if let Some(qualified_name) =
-                        self.semantic.resolve_qualified_name(map_callable(exc))
-                    {
+                    let callable = map_callable(exc);
+                    // If the exception is raised via a method call on a class
+                    // (e.g., `ValidationError.from_exception_data(...)`),
+                    // `map_callable` strips the call, leaving an attribute
+                    // expression like `ValidationError.from_exception_data`.
+                    // In that case, try resolving the object (class) part so
+                    // that classmethod-constructed exceptions are recognised.
+                    let resolved =
+                        if exc.is_call_expr() {
+                            if let ast::Expr::Attribute(ast::ExprAttribute {
+                                value, ..
+                            }) = callable
+                            {
+                                self.semantic
+                                    .resolve_qualified_name(value)
+                                    .or_else(|| {
+                                        self.semantic.resolve_qualified_name(callable)
+                                    })
+                            } else {
+                                self.semantic.resolve_qualified_name(callable)
+                            }
+                        } else {
+                            self.semantic.resolve_qualified_name(callable)
+                        };
+                    if let Some(qualified_name) = resolved {
                         self.raised_exceptions.push(ExceptionEntry {
                             qualified_name,
                             range: exc.range(),

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py.snap
@@ -226,3 +226,18 @@ DOC501 Raised exception `ValueError` missing from docstring
 244 |           raise TypeError  # DOC501
     |
 help: Add `ValueError` to the docstring
+
+DOC501 Raised exception `MyError` missing from docstring
+   --> DOC501_google.py:269:5
+    |
+267 |   # DOC501: classmethod-constructed exception missing from docstring
+268 |   def bar_classmethod():
+269 | /     """Bar.
+270 | |
+271 | |     Raises:
+272 | |         ValueError: Some other error.
+273 | |     """
+    | |_______^
+274 |       raise MyError.from_code(42)  # DOC501
+    |
+help: Add `MyError` to the docstring

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py_ignore_one_line.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py_ignore_one_line.snap
@@ -226,3 +226,18 @@ DOC501 Raised exception `ValueError` missing from docstring
 244 |           raise TypeError  # DOC501
     |
 help: Add `ValueError` to the docstring
+
+DOC501 Raised exception `MyError` missing from docstring
+   --> DOC501_google.py:269:5
+    |
+267 |   # DOC501: classmethod-constructed exception missing from docstring
+268 |   def bar_classmethod():
+269 | /     """Bar.
+270 | |
+271 | |     Raises:
+272 | |         ValueError: Some other error.
+273 | |     """
+    | |_______^
+274 |       raise MyError.from_code(42)  # DOC501
+    |
+help: Add `MyError` to the docstring


### PR DESCRIPTION
## Summary

Fixes #23570

When an exception is raised via a classmethod or alternative constructor (e.g., `raise ValidationError.from_exception_data(...)`), `map_callable` strips the call, leaving an attribute expression like `ValidationError.from_exception_data`. The qualified name resolver then produces a path ending in the method name rather than the class name, causing:

- **DOC501** to report the method name (`from_exception_data`) as a missing exception
- **DOC502** to treat the documented exception class (`ValidationError`) as extraneous

This PR resolves the class (attribute value) instead of the full method path when the raise target is a call on an attribute expression, so that the exception class is correctly matched against the docstring.

## Test Plan

Added test cases to `DOC501_google.py` and `DOC502_google.py`:
- A classmethod-constructed exception that IS documented (should not trigger DOC501/DOC502)
- A classmethod-constructed exception that is NOT documented (should trigger DOC501 with the correct class name)

All existing pydoclint tests continue to pass.