### PR TITLE
[ty] Fix variance of frozen dataclass-transform models

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
@@ -531,6 +531,29 @@ static_assert(is_subtype_of(E[B], E[A]))
 static_assert(not is_subtype_of(E[A], E[B]))
 ```
 
+This also works for dataclass-transformers:
+
+```py
+from typing import dataclass_transform
+
+@dataclass_transform(frozen_default=False)
+class ModelBase:
+    def __init_subclass__(cls, frozen: bool = False) -> None:
+        pass
+
+class NonFrozenModel[T](ModelBase):
+    value: T
+
+static_assert(not is_subtype_of(NonFrozenModel[B], NonFrozenModel[A]))
+static_assert(not is_subtype_of(NonFrozenModel[A], NonFrozenModel[B]))
+
+class FrozenModel[T](ModelBase, frozen=True):
+    value: T
+
+static_assert(is_subtype_of(FrozenModel[B], FrozenModel[A]))
+static_assert(not is_subtype_of(FrozenModel[A], FrozenModel[B]))
+```
+
 #### Frozen dataclasses in Python 3.13 and later
 
 ```toml
@@ -555,6 +578,29 @@ class D[U]:
 
 static_assert(not is_subtype_of(D[B], D[A]))
 static_assert(not is_subtype_of(D[A], D[B]))
+```
+
+The same holds for dataclass-transformers:
+
+```py
+from typing import dataclass_transform
+
+@dataclass_transform(frozen_default=True)
+class ModelBase:
+    def __init_subclass__(cls, frozen: bool = True) -> None:
+        pass
+
+class DefaultFrozenModel[T](ModelBase):
+    value: T
+
+static_assert(not is_subtype_of(DefaultFrozenModel[B], DefaultFrozenModel[A]))
+static_assert(not is_subtype_of(DefaultFrozenModel[A], DefaultFrozenModel[B]))
+
+class ExplicitFrozenModel[T](ModelBase, frozen=True):
+    value: T
+
+static_assert(not is_subtype_of(ExplicitFrozenModel[B], ExplicitFrozenModel[A]))
+static_assert(not is_subtype_of(ExplicitFrozenModel[A], ExplicitFrozenModel[B]))
 ```
 
 #### NamedTuple

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -3018,11 +3018,12 @@ impl<'db> VarianceInferable<'db> for StaticClassLiteral<'db> {
             // not considered here, since they don't use field types in their signatures. TODO:
             // ideally we'd have a single source of truth for information about synthesized
             // methods, so we just look them up normally and don't hardcode this knowledge here.
-            let is_frozen_dataclass = Program::get(db).python_version(db) <= PythonVersion::PY312
-                && self
-                    .dataclass_params(db)
-                    .is_some_and(|params| params.flags(db).contains(DataclassFlags::FROZEN));
-            if is_namedtuple || is_frozen_dataclass {
+            let is_frozen_dataclass_prior_to_313 = Program::get(db).python_version(db)
+                <= PythonVersion::PY312
+                && CodeGeneratorKind::from_static_class(db, self, None)
+                    .is_some_and(|kind| self.has_dataclass_param(db, kind, DataclassFlags::FROZEN));
+
+            if is_namedtuple || is_frozen_dataclass_prior_to_313 {
                 TypeVarVariance::Covariant
             } else {
                 TypeVarVariance::Invariant


### PR DESCRIPTION
## Summary

Similar in spirit to https://github.com/astral-sh/ruff/pull/23930. This is the last remaining place (I think) where we determined the presence of dataclass parameters in a way that did not account for defaults that were set on the model base.

## Test Plan

New Markdown tests