### PR TITLE
[ty] Smarter semantic token classification for attribute access on union type

### DIFF
--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -442,74 +442,85 @@ impl<'db> SemanticTokenVisitor<'db> {
         ty: Type,
         attr_name: &ast::Identifier,
     ) -> (SemanticTokenType, SemanticTokenModifier) {
+        enum UnifiedTokenType {
+            None,
+            /// All types have the same semantic token type
+            Uniform(SemanticTokenType),
+            /// The elements have different semantic token types
+            Fallback,
+        }
+
+        impl UnifiedTokenType {
+            fn add(&mut self, ty: SemanticTokenType) {
+                *self = match self {
+                    Self::None => Self::Uniform(ty),
+                    Self::Uniform(current) if *current == ty => Self::Uniform(ty),
+                    Self::Uniform(_) | Self::Fallback => Self::Fallback,
+                }
+            }
+
+            fn into_semantic_token_type(self) -> Option<SemanticTokenType> {
+                match self {
+                    UnifiedTokenType::None | UnifiedTokenType::Fallback => None,
+                    UnifiedTokenType::Uniform(ty) => Some(ty),
+                }
+            }
+        }
+
         let attr_name_str = attr_name.id.as_str();
         let mut modifiers = SemanticTokenModifier::empty();
 
         if let Some(classification) = self.classify_annotation_type_expr(ty) {
             return classification;
         }
-        // If we are dealing with a union type, classify all elements of the union and check if
-        // the classifications equal.
-        if let Type::Union(union) = ty
-            && let Ok(Some(classification)) = union
-                .elements(self.model.db())
-                .iter()
-                .map(|ty| self.classify_from_type_for_attribute(*ty, attr_name))
-                // Would be a lot cleaner with `try_reduce`, but that is still experimental
-                .try_fold(None, |prev, (class, mods)| {
-                    match prev {
-                        // First element gets special handling, because accumulator starts with None
-                        None => Ok(Some((class, mods))),
-                        // Later iterations have the comparison logic
-                        Some((class_prev, mods_prev)) => {
-                            if std::mem::discriminant(&class_prev) == std::mem::discriminant(&class)
-                            {
-                                Ok(Some((
-                                    class,
-                                    if mods_prev == mods {
-                                        mods
-                                    } else {
-                                        SemanticTokenModifier::empty()
-                                    },
-                                )))
-                            } else {
-                                Err(()) // Short-circuits when classes don't match
-                            }
-                        }
-                    }
-                })
-        {
-            return classification;
-        }
-        // Classify based on the inferred type of the attribute
-        match ty {
-            Type::ClassLiteral(_) => (SemanticTokenType::Class, modifiers),
-            Type::FunctionLiteral(_) => {
-                // This is a function accessed as an attribute, likely a method
-                (SemanticTokenType::Method, modifiers)
-            }
-            Type::BoundMethod(_) => {
-                // Method bound to an instance
-                (SemanticTokenType::Method, modifiers)
-            }
-            Type::ModuleLiteral(_) => {
-                // Module accessed as an attribute (e.g., from os import path)
-                (SemanticTokenType::Namespace, modifiers)
-            }
-            _ if ty.is_property_instance() => {
-                // Actual Python property
-                (SemanticTokenType::Property, modifiers)
-            }
-            _ => {
-                // Check for constant naming convention
-                if Self::is_constant_name(attr_name_str) {
-                    modifiers |= SemanticTokenModifier::READONLY;
-                }
 
-                // For other types (variables, constants, etc.), classify as variable
-                (SemanticTokenType::Variable, modifiers)
+        let elements = if let Some(union) = ty.as_union() {
+            union.elements(self.model.db())
+        } else {
+            std::slice::from_ref(&ty)
+        };
+
+        let mut token_type = UnifiedTokenType::None;
+
+        for element in elements {
+            // Classify based on the inferred type of the attribute
+            match element {
+                Type::ClassLiteral(_) => {
+                    token_type.add(SemanticTokenType::Class);
+                }
+                Type::FunctionLiteral(_) => {
+                    // This is a function accessed as an attribute, likely a method
+                    token_type.add(SemanticTokenType::Method);
+                }
+                Type::BoundMethod(_) | Type::KnownBoundMethod(_) => {
+                    // Method bound to an instance
+                    token_type.add(SemanticTokenType::Method);
+                }
+                Type::ModuleLiteral(_) => {
+                    // Module accessed as an attribute (e.g., from os import path)
+                    token_type.add(SemanticTokenType::Namespace);
+                }
+                ty if ty.is_property_instance() => {
+                    token_type.add(SemanticTokenType::Property);
+                }
+                _ => {
+                    token_type = UnifiedTokenType::Fallback;
+                }
             }
         }
+
+        if let Some(uniform) = token_type.into_semantic_token_type() {
+            return (uniform, modifiers);
+        }
+
+        // Check for constant naming convention
+        if Self::is_constant_name(attr_name_str) {
+            modifiers |= SemanticTokenModifier::READONLY;
+        }
+
+        // For other types (variables, constants, etc.), classify as variable
+        // Should this always be property?
+        (SemanticTokenType::Variable, modifiers)
     }
 
     fn classify_parameter(

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1306,7 +1306,7 @@ impl<'db> Type<'db> {
         matches!(self, Type::Union(_))
     }
 
-    pub(crate) const fn as_union(self) -> Option<UnionType<'db>> {
+    pub const fn as_union(self) -> Option<UnionType<'db>> {
         match self {
             Type::Union(union_type) => Some(union_type),
             _ => None,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

ref [ty/#791](https://github.com/astral-sh/ty/issues/791#issuecomment-4010675932)

Updates the semantic token classification for attribute access on union types. It now checks if all elements of the union belong to the same type variant and if so, recursively tries to classify that common variant. Imo this produces nicer results especially when calling a method on an object of some union type.

I decided not to specifically check if all union elements are of some fixed set of variants (e.g. only `Type::BoundMethod` etc), because i felt like duplicating the logic may be brittle. That means, that some hypothetical type of `Union[Union[BoundMethod, BoundMethod], Union[something_else, something_else]]` may be misclassified as `Method` in this case, by i am unsure if it is possible to create such a type.

<details>
<summary>  </summary>
I also did not change behavior for free function classification, because i could not think of a way where this matters, i.e. creating an alias to a function, already changes the classification to `Variable` without involving unions at all:

```python
from random import random

def f(): ...
def g(): ...

f_alias = f
f_alias()

f_or_g = f if random() else g
f_or_g()
```

https://play.ty.dev/d8acae76-5642-4841-b4cf-8fd6066cea87

</details>

I also added a line in the existing `semantic_token::test::attribute_classification` test, where there was no test for `MyClass.prop`, which actually classifies as `Property`.

## Test Plan

<!-- How was it tested? -->
Added these two unit test to `semantic_tokens.rs`:

<details>
<summary>attribute_on_union_1</summary>

## [Playground 1](https://play.ty.dev/25fde36a-78a0-44ca-a191-5f05c80107e9)
### `main.py`

```py
from random import random

class Foo:
    CONSTANT = 42

    def method(self):
        return "hello"

    @property
    def prop(self) -> str:
        return "hello"

class Bar:
    CONSTANT = 24

    def method(self, x: int = 1) -> int:
        return 42

    @property
    def prop(self) -> int:
        return self.CONSTANT


foobar = Foo() if random() else Bar()
y = foobar.method                                # method should be method (bound method)
z = foobar.CONSTANT                              # CONSTANT should be variable with readonly modifier
w = foobar.prop                                  # prop should be property
foobar_cls = Foo if random() else Bar
v = foobar_cls.method                            # method should be method (function)
x = foobar_cls.prop                              # prop should be property

```
</details>

<details>
<summary> attribute_on_union_2 </summary> 

## [Playground 2](https://play.ty.dev/2baffe2c-4bc5-444a-b243-7564c6e5ea40)
### `main.py`

```py
from random import random

# There is also this way to create union types:
class Baz:
    if random():
        CONSTANT = 42

        def method(self) -> int:
            return 42

        @property
        def prop(self) -> int:
            return 42
    else:
        CONSTANT = "hello"

        def method(self) -> str:
            return "hello"

        @property
        def prop(self) -> str:
            return "hello"

baz = Baz()
s = baz.method      # method should be bound method
t = baz.CONSTANT    # CONSTANT should be variable with readonly
r = baz.prop        # prop should be property
q = Baz.prop        # prop should be property on the class as well

```
</details>

<details>
<summary> attributes_on_union_3 </summary>

## [Playground 3](https://play.ty.dev/19a02170-67d1-4cda-a550-631d4cb72f53)

This one is more of a negative test, where the union does not contain elements of the same type variant and the classification should therefore fallback to just `Variable`.

### `main.py`

```py
from random import random

class Baz:
    if random():
        CONSTANT = 42

        def method(self) -> int:
            return 42

        @property
        def prop(self) -> int:
            return 42
    else:
        def CONSTANT(self):
            return "hello"

        @property
        def method(self) -> str:
            return "hello"

        prop: str = "hello"

baz = Baz()
s = baz.method 
t = baz.CONSTANT
r = baz.prop
q = Baz.prop

```
</details>

