### PR TITLE
[ty] Show flaky project names in ecosystem report

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -74,7 +74,7 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@3f567bd8ee20bce7a42f1334ac266829ab3f4eb5"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@3b27e0b28a5314240c218e939bde0c6c02a39652"
 
           ecosystem-analyzer \
             --repository ruff \

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -56,7 +56,7 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@3f567bd8ee20bce7a42f1334ac266829ab3f4eb5"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@3b27e0b28a5314240c218e939bde0c6c02a39652"
 
           ecosystem-analyzer \
             --verbose \


### PR DESCRIPTION
## Summary

Show all flaky project names in a tooltip, no matter if they are included in the report or not.

<img width="582" height="292" alt="image" src="https://github.com/user-attachments/assets/5ba5b47b-a68d-463d-8ecc-aff6764a28e4" />


## Test Plan

- [x] [This run](https://github.com/astral-sh/ruff/actions/runs/22895734470)