### PR TITLE
[ty] Avoid duplicated work during multi-inference

### DIFF
--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -303,7 +303,7 @@ mod tests {
         "#,
         );
 
-        assert_snapshot!(test.hover(), @"
+        assert_snapshot!(test.hover(), @r"
         def my_func(
             a,
             b
@@ -358,7 +358,7 @@ mod tests {
         "#,
         );
 
-        assert_snapshot!(test.hover(), @"
+        assert_snapshot!(test.hover(), @r"
         def my_func(
             a,
             b
@@ -427,7 +427,7 @@ mod tests {
         "#,
         );
 
-        assert_snapshot!(test.hover(), @"
+        assert_snapshot!(test.hover(), @r"
         <class 'MyClass'>
         ---------------------------------------------
         This is such a great class!!
@@ -489,7 +489,7 @@ mod tests {
         "#,
         );
 
-        assert_snapshot!(test.hover(), @"
+        assert_snapshot!(test.hover(), @r"
         <class 'MyClass'>
         ---------------------------------------------
         This is such a great class!!
@@ -664,7 +664,7 @@ mod tests {
         "#,
         );
 
-        assert_snapshot!(test.hover(), @"
+        assert_snapshot!(test.hover(), @r"
         <class 'MyClass'>
         ---------------------------------------------
         This is such a great class!!
@@ -729,7 +729,7 @@ mod tests {
         "#,
         );
 
-        assert_snapshot!(test.hover(), @"
+        assert_snapshot!(test.hover(), @r"
         bound method MyClass.my_method(
             a,
             b
@@ -2045,7 +2045,7 @@ def ab(a: int, *, c: int):
         )
         .unwrap();
 
-        assert_snapshot!(test.hover(), @"
+        assert_snapshot!(test.hover(), @r"
         <module 'lib'>
         ---------------------------------------------
         The cool lib_py module!
@@ -2599,7 +2599,7 @@ def function():
         )
         .unwrap();
 
-        assert_snapshot!(test.hover(), @"
+        assert_snapshot!(test.hover(), @r"
         <module 'lib'>
         ---------------------------------------------
         The cool lib_py module!
@@ -2999,7 +2999,7 @@ def function():
         "#,
         );
 
-        assert_snapshot!(test.hover(), @"
+        assert_snapshot!(test.hover(), @r"
         int
         ---------------------------------------------
         This is the docs for this value
@@ -3088,7 +3088,7 @@ def function():
         "#,
         );
 
-        assert_snapshot!(test.hover(), @"
+        assert_snapshot!(test.hover(), @r"
         int
         ---------------------------------------------
         This is the docs for this value
@@ -4584,6 +4584,115 @@ def function():
           |                             ^^^- Cursor offset
           |                             |
           |                             source
+          |
+        ");
+    }
+
+    #[test]
+    fn hover_multi_inference() {
+        let test = cursor_test(
+            r#"
+            def list1[T](x: T) -> list[T]:
+                return [x]
+
+            def f(x: int, y: int) -> list[int] | list[str]:
+                return list1(x<CURSOR> + y)
+        "#,
+        );
+
+        assert_snapshot!(test.hover(), @r"
+        int
+        ---------------------------------------------
+        ```python
+        int
+        ```
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:6:18
+          |
+        5 | def f(x: int, y: int) -> list[int] | list[str]:
+        6 |     return list1(x + y)
+          |                  ^- Cursor offset
+          |                  |
+          |                  source
+          |
+        ");
+
+        let test = cursor_test(
+            r#"
+            def f(x: int, y: int) -> list[int] | list[str]:
+                return [x<CURSOR> + y]
+        "#,
+        );
+
+        assert_snapshot!(test.hover(), @r"
+        int
+        ---------------------------------------------
+        ```python
+        int
+        ```
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:3:13
+          |
+        2 | def f(x: int, y: int) -> list[int] | list[str]:
+        3 |     return [x + y]
+          |             ^- Cursor offset
+          |             |
+          |             source
+          |
+        ");
+
+        let test = cursor_test(
+            r#"
+            def list1[T](x: T) -> list[T]:
+                return [x]
+
+            def f(x: int, y: int) -> list[int] | list[str]:
+                return (_<CURSOR> := list1(x + y))
+        "#,
+        );
+
+        assert_snapshot!(test.hover(), @r"
+        list[int]
+        ---------------------------------------------
+        ```python
+        list[int]
+        ```
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:6:13
+          |
+        5 | def f(x: int, y: int) -> list[int] | list[str]:
+        6 |     return (_ := list1(x + y))
+          |             ^- Cursor offset
+          |             |
+          |             source
+          |
+        ");
+
+        let test = cursor_test(
+            r#"
+            def f(x: int, y: int) -> list[int] | list[str]:
+                return (_<CURSOR> := [x + y])
+        "#,
+        );
+
+        assert_snapshot!(test.hover(), @r"
+        list[int]
+        ---------------------------------------------
+        ```python
+        list[int]
+        ```
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:3:13
+          |
+        2 | def f(x: int, y: int) -> list[int] | list[str]:
+        3 |     return (_ := [x + y])
+          |             ^- Cursor offset
+          |             |
+          |             source
           |
         ");
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4989,7 +4989,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 infer_argument_ty,
                 bindings,
                 narrowed_tcx,
-                MultiInferenceState::Ignore,
             );
 
             // Ensure the argument types match their annotated types.
@@ -5061,7 +5060,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             infer_argument_ty,
             bindings,
             call_expression_tcx,
-            MultiInferenceState::Intersect,
         );
 
         bindings.check_types_impl(
@@ -5085,7 +5083,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         infer_argument_ty: &mut dyn FnMut(&mut Self, ArgExpr<'db, '_>) -> Type<'db>,
         bindings: &Bindings<'db>,
         call_expression_tcx: TypeContext<'db>,
-        multi_inference_state: MultiInferenceState,
     ) {
         debug_assert_eq!(arguments_types.len(), bindings.argument_forms().len());
 
@@ -5121,7 +5118,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .flatten()
             .collect::<Vec<_>>();
 
-        let old_multi_inference_state = self.set_multi_inference_state(multi_inference_state);
+        // Each type is a valid independent inference of the given argument, and we may require
+        // different permutations of argument types to correctly perform argument expansion during
+        // overload evaluation, so we take the intersection of all the types we inferred for each
+        // argument.
+        let old_multi_inference_state =
+            self.set_multi_inference_state(MultiInferenceState::Intersect);
 
         for (argument_index, (_, argument_type), argument_form, ast_argument) in iter {
             let ast_argument = match ast_argument {
@@ -5244,11 +5246,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         continue;
                     }
 
-                    // Each type is a valid independent inference of the given argument, and we may require different
-                    // permutations of argument types to correctly perform argument expansion during overload evaluation,
-                    // so we take the intersection of all the types we inferred for each argument.
-                    //
-                    // TODO: intersecting the inferred argument types is correct for unions of
+                    // TODO: Intersecting the inferred argument types is correct for unions of
                     // callables, since the argument must satisfy each callable, but it's not clear
                     // that it's correct for an intersection of callables, or for a case where
                     // different overloads provide different type context; unioning may be more


### PR DESCRIPTION
Instead of ignoring intermediate inference results, we can create a temporary `TypeInferenceBuilder` and merge the chosen inference results into the current region. This should hopefully reclaim some of the performance regressions introduced by https://github.com/astral-sh/ruff/pull/23844 and https://github.com/astral-sh/ruff/pull/21210.