### PR TITLE
[ty] Synthesize TypedDict constructors via `__new__`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -467,6 +467,142 @@ def _(ATD: type[MyTD]):
     z = ATD(a="foo")
 ```
 
+Constructor validation should also work when the call target is a union or intersection of
+`type[...]` values:
+
+```py
+from typing import Any, List, Union
+from ty_extensions import Intersection
+
+class CtorRequired(TypedDict):
+    a: int
+
+class CtorOptional(TypedDict, total=False):
+    a: int
+
+def _(ATD: Union[type[CtorRequired], type[CtorOptional]]):
+    ok = ATD(a=1)
+
+    # Both union variants reject the `str` argument for `a`.
+    # error: [invalid-argument-type]
+    # error: [invalid-argument-type]
+    bad = ATD(a="foo")
+
+    # 0-arg construction is still invalid because the `CtorRequired` arm requires `a`.
+    # error: [missing-typed-dict-key] "Missing required key 'a' in TypedDict `CtorRequired` constructor"
+    no_args = ATD()
+
+    # Dict-literal construction through a union.
+    ok_dict = ATD({"a": 1})
+
+    # error: [invalid-argument-type]
+    # error: [invalid-argument-type]
+    bad_dict = ATD({"a": "foo"})
+
+def _(ATD: Intersection[type[CtorRequired], type[CtorRequired]]):
+    ok = ATD(a=1)
+
+    # error: [invalid-argument-type]
+    bad = ATD(a="foo")
+
+def _(ATD: Intersection[type[CtorRequired], type[CtorOptional]]):
+    ok = ATD(a=1)
+
+    # Both intersection members check the argument independently.
+    # error: [invalid-argument-type]
+    # error: [invalid-argument-type]
+    bad = ATD(a="foo")
+
+    # Dict-literal construction through an intersection.
+    ok_dict = ATD({"a": 1})
+
+class CtorOverride(TypedDict, total=False):
+    a: str
+
+def _(ATD: Union[type[CtorRequired], type[CtorOptional]], override: CtorOverride):
+    ok_merge = ATD(override, a=1)
+    ok_literal_merge = ATD({"a": "wrong"}, a=1)
+
+class Comparison(TypedDict):
+    field: str
+    value: Any
+
+class LogicalA(TypedDict):
+    tag: str
+    conditions: List["Filter"]
+
+class LogicalB(TypedDict):
+    tag: str
+    conditions: List["Filter"]
+
+Filter = Union[Comparison, LogicalA, LogicalB]
+
+def _(T: Union[type[LogicalA], type[LogicalB]]):
+    ok_recursive = T(tag="x", conditions=[Comparison(field="a", value="b")])
+    ok_recursive_dict = T({"tag": "x", "conditions": [Comparison(field="a", value="b")]})
+    ok_recursive_merge = T({"conditions": [Comparison(field="a", value="b")]}, tag="x")
+```
+
+TypedDict constructors also support the `dict(mapping, **kwargs)`-style merge form. Keyword
+arguments should override the positional mapping when validating the final shape:
+
+```py
+from typing import Union
+
+class BaseKwargs(TypedDict, total=False):
+    name: str
+
+class ChildKwargs(BaseKwargs, total=False):
+    count: int
+
+class OverrideCountKwargs(TypedDict, total=False):
+    count: str
+
+def _(base: BaseKwargs, override: OverrideCountKwargs):
+    ok = ChildKwargs(base, count=1)
+    overridden = ChildKwargs(override, count=1)
+    overridden_literal = ChildKwargs({"count": "wrong"}, count=1)
+
+    # error: [invalid-argument-type]
+    bad_value = ChildKwargs({"name": 1}, count=1)
+
+    # error: [invalid-argument-type]
+    bad_mapping = ChildKwargs(1, count=1)
+
+def _(flag: bool):
+    contextual_merge = ChildKwargs({"count": 1} if flag else {"count": 2}, name="x")
+    reveal_type(contextual_merge)  # revealed: ChildKwargs
+
+class UnionBaseLeft(TypedDict):
+    name: str
+
+class UnionBaseRight(TypedDict):
+    name: str
+
+class UnionChildKwargs(TypedDict):
+    name: str
+    count: int
+
+def _(base: Union[UnionBaseLeft, UnionBaseRight]):
+    ok_union_mapping = UnionChildKwargs(base, count=1)
+```
+
+Unpacked optional keys are not guaranteed to satisfy required target fields:
+
+```py
+from typing import TypedDict
+
+class MaybeName(TypedDict, total=False):
+    name: str
+
+class NeedsName(TypedDict):
+    name: str
+
+def _(maybe: MaybeName):
+    # error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `NeedsName` constructor"
+    NeedsName(**maybe)
+```
+
 All of these have an invalid type for the `name` field:
 
 ```py
@@ -2346,6 +2482,28 @@ class BadMerge(L[int], R[str]): ...
 class BadMergeGeneric[T](L[int], R[T]): ...
 ```
 
+### Unspecialized generic `TypedDict` constructors use the default specialization
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import TypedDict
+
+class Box[T](TypedDict):
+    value: T
+
+x = Box(value="ok")
+reveal_type(x)  # revealed: Box[Unknown]
+y: str = x["value"]
+
+src: Box[str] = {"value": "ok"}
+mapped = Box(src)
+z: str = mapped["value"]
+```
+
 ## Recursive `TypedDict`
 
 `TypedDict`s can also be recursive, allowing for nested structures:
@@ -2380,6 +2538,27 @@ def _(node: Node, person: Person):
     _: Node = person
 
 _: Node = Person(name="Alice", parent=Node(name="Bob", parent=Person(name="Charlie", parent=None)))
+```
+
+TypedDict constructor calls should also use field type context when inferring nested recursive
+values:
+
+```py
+from typing import Any, List, TypedDict, Union
+from typing_extensions import NotRequired
+
+class Comparison(TypedDict):
+    field: str
+    op: NotRequired[str]
+    value: Any
+
+class Logical(TypedDict):
+    op: NotRequired[str]
+    conditions: List["Filter"]
+
+Filter = Union[Comparison, Logical]
+
+logical = Logical(conditions=[Comparison(field="a", value="b")])
 ```
 
 ## Function/assignment syntax

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2323,7 +2323,12 @@ impl<'db> Type<'db> {
             }
 
             Type::GenericAlias(alias) if alias.is_typed_dict(db) => {
-                Some(alias.origin(db).typed_dict_member(db, None, name, policy))
+                Some(alias.origin(db).typed_dict_member(
+                    db,
+                    Some(alias.specialization(db)),
+                    name,
+                    policy,
+                ))
             }
 
             Type::GenericAlias(alias) => {
@@ -4379,6 +4384,85 @@ impl<'db> Type<'db> {
     // Build bindings for constructor calls by combining `__new__`/`__init__` signatures.
     // Returns fallback bindings for cases that intentionally keep bespoke call behavior.
     fn constructor_bindings(self, db: &'db dyn Db, class: ClassType<'db>) -> Bindings<'db> {
+        fn typed_dict_constructor_bindings<'db>(
+            db: &'db dyn Db,
+            owner: Type<'db>,
+            signature_class: ClassType<'db>,
+            constructor_instance_ty: Type<'db>,
+        ) -> Bindings<'db> {
+            let (class_literal, class_specialization) =
+                signature_class.class_literal_and_specialization(db);
+            let ClassLiteral::Static(class_literal) = class_literal else {
+                return Binding::single(
+                    owner,
+                    Signature::new(Parameters::gradual_form(), constructor_instance_ty),
+                )
+                .into();
+            };
+
+            let typed_dict = TypedDictType::new(signature_class);
+            let fields = class_literal.fields(
+                db,
+                class_specialization,
+                class::CodeGeneratorKind::TypedDict,
+            );
+
+            let keyword_signature = Signature::new(
+                Parameters::new(
+                    db,
+                    fields.iter().map(|(name, field)| {
+                        let parameter = Parameter::keyword_only(name.clone())
+                            .with_annotated_type(field.declared_ty);
+                        if field.is_required() {
+                            parameter
+                        } else {
+                            parameter.with_default_type(field.declared_ty)
+                        }
+                    }),
+                ),
+                constructor_instance_ty,
+            );
+
+            let positional_signature = Signature::new(
+                Parameters::new(
+                    db,
+                    [
+                        Parameter::positional_only(Some(Name::new_static("mapping")))
+                            .with_annotated_type(Type::TypedDict(typed_dict)),
+                    ],
+                ),
+                constructor_instance_ty,
+            );
+
+            // `TypedDict(mapping, **kwargs)` needs a permissive mapping parameter so keyword
+            // overrides can replace incompatible values from the positional mapping. The
+            // TypedDict-specific validator checks the merged result precisely after inference.
+            let mapping_and_keywords_signature = Signature::new(
+                Parameters::new(
+                    db,
+                    std::iter::once(
+                        Parameter::positional_only(Some(Name::new_static("mapping")))
+                            .with_annotated_type(Type::unknown()),
+                    )
+                    .chain(fields.iter().map(|(name, field)| {
+                        Parameter::keyword_only(name.clone())
+                            .with_annotated_type(field.declared_ty)
+                            .with_default_type(field.declared_ty)
+                    })),
+                ),
+                constructor_instance_ty,
+            );
+
+            CallableBinding::from_overloads(
+                owner,
+                [
+                    keyword_signature,
+                    positional_signature,
+                    mapping_and_keywords_signature,
+                ],
+            )
+            .into()
+        }
         fn resolve_dunder_new_callable<'db>(
             db: &'db dyn Db,
             owner: Type<'db>,
@@ -4440,13 +4524,28 @@ impl<'db> Type<'db> {
             .into()
         };
 
-        // Checking TypedDict construction happens in `infer_call_expression_impl`, so here we just
-        // return a permissive fallback binding. TODO maybe we should just synthesize bindings for
-        // a TypedDict constructor? That would handle unions/intersections correctly.
+        // Synthesize TypedDict constructor bindings so constructor calls participate in normal
+        // overload handling.
         if class_literal.is_typed_dict(db)
             || class::CodeGeneratorKind::TypedDict.matches(db, class_literal, class_specialization)
         {
-            return fallback_bindings();
+            // Unlike ordinary generic class constructors, unspecialized generic TypedDict
+            // constructors should preserve the class literal's default specialization here.
+            // That keeps their synthesized field types gradual (`Unknown`) instead of leaking
+            // unresolved class type variables into user code.
+            let self_type = self;
+            let Some(constructor_instance_ty) = self_type.to_instance(db) else {
+                return fallback_bindings();
+            };
+            let signature_class = self_type.to_class_type(db).unwrap_or(class);
+            return typed_dict_constructor_bindings(
+                db,
+                self,
+                signature_class,
+                constructor_instance_ty,
+            )
+            .into_constructor_bindings(constructor_instance_ty, ConstructorCallableKind::Init)
+            .with_generic_context(db, class_generic_context);
         }
 
         // These cases are checked in `Type::known_class_literal_bindings`, but currently we only

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 
 use itertools::{Either, Itertools};
 use ruff_python_ast as ast;
+use ruff_python_ast::HasNodeIndex;
 use rustc_hash::FxHashMap;
 
 use crate::Db;
@@ -227,6 +228,32 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         &mut self,
     ) -> impl Iterator<Item = (Argument<'a>, &mut CallArgumentTypes<'db>)> + '_ {
         (self.arguments.iter().copied()).zip(self.types.iter_mut())
+    }
+
+    pub(crate) fn expression_type(
+        &self,
+        arguments: &'a ast::Arguments,
+        expr: &ast::Expr,
+        tcx: TypeContext<'db>,
+    ) -> Option<Type<'db>> {
+        arguments
+            .arguments_source_order()
+            .zip(self.iter())
+            .find_map(|(ast_argument, (_, argument_types))| {
+                let candidate = match ast_argument {
+                    ast::ArgOrKeyword::Arg(argument) => argument,
+                    ast::ArgOrKeyword::Keyword(ast::Keyword { value, .. }) => value,
+                };
+
+                (candidate.node_index().load() == expr.node_index().load())
+                    .then(|| match tcx.annotation {
+                        Some(declared_ty) => argument_types.iter().find_map(|(cached_tcx, ty)| {
+                            (cached_tcx.annotation == Some(declared_ty)).then_some(ty)
+                        }),
+                        None => argument_types.get_default(),
+                    })
+                    .flatten()
+            })
     }
 
     /// Create a new [`CallArguments`] starting from the specified index.

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -921,11 +921,6 @@ impl<'db> ClassType<'db> {
         self.is_known(db, KnownClass::Object)
     }
 
-    /// Return `true` if this class is a `TypedDict`.
-    pub(crate) fn is_typed_dict(self, db: &'db dyn Db) -> bool {
-        self.class_literal(db).is_typed_dict(db)
-    }
-
     /// Return `true` if this class is a subtype of (any specialization of) `class_literal`.
     pub(crate) fn is_subtype_of_class_literal(
         self,
@@ -936,7 +931,6 @@ impl<'db> ClassType<'db> {
             .filter_map(ClassBase::into_class)
             .any(|base| base.class_literal(db) == class_literal)
     }
-
     pub(super) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -98,7 +98,10 @@ use crate::types::special_form::TypeQualifier;
 use crate::types::subclass_of::SubclassOfInner;
 use crate::types::tuple::{Tuple, TupleLength, TupleSpecBuilder, TupleType};
 use crate::types::type_alias::{ManualPEP695TypeAliasType, PEP695TypeAliasType};
-use crate::types::typed_dict::{validate_typed_dict_constructor, validate_typed_dict_dict_literal};
+use crate::types::typed_dict::{
+    typed_dict_constructor_targets, validate_typed_dict_constructor,
+    validate_typed_dict_dict_literal,
+};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarConstraints, TypeVarIdentity};
 use crate::types::{
     CallDunderError, CallableBinding, CallableType, CallableTypes, ClassType, DynamicType,
@@ -5710,31 +5713,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         typed_dict: TypedDictType<'db>,
         item_types: &mut FxHashMap<NodeIndex, Type<'db>>,
     ) -> Option<Type<'db>> {
-        let ast::ExprDict {
-            range: _,
-            node_index: _,
-            items,
-        } = dict;
-
-        let typed_dict_items = typed_dict.items(self.db());
-
-        for item in items {
-            let key_ty = self.infer_optional_expression(item.key.as_ref(), TypeContext::default());
-            if let Some((key, key_ty)) = item.key.as_ref().zip(key_ty) {
-                item_types.insert(key.node_index().load(), key_ty);
-            }
-
-            let value_ty = if let Some(key_ty) = key_ty
-                && let Some(key) = key_ty.as_string_literal()
-                && let Some(field) = typed_dict_items.get(key.value(self.db()))
-            {
-                self.infer_expression(&item.value, TypeContext::new(Some(field.declared_ty)))
-            } else {
-                self.infer_expression(&item.value, TypeContext::default())
-            };
-
-            item_types.insert(item.value.node_index().load(), value_ty);
-        }
+        self.infer_typed_dict_item_types(dict, typed_dict, item_types);
 
         validate_typed_dict_dict_literal(&self.context, typed_dict, dict, dict.into(), |expr| {
             item_types
@@ -5744,6 +5723,33 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         })
         .ok()
         .map(|_| Type::TypedDict(typed_dict))
+    }
+
+    fn infer_typed_dict_item_types(
+        &mut self,
+        dict: &ast::ExprDict,
+        typed_dict: TypedDictType<'db>,
+        item_types: &mut FxHashMap<NodeIndex, Type<'db>>,
+    ) {
+        let typed_dict_items = typed_dict.items(self.db());
+
+        for item in &dict.items {
+            let key_ty = self.infer_optional_expression(item.key.as_ref(), TypeContext::default());
+            if let Some(key) = item.key.as_ref()
+                && let Some(key_ty) = key_ty
+            {
+                item_types.insert(key.node_index().load(), key_ty);
+            }
+
+            let value_tcx = key_ty
+                .and_then(Type::as_string_literal)
+                .and_then(|key| typed_dict_items.get(key.value(self.db())))
+                .map(|field| TypeContext::new(Some(field.declared_ty)))
+                .unwrap_or_default();
+
+            let value_ty = self.infer_expression(&item.value, value_tcx);
+            item_types.insert(item.value.node_index().load(), value_ty);
+        }
     }
 
     // Infer the type of a collection literal expression.
@@ -7096,6 +7102,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .bindings(self.db())
             .match_parameters(self.db(), &call_arguments);
 
+        let typed_dict_constructor_targets =
+            typed_dict_constructor_targets(self.db(), callable_type);
+
+        let typed_dict_constructor_shape_supported =
+            typed_dict_constructor_targets.is_some() && arguments.args.len() <= 1;
+
         report_missing_implicit_constructor_call(
             &self.context,
             self.db(),
@@ -7113,20 +7125,35 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         );
 
         // Validate `TypedDict` constructor calls after argument type inference.
-        if let Some(class) = class
-            && class.is_typed_dict(self.db())
+        //
+        // This remains the authoritative path for constructor diagnostics, even for
+        // dict-literal positional args. The synthesized overloads provide type context and make
+        // merge-form calls bind, but they intentionally stay permissive enough that validation
+        // here still needs to check the final constructor shape.
+        if let Some(typed_dict_targets) = typed_dict_constructor_targets.as_ref()
+            && typed_dict_constructor_shape_supported
         {
-            validate_typed_dict_constructor(
-                &self.context,
-                TypedDictType::new(class),
-                arguments,
-                func.as_ref().into(),
-                |expr| self.expression_type(expr),
-            );
+            for typed_dict in typed_dict_targets {
+                let mut speculative = self.speculate();
+                validate_typed_dict_constructor(
+                    &self.context,
+                    *typed_dict,
+                    arguments,
+                    Some(&call_arguments),
+                    func.as_ref().into(),
+                    |expr, tcx| speculative.infer_expression(expr, tcx),
+                );
+            }
         }
 
         let mut bindings = match bindings_result {
             Ok(()) => bindings,
+            // For TypedDict constructors with supported call shapes (keyword-only or single
+            // positional mapping), suppress binding errors from the synthesized `__new__` — the
+            // TypedDict-specific validator above produces more precise diagnostics.
+            Err(CallErrorKind::BindingError) if typed_dict_constructor_shape_supported => {
+                return bindings.return_type(self.db());
+            }
             Err(_) => {
                 bindings.report_diagnostics(&self.context, call_expression.into());
                 return bindings.return_type(self.db());

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -44,8 +44,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 &self.context,
                 typed_dict,
                 arguments,
+                None,
                 func.into(),
-                |expr| self.expression_type(expr),
+                |expr, _| self.expression_type(expr),
             );
 
             return Some(Type::TypedDict(typed_dict));

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -10,6 +10,7 @@ use ruff_python_ast::Arguments;
 use ruff_python_ast::{self as ast, AnyNodeRef, StmtClassDef, name::Name};
 use ruff_text_size::Ranged;
 
+use super::call::CallArguments;
 use super::class::{ClassLiteral, ClassType, CodeGeneratorKind, Field};
 use super::context::InferContext;
 use super::diagnostic::{
@@ -18,7 +19,7 @@ use super::diagnostic::{
 };
 use super::infer::infer_deferred_types;
 use super::{
-    ApplyTypeMappingVisitor, IntersectionBuilder, Type, TypeMapping, TypeQualifiers,
+    ApplyTypeMappingVisitor, IntersectionBuilder, Type, TypeMapping, TypeQualifiers, UnionBuilder,
     definition_expression_type, visitor,
 };
 use crate::Db;
@@ -196,6 +197,23 @@ impl<'db> TypedDictType<'db> {
                 }
                 (name.clone(), field)
             })
+            .collect();
+
+        Self::from_patch_items(db, items)
+    }
+
+    /// Returns a patch version of this `TypedDict` after explicit constructor keywords have
+    /// already supplied some keys.
+    fn to_constructor_patch_without_keys(
+        self,
+        db: &'db dyn Db,
+        excluded_keys: &OrderSet<Name>,
+    ) -> Self {
+        let items: TypedDictSchema<'db> = self
+            .items(db)
+            .iter()
+            .filter(|(name, _)| !excluded_keys.contains(*name))
+            .map(|(name, field)| (name.clone(), field.clone().with_required(false)))
             .collect();
 
         Self::from_patch_items(db, items)
@@ -816,27 +834,43 @@ pub(super) fn validate_typed_dict_required_keys<'db, 'ast>(
     !has_missing_key
 }
 
-/// Extracts `TypedDict` keys and their types from a type, resolving type aliases and handling
-/// intersections.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ExtractedTypedDictKey<'db> {
+    /// The value type when this key is present.
+    value_ty: Type<'db>,
+    /// Whether this key is definitely present on every inhabitant of the type.
+    guaranteed: bool,
+}
+
+/// Extracts possible `TypedDict` keys from a type, resolving aliases and handling set-theoretic
+/// combinations.
 ///
-/// For intersections, returns ALL keys from ALL `TypedDict` types (union of keys), because a
-/// value of an intersection type must satisfy all `TypedDict`s and therefore has all their keys.
-/// For keys that appear in multiple `TypedDict`s, the types are intersected.
+/// The returned key info distinguishes keys that are merely possible from keys that are
+/// guaranteed, which is necessary when validating `**kwargs` and `dict(mapping, **kwargs)`-style
+/// constructor merges.
 fn extract_typed_dict_keys<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
-) -> Option<BTreeMap<Name, Type<'db>>> {
+) -> Option<BTreeMap<Name, ExtractedTypedDictKey<'db>>> {
     match ty {
         Type::TypedDict(td) => {
             let keys = td
                 .items(db)
                 .iter()
-                .map(|(name, field)| (name.clone(), field.declared_ty))
+                .map(|(name, field)| {
+                    (
+                        name.clone(),
+                        ExtractedTypedDictKey {
+                            value_ty: field.declared_ty,
+                            guaranteed: field.is_required(),
+                        },
+                    )
+                })
                 .collect();
             Some(keys)
         }
         Type::Intersection(intersection) => {
-            // Collect key maps from all TypedDicts in the intersection
+            // Collect key maps from all TypedDicts in the intersection.
             let all_key_maps: Vec<_> = intersection
                 .positive(db)
                 .iter()
@@ -847,28 +881,65 @@ fn extract_typed_dict_keys<'db>(
                 return None;
             }
 
-            // Union all keys from all TypedDicts, intersecting types for shared keys
-            let mut result: BTreeMap<Name, Type<'db>> = BTreeMap::new();
+            // A value of an intersection must satisfy every TypedDict element.
+            // Keys are possible if any element may provide them, and guaranteed if at least one
+            // element requires them. Shared key types are intersected.
+            let mut result: BTreeMap<Name, ExtractedTypedDictKey<'db>> = BTreeMap::new();
 
             for key_map in all_key_maps {
-                for (key, ty) in key_map {
+                for (key, extracted_key) in key_map {
                     result
                         .entry(key)
-                        .and_modify(|existing_ty| {
-                            // Key exists in multiple TypedDicts - intersect the types
-                            *existing_ty = IntersectionBuilder::new(db)
-                                .add_positive(*existing_ty)
-                                .add_positive(ty)
+                        .and_modify(|existing_key| {
+                            existing_key.value_ty = IntersectionBuilder::new(db)
+                                .add_positive(existing_key.value_ty)
+                                .add_positive(extracted_key.value_ty)
                                 .build();
+                            existing_key.guaranteed |= extracted_key.guaranteed;
                         })
-                        .or_insert(ty);
+                        .or_insert(extracted_key);
                 }
             }
 
             Some(result)
         }
-        // TODO: handle unions by checking all TypedDict elements separately
-        Type::Union(_) => None,
+        Type::Union(union) => {
+            let mut all_key_maps = Vec::with_capacity(union.elements(db).len());
+
+            for element in union.elements(db) {
+                all_key_maps.push(extract_typed_dict_keys(db, *element)?);
+            }
+
+            if all_key_maps.is_empty() {
+                return None;
+            }
+
+            // A value of a union only guarantees keys that are guaranteed by every arm.
+            // Shared key values are unioned because the runtime value may come from any arm.
+            let mut result: BTreeMap<Name, ExtractedTypedDictKey<'db>> = BTreeMap::new();
+
+            for key_map in &all_key_maps {
+                for (key, extracted_key) in key_map {
+                    result
+                        .entry(key.clone())
+                        .and_modify(|existing_key| {
+                            existing_key.value_ty = UnionBuilder::new(db)
+                                .add(existing_key.value_ty)
+                                .add(extracted_key.value_ty)
+                                .build();
+                        })
+                        .or_insert(*extracted_key);
+                }
+            }
+
+            for (key, extracted_key) in &mut result {
+                extracted_key.guaranteed = all_key_maps
+                    .iter()
+                    .all(|key_map| key_map.get(key).is_some_and(|key| key.guaranteed));
+            }
+
+            Some(result)
+        }
         Type::TypeAlias(alias) => extract_typed_dict_keys(db, alias.value_type(db)),
         // All other types cannot contain a TypedDict
         Type::Dynamic(_)
@@ -901,70 +972,244 @@ fn extract_typed_dict_keys<'db>(
     }
 }
 
+pub(super) fn typed_dict_constructor_targets<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+) -> Option<Vec<TypedDictType<'db>>> {
+    match ty {
+        Type::ClassLiteral(class) if class.is_typed_dict(db) => {
+            Some(vec![TypedDictType::new(ClassType::NonGeneric(class))])
+        }
+        Type::GenericAlias(alias) if alias.is_typed_dict(db) => {
+            Some(vec![TypedDictType::new(ClassType::Generic(alias))])
+        }
+        Type::SubclassOf(subclass) => subclass
+            .subclass_of()
+            .into_class(db)
+            .filter(|class| class.class_literal(db).is_typed_dict(db))
+            .map(|class| vec![TypedDictType::new(class)]),
+        Type::TypeAlias(alias) => typed_dict_constructor_targets(db, alias.value_type(db)),
+        Type::Union(union) => {
+            let mut targets = Vec::new();
+            for element in union.elements(db) {
+                for target in typed_dict_constructor_targets(db, *element)? {
+                    if !targets.contains(&target) {
+                        targets.push(target);
+                    }
+                }
+            }
+            Some(targets)
+        }
+        Type::Intersection(intersection) if intersection.negative(db).is_empty() => {
+            let mut targets = Vec::new();
+            for element in intersection.positive(db) {
+                for target in typed_dict_constructor_targets(db, *element)? {
+                    if !targets.contains(&target) {
+                        targets.push(target);
+                    }
+                }
+            }
+            Some(targets)
+        }
+        Type::Intersection(_) => None,
+        _ => None,
+    }
+}
+
 pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
     context: &InferContext<'db, 'ast>,
     typed_dict: TypedDictType<'db>,
     arguments: &'ast Arguments,
+    call_arguments: Option<&CallArguments<'_, 'db>>,
     error_node: AnyNodeRef<'ast>,
-    expression_type_fn: impl Fn(&ast::Expr) -> Type<'db>,
+    infer_expression_type: impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) {
-    let db = context.db();
+    let mut expression_types = TypedDictConstructorExpressionTypes::new(
+        context.db(),
+        typed_dict,
+        arguments,
+        call_arguments,
+        infer_expression_type,
+    );
 
-    // Check for a single positional argument that is a dict literal
-    let has_positional_dict_literal = arguments.args.len() == 1 && arguments.args[0].is_dict_expr();
+    match (arguments.args.len(), arguments.keywords.is_empty()) {
+        (0, _) => {
+            let provided_keys = validate_from_keywords(
+                context,
+                typed_dict,
+                arguments,
+                error_node,
+                &mut expression_types,
+            );
+            validate_typed_dict_required_keys(context, typed_dict, &provided_keys, error_node);
+        }
+        (1, true) if arguments.args[0].is_dict_expr() => {
+            let provided_keys = validate_from_dict_literal(
+                context,
+                typed_dict,
+                arguments,
+                error_node,
+                &mut expression_types,
+                None,
+            );
+            validate_typed_dict_required_keys(context, typed_dict, &provided_keys, error_node);
+        }
+        (1, true) => {
+            // Single positional argument: check if assignable to the target TypedDict.
+            // This handles TypedDict, intersections, unions, and type aliases correctly.
+            // Assignability already checks for required keys and type compatibility,
+            // so we don't need separate validation.
+            let arg = &arguments.args[0];
+            let target_ty = Type::TypedDict(typed_dict);
+            let arg_ty = expression_types.expression_type(arg, TypeContext::new(Some(target_ty)));
 
-    // Check for a single positional argument (not a dict literal)
-    let is_single_positional_arg =
-        arguments.args.len() == 1 && arguments.keywords.is_empty() && !has_positional_dict_literal;
-
-    if has_positional_dict_literal {
-        let provided_keys = validate_from_dict_literal(
-            context,
-            typed_dict,
-            arguments,
-            error_node,
-            &expression_type_fn,
-        );
-        validate_typed_dict_required_keys(context, typed_dict, &provided_keys, error_node);
-    } else if is_single_positional_arg {
-        // Single positional argument: check if assignable to the target TypedDict.
-        // This handles TypedDict, intersections, unions, and type aliases correctly.
-        // Assignability already checks for required keys and type compatibility,
-        // so we don't need separate validation.
-        let arg = &arguments.args[0];
-        let arg_ty = expression_type_fn(arg);
-        let target_ty = Type::TypedDict(typed_dict);
-
-        if !arg_ty.is_assignable_to(db, target_ty) {
-            if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, arg) {
+            if !arg_ty.is_assignable_to(context.db(), target_ty)
+                && let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, arg)
+            {
                 builder.into_diagnostic(format_args!(
                     "Argument of type `{}` is not assignable to `{}`",
-                    arg_ty.display(db),
-                    target_ty.display(db),
+                    arg_ty.display(context.db()),
+                    target_ty.display(context.db()),
                 ));
             }
         }
-    } else {
-        let provided_keys = validate_from_keywords(
-            context,
-            typed_dict,
-            arguments,
-            error_node,
-            &expression_type_fn,
-        );
-        validate_typed_dict_required_keys(context, typed_dict, &provided_keys, error_node);
+        (1, false) => {
+            let provided_keys = validate_from_mapping_and_keywords(
+                context,
+                typed_dict,
+                arguments,
+                error_node,
+                &mut expression_types,
+            );
+            validate_typed_dict_required_keys(context, typed_dict, &provided_keys, error_node);
+        }
+        _ => {}
     }
 }
 
-/// Validates a `TypedDict` constructor call with a single positional dictionary argument
-/// e.g. `Person({"name": "Alice", "age": 30})`
-fn validate_from_dict_literal<'db, 'ast>(
+struct TypedDictConstructorExpressionTypes<'a, 'db, F>
+where
+    F: FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+{
+    arguments: &'a Arguments,
+    call_arguments: Option<&'a CallArguments<'a, 'db>>,
+    typed_dict_items: &'db TypedDictSchema<'db>,
+    infer_expression_type: F,
+}
+
+impl<'a, 'db, F> TypedDictConstructorExpressionTypes<'a, 'db, F>
+where
+    F: FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+{
+    fn new(
+        db: &'db dyn Db,
+        typed_dict: TypedDictType<'db>,
+        arguments: &'a Arguments,
+        call_arguments: Option<&'a CallArguments<'a, 'db>>,
+        infer_expression_type: F,
+    ) -> Self {
+        Self {
+            arguments,
+            call_arguments,
+            typed_dict_items: typed_dict.items(db),
+            infer_expression_type,
+        }
+    }
+
+    fn expression_type(&mut self, expr: &ast::Expr, tcx: TypeContext<'db>) -> Type<'db> {
+        self.call_arguments
+            .and_then(|call_arguments| call_arguments.expression_type(self.arguments, expr, tcx))
+            .unwrap_or_else(|| (self.infer_expression_type)(expr, tcx))
+    }
+
+    fn typed_dict_value_type(&mut self, key: &str, value: &ast::Expr) -> Type<'db> {
+        let value_tcx = self
+            .typed_dict_items
+            .get(key)
+            .map(|field| TypeContext::new(Some(field.declared_ty)))
+            .unwrap_or_default();
+
+        self.expression_type(value, value_tcx)
+    }
+}
+
+fn validate_from_mapping_and_keywords<'db, 'ast, F>(
     context: &InferContext<'db, 'ast>,
     typed_dict: TypedDictType<'db>,
     arguments: &'ast Arguments,
     typed_dict_node: AnyNodeRef<'ast>,
-    expression_type_fn: &impl Fn(&ast::Expr) -> Type<'db>,
-) -> OrderSet<Name> {
+    expression_types: &mut TypedDictConstructorExpressionTypes<'_, 'db, F>,
+) -> OrderSet<Name>
+where
+    F: FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+{
+    let db = context.db();
+    let mapping_arg = &arguments.args[0];
+    let mut provided_keys = validate_from_keywords(
+        context,
+        typed_dict,
+        arguments,
+        typed_dict_node,
+        expression_types,
+    );
+
+    if mapping_arg.is_dict_expr() {
+        let mapping_keys = validate_from_dict_literal(
+            context,
+            typed_dict,
+            arguments,
+            typed_dict_node,
+            expression_types,
+            Some(&provided_keys),
+        );
+        provided_keys.extend(mapping_keys);
+    } else {
+        let remaining_target_ty =
+            Type::TypedDict(typed_dict.to_constructor_patch_without_keys(db, &provided_keys));
+        let mapping_ty = expression_types
+            .expression_type(mapping_arg, TypeContext::new(Some(remaining_target_ty)));
+
+        if !mapping_ty.is_assignable_to(db, remaining_target_ty)
+            && let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, mapping_arg)
+        {
+            builder.into_diagnostic(format_args!(
+                "Argument of type `{}` is not assignable to `{}`",
+                mapping_ty.display(db),
+                remaining_target_ty.display(db),
+            ));
+        }
+
+        if mapping_ty.is_never() || mapping_ty.is_dynamic() {
+            for (key_name, field) in typed_dict.items(db) {
+                if field.is_required() {
+                    provided_keys.insert(key_name.clone());
+                }
+            }
+        } else if let Some(mapping_keys) = extract_typed_dict_keys(db, mapping_ty) {
+            provided_keys.extend(
+                mapping_keys
+                    .into_iter()
+                    .filter_map(|(key_name, key)| key.guaranteed.then_some(key_name)),
+            );
+        }
+    }
+
+    provided_keys
+}
+
+/// Validates a `TypedDict` constructor call with a single positional dictionary argument
+/// e.g. `Person({"name": "Alice", "age": 30})`
+fn validate_from_dict_literal<'db, 'ast, F>(
+    context: &InferContext<'db, 'ast>,
+    typed_dict: TypedDictType<'db>,
+    arguments: &'ast Arguments,
+    typed_dict_node: AnyNodeRef<'ast>,
+    expression_types: &mut TypedDictConstructorExpressionTypes<'_, 'db, F>,
+    overridden_keys: Option<&OrderSet<Name>>,
+) -> OrderSet<Name>
+where
+    F: FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+{
     let mut provided_keys = OrderSet::new();
 
     if let ast::Expr::Dict(dict_expr) = &arguments.args[0] {
@@ -976,10 +1221,14 @@ fn validate_from_dict_literal<'db, 'ast>(
                 }) = key_expr
             {
                 let key = key_value.to_str();
-                provided_keys.insert(Name::new(key));
+                let key_name = Name::new(key);
+                provided_keys.insert(key_name.clone());
 
-                // Get the already-inferred argument type
-                let value_ty = expression_type_fn(&dict_item.value);
+                if overridden_keys.is_some_and(|keys| keys.contains(&key_name)) {
+                    continue;
+                }
+
+                let value_ty = expression_types.typed_dict_value_type(key, &dict_item.value);
                 TypedDictKeyAssignment {
                     context,
                     typed_dict,
@@ -1002,13 +1251,16 @@ fn validate_from_dict_literal<'db, 'ast>(
 
 /// Validates a `TypedDict` constructor call with keywords
 /// e.g. `Person(name="Alice", age=30)` or `Person(**other_typed_dict)`
-fn validate_from_keywords<'db, 'ast>(
+fn validate_from_keywords<'db, 'ast, F>(
     context: &InferContext<'db, 'ast>,
     typed_dict: TypedDictType<'db>,
     arguments: &'ast Arguments,
     typed_dict_node: AnyNodeRef<'ast>,
-    expression_type_fn: &impl Fn(&ast::Expr) -> Type<'db>,
-) -> OrderSet<Name> {
+    expression_types: &mut TypedDictConstructorExpressionTypes<'_, 'db, F>,
+) -> OrderSet<Name>
+where
+    F: FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+{
     let db = context.db();
 
     // Collect keys from explicit keyword arguments
@@ -1022,7 +1274,8 @@ fn validate_from_keywords<'db, 'ast>(
     for keyword in &arguments.keywords {
         if let Some(arg_name) = &keyword.arg {
             // Explicit keyword argument: e.g., `name="Alice"`
-            let value_ty = expression_type_fn(&keyword.value);
+            let value_ty =
+                expression_types.typed_dict_value_type(arg_name.as_str(), &keyword.value);
             TypedDictKeyAssignment {
                 context,
                 typed_dict,
@@ -1041,7 +1294,8 @@ fn validate_from_keywords<'db, 'ast>(
             // Unlike positional TypedDict arguments, unpacking passes all keys as explicit
             // keyword arguments, so extra keys should be flagged as errors (consistent with
             // explicitly providing those keys).
-            let unpacked_type = expression_type_fn(&keyword.value);
+            let unpacked_type =
+                expression_types.expression_type(&keyword.value, TypeContext::default());
 
             // Never and Dynamic types are special: they can have any keys, so we skip
             // validation and mark all required keys as provided.
@@ -1052,14 +1306,16 @@ fn validate_from_keywords<'db, 'ast>(
                     }
                 }
             } else if let Some(unpacked_keys) = extract_typed_dict_keys(db, unpacked_type) {
-                for (key_name, value_ty) in &unpacked_keys {
-                    provided_keys.insert(key_name.clone());
+                for (key_name, extracted_key) in &unpacked_keys {
+                    if extracted_key.guaranteed {
+                        provided_keys.insert(key_name.clone());
+                    }
                     TypedDictKeyAssignment {
                         context,
                         typed_dict,
                         full_object_ty: None,
                         key: key_name.as_str(),
-                        value_ty: *value_ty,
+                        value_ty: extracted_key.value_ty,
                         typed_dict_node,
                         key_node: keyword.into(),
                         value_node: (&keyword.value).into(),


### PR DESCRIPTION
## Summary

This PR synthesizes a constructor for `TypedDict`, which moves constructor checking onto the normal callable machinery (keeps generic-alias specialization intact, preserves TypedDict-specific validation/diagnostics, etc.).

Closes https://github.com/astral-sh/ty/issues/3027.
