### PR TITLE
[ty] Preserve cycle detection in unary overload aggregation

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3079,6 +3079,23 @@ class Nominal:
 static_assert(not is_disjoint_from(Proto, Nominal))
 ```
 
+### Regression test: recursive protocol through `dict.items()`
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+
+class IntArray(Protocol):
+    def __add__(self, other: IntArray | int) -> IntArray: ...
+    def __getitem__(self, key: slice) -> IntArray: ...
+
+data: dict[str, IntArray] = {}
+indexed_data = {k: v[0:10] for k, v in data.items()}
+
+reveal_type(indexed_data)  # revealed: dict[str, IntArray]
+```
+
 ### Regression test: narrowing with self-referential protocols
 
 This snippet caused us to panic on an early version of the implementation for protocols.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -358,6 +358,7 @@ impl<'db> CallableSignature<'db> {
     ///
     /// This is intentionally accept-only. If the probe does not definitely succeed, it returns
     /// `None` and callers should fall back to legacy per-overload relation checks.
+    #[expect(clippy::too_many_arguments)]
     fn try_unary_overload_aggregate_relation<'c>(
         db: &'db dyn Db,
         constraints: &'c ConstraintSetBuilder<'db>,
@@ -365,6 +366,8 @@ impl<'db> CallableSignature<'db> {
         other_signature: &Signature<'db>,
         inferable: InferableTypeVars<'_, 'db>,
         relation: TypeRelation,
+        relation_visitor: &HasRelationToVisitor<'db, 'c>,
+        disjointness_visitor: &IsDisjointVisitor<'db, 'c>,
     ) -> Option<ConstraintSet<'db, 'c>> {
         let single_required_positional_parameter_type = |signature: &Signature<'db>| {
             if signature.parameters().len() != 1 {
@@ -414,7 +417,14 @@ impl<'db> CallableSignature<'db> {
                 return None;
             }
             let signatures_are_disjoint = self_parameter_type
-                .when_disjoint_from(db, other_parameter_type, constraints, inferable)
+                .is_disjoint_from_impl(
+                    db,
+                    other_parameter_type,
+                    constraints,
+                    inferable,
+                    disjointness_visitor,
+                    relation_visitor,
+                )
                 .is_always_satisfied(db);
 
             if signatures_are_disjoint {
@@ -431,19 +441,23 @@ impl<'db> CallableSignature<'db> {
         }
 
         // Function assignability here is parameter-contravariant and return-covariant.
-        let parameters_cover_target = other_parameter_type.has_relation_to(
+        let parameters_cover_target = other_parameter_type.has_relation_to_impl(
             db,
             parameter_type_union.build(),
             constraints,
             inferable,
             relation,
+            relation_visitor,
+            disjointness_visitor,
         );
-        let returns_match_target = return_type_union.build().has_relation_to(
+        let returns_match_target = return_type_union.build().has_relation_to_impl(
             db,
             other_signature.return_ty,
             constraints,
             inferable,
             relation,
+            relation_visitor,
+            disjointness_visitor,
         );
         let aggregate_relation =
             parameters_cover_target.and(db, constraints, || returns_match_target);
@@ -601,6 +615,8 @@ impl<'db> CallableSignature<'db> {
                     other_signature,
                     inferable,
                     relation,
+                    relation_visitor,
+                    disjointness_visitor,
                 ) {
                     return aggregate_relation;
                 }


### PR DESCRIPTION
## Summary

The fast path was discarding the cycle detector visitors.

Closes https://github.com/astral-sh/ty/issues/3015.
