### PR TITLE
Revert "[`ruff`] use `bitcode` instead of `bincode`"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,30 +298,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitcode"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6ed1b54d8dc333e7be604d00fa9262f4635485ffea923647b6521a5fff045d"
-dependencies = [
- "arrayvec",
- "bitcode_derive",
- "bytemuck",
- "glam",
- "serde",
-]
-
-[[package]]
-name = "bitcode_derive"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238b90427dfad9da4a9abd60f3ec1cdee6b80454bde49ed37f1781dd8e9dc7f9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "bitflags"
@@ -370,12 +366,6 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -1389,12 +1379,6 @@ dependencies = [
  "wasip3",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "glam"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34627c5158214743a374170fed714833fdf4e4b0cbcc1ea98417866a4c5d4441"
 
 [[package]]
 name = "glob"
@@ -3019,7 +3003,7 @@ dependencies = [
  "anyhow",
  "argfile",
  "assert_fs",
- "bitcode",
+ "bincode",
  "bitflags 2.11.0",
  "cachedir",
  "clap",
@@ -5028,6 +5012,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5096,6 +5086,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vt100"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ anyhow = { version = "1.0.80" }
 arc-swap = { version = "1.7.1" }
 argfile = { version = "1.0.0" }
 assert_fs = { version = "1.1.0" }
-bitcode = { version = "0.6.9" }
+bincode = { version = "2.0.0" }
 bitflags = { version = "2.5.0" }
 bitvec = { version = "1.0.1", default-features = false, features = [
     "alloc",

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -39,7 +39,7 @@ ruff_workspace = { workspace = true }
 
 anyhow = { workspace = true }
 argfile = { workspace = true }
-bitcode = { workspace = true, features = ["serde"] }
+bincode = { workspace = true, features = ["serde"] }
 bitflags = { workspace = true }
 cachedir = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }

--- a/crates/ruff/src/cache.rs
+++ b/crates/ruff/src/cache.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
-use std::fs;
+use std::fs::{self, File};
 use std::hash::Hasher;
-use std::io::{self, Write};
+use std::io::{self, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -97,8 +97,8 @@ impl Cache {
         let key = format!("{}", cache_key(&package_root, settings));
         let path = PathBuf::from_iter([&settings.cache_dir, Path::new(VERSION), Path::new(&key)]);
 
-        let serialized = match fs::read(&path) {
-            Ok(serialized) => serialized,
+        let file = match File::open(&path) {
+            Ok(file) => file,
             Err(err) if err.kind() == io::ErrorKind::NotFound => {
                 // No cache exist yet, return an empty cache.
                 return Cache::empty(path, package_root);
@@ -109,13 +109,14 @@ impl Cache {
             }
         };
 
-        let mut package: PackageCache = match bitcode::deserialize(&serialized) {
-            Ok(package) => package,
-            Err(err) => {
-                warn_user!("Failed parse cache file `{}`: {err}", path.display());
-                return Cache::empty(path, package_root);
-            }
-        };
+        let mut package: PackageCache =
+            match bincode::decode_from_reader(BufReader::new(file), bincode::config::standard()) {
+                Ok(package) => package,
+                Err(err) => {
+                    warn_user!("Failed parse cache file `{}`: {err}", path.display());
+                    return Cache::empty(path, package_root);
+                }
+            };
 
         // Sanity check.
         if package.package_root != package_root {
@@ -167,7 +168,8 @@ impl Cache {
 
         // Serialize to in-memory buffer because hyperfine benchmark showed that it's faster than
         // using a `BufWriter` and our cache files are small enough that streaming isn't necessary.
-        let serialized = bitcode::serialize(&self.package).context("Failed to serialize cache")?;
+        let serialized = bincode::encode_to_vec(&self.package, bincode::config::standard())
+            .context("Failed to serialize cache data")?;
         temp_file
             .write_all(&serialized)
             .context("Failed to write serialized cache to temporary file.")?;
@@ -296,8 +298,8 @@ impl Cache {
     }
 }
 
-/// Runtime representation of a cache of a package.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+/// On disk representation of a cache of a package.
+#[derive(bincode::Encode, Debug, bincode::Decode)]
 struct PackageCache {
     /// Path to the root of the package.
     ///
@@ -308,8 +310,8 @@ struct PackageCache {
     files: FxHashMap<RelativePathBuf, FileCache>,
 }
 
-/// Runtime representation of the cache per source file.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+/// On disk representation of the cache per source file.
+#[derive(bincode::Decode, Debug, bincode::Encode)]
 pub(crate) struct FileCache {
     /// Key that determines if the cached item is still valid.
     key: u64,
@@ -329,7 +331,7 @@ impl FileCache {
     }
 }
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, bincode::Decode, bincode::Encode)]
 struct FileCacheData {
     linted: bool,
     formatted: bool,
@@ -570,7 +572,7 @@ mod tests {
                 expected_diagnostics += diagnostics;
             }
         }
-        assert_ne!(paths, &[] as &[PathBuf], "no files checked");
+        assert_ne!(paths, &[] as &[std::path::PathBuf], "no files checked");
 
         cache.persist().unwrap();
 


### PR DESCRIPTION
Reverts astral-sh/ruff#23544

bitcode depends [on unsound code](https://github.com/SoftbearStudios/bitcode/issues/50). 