### PR TITLE
[`ruff`] Add unsafe fix for os-path-commonprefix  (`RUF071`)

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/os_path_commonprefix.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/os_path_commonprefix.rs
@@ -3,6 +3,7 @@ use ruff_python_ast as ast;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
+use crate::importer::ImportRequest;
 use crate::{Edit, Fix, FixAvailability, Violation};
 
 /// ## What it does
@@ -64,11 +65,13 @@ pub(crate) fn os_path_commonprefix(checker: &Checker, call: &ast::ExprCall, segm
     let mut diagnostic = checker.report_diagnostic(OsPathCommonprefix, call.func.range());
     diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
 
-    let func_text = checker.locator().slice(call.func.range());
-    if let Some(prefix) = func_text.strip_suffix("commonprefix") {
-        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
-            format!("{prefix}commonpath"),
-            call.func.range(),
-        )));
-    }
+    diagnostic.try_set_fix(|| {
+        let (import_edit, binding) = checker.importer().get_or_import_symbol(
+            &ImportRequest::import_from("os.path", "commonpath"),
+            call.func.start(),
+            checker.semantic(),
+        )?;
+        let reference_edit = Edit::range_replacement(binding, call.func.range());
+        Ok(Fix::unsafe_edits(import_edit, [reference_edit]))
+    });
 }

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF071_RUF071.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF071_RUF071.py.snap
@@ -35,7 +35,7 @@ help: Use `os.path.commonpath()` to compare path components
 6  | # Errors
 7  | os.path.commonprefix(["/usr/lib", "/usr/local/lib"])
    - commonprefix(["/usr/lib", "/usr/local/lib"])
-8  + commonpath(["/usr/lib", "/usr/local/lib"])
+8  + os.path.commonpath(["/usr/lib", "/usr/local/lib"])
 9  | path.commonprefix(["/usr/lib", "/usr/local/lib"])
 10 | 
 11 | # OK
@@ -56,7 +56,7 @@ help: Use `os.path.commonpath()` to compare path components
 7  | os.path.commonprefix(["/usr/lib", "/usr/local/lib"])
 8  | commonprefix(["/usr/lib", "/usr/local/lib"])
    - path.commonprefix(["/usr/lib", "/usr/local/lib"])
-9  + path.commonpath(["/usr/lib", "/usr/local/lib"])
+9  + os.path.commonpath(["/usr/lib", "/usr/local/lib"])
 10 | 
 11 | # OK
 12 | os.path.commonpath(["/usr/lib", "/usr/local/lib"])


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Adds an unsafe autofix for RUF071 (os-path-commonprefix) that replaces os.path.commonprefix() calls with os.path.commonpath().

## Test Plan

 - cargo nextest run -p ruff_linter -- rule_ospathcommonprefix
