### PR TITLE
[`ruff`] Comment out unreliable float-division checks for `RUF069`

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/float_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/float_equality_comparison.rs
@@ -155,47 +155,18 @@ fn has_float(expr: &Expr, semantic: &SemanticModel) -> bool {
         ResolvedPythonType::Atom(PythonType::Number(NumberLike::Float | NumberLike::Complex)) => {
             true
         }
-        _ => {
-            match expr {
-                Expr::Call(ast::ExprCall { func, .. }) => ["float", "complex"]
-                    .iter()
-                    .any(|s| semantic.match_builtin_expr(func, s)),
-                Expr::BinOp(ast::ExprBinOp {
-                    left, right, op, ..
-                }) => {
-                    // Division always returns float in Python
-                    // https://docs.python.org/3/tutorial/introduction.html#numbers
-                    match op {
-                        // For now, we intentionally do not treat division as reliably float-producing.
-                        // Without type information from ty, we cannot precisely determine whether the
-                        // operands are `Decimal` or some other non-float type.
-                        //
-                        // ast::Operator::Div => {
-                        //     // Only trigger for numeric divisions, not path operations
-                        //     // Ex) `Path(__file__).parents[2] / "text.txt"`
-                        //     is_numeric_expr(left) || is_numeric_expr(right)
-                        // }
-                        _ => has_float(left, semantic) || has_float(right, semantic),
-                    }
-                }
-                Expr::Named(ast::ExprNamed { value, .. }) => has_float(value, semantic),
-                _ => false,
+        _ => match expr {
+            Expr::Call(ast::ExprCall { func, .. }) => ["float", "complex"]
+                .iter()
+                .any(|s| semantic.match_builtin_expr(func, s)),
+            Expr::BinOp(ast::ExprBinOp { left, right, .. }) => {
+                has_float(left, semantic) || has_float(right, semantic)
             }
-        }
+            Expr::Named(ast::ExprNamed { value, .. }) => has_float(value, semantic),
+            _ => false,
+        },
     }
 }
-
-// fn is_numeric_expr(expr: &Expr) -> bool {
-//     match expr {
-//         Expr::NumberLiteral(_) => true,
-//         Expr::BinOp(ast::ExprBinOp { left, right, .. }) => {
-//             is_numeric_expr(left) || is_numeric_expr(right)
-//         }
-//         Expr::UnaryOp(ast::ExprUnaryOp { operand, .. }) => is_numeric_expr(operand),
-//         Expr::Named(ast::ExprNamed { value, .. }) => is_numeric_expr(value),
-//         _ => false,
-//     }
-// }
 
 fn should_skip_comparison(expr: &Expr, semantic: &SemanticModel) -> bool {
     match expr {

--- a/crates/ruff_linter/src/rules/ruff/rules/float_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/float_equality_comparison.rs
@@ -166,11 +166,15 @@ fn has_float(expr: &Expr, semantic: &SemanticModel) -> bool {
                     // Division always returns float in Python
                     // https://docs.python.org/3/tutorial/introduction.html#numbers
                     match op {
-                        ast::Operator::Div => {
-                            // Only trigger for numeric divisions, not path operations
-                            // Ex) `Path(__file__).parents[2] / "text.txt"`
-                            is_numeric_expr(left) || is_numeric_expr(right)
-                        }
+                        // For now, we intentionally do not treat division as reliably float-producing.
+                        // Without type information from ty, we cannot precisely determine whether the
+                        // operands are `Decimal` or some other non-float type.
+                        //
+                        // ast::Operator::Div => {
+                        //     // Only trigger for numeric divisions, not path operations
+                        //     // Ex) `Path(__file__).parents[2] / "text.txt"`
+                        //     is_numeric_expr(left) || is_numeric_expr(right)
+                        // }
                         _ => has_float(left, semantic) || has_float(right, semantic),
                     }
                 }
@@ -181,17 +185,17 @@ fn has_float(expr: &Expr, semantic: &SemanticModel) -> bool {
     }
 }
 
-fn is_numeric_expr(expr: &Expr) -> bool {
-    match expr {
-        Expr::NumberLiteral(_) => true,
-        Expr::BinOp(ast::ExprBinOp { left, right, .. }) => {
-            is_numeric_expr(left) || is_numeric_expr(right)
-        }
-        Expr::UnaryOp(ast::ExprUnaryOp { operand, .. }) => is_numeric_expr(operand),
-        Expr::Named(ast::ExprNamed { value, .. }) => is_numeric_expr(value),
-        _ => false,
-    }
-}
+// fn is_numeric_expr(expr: &Expr) -> bool {
+//     match expr {
+//         Expr::NumberLiteral(_) => true,
+//         Expr::BinOp(ast::ExprBinOp { left, right, .. }) => {
+//             is_numeric_expr(left) || is_numeric_expr(right)
+//         }
+//         Expr::UnaryOp(ast::ExprUnaryOp { operand, .. }) => is_numeric_expr(operand),
+//         Expr::Named(ast::ExprNamed { value, .. }) => is_numeric_expr(value),
+//         _ => false,
+//     }
+// }
 
 fn should_skip_comparison(expr: &Expr, semantic: &SemanticModel) -> bool {
     match expr {

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF069_RUF069.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF069_RUF069.py.snap
@@ -176,26 +176,6 @@ RUF069 Unreliable floating point equality comparison `i != 2.0`
 35 | assert x / 2 == 1
    |
 
-RUF069 Unreliable floating point equality comparison `x / 2 == 1`
-  --> RUF069.py:35:8
-   |
-33 | {i for i in range(10) if i != 2.0}
-34 |
-35 | assert x / 2 == 1
-   |        ^^^^^^^^^^
-36 | assert (x / 2) == (y / 3)
-   |
-
-RUF069 Unreliable floating point equality comparison `x / 2 == y / 3`
-  --> RUF069.py:36:9
-   |
-35 | assert x / 2 == 1
-36 | assert (x / 2) == (y / 3)
-   |         ^^^^^^^^^^^^^^^^
-37 |
-38 | # ok
-   |
-
 RUF069 Unreliable floating point equality comparison `a == b * float("2")`
   --> RUF069.py:42:12
    |
@@ -215,17 +195,6 @@ RUF069 Unreliable floating point equality comparison `complex(0.3, 0.2) == compl
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 45 |
 46 | assert (y := x / 2) == 1
-   |
-
-RUF069 Unreliable floating point equality comparison `y := x / 2 == 1`
-  --> RUF069.py:46:9
-   |
-44 | assert complex(0.3, 0.2) == complex(0.1 + 0.2, 0.1 + 0.1)
-45 |
-46 | assert (y := x / 2) == 1
-   |         ^^^^^^^^^^^^^^^^
-47 |
-48 | assert (0.3 if x > 0 else 1) == 0.1 + 0.2
    |
 
 RUF069 Unreliable floating point equality comparison `0.3 if x > 0 else 1 == 0.1 + 0.2`


### PR DESCRIPTION
## Summary

See: #23281

## Test Plan

```bash
cargo nextest run ruf069
```
