### PR TITLE
[ty] Narrow constrained TypeVars using positive intersection evidence

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -728,6 +728,23 @@ def test(a: Any, items: list[T]) -> None:
         cast(T, v)  # no panic
 ```
 
+Constrained `TypeVar`s should also eliminate impossible constraints when narrowed by
+`isinstance(x, dict)`:
+
+```py
+from typing import Mapping, TypeVar, TypedDict
+
+class TD(TypedDict, total=False):
+    x: str
+
+T = TypeVar("T", list[str], TD)
+
+def takes_mapping(value: Mapping[str, object]) -> None: ...
+def _(x: T):
+    if isinstance(x, dict):
+        takes_mapping(x)
+```
+
 ## Narrowing with named expressions (walrus operator)
 
 When `isinstance()` is used with a named expression, the target of the named expression should be

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1439,6 +1439,9 @@ impl<'db> InnerIntersectionBuilder<'db> {
     /// - If the intersection contains negative entries for all but one of the constraints, we can
     ///   add that remaining constraint as a positive entry.
     ///
+    /// - If the intersection contains other positive entries that are disjoint from all but one
+    ///   of the constraints, we can also add that remaining constraint as a positive entry.
+    ///
     /// - If the intersection contains negative entries for all of the constraints, the overall
     ///   intersection is `Never`.
     fn simplify_constrained_typevars(&mut self, db: &'db dyn Db) {
@@ -1466,6 +1469,22 @@ impl<'db> InnerIntersectionBuilder<'db> {
                     .filter(|(_, c)| c.is_subtype_of(db, *negative));
                 for (constraint_index, _) in matching_constraints {
                     remaining_constraints[constraint_index] = None;
+                }
+            }
+
+            for positive in &self.positive {
+                if positive == ty {
+                    continue;
+                }
+
+                for (constraint_index, constraint) in constraints.iter().enumerate() {
+                    if remaining_constraints[constraint_index].is_none() {
+                        continue;
+                    }
+
+                    if constraint.is_disjoint_from(db, *positive) {
+                        remaining_constraints[constraint_index] = None;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

This PR teaches ty to make the following deduction:

- If `T` can be either `list[str]` or a `TypedDict`...
- And a runtime check proves `x` is a `dict`
- Then `x` can’t still be `list[str]`
- So we should treat it as a `TypedDict`

This came up while debugging regressions in https://github.com/astral-sh/ruff/pull/23936.
