### PR TITLE
Don't return code actions for non-Python documents

### DIFF
--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -370,8 +370,7 @@ mod tests {
         .unwrap();
 
         let file_url = Url::from_file_path(workspace_dir.join(file_name)).unwrap();
-        let document =
-            TextDocument::new(content.to_string(), 0).with_language_id(language_id);
+        let document = TextDocument::new(content.to_string(), 0).with_language_id(language_id);
         session.open_text_document(file_url.clone(), document);
 
         (session, file_url)
@@ -414,8 +413,7 @@ mod tests {
 
     #[test]
     fn code_actions_for_python() {
-        let (session, file_url) =
-            create_session_and_snapshot("test.py", "python", "import os\n");
+        let (session, file_url) = create_session_and_snapshot("test.py", "python", "import os\n");
 
         let snapshot = session.take_snapshot(file_url.clone()).unwrap();
 


### PR DESCRIPTION
## Summary
- Add early return in the code action handler for non-Python documents (e.g., markdown), matching the existing guard pattern in `lint::check()` and `fix::fix_all()`
- The server was incorrectly returning `source.fixAll.ruff` and `source.organizeImports.ruff` actions for files like `.md`

Closes https://github.com/astral-sh/ruff/issues/23861

## Test plan
- Added unit tests in `code_action.rs`:
  - `no_code_actions_for_markdown` — verifies empty response for `.md` files
  - `code_actions_for_python` — verifies non-empty response for `.py` files

```sh
cargo test -p ruff_server -- code_action::tests
```
