### PR TITLE
Allow selecting rules with severity `warning` in preview

### DIFF
--- a/crates/ruff/src/commands/check.rs
+++ b/crates/ruff/src/commands/check.rs
@@ -143,7 +143,11 @@ pub(crate) fn check(
                         SourceFileBuilder::new(path.to_string_lossy().as_ref(), "").finish();
 
                     Diagnostics::new(
-                        vec![IOError { message }.into_diagnostic(TextRange::default(), &dummy)],
+                        vec![IOError { message }.into_diagnostic(
+                            TextRange::default(),
+                            &dummy,
+                            settings.linter.rules.severity(Rule::IOError),
+                        )],
                         FxHashMap::default(),
                     )
                 } else {

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -71,7 +71,11 @@ impl Diagnostics {
                             IOError {
                                 message: err.to_string(),
                             }
-                            .into_diagnostic(TextRange::default(), &source_file),
+                            .into_diagnostic(
+                                TextRange::default(),
+                                &source_file,
+                                settings.rules.severity(Rule::IOError),
+                            ),
                         ],
                         FxHashMap::default(),
                     )

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -498,14 +498,10 @@ https://github.com/astral-sh/ruff/issues/new?title=%5BLinter%20panic%5D
                 // If we're running the linter (not just fixing), we want to exit non-zero if
                 // there are any violations, unless we're explicitly asked to exit zero on
                 // fix.
-                if cli.exit_non_zero_on_fix {
-                    if !diagnostics.fixed.is_empty() || !diagnostics.inner.is_empty() {
-                        return Ok(ExitStatus::Failure);
-                    }
-                } else {
-                    if !diagnostics.inner.is_empty() {
-                        return Ok(ExitStatus::Failure);
-                    }
+                if max_severity >= Severity::Error
+                    || (cli.exit_non_zero_on_fix && !diagnostics.fixed.is_empty())
+                {
+                    return Ok(ExitStatus::Failure);
                 }
             }
         }

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -16,6 +16,7 @@ use notify::{RecursiveMode, Watcher, recommended_watcher};
 use args::{GlobalConfigArgs, ServerCommand};
 use ruff_db::diagnostic::{Diagnostic, Severity};
 use ruff_linter::logging::{LogLevel, set_up_logging};
+use ruff_linter::preview::is_warning_severity_enabled;
 use ruff_linter::settings::flags::FixMode;
 use ruff_linter::{fs, warn_user, warn_user_once};
 use ruff_workspace::Settings;
@@ -363,6 +364,21 @@ pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<Exi
     //   is resolved.
     let preview = pyproject_config.settings.linter.preview;
 
+    if !is_warning_severity_enabled(preview)
+        && pyproject_config
+            .settings
+            .linter
+            .rules
+            .iter_warn()
+            // TODO use `exact_size_is_empty` if that API stabilizes
+            .len()
+            .ne(&0)
+    {
+        warn_user_once!(
+            "Enabling rules with severity 'warning' requires preview mode, otherwise all rules are interpreted with severity 'error'."
+        );
+    }
+
     if cli.watch {
         // Configure the file watcher.
         let (tx, rx) = channel();
@@ -495,10 +511,11 @@ https://github.com/astral-sh/ruff/issues/new?title=%5BLinter%20panic%5D
                     }
                 }
             } else {
-                // If we're running the linter (not just fixing), we want to exit non-zero if
-                // there are any violations, unless we're explicitly asked to exit zero on
-                // fix.
+                // If we're running the linter (not just fixing), we want to
+                // exit non-zero if there are any (error level) violations,
+                // unless we're explicitly asked to exit zero on fix.
                 if max_severity >= Severity::Error
+                    || (!is_warning_severity_enabled(preview) && !diagnostics.inner.is_empty())
                     || (cli.exit_non_zero_on_fix && !diagnostics.fixed.is_empty())
                 {
                     return Ok(ExitStatus::Failure);

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -468,7 +468,7 @@ pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<Exi
             writer
         };
         if cli.statistics {
-            printer.write_statistics(&diagnostics, &mut summary_writer)?;
+            printer.write_statistics(&diagnostics, &mut summary_writer, preview)?;
         } else {
             printer.write_once(&diagnostics, &mut summary_writer, preview)?;
         }

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -81,7 +81,12 @@ impl Printer {
         }
     }
 
-    fn write_summary_text(&self, writer: &mut dyn Write, diagnostics: &Diagnostics) -> Result<()> {
+    fn write_summary_text(
+        &self,
+        writer: &mut dyn Write,
+        diagnostics: &Diagnostics,
+        preview: PreviewMode,
+    ) -> Result<()> {
         if self.log_level >= LogLevel::Default {
             let fixables = FixableStatistics::try_from(diagnostics, self.unsafe_fixes);
 
@@ -91,6 +96,12 @@ impl Printer {
                 .flat_map(FixTable::counts)
                 .sum::<usize>();
 
+            let reportable = if preview.is_enabled() {
+                "diagnostic"
+            } else {
+                "error"
+            };
+
             if self.flags.intersects(Flags::SHOW_VIOLATIONS) {
                 let remaining = diagnostics.inner.len();
                 let total = fixed + remaining;
@@ -98,11 +109,11 @@ impl Printer {
                     let s = if total == 1 { "" } else { "s" };
                     writeln!(
                         writer,
-                        "Found {total} error{s} ({fixed} fixed, {remaining} remaining)."
+                        "Found {total} {reportable}{s} ({fixed} fixed, {remaining} remaining)."
                     )?;
                 } else if remaining > 0 {
                     let s = if remaining == 1 { "" } else { "s" };
-                    writeln!(writer, "Found {remaining} error{s}.")?;
+                    writeln!(writer, "Found {remaining} {reportable}{s}.")?;
                 } else if remaining == 0 {
                     writeln!(writer, "All checks passed!")?;
                 }
@@ -169,12 +180,12 @@ impl Printer {
                         if self.fix_mode.is_apply() {
                             writeln!(
                                 writer,
-                                "Fixed {fixed} error{s} ({unapplied} additional fix{es} available with `--unsafe-fixes`)."
+                                "Fixed {fixed} {reportable}{s} ({unapplied} additional fix{es} available with `--unsafe-fixes`)."
                             )?;
                         } else {
                             writeln!(
                                 writer,
-                                "Would fix {fixed} error{s} ({unapplied} additional fix{es} available with `--unsafe-fixes`)."
+                                "Would fix {fixed} {reportable}{s} ({unapplied} additional fix{es} available with `--unsafe-fixes`)."
                             )?;
                         }
                     } else {
@@ -194,9 +205,9 @@ impl Printer {
                     if fixed > 0 {
                         let s = if fixed == 1 { "" } else { "s" };
                         if self.fix_mode.is_apply() {
-                            writeln!(writer, "Fixed {fixed} error{s}.")?;
+                            writeln!(writer, "Fixed {fixed} {reportable}{s}.")?;
                         } else {
-                            writeln!(writer, "Would fix {fixed} error{s}.")?;
+                            writeln!(writer, "Would fix {fixed} {reportable}{s}.")?;
                         }
                     }
                 }
@@ -227,7 +238,7 @@ impl Printer {
                         writeln!(writer)?;
                     }
                 }
-                self.write_summary_text(writer, diagnostics)?;
+                self.write_summary_text(writer, diagnostics, preview)?;
             }
             return Ok(());
         }
@@ -256,7 +267,7 @@ impl Printer {
                     writeln!(writer)?;
                 }
             }
-            self.write_summary_text(writer, diagnostics)?;
+            self.write_summary_text(writer, diagnostics, preview)?;
         }
 
         writer.flush()?;
@@ -268,6 +279,7 @@ impl Printer {
         &self,
         diagnostics: &Diagnostics,
         writer: &mut dyn Write,
+        preview: PreviewMode,
     ) -> Result<()> {
         let required_applicability = self.unsafe_fixes.required_applicability();
         let statistics: Vec<ExpandedStatistics> = diagnostics
@@ -360,7 +372,7 @@ impl Printer {
                     )?;
                 }
 
-                self.write_summary_text(writer, diagnostics)?;
+                self.write_summary_text(writer, diagnostics, preview)?;
                 return Ok(());
             }
             OutputFormat::Json => {

--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -2734,7 +2734,7 @@ fn nested_implicit_namespace_package() -> Result<()> {
     exit_code: 1
     ----- stdout -----
     foo/bar/baz/__init__.py:1:1: error[INP001] File `foo/bar/baz/__init__.py` declares a package, but is nested under an implicit namespace package. Add an `__init__.py` to `foo/bar`.
-    Found 1 error.
+    Found 1 diagnostic.
 
     ----- stderr -----
     "###);
@@ -3021,7 +3021,7 @@ d: Literal[None,] | Literal[None]
         .arg("--preview")
         .arg("--diff")
         .arg("-")
-        .pass_stdin(snippet), @"
+        .pass_stdin(snippet), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -3042,8 +3042,8 @@ d: Literal[None,] | Literal[None]
 
 
     ----- stderr -----
-    Would fix 4 errors.
-    ");
+    Would fix 4 diagnostics.
+    "###);
 }
 
 /// Test that private, old-style `TypeVar` generics
@@ -3075,7 +3075,7 @@ def func(t: _T) -> _T:
     return x
 "#
         ),
-        @"
+        @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -3089,8 +3089,8 @@ def func(t: _T) -> _T:
         return x
 
     ----- stderr -----
-    Found 7 errors (7 fixed, 0 remaining).
-    "
+    Found 7 diagnostics (7 fixed, 0 remaining).
+    "###
     );
 }
 
@@ -3124,7 +3124,7 @@ class Foo[_T, __T]:
 
     ----- stderr -----
     test.py:2:14: error[UP049] Generic class uses private type parameters
-    Found 2 errors (1 fixed, 1 remaining).
+    Found 2 diagnostics (1 fixed, 1 remaining).
     "###
     );
 }
@@ -3270,7 +3270,7 @@ class A(Generic[T]):
     exit_code: 1
     ----- stdout -----
     test.py:6:9: error[UP046] Generic class `A` uses `Generic` subclass instead of type parameters
-    Found 1 error.
+    Found 1 diagnostic.
     No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
     ----- stderr -----
@@ -3412,7 +3412,7 @@ match 2:
     exit_code: 1
     ----- stdout -----
     test.py:2:1: error[invalid-syntax] Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)
-    Found 1 error.
+    Found 1 diagnostic.
 
     ----- stderr -----
     "###
@@ -3591,7 +3591,7 @@ fn semantic_syntax_errors() -> Result<()> {
     exit_code: 1
     ----- stdout -----
     -:1:3: error[invalid-syntax] assignment expression cannot rebind comprehension variable
-    Found 1 error.
+    Found 1 diagnostic.
 
     ----- stderr -----
     "###
@@ -3756,7 +3756,7 @@ fn show_fixes_in_full_output_with_preview_enabled() {
     help: Remove unused import: `math`
       - import math
 
-    Found 1 error.
+    Found 1 diagnostic.
     [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
@@ -3785,7 +3785,7 @@ fn rule_panic_mixed_results_concise() -> Result<()> {
     normal.py:1:1: error[RUF911] Hey this is a preview test rule.
     normal.py:1:1: error[RUF950] Hey this is a test rule that was redirected from another.
     panic.py: fatal[panic] Panicked at <location> when checking `[TMP]/panic.py`: `This is a fake panic for testing.`
-    Found 7 errors.
+    Found 7 diagnostics.
     [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
     ----- stderr -----
@@ -3839,7 +3839,7 @@ fn rule_panic_mixed_results_full() -> Result<()> {
     info: If you could open an issue at https://github.com/astral-sh/ruff/issues/new?title=%5Bpanic%5D, we'd be very appreciative!
     info: run with `RUST_BACKTRACE=1` environment variable to show the full backtrace information
 
-    Found 7 errors.
+    Found 7 diagnostics.
     [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
     ----- stderr -----
@@ -4006,7 +4006,7 @@ fn supported_file_extensions_preview_enabled() -> Result<()> {
     src/thing.py:1:8: error[F401] [*] `os` imported but unused
     src/thing.pyi:1:8: error[F401] [*] `os` imported but unused
     src/thing.pyw:1:8: error[F401] [*] `os` imported but unused
-    Found 4 errors.
+    Found 4 diagnostics.
     [*] 4 fixable with the `--fix` option.
 
     ----- stderr -----
@@ -4462,7 +4462,7 @@ warn = ["F401"]
     exit_code: 0
     ----- stdout -----
     try.py:1:8: warning[F401] [*] `os` imported but unused
-    Found 1 error.
+    Found 1 diagnostic.
     [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
@@ -4499,7 +4499,7 @@ warn = ["F401"]
     exit_code: 0
     ----- stdout -----
     try.py:1:8: warning[F401] [*] `os` imported but unused
-    Found 1 error.
+    Found 1 diagnostic.
     [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
@@ -4554,7 +4554,7 @@ warn = ["F401"]
     exit_code: 0
     ----- stdout -----
     try.py:1:8: warning[F401] [*] `os` imported but unused
-    Found 1 error.
+    Found 1 diagnostic.
     [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
@@ -4583,7 +4583,7 @@ select = ["F401"]
     exit_code: 1
     ----- stdout -----
     try.py:1:8: error[F401] [*] `os` imported but unused
-    Found 1 error.
+    Found 1 diagnostic.
     [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
@@ -4647,7 +4647,7 @@ warn = ["F401"]
     ----- stdout -----
     try.py:1:8: warning[F401] [*] `os` imported but unused
     try.py:1:22: error[F811] Redefinition of unused `foo` from line 1: `foo` redefined here
-    Found 2 errors.
+    Found 2 diagnostics.
     [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
@@ -4684,7 +4684,7 @@ select = ["F401"]
     ----- stdout -----
     try.py:1:8: error[F401] [*] `os` imported but unused
     try.py:1:22: warning[F811] Redefinition of unused `foo` from line 1: `foo` redefined here
-    Found 2 errors.
+    Found 2 diagnostics.
     [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
@@ -4754,7 +4754,7 @@ warn = ["F401"]
     exit_code: 0
     ----- stdout -----
     try.py:1:8: warning[F401] [*] `os` imported but unused
-    Found 1 error.
+    Found 1 diagnostic.
     [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----

--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -4508,6 +4508,80 @@ warn = ["F401"]
 }
 
 #[test]
+fn warn_outer_select_inner_precedence() -> Result<()> {
+    let test = CliTest::new()?;
+    test.write_file(
+        "ruff.toml",
+        r#"
+[lint]
+preview = true
+warn = ["F401"]
+"#,
+    )?;
+    test.write_file(
+        ".ruff.toml",
+        r#"
+extend = "ruff.toml"
+[lint]
+select = ["F401"]
+"#,
+    )?;
+
+    test.write_file("try.py", "import os")?;
+
+    assert_cmd_snapshot!(
+        test.check_command().args(["--preview", "try.py"]),
+        @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    try.py:1:8: error[F401] [*] `os` imported but unused
+    Found 1 diagnostic.
+    [*] 1 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "###);
+    Ok(())
+}
+
+#[test]
+fn warn_outer_rule_select_inner_prefix_precedence() -> Result<()> {
+    let test = CliTest::new()?;
+    test.write_file(
+        "ruff.toml",
+        r#"
+[lint]
+preview = true
+warn = ["F401"]
+"#,
+    )?;
+    test.write_file(
+        ".ruff.toml",
+        r#"
+extend = "ruff.toml"
+[lint]
+select = ["F"]
+"#,
+    )?;
+
+    test.write_file("try.py", "import os")?;
+
+    assert_cmd_snapshot!(
+        test.check_command().args(["--preview", "try.py"]),
+        @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    try.py:1:8: error[F401] [*] `os` imported but unused
+    Found 1 diagnostic.
+    [*] 1 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "###);
+    Ok(())
+}
+
+#[test]
 fn ignore_overrides_warn() -> Result<()> {
     let test = CliTest::new()?;
     test.write_file(

--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -886,7 +886,7 @@ fn value_given_to_table_key_is_not_inline_table_2() {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .args(STDIN_BASE_OPTIONS)
         .args([".", "--config", r#"lint=123"#]),
-        @"
+        @r###"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -923,12 +923,14 @@ fn value_given_to_table_key_is_not_inline_table_2() {
     - `lint.per-file-ignores`
     - `lint.extend-per-file-ignores`
     - `lint.exclude`
+    - `lint.warn`
+    - `lint.extend-warn`
     - `lint.preview`
     - `lint.typing-extensions`
     - `lint.future-annotations`
 
     For more information, try '--help'.
-    ");
+    "###);
 }
 
 #[test]
@@ -4434,6 +4436,329 @@ fn preview_default_rules() -> Result<()> {
     	verbose-log-message (TRY401),
     ]
     ",
+    );
+    Ok(())
+}
+
+#[test]
+fn warn_and_select_precedence() -> Result<()> {
+    let test = CliTest::new()?;
+    test.write_file(
+        "ruff.toml",
+        r#"
+[lint]
+preview = true
+select = ["F401"]
+warn = ["F401"]
+"#,
+    )?;
+
+    test.write_file("try.py", "import os")?;
+
+    assert_cmd_snapshot!(
+        test.check_command().args(["--preview", "try.py"]),
+        @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    try.py:1:8: warning[F401] [*] `os` imported but unused
+    Found 1 error.
+    [*] 1 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "###);
+    Ok(())
+}
+
+#[test]
+fn warn_inner_select_outer_precedence() -> Result<()> {
+    let test = CliTest::new()?;
+    test.write_file(
+        "ruff.toml",
+        r#"
+[lint]
+preview = true
+select = ["F401"]
+"#,
+    )?;
+    test.write_file(
+        ".ruff.toml",
+        r#"
+extend = "ruff.toml"
+[lint]
+warn = ["F401"]
+"#,
+    )?;
+
+    test.write_file("try.py", "import os")?;
+
+    assert_cmd_snapshot!(
+        test.check_command().args(["--preview", "try.py"]),
+        @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    try.py:1:8: warning[F401] [*] `os` imported but unused
+    Found 1 error.
+    [*] 1 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "###);
+    Ok(())
+}
+
+#[test]
+fn ignore_overrides_warn() -> Result<()> {
+    let test = CliTest::new()?;
+    test.write_file(
+        "ruff.toml",
+        r#"
+[lint]
+preview = true
+warn = ["F401"]
+ignore = ["F401"]
+"#,
+    )?;
+    test.write_file("try.py", "import os")?;
+    assert_cmd_snapshot!(
+        test.check_command().args(["--preview", "try.py"]),
+        @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    "###
+    );
+    Ok(())
+}
+
+#[test]
+fn select_prefix_warn_specific_rule() -> Result<()> {
+    let test = CliTest::new()?;
+    test.write_file(
+        "ruff.toml",
+        r#"
+[lint]
+preview = true
+select = ["F"]
+warn = ["F401"]
+"#,
+    )?;
+    test.write_file("try.py", "import os")?;
+    assert_cmd_snapshot!(
+        test.check_command().args(["--preview", "try.py"]),
+        @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    try.py:1:8: warning[F401] [*] `os` imported but unused
+    Found 1 error.
+    [*] 1 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "###
+    );
+    Ok(())
+}
+
+#[test]
+fn warn_prefix_select_specific_rule() -> Result<()> {
+    let test = CliTest::new()?;
+    test.write_file(
+        "ruff.toml",
+        r#"
+[lint]
+preview = true
+warn = ["F"]
+select = ["F401"]
+"#,
+    )?;
+    test.write_file("try.py", "import os")?;
+    assert_cmd_snapshot!(
+        test.check_command().args(["--preview", "try.py"]),
+        @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    try.py:1:8: error[F401] [*] `os` imported but unused
+    Found 1 error.
+    [*] 1 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "###
+    );
+    Ok(())
+}
+
+#[test]
+fn warn_prefix_ignore_specific_rule() -> Result<()> {
+    let test = CliTest::new()?;
+    test.write_file(
+        "ruff.toml",
+        r#"
+[lint]
+preview = true
+warn = ["F"]
+ignore = ["F401"]
+"#,
+    )?;
+    test.write_file("try.py", "import os")?;
+    assert_cmd_snapshot!(
+        test.check_command().args(["--preview", "try.py"]),
+        @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    "###
+    );
+    Ok(())
+}
+
+#[test]
+fn select_category_outer_warn_specific_inner() -> Result<()> {
+    let test = CliTest::new()?;
+    test.write_file(
+        "ruff.toml",
+        r#"
+[lint]
+preview = true
+select = ["F"]
+"#,
+    )?;
+    test.write_file(
+        ".ruff.toml",
+        r#"
+extend = "ruff.toml"
+[lint]
+warn = ["F401"]
+"#,
+    )?;
+    test.write_file("try.py", "import os;import foo;foo=1")?;
+    assert_cmd_snapshot!(
+        test.check_command().args(["--preview", "try.py"]),
+        @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    try.py:1:8: warning[F401] [*] `os` imported but unused
+    try.py:1:22: error[F811] Redefinition of unused `foo` from line 1: `foo` redefined here
+    Found 2 errors.
+    [*] 1 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "###
+    );
+    Ok(())
+}
+
+#[test]
+fn warn_category_outer_select_specific_inner() -> Result<()> {
+    let test = CliTest::new()?;
+    test.write_file(
+        "ruff.toml",
+        r#"
+[lint]
+preview = true
+warn = ["F"]
+"#,
+    )?;
+    test.write_file(
+        ".ruff.toml",
+        r#"
+extend = "ruff.toml"
+[lint]
+select = ["F401"]
+"#,
+    )?;
+    test.write_file("try.py", "import os;import foo;foo=1")?;
+    assert_cmd_snapshot!(
+        test.check_command().args(["--preview", "try.py"]),
+        @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    try.py:1:8: error[F401] [*] `os` imported but unused
+    try.py:1:22: warning[F811] Redefinition of unused `foo` from line 1: `foo` redefined here
+    Found 2 errors.
+    [*] 1 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "###
+    );
+    Ok(())
+}
+
+#[test]
+fn warn_specific_outer_ignore_inner() -> Result<()> {
+    let test = CliTest::new()?;
+    test.write_file(
+        "ruff.toml",
+        r#"
+[lint]
+preview = true
+warn = ["F401"]
+"#,
+    )?;
+    test.write_file(
+        ".ruff.toml",
+        r#"
+extend = "ruff.toml"
+[lint]
+ignore = ["F401"]
+"#,
+    )?;
+    test.write_file("try.py", "import os")?;
+    assert_cmd_snapshot!(
+        test.check_command().args(["--preview", "try.py"]),
+        @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    "###
+    );
+    Ok(())
+}
+
+#[test]
+fn ignore_outer_warn_inner() -> Result<()> {
+    let test = CliTest::new()?;
+    test.write_file(
+        "ruff.toml",
+        r#"
+[lint]
+preview = true
+ignore = ["ALL"]
+"#,
+    )?;
+    test.write_file(
+        ".ruff.toml",
+        r#"
+extend = "ruff.toml"
+[lint]
+warn = ["F401"]
+"#,
+    )?;
+    test.write_file("try.py", "import os")?;
+    assert_cmd_snapshot!(
+        test.check_command().args(["--preview", "try.py"]),
+        @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    try.py:1:8: warning[F401] [*] `os` imported but unused
+    Found 1 error.
+    [*] 1 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "###
     );
     Ok(())
 }

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_extend_from_shared_config.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_extend_from_shared_config.snap
@@ -70,6 +70,7 @@ linter.project_root = "[TMP]/"
 linter.rules.enabled = [
 	non-pep604-annotation-union (UP007),
 ]
+linter.rules.warn = []
 linter.rules.should_fix = [
 	non-pep604-annotation-union (UP007),
 ]

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool.snap
@@ -72,6 +72,7 @@ linter.project_root = "[TMP]/"
 linter.rules.enabled = [
 	non-pep604-annotation-union (UP007),
 ]
+linter.rules.warn = []
 linter.rules.should_fix = [
 	non-pep604-annotation-union (UP007),
 ]

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_preview_enabled.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_preview_enabled.snap
@@ -75,6 +75,7 @@ linter.project_root = "[TMP]/"
 linter.rules.enabled = [
 	non-pep604-annotation-union (UP007),
 ]
+linter.rules.warn = []
 linter.rules.should_fix = [
 	non-pep604-annotation-union (UP007),
 ]

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_target_version_override.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_target_version_override.snap
@@ -74,6 +74,7 @@ linter.project_root = "[TMP]/"
 linter.rules.enabled = [
 	non-pep604-annotation-union (UP007),
 ]
+linter.rules.warn = []
 linter.rules.should_fix = [
 	non-pep604-annotation-union (UP007),
 ]

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above.snap
@@ -71,6 +71,7 @@ linter.project_root = "[TMP]/"
 linter.rules.enabled = [
 	non-pep604-annotation-union (UP007),
 ]
+linter.rules.warn = []
 linter.rules.should_fix = [
 	non-pep604-annotation-union (UP007),
 ]

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above_with_tool.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above_with_tool.snap
@@ -72,6 +72,7 @@ linter.project_root = "[TMP]/foo"
 linter.rules.enabled = [
 	non-pep604-annotation-union (UP007),
 ]
+linter.rules.warn = []
 linter.rules.should_fix = [
 	non-pep604-annotation-union (UP007),
 ]

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above-2.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above-2.snap
@@ -70,6 +70,7 @@ linter.project_root = "[TMP]/"
 linter.rules.enabled = [
 	non-pep604-annotation-union (UP007),
 ]
+linter.rules.warn = []
 linter.rules.should_fix = [
 	non-pep604-annotation-union (UP007),
 ]

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above.snap
@@ -70,6 +70,7 @@ linter.project_root = "[TMP]/"
 linter.rules.enabled = [
 	non-pep604-annotation-union (UP007),
 ]
+linter.rules.warn = []
 linter.rules.should_fix = [
 	non-pep604-annotation-union (UP007),
 ]

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_no_target_fallback.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_no_target_fallback.snap
@@ -70,6 +70,7 @@ linter.project_root = "[TMP]/"
 linter.rules.enabled = [
 	non-pep604-annotation-union (UP007),
 ]
+linter.rules.warn = []
 linter.rules.should_fix = [
 	non-pep604-annotation-union (UP007),
 ]

--- a/crates/ruff/tests/cli/snapshots/cli__show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__show_settings__display_default_settings.snap
@@ -125,6 +125,7 @@ linter.rules.enabled = [
 	unused-annotation (F842),
 	raise-not-implemented (F901),
 ]
+linter.rules.warn = []
 linter.rules.should_fix = [
 	multiple-imports-on-one-line (E401),
 	module-import-not-at-top-of-file (E402),

--- a/crates/ruff/tests/cli/snapshots/cli__show_settings__display_settings_from_nested_directory.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__show_settings__display_settings_from_nested_directory.snap
@@ -129,6 +129,7 @@ linter.rules.enabled = [
 	unused-annotation (F842),
 	raise-not-implemented (F901),
 ]
+linter.rules.warn = []
 linter.rules.should_fix = [
 	unsorted-imports (I001),
 	missing-required-import (I002),

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -927,7 +927,7 @@ fn full_output_preview() {
       | ^
       |
 
-    Found 1 error.
+    Found 1 diagnostic.
 
     ----- stderr -----
     "###);
@@ -956,7 +956,7 @@ preview = true
       | ^
       |
 
-    Found 1 error.
+    Found 1 diagnostic.
 
     ----- stderr -----
     "###);
@@ -1211,41 +1211,41 @@ fn show_statistics_syntax_errors() {
     // ParseError
     assert_cmd_snapshot!(
         cmd.pass_stdin("x ="),
-        @"
+        @r###"
     success: false
     exit_code: 1
     ----- stdout -----
     1		invalid-syntax
-    Found 1 error.
+    Found 1 diagnostic.
 
     ----- stderr -----
-    ");
+    "###);
 
     // match before 3.10, UnsupportedSyntaxError
     assert_cmd_snapshot!(
         cmd.pass_stdin("match 2:\n  case 1: ..."),
-        @"
+        @r###"
     success: false
     exit_code: 1
     ----- stdout -----
     1		invalid-syntax
-    Found 1 error.
+    Found 1 diagnostic.
 
     ----- stderr -----
-    ");
+    "###);
 
     // rebound comprehension variable, SemanticSyntaxError
     assert_cmd_snapshot!(
         cmd.pass_stdin("[x := 1 for x in range(0)]"),
-        @"
+        @r###"
     success: false
     exit_code: 1
     ----- stdout -----
     1		invalid-syntax
-    Found 1 error.
+    Found 1 diagnostic.
 
     ----- stderr -----
-    ");
+    "###);
 }
 
 #[test]
@@ -1264,7 +1264,7 @@ fn preview_enabled_prefix() {
     -:1:1: error[RUF903] Hey this is a stable test rule with a display only fix.
     -:1:1: error[RUF911] Hey this is a preview test rule.
     -:1:1: error[RUF950] Hey this is a test rule that was redirected from another.
-    Found 6 errors.
+    Found 6 diagnostics.
     [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
     ----- stderr -----
@@ -1288,7 +1288,7 @@ fn preview_enabled_all() {
     -:1:1: error[RUF903] Hey this is a stable test rule with a display only fix.
     -:1:1: error[RUF911] Hey this is a preview test rule.
     -:1:1: error[RUF950] Hey this is a test rule that was redirected from another.
-    Found 8 errors.
+    Found 8 diagnostics.
     [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
     ----- stderr -----
@@ -1308,7 +1308,7 @@ fn preview_enabled_direct() {
     exit_code: 1
     ----- stdout -----
     -:1:1: error[RUF911] Hey this is a preview test rule.
-    Found 1 error.
+    Found 1 diagnostic.
 
     ----- stderr -----
     "###);
@@ -1427,7 +1427,7 @@ fn preview_enabled_group_ignore() {
     -:1:1: error[RUF903] Hey this is a stable test rule with a display only fix.
     -:1:1: error[RUF911] Hey this is a preview test rule.
     -:1:1: error[RUF950] Hey this is a test rule that was redirected from another.
-    Found 6 errors.
+    Found 6 diagnostics.
     [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
     ----- stderr -----
@@ -2411,7 +2411,7 @@ select = ["RUF017"]
       |
     help: Replace with `functools.reduce`
 
-    Found 1 error.
+    Found 1 diagnostic.
     No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
     ----- stderr -----
@@ -2452,7 +2452,7 @@ unfixable = ["RUF"]
       |
     help: Replace with `functools.reduce`
 
-    Found 1 error.
+    Found 1 diagnostic.
 
     ----- stderr -----
     "###);

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -3450,7 +3450,11 @@ impl<'a> LintContext<'a> {
     ) -> DiagnosticGuard<'chk, 'a> {
         DiagnosticGuard {
             context: self,
-            diagnostic: Some(kind.into_diagnostic(range, &self.source_file)),
+            diagnostic: Some(kind.into_diagnostic(
+                range,
+                &self.source_file,
+                self.rules.severity(T::rule()),
+            )),
             rule: T::rule(),
             before_drop_fns: SmallVec::new(),
         }
@@ -3470,7 +3474,11 @@ impl<'a> LintContext<'a> {
         if self.is_rule_enabled(rule) {
             Some(DiagnosticGuard {
                 context: self,
-                diagnostic: Some(kind.into_diagnostic(range, &self.source_file)),
+                diagnostic: Some(kind.into_diagnostic(
+                    range,
+                    &self.source_file,
+                    self.rules.severity(T::rule()),
+                )),
                 rule,
                 before_drop_fns: SmallVec::new(),
             })
@@ -3493,6 +3501,7 @@ impl<'a> LintContext<'a> {
             kind.message(),
             Option::<&'static str>::None,
             range,
+            self.rules.severity(T::rule()),
             None,
             None,
             self.source_file.clone(),

--- a/crates/ruff_linter/src/fix/edits.rs
+++ b/crates/ruff_linter/src/fix/edits.rs
@@ -654,6 +654,7 @@ fn all_lines_fit(
 #[cfg(test)]
 mod tests {
     use anyhow::{Result, anyhow};
+    use ruff_db::diagnostic::Severity;
     use ruff_source_file::SourceFileBuilder;
     use test_case::test_case;
 
@@ -801,6 +802,7 @@ x = 1 \
             let mut diagnostic = MissingNewlineAtEndOfFile.into_diagnostic(
                 TextRange::default(),
                 &SourceFileBuilder::new("<filename>", "<code>").finish(),
+                Severity::Error,
             );
             diagnostic.set_fix(Fix::safe_edits(
                 iter.next().ok_or(anyhow!("expected edits nonempty"))?,

--- a/crates/ruff_linter/src/fix/mod.rs
+++ b/crates/ruff_linter/src/fix/mod.rs
@@ -176,7 +176,7 @@ mod tests {
     use crate::rules::pycodestyle::rules::MissingNewlineAtEndOfFile;
     use crate::{Edit, Fix};
     use crate::{Locator, Violation};
-    use ruff_db::diagnostic::Diagnostic;
+    use ruff_db::diagnostic::{Diagnostic, Severity};
 
     fn create_diagnostics(
         filename: &str,
@@ -189,6 +189,7 @@ mod tests {
                 let mut diagnostic = MissingNewlineAtEndOfFile.into_diagnostic(
                     edit.range(),
                     &SourceFileBuilder::new(filename, source).finish(),
+                    Severity::Error,
                 );
                 diagnostic.set_fix(Fix::safe_edit(edit));
                 diagnostic

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -80,6 +80,7 @@ pub fn create_lint_diagnostic<B, S>(
     body: B,
     suggestion: Option<S>,
     range: TextRange,
+    severity: Severity,
     fix: Option<Fix>,
     parent: Option<TextSize>,
     file: SourceFile,
@@ -92,7 +93,7 @@ where
 {
     let mut diagnostic = Diagnostic::new(
         DiagnosticId::Lint(LintName::of(rule.into())),
-        Severity::Error,
+        severity,
         body,
     );
 
@@ -229,7 +230,7 @@ pub fn render_diagnostics(
 mod tests {
     use rustc_hash::FxHashMap;
 
-    use ruff_db::diagnostic::Diagnostic;
+    use ruff_db::diagnostic::{Diagnostic, Severity};
     use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
     use ruff_source_file::SourceFileBuilder;
     use ruff_text_size::{TextRange, TextSize};
@@ -277,6 +278,7 @@ def fibonacci(n):
             "`os` imported but unused",
             Some("Remove unused import: `os`"),
             TextRange::new(unused_import_start, TextSize::from(9)),
+            Severity::Error,
             Some(Fix::unsafe_edit(Edit::range_deletion(TextRange::new(
                 TextSize::from(0),
                 TextSize::from(10),
@@ -292,6 +294,7 @@ def fibonacci(n):
             "Local variable `x` is assigned to but never used",
             Some("Remove assignment to unused variable `x`"),
             TextRange::new(unused_variable_start, TextSize::from(95)),
+            Severity::Error,
             Some(Fix::unsafe_edit(Edit::deletion(
                 TextSize::from(94),
                 TextSize::from(99),
@@ -309,6 +312,7 @@ def fibonacci(n):
             "Undefined name `a`",
             Option::<&'static str>::None,
             TextRange::new(undefined_name_start, TextSize::from(4)),
+            Severity::Error,
             None,
             None,
             SourceFileBuilder::new("undef.py", file_2).finish(),

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -1248,6 +1248,7 @@ mod tests {
 
     use insta::assert_debug_snapshot;
 
+    use ruff_db::diagnostic::Severity;
     use ruff_python_trivia::CommentRanges;
     use ruff_source_file::{LineEnding, SourceFileBuilder};
     use ruff_text_size::{TextLen, TextRange, TextSize};
@@ -2867,6 +2868,7 @@ mod tests {
         .into_diagnostic(
             TextRange::new(TextSize::from(0), TextSize::from(0)),
             &source_file,
+            Severity::Error,
         )];
 
         let contents = "x = 1";
@@ -2890,6 +2892,7 @@ mod tests {
             AmbiguousVariableName("x".to_string()).into_diagnostic(
                 TextRange::new(TextSize::from(0), TextSize::from(0)),
                 &source_file,
+                Severity::Error,
             ),
             UnusedVariable {
                 name: "x".to_string(),
@@ -2897,6 +2900,7 @@ mod tests {
             .into_diagnostic(
                 TextRange::new(TextSize::from(0), TextSize::from(0)),
                 &source_file,
+                Severity::Error,
             ),
         ];
         let contents = "x = 1  # noqa: E741\n";
@@ -2922,6 +2926,7 @@ mod tests {
             AmbiguousVariableName("x".to_string()).into_diagnostic(
                 TextRange::new(TextSize::from(0), TextSize::from(0)),
                 &source_file,
+                Severity::Error,
             ),
             UnusedVariable {
                 name: "x".to_string(),
@@ -2929,6 +2934,7 @@ mod tests {
             .into_diagnostic(
                 TextRange::new(TextSize::from(0), TextSize::from(0)),
                 &source_file,
+                Severity::Error,
             ),
         ];
         let contents = "x = 1  # noqa";
@@ -2964,8 +2970,11 @@ print(
 "#;
         let noqa_line_for = [TextRange::new(8.into(), 68.into())].into_iter().collect();
         let source_file = SourceFileBuilder::new(path.to_string_lossy(), source).finish();
-        let messages = [PrintfStringFormatting
-            .into_diagnostic(TextRange::new(12.into(), 79.into()), &source_file)];
+        let messages = [PrintfStringFormatting.into_diagnostic(
+            TextRange::new(12.into(), 79.into()),
+            &source_file,
+            Severity::Error,
+        )];
         let comment_ranges = CommentRanges::default();
         let suppressions = Suppressions::default();
         let edits = generate_noqa_edits(
@@ -2996,8 +3005,11 @@ foo;
 bar =
 ";
         let source_file = SourceFileBuilder::new(path.to_string_lossy(), source).finish();
-        let messages =
-            [UselessSemicolon.into_diagnostic(TextRange::new(4.into(), 5.into()), &source_file)];
+        let messages = [UselessSemicolon.into_diagnostic(
+            TextRange::new(4.into(), 5.into()),
+            &source_file,
+            Severity::Error,
+        )];
         let noqa_line_for = NoqaMapping::default();
         let comment_ranges = CommentRanges::default();
         let suppressions = Suppressions::default();

--- a/crates/ruff_linter/src/pyproject_toml.rs
+++ b/crates/ruff_linter/src/pyproject_toml.rs
@@ -29,8 +29,11 @@ pub fn lint_pyproject_toml(source_file: &SourceFile, settings: &LinterSettings) 
                     source_file.name(),
                 );
                 if settings.rules.enabled(Rule::IOError) {
-                    let diagnostic =
-                        IOError { message }.into_diagnostic(TextRange::default(), source_file);
+                    let diagnostic = IOError { message }.into_diagnostic(
+                        TextRange::default(),
+                        source_file,
+                        settings.rules.severity(Rule::IOError),
+                    );
                     messages.push(diagnostic);
                 } else {
                     warn!(
@@ -52,8 +55,11 @@ pub fn lint_pyproject_toml(source_file: &SourceFile, settings: &LinterSettings) 
 
     if settings.rules.enabled(Rule::InvalidPyprojectToml) {
         let toml_err = err.message().to_string();
-        let diagnostic =
-            InvalidPyprojectToml { message: toml_err }.into_diagnostic(range, source_file);
+        let diagnostic = InvalidPyprojectToml { message: toml_err }.into_diagnostic(
+            range,
+            source_file,
+            settings.rules.severity(Rule::InvalidPyprojectToml),
+        );
         messages.push(diagnostic);
     }
 

--- a/crates/ruff_linter/src/settings/rule_table.rs
+++ b/crates/ruff_linter/src/settings/rule_table.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Debug, Display, Formatter};
 
 use crate::display_settings;
+use ruff_db::diagnostic::Severity;
 use ruff_macros::CacheKey;
 
 use crate::registry::{Rule, RuleSet, RuleSetIterator};
@@ -10,6 +11,7 @@ use crate::registry::{Rule, RuleSet, RuleSetIterator};
 pub struct RuleTable {
     /// Maps rule codes to a boolean indicating if the rule should be fixed.
     enabled: RuleSet,
+    warn: RuleSet,
     should_fix: RuleSet,
 }
 
@@ -18,6 +20,7 @@ impl RuleTable {
     pub const fn empty() -> Self {
         Self {
             enabled: RuleSet::empty(),
+            warn: RuleSet::empty(),
             should_fix: RuleSet::empty(),
         }
     }
@@ -40,6 +43,16 @@ impl RuleTable {
         self.should_fix.contains(rule)
     }
 
+    /// Returns whether violations of the given rule should be fixed.
+    #[inline]
+    pub const fn severity(&self, rule: Rule) -> Severity {
+        if self.warn.contains(rule) {
+            Severity::Warning
+        } else {
+            Severity::Error
+        }
+    }
+
     /// Returns an iterator over all enabled rules.
     pub fn iter_enabled(&self) -> RuleSetIterator {
         self.enabled.iter()
@@ -55,10 +68,22 @@ impl RuleTable {
         }
     }
 
+    /// Enables the given rule and sets its severity to `warning`.
+    #[inline]
+    pub fn warn(&mut self, rule: Rule, should_fix: bool) {
+        self.enabled.insert(rule);
+        self.warn.insert(rule);
+
+        if should_fix {
+            self.should_fix.insert(rule);
+        }
+    }
+
     /// Disables the given rule.
     #[inline]
     pub fn disable(&mut self, rule: Rule) {
         self.enabled.remove(rule);
+        self.warn.remove(rule);
         self.should_fix.remove(rule);
     }
 }
@@ -70,6 +95,7 @@ impl Display for RuleTable {
             namespace = "linter.rules",
             fields = [
                 self.enabled,
+                self.warn,
                 self.should_fix
             ]
         }
@@ -82,6 +108,7 @@ impl FromIterator<Rule> for RuleTable {
         let rules = RuleSet::from_iter(iter);
         Self {
             enabled: rules.clone(),
+            warn: RuleSet::empty(),
             should_fix: rules,
         }
     }

--- a/crates/ruff_linter/src/settings/rule_table.rs
+++ b/crates/ruff_linter/src/settings/rule_table.rs
@@ -58,6 +58,11 @@ impl RuleTable {
         self.enabled.iter()
     }
 
+    /// Returns an iterator over all enabled rules.
+    pub fn iter_warn(&self) -> RuleSetIterator {
+        self.warn.iter()
+    }
+
     /// Enables the given rule.
     #[inline]
     pub fn enable(&mut self, rule: Rule, should_fix: bool) {

--- a/crates/ruff_linter/src/violation.rs
+++ b/crates/ruff_linter/src/violation.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Display};
 
 use serde::Serialize;
 
-use ruff_db::diagnostic::Diagnostic;
+use ruff_db::diagnostic::{Diagnostic, Severity};
 use ruff_source_file::SourceFile;
 use ruff_text_size::TextRange;
 
@@ -68,11 +68,17 @@ pub trait Violation: ViolationMetadata + Sized {
     fn message_formats() -> &'static [&'static str];
 
     /// Convert the violation into a [`Diagnostic`].
-    fn into_diagnostic(self, range: TextRange, file: &SourceFile) -> Diagnostic {
+    fn into_diagnostic(
+        self,
+        range: TextRange,
+        file: &SourceFile,
+        severity: Severity,
+    ) -> Diagnostic {
         create_lint_diagnostic(
             self.message(),
             self.fix_title(),
             range,
+            severity,
             None,
             None,
             file.clone(),

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -65,8 +65,10 @@ use crate::settings::{
 #[derive(Clone, Debug, Default)]
 pub struct RuleSelection {
     pub select: Option<Vec<RuleSelector>>,
+    pub warn: Option<Vec<RuleSelector>>,
     pub ignore: Vec<RuleSelector>,
     pub extend_select: Vec<RuleSelector>,
+    pub extend_warn: Vec<RuleSelector>,
     pub fixable: Option<Vec<RuleSelector>>,
     pub unfixable: Vec<RuleSelector>,
     pub extend_fixable: Vec<RuleSelector>,
@@ -95,6 +97,12 @@ impl RuleSelection {
                     .map(|selector| (RuleSelectorKind::Modify, selector)),
             )
             .chain(
+                self.warn
+                    .iter()
+                    .flatten()
+                    .map(|selector| (RuleSelectorKind::Enable, selector)),
+            )
+            .chain(
                 self.ignore
                     .iter()
                     .map(|selector| (RuleSelectorKind::Disable, selector)),
@@ -113,6 +121,11 @@ impl RuleSelection {
                 self.extend_fixable
                     .iter()
                     .map(|selector| (RuleSelectorKind::Modify, selector)),
+            )
+            .chain(
+                self.extend_warn
+                    .iter()
+                    .map(|selector| (RuleSelectorKind::Enable, selector)),
             )
     }
 }
@@ -762,6 +775,8 @@ impl LintConfiguration {
 
             rule_selections: vec![RuleSelection {
                 select: options.common.select,
+                warn: options.warn,
+                extend_warn: options.extend_warn.unwrap_or_default(),
                 ignore,
                 extend_select: options.common.extend_select.unwrap_or_default(),
                 fixable: options.common.fixable,
@@ -858,6 +873,9 @@ impl LintConfiguration {
         // The fixable set keeps track of which rules are fixable.
         let mut fixable_set: RuleSet = RuleSelector::All.all_rules().collect();
 
+        // The warn set keeps track of which rules have severity `Warning`.
+        let mut warn_set: RuleSet = RuleSet::empty();
+
         // Ignores normally only subtract from the current set of selected
         // rules.  By that logic the ignore in `select = [], ignore = ["E501"]`
         // would be effectless. Instead we carry over the ignores to the next
@@ -888,6 +906,7 @@ impl LintConfiguration {
             // whether to enable or disable the given rule.
             let mut select_map_updates: FxHashMap<Rule, bool> = FxHashMap::default();
             let mut fixable_map_updates: FxHashMap<Rule, bool> = FxHashMap::default();
+            let mut warn_map_updates: FxHashMap<Rule, bool> = FxHashMap::default();
 
             let mut docstring_override_updates: FxHashSet<Rule> = FxHashSet::default();
 
@@ -911,6 +930,18 @@ impl LintConfiguration {
                         }
                     }
                 }
+                // Apply the same logic to `fixable`, `unfixable`, and `warn`
+                for selector in selection
+                    .warn
+                    .iter()
+                    .flatten()
+                    .chain(&selection.extend_warn)
+                    .filter(|s| s.specificity() == spec)
+                {
+                    for rule in selector.rules(&preview) {
+                        warn_map_updates.insert(rule, true);
+                    }
+                }
                 for selector in selection
                     .ignore
                     .iter()
@@ -919,10 +950,9 @@ impl LintConfiguration {
                 {
                     for rule in selector.rules(&preview) {
                         select_map_updates.insert(rule, false);
+                        warn_map_updates.insert(rule, false);
                     }
                 }
-
-                // Apply the same logic to `fixable` and `unfixable`.
                 for selector in selection
                     .fixable
                     .iter()
@@ -972,8 +1002,24 @@ impl LintConfiguration {
                     docstring_overrides.insert(rule);
                 }
             }
+            // Apply the same logic to `fixable`, `unfixable`, and `warn`
+            if let Some(warn) = &selection.warn {
+                warn_set = warn_map_updates
+                    .into_iter()
+                    .filter_map(|(rule, enabled)| enabled.then_some(rule))
+                    .collect();
 
-            // Apply the same logic to `fixable` and `unfixable`.
+                if warn.is_empty()
+                    && selection.extend_warn.is_empty()
+                    && !selection.ignore.is_empty()
+                {
+                    carryover_ignores = Some(&selection.ignore);
+                }
+            } else {
+                for (rule, enabled) in warn_map_updates {
+                    warn_set.set(rule, enabled);
+                }
+            }
             if let Some(fixable) = &selection.fixable {
                 fixable_set = fixable_map_updates
                     .into_iter()
@@ -1136,6 +1182,11 @@ impl LintConfiguration {
         for rule in select_set {
             let fix = fixable_set.contains(rule);
             rules.enable(rule, fix);
+        }
+
+        for rule in warn_set {
+            let fix = fixable_set.contains(rule);
+            rules.warn(rule, fix);
         }
 
         // If a docstring convention is specified, disable any incompatible error

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -924,6 +924,15 @@ impl LintConfiguration {
                 {
                     for rule in selector.rules(&preview) {
                         select_map_updates.insert(rule, true);
+                        // Override warnings of weaker specificity
+                        // For example:
+                        // ```
+                        // select = ["F401"]
+                        // warn = ["F"]
+                        // ```
+                        // should warn on all Pyflakes rules
+                        // except for `F401` where it should error.
+                        warn_map_updates.insert(rule, false);
 
                         if spec == Specificity::Rule {
                             docstring_override_updates.insert(rule);
@@ -940,6 +949,15 @@ impl LintConfiguration {
                 {
                     for rule in selector.rules(&preview) {
                         warn_map_updates.insert(rule, true);
+                        // Note that here we need not override
+                        // `select` statements of weaker specificity
+                        // because the rule table records simply a
+                        // set of _enabled_ rules and some _subset_
+                        // which are given a severity of `warning`.
+                        // Therefore, the presence of a rule in the
+                        // `warn_set` will cause the rule to have this
+                        // severity, regardless of whether it is in
+                        // the `select_set` already.
                     }
                 }
                 for selector in selection

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -527,6 +527,34 @@ pub struct LintOptions {
     )]
     pub exclude: Option<Vec<String>>,
 
+    /// A list of rule codes or prefixes to enable with severity level
+    /// `warning`. Prefixes can specify exact  rules (like `F841`), entire
+    /// categories (like `F`), or anything in  between.
+    ///
+    /// When breaking ties between enabled and disabled rules (via `select`,
+    /// `warn`, and  `ignore`, respectively), more specific prefixes override
+    /// less  specific prefixes. In case of a tie, the precedence, from highest
+    /// to lowest, is `ignore`, `warn`, and then `select`.
+    #[option(
+        default = r#"[]"#,
+        value_type = "list[RuleSelector]",
+        example = r#"
+            warn = ["PLW"]
+        "#
+    )]
+    pub warn: Option<Vec<RuleSelector>>,
+
+    /// A list of rule codes or prefixes to enable with severity `warning`,
+    /// in addition to those specified by [`warn`](#lint_warn).
+    #[option(
+        default = "[]",
+        value_type = "list[RuleSelector]",
+        example = r#"
+            extend-warn= ["ARG", "PLW"]
+        "#
+    )]
+    pub extend_warn: Option<Vec<RuleSelector>>,
+
     /// Options for the `pydoclint` plugin.
     #[option_group]
     pub pydoclint: Option<PydoclintOptions>,
@@ -4131,6 +4159,7 @@ pub struct LintOptionsWire {
     dummy_variable_rgx: Option<String>,
     extend_ignore: Option<Vec<RuleSelector>>,
     extend_select: Option<Vec<RuleSelector>>,
+    extend_warn: Option<Vec<RuleSelector>>,
     extend_fixable: Option<Vec<RuleSelector>>,
     extend_unfixable: Option<Vec<RuleSelector>>,
     external: Option<Vec<String>>,
@@ -4141,6 +4170,7 @@ pub struct LintOptionsWire {
     ignore_init_module_imports: Option<bool>,
     logger_objects: Option<Vec<String>>,
     select: Option<Vec<RuleSelector>>,
+    warn: Option<Vec<RuleSelector>>,
     explicit_preview_rules: Option<bool>,
     task_tags: Option<Vec<String>>,
     typing_modules: Option<Vec<String>>,
@@ -4188,6 +4218,7 @@ impl From<LintOptionsWire> for LintOptions {
             dummy_variable_rgx,
             extend_ignore,
             extend_select,
+            extend_warn,
             extend_fixable,
             extend_unfixable,
             external,
@@ -4198,6 +4229,7 @@ impl From<LintOptionsWire> for LintOptions {
             ignore_init_module_imports,
             logger_objects,
             select,
+            warn,
             explicit_preview_rules,
             task_tags,
             typing_modules,
@@ -4286,6 +4318,8 @@ impl From<LintOptionsWire> for LintOptions {
                 per_file_ignores,
                 extend_per_file_ignores,
             },
+            extend_warn,
+            warn,
             exclude,
             pydoclint,
             ruff,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -638,10 +638,16 @@ Rule selection:
       --select <RULE_CODE>
           Comma-separated list of rule codes to enable (or ALL, to enable all
           rules)
+      --warn <RULE_CODE>
+          Comma-separated list of rule codes to enable (or ALL, to enable all
+          rules) with severity `warning`
       --ignore <RULE_CODE>
           Comma-separated list of rule codes to disable
       --extend-select <RULE_CODE>
           Like --select, but adds additional rule codes on top of those already
+          specified
+      --extend-warn <RULE_CODE>
+          Like --warn, but adds additional rule codes on top of those already
           specified
       --per-file-ignores <PER_FILE_IGNORES>
           List of mappings from file pattern to code to exclude

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -2218,6 +2218,16 @@
             "$ref": "#/definitions/RuleSelector"
           }
         },
+        "extend-warn": {
+          "description": "A list of rule codes or prefixes to enable with severity `warning`,\nin addition to those specified by [`warn`](#lint_warn).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/RuleSelector"
+          }
+        },
         "external": {
           "description": "A list of rule codes or prefixes that are unsupported by Ruff, but should be\npreserved when (e.g.) validating `# noqa` directives. Useful for\nretaining `# noqa` directives that cover plugins not yet implemented\nby Ruff.",
           "type": [
@@ -2629,6 +2639,16 @@
         },
         "unfixable": {
           "description": "A list of rule codes or prefixes to consider non-fixable.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/RuleSelector"
+          }
+        },
+        "warn": {
+          "description": "A list of rule codes or prefixes to enable with severity level\n`warning`. Prefixes can specify exact  rules (like `F841`), entire\ncategories (like `F`), or anything in  between.\n\nWhen breaking ties between enabled and disabled rules (via `select`,\n`warn`, and  `ignore`, respectively), more specific prefixes override\nless  specific prefixes. In case of a tie, the precedence, from highest\nto lowest, is `ignore`, `warn`, and then `select`.",
           "type": [
             "array",
             "null"


### PR DESCRIPTION
This PR allows users to specify a set of rules to enable with severity level `warning` (in `preview`).

They may do so in the CLI using `--warn` and `--extend-warn` or in a configuration file via

```toml
[lint]
warn = [ ... ]
```

Closes #1256

## Details on Resolving the Configuration

The precedence between `select` and `ignore`, within a configuration file, is as follows:
1. More specific designations take precedence over less specific, e.g. `--warn F --select F401` will give all Pyflakes diagnostics _except_ `F401` a severity of `warning`, and give `F401` a severity of `error`.
2. Between designations of equal specificity, `warn` takes precedence over `select`, e.g. `--select F401 --warn F401` will resolve to `--warn F401`.

As in the case of `select` vs `extend-select`, specifying `warn = [...]` will overwrite any inherited configuration for `warn`. **However, it will _not_ overwrite an inherited configuration for `select`**. 

For example, 

```console
ruff check --warn ARG ex.py
```

will return diagnostics for _all default rules_ with `error` severity and then _also_ the `ARG` rules with severity `warning`.

In order to warn on a single rule, the user has to do something like this:

```console
ruff check --select ARG --warn ARG ex.py
```

which looks a bit funny.