### PR TITLE
Preserve required annotation parentheses in annotated assignments

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/ann_assign.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/ann_assign.py
@@ -17,6 +17,8 @@ JSONSerializable: str | int | float | bool | None | list | tuple | JSONMapping =
 
 JSONSerializable: str | int | float | bool | None | list | tuple | JSONMapping = aaaaaaaaaaaaaaaa
 
+D: (E := 4) = (F := 5)
+
 # Regression test: Don't forget the parentheses in the annotation when breaking
 class DefaultRunner:
     task_runner_cls: TaskRunnerProtocol | typing.Callable[[], typing.Any] = DefaultTaskRunner

--- a/crates/ruff_python_formatter/src/statement/stmt_ann_assign.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_ann_assign.rs
@@ -2,7 +2,7 @@ use ruff_formatter::write;
 use ruff_python_ast::StmtAnnAssign;
 
 use crate::expression::is_splittable_expression;
-use crate::expression::parentheses::Parentheses;
+use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses, Parentheses};
 use crate::prelude::*;
 use crate::statement::stmt_assign::{
     AnyAssignmentOperator, AnyBeforeOperator, FormatStatementsLastExpression,
@@ -37,9 +37,16 @@ impl FormatNodeRule<StmtAnnAssign> for FormatStmtAnnAssign {
             } else {
                 // Remove unnecessary parentheses around the annotation if the parenthesize long type hints preview style is enabled.
                 // Ensure we keep the parentheses if the annotation has any comments.
-                if f.context().comments().has_leading(annotation.as_ref())
+                let preserve_parentheses = f.context().comments().has_leading(annotation.as_ref())
                     || f.context().comments().has_trailing(annotation.as_ref())
-                {
+                    || matches!(
+                        annotation
+                            .as_ref()
+                            .needs_parentheses(item.into(), f.context()),
+                        OptionalParentheses::Always
+                    );
+
+                if preserve_parentheses {
                     annotation
                         .format()
                         .with_options(Parentheses::Always)

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__ann_assign.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__ann_assign.py.snap
@@ -23,6 +23,8 @@ JSONSerializable: str | int | float | bool | None | list | tuple | JSONMapping =
 
 JSONSerializable: str | int | float | bool | None | list | tuple | JSONMapping = aaaaaaaaaaaaaaaa
 
+D: (E := 4) = (F := 5)
+
 # Regression test: Don't forget the parentheses in the annotation when breaking
 class DefaultRunner:
     task_runner_cls: TaskRunnerProtocol | typing.Callable[[], typing.Any] = DefaultTaskRunner
@@ -57,6 +59,8 @@ JSONSerializable: str | int | float | bool | None | list | tuple | JSONMapping =
 JSONSerializable: str | int | float | bool | None | list | tuple | JSONMapping = (
     aaaaaaaaaaaaaaaa
 )
+
+D: (E := 4) = (F := 5)
 
 
 # Regression test: Don't forget the parentheses in the annotation when breaking


### PR DESCRIPTION
## Summary

Previously, we were forcing `Parentheses::Never` unless the annotation had comments.

Closes https://github.com/astral-sh/ruff/issues/23864.
