### PR TITLE
Exclude broken symlink in ecosystem check

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -26,7 +26,7 @@ DEFAULT_TARGETS = [
         config_overrides={
             # Broken symlink
             "exclude": [
-                # "task-sdk/src/airflow/sdk/_shared/AGENTS.md",
+                "task-sdk/src/airflow/sdk/_shared/AGENTS.md",
             ]
         },
     ),


### PR DESCRIPTION
Summary
--

This should resolve the ecosystem errors in #23919.

Test Plan
--

This PR, first with the exclude commented out, then included.
