### PR TITLE
[ty] Show truthiness in ConstraintSet display and simplify falsy error message

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/snapshots/ty_extensions.md_-_`ty_extensions`_-_Diagnostic_snapshots_(662547cd88c67f9f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/ty_extensions.md_-_`ty_extensions`_-_Diagnostic_snapshots_(662547cd88c67f9f).snap
@@ -73,7 +73,7 @@ info: rule `static-assert-error` is enabled by default
 ```
 
 ```
-error[static-assert-error]: Static assertion error: argument of type `Literal[""]` is statically known to be falsy
+error[static-assert-error]: Static assertion error: argument of type `Literal[""]` is always falsy
   --> src/mdtest_snippet.py:17:1
    |
 15 | # evaluates to something falsey

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -203,19 +203,19 @@ from ty_extensions import static_assert
 static_assert(True)
 static_assert(False)  # error: "Static assertion error: argument evaluates to `False`"
 
-static_assert(None)  # error: "Static assertion error: argument of type `None` is statically known to be falsy"
+static_assert(None)  # error: "Static assertion error: argument of type `None` is always falsy"
 
 static_assert(1)
-static_assert(0)  # error: "Static assertion error: argument of type `Literal[0]` is statically known to be falsy"
+static_assert(0)  # error: "Static assertion error: argument of type `Literal[0]` is always falsy"
 
 static_assert((0,))
-static_assert(())  # error: "Static assertion error: argument of type `tuple[()]` is statically known to be falsy"
+static_assert(())  # error: "Static assertion error: argument of type `tuple[()]` is always falsy"
 
 static_assert("a")
-static_assert("")  # error: "Static assertion error: argument of type `Literal[""]` is statically known to be falsy"
+static_assert("")  # error: "Static assertion error: argument of type `Literal[""]` is always falsy"
 
 static_assert(b"a")
-static_assert(b"")  # error: "Static assertion error: argument of type `Literal[b""]` is statically known to be falsy"
+static_assert(b"")  # error: "Static assertion error: argument of type `Literal[b""]` is always falsy"
 ```
 
 ### Error messages
@@ -398,7 +398,7 @@ the expression `str`:
 from ty_extensions import TypeOf, is_subtype_of, static_assert
 
 # This is incorrect and therefore fails with ...
-# error: "Static assertion error: argument of type `ty_extensions.ConstraintSet` is statically known to be falsy"
+# error: "Static assertion error: argument of type `ConstraintSet[Literal[False]]` is always falsy"
 static_assert(is_subtype_of(str, type[str]))
 
 # Correct, returns True:

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -24,6 +24,7 @@ use crate::semantic_index::scope::{FileScopeId, ScopeKind};
 use crate::semantic_index::semantic_index;
 use crate::types::callable::CallableTypeKind;
 use crate::types::class::{ClassLiteral, ClassType, GenericAlias};
+use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::function::{FunctionType, OverloadLiteral};
 use crate::types::generics::{GenericContext, Specialization};
 use crate::types::signatures::{
@@ -2965,8 +2966,17 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
                 }
                 Ok(())
             }
-            KnownInstanceType::ConstraintSet(_) => {
-                f.with_type(ty).write_str("ty_extensions.ConstraintSet")
+            KnownInstanceType::ConstraintSet(interned_set) => {
+                f.with_type(ty).write_str("ConstraintSet")?;
+                let constraints = ConstraintSetBuilder::new();
+                let set = constraints.load(self.db, interned_set.constraints(self.db));
+                if set.is_always_satisfied(self.db) {
+                    f.write_str("[Literal[True]]")
+                } else if set.is_never_satisfied(self.db) {
+                    f.write_str("[Literal[False]]")
+                } else {
+                    f.write_str("[bool]")
+                }
             }
             KnownInstanceType::GenericContext(generic_context) => {
                 f.with_type(ty).write_str("ty_extensions.GenericContext")?;

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1987,7 +1987,7 @@ impl KnownFunction {
                     } else if truthiness.is_always_false() {
                         builder.into_diagnostic(format_args!(
                             "Static assertion error: argument of type `{parameter_ty}` \
-                            is statically known to be falsy",
+                            is always falsy",
                             parameter_ty = parameter_ty.display(db)
                         ))
                     } else {


### PR DESCRIPTION
## Summary

A small quality-of-life improvement for playground debugging.

I always find it annoying when I do `reveal_type(is_subtype_of(bool, int))` or similar and ty just tells me it's a `ConstraintSet` 😆 I have to do `reveal_type(bool(is_subtype_of(bool, int)))` to get the information I actually _wanted_ out of ty. Now, we'll tell you whether the constraint set is known to be always, never or sometimes satisfied as part of the display of that constraint set:

```py
from ty_extensions import is_subtype_of

reveal_type(is_subtype_of(bool, int))  # revealed: ConstraintSet[Literal[True]]
reveal_type(is_subtype_of(str, int))  # revealed: ConstraintSet[Literal[False]]
```

I also shortened the error message for `static_assert`.

## Test Plan

mdtests updated
