### PR TITLE
[ty] Fix false-positive diagnostics for PEP-604 union annotations on attribute targets on Python 3.9 when `from __future__ import annotations` is active

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/string.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/string.md
@@ -170,7 +170,12 @@ from __future__ import annotations
 def f(v: int | "Foo"):  # fine
     reveal_type(v)  # revealed: int | Foo
 
-class Foo: ...
+class Foo:
+    def __init__(self):
+        self.x: "int" | "str" = 42
+
+d = {}
+d[0]: "int" | "str" = 42
 
 # error: [unsupported-operator]
 X = list["int" | None]

--- a/crates/ty_python_semantic/resources/mdtest/annotations/union.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/union.md
@@ -83,3 +83,45 @@ X = int | str
 def f(y: X):
     reveal_type(y)  # revealed: int | str
 ```
+
+## Diagnostics for PEP-604 unions used on Python less than 3.10
+
+<!-- snapshot-diagnostics -->
+
+PEP-604 unions generally don't work on Python \<=3.9:
+
+```toml
+[environment]
+python-version = "3.9"
+```
+
+`a.py`:
+
+```py
+x: int | str  # error: [unsupported-operator]
+
+class Foo:
+    def __init__(self):
+        self.x: int | str = 42  # error: [unsupported-operator]
+
+d = {}
+d[0]: int | str = 42  # error: [unsupported-operator]
+```
+
+But these runtime errors can be avoided if you add `from __future__ import annotations` to the top
+of your file:
+
+`b.py`:
+
+```py
+from __future__ import annotations
+
+x: int | str
+
+class Foo:
+    def __init__(self):
+        self.x: int | str = 42
+
+d = {}
+d[0]: int | str = 42
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union.md_-_Union_-_Diagnostics_for_PEP-…_(8fa61a3cfe810040).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union.md_-_Union_-_Diagnostics_for_PEP-…_(8fa61a3cfe810040).snap
@@ -1,0 +1,96 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: union.md - Union - Diagnostics for PEP-604 unions used on Python less than 3.10
+mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/union.md
+---
+
+# Python source files
+
+## a.py
+
+```
+1 | x: int | str  # error: [unsupported-operator]
+2 | 
+3 | class Foo:
+4 |     def __init__(self):
+5 |         self.x: int | str = 42  # error: [unsupported-operator]
+6 | 
+7 | d = {}
+8 | d[0]: int | str = 42  # error: [unsupported-operator]
+```
+
+## b.py
+
+```
+ 1 | from __future__ import annotations
+ 2 | 
+ 3 | x: int | str
+ 4 | 
+ 5 | class Foo:
+ 6 |     def __init__(self):
+ 7 |         self.x: int | str = 42
+ 8 | 
+ 9 | d = {}
+10 | d[0]: int | str = 42
+```
+
+# Diagnostics
+
+```
+error[unsupported-operator]: Unsupported `|` operation
+ --> src/a.py:1:4
+  |
+1 | x: int | str  # error: [unsupported-operator]
+  |    ---^^^---
+  |    |     |
+  |    |     Has type `<class 'str'>`
+  |    Has type `<class 'int'>`
+2 |
+3 | class Foo:
+  |
+info: PEP 604 `|` unions are only available on Python 3.10+ unless they are quoted
+info: Python 3.9 was assumed when inferring types because it was specified on the command line
+info: rule `unsupported-operator` is enabled by default
+
+```
+
+```
+error[unsupported-operator]: Unsupported `|` operation
+ --> src/a.py:5:17
+  |
+3 | class Foo:
+4 |     def __init__(self):
+5 |         self.x: int | str = 42  # error: [unsupported-operator]
+  |                 ---^^^---
+  |                 |     |
+  |                 |     Has type `<class 'str'>`
+  |                 Has type `<class 'int'>`
+6 |
+7 | d = {}
+  |
+info: PEP 604 `|` unions are only available on Python 3.10+ unless they are quoted
+info: Python 3.9 was assumed when inferring types because it was specified on the command line
+info: rule `unsupported-operator` is enabled by default
+
+```
+
+```
+error[unsupported-operator]: Unsupported `|` operation
+ --> src/a.py:8:7
+  |
+7 | d = {}
+8 | d[0]: int | str = 42  # error: [unsupported-operator]
+  |       ---^^^---
+  |       |     |
+  |       |     Has type `<class 'str'>`
+  |       Has type `<class 'int'>`
+  |
+info: PEP 604 `|` unions are only available on Python 3.10+ unless they are quoted
+info: Python 3.9 was assumed when inferring types because it was specified on the command line
+info: rule `unsupported-operator` is enabled by default
+
+```

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3780,8 +3780,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 target,
                 simple: _,
             } = assignment;
-            let annotated =
-                self.infer_annotation_expression(annotation, DeferredExpressionState::None);
+            let annotated = self.infer_annotation_expression(
+                annotation,
+                DeferredExpressionState::from(self.defer_annotations()),
+            );
 
             if !annotated.qualifiers.is_empty() {
                 for qualifier in [TypeQualifiers::CLASS_VAR, TypeQualifiers::INIT_VAR] {


### PR DESCRIPTION
## Summary

This PR fixes a regression introduced in 0.0.22 just now. This works fine at runtime, even on Python 3.9 -- because of `__future__.annotations`, the annotation is never evaluated:

```py
from __future__ import annotations

class Foo:
    def __init__(self):
        self.x: int | str
```

but a latent bug in `infer/builder.rs` (that must have been there for quite some time) meant that we weren't setting `deferred_state` to `DeferredExpressionState::Deferred` for annotations on _attribute_ expressions even when `__future__.annotations` was imported -- we were only doing so for annotations on _name_ expressions.

This PR fixes the regression.

## Test Plan

New mdtests
