### PR TITLE
[`flake8-bandit`] flag `S501` with `requests.request`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S501.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S501.py
@@ -15,6 +15,8 @@ requests.options('https://gmail.com', timeout=30, verify=True)
 requests.options('https://gmail.com', timeout=30, verify=False)
 requests.head('https://gmail.com', timeout=30, verify=True)
 requests.head('https://gmail.com', timeout=30, verify=False)
+requests.request('GET', 'https://gmail.com', timeout=30, verify=True)
+requests.request('GET', 'https://gmail.com', timeout=30, verify=False)
 
 httpx.request('GET', 'https://gmail.com', verify=True)
 httpx.request('GET', 'https://gmail.com', verify=False)

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
@@ -54,7 +54,7 @@ pub(crate) fn request_with_no_cert_validation(checker: &Checker, call: &ast::Exp
         .and_then(|qualified_name| match qualified_name.segments() {
             [
                 "requests",
-                "get" | "options" | "head" | "post" | "put" | "patch" | "delete",
+                "get" | "options" | "head" | "post" | "put" | "patch" | "delete" | "request",
             ] => Some("requests"),
             [
                 "httpx",

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S501_S501.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S501_S501.py.snap
@@ -73,124 +73,135 @@ S501 Probable use of `requests` call with `verify=False` disabling SSL certifica
 16 | requests.head('https://gmail.com', timeout=30, verify=True)
 17 | requests.head('https://gmail.com', timeout=30, verify=False)
    |                                                ^^^^^^^^^^^^
-18 |
-19 | httpx.request('GET', 'https://gmail.com', verify=True)
+18 | requests.request('GET', 'https://gmail.com', timeout=30, verify=True)
+19 | requests.request('GET', 'https://gmail.com', timeout=30, verify=False)
+   |
+
+S501 Probable use of `requests` call with `verify=False` disabling SSL certificate checks
+  --> S501.py:19:58
+   |
+17 | requests.head('https://gmail.com', timeout=30, verify=False)
+18 | requests.request('GET', 'https://gmail.com', timeout=30, verify=True)
+19 | requests.request('GET', 'https://gmail.com', timeout=30, verify=False)
+   |                                                          ^^^^^^^^^^^^
+20 |
+21 | httpx.request('GET', 'https://gmail.com', verify=True)
    |
 
 S501 Probable use of `httpx` call with `verify=False` disabling SSL certificate checks
-  --> S501.py:20:43
+  --> S501.py:22:43
    |
-19 | httpx.request('GET', 'https://gmail.com', verify=True)
-20 | httpx.request('GET', 'https://gmail.com', verify=False)
+21 | httpx.request('GET', 'https://gmail.com', verify=True)
+22 | httpx.request('GET', 'https://gmail.com', verify=False)
    |                                           ^^^^^^^^^^^^
-21 | httpx.get('https://gmail.com', verify=True)
-22 | httpx.get('https://gmail.com', verify=False)
+23 | httpx.get('https://gmail.com', verify=True)
+24 | httpx.get('https://gmail.com', verify=False)
    |
 
 S501 Probable use of `httpx` call with `verify=False` disabling SSL certificate checks
-  --> S501.py:22:32
+  --> S501.py:24:32
    |
-20 | httpx.request('GET', 'https://gmail.com', verify=False)
-21 | httpx.get('https://gmail.com', verify=True)
-22 | httpx.get('https://gmail.com', verify=False)
+22 | httpx.request('GET', 'https://gmail.com', verify=False)
+23 | httpx.get('https://gmail.com', verify=True)
+24 | httpx.get('https://gmail.com', verify=False)
    |                                ^^^^^^^^^^^^
-23 | httpx.options('https://gmail.com', verify=True)
-24 | httpx.options('https://gmail.com', verify=False)
+25 | httpx.options('https://gmail.com', verify=True)
+26 | httpx.options('https://gmail.com', verify=False)
    |
 
 S501 Probable use of `httpx` call with `verify=False` disabling SSL certificate checks
-  --> S501.py:24:36
+  --> S501.py:26:36
    |
-22 | httpx.get('https://gmail.com', verify=False)
-23 | httpx.options('https://gmail.com', verify=True)
-24 | httpx.options('https://gmail.com', verify=False)
+24 | httpx.get('https://gmail.com', verify=False)
+25 | httpx.options('https://gmail.com', verify=True)
+26 | httpx.options('https://gmail.com', verify=False)
    |                                    ^^^^^^^^^^^^
-25 | httpx.head('https://gmail.com', verify=True)
-26 | httpx.head('https://gmail.com', verify=False)
-   |
-
-S501 Probable use of `httpx` call with `verify=False` disabling SSL certificate checks
-  --> S501.py:26:33
-   |
-24 | httpx.options('https://gmail.com', verify=False)
-25 | httpx.head('https://gmail.com', verify=True)
-26 | httpx.head('https://gmail.com', verify=False)
-   |                                 ^^^^^^^^^^^^
-27 | httpx.post('https://gmail.com', verify=True)
-28 | httpx.post('https://gmail.com', verify=False)
+27 | httpx.head('https://gmail.com', verify=True)
+28 | httpx.head('https://gmail.com', verify=False)
    |
 
 S501 Probable use of `httpx` call with `verify=False` disabling SSL certificate checks
   --> S501.py:28:33
    |
-26 | httpx.head('https://gmail.com', verify=False)
-27 | httpx.post('https://gmail.com', verify=True)
-28 | httpx.post('https://gmail.com', verify=False)
+26 | httpx.options('https://gmail.com', verify=False)
+27 | httpx.head('https://gmail.com', verify=True)
+28 | httpx.head('https://gmail.com', verify=False)
    |                                 ^^^^^^^^^^^^
-29 | httpx.put('https://gmail.com', verify=True)
-30 | httpx.put('https://gmail.com', verify=False)
+29 | httpx.post('https://gmail.com', verify=True)
+30 | httpx.post('https://gmail.com', verify=False)
    |
 
 S501 Probable use of `httpx` call with `verify=False` disabling SSL certificate checks
-  --> S501.py:30:32
+  --> S501.py:30:33
    |
-28 | httpx.post('https://gmail.com', verify=False)
-29 | httpx.put('https://gmail.com', verify=True)
-30 | httpx.put('https://gmail.com', verify=False)
+28 | httpx.head('https://gmail.com', verify=False)
+29 | httpx.post('https://gmail.com', verify=True)
+30 | httpx.post('https://gmail.com', verify=False)
+   |                                 ^^^^^^^^^^^^
+31 | httpx.put('https://gmail.com', verify=True)
+32 | httpx.put('https://gmail.com', verify=False)
+   |
+
+S501 Probable use of `httpx` call with `verify=False` disabling SSL certificate checks
+  --> S501.py:32:32
+   |
+30 | httpx.post('https://gmail.com', verify=False)
+31 | httpx.put('https://gmail.com', verify=True)
+32 | httpx.put('https://gmail.com', verify=False)
    |                                ^^^^^^^^^^^^
-31 | httpx.patch('https://gmail.com', verify=True)
-32 | httpx.patch('https://gmail.com', verify=False)
+33 | httpx.patch('https://gmail.com', verify=True)
+34 | httpx.patch('https://gmail.com', verify=False)
    |
 
 S501 Probable use of `httpx` call with `verify=False` disabling SSL certificate checks
-  --> S501.py:32:34
+  --> S501.py:34:34
    |
-30 | httpx.put('https://gmail.com', verify=False)
-31 | httpx.patch('https://gmail.com', verify=True)
-32 | httpx.patch('https://gmail.com', verify=False)
+32 | httpx.put('https://gmail.com', verify=False)
+33 | httpx.patch('https://gmail.com', verify=True)
+34 | httpx.patch('https://gmail.com', verify=False)
    |                                  ^^^^^^^^^^^^
-33 | httpx.delete('https://gmail.com', verify=True)
-34 | httpx.delete('https://gmail.com', verify=False)
-   |
-
-S501 Probable use of `httpx` call with `verify=False` disabling SSL certificate checks
-  --> S501.py:34:35
-   |
-32 | httpx.patch('https://gmail.com', verify=False)
-33 | httpx.delete('https://gmail.com', verify=True)
-34 | httpx.delete('https://gmail.com', verify=False)
-   |                                   ^^^^^^^^^^^^
-35 | httpx.stream('https://gmail.com', verify=True)
-36 | httpx.stream('https://gmail.com', verify=False)
+35 | httpx.delete('https://gmail.com', verify=True)
+36 | httpx.delete('https://gmail.com', verify=False)
    |
 
 S501 Probable use of `httpx` call with `verify=False` disabling SSL certificate checks
   --> S501.py:36:35
    |
-34 | httpx.delete('https://gmail.com', verify=False)
-35 | httpx.stream('https://gmail.com', verify=True)
-36 | httpx.stream('https://gmail.com', verify=False)
+34 | httpx.patch('https://gmail.com', verify=False)
+35 | httpx.delete('https://gmail.com', verify=True)
+36 | httpx.delete('https://gmail.com', verify=False)
    |                                   ^^^^^^^^^^^^
-37 | httpx.Client()
-38 | httpx.Client(verify=False)
+37 | httpx.stream('https://gmail.com', verify=True)
+38 | httpx.stream('https://gmail.com', verify=False)
    |
 
 S501 Probable use of `httpx` call with `verify=False` disabling SSL certificate checks
-  --> S501.py:38:14
+  --> S501.py:38:35
    |
-36 | httpx.stream('https://gmail.com', verify=False)
-37 | httpx.Client()
-38 | httpx.Client(verify=False)
+36 | httpx.delete('https://gmail.com', verify=False)
+37 | httpx.stream('https://gmail.com', verify=True)
+38 | httpx.stream('https://gmail.com', verify=False)
+   |                                   ^^^^^^^^^^^^
+39 | httpx.Client()
+40 | httpx.Client(verify=False)
+   |
+
+S501 Probable use of `httpx` call with `verify=False` disabling SSL certificate checks
+  --> S501.py:40:14
+   |
+38 | httpx.stream('https://gmail.com', verify=False)
+39 | httpx.Client()
+40 | httpx.Client(verify=False)
    |              ^^^^^^^^^^^^
-39 | httpx.AsyncClient()
-40 | httpx.AsyncClient(verify=False)
+41 | httpx.AsyncClient()
+42 | httpx.AsyncClient(verify=False)
    |
 
 S501 Probable use of `httpx` call with `verify=False` disabling SSL certificate checks
-  --> S501.py:40:19
+  --> S501.py:42:19
    |
-38 | httpx.Client(verify=False)
-39 | httpx.AsyncClient()
-40 | httpx.AsyncClient(verify=False)
+40 | httpx.Client(verify=False)
+41 | httpx.AsyncClient()
+42 | httpx.AsyncClient(verify=False)
    |                   ^^^^^^^^^^^^
    |


### PR DESCRIPTION
Fix [23735](https://github.com/astral-sh/ruff/issues/23735): [S501](https://docs.astral.sh/ruff/rules/request-with-no-cert-validation/) not raised when calling requests.request (instead of requests.get, requests.post, ...)

# Changes

Very minimal changes. 
Just added "request" in the field of possible function call in the requests module.

# Test plan

Tests were updated, I added calls with requests.request and `verify = false` / `verify = true`, according to the previous tests. 
