### PR TITLE
[ty] Narrow TypedDicts through `isinstance(..., dict)`

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -9777,6 +9777,8 @@ TypedDi<CURSOR>
             @"
         TypedDict :: , TypedDict
         is_typeddict :: , is_typeddict
+        TypedDictTop :: from ty_extensions import TypedDictTop
+
         _FilterConfigurationTypedDict :: from logging.config import _FilterConfigurationTypedDict
 
         _FormatterConfigurationTypedDict :: from logging.config import _FormatterConfigurationTypedDict

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -2821,6 +2821,7 @@ fn completion_kind_from_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Comp
             Type::NominalInstance(_)
             | Type::PropertyInstance(_)
             | Type::BoundSuper(_)
+            | Type::TypedDictTop
             | Type::TypedDict(_)
             | Type::NewTypeInstance(_)
             | Type::EnumComplement(_) => CompletionKind::Struct,

--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -166,6 +166,38 @@ mod tests {
     }
 
     #[test]
+    fn goto_type_of_ty_extensions_typed_dict_top_special_form() {
+        let test = cursor_test(
+            r#"
+            from ty_extensions import TypedDictTop
+
+            value: TypedDic<CURSOR>tTop
+            "#,
+        );
+
+        assert_snapshot!(test.goto_type_definition(), @"
+        info[goto-type definition]: Go to type definition
+         --> main.py:4:8
+          |
+        2 | from ty_extensions import TypedDictTop
+        3 |
+        4 | value: TypedDictTop
+          |        ^^^^^^^^^^^^ Clicking here
+          |
+        info: Found 1 type definition
+           --> stdlib/ty_extensions.pyi:105:1
+            |
+        103 | \"\"\"
+        104 |
+        105 | TypedDictTop: _SpecialForm
+            | ------------
+        106 | \"\"\"
+        107 | `TypedDictTop` represents the top type of all `TypedDict` instances.
+            |
+        ");
+    }
+
+    #[test]
     fn goto_type_of_expression_with_function_type() {
         let test = cursor_test(
             r#"

--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -179,20 +179,14 @@ mod tests {
         info[goto-type definition]: Go to type definition
          --> main.py:4:8
           |
-        2 | from ty_extensions import TypedDictTop
-        3 |
         4 | value: TypedDictTop
           |        ^^^^^^^^^^^^ Clicking here
           |
         info: Found 1 type definition
            --> stdlib/ty_extensions.pyi:105:1
             |
-        103 | \"\"\"
-        104 |
         105 | TypedDictTop: _SpecialForm
             | ------------
-        106 | \"\"\"
-        107 | `TypedDictTop` represents the top type of all `TypedDict` instances.
             |
         ");
     }

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -6510,8 +6510,6 @@ except <CURSOR># Trigger completion/hover here
         info[hover]: Hovered content is
          --> main.py:4:8
           |
-        2 | from ty_extensions import TypedDictTop
-        3 |
         4 | value: TypedDictTop
           |        ^^^^^^^^-^^^
           |        |       |

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -6479,6 +6479,48 @@ except <CURSOR># Trigger completion/hover here
         assert_snapshot!(test.hover(), @"Hover provided no content");
     }
 
+    #[test]
+    fn hover_ty_extensions_typed_dict_top_special_form() {
+        let test = hover_test(
+            r#"
+            from ty_extensions import TypedDictTop
+
+            value: TypedDic<CURSOR>tTop
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        TypedDictTop
+        ---------------------------------------------
+        `TypedDictTop` represents the top type of all `TypedDict` instances.
+
+        Use this to describe values that are known to be `TypedDict`s, but whose concrete key set
+        is not statically known.
+
+        ---------------------------------------------
+        ```python
+        TypedDictTop
+        ```
+        ---
+        `TypedDictTop` represents the top type of all `TypedDict` instances.<HB>
+        <HB>
+        Use this to describe values that are known to be `TypedDict`s, but whose concrete key set<HB>
+        is not statically known.
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:4:8
+          |
+        2 | from ty_extensions import TypedDictTop
+        3 |
+        4 | value: TypedDictTop
+          |        ^^^^^^^^-^^^
+          |        |       |
+          |        |       Cursor offset
+          |        source
+          |
+        ");
+    }
+
     impl CursorTest {
         fn hover(&self) -> String {
             use std::fmt::Write;

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -193,6 +193,19 @@ def g(attributes: Namespace):
     reveal_type(y.unknown)  # revealed: Unknown
 ```
 
+`TypedDictTop` is also a valid dynamic namespace, but it has no known keys to extract:
+
+```py
+from ty_extensions import TypedDictTop
+
+def g(attributes: TypedDictTop):
+    Y = type("Y", (), attributes)
+
+    reveal_type(Y)  # revealed: <class 'Y'>
+    reveal_type(Y.unknown)  # revealed: Unknown
+    reveal_type(Y().unknown)  # revealed: Unknown
+```
+
 ## Closed TypedDicts (PEP-728)
 
 TODO: We don't support the PEP-728 `closed=True` keyword argument to `TypedDict` yet. When we do, a

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -196,7 +196,13 @@ def g(attributes: Namespace):
 `TypedDictTop` is also a valid dynamic namespace, but it has no known keys to extract:
 
 ```py
-from ty_extensions import TypedDictTop
+from typing import Protocol, TypeAlias
+from ty_extensions import Intersection, TypedDictTop
+
+class HasClear(Protocol):
+    def clear(self) -> None: ...
+
+NamespaceAlias: TypeAlias = TypedDictTop
 
 def g(attributes: TypedDictTop):
     Y = type("Y", (), attributes)
@@ -204,6 +210,39 @@ def g(attributes: TypedDictTop):
     reveal_type(Y)  # revealed: <class 'Y'>
     reveal_type(Y.unknown)  # revealed: Unknown
     reveal_type(Y().unknown)  # revealed: Unknown
+
+def h(attributes: NamespaceAlias):
+    Y = type("Y", (), attributes)
+
+    reveal_type(Y)  # revealed: <class 'Y'>
+
+def i(attributes: TypedDictTop | dict[str, object]):
+    Y = type("Y", (), attributes)
+
+    reveal_type(Y)  # revealed: <class 'Y'>
+
+def j(attributes: Intersection[TypedDictTop, HasClear]):
+    Y = type("Y", (), attributes)
+
+    reveal_type(Y)  # revealed: <class 'Y'>
+```
+
+## PEP 695 alias namespaces
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from ty_extensions import TypedDictTop
+
+type NamespaceAlias = TypedDictTop
+
+def f(attributes: NamespaceAlias):
+    Y = type("Y", (), attributes)
+
+    reveal_type(Y)  # revealed: <class 'Y'>
 ```
 
 ## Closed TypedDicts (PEP-728)

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -143,11 +143,16 @@ Every `TypedDict` inhabitant is a runtime dictionary, so the identity branch rem
 
 ```py
 from typing import TypedDict
+from ty_extensions import TypedDictTop
 
 class Movie(TypedDict):
     title: str
 
 def _(x: Movie, y: dict[str, object]) -> None:
+    if x is y:
+        x.missing  # error: [unresolved-attribute]
+
+def _(x: TypedDictTop, y: dict[str | int, object]) -> None:
     if x is y:
         x.missing  # error: [unresolved-attribute]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -137,6 +137,21 @@ def _(a: Literal[1], b: Literal[1, 2], c: Literal[1, 2, 3]):
         reveal_type(c)  # revealed: Literal[1]
 ```
 
+## `is` between a `TypedDict` and `dict`
+
+Every `TypedDict` inhabitant is a runtime dictionary, so the identity branch remains reachable:
+
+```py
+from typing import TypedDict
+
+class Movie(TypedDict):
+    title: str
+
+def _(x: Movie, y: dict[str, object]) -> None:
+    if x is y:
+        x.missing  # error: [unresolved-attribute]
+```
+
 ## `is` where the other operand is a call expression
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -143,9 +143,13 @@ Every `TypedDict` inhabitant is a runtime dictionary, so the identity branch rem
 
 ```py
 from typing import TypedDict
+from typing_extensions import Never
 from ty_extensions import TypedDictTop
 
 class Movie(TypedDict):
+    title: str
+
+class PartialMovie(TypedDict, total=False):
     title: str
 
 def _(x: Movie, y: dict[str, object]) -> None:
@@ -153,6 +157,14 @@ def _(x: Movie, y: dict[str, object]) -> None:
         x.missing  # error: [unresolved-attribute]
 
 def _(x: TypedDictTop, y: dict[str | int, object]) -> None:
+    if x is y:
+        x.missing  # error: [unresolved-attribute]
+
+def _(x: TypedDictTop, y: dict[Never, Never]) -> None:
+    if x is y:
+        x.missing  # error: [unresolved-attribute]
+
+def _(x: PartialMovie, y: dict[Never, Never]) -> None:
     if x is y:
         x.missing  # error: [unresolved-attribute]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -1003,6 +1003,25 @@ def narrow_iterable_keys(choices: Iterable[Any] | None) -> None:
         sink(choices.keys())
 ```
 
+`reversed()` is a read-only dict operation, so it should dispatch through the `TypedDictTop` arm
+without raising a spurious overload-resolution error:
+
+```py
+from typing import TypedDict
+
+class Movie(TypedDict):
+    name: str
+    year: int
+
+def narrow_reversed_typeddict_union(x: Movie | int) -> None:
+    if isinstance(x, dict):
+        reveal_type(reversed(x))  # revealed: Iterator[Unknown]
+
+def narrow_reversed_object(x: object) -> None:
+    if isinstance(x, dict):
+        reveal_type(reversed(x))  # revealed: Iterator[object]
+```
+
 ## Narrowing with named expressions (walrus operator)
 
 When `isinstance()` is used with a named expression, the target of the named expression should be

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -1015,7 +1015,7 @@ class Movie(TypedDict):
 
 def narrow_reversed_typeddict_union(x: Movie | int) -> None:
     if isinstance(x, dict):
-        reveal_type(reversed(x))  # revealed: Iterator[Unknown]
+        reveal_type(reversed(x))  # revealed: Iterator[str]
 
 def narrow_reversed_object(x: object) -> None:
     if isinstance(x, dict):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -974,10 +974,16 @@ def narrow_typeddict_or_class(value: A | Vulnerability) -> None:
     else:
         reveal_type(value)  # revealed: Vulnerability & ~Top[dict[Unknown, Unknown]]
         reveal_type(value.package.ecosystem)  # revealed: str
+
+def narrow_non_dict_object(value: object) -> None:
+    if isinstance(value, dict):
+        pass
+    else:
+        reveal_type(value)  # revealed: ~Top[dict[Unknown, Unknown]] & ~TypedDictTop
 ```
 
-`dict` methods should also remain callable on the narrowed value, even when the original type only
-exposed `Mapping` or `Iterable` APIs.
+Read-only `dict` APIs should remain callable on the narrowed value, but mutation APIs must still be
+rejected when a `TypedDict` arm remains possible.
 
 ```py
 from typing import Any, Iterable, Mapping
@@ -986,11 +992,11 @@ def sink(x: object) -> None: ...
 def narrow_mapping_items(value: Mapping[str, Any] | Iterable[tuple[str, Any]]) -> None:
     if isinstance(value, dict):
         sink(value.items())
-        value.clear()
+        value.clear()  # error: [unresolved-attribute]
 
 def narrow_dict_items(value: dict[str, Any] | Iterable[tuple[str, Any]]) -> None:
     if isinstance(value, dict):
-        value.clear()
+        value.clear()  # error: [unresolved-attribute]
 
 def narrow_iterable_keys(choices: Iterable[Any] | None) -> None:
     if isinstance(choices, dict):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -723,7 +723,7 @@ def _(x: Invariant[int] | Covariant[str]):
         reveal_type(x)  # revealed: Covariant[str] & ~Top[Invariant[Unknown]]
 ```
 
-For dict-like runtime checks, we include `Top[TypedDict]` alongside the ordinary top dict-like
+For dict-like runtime checks, we include `TypedDictTop` alongside the ordinary top dict-like
 constraint when it contributes additional information. For `Mapping`, that extra arm simplifies away
 because `TypedDict` is already statically compatible there:
 
@@ -736,13 +736,13 @@ class Movie(TypedDict):
 
 def _(x: object, y: Movie):
     if isinstance(x, dict):
-        reveal_type(x)  # revealed: Top[dict[Unknown, Unknown]] | Top[TypedDict]
+        reveal_type(x)  # revealed: Top[dict[Unknown, Unknown]] | TypedDictTop
 
     if isinstance(x, Mapping):
         reveal_type(x)  # revealed: Top[Mapping[Unknown, object]]
 
     if isinstance(x, MutableMapping):
-        reveal_type(x)  # revealed: Top[MutableMapping[Unknown, Unknown]] | Top[TypedDict]
+        reveal_type(x)  # revealed: Top[MutableMapping[Unknown, Unknown]] | TypedDictTop
 
     if isinstance(y, dict):
         reveal_type(y)  # revealed: Movie
@@ -765,7 +765,7 @@ def _(z: int | Movie):
         reveal_type(z)  # revealed: int
 ```
 
-When a gradual arm remains after narrowing, that `Top[TypedDict]` fallback remains visible too.
+When a gradual arm remains after narrowing, that `TypedDictTop` fallback remains visible too.
 
 ```py
 from typing import TypeVar
@@ -774,7 +774,7 @@ T = TypeVar("T")
 
 def _(value: Movie | T):
     if isinstance(value, dict):
-        reveal_type(value)  # revealed: (T@_ & Top[dict[Unknown, Unknown]]) | Movie | (T@_ & Top[TypedDict])
+        reveal_type(value)  # revealed: (T@_ & Top[dict[Unknown, Unknown]]) | Movie | (T@_ & TypedDictTop)
 ```
 
 This also needs to preserve common dict-key correlations from ecosystem code:
@@ -782,12 +782,27 @@ This also needs to preserve common dict-key correlations from ecosystem code:
 ```py
 def compare_common_keys(value: object, default: object):
     if isinstance(value, dict) and isinstance(default, dict):
-        reveal_type(value)  # revealed: Top[dict[Unknown, Unknown]] | Top[TypedDict]
+        reveal_type(value)  # revealed: Top[dict[Unknown, Unknown]] | TypedDictTop
         for key in value.keys() & default.keys():
             reveal_type(key)  # revealed: Unknown | str
             reveal_type(value[key])  # revealed: object
             reveal_type(default[key])  # revealed: object
             reveal_type(default.get(key))  # revealed: object
+```
+
+The `TypedDictTop` arm also has a stable surface name, so users can refer to it directly in
+annotations:
+
+```py
+from ty_extensions import TypedDictTop
+
+type Alias = TypedDictTop
+
+def takes_typed_dict_top(value: TypedDictTop):
+    reveal_type(value)  # revealed: TypedDictTop
+
+def takes_typed_dict_top_alias(value: Alias):
+    reveal_type(value)  # revealed: TypedDictTop
 ```
 
 It should also keep `dict` methods callable for concrete `dict` unions keyed by `IntEnum` values:
@@ -819,7 +834,7 @@ But plain-dict mutation APIs should still be rejected when the narrowed value ma
 def takes_dict(value: dict[str, object]) -> None: ...
 def mutate_dict_like(value: object) -> None:
     if isinstance(value, dict):
-        reveal_type(value)  # revealed: Top[dict[Unknown, Unknown]] | Top[TypedDict]
+        reveal_type(value)  # revealed: Top[dict[Unknown, Unknown]] | TypedDictTop
         value.popitem()  # error: [unresolved-attribute]
         takes_dict(value)  # error: [invalid-argument-type]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -754,8 +754,8 @@ def _(x: object, y: Movie):
         reveal_type(y)  # revealed: Movie
 ```
 
-When the original type already contains a concrete `TypedDict` arm, runtime narrowing keeps that arm
-directly instead of routing it through the fallback:
+When the original type already contains a concrete `TypedDict` arm, runtime narrowing keeps that
+arm:
 
 ```py
 def _(z: int | Movie):
@@ -777,7 +777,7 @@ def _(value: Movie | T):
         reveal_type(value)  # revealed: (T@_ & Top[dict[Unknown, Unknown]]) | Movie | (T@_ & TypedDictTop)
 ```
 
-This also needs to preserve common dict-key correlations from ecosystem code:
+This also needs to preserve common dict-key correlations:
 
 ```py
 def compare_common_keys(value: object, default: object):
@@ -809,15 +809,15 @@ It should also keep `dict` methods callable for concrete `dict` unions keyed by 
 
 ```py
 from enum import IntEnum
-from typing import Dict, Optional, Protocol, Union
+from typing import Protocol
 
 class DiagnosticField(IntEnum):
     MESSAGE = 77
 
 class PGresult(Protocol):
-    def error_field(self, fieldcode: int) -> Optional[bytes]: ...
+    def error_field(self, fieldcode: int) -> bytes | None: ...
 
-ErrorInfo = Union[PGresult, Dict[int, Optional[bytes]], None]
+ErrorInfo = PGresult | dict[int, bytes | None] | None
 
 def _(info: ErrorInfo):
     if isinstance(info, dict):
@@ -835,6 +835,8 @@ def takes_dict(value: dict[str, object]) -> None: ...
 def mutate_dict_like(value: object) -> None:
     if isinstance(value, dict):
         reveal_type(value)  # revealed: Top[dict[Unknown, Unknown]] | TypedDictTop
+        # TODO: Report this more precisely as an unsound TypedDict mutation, rather than as a
+        # missing attribute.
         value.popitem()  # error: [unresolved-attribute]
         takes_dict(value)  # error: [invalid-argument-type]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -500,7 +500,7 @@ In order to preserve the gradual guarantee, we intersect with the type of the se
 type of the second argument is a dynamic type:
 
 ```py
-from typing import Any
+from typing import Any, TypedDict
 from something_unresolvable import SomethingUnknown  # error: [unresolved-import]
 
 class Foo: ...
@@ -511,6 +511,13 @@ def f(a: Foo, b: Any):
 
     if isinstance(a, b):
         reveal_type(a)  # revealed: Foo & Any
+
+class Bar(TypedDict):
+    status: str
+
+def g(a: Bar | int):
+    if isinstance(a, SomethingUnknown):
+        reveal_type(a)  # revealed: (Bar & Unknown) | (int & Unknown)
 ```
 
 ## Narrowing if an object with an intersection/union/TypeVar type is used as the second argument
@@ -716,6 +723,107 @@ def _(x: Invariant[int] | Covariant[str]):
         reveal_type(x)  # revealed: Covariant[str] & ~Top[Invariant[Unknown]]
 ```
 
+For dict-like runtime checks, we include `Top[TypedDict]` alongside the ordinary top dict-like
+constraint when it contributes additional information. For `Mapping`, that extra arm simplifies away
+because `TypedDict` is already statically compatible there:
+
+```py
+from collections.abc import Mapping, MutableMapping
+from typing import TypedDict
+
+class Movie(TypedDict):
+    title: str
+
+def _(x: object, y: Movie):
+    if isinstance(x, dict):
+        reveal_type(x)  # revealed: Top[dict[Unknown, Unknown]] | Top[TypedDict]
+
+    if isinstance(x, Mapping):
+        reveal_type(x)  # revealed: Top[Mapping[Unknown, object]]
+
+    if isinstance(x, MutableMapping):
+        reveal_type(x)  # revealed: Top[MutableMapping[Unknown, Unknown]] | Top[TypedDict]
+
+    if isinstance(y, dict):
+        reveal_type(y)  # revealed: Movie
+
+    if isinstance(y, Mapping):
+        reveal_type(y)  # revealed: Movie
+
+    if isinstance(y, MutableMapping):
+        reveal_type(y)  # revealed: Movie
+```
+
+When the original type already contains a concrete `TypedDict` arm, runtime narrowing keeps that arm
+directly instead of routing it through the fallback:
+
+```py
+def _(z: int | Movie):
+    if isinstance(z, dict):
+        reveal_type(z)  # revealed: Movie
+    else:
+        reveal_type(z)  # revealed: int
+```
+
+When a gradual arm remains after narrowing, that `Top[TypedDict]` fallback remains visible too.
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def _(value: Movie | T):
+    if isinstance(value, dict):
+        reveal_type(value)  # revealed: (T@_ & Top[dict[Unknown, Unknown]]) | Movie | (T@_ & Top[TypedDict])
+```
+
+This also needs to preserve common dict-key correlations from ecosystem code:
+
+```py
+def compare_common_keys(value: object, default: object):
+    if isinstance(value, dict) and isinstance(default, dict):
+        reveal_type(value)  # revealed: Top[dict[Unknown, Unknown]] | Top[TypedDict]
+        for key in value.keys() & default.keys():
+            reveal_type(key)  # revealed: Unknown | str
+            reveal_type(value[key])  # revealed: object
+            reveal_type(default[key])  # revealed: object
+            reveal_type(default.get(key))  # revealed: object
+```
+
+It should also keep `dict` methods callable for concrete `dict` unions keyed by `IntEnum` values:
+
+```py
+from enum import IntEnum
+from typing import Dict, Optional, Protocol, Union
+
+class DiagnosticField(IntEnum):
+    MESSAGE = 77
+
+class PGresult(Protocol):
+    def error_field(self, fieldcode: int) -> Optional[bytes]: ...
+
+ErrorInfo = Union[PGresult, Dict[int, Optional[bytes]], None]
+
+def _(info: ErrorInfo):
+    if isinstance(info, dict):
+        reveal_type(info)  # revealed: (PGresult & Top[dict[Unknown, Unknown]]) | dict[int, bytes | None]
+        reveal_type(info.get(DiagnosticField.MESSAGE))  # revealed: Unknown | None | bytes
+    elif info:
+        reveal_type(info)  # revealed: PGresult & ~Top[dict[Unknown, Unknown]] & ~AlwaysFalsy
+        reveal_type(info.error_field(DiagnosticField.MESSAGE))  # revealed: bytes | None
+```
+
+But plain-dict mutation APIs should still be rejected when the narrowed value may be a `TypedDict`:
+
+```py
+def takes_dict(value: dict[str, object]) -> None: ...
+def mutate_dict_like(value: object) -> None:
+    if isinstance(value, dict):
+        reveal_type(value)  # revealed: Top[dict[Unknown, Unknown]] | Top[TypedDict]
+        value.popitem()  # error: [unresolved-attribute]
+        takes_dict(value)  # error: [invalid-argument-type]
+```
+
 The behavior of `issubclass()` is similar.
 
 ```py
@@ -796,12 +904,13 @@ def f(fn: Callable[P, R] | classmethod[Any, P, R]) -> Callable[P, R]:
 
 ## Narrowing with TypedDict unions
 
-Narrowing unions of `int` and multiple TypedDicts using `isinstance(x, dict)` should not panic
-during type ordering of normalized intersection types. Regression test for
+`TypedDict` unions should narrow cleanly through `isinstance(x, dict)` without leaving behind
+`Top[dict[...]]` intersections. This also covers the previous panic regression from
 <https://github.com/astral-sh/ty/issues/2451>.
 
 ```py
-from typing import Any, TypedDict, cast
+from collections.abc import MutableMapping
+from typing import TypedDict
 
 class A(TypedDict):
     x: str
@@ -811,11 +920,59 @@ class B(TypedDict):
 
 T = int | A | B
 
-def test(a: Any, items: list[T]) -> None:
-    combined = a or items
-    v = combined[0]
+def narrow_typeddict_union(v: T) -> None:
     if isinstance(v, dict):
-        cast(T, v)  # no panic
+        reveal_type(v)  # revealed: A | B
+    else:
+        reveal_type(v)  # revealed: int
+
+def narrow_single_typeddict(x: list | A) -> None:
+    if isinstance(x, dict):
+        reveal_type(x)  # revealed: A
+    else:
+        reveal_type(x)  # revealed: list[Unknown]
+
+def narrow_mutable_mapping_or_typeddict(x: dict[str, str] | A) -> None:
+    if isinstance(x, MutableMapping):
+        reveal_type(x)  # revealed: dict[str, str] | A
+    else:
+        reveal_type(x)  # revealed: Never
+
+def narrow_dict_or_typeddict(x: dict[str, str] | A) -> None:
+    if isinstance(x, dict):
+        reveal_type(x)  # revealed: dict[str, str] | A
+    else:
+        reveal_type(x)  # revealed: Never
+
+class Package:
+    ecosystem: str
+
+class Vulnerability:
+    package: Package
+    patched_versions: str | None
+
+def narrow_typeddict_or_class(value: A | Vulnerability) -> None:
+    if isinstance(value, dict):
+        pass
+    else:
+        reveal_type(value)  # revealed: Vulnerability & ~Top[dict[Unknown, Unknown]]
+        reveal_type(value.package.ecosystem)  # revealed: str
+```
+
+`dict` methods should also remain callable on the narrowed value, even when the original type only
+exposed `Mapping` or `Iterable` APIs.
+
+```py
+from typing import Any, Iterable, Mapping
+
+def sink(x: object) -> None: ...
+def narrow_mapping_items(value: Mapping[str, Any] | Iterable[tuple[str, Any]]) -> None:
+    if isinstance(value, dict):
+        sink(value.items())
+
+def narrow_iterable_keys(choices: Iterable[Any] | None) -> None:
+    if isinstance(choices, dict):
+        sink(choices.keys())
 ```
 
 ## Narrowing with named expressions (walrus operator)

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -969,6 +969,11 @@ def sink(x: object) -> None: ...
 def narrow_mapping_items(value: Mapping[str, Any] | Iterable[tuple[str, Any]]) -> None:
     if isinstance(value, dict):
         sink(value.items())
+        value.clear()
+
+def narrow_dict_items(value: dict[str, Any] | Iterable[tuple[str, Any]]) -> None:
+    if isinstance(value, dict):
+        value.clear()
 
 def narrow_iterable_keys(choices: Iterable[Any] | None) -> None:
     if isinstance(choices, dict):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -892,7 +892,9 @@ def mutate_dict_like(value: object) -> None:
 
 The restricted static API for `TypedDictTop` should not make runtime protocol checks disjoint from
 `TypedDict`s. Every `TypedDict` inhabitant is a runtime `dict`, so it has mutating `dict` methods
-such as `clear()` even though those methods are intentionally hidden from direct static access:
+such as `clear()` even though those methods are intentionally hidden from direct static access.
+Runtime protocol checks only test whether an attribute is present, not whether its type is
+compatible with the protocol member:
 
 ```py
 from typing import Protocol, TypedDict, runtime_checkable
@@ -901,12 +903,28 @@ from typing import Protocol, TypedDict, runtime_checkable
 class HasClear(Protocol):
     def clear(self) -> None: ...
 
+@runtime_checkable
+class BadClear(Protocol):
+    def clear(self, value: int) -> str: ...
+
+@runtime_checkable
+class HasMissing(Protocol):
+    def missing(self) -> None: ...
+
 class Movie(TypedDict):
     title: str
 
 def narrow_typed_dict_protocol(movie: Movie) -> None:
     if isinstance(movie, HasClear):
         movie.missing  # error: [unresolved-attribute]
+
+def narrow_typed_dict_incompatible_protocol(movie: Movie) -> None:
+    if isinstance(movie, BadClear):
+        movie.missing  # error: [unresolved-attribute]
+
+def narrow_typed_dict_missing_protocol_member(movie: Movie) -> None:
+    if isinstance(movie, HasMissing):
+        reveal_type(movie)  # revealed: Never
 
 def preserve_typed_dict_top_protocol(value: object) -> None:
     if isinstance(value, dict) and isinstance(value, HasClear):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -1041,6 +1041,15 @@ def narrow_iterable_keys(choices: Iterable[Any] | None) -> None:
         sink(choices.keys())
 ```
 
+`fromkeys()` creates a new dictionary rather than mutating the narrowed value, so it should also
+remain available:
+
+```py
+def narrow_dict_fromkeys(value: object) -> None:
+    if isinstance(value, dict):
+        reveal_type(value.fromkeys(["a"], 1))  # revealed: dict[str, int]
+```
+
 `reversed()` is a read-only dict operation, so it should dispatch through the `TypedDictTop` arm
 without raising a spurious overload-resolution error:
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -819,6 +819,10 @@ def takes_typed_dict_top(value: TypedDictTop):
 
 def takes_typed_dict_top_alias(value: Alias):
     reveal_type(value)  # revealed: TypedDictTop
+
+def merge_typed_dict_top_alias(value: Alias, other: dict[int, bytes]) -> None:
+    _ = value | other
+    _ = other | value
 ```
 
 `TypedDictTop` should retain its known string-key projection when passed to generic APIs:
@@ -908,6 +912,11 @@ def preserve_typed_dict_top_protocol(value: object) -> None:
     if isinstance(value, dict) and isinstance(value, HasClear):
         reveal_type(value)  # revealed: Top[dict[Unknown, Unknown]] | (TypedDictTop & HasClear)
         value.clear()
+
+def merge_typed_dict_top_protocol(value: object, other: dict[int, bytes]) -> None:
+    if isinstance(value, dict) and isinstance(value, HasClear):
+        _ = value | other
+        _ = other | value
 ```
 
 `TypedDict` inhabitants have exact runtime type `dict`, so they remain disjoint from proper

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -774,7 +774,7 @@ T = TypeVar("T")
 
 def _(value: Movie | T):
     if isinstance(value, dict):
-        reveal_type(value)  # revealed: (T@_ & Top[dict[Unknown, Unknown]]) | Movie | (T@_ & TypedDictTop)
+        reveal_type(value)  # revealed: Movie | (T@_ & Top[dict[Unknown, Unknown]]) | (T@_ & TypedDictTop)
 ```
 
 This also needs to preserve common dict-key correlations:
@@ -788,6 +788,15 @@ def compare_common_keys(value: object, default: object):
             reveal_type(value[key])  # revealed: object
             reveal_type(default[key])  # revealed: object
             reveal_type(default.get(key))  # revealed: object
+```
+
+Non-mutating dictionary merges should remain valid after both operands are narrowed through runtime
+`dict` checks:
+
+```py
+def merge_narrowed_dicts(left: object, right: object) -> None:
+    if isinstance(left, dict) and isinstance(right, dict):
+        reveal_type(left | right)  # revealed: dict[Unknown, Unknown]
 ```
 
 The `TypedDictTop` arm also has a stable surface name, so users can refer to it directly in
@@ -805,6 +814,20 @@ def takes_typed_dict_top_alias(value: Alias):
     reveal_type(value)  # revealed: TypedDictTop
 ```
 
+`TypedDictTop` should retain its known string-key projection when passed to generic APIs:
+
+```py
+from collections.abc import Mapping
+from ty_extensions import TypedDictTop
+
+def project[K, V](value: Mapping[K, V]) -> tuple[K, V]:
+    raise NotImplementedError
+
+def project_typed_dict_top(value: TypedDictTop) -> None:
+    reveal_type(project(value))  # revealed: tuple[str, object]
+    reveal_type(iter(value))  # revealed: Iterator[str]
+```
+
 Since the schema is unknown, mutating operations are not available directly on `TypedDictTop`:
 
 ```py
@@ -814,6 +837,10 @@ def mutate_typed_dict_top(dst: TypedDictTop, src: TypedDictTop) -> None:
     reveal_type(dst | src)  # revealed: TypedDictTop
     dst.update(src)  # error: [unresolved-attribute]
     dst |= src  # error: [unsupported-operator]
+
+def merge_typed_dict_top_with_dict(dst: TypedDictTop, src: dict[int, bytes]) -> None:
+    reveal_type(dst | src)  # revealed: dict[str | int, object]
+    reveal_type(src | dst)  # revealed: dict[int | str, object]
 ```
 
 It should also keep `dict` methods callable for concrete `dict` unions keyed by `IntEnum` values:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -797,6 +797,13 @@ Non-mutating dictionary merges should remain valid after both operands are narro
 def merge_narrowed_dicts(left: object, right: object) -> None:
     if isinstance(left, dict) and isinstance(right, dict):
         reveal_type(left | right)  # revealed: dict[Unknown, Unknown]
+
+class CustomDict(dict[int, bytes]): ...
+
+def merge_custom_dict_with_narrowed_dict(custom: CustomDict, value: object) -> None:
+    if isinstance(value, dict):
+        reveal_type(custom | value)  # revealed: dict[int | Unknown, bytes | Unknown]
+        reveal_type(value | custom)  # revealed: dict[Unknown | int, Unknown | bytes]
 ```
 
 The `TypedDictTop` arm also has a stable surface name, so users can refer to it directly in
@@ -1108,6 +1115,7 @@ def narrow_reversed_typeddict_union(x: Movie | int) -> None:
 def narrow_reversed_object(x: object) -> None:
     if isinstance(x, dict):
         reveal_type(reversed(x))  # revealed: Iterator[object]
+        reveal_type(reversed(x.keys()))  # revealed: Iterator[Unknown | str]
 ```
 
 ## Narrowing with named expressions (walrus operator)

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -805,6 +805,17 @@ def takes_typed_dict_top_alias(value: Alias):
     reveal_type(value)  # revealed: TypedDictTop
 ```
 
+Since the schema is unknown, mutating operations are not available directly on `TypedDictTop`:
+
+```py
+from ty_extensions import TypedDictTop
+
+def mutate_typed_dict_top(dst: TypedDictTop, src: TypedDictTop) -> None:
+    reveal_type(dst | src)  # revealed: TypedDictTop
+    dst.update(src)  # error: [unresolved-attribute]
+    dst |= src  # error: [unsupported-operator]
+```
+
 It should also keep `dict` methods callable for concrete `dict` unions keyed by `IntEnum` values:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -879,6 +879,47 @@ def mutate_dict_like(value: object) -> None:
         takes_dict(value)  # error: [invalid-argument-type]
 ```
 
+The restricted static API for `TypedDictTop` should not make runtime protocol checks disjoint from
+`TypedDict`s. Every `TypedDict` inhabitant is a runtime `dict`, so it has mutating `dict` methods
+such as `clear()` even though those methods are intentionally hidden from direct static access:
+
+```py
+from typing import Protocol, TypedDict, runtime_checkable
+
+@runtime_checkable
+class HasClear(Protocol):
+    def clear(self) -> None: ...
+
+class Movie(TypedDict):
+    title: str
+
+def narrow_typed_dict_protocol(movie: Movie) -> None:
+    if isinstance(movie, HasClear):
+        movie.missing  # error: [unresolved-attribute]
+
+def preserve_typed_dict_top_protocol(value: object) -> None:
+    if isinstance(value, dict) and isinstance(value, HasClear):
+        reveal_type(value)  # revealed: Top[dict[Unknown, Unknown]] | (TypedDictTop & HasClear)
+        value.clear()
+```
+
+`TypedDict` inhabitants have exact runtime type `dict`, so they remain disjoint from proper
+subclasses of `dict`:
+
+```py
+from collections import defaultdict
+
+class CustomDict(dict[str, object]): ...
+
+def narrow_typed_dict_defaultdict(movie: Movie) -> None:
+    if isinstance(movie, defaultdict):
+        reveal_type(movie)  # revealed: Never
+
+def narrow_typed_dict_custom_dict(movie: Movie) -> None:
+    if isinstance(movie, CustomDict):
+        reveal_type(movie)  # revealed: Never
+```
+
 The behavior of `issubclass()` is similar.
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -44,6 +44,24 @@ match x:
 reveal_type(x)  # revealed: object
 ```
 
+Every `TypedDict` inhabitant matches a `dict()` class pattern at runtime, even though a `TypedDict`
+is not statically assignable to `dict`:
+
+```py
+from typing import TypedDict
+
+class Movie(TypedDict):
+    title: str
+
+def _(x: Movie | int):
+    match x:
+        case dict():
+            reveal_type(x)  # revealed: Movie
+            x.missing  # error: [unresolved-attribute]
+        case _:
+            reveal_type(x)  # revealed: int
+```
+
 ## Class pattern with guard
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type.md
@@ -53,6 +53,24 @@ def _(x: A | B, y: A | C):
         reveal_type(y)  # revealed: A | C
 ```
 
+## `type(x) is dict` with `TypedDict`
+
+Every `TypedDict` inhabitant has an exact runtime type of `dict`, even though a `TypedDict` is not
+statically assignable to `dict`.
+
+```py
+from typing import TypedDict
+
+class Movie(TypedDict):
+    title: str
+
+def _(x: Movie | int):
+    if type(x) is dict:
+        reveal_type(x)  # revealed: Movie
+    else:
+        reveal_type(x)  # revealed: int
+```
+
 ## `type(x) is C` in chained comparisons
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2325,6 +2325,28 @@ def _(u: IntX | StrX) -> None:
     reveal_type(u.setdefault("x", 1))  # revealed: int | str
 ```
 
+## `reversed()` on Python 3.7
+
+`TypedDict` should not be treated as reversible before dictionaries gained `__reversed__` in Python
+3.8.
+
+```toml
+[environment]
+python-version = "3.7"
+```
+
+```py
+from typing_extensions import TypedDict
+
+class Movie(TypedDict):
+    name: str
+    year: int
+
+def _(movie: Movie) -> None:
+    # error: [no-matching-overload]
+    reveal_type(reversed(movie))  # revealed: Iterator[Unknown]
+```
+
 ## Unlike normal classes
 
 `TypedDict` types do not act like normal classes. For example, calling `type(..)` on an inhabitant

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -4385,17 +4385,8 @@ static_assert(not is_disjoint_from(TD, object))
 static_assert(not is_disjoint_from(TD, Mapping[str, object]))
 static_assert(is_disjoint_from(TD, Mapping[int, object]))
 static_assert(is_disjoint_from(TD, RegularNonTD))
-
-# TODO: We approximate disjointness with other types `T` by asking whether `dict[str, Any]` is
-# assignable to `T`. That covers common cases like the ones above, but does it have some false
-# negatives with `dict` types. A `TypedDict` is almost never assignable to a `dict` (or vice versa),
-# even when all of the `TypedDict`'s field types match the `dict`'s value type (and are mutable).
-# The problem is that the `TypedDict` could have been assigned to from *another* `TypedDict` with
-# additional fields, and we don't usually know anything about the types or mutability of those. On
-# the other hand, the assignment to `dict` can be allowed if the `TypedDict` has mutable
-# `extra_items` of a compatible type. See: https://typing.python.org/en/latest/spec/typeddict.html#subtyping-with-dict
-static_assert(is_disjoint_from(TD, dict[str, int]))  # error: [static-assert-error]
-static_assert(is_disjoint_from(TD, dict[str, str]))  # error: [static-assert-error]
+static_assert(is_disjoint_from(TD, dict[str, int]))
+static_assert(is_disjoint_from(TD, dict[str, str]))
 ```
 
 ## Narrowing tagged unions of `TypedDict`s
@@ -4536,9 +4527,7 @@ We can still narrow `Literal` tags even when non-`TypedDict` types are present i
 ```py
 def _(u: Foo | Bar | dict):
     if u["tag"] == "foo":
-        # TODO: `dict & ~<TypedDict ...>` should simplify to `dict` here, but that's currently a
-        # false negative in `is_disjoint_impl`.
-        reveal_type(u)  # revealed: Foo | (dict[Unknown, Unknown] & ~<TypedDict with items 'tag'>)
+        reveal_type(u)  # revealed: Foo | dict[Unknown, Unknown]
 
 # The negation(s) will simplify out if we add something to the union that doesn't inherit from
 # `dict`. It just needs to support indexing with a string key.
@@ -4778,9 +4767,7 @@ We can still narrow `Literal` tags even when non-`TypedDict` types are present i
 def match_with_dict(u: Foo | Bar | dict):
     match u["tag"]:
         case "foo":
-            # TODO: `dict & ~<TypedDict ...>` should simplify to `dict` here, but that's currently a
-            # false negative in `is_disjoint_impl`.
-            reveal_type(u)  # revealed: Foo | (dict[Unknown, Unknown] & ~<TypedDict with items 'tag'>)
+            reveal_type(u)  # revealed: Foo | dict[Unknown, Unknown]
 ```
 
 ## Narrowing tagged unions of `TypedDict`s from PEP 695 type aliases

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -4397,7 +4397,7 @@ static_assert(not is_disjoint_from(NotRequiredReadOnlyBoolTD, NotRequiredReadOnl
 ```py
 from collections.abc import MutableMapping
 from typing import TypedDict, Mapping
-from ty_extensions import static_assert, is_disjoint_from
+from ty_extensions import TypedDictTop, static_assert, is_disjoint_from
 
 class TD(TypedDict):
     x: int
@@ -4407,6 +4407,7 @@ class RegularNonTD: ...
 static_assert(not is_disjoint_from(TD, object))
 static_assert(not is_disjoint_from(TD, Mapping[str, object]))
 static_assert(not is_disjoint_from(TD, MutableMapping[str, object]))
+static_assert(not is_disjoint_from(TypedDictTop, dict[str | int, object]))
 static_assert(is_disjoint_from(TD, Mapping[int, object]))
 static_assert(is_disjoint_from(TD, RegularNonTD))
 static_assert(not is_disjoint_from(TD, dict[str, int]))

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -4395,6 +4395,7 @@ static_assert(not is_disjoint_from(NotRequiredReadOnlyBoolTD, NotRequiredReadOnl
 ## Disjointness with other types
 
 ```py
+from collections.abc import MutableMapping
 from typing import TypedDict, Mapping
 from ty_extensions import static_assert, is_disjoint_from
 
@@ -4405,10 +4406,11 @@ class RegularNonTD: ...
 
 static_assert(not is_disjoint_from(TD, object))
 static_assert(not is_disjoint_from(TD, Mapping[str, object]))
+static_assert(not is_disjoint_from(TD, MutableMapping[str, object]))
 static_assert(is_disjoint_from(TD, Mapping[int, object]))
 static_assert(is_disjoint_from(TD, RegularNonTD))
-static_assert(is_disjoint_from(TD, dict[str, int]))
-static_assert(is_disjoint_from(TD, dict[str, str]))
+static_assert(not is_disjoint_from(TD, dict[str, int]))
+static_assert(not is_disjoint_from(TD, dict[str, str]))
 ```
 
 ## Narrowing tagged unions of `TypedDict`s
@@ -4549,7 +4551,7 @@ We can still narrow `Literal` tags even when non-`TypedDict` types are present i
 ```py
 def _(u: Foo | Bar | dict):
     if u["tag"] == "foo":
-        reveal_type(u)  # revealed: Foo | dict[Unknown, Unknown]
+        reveal_type(u)  # revealed: Foo | (dict[Unknown, Unknown] & ~<TypedDict with items 'tag'>)
 
 # The negation(s) will simplify out if we add something to the union that doesn't inherit from
 # `dict`. It just needs to support indexing with a string key.
@@ -4789,7 +4791,7 @@ We can still narrow `Literal` tags even when non-`TypedDict` types are present i
 def match_with_dict(u: Foo | Bar | dict):
     match u["tag"]:
         case "foo":
-            reveal_type(u)  # revealed: Foo | dict[Unknown, Unknown]
+            reveal_type(u)  # revealed: Foo | (dict[Unknown, Unknown] & ~<TypedDict with items 'tag'>)
 ```
 
 ## Narrowing tagged unions of `TypedDict`s from PEP 695 type aliases

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -647,13 +647,10 @@ fn apply_accumulated_narrowing<'db>(
     accumulated: Option<NarrowingConstraint<'db>>,
 ) -> Type<'db> {
     match accumulated {
-        Some(constraint) => NarrowingConstraint::intersection(base_ty)
-            .merge_constraint_and(constraint)
-            .evaluate_constraint_type(db),
+        Some(constraint) => constraint.narrow_base_type(db, base_ty),
         None => base_ty,
     }
 }
-
 /// Identifier for a node in a projected narrowing graph.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct ProjectedNarrowingNodeId(usize);

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -200,7 +200,7 @@ use crate::{
     types::{
         CallableTypes, ClassLiteral, IntersectionBuilder, KnownClass, NarrowingConstraint, Type,
         TypeContext, UnionBuilder, UnionType, enum_metadata, infer_expression_type,
-        infer_narrowing_constraint,
+        infer_narrowing_constraint, narrow::runtime_instance_constraint_for_class_literal,
     },
 };
 use ruff_index::IndexSlice;
@@ -265,9 +265,9 @@ fn pattern_kind_to_type<'db>(db: &'db dyn Db, kind: &PatternPredicateKind<'db>) 
         PatternPredicateKind::Class(class_expr, kind) => {
             if kind.is_irrefutable() {
                 infer_expression_type(db, *class_expr, TypeContext::default())
-                    .to_instance(db)
+                    .as_class_literal()
+                    .map(|class| runtime_instance_constraint_for_class_literal(db, class))
                     .unwrap_or(Type::Never)
-                    .top_materialization(db)
             } else {
                 Type::Never
             }
@@ -1045,7 +1045,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
         PatternPredicateKind::Class(class_expr, kind) => {
             let class_ty = infer_expression_type(db, *class_expr, TypeContext::default())
                 .as_class_literal()
-                .map(|class| Type::instance(db, class.top_materialization(db)));
+                .map(|class| runtime_instance_constraint_for_class_literal(db, class));
 
             class_ty.map_or(Truthiness::Ambiguous, |class_ty| {
                 if subject_ty.is_subtype_of(db, class_ty) {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -884,6 +884,8 @@ pub enum Type<'db> {
     TypeForm(TypeFormType<'db>),
     /// A type that represents an inhabitant of a `TypedDict`.
     TypedDict(TypedDictType<'db>),
+    /// The infinite union of all `TypedDict` inhabitant types.
+    TypedDictTop,
     /// An aliased type (lazily not-yet-unpacked to its value type).
     TypeAlias(TypeAliasType<'db>),
     /// The set of Python objects that belong to a `typing.NewType` subtype. Note that
@@ -1490,6 +1492,10 @@ impl<'db> Type<'db> {
         matches!(self, Type::TypedDict(..))
     }
 
+    pub(crate) const fn is_typed_dict_like(&self) -> bool {
+        matches!(self, Type::TypedDict(..) | Type::TypedDictTop)
+    }
+
     pub(crate) const fn as_typed_dict(self) -> Option<TypedDictType<'db>> {
         match self {
             Type::TypedDict(typed_dict) => Some(typed_dict),
@@ -1748,6 +1754,7 @@ impl<'db> Type<'db> {
             | Type::TypeForm(_)
             | Type::TypeVar(_)
             | Type::TypedDict(_)
+            | Type::TypedDictTop
             | Type::NewTypeInstance(_)
             | Type::NominalInstance(_)
             | Type::ProtocolInstance(_)
@@ -1820,7 +1827,8 @@ impl<'db> Type<'db> {
             | Type::DataclassTransformer(_)
             | Type::ClassLiteral(_)
             | Type::GenericAlias(_)
-            | Type::KnownInstance(_) => false,
+            | Type::KnownInstance(_)
+            | Type::TypedDictTop => false,
             Type::Union(union) => union.elements(db).iter().all(|ty| ty.is_spellable(db)),
         }
     }
@@ -1877,6 +1885,8 @@ impl<'db> Type<'db> {
             Type::Union(union) => union.elements(db).iter().all(|ty| ty.is_hintable(db)),
 
             Type::TypedDict(td) => td.defining_class().is_some(),
+
+            Type::TypedDictTop => false,
 
             Type::ProtocolInstance(ProtocolInstanceType { inner, .. }) => !inner.is_synthesized(),
 
@@ -2092,7 +2102,7 @@ impl<'db> Type<'db> {
                 .map(|ty| TypeFormType::from_type_expression(db, ty)),
             Type::Divergent(_) => Some(self),
             Type::Dynamic(dynamic) => Some(Type::Dynamic(dynamic.recursive_type_normalized())),
-            Type::TypedDict(_) => {
+            Type::TypedDict(_) | Type::TypedDictTop => {
                 // TODO: Normalize TypedDicts
                 Some(self)
             }
@@ -2310,7 +2320,7 @@ impl<'db> Type<'db> {
             Type::TypeIs(type_is) => type_is.is_bound(db),
             Type::TypeGuard(type_guard) => type_guard.is_bound(db),
             Type::TypeForm(_) => false,
-            Type::TypedDict(_) => false,
+            Type::TypedDict(_) | Type::TypedDictTop => false,
             Type::TypeAlias(alias) => alias.value_type(db).is_singleton(db),
             Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).is_singleton(db),
         }
@@ -2398,7 +2408,8 @@ impl<'db> Type<'db> {
             | Type::PropertyInstance(_)
             | Type::DataclassDecorator(_)
             | Type::DataclassTransformer(_)
-            | Type::TypedDict(_) => false,
+            | Type::TypedDict(_)
+            | Type::TypedDictTop => false,
 
             Type::Intersection(intersection) => intersection
                 .enum_complement(db)
@@ -2543,6 +2554,7 @@ impl<'db> Type<'db> {
             | Type::TypeGuard(_)
             | Type::TypeForm(_)
             | Type::TypedDict(_)
+            | Type::TypedDictTop
             | Type::EnumComplement(_)
             | Type::NewTypeInstance(_) => None,
         }
@@ -2624,6 +2636,20 @@ impl<'db> Type<'db> {
                         )
                 }
             }
+
+            Type::TypedDictTop => KnownClass::TypedDictFallback
+                .to_class_literal(db)
+                .find_name_in_mro_with_policy(db, name.as_str(), policy)
+                .expect("`find_name_in_mro` should return `Some` for a class literal")
+                .map_type(|ty| {
+                    ty.apply_type_mapping(
+                        db,
+                        &TypeMapping::ReplaceSelf {
+                            new_upper_bound: Type::TypedDictTop,
+                        },
+                        TypeContext::default(),
+                    )
+                }),
 
             Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_) => self
                 .to_meta_type(db)
@@ -2805,6 +2831,9 @@ impl<'db> Type<'db> {
                 Place::Undefined.into()
             }
 
+            Type::TypedDictTop => KnownClass::TypedDictFallback
+                .to_instance(db)
+                .instance_member(db, name),
             Type::TypedDict(_) => Place::Undefined.into(),
 
             Type::TypeAlias(alias) => alias.value_type(db).instance_member(db, name),
@@ -3658,6 +3687,7 @@ impl<'db> Type<'db> {
             | Type::TypeIs(..)
             | Type::TypeGuard(..)
             | Type::TypeForm(..)
+            | Type::TypedDictTop
             | Type::TypedDict(_) => {
                 // Enum members can be accessed through enum instances and other enum members,
                 // e.g. `answer.YES` or `Answer.YES.NO`.
@@ -3684,7 +3714,7 @@ impl<'db> Type<'db> {
                     policy,
                 );
 
-                if result.is_class_var() && self.is_typed_dict() {
+                if result.is_class_var() && self.is_typed_dict_like() {
                     // `ClassVar`s on `TypedDictFallback` cannot be accessed on inhabitants of `SomeTypedDict`.
                     // They can only be accessed on `SomeTypedDict` directly.
                     return Place::Undefined.into();
@@ -4276,6 +4306,7 @@ impl<'db> Type<'db> {
             | Type::TypeIs(_)
             | Type::TypeGuard(_)
             | Type::TypeForm(_)
+            | Type::TypedDictTop
             | Type::TypedDict(_) => CallableBinding::not_callable(self).into(),
         }
     }
@@ -5352,6 +5383,7 @@ impl<'db> Type<'db> {
             | Type::TypeGuard(_)
             | Type::TypeForm(_)
             | Type::TypedDict(_)
+            | Type::TypedDictTop
             | Type::EnumComplement(_)
             | Type::NewTypeInstance(_) => None,
         }
@@ -5407,6 +5439,7 @@ impl<'db> Type<'db> {
             | Type::TypeIs(_)
             | Type::TypeGuard(_)
             | Type::TypeForm(_)
+            | Type::TypedDictTop
             | Type::TypedDict(_) => Err(InvalidTypeExpressionError {
                 invalid_expressions: smallvec_inline![InvalidTypeExpression::InvalidType(
                     *self, scope_id
@@ -5652,6 +5685,7 @@ impl<'db> Type<'db> {
             Type::AlwaysTruthy | Type::AlwaysFalsy => KnownClass::Type.to_instance(db),
             Type::BoundSuper(_) => KnownClass::Super.to_class_literal(db),
             Type::ProtocolInstance(protocol) => protocol.to_meta_type(db),
+            Type::TypedDictTop => KnownClass::Dict.to_class_literal(db),
             // `TypedDict` instances are instances of `dict` at runtime, but its important that we
             // understand a more specific meta type in order to correctly handle `__getitem__`.
             Type::TypedDict(typed_dict) => match typed_dict {
@@ -5673,7 +5707,7 @@ impl<'db> Type<'db> {
     /// instances of `dict` at runtime.
     #[must_use]
     pub(crate) fn dunder_class(self, db: &'db dyn Db) -> Type<'db> {
-        if self.is_typed_dict() {
+        if self.is_typed_dict_like() {
             return KnownClass::Dict
                 .to_specialized_class_type(db, &[KnownClass::Str.to_instance(db), Type::object()])
                 .map(Type::from)
@@ -5871,6 +5905,7 @@ impl<'db> Type<'db> {
             Type::TypedDict(typed_dict) => {
                 Type::TypedDict(typed_dict.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
             }
+            Type::TypedDictTop => Type::TypedDictTop,
 
             Type::SubclassOf(subclass_of) => subclass_of.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
 
@@ -6303,6 +6338,7 @@ impl<'db> Type<'db> {
             | Type::LiteralValue(_)
             | Type::BoundSuper(_)
             | Type::SpecialForm(_)
+            | Type::TypedDictTop
             | Type::TypedDict(_) => {}
         }
     }
@@ -6493,6 +6529,7 @@ impl<'db> Type<'db> {
                 Protocol::Synthesized(_) => None,
             },
 
+            Self::TypedDictTop => None,
             Self::TypedDict(typed_dict) => typed_dict.type_definition(db),
 
             Self::Union(_) => None,
@@ -6845,6 +6882,7 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
             | Type::AlwaysFalsy
             | Type::AlwaysTruthy
             | Type::BoundSuper(_)
+            | Type::TypedDictTop
             | Type::TypeVar(_)
             | Type::TypedDict(_)
             | Type::TypeAlias(_)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2637,7 +2637,7 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::TypedDictTop => KnownClass::TypedDictFallback
+            Type::TypedDictTop => KnownClass::TypedDictReadOnlyFallback
                 .to_class_literal(db)
                 .find_name_in_mro_with_policy(db, name.as_str(), policy)
                 .expect("`find_name_in_mro` should return `Some` for a class literal")
@@ -2831,7 +2831,7 @@ impl<'db> Type<'db> {
                 Place::Undefined.into()
             }
 
-            Type::TypedDictTop => KnownClass::TypedDictFallback
+            Type::TypedDictTop => KnownClass::TypedDictReadOnlyFallback
                 .to_instance(db)
                 .instance_member(db, name),
             Type::TypedDict(_) => Place::Undefined.into(),
@@ -5706,15 +5706,15 @@ impl<'db> Type<'db> {
     /// instances of `dict` at runtime.
     #[must_use]
     pub(crate) fn dunder_class(self, db: &'db dyn Db) -> Type<'db> {
-        if self.is_typed_dict_like() {
-            return KnownClass::Dict
+        match self {
+            Type::TypedDict(_) | Type::TypedDictTop => KnownClass::Dict
                 .to_specialized_class_type(db, &[KnownClass::Str.to_instance(db), Type::object()])
                 .map(Type::from)
                 // Guard against user-customized typesheds with a broken `dict` class
-                .unwrap_or_else(Type::unknown);
+                .unwrap_or_else(Type::unknown),
+            Type::Union(union) => union.map(db, |element| element.dunder_class(db)),
+            _ => self.to_meta_type(db),
         }
-
-        self.to_meta_type(db)
     }
 
     #[must_use]

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3715,8 +3715,9 @@ impl<'db> Type<'db> {
                 );
 
                 if result.is_class_var() && self.is_typed_dict_like() {
-                    // `ClassVar`s on `TypedDictFallback` cannot be accessed on inhabitants of `SomeTypedDict`.
-                    // They can only be accessed on `SomeTypedDict` directly.
+                    // `ClassVar`s on the TypedDict fallback classes cannot be accessed on
+                    // TypedDict inhabitants. They can only be accessed on concrete TypedDict
+                    // classes directly.
                     return Place::Undefined.into();
                 }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5439,7 +5439,6 @@ impl<'db> Type<'db> {
             | Type::TypeIs(_)
             | Type::TypeGuard(_)
             | Type::TypeForm(_)
-            | Type::TypedDictTop
             | Type::TypedDict(_) => Err(InvalidTypeExpressionError {
                 invalid_expressions: smallvec_inline![InvalidTypeExpression::InvalidType(
                     *self, scope_id
@@ -5586,7 +5585,7 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::Dynamic(_) | Type::Divergent(_) => Ok(*self),
+            Type::TypedDictTop | Type::Dynamic(_) | Type::Divergent(_) => Ok(*self),
 
             Type::NominalInstance(instance) => match instance.known_class(db) {
                 Some(KnownClass::NoneType) => Ok(Type::none(db)),
@@ -6529,7 +6528,7 @@ impl<'db> Type<'db> {
                 Protocol::Synthesized(_) => None,
             },
 
-            Self::TypedDictTop => None,
+            Self::TypedDictTop => Type::SpecialForm(SpecialFormType::TypedDictTop).definition(db),
             Self::TypedDict(typed_dict) => typed_dict.type_definition(db),
 
             Self::Union(_) => None,

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -214,7 +214,8 @@ impl<'db> Type<'db> {
             | Type::Callable(_)
             | Type::TypeIs(_)
             | Type::TypeGuard(_)
-            | Type::TypeForm(_) => Truthiness::Ambiguous,
+            | Type::TypeForm(_)
+            | Type::TypedDictTop => Truthiness::Ambiguous,
 
             Type::TypedDict(td) => {
                 if td.items(db).values().any(TypedDictField::is_required) {

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -841,8 +841,7 @@ impl<'db> BoundSuperType<'db> {
             | Type::Callable(_)
             | Type::DataclassTransformer(_)
             | Type::TypeForm(_)
-            | Type::TypedDictTop
-            => {
+            | Type::TypedDictTop => {
                 return Err(BoundSuperError::AbstractOwnerType {
                     owner_type,
                     pivot_class: pivot_class_type,

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -840,7 +840,9 @@ impl<'db> BoundSuperType<'db> {
             | Type::AlwaysTruthy
             | Type::Callable(_)
             | Type::DataclassTransformer(_)
-            | Type::TypeForm(_) => {
+            | Type::TypeForm(_)
+            | Type::TypedDictTop
+            => {
                 return Err(BoundSuperError::AbstractOwnerType {
                     owner_type,
                     pivot_class: pivot_class_type,

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -265,6 +265,7 @@ impl<'db> Type<'db> {
             | Type::TypeIs(_)
             | Type::TypeGuard(_)
             | Type::TypeForm(_)
+            | Type::TypedDictTop
             | Type::TypedDict(_) => None,
 
             Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1352,7 +1352,7 @@ impl<'db> ClassType<'db> {
                 let specialization = generic.specialization(db);
 
                 if let Some(readonly_projection) =
-                    Self::dict_top_readonly_projection(db, class_literal, specialization)
+                    Self::dict_top_readonly_projection(db, class_literal, specialization, name)
                 {
                     let projected_member = readonly_projection.class_member(db, name, policy);
                     if !projected_member.is_undefined() {
@@ -1710,7 +1710,7 @@ impl<'db> ClassType<'db> {
                 }
 
                 if let Some(readonly_projection) =
-                    Self::dict_top_readonly_projection(db, class_literal, specialization)
+                    Self::dict_top_readonly_projection(db, class_literal, specialization, name)
                 {
                     let projected_member = readonly_projection.instance_member(db, name);
                     if !projected_member.is_undefined() {
@@ -1748,12 +1748,14 @@ impl<'db> ClassType<'db> {
         }
     }
 
-    /// Top-materialized `dict`s can project read-only members through `Mapping` so lookups
-    /// preserve observer signatures without also loosening mutation APIs.
+    /// Top-materialized `dict`s can project read-only members through `Mapping`. Use `dict` itself
+    /// for its view methods so lookups preserve concrete observer types without also loosening
+    /// mutation APIs.
     fn dict_top_readonly_projection(
         db: &'db dyn Db,
         class_literal: StaticClassLiteral<'db>,
         specialization: Specialization<'db>,
+        name: &str,
     ) -> Option<ClassType<'db>> {
         if specialization.materialization_kind(db) != Some(MaterializationKind::Top)
             || !specialization.types(db).iter().all(Type::is_unknown)
@@ -1762,7 +1764,11 @@ impl<'db> ClassType<'db> {
             return None;
         }
 
-        KnownClass::Mapping.to_specialized_class_type(db, specialization.types(db))
+        let projection = match name {
+            "items" | "keys" | "values" => KnownClass::Dict,
+            _ => KnownClass::Mapping,
+        };
+        projection.to_specialized_class_type(db, specialization.types(db))
     }
 
     /// A helper function for `instance_member` that looks up the `name` attribute only on

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -14,8 +14,8 @@ pub(crate) use self::static_literal::{
 };
 pub(super) use self::typed_dict::{DynamicTypedDictAnchor, DynamicTypedDictLiteral};
 use super::{
-    BoundTypeVarInstance, MemberLookupPolicy, MroIterator, SpecialFormType, SubclassOfType, Type,
-    TypeQualifiers, class_base::ClassBase, function::FunctionType,
+    BoundTypeVarInstance, MaterializationKind, MemberLookupPolicy, MroIterator, SpecialFormType,
+    SubclassOfType, Type, TypeQualifiers, class_base::ClassBase, function::FunctionType,
 };
 use super::{TypeVarVariance, display};
 use crate::place::{DefinedPlace, TypeOrigin};
@@ -1347,12 +1347,21 @@ impl<'db> ClassType<'db> {
     ) -> PlaceAndQualifiers<'db> {
         match self {
             Self::NonGeneric(class) => class.class_member(db, name, policy),
-            Self::Generic(generic) => generic.origin(db).class_member_inner(
-                db,
-                Some(generic.specialization(db)),
-                name,
-                policy,
-            ),
+            Self::Generic(generic) => {
+                let class_literal = generic.origin(db);
+                let specialization = generic.specialization(db);
+
+                if let Some(readonly_projection) =
+                    Self::dict_top_readonly_projection(db, class_literal, specialization)
+                {
+                    let projected_member = readonly_projection.class_member(db, name, policy);
+                    if !projected_member.is_undefined() {
+                        return projected_member;
+                    }
+                }
+
+                class_literal.class_member_inner(db, Some(specialization), name, policy)
+            }
         }
     }
 
@@ -1694,15 +1703,24 @@ impl<'db> ClassType<'db> {
             }
             Self::Generic(generic) => {
                 let class_literal = generic.origin(db);
-                let specialization = Some(generic.specialization(db));
+                let specialization = generic.specialization(db);
 
                 if class_literal.is_typed_dict(db) {
                     return Place::Undefined.into();
                 }
 
+                if let Some(readonly_projection) =
+                    Self::dict_top_readonly_projection(db, class_literal, specialization)
+                {
+                    let projected_member = readonly_projection.instance_member(db, name);
+                    if !projected_member.is_undefined() {
+                        return projected_member;
+                    }
+                }
+
                 class_literal
-                    .instance_member(db, specialization, name)
-                    .map_type(|ty| ty.apply_optional_specialization(db, specialization))
+                    .instance_member(db, Some(specialization), name)
+                    .map_type(|ty| ty.apply_optional_specialization(db, Some(specialization)))
             }
         }
     }
@@ -1728,6 +1746,23 @@ impl<'db> ClassType<'db> {
                 | ClassLiteral::DynamicEnum(_),
             ) => None,
         }
+    }
+
+    /// Top-materialized `dict`s can project read-only members through `Mapping` so lookups
+    /// preserve observer signatures without also loosening mutation APIs.
+    fn dict_top_readonly_projection(
+        db: &'db dyn Db,
+        class_literal: StaticClassLiteral<'db>,
+        specialization: Specialization<'db>,
+    ) -> Option<ClassType<'db>> {
+        if specialization.materialization_kind(db) != Some(MaterializationKind::Top)
+            || !specialization.types(db).iter().all(Type::is_unknown)
+            || class_literal.known(db) != Some(KnownClass::Dict)
+        {
+            return None;
+        }
+
+        KnownClass::Mapping.to_specialized_class_type(db, specialization.types(db))
     }
 
     /// A helper function for `instance_member` that looks up the `name` attribute only on

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -115,6 +115,7 @@ pub enum KnownClass {
     AsyncIterator,
     Sequence,
     Mapping,
+    MutableMapping,
     // typing_extensions
     ExtensionsTypeVar, // must be distinct from typing.TypeVar, backports new features
     Sentinel,
@@ -240,6 +241,7 @@ impl KnownClass {
             | Self::AsyncIterator
             | Self::Sequence
             | Self::Mapping
+            | Self::MutableMapping
             // Evaluating `NotImplementedType` in a boolean context was deprecated in Python 3.9
             // and raises a `TypeError` in Python >=3.14
             // (see https://docs.python.org/3/library/constants.html#NotImplemented)
@@ -337,6 +339,7 @@ impl KnownClass {
             | KnownClass::AsyncIterator
             | KnownClass::Sequence
             | KnownClass::Mapping
+            | KnownClass::MutableMapping
             | KnownClass::ChainMap
             | KnownClass::Counter
             | KnownClass::DefaultDict
@@ -432,6 +435,7 @@ impl KnownClass {
             | KnownClass::AsyncIterator
             | KnownClass::Sequence
             | KnownClass::Mapping
+            | KnownClass::MutableMapping
             | KnownClass::ChainMap
             | KnownClass::Counter
             | KnownClass::DefaultDict
@@ -527,6 +531,7 @@ impl KnownClass {
             | KnownClass::AsyncIterator
             | KnownClass::Sequence
             | KnownClass::Mapping
+            | KnownClass::MutableMapping
             | KnownClass::ChainMap
             | KnownClass::Counter
             | KnownClass::DefaultDict
@@ -653,6 +658,7 @@ impl KnownClass {
             | Self::Path
             | Self::FunctoolsPartial
             | Self::Mapping
+            | Self::MutableMapping
             | Self::Sequence => false,
         }
     }
@@ -736,6 +742,7 @@ impl KnownClass {
             | KnownClass::AsyncIterator
             | KnownClass::Sequence
             | KnownClass::Mapping
+            | KnownClass::MutableMapping
             | KnownClass::ChainMap
             | KnownClass::Counter
             | KnownClass::DefaultDict
@@ -836,6 +843,7 @@ impl KnownClass {
             Self::AsyncIterator => "AsyncIterator",
             Self::Sequence => "Sequence",
             Self::Mapping => "Mapping",
+            Self::MutableMapping => "MutableMapping",
             // For example, `typing.List` is defined as `List = _Alias()` in typeshed
             Self::StdlibAlias => "_Alias",
             // This is the name the type of `sys.version_info` has in typeshed,
@@ -1174,6 +1182,7 @@ impl KnownClass {
             | Self::AsyncIterator
             | Self::Sequence
             | Self::Mapping
+            | Self::MutableMapping
             | Self::ProtocolMeta
             | Self::ParamSpec
             | Self::SupportsIndex => KnownModule::Typing,
@@ -1297,6 +1306,7 @@ impl KnownClass {
             | Self::AsyncIterator
             | Self::Sequence
             | Self::Mapping
+            | Self::MutableMapping
             | Self::NamedTupleFallback
             | Self::NamedTupleLike
             | Self::ConstraintSet
@@ -1398,6 +1408,7 @@ impl KnownClass {
             | Self::AsyncIterator
             | Self::Sequence
             | Self::Mapping
+            | Self::MutableMapping
             | Self::NamedTupleFallback
             | Self::NamedTupleLike
             | Self::ConstraintSet
@@ -1467,6 +1478,7 @@ impl KnownClass {
             "AsyncIterator" => &[Self::AsyncIterator],
             "Sequence" => &[Self::Sequence],
             "Mapping" => &[Self::Mapping],
+            "MutableMapping" => &[Self::MutableMapping],
             "ParamSpec" => &[Self::ParamSpec, Self::ExtensionsParamSpec],
             "ParamSpecArgs" => &[Self::ParamSpecArgs],
             "ParamSpecKwargs" => &[Self::ParamSpecKwargs],
@@ -1612,6 +1624,7 @@ impl KnownClass {
             | Self::AsyncIterator
             | Self::Sequence
             | Self::Mapping
+            | Self::MutableMapping
             | Self::ProtocolMeta
             | Self::NewType => matches!(module, KnownModule::Typing | KnownModule::TypingExtensions),
             Self::Deprecated => matches!(module, KnownModule::Warnings | KnownModule::TypingExtensions),

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -133,6 +133,7 @@ pub enum KnownClass {
     // _typeshed._type_checker_internals
     NamedTupleFallback,
     NamedTupleLike,
+    TypedDictReadOnlyFallback,
     TypedDictFallback,
     // string.templatelib
     Template,
@@ -261,6 +262,7 @@ impl KnownClass {
             | Self::Specialization
             | Self::ProtocolMeta
             | Self::FunctoolsPartial
+            | Self::TypedDictReadOnlyFallback
             | Self::TypedDictFallback => Some(Truthiness::Ambiguous),
 
             Self::Tuple => None,
@@ -355,6 +357,7 @@ impl KnownClass {
             | KnownClass::ConstraintSet
             | KnownClass::GenericContext
             | KnownClass::Specialization
+            | KnownClass::TypedDictReadOnlyFallback
             | KnownClass::TypedDictFallback
             | KnownClass::BuiltinFunctionType
             | KnownClass::ProtocolMeta
@@ -451,6 +454,7 @@ impl KnownClass {
             | KnownClass::ConstraintSet
             | KnownClass::GenericContext
             | KnownClass::Specialization
+            | KnownClass::TypedDictReadOnlyFallback
             | KnownClass::TypedDictFallback
             | KnownClass::BuiltinFunctionType
             | KnownClass::ProtocolMeta
@@ -541,6 +545,7 @@ impl KnownClass {
             | KnownClass::NotImplementedType
             | KnownClass::Field
             | KnownClass::KwOnly
+            | KnownClass::TypedDictReadOnlyFallback
             | KnownClass::TypedDictFallback
             | KnownClass::NamedTupleLike
             | KnownClass::NamedTupleFallback
@@ -651,6 +656,7 @@ impl KnownClass {
             | Self::ConstraintSet
             | Self::GenericContext
             | Self::Specialization
+            | Self::TypedDictReadOnlyFallback
             | Self::TypedDictFallback
             | Self::BuiltinFunctionType
             | Self::ProtocolMeta
@@ -758,7 +764,9 @@ impl KnownClass {
             | KnownClass::ConstraintSet
             | KnownClass::GenericContext
             | KnownClass::Specialization => false,
-            KnownClass::NamedTupleFallback | KnownClass::TypedDictFallback => true,
+            KnownClass::NamedTupleFallback
+            | KnownClass::TypedDictReadOnlyFallback
+            | KnownClass::TypedDictFallback => true,
         }
     }
 
@@ -861,6 +869,7 @@ impl KnownClass {
             Self::ConstraintSet => "ConstraintSet",
             Self::GenericContext => "GenericContext",
             Self::Specialization => "Specialization",
+            Self::TypedDictReadOnlyFallback => "TypedDictReadOnlyFallback",
             Self::TypedDictFallback => "TypedDictFallback",
             Self::Template => "Template",
             Self::Path => "Path",
@@ -1213,7 +1222,9 @@ impl KnownClass {
             | Self::Deque
             | Self::OrderedDict => KnownModule::Collections,
             Self::Field | Self::KwOnly => KnownModule::Dataclasses,
-            Self::NamedTupleFallback | Self::TypedDictFallback => KnownModule::TypeCheckerInternals,
+            Self::NamedTupleFallback
+            | Self::TypedDictReadOnlyFallback
+            | Self::TypedDictFallback => KnownModule::TypeCheckerInternals,
             Self::NamedTupleLike
             | Self::ConstraintSet
             | Self::GenericContext
@@ -1312,6 +1323,7 @@ impl KnownClass {
             | Self::ConstraintSet
             | Self::GenericContext
             | Self::Specialization
+            | Self::TypedDictReadOnlyFallback
             | Self::TypedDictFallback
             | Self::BuiltinFunctionType
             | Self::ProtocolMeta
@@ -1414,6 +1426,7 @@ impl KnownClass {
             | Self::ConstraintSet
             | Self::GenericContext
             | Self::Specialization
+            | Self::TypedDictReadOnlyFallback
             | Self::TypedDictFallback
             | Self::BuiltinFunctionType
             | Self::ProtocolMeta
@@ -1519,6 +1532,7 @@ impl KnownClass {
             "ConstraintSet" => &[Self::ConstraintSet],
             "GenericContext" => &[Self::GenericContext],
             "Specialization" => &[Self::Specialization],
+            "TypedDictReadOnlyFallback" => &[Self::TypedDictReadOnlyFallback],
             "TypedDictFallback" => &[Self::TypedDictFallback],
             "Template" => &[Self::Template],
             "Path" => &[Self::Path],
@@ -1595,6 +1609,7 @@ impl KnownClass {
             | Self::Field
             | Self::KwOnly
             | Self::NamedTupleFallback
+            | Self::TypedDictReadOnlyFallback
             | Self::TypedDictFallback
             | Self::TypeVar
             | Self::ExtensionsTypeVar

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -176,6 +176,7 @@ impl<'db> ClassBase<'db> {
             | Type::TypeIs(_)
             | Type::TypeGuard(_)
             | Type::TypeForm(_)
+            | Type::TypedDictTop
             | Type::TypedDict(_) => None,
 
             Type::KnownInstance(known_instance) => match known_instance {

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -233,6 +233,7 @@ impl<'db> ClassBase<'db> {
                 | SpecialFormType::Optional
                 | SpecialFormType::Not
                 | SpecialFormType::Top
+                | SpecialFormType::TypedDictTop
                 | SpecialFormType::Bottom
                 | SpecialFormType::Intersection
                 | SpecialFormType::TypeOf

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1288,12 +1288,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .fmt_detailed(f)?;
                 f.write_char(']')
             }
-            Type::TypedDictTop => {
-                f.set_invalid_type_annotation();
-                f.write_str("Top[")?;
-                f.with_type(self.ty).write_str("TypedDict")?;
-                f.write_char(']')
-            }
+            Type::TypedDictTop => f.with_type(self.ty).write_str("TypedDictTop"),
             Type::TypedDict(TypedDictType::Class(defining_class)) => match defining_class {
                 ClassType::NonGeneric(class) => class
                     .display_with(self.db, self.settings.clone())

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1288,6 +1288,12 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .fmt_detailed(f)?;
                 f.write_char(']')
             }
+            Type::TypedDictTop => {
+                f.set_invalid_type_annotation();
+                f.write_str("Top[")?;
+                f.with_type(self.ty).write_str("TypedDict")?;
+                f.write_char(']')
+            }
             Type::TypedDict(TypedDictType::Class(defining_class)) => match defining_class {
                 ClassType::NonGeneric(class) => class
                     .display_with(self.db, self.settings.clone())

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1759,6 +1759,7 @@ fn is_instance_truthiness<'db>(
         | Type::Dynamic(..)
         | Type::Divergent(_)
         | Type::Never
+        | Type::TypedDictTop
         | Type::TypedDict(_) => {
             // We could probably try to infer more precise types in some of these cases, but it's unclear
             // if it's worth the effort.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2654,6 +2654,14 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
             }
 
+            (formal @ Type::NominalInstance(_), Type::TypedDict(_) | Type::TypedDictTop) => {
+                let str_object_map = KnownClass::Mapping.to_specialized_instance(
+                    self.db,
+                    &[KnownClass::Str.to_instance(self.db), Type::object()],
+                );
+                return self.infer_map_impl(formal, str_object_map, polarity, seen);
+            }
+
             (Type::Intersection(formal_intersection), _) => {
                 // The actual type must be assignable to every (positive) element of the
                 // formal intersection, so we must infer type mappings for each of them. (The
@@ -2840,7 +2848,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 return Ok(());
             }
 
-            (formal @ Type::ProtocolInstance(_), actual @ Type::TypedDict(_)) => {
+            (
+                formal @ Type::ProtocolInstance(_),
+                actual @ (Type::TypedDict(_) | Type::TypedDictTop),
+            ) => {
                 let when = actual.when_constraint_set_assignable_to_owned(self.db, formal);
                 let when = self.constraints.load(self.db, when);
                 // For protocol inference via constraint sets, keep unsatisfiable results non-fatal

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2553,6 +2553,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             | Type::TypeIs(_)
             | Type::TypeGuard(_)
             | Type::TypeForm(_)
+            | Type::TypedDictTop
             | Type::TypedDict(_)
             | Type::NewTypeInstance(_) => {
                 // We may infer the value type multiple times with distinct type context during
@@ -3173,6 +3174,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             | Type::TypeGuard(_)
             | Type::TypeForm(_)
             | Type::TypedDict(_)
+            | Type::TypedDictTop
             | Type::NewTypeInstance(_) => {
                 let delattr_dunder_call_result = object_ty.try_call_dunder_with_policy(
                     db,
@@ -3347,7 +3349,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 | Type::Divergent(_)
                 | Type::Never
                 | Type::ModuleLiteral(..)
-                | Type::BoundSuper(..) => return None,
+                | Type::BoundSuper(..)
+                | Type::TypedDictTop => return None,
             })
         } else {
             None
@@ -5140,6 +5143,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 | Type::TypeIs(_)
                 | Type::TypeGuard(_)
                 | Type::TypeForm(_)
+                | Type::TypedDictTop
                 | Type::TypedDict(_)
                 | Type::NewTypeInstance(_) => None,
             }
@@ -9852,6 +9856,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 | Type::TypeIs(_)
                 | Type::TypeGuard(_)
                 | Type::TypeForm(_)
+                | Type::TypedDictTop
                 | Type::TypedDict(_)
                 | Type::NewTypeInstance(_),
             ) => fallback_unary_expression_type(),

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -25,6 +25,55 @@ type BinaryExpressionVisitor<'db> =
     CycleDetector<ast::Operator, (Type<'db>, ast::Operator, Type<'db>), Option<Type<'db>>>;
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
+    /// Return an ordinary `dict` approximation for a type known to contain only runtime
+    /// dictionaries.
+    ///
+    /// This is only used as a fallback for the non-mutating `|` operator. Projecting a
+    /// `TypedDict` to `dict` generally would expose mutation APIs that are not schema-safe.
+    /// A union is widened because its arms can have incompatible key and value types.
+    fn dict_merge_projection(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
+        match ty {
+            Type::TypedDict(_) | Type::TypedDictTop => {
+                Some(KnownClass::Dict.to_specialized_instance(
+                    db,
+                    &[KnownClass::Str.to_instance(db), Type::object()],
+                ))
+            }
+            Type::Union(union) => union
+                .elements(db)
+                .iter()
+                .all(|element| Self::dict_merge_projection(db, *element).is_some())
+                .then(|| {
+                    KnownClass::Dict
+                        .to_specialized_instance(db, &[Type::unknown(), Type::unknown()])
+                }),
+            _ => ty
+                .known_specialization(db, KnownClass::Dict)
+                .map(|specialization| {
+                    KnownClass::Dict.to_specialized_instance(db, specialization.types(db))
+                }),
+        }
+    }
+
+    fn try_dict_merge_fallback(
+        db: &'db dyn Db,
+        left_ty: Type<'db>,
+        op: ast::Operator,
+        right_ty: Type<'db>,
+    ) -> Option<Type<'db>> {
+        if op != ast::Operator::BitOr {
+            return None;
+        }
+
+        let left_dict = Self::dict_merge_projection(db, left_ty)?;
+        let right_dict = Self::dict_merge_projection(db, right_ty)?;
+        if left_dict == left_ty && right_dict == right_ty {
+            return None;
+        }
+
+        Type::try_call_bin_op_return_type(db, left_dict, op, right_dict)
+    }
+
     pub(super) fn infer_binary_expression(
         &mut self,
         binary: &ast::ExprBinOp,
@@ -309,6 +358,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             op,
             &BinaryExpressionVisitor::new(Some(Type::Never)),
         )
+        .or_else(|| Self::try_dict_merge_fallback(self.db(), left_ty, op, right_ty))
     }
 
     fn infer_binary_expression_type_impl(

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -1003,6 +1003,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 | Type::TypeIs(_)
                 | Type::TypeGuard(_)
                 | Type::TypeForm(_)
+                | Type::TypedDictTop
                 | Type::TypedDict(_),
                 Type::FunctionLiteral(_)
                 | Type::Callable(..)
@@ -1030,6 +1031,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 | Type::TypeIs(_)
                 | Type::TypeGuard(_)
                 | Type::TypeForm(_)
+                | Type::TypedDictTop
                 | Type::TypedDict(_),
                 op,
             ) => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty),

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -24,46 +24,67 @@ enum BinaryExpressionOperandTypes<'db> {
 type BinaryExpressionVisitor<'db> =
     CycleDetector<ast::Operator, (Type<'db>, ast::Operator, Type<'db>), Option<Type<'db>>>;
 
+struct DictMergeProjection;
+type DictMergeProjectionVisitor<'db> =
+    CycleDetector<DictMergeProjection, Type<'db>, Option<Type<'db>>>;
+
 impl<'db> TypeInferenceBuilder<'db, '_> {
     /// Return an ordinary `dict` approximation for a type known to contain only runtime
     /// dictionaries.
     ///
     /// This is only used as a fallback for the non-mutating `|` operator. Projecting a
     /// `TypedDict` to `dict` generally would expose mutation APIs that are not schema-safe.
-    /// A union is widened because its arms can have incompatible key and value types.
+    /// A union is widened because its arms can have incompatible key and value types. An
+    /// intersection can use any positive arm that guarantees every inhabitant is a runtime dict.
     fn dict_merge_projection(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
-        match ty {
-            Type::TypedDict(_) | Type::TypedDictTop => {
-                Some(KnownClass::Dict.to_specialized_instance(
-                    db,
-                    &[KnownClass::Str.to_instance(db), Type::object()],
-                ))
-            }
-            Type::Union(union) => union
-                .elements(db)
-                .iter()
-                .all(|element| Self::dict_merge_projection(db, *element).is_some())
-                .then(|| {
-                    KnownClass::Dict
-                        .to_specialized_instance(db, &[Type::unknown(), Type::unknown()])
-                }),
-            _ => {
-                let class = ty.nominal_class(db)?;
-                for base in class.iter_mro(db).filter_map(ClassBase::into_class) {
-                    if base.is_known(db, KnownClass::Dict) {
-                        return Some(Type::instance(db, base));
-                    }
-                    // The projection can be used on either side of `|`. Stop if it would replace
-                    // a subclass implementation with the builtin `dict` merge behavior.
-                    if !base.own_instance_member(db, "__or__").is_undefined()
-                        || !base.own_instance_member(db, "__ror__").is_undefined()
-                    {
-                        return None;
-                    }
+        fn imp<'db>(
+            db: &'db dyn Db,
+            ty: Type<'db>,
+            visitor: &DictMergeProjectionVisitor<'db>,
+        ) -> Option<Type<'db>> {
+            match ty {
+                Type::TypedDict(_) | Type::TypedDictTop => {
+                    Some(KnownClass::Dict.to_specialized_instance(
+                        db,
+                        &[KnownClass::Str.to_instance(db), Type::object()],
+                    ))
                 }
-                None
+                Type::Union(union) => union
+                    .elements(db)
+                    .iter()
+                    .all(|element| imp(db, *element, visitor).is_some())
+                    .then(|| {
+                        KnownClass::Dict
+                            .to_specialized_instance(db, &[Type::unknown(), Type::unknown()])
+                    }),
+                Type::Intersection(intersection) => intersection
+                    .positive(db)
+                    .iter()
+                    .find_map(|element| imp(db, *element, visitor)),
+                Type::TypeAlias(alias) => {
+                    visitor.visit(ty, || imp(db, alias.value_type(db), visitor))
+                }
+                _ => {
+                    let class = ty.nominal_class(db)?;
+                    for base in class.iter_mro(db).filter_map(ClassBase::into_class) {
+                        if base.is_known(db, KnownClass::Dict) {
+                            return Some(Type::instance(db, base));
+                        }
+                        // The projection can be used on either side of `|`. Stop if it would
+                        // replace a subclass implementation with the builtin `dict` merge
+                        // behavior.
+                        if !base.own_instance_member(db, "__or__").is_undefined()
+                            || !base.own_instance_member(db, "__ror__").is_undefined()
+                        {
+                            return None;
+                        }
+                    }
+                    None
+                }
             }
         }
+
+        imp(db, ty, &DictMergeProjectionVisitor::default())
     }
 
     fn try_dict_merge_fallback(

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -43,11 +43,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             visitor: &DictMergeProjectionVisitor<'db>,
         ) -> Option<Type<'db>> {
             match ty {
-                Type::TypedDict(_) | Type::TypedDictTop => {
-                    Some(KnownClass::Dict.to_specialized_instance(
-                        db,
-                        &[KnownClass::Str.to_instance(db), Type::object()],
-                    ))
+                typed_dict @ (Type::TypedDict(_) | Type::TypedDictTop) => {
+                    typed_dict.dunder_class(db).to_instance(db)
                 }
                 Type::Union(union) => union
                     .elements(db)

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -218,6 +218,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             return None;
         }
 
+        if target_type == Type::TypedDictTop {
+            let value_ty = infer_value_ty(self, TypeContext::default());
+            report_unsupported_augmented_assignment(
+                &self.context,
+                assignment,
+                target_type,
+                value_ty,
+            );
+            return Some(Type::TypedDictTop);
+        }
+
         let Type::TypedDict(typed_dict) = target_type else {
             return None;
         };

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -11,9 +11,9 @@ use crate::types::diagnostic::{
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::typevar::TypeVarConstraints;
 use crate::types::{
-    DynamicType, InternedConstraintSet, KnownClass, KnownInstanceType, LiteralValueTypeKind,
-    MemberLookupPolicy, Type, TypeContext, TypeVarBoundOrConstraints, TypedDictType, UnionBuilder,
-    UnionTypeInstance,
+    ClassBase, DynamicType, InternedConstraintSet, KnownClass, KnownInstanceType,
+    LiteralValueTypeKind, MemberLookupPolicy, Type, TypeContext, TypeVarBoundOrConstraints,
+    TypedDictType, UnionBuilder, UnionTypeInstance,
 };
 
 enum BinaryExpressionOperandTypes<'db> {
@@ -47,11 +47,22 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     KnownClass::Dict
                         .to_specialized_instance(db, &[Type::unknown(), Type::unknown()])
                 }),
-            _ => ty
-                .known_specialization(db, KnownClass::Dict)
-                .map(|specialization| {
-                    KnownClass::Dict.to_specialized_instance(db, specialization.types(db))
-                }),
+            _ => {
+                let class = ty.nominal_class(db)?;
+                for base in class.iter_mro(db).filter_map(ClassBase::into_class) {
+                    if base.is_known(db, KnownClass::Dict) {
+                        return Some(Type::instance(db, base));
+                    }
+                    // The projection can be used on either side of `|`. Stop if it would replace
+                    // a subclass implementation with the builtin `dict` merge behavior.
+                    if !base.own_instance_member(db, "__or__").is_undefined()
+                        || !base.own_instance_member(db, "__ror__").is_undefined()
+                    {
+                        return None;
+                    }
+                }
+                None
+            }
         }
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
@@ -1,6 +1,8 @@
+use crate::Db;
 use crate::types::class::{
     ClassLiteral, DynamicClassAnchor, DynamicClassLiteral, DynamicMetaclassConflict,
 };
+use crate::types::cyclic::CycleDetector;
 use crate::types::diagnostic::{
     INVALID_ARGUMENT_TYPE, NO_MATCHING_OVERLOAD, report_conflicting_metaclass_from_bases,
     report_instance_layout_conflict,
@@ -15,6 +17,43 @@ use crate::types::{KnownClass, SubclassOfType, Type, TypeContext, definition_exp
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, HasNodeIndex, NodeIndex};
 use ty_python_core::definition::Definition;
+
+struct DynamicClassNamespace;
+type DynamicClassNamespaceVisitor<'db> = CycleDetector<DynamicClassNamespace, Type<'db>, bool>;
+
+/// Return whether every inhabitant of `ty` can be used as the namespace in a three-argument
+/// `type()` call.
+fn is_assignable_to_dynamic_class_namespace<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    fn imp<'db>(
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        visitor: &DynamicClassNamespaceVisitor<'db>,
+    ) -> bool {
+        match ty {
+            Type::Union(union) => union
+                .elements(db)
+                .iter()
+                .all(|element| imp(db, *element, visitor)),
+            Type::Intersection(intersection) => intersection
+                .positive(db)
+                .iter()
+                .any(|element| imp(db, *element, visitor)),
+            Type::TypeAlias(alias) => visitor.visit(ty, || imp(db, alias.value_type(db), visitor)),
+            _ => {
+                ty.is_typed_dict_like()
+                    || ty.is_assignable_to(
+                        db,
+                        KnownClass::Dict.to_specialized_instance(
+                            db,
+                            &[KnownClass::Str.to_instance(db), Type::any()],
+                        ),
+                    )
+            }
+        }
+    }
+
+    imp(db, ty, &DynamicClassNamespaceVisitor::default())
+}
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
     /// Infer a call to `builtins.type()`.
@@ -173,12 +212,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 (Box::new([]), true)
             };
 
-        if !namespace_type.is_typed_dict_like()
-            && !namespace_type.is_assignable_to(
-                db,
-                KnownClass::Dict
-                    .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]),
-            )
+        if !is_assignable_to_dynamic_class_namespace(db, namespace_type)
             && let Some(builder) = self
                 .context
                 .report_lint(&INVALID_ARGUMENT_TYPE, namespace_arg)

--- a/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
@@ -1,8 +1,6 @@
-use crate::Db;
 use crate::types::class::{
     ClassLiteral, DynamicClassAnchor, DynamicClassLiteral, DynamicMetaclassConflict,
 };
-use crate::types::cyclic::CycleDetector;
 use crate::types::diagnostic::{
     INVALID_ARGUMENT_TYPE, NO_MATCHING_OVERLOAD, report_conflicting_metaclass_from_bases,
     report_instance_layout_conflict,
@@ -13,47 +11,12 @@ use crate::types::infer::builder::{
         DynamicClassKind, report_dynamic_mro_errors, report_inconsistent_dynamic_generic_bases,
     },
 };
-use crate::types::{KnownClass, SubclassOfType, Type, TypeContext, definition_expression_type};
+use crate::types::{
+    KnownClass, SubclassOfType, Type, TypeContext, UnionType, definition_expression_type,
+};
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, HasNodeIndex, NodeIndex};
 use ty_python_core::definition::Definition;
-
-struct DynamicClassNamespace;
-type DynamicClassNamespaceVisitor<'db> = CycleDetector<DynamicClassNamespace, Type<'db>, bool>;
-
-/// Return whether every inhabitant of `ty` can be used as the namespace in a three-argument
-/// `type()` call.
-fn is_assignable_to_dynamic_class_namespace<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-    fn imp<'db>(
-        db: &'db dyn Db,
-        ty: Type<'db>,
-        visitor: &DynamicClassNamespaceVisitor<'db>,
-    ) -> bool {
-        match ty {
-            Type::Union(union) => union
-                .elements(db)
-                .iter()
-                .all(|element| imp(db, *element, visitor)),
-            Type::Intersection(intersection) => intersection
-                .positive(db)
-                .iter()
-                .any(|element| imp(db, *element, visitor)),
-            Type::TypeAlias(alias) => visitor.visit(ty, || imp(db, alias.value_type(db), visitor)),
-            _ => {
-                ty.is_typed_dict_like()
-                    || ty.is_assignable_to(
-                        db,
-                        KnownClass::Dict.to_specialized_instance(
-                            db,
-                            &[KnownClass::Str.to_instance(db), Type::any()],
-                        ),
-                    )
-            }
-        }
-    }
-
-    imp(db, ty, &DynamicClassNamespaceVisitor::default())
-}
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
     /// Infer a call to `builtins.type()`.
@@ -212,7 +175,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 (Box::new([]), true)
             };
 
-        if !is_assignable_to_dynamic_class_namespace(db, namespace_type)
+        let namespace_target = UnionType::from_two_elements(
+            db,
+            KnownClass::Dict
+                .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]),
+            Type::TypedDictTop,
+        );
+
+        if !namespace_type.is_assignable_to(db, namespace_target)
             && let Some(builder) = self
                 .context
                 .report_lint(&INVALID_ARGUMENT_TYPE, namespace_arg)

--- a/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
@@ -173,7 +173,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 (Box::new([]), true)
             };
 
-        if !matches!(namespace_type, Type::TypedDict(_))
+        if !namespace_type.is_typed_dict_like()
             && !namespace_type.is_assignable_to(
                 db,
                 KnownClass::Dict

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2376,6 +2376,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             SpecialFormType::TypingSelf
             | SpecialFormType::TypeAlias
             | SpecialFormType::TypedDict
+            | SpecialFormType::TypedDictTop
             | SpecialFormType::Unknown
             | SpecialFormType::Any
             | SpecialFormType::NamedTuple => {

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -246,6 +246,7 @@ impl<'db> Type<'db> {
                 | Type::TypeIs(_)
                 | Type::TypeGuard(_)
                 | Type::TypeForm(_)
+                | Type::TypedDictTop
                 | Type::TypedDict(_) => None
             }
         }

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -348,6 +348,14 @@ impl<'db> AllMembers<'db> {
                 _ => {}
             },
 
+            Type::TypedDictTop => {
+                if let Type::ClassLiteral(ClassLiteral::Static(class)) =
+                    KnownClass::TypedDictFallback.to_class_literal(db)
+                {
+                    self.extend_with_instance_members(db, ty, class);
+                }
+            }
+
             Type::TypedDict(_) => {
                 if let Type::ClassLiteral(class_literal) = ty.to_meta_type(db) {
                     self.extend_with_class_members(db, ty, class_literal);

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -350,7 +350,7 @@ impl<'db> AllMembers<'db> {
 
             Type::TypedDictTop => {
                 if let Type::ClassLiteral(ClassLiteral::Static(class)) =
-                    KnownClass::TypedDictFallback.to_class_literal(db)
+                    KnownClass::TypedDictReadOnlyFallback.to_class_literal(db)
                 {
                     self.extend_with_instance_members(db, ty, class);
                 }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -254,6 +254,7 @@ impl ClassInfoConstraintFunction {
     fn generate_constraint<'db>(
         self,
         db: &'db dyn Db,
+        subject_ty: Type<'db>,
         classinfo: Type<'db>,
         is_positive: bool,
     ) -> Option<Type<'db>> {
@@ -261,9 +262,13 @@ impl ClassInfoConstraintFunction {
             ClassInfoConstraintFunction::IsInstance => {
                 let constraint = Type::instance(db, class.top_materialization(db));
                 if class_literal_matches_typed_dict_runtime_supertype(db, class) {
+                    let typed_dict_fallback = IntersectionBuilder::new(db)
+                        .add_positive(typed_dict_fallback_portion(db, subject_ty))
+                        .add_positive(Type::TypedDictTop)
+                        .build();
                     UnionBuilder::new(db)
                         .add(constraint)
-                        .add(Type::TypedDictTop)
+                        .add(typed_dict_fallback)
                         .build()
                 } else {
                     constraint
@@ -276,7 +281,7 @@ impl ClassInfoConstraintFunction {
 
         match classinfo {
             Type::TypeAlias(alias) => {
-                self.generate_constraint(db, alias.value_type(db), is_positive)
+                self.generate_constraint(db, subject_ty, alias.value_type(db), is_positive)
             }
             Type::ClassLiteral(class_literal) => Some(constraint_from_class_literal(class_literal)),
             Type::SubclassOf(subclass_of_ty) => {
@@ -310,6 +315,7 @@ impl ClassInfoConstraintFunction {
                     for element in intersection.positive(db) {
                         builder = builder.add_positive(self.generate_constraint(
                             db,
+                            subject_ty,
                             *element,
                             is_positive,
                         )?);
@@ -321,16 +327,15 @@ impl ClassInfoConstraintFunction {
                 }
             }
             Type::Union(union) => union.try_map(db, |element| {
-                self.generate_constraint(db, *element, is_positive)
+                self.generate_constraint(db, subject_ty, *element, is_positive)
             }),
             Type::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db)? {
                     TypeVarBoundOrConstraints::UpperBound(bound) => {
-                        self.generate_constraint(db, bound, is_positive)
+                        self.generate_constraint(db, subject_ty, bound, is_positive)
                     }
-                    TypeVarBoundOrConstraints::Constraints(constraints) => {
-                        self.generate_constraint(db, constraints.as_type(db), is_positive)
-                    }
+                    TypeVarBoundOrConstraints::Constraints(constraints) => self
+                        .generate_constraint(db, subject_ty, constraints.as_type(db), is_positive),
                 }
             }
 
@@ -341,9 +346,9 @@ impl ClassInfoConstraintFunction {
             Type::NominalInstance(nominal) => nominal.tuple_spec(db).and_then(|tuple| {
                 UnionType::try_from_elements(
                     db,
-                    tuple
-                        .iter_all_elements()
-                        .map(|element| self.generate_constraint(db, element, is_positive)),
+                    tuple.iter_all_elements().map(|element| {
+                        self.generate_constraint(db, subject_ty, element, is_positive)
+                    }),
                 )
             }),
 
@@ -358,11 +363,12 @@ impl ClassInfoConstraintFunction {
                         if element.is_none(db) {
                             self.generate_constraint(
                                 db,
+                                subject_ty,
                                 KnownClass::NoneType.to_class_literal(db),
                                 is_positive,
                             )
                         } else {
-                            self.generate_constraint(db, element, is_positive)
+                            self.generate_constraint(db, subject_ty, element, is_positive)
                         }
                     }),
                 )
@@ -371,17 +377,22 @@ impl ClassInfoConstraintFunction {
             Type::SpecialForm(form) => match form {
                 SpecialFormType::LegacyStdlibAlias(alias) => self.generate_constraint(
                     db,
+                    subject_ty,
                     alias.aliased_class().to_class_literal(db),
                     is_positive,
                 ),
                 SpecialFormType::Tuple => self.generate_constraint(
                     db,
+                    subject_ty,
                     KnownClass::Tuple.to_class_literal(db),
                     is_positive,
                 ),
-                SpecialFormType::Type => {
-                    self.generate_constraint(db, KnownClass::Type.to_class_literal(db), is_positive)
-                }
+                SpecialFormType::Type => self.generate_constraint(
+                    db,
+                    subject_ty,
+                    KnownClass::Type.to_class_literal(db),
+                    is_positive,
+                ),
 
                 // We don't have a good meta-type for `Callable`s right now,
                 // so only apply `isinstance()` narrowing, not `issubclass()`
@@ -476,6 +487,56 @@ impl<'db> Conjunctions<'db> {
             intersection = intersection.add_positive(conjunct);
         }
         intersection.build()
+    }
+}
+
+/// Return the portion of a subject type that should preserve the `Top[TypedDict]` fallback arm
+/// for dict-like `isinstance()` narrowing.
+///
+/// This keeps explicit `TypedDict` content and gradual/top-like sources such as `object`,
+/// `Any`/`Unknown`, and unconstrained type variables, while excluding ordinary structural
+/// types like `Mapping` that should not retain a `TypedDict` possibility.
+fn typed_dict_fallback_portion<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+    let ty = ty.resolve_type_alias(db);
+
+    match ty {
+        Type::Union(union) => union.map(db, |element| typed_dict_fallback_portion(db, *element)),
+        Type::Intersection(intersection)
+            if intersection
+                .positive(db)
+                .iter()
+                .all(|element| preserves_typed_dict_fallback(db, *element)) =>
+        {
+            ty
+        }
+        _ if preserves_typed_dict_fallback(db, ty) => ty,
+        _ => Type::Never,
+    }
+}
+
+/// Return `true` if this type should keep participating in the `Top[TypedDict]` fallback arm
+/// produced by dict-like `isinstance()` narrowing.
+///
+/// The intent is to preserve the fallback only for types where it still models a real
+/// possibility after narrowing, and to reject interface-only types like `Mapping` or
+/// `Iterable` that would otherwise create impossible `... & Top[TypedDict]` intersections.
+fn preserves_typed_dict_fallback<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    match ty.resolve_type_alias(db) {
+        Type::Dynamic(_) | Type::Divergent(_) | Type::TypedDict(_) | Type::TypedDictTop => true,
+        Type::NominalInstance(instance) => instance.is_object(),
+        Type::TypeVar(bound_typevar) => bound_typevar
+            .typevar(db)
+            .bound_or_constraints(db)
+            .is_none_or(|bound_or_constraints| match bound_or_constraints {
+                TypeVarBoundOrConstraints::UpperBound(bound) => {
+                    preserves_typed_dict_fallback(db, bound)
+                }
+                TypeVarBoundOrConstraints::Constraints(constraints) => constraints
+                    .elements(db)
+                    .iter()
+                    .any(|constraint| preserves_typed_dict_fallback(db, *constraint)),
+            }),
+        _ => false,
     }
 }
 
@@ -1822,10 +1883,12 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 }
 
                 let function = function.into_classinfo_constraint_function()?;
+                let first_arg_ty = inference.expression_type(first_arg_node);
 
                 function
                     .generate_constraint(
                         self.db,
+                        first_arg_ty,
                         inference.expression_type(second_arg),
                         is_positive,
                     )
@@ -1961,6 +2024,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         let mapping_type = ClassInfoConstraintFunction::IsInstance
             .generate_constraint(
                 self.db,
+                Type::object(),
                 KnownClass::Mapping.to_class_literal(self.db),
                 is_positive,
             )?

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -257,15 +257,7 @@ impl ClassInfoConstraintFunction {
     ) -> Option<Type<'db>> {
         let constraint_from_class_literal = |class: ClassLiteral<'db>| match self {
             ClassInfoConstraintFunction::IsInstance => {
-                let constraint = Type::instance(db, class.top_materialization(db));
-                if class_literal_matches_typed_dict_runtime_supertype(db, class) {
-                    UnionBuilder::new(db)
-                        .add(constraint)
-                        .add(Type::TypedDictTop)
-                        .build()
-                } else {
-                    constraint
-                }
+                runtime_instance_constraint_for_class_literal(db, class)
             }
             ClassInfoConstraintFunction::IsSubclass => {
                 SubclassOfType::from(db, class.top_materialization(db))
@@ -422,14 +414,47 @@ impl ClassInfoConstraintFunction {
     }
 }
 
-/// Returns `true` for classes that are runtime supertypes of all `TypedDict` instances
-/// (`dict` and `MutableMapping`), so that `isinstance()` narrowing can include a
-/// `TypedDictTop` arm alongside the ordinary top-materialized instance.
-fn class_literal_matches_typed_dict_runtime_supertype<'db>(
+/// Return the constraint imposed by an `isinstance()`-style runtime check against `class`.
+///
+/// `TypedDict` instances are runtime dictionaries, even though they are not statically assignable
+/// to mutable dictionary types. `Mapping` does not need an explicit `TypedDictTop` arm because
+/// `TypedDict` is already statically assignable to it.
+pub(crate) fn runtime_instance_constraint_for_class_literal<'db>(
     db: &'db dyn Db,
     class: ClassLiteral<'db>,
-) -> bool {
-    class.is_known(db, KnownClass::Dict) || class.is_known(db, KnownClass::MutableMapping)
+) -> Type<'db> {
+    let constraint = Type::instance(db, class.top_materialization(db));
+    if class.is_known(db, KnownClass::Dict) || class.is_known(db, KnownClass::MutableMapping) {
+        UnionBuilder::new(db)
+            .add(constraint)
+            .add(Type::TypedDictTop)
+            .build()
+    } else {
+        constraint
+    }
+}
+
+fn exact_class_narrowing_constraint<'db>(
+    db: &'db dyn Db,
+    class: ClassLiteral<'db>,
+    is_positive: bool,
+) -> Option<Type<'db>> {
+    let instance = Type::instance(db, class.top_materialization(db));
+    if is_positive {
+        Some(if class.is_known(db, KnownClass::Dict) {
+            runtime_instance_constraint_for_class_literal(db, class)
+        } else {
+            instance
+        })
+    } else if class.is_final(db) {
+        Some(instance.negate(db))
+    } else if class.is_known(db, KnownClass::Dict) {
+        // `dict` subclasses can fail an exact-class check, but `TypedDict` instances cannot:
+        // every `TypedDict` inhabitant has an exact runtime type of `dict`.
+        Some(Type::TypedDictTop.negate(db))
+    } else {
+        None
+    }
 }
 
 fn negate_classinfo_constraint<'db>(db: &'db dyn Db, constraint: Type<'db>) -> Type<'db> {
@@ -1679,18 +1704,11 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 if let Some(is_positive) = is_positive
                     && let Some(target) = PlaceExpr::try_from_expr(target_expr)
                     && let Some(other_class) = find_underlying_class(self.db, other)
-                    // `else`-branch narrowing for `if type(x) is Y` can only be done
-                    // if `Y` is a final class
-                    && (is_positive || other_class.is_final(self.db))
+                    && let Some(constraint) =
+                        exact_class_narrowing_constraint(self.db, other_class, is_positive)
                 {
                     let place = self.expect_place(&target);
-                    constraints.insert(
-                        place,
-                        NarrowingConstraint::intersection(
-                            Type::instance(self.db, other_class.top_materialization(self.db))
-                                .negate_if(self.db, !is_positive),
-                        ),
-                    );
+                    constraints.insert(place, NarrowingConstraint::intersection(constraint));
                 }
             }
 
@@ -1930,8 +1948,12 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
         let narrowed_type = match class_type {
             Type::ClassLiteral(class) => {
-                Type::instance(self.db, class.top_materialization(self.db))
-                    .negate_if(self.db, !is_positive)
+                let constraint = runtime_instance_constraint_for_class_literal(self.db, class);
+                if is_positive {
+                    constraint
+                } else {
+                    negate_classinfo_constraint(self.db, constraint)
+                }
             }
             dynamic @ Type::Dynamic(_) => dynamic,
             _ => return None,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -490,7 +490,7 @@ impl<'db> Conjunctions<'db> {
     }
 }
 
-/// Return the portion of a subject type that should preserve the `Top[TypedDict]` fallback arm
+/// Return the portion of a subject type that should preserve the `TypedDictTop` fallback arm
 /// for dict-like `isinstance()` narrowing.
 ///
 /// This keeps explicit `TypedDict` content and gradual/top-like sources such as `object`,
@@ -514,12 +514,12 @@ fn typed_dict_fallback_portion<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db>
     }
 }
 
-/// Return `true` if this type should keep participating in the `Top[TypedDict]` fallback arm
+/// Return `true` if this type should keep participating in the `TypedDictTop` fallback arm
 /// produced by dict-like `isinstance()` narrowing.
 ///
 /// The intent is to preserve the fallback only for types where it still models a real
 /// possibility after narrowing, and to reject interface-only types like `Mapping` or
-/// `Iterable` that would otherwise create impossible `... & Top[TypedDict]` intersections.
+/// `Iterable` that would otherwise create impossible `... & TypedDictTop` intersections.
 fn preserves_typed_dict_fallback<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     match ty.resolve_type_alias(db) {
         Type::Dynamic(_) | Type::Divergent(_) | Type::TypedDict(_) | Type::TypedDictTop => true,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1,4 +1,5 @@
 use crate::Db;
+use crate::place::known_module_symbol;
 use crate::reachability::{ReachabilityConstraintsExtension, sequence_pattern_type};
 use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
@@ -33,6 +34,7 @@ use ruff_python_ast::{BoolOp, ExprBoolOp};
 use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec, smallvec_inline};
 use std::collections::hash_map::Entry;
+use ty_module_resolver::KnownModule;
 
 fn is_union_of_single_valued<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     let ty = ty.resolve_type_alias(db);
@@ -257,7 +259,15 @@ impl ClassInfoConstraintFunction {
     ) -> Option<Type<'db>> {
         let constraint_from_class_literal = |class: ClassLiteral<'db>| match self {
             ClassInfoConstraintFunction::IsInstance => {
-                Type::instance(db, class.top_materialization(db))
+                let constraint = Type::instance(db, class.top_materialization(db));
+                if class_literal_matches_typed_dict_runtime_supertype(db, class) {
+                    UnionBuilder::new(db)
+                        .add(constraint)
+                        .add(Type::TypedDictTop)
+                        .build()
+                } else {
+                    constraint
+                }
             }
             ClassInfoConstraintFunction::IsSubclass => {
                 SubclassOfType::from(db, class.top_materialization(db))
@@ -407,10 +417,30 @@ impl ClassInfoConstraintFunction {
             | Type::TypeForm(_)
             | Type::WrapperDescriptor(_)
             | Type::DataclassTransformer(_)
+            | Type::TypedDictTop
             | Type::TypedDict(_)
             | Type::NewTypeInstance(_) => None,
         }
     }
+}
+
+/// Returns `true` for classes that are runtime supertypes of all `TypedDict` instances
+/// (`dict` and `MutableMapping`), so that `isinstance()` narrowing can include a
+/// `TypedDictTop` arm alongside the ordinary top-materialized instance.
+///
+/// `Mapping` is intentionally excluded: `TypedDict` is already statically compatible with
+/// `Mapping[str, object]`, so the extra `TypedDictTop` arm would simplify away during
+/// intersection and is not needed.
+fn class_literal_matches_typed_dict_runtime_supertype<'db>(
+    db: &'db dyn Db,
+    class: ClassLiteral<'db>,
+) -> bool {
+    let mutable_mapping = known_module_symbol(db, KnownModule::Typing, "MutableMapping")
+        .place
+        .ignore_possibly_undefined()
+        .and_then(Type::as_class_literal);
+
+    class.is_known(db, KnownClass::Dict) || mutable_mapping == Some(class)
 }
 
 #[derive(Hash, PartialEq, Debug, Eq, Clone, salsa::Update, get_size2::GetSize)]
@@ -419,14 +449,16 @@ struct Conjunctions<'db> {
 }
 
 impl<'db> Conjunctions<'db> {
-    fn singleton(ty: Type<'db>) -> Self {
+    fn singleton(constraint: Type<'db>) -> Self {
         Self {
-            conjuncts: smallvec![ty],
+            conjuncts: smallvec![constraint],
         }
     }
 
     fn and_with(mut self, other: Self) -> Self {
-        if self.conjuncts.iter().any(Type::is_never) || other.conjuncts.iter().any(Type::is_never) {
+        let has_never = |constraint: &Type<'db>| constraint.is_never();
+
+        if self.conjuncts.iter().any(has_never) || other.conjuncts.iter().any(has_never) {
             return Self::singleton(Type::Never);
         }
 
@@ -438,12 +470,8 @@ impl<'db> Conjunctions<'db> {
         self
     }
 
-    fn evaluate_constraint_type(self, db: &'db dyn Db) -> Type<'db> {
-        if self.conjuncts.len() == 1 {
-            return self.conjuncts[0];
-        }
-
-        let mut intersection = IntersectionBuilder::new(db);
+    fn evaluate_constraint_type(self, db: &'db dyn Db, base_ty: Type<'db>) -> Type<'db> {
+        let mut intersection = IntersectionBuilder::new(db).add_positive(base_ty);
         for conjunct in self.conjuncts {
             intersection = intersection.add_positive(conjunct);
         }
@@ -505,6 +533,10 @@ impl<'db> NarrowingConstraint<'db> {
         }
     }
 
+    fn classinfo(constraint: Type<'db>) -> Self {
+        Self::intersection(constraint)
+    }
+
     /// Merge two constraints, taking their intersection but respecting "replacement" semantics (with
     /// `other` winning)
     pub(crate) fn merge_constraint_and(&self, other: Self) -> Self {
@@ -558,17 +590,14 @@ impl<'db> NarrowingConstraint<'db> {
         }
     }
 
-    /// Evaluate the type this effectively constrains to
-    ///
-    /// Forgets whether each constraint originated from a `replacement` disjunct or not
-    pub(crate) fn evaluate_constraint_type(self, db: &'db dyn Db) -> Type<'db> {
+    /// Apply the constraint to a base type.
+    pub(crate) fn narrow_base_type(self, db: &'db dyn Db, base_ty: Type<'db>) -> Type<'db> {
         let mut union = UnionBuilder::new(db);
-        for conjunctions in self
-            .replacement_disjuncts
-            .into_iter()
-            .chain(self.intersection_disjuncts)
-        {
-            union = union.add(conjunctions.evaluate_constraint_type(db));
+        for conjunctions in self.replacement_disjuncts {
+            union = union.add(conjunctions.evaluate_constraint_type(db, Type::object()));
+        }
+        for conjunctions in self.intersection_disjuncts {
+            union = union.add(conjunctions.evaluate_constraint_type(db, base_ty));
         }
         union.build()
     }
@@ -1762,10 +1791,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 }
             }
             Type::FunctionLiteral(function_type) if expr_call.arguments.keywords.is_empty() => {
-                let [first_arg, second_arg] = &*expr_call.arguments.args else {
+                let [first_arg_node, second_arg] = &*expr_call.arguments.args else {
                     return None;
                 };
-                let first_arg = PlaceExpr::try_from_expr(first_arg)?;
+                let first_arg = PlaceExpr::try_from_expr(first_arg_node)?;
                 let function = function_type.known(self.db)?;
                 let place = self.expect_place(&first_arg);
 
@@ -1794,15 +1823,17 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
                 let function = function.into_classinfo_constraint_function()?;
 
-                let class_info_ty = inference.expression_type(second_arg);
-
                 function
-                    .generate_constraint(self.db, class_info_ty, is_positive)
-                    .map(|constraint| {
+                    .generate_constraint(
+                        self.db,
+                        inference.expression_type(second_arg),
+                        is_positive,
+                    )
+                    .map(|classinfo| {
                         NarrowingConstraints::from_iter([(
                             place,
-                            NarrowingConstraint::intersection(
-                                constraint.negate_if(self.db, !is_positive),
+                            NarrowingConstraint::classinfo(
+                                classinfo.negate_if(self.db, !is_positive),
                             ),
                         )])
                     })
@@ -2292,6 +2323,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 fn is_or_contains_typeddict<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     match ty {
         Type::TypedDict(_) => true,
+        Type::TypedDictTop => false,
         Type::Intersection(intersection) => intersection
             .positive(db)
             .iter()
@@ -2382,6 +2414,7 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
 
     match ty {
         Type::TypedDict(td) => matching_field_is_literal(&td),
+        Type::TypedDictTop => false,
         Type::Union(union) => union.elements(db).iter().all(|union_member_ty| {
             !is_or_contains_typeddict(db, *union_member_ty)
                 || all_matching_typeddict_fields_have_literal_types(

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -34,7 +34,6 @@ use ruff_python_ast::{BoolOp, ExprBoolOp};
 use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec, smallvec_inline};
 use std::collections::hash_map::Entry;
-use ty_module_resolver::KnownModule;
 
 fn is_union_of_single_valued<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     let ty = ty.resolve_type_alias(db);
@@ -254,7 +253,6 @@ impl ClassInfoConstraintFunction {
     fn generate_constraint<'db>(
         self,
         db: &'db dyn Db,
-        subject_ty: Type<'db>,
         classinfo: Type<'db>,
         is_positive: bool,
     ) -> Option<Type<'db>> {
@@ -262,13 +260,9 @@ impl ClassInfoConstraintFunction {
             ClassInfoConstraintFunction::IsInstance => {
                 let constraint = Type::instance(db, class.top_materialization(db));
                 if class_literal_matches_typed_dict_runtime_supertype(db, class) {
-                    let typed_dict_fallback = IntersectionBuilder::new(db)
-                        .add_positive(typed_dict_fallback_portion(db, subject_ty))
-                        .add_positive(Type::TypedDictTop)
-                        .build();
                     UnionBuilder::new(db)
                         .add(constraint)
-                        .add(typed_dict_fallback)
+                        .add(Type::TypedDictTop)
                         .build()
                 } else {
                     constraint
@@ -281,7 +275,7 @@ impl ClassInfoConstraintFunction {
 
         match classinfo {
             Type::TypeAlias(alias) => {
-                self.generate_constraint(db, subject_ty, alias.value_type(db), is_positive)
+                self.generate_constraint(db, alias.value_type(db), is_positive)
             }
             Type::ClassLiteral(class_literal) => Some(constraint_from_class_literal(class_literal)),
             Type::SubclassOf(subclass_of_ty) => {
@@ -315,7 +309,6 @@ impl ClassInfoConstraintFunction {
                     for element in intersection.positive(db) {
                         builder = builder.add_positive(self.generate_constraint(
                             db,
-                            subject_ty,
                             *element,
                             is_positive,
                         )?);
@@ -327,15 +320,16 @@ impl ClassInfoConstraintFunction {
                 }
             }
             Type::Union(union) => union.try_map(db, |element| {
-                self.generate_constraint(db, subject_ty, *element, is_positive)
+                self.generate_constraint(db, *element, is_positive)
             }),
             Type::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db)? {
                     TypeVarBoundOrConstraints::UpperBound(bound) => {
-                        self.generate_constraint(db, subject_ty, bound, is_positive)
+                        self.generate_constraint(db, bound, is_positive)
                     }
-                    TypeVarBoundOrConstraints::Constraints(constraints) => self
-                        .generate_constraint(db, subject_ty, constraints.as_type(db), is_positive),
+                    TypeVarBoundOrConstraints::Constraints(constraints) => {
+                        self.generate_constraint(db, constraints.as_type(db), is_positive)
+                    }
                 }
             }
 
@@ -346,9 +340,9 @@ impl ClassInfoConstraintFunction {
             Type::NominalInstance(nominal) => nominal.tuple_spec(db).and_then(|tuple| {
                 UnionType::try_from_elements(
                     db,
-                    tuple.iter_all_elements().map(|element| {
-                        self.generate_constraint(db, subject_ty, element, is_positive)
-                    }),
+                    tuple
+                        .iter_all_elements()
+                        .map(|element| self.generate_constraint(db, element, is_positive)),
                 )
             }),
 
@@ -363,12 +357,11 @@ impl ClassInfoConstraintFunction {
                         if element.is_none(db) {
                             self.generate_constraint(
                                 db,
-                                subject_ty,
                                 KnownClass::NoneType.to_class_literal(db),
                                 is_positive,
                             )
                         } else {
-                            self.generate_constraint(db, subject_ty, element, is_positive)
+                            self.generate_constraint(db, element, is_positive)
                         }
                     }),
                 )
@@ -377,22 +370,17 @@ impl ClassInfoConstraintFunction {
             Type::SpecialForm(form) => match form {
                 SpecialFormType::LegacyStdlibAlias(alias) => self.generate_constraint(
                     db,
-                    subject_ty,
                     alias.aliased_class().to_class_literal(db),
                     is_positive,
                 ),
                 SpecialFormType::Tuple => self.generate_constraint(
                     db,
-                    subject_ty,
                     KnownClass::Tuple.to_class_literal(db),
                     is_positive,
                 ),
-                SpecialFormType::Type => self.generate_constraint(
-                    db,
-                    subject_ty,
-                    KnownClass::Type.to_class_literal(db),
-                    is_positive,
-                ),
+                SpecialFormType::Type => {
+                    self.generate_constraint(db, KnownClass::Type.to_class_literal(db), is_positive)
+                }
 
                 // We don't have a good meta-type for `Callable`s right now,
                 // so only apply `isinstance()` narrowing, not `issubclass()`
@@ -438,20 +426,24 @@ impl ClassInfoConstraintFunction {
 /// Returns `true` for classes that are runtime supertypes of all `TypedDict` instances
 /// (`dict` and `MutableMapping`), so that `isinstance()` narrowing can include a
 /// `TypedDictTop` arm alongside the ordinary top-materialized instance.
-///
-/// `Mapping` is intentionally excluded: `TypedDict` is already statically compatible with
-/// `Mapping[str, object]`, so the extra `TypedDictTop` arm would simplify away during
-/// intersection and is not needed.
 fn class_literal_matches_typed_dict_runtime_supertype<'db>(
     db: &'db dyn Db,
     class: ClassLiteral<'db>,
 ) -> bool {
-    let mutable_mapping = known_module_symbol(db, KnownModule::Typing, "MutableMapping")
-        .place
-        .ignore_possibly_undefined()
-        .and_then(Type::as_class_literal);
+    class.is_known(db, KnownClass::Dict) || class.is_known(db, KnownClass::MutableMapping)
+}
 
-    class.is_known(db, KnownClass::Dict) || mutable_mapping == Some(class)
+fn negate_classinfo_constraint<'db>(db: &'db dyn Db, constraint: Type<'db>) -> Type<'db> {
+    match constraint {
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .fold(IntersectionBuilder::new(db), |builder, element| {
+                builder.add_negative(*element)
+            })
+            .build(),
+        _ => constraint.negate(db),
+    }
 }
 
 #[derive(Hash, PartialEq, Debug, Eq, Clone, salsa::Update, get_size2::GetSize)]
@@ -487,56 +479,6 @@ impl<'db> Conjunctions<'db> {
             intersection = intersection.add_positive(conjunct);
         }
         intersection.build()
-    }
-}
-
-/// Return the portion of a subject type that should preserve the `TypedDictTop` fallback arm
-/// for dict-like `isinstance()` narrowing.
-///
-/// This keeps explicit `TypedDict` content and gradual/top-like sources such as `object`,
-/// `Any`/`Unknown`, and unconstrained type variables, while excluding ordinary structural
-/// types like `Mapping` that should not retain a `TypedDict` possibility.
-fn typed_dict_fallback_portion<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
-    let ty = ty.resolve_type_alias(db);
-
-    match ty {
-        Type::Union(union) => union.map(db, |element| typed_dict_fallback_portion(db, *element)),
-        Type::Intersection(intersection)
-            if intersection
-                .positive(db)
-                .iter()
-                .all(|element| preserves_typed_dict_fallback(db, *element)) =>
-        {
-            ty
-        }
-        _ if preserves_typed_dict_fallback(db, ty) => ty,
-        _ => Type::Never,
-    }
-}
-
-/// Return `true` if this type should keep participating in the `TypedDictTop` fallback arm
-/// produced by dict-like `isinstance()` narrowing.
-///
-/// The intent is to preserve the fallback only for types where it still models a real
-/// possibility after narrowing, and to reject interface-only types like `Mapping` or
-/// `Iterable` that would otherwise create impossible `... & TypedDictTop` intersections.
-fn preserves_typed_dict_fallback<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-    match ty.resolve_type_alias(db) {
-        Type::Dynamic(_) | Type::Divergent(_) | Type::TypedDict(_) | Type::TypedDictTop => true,
-        Type::NominalInstance(instance) => instance.is_object(),
-        Type::TypeVar(bound_typevar) => bound_typevar
-            .typevar(db)
-            .bound_or_constraints(db)
-            .is_none_or(|bound_or_constraints| match bound_or_constraints {
-                TypeVarBoundOrConstraints::UpperBound(bound) => {
-                    preserves_typed_dict_fallback(db, bound)
-                }
-                TypeVarBoundOrConstraints::Constraints(constraints) => constraints
-                    .elements(db)
-                    .iter()
-                    .any(|constraint| preserves_typed_dict_fallback(db, *constraint)),
-            }),
-        _ => false,
     }
 }
 
@@ -1883,21 +1825,21 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 }
 
                 let function = function.into_classinfo_constraint_function()?;
-                let first_arg_ty = inference.expression_type(first_arg_node);
 
                 function
                     .generate_constraint(
                         self.db,
-                        first_arg_ty,
                         inference.expression_type(second_arg),
                         is_positive,
                     )
                     .map(|classinfo| {
                         NarrowingConstraints::from_iter([(
                             place,
-                            NarrowingConstraint::classinfo(
-                                classinfo.negate_if(self.db, !is_positive),
-                            ),
+                            NarrowingConstraint::classinfo(if is_positive {
+                                classinfo
+                            } else {
+                                negate_classinfo_constraint(self.db, classinfo)
+                            }),
                         )])
                     })
             }
@@ -2021,14 +1963,16 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
         let place = self.expect_place(&subject);
 
-        let mapping_type = ClassInfoConstraintFunction::IsInstance
-            .generate_constraint(
-                self.db,
-                Type::object(),
-                KnownClass::Mapping.to_class_literal(self.db),
-                is_positive,
-            )?
-            .negate_if(self.db, !is_positive);
+        let mapping_type = ClassInfoConstraintFunction::IsInstance.generate_constraint(
+            self.db,
+            KnownClass::Mapping.to_class_literal(self.db),
+            is_positive,
+        )?;
+        let mapping_type = if is_positive {
+            mapping_type
+        } else {
+            negate_classinfo_constraint(self.db, mapping_type)
+        };
 
         Some(NarrowingConstraints::from_iter([(
             place,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1,5 +1,4 @@
 use crate::Db;
-use crate::place::known_module_symbol;
 use crate::reachability::{ReachabilityConstraintsExtension, sequence_pattern_type};
 use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
@@ -452,16 +451,14 @@ struct Conjunctions<'db> {
 }
 
 impl<'db> Conjunctions<'db> {
-    fn singleton(constraint: Type<'db>) -> Self {
+    fn singleton(ty: Type<'db>) -> Self {
         Self {
-            conjuncts: smallvec![constraint],
+            conjuncts: smallvec![ty],
         }
     }
 
     fn and_with(mut self, other: Self) -> Self {
-        let has_never = |constraint: &Type<'db>| constraint.is_never();
-
-        if self.conjuncts.iter().any(has_never) || other.conjuncts.iter().any(has_never) {
+        if self.conjuncts.iter().any(Type::is_never) || other.conjuncts.iter().any(Type::is_never) {
             return Self::singleton(Type::Never);
         }
 
@@ -534,10 +531,6 @@ impl<'db> NarrowingConstraint<'db> {
             intersection_disjuncts: smallvec![],
             replacement_disjuncts: smallvec_inline![Conjunctions::singleton(constraint)],
         }
-    }
-
-    fn classinfo(constraint: Type<'db>) -> Self {
-        Self::intersection(constraint)
     }
 
     /// Merge two constraints, taking their intersection but respecting "replacement" semantics (with
@@ -1794,10 +1787,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 }
             }
             Type::FunctionLiteral(function_type) if expr_call.arguments.keywords.is_empty() => {
-                let [first_arg_node, second_arg] = &*expr_call.arguments.args else {
+                let [first_arg, second_arg] = &*expr_call.arguments.args else {
                     return None;
                 };
-                let first_arg = PlaceExpr::try_from_expr(first_arg_node)?;
+                let first_arg = PlaceExpr::try_from_expr(first_arg)?;
                 let function = function_type.known(self.db)?;
                 let place = self.expect_place(&first_arg);
 
@@ -1835,7 +1828,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     .map(|classinfo| {
                         NarrowingConstraints::from_iter([(
                             place,
-                            NarrowingConstraint::classinfo(if is_positive {
+                            NarrowingConstraint::intersection(if is_positive {
                                 classinfo
                             } else {
                                 negate_classinfo_constraint(self.db, classinfo)
@@ -1963,16 +1956,13 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
         let place = self.expect_place(&subject);
 
-        let mapping_type = ClassInfoConstraintFunction::IsInstance.generate_constraint(
-            self.db,
-            KnownClass::Mapping.to_class_literal(self.db),
-            is_positive,
-        )?;
-        let mapping_type = if is_positive {
-            mapping_type
-        } else {
-            negate_classinfo_constraint(self.db, mapping_type)
-        };
+        let mapping_type = ClassInfoConstraintFunction::IsInstance
+            .generate_constraint(
+                self.db,
+                KnownClass::Mapping.to_class_literal(self.db),
+                is_positive,
+            )?
+            .negate_if(self.db, !is_positive);
 
         Some(NarrowingConstraints::from_iter([(
             place,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -425,10 +425,7 @@ pub(crate) fn runtime_instance_constraint_for_class_literal<'db>(
 ) -> Type<'db> {
     let constraint = Type::instance(db, class.top_materialization(db));
     if class.is_known(db, KnownClass::Dict) || class.is_known(db, KnownClass::MutableMapping) {
-        UnionBuilder::new(db)
-            .add(constraint)
-            .add(Type::TypedDictTop)
-            .build()
+        UnionType::from_two_elements(db, constraint, Type::TypedDictTop)
     } else {
         constraint
     }
@@ -454,19 +451,6 @@ fn exact_class_narrowing_constraint<'db>(
         Some(Type::TypedDictTop.negate(db))
     } else {
         None
-    }
-}
-
-fn negate_classinfo_constraint<'db>(db: &'db dyn Db, constraint: Type<'db>) -> Type<'db> {
-    match constraint {
-        Type::Union(union) => union
-            .elements(db)
-            .iter()
-            .fold(IntersectionBuilder::new(db), |builder, element| {
-                builder.add_negative(*element)
-            })
-            .build(),
-        _ => constraint.negate(db),
     }
 }
 
@@ -1849,7 +1833,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                             NarrowingConstraint::intersection(if is_positive {
                                 classinfo
                             } else {
-                                negate_classinfo_constraint(self.db, classinfo)
+                                classinfo.negate(self.db)
                             }),
                         )])
                     })
@@ -1952,7 +1936,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 if is_positive {
                     constraint
                 } else {
-                    negate_classinfo_constraint(self.db, constraint)
+                    constraint.negate(self.db)
                 }
             }
             dynamic @ Type::Dynamic(_) => dynamic,

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -3076,16 +3076,17 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             (Type::TypedDictTop | Type::TypedDict(_), Type::TypedDictTop)
             | (Type::TypedDictTop, Type::TypedDict(_)) => self.never(),
 
-            // Other than the special cases enumerated above,
-            // a typeddict type is always disjoint from any type that is not
-            // a supertype of `Top[Mapping[str, Any]]`.
+            // Other than the special cases enumerated above, a TypedDict type is always disjoint
+            // from any type that is not a supertype of `dict[str, Any]`. TypedDict is not
+            // statically assignable to mutable dictionary types, but every inhabitant is a
+            // runtime `dict`, so disjointness must preserve that possible overlap.
             (Type::TypedDictTop | Type::TypedDict(_), other)
             | (other, Type::TypedDictTop | Type::TypedDict(_)) => {
-                let mapping_str_any = KnownClass::Mapping
+                let dict_str_any = KnownClass::Dict
                     .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]);
 
                 self.as_relation_checker(TypeRelation::Assignability)
-                    .check_type_pair(db, mapping_str_any, other)
+                    .check_type_pair(db, dict_str_any, other)
                     .negate(db, self.constraints)
             }
         }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -295,6 +295,7 @@ impl<'db> Type<'db> {
             | Type::TypeIs(_)
             | Type::TypeGuard(_)
             | Type::TypeForm(_)
+            | Type::TypedDictTop
             | Type::TypedDict(_)
             | Type::TypeAlias(_)
             | Type::NewTypeInstance(_) => false,
@@ -1756,27 +1757,32 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 })
             }
 
+            (Type::TypedDict(_) | Type::TypedDictTop, Type::TypedDictTop) => self.always(),
+
             // TODO: When we support `closed` and/or `extra_items`, we could allow assignments to other
             // compatible `Mapping`s. `extra_items` could also allow for some assignments to `dict`, as
             // long as `total=False`. (But then again, does anyone want a non-total `TypedDict` where all
             // key types are a supertype of the extra items type?)
-            (Type::TypedDict(typed_dict), _) => self.with_recursion_guard(source, target, || {
-                let spec = &[KnownClass::Str.to_instance(db), Type::object()];
-                let str_object_map = KnownClass::Mapping.to_specialized_instance(db, spec);
-                let result = self.check_type_pair(db, str_object_map, target);
-                if result.is_never_satisfied(db) {
-                    if let Type::NominalInstance(instance) = target
+            (Type::TypedDict(_) | Type::TypedDictTop, _) => {
+                self.with_recursion_guard(source, target, || {
+                    let spec = &[KnownClass::Str.to_instance(db), Type::object()];
+                    let str_object_map = KnownClass::Mapping.to_specialized_instance(db, spec);
+                    let result = self.check_type_pair(db, str_object_map, target);
+                    if result.is_never_satisfied(db)
+                        && let Type::NominalInstance(instance) = target
                         && instance.class(db).is_known(db, KnownClass::Dict)
+                        && let Type::TypedDict(typed_dict) = source
                     {
                         self.provide_context(|| {
                             ErrorContext::TypedDictNotAssignableToDict(typed_dict)
                         });
                     }
-                }
-                result
-            }),
+                    result
+                })
+            }
 
             // A non-`TypedDict` cannot subtype a `TypedDict`
+            (_, Type::TypedDictTop) => self.never(),
             (_, Type::TypedDict(_)) => self.never(),
 
             // A string literal `Literal["abc"]` is assignable to `str` *and* to
@@ -2704,6 +2710,23 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 })
             }
 
+            (Type::ProtocolInstance(protocol), Type::TypedDictTop)
+            | (Type::TypedDictTop, Type::ProtocolInstance(protocol)) => {
+                self.with_recursion_guard(left, right, || {
+                    self.any_protocol_members_absent_or_disjoint(
+                        db,
+                        protocol,
+                        KnownClass::TypedDictFallback.to_instance(db),
+                    )
+                })
+            }
+
+            (Type::ProtocolInstance(protocol), typed_dict @ Type::TypedDict(_))
+            | (typed_dict @ Type::TypedDict(_), Type::ProtocolInstance(protocol)) => self
+                .with_recursion_guard(left, right, || {
+                    self.any_protocol_members_absent_or_disjoint(db, protocol, typed_dict)
+                }),
+
             (Type::ProtocolInstance(protocol), other)
             | (other, Type::ProtocolInstance(protocol)) => {
                 self.with_recursion_guard(left, right, || {
@@ -3050,16 +3073,19 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 })
             }
 
-            // For any type `T`, if `dict[str, Any]` is not assignable to `T`, then all `TypedDict`
-            // types will always be disjoint from `T`. This doesn't cover all cases -- in fact
-            // `dict` *itself* is almost always disjoint from `TypedDict` -- but it's a good
-            // approximation, and some false negatives are acceptable.
-            (Type::TypedDict(_), other) | (other, Type::TypedDict(_)) => {
-                let dict_str_any = KnownClass::Dict
+            (Type::TypedDictTop | Type::TypedDict(_), Type::TypedDictTop)
+            | (Type::TypedDictTop, Type::TypedDict(_)) => self.never(),
+
+            // Other than the special cases enumerated above,
+            // a typeddict type is always disjoint from any type that is not
+            // a supertype of `Top[Mapping[str, Any]]`.
+            (Type::TypedDictTop | Type::TypedDict(_), other)
+            | (other, Type::TypedDictTop | Type::TypedDict(_)) => {
+                let mapping_str_any = KnownClass::Mapping
                     .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]);
 
                 self.as_relation_checker(TypeRelation::Assignability)
-                    .check_type_pair(db, dict_str_any, other)
+                    .check_type_pair(db, mapping_str_any, other)
                     .negate(db, self.constraints)
             }
         }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -13,11 +13,12 @@ use crate::types::enums::is_single_member_enum;
 use crate::types::function::FunctionDecorators;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::signatures::{ParametersKind, SignatureRelationVisitor};
+use crate::types::typed_dict::TypedDictField;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
     MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType, SubclassOfInner,
-    SubclassOfType, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
+    SubclassOfType, TypeVarBoundOrConstraints, TypedDictType, UnionType, UpcastPolicy,
 };
 use crate::{
     Db,
@@ -3073,9 +3074,12 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             // from any type that cannot overlap with `dict[str, Any]`. TypedDict is not statically
             // assignable to mutable dictionary types, but every inhabitant is a runtime `dict`,
             // so disjointness must preserve that possible overlap.
-            (Type::TypedDictTop | Type::TypedDict(_), other)
-            | (other, Type::TypedDictTop | Type::TypedDict(_)) => {
-                self.check_typed_dict_runtime_dict_disjointness(db, other)
+            (Type::TypedDictTop, other) | (other, Type::TypedDictTop) => {
+                self.check_typed_dict_runtime_dict_disjointness(db, None, other)
+            }
+
+            (Type::TypedDict(typed_dict), other) | (other, Type::TypedDict(typed_dict)) => {
+                self.check_typed_dict_runtime_dict_disjointness(db, Some(typed_dict), other)
             }
         }
     }
@@ -3083,6 +3087,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
     fn check_typed_dict_runtime_dict_disjointness(
         &self,
         db: &'db dyn Db,
+        typed_dict: Option<TypedDictType<'db>>,
         other: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
         let other_mapping = other
@@ -3104,13 +3109,21 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 })
             });
 
-        // A TypedDict only has string keys at runtime. Comparing that guarantee against the
-        // projected Mapping key preserves overlap with wider key types without relying on the
-        // invariant assignability of dict.
-        if let Some(other_mapping) = other_mapping
-            && let Some(other_key) = other_mapping.types(db).first()
-        {
-            return self.check_type_pair(db, KnownClass::Str.to_instance(db), *other_key);
+        if let Some(other_mapping) = other_mapping {
+            // A concrete TypedDict with a required field must contain at least one string key, so
+            // it cannot overlap a Mapping whose key type is disjoint from str. TypedDictTop and
+            // optional-only schemas may be empty, however: `{}` can inhabit both an optional-only
+            // TypedDict and `dict[Never, Never]`, so key types alone cannot prove disjointness.
+            if typed_dict.is_some_and(|typed_dict| {
+                typed_dict
+                    .items(db)
+                    .values()
+                    .any(TypedDictField::is_required)
+            }) && let Some(other_key) = other_mapping.types(db).first()
+            {
+                return self.check_type_pair(db, KnownClass::Str.to_instance(db), *other_key);
+            }
+            return self.never();
         }
 
         self.as_relation_checker(TypeRelation::Assignability)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2332,6 +2332,23 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             })
     }
 
+    fn any_protocol_members_absent(
+        &self,
+        db: &'db dyn Db,
+        protocol: ProtocolInstanceType<'db>,
+        other: Type<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        protocol
+            .interface(db)
+            .members(db)
+            .when_any(db, self.constraints, |member| {
+                ConstraintSet::from_bool(
+                    self.constraints,
+                    other.member(db, member.name()).place.is_undefined(),
+                )
+            })
+    }
+
     pub(super) fn always(&self) -> ConstraintSet<'db, 'c> {
         ConstraintSet::from_bool(self.constraints, true)
     }
@@ -2711,10 +2728,13 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 })
             }
 
+            // TypedDict inhabitants have exact runtime type `dict`. Protocol member types cannot
+            // prove disjointness here because runtime protocol checks only inspect attribute
+            // presence.
             (Type::ProtocolInstance(protocol), Type::TypedDictTop | Type::TypedDict(_))
             | (Type::TypedDictTop | Type::TypedDict(_), Type::ProtocolInstance(protocol)) => self
                 .with_recursion_guard(left, right, || {
-                    self.any_protocol_members_absent_or_disjoint(
+                    self.any_protocol_members_absent(
                         db,
                         protocol,
                         Self::typed_dict_runtime_dict(db),

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -3077,19 +3077,47 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             | (Type::TypedDictTop, Type::TypedDict(_)) => self.never(),
 
             // Other than the special cases enumerated above, a TypedDict type is always disjoint
-            // from any type that is not a supertype of `dict[str, Any]`. TypedDict is not
-            // statically assignable to mutable dictionary types, but every inhabitant is a
-            // runtime `dict`, so disjointness must preserve that possible overlap.
+            // from any type that cannot overlap with `dict[str, Any]`. TypedDict is not statically
+            // assignable to mutable dictionary types, but every inhabitant is a runtime `dict`,
+            // so disjointness must preserve that possible overlap.
             (Type::TypedDictTop | Type::TypedDict(_), other)
             | (other, Type::TypedDictTop | Type::TypedDict(_)) => {
-                let dict_str_any = KnownClass::Dict
-                    .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]);
-
-                self.as_relation_checker(TypeRelation::Assignability)
-                    .check_type_pair(db, dict_str_any, other)
-                    .negate(db, self.constraints)
+                self.check_typed_dict_runtime_dict_disjointness(db, other)
             }
         }
+    }
+
+    fn check_typed_dict_runtime_dict_disjointness(
+        &self,
+        db: &'db dyn Db,
+        other: Type<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        let other_mapping = KnownClass::Mapping
+            .try_to_class_literal(db)
+            .and_then(|mapping| {
+                other.nominal_class(db)?.iter_mro(db).find_map(|base| {
+                    let ClassType::Generic(alias) = base.into_class()? else {
+                        return None;
+                    };
+                    (alias.origin(db) == mapping).then(|| alias.specialization(db))
+                })
+            });
+
+        // A TypedDict only has string keys at runtime. Comparing that guarantee against the
+        // projected Mapping key preserves overlap with wider key types without relying on the
+        // invariant assignability of dict.
+        if let Some(other_mapping) = other_mapping
+            && let Some(other_key) = other_mapping.types(db).first()
+        {
+            return self.check_type_pair(db, KnownClass::Str.to_instance(db), *other_key);
+        }
+
+        let dict_str_any = KnownClass::Dict
+            .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]);
+
+        self.as_relation_checker(TypeRelation::Assignability)
+            .check_type_pair(db, dict_str_any, other)
+            .negate(db, self.constraints)
     }
 
     fn check_property_instance_pair(

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2710,21 +2710,14 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 })
             }
 
-            (Type::ProtocolInstance(protocol), Type::TypedDictTop)
-            | (Type::TypedDictTop, Type::ProtocolInstance(protocol)) => {
-                self.with_recursion_guard(left, right, || {
+            (Type::ProtocolInstance(protocol), Type::TypedDictTop | Type::TypedDict(_))
+            | (Type::TypedDictTop | Type::TypedDict(_), Type::ProtocolInstance(protocol)) => self
+                .with_recursion_guard(left, right, || {
                     self.any_protocol_members_absent_or_disjoint(
                         db,
                         protocol,
-                        KnownClass::TypedDictFallback.to_instance(db),
+                        Self::typed_dict_runtime_dict(db),
                     )
-                })
-            }
-
-            (Type::ProtocolInstance(protocol), typed_dict @ Type::TypedDict(_))
-            | (typed_dict @ Type::TypedDict(_), Type::ProtocolInstance(protocol)) => self
-                .with_recursion_guard(left, right, || {
-                    self.any_protocol_members_absent_or_disjoint(db, protocol, typed_dict)
                 }),
 
             (Type::ProtocolInstance(protocol), other)
@@ -3092,10 +3085,18 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         db: &'db dyn Db,
         other: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let other_mapping = KnownClass::Mapping
-            .try_to_class_literal(db)
-            .and_then(|mapping| {
-                other.nominal_class(db)?.iter_mro(db).find_map(|base| {
+        let other_mapping = other
+            .nominal_class(db)
+            .and_then(|class| {
+                let dict = KnownClass::Dict.try_to_class_literal(db)?;
+                dict.iter_mro(db, None)
+                    .filter_map(ClassBase::into_class)
+                    .any(|base| base.class_literal(db) == class.class_literal(db))
+                    .then_some(class)
+            })
+            .and_then(|class| {
+                let mapping = KnownClass::Mapping.try_to_class_literal(db)?;
+                class.iter_mro(db).find_map(|base| {
                     let ClassType::Generic(alias) = base.into_class()? else {
                         return None;
                     };
@@ -3112,12 +3113,14 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             return self.check_type_pair(db, KnownClass::Str.to_instance(db), *other_key);
         }
 
-        let dict_str_any = KnownClass::Dict
-            .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]);
-
         self.as_relation_checker(TypeRelation::Assignability)
-            .check_type_pair(db, dict_str_any, other)
+            .check_type_pair(db, Self::typed_dict_runtime_dict(db), other)
             .negate(db, self.constraints)
+    }
+
+    fn typed_dict_runtime_dict(db: &'db dyn Db) -> Type<'db> {
+        KnownClass::Dict
+            .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()])
     }
 
     fn check_property_instance_pair(

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -93,6 +93,8 @@ pub enum SpecialFormType {
     RegularCallableTypeOf,
     /// The symbol `ty_extensions.Top`
     Top,
+    /// The symbol `ty_extensions.TypedDictTop`
+    TypedDictTop,
     /// The symbol `ty_extensions.Bottom`
     Bottom,
     /// The symbol `typing.Self` (which can also be found as `typing_extensions.Self`)
@@ -154,6 +156,7 @@ impl SpecialFormType {
             | Self::TypeOf
             | Self::Not
             | Self::Top
+            | Self::TypedDictTop
             | Self::Bottom
             | Self::Intersection
             | Self::CallableTypeOf
@@ -280,6 +283,7 @@ impl SpecialFormType {
             CallableTypeOf,
             RegularCallableTypeOf,
             Top,
+            TypedDictTop,
             Bottom,
             #[strum(serialize = "Self")]
             TypingSelf,
@@ -344,6 +348,7 @@ impl SpecialFormType {
                     SpecialFormType::Any => Self::Any,
                     SpecialFormType::Bottom => Self::Bottom,
                     SpecialFormType::Top => Self::Top,
+                    SpecialFormType::TypedDictTop => Self::TypedDictTop,
                     SpecialFormType::Unpack => Self::Unpack,
                     SpecialFormType::Tuple => Self::Tuple,
                     SpecialFormType::TypedDict => Self::TypedDict,
@@ -402,6 +407,7 @@ impl SpecialFormType {
                 SpecialFormTypeBuilder::Any => Self::Any,
                 SpecialFormTypeBuilder::Bottom => Self::Bottom,
                 SpecialFormTypeBuilder::Top => Self::Top,
+                SpecialFormTypeBuilder::TypedDictTop => Self::TypedDictTop,
                 SpecialFormTypeBuilder::Unpack => Self::Unpack,
                 SpecialFormTypeBuilder::Tuple => Self::Tuple,
                 SpecialFormTypeBuilder::TypedDict => Self::TypedDict,
@@ -475,6 +481,7 @@ impl SpecialFormType {
             | Self::AlwaysFalsy
             | Self::Not
             | Self::Top
+            | Self::TypedDictTop
             | Self::Bottom
             | Self::Intersection
             | Self::TypeOf
@@ -538,6 +545,7 @@ impl SpecialFormType {
             | Self::AlwaysFalsy
             | Self::Not
             | Self::Top
+            | Self::TypedDictTop
             | Self::Bottom
             | Self::Intersection
             | Self::TypeOf
@@ -589,6 +597,7 @@ impl SpecialFormType {
             | Self::NamedTuple
             | Self::Optional
             | Self::Top
+            | Self::TypedDictTop
             | Self::TypeIs
             | Self::TypedDict
             | Self::TypingSelf
@@ -642,6 +651,7 @@ impl SpecialFormType {
             SpecialFormType::CallableTypeOf => "CallableTypeOf",
             SpecialFormType::RegularCallableTypeOf => "RegularCallableTypeOf",
             SpecialFormType::Top => "Top",
+            SpecialFormType::TypedDictTop => "TypedDictTop",
             SpecialFormType::Bottom => "Bottom",
             SpecialFormType::Protocol => "Protocol",
             SpecialFormType::Generic => "Generic",
@@ -691,6 +701,7 @@ impl SpecialFormType {
             | SpecialFormType::CallableTypeOf
             | SpecialFormType::RegularCallableTypeOf
             | SpecialFormType::Top
+            | SpecialFormType::TypedDictTop
             | SpecialFormType::Bottom => &[KnownModule::TyExtensions],
         }
     }
@@ -730,6 +741,7 @@ impl SpecialFormType {
             Self::Unknown => Ok(Type::unknown()),
             Self::AlwaysTruthy => Ok(Type::AlwaysTruthy),
             Self::AlwaysFalsy => Ok(Type::AlwaysFalsy),
+            Self::TypedDictTop => Ok(Type::TypedDictTop),
 
             // Special case: `NamedTuple` in a type expression is understood to describe the type
             // `tuple[object, ...] & <a protocol that any `NamedTuple` class would satisfy>`.

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -784,6 +784,7 @@ impl<'db> Type<'db> {
                 | Type::TypeIs(_)
                 | Type::TypeGuard(_)
                 | Type::TypeForm(_)
+                | Type::TypedDictTop
                 | Type::TypedDict(_)
                 | Type::NewTypeInstance(_)
                 | Type::NominalInstance(_)

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -983,6 +983,7 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
 
             Some(result)
         }
+        Type::TypedDictTop => None,
         Type::TypeAlias(alias) => {
             extract_unpacked_typed_dict_keys_from_value_type(db, alias.value_type(db))
         }

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -176,6 +176,7 @@ impl<'db> From<Type<'db>> for TypeKind<'db> {
             | Type::ClassLiteral(_)
             | Type::SpecialForm(_)
             | Type::Divergent(_)
+            | Type::TypedDictTop
             | Type::Dynamic(_) => TypeKind::Atomic,
 
             // Non-atomic types

--- a/crates/ty_server/tests/e2e/completions.rs
+++ b/crates/ty_server/tests/e2e/completions.rs
@@ -268,9 +268,30 @@ TypedDi<CURSOR>
         "insertText": "typing.is_typeddict"
       },
       {
+        "label": "TypedDictTop (import ty_extensions)",
+        "kind": 6,
+        "sortText": "2",
+        "insertText": "TypedDictTop",
+        "additionalTextEdits": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 0
+              }
+            },
+            "newText": "from ty_extensions import TypedDictTop\n"
+          }
+        ]
+      },
+      {
         "label": "_FilterConfigurationTypedDict (import logging.config)",
         "kind": 7,
-        "sortText": "2",
+        "sortText": "3",
         "insertText": "_FilterConfigurationTypedDict",
         "additionalTextEdits": [
           {
@@ -291,7 +312,7 @@ TypedDi<CURSOR>
       {
         "label": "_FormatterConfigurationTypedDict (import logging.config)",
         "kind": 6,
-        "sortText": "3",
+        "sortText": "4",
         "insertText": "_FormatterConfigurationTypedDict",
         "additionalTextEdits": [
           {
@@ -382,9 +403,30 @@ TypedDi<CURSOR>
         ]
       },
       {
+        "label": "TypedDictTop (import ty_extensions)",
+        "kind": 6,
+        "sortText": "2",
+        "insertText": "TypedDictTop",
+        "additionalTextEdits": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 0
+              }
+            },
+            "newText": "from ty_extensions import TypedDictTop\n"
+          }
+        ]
+      },
+      {
         "label": "_FilterConfigurationTypedDict (import logging.config)",
         "kind": 7,
-        "sortText": "2",
+        "sortText": "3",
         "insertText": "_FilterConfigurationTypedDict",
         "additionalTextEdits": [
           {
@@ -405,7 +447,7 @@ TypedDi<CURSOR>
       {
         "label": "_FormatterConfigurationTypedDict (import logging.config)",
         "kind": 6,
-        "sortText": "3",
+        "sortText": "4",
         "insertText": "_FormatterConfigurationTypedDict",
         "additionalTextEdits": [
           {

--- a/crates/ty_vendored/ty_extensions/ty_extensions.pyi
+++ b/crates/ty_vendored/ty_extensions/ty_extensions.pyi
@@ -102,6 +102,14 @@ eagerly.
 [Any]: https://typing.python.org/en/latest/spec/special-types.html#any
 """
 
+TypedDictTop: _SpecialForm
+"""
+`TypedDictTop` represents the top type of all `TypedDict` instances.
+
+Use this to describe values that are known to be `TypedDict`s, but whose concrete key set
+is not statically known.
+"""
+
 # ty treats annotations of `float` to mean `float | int`, and annotations of `complex`
 # to mean `complex | float | int`. This is to support a typing-system special case [1].
 # We therefore provide `JustFloat` and `JustComplex` to represent the "bare" `float` and

--- a/crates/ty_vendored/vendor/typeshed/stdlib/_typeshed/_type_checker_internals.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/_typeshed/_type_checker_internals.pyi
@@ -6,7 +6,7 @@ import sys
 import typing_extensions
 from _collections_abc import dict_items, dict_keys, dict_values
 from abc import ABCMeta
-from collections.abc import Awaitable, Generator, Iterable, Mapping
+from collections.abc import Awaitable, Generator, Iterable, Iterator, Mapping
 from typing import Any, ClassVar, Generic, TypeVar, overload
 from typing_extensions import Never
 
@@ -40,6 +40,8 @@ class TypedDictFallback(Mapping[str, object], metaclass=ABCMeta):
     def items(self) -> dict_items[str, object]: ...
     def keys(self) -> dict_keys[str, object]: ...
     def values(self) -> dict_values[str, object]: ...
+    if sys.version_info >= (3, 8):
+        def __reversed__(self) -> Iterator[str]: ...
 
     @overload
     def __or__(self, value: typing_extensions.Self, /) -> typing_extensions.Self: ...

--- a/crates/ty_vendored/vendor/typeshed/stdlib/_typeshed/_type_checker_internals.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/_typeshed/_type_checker_internals.pyi
@@ -11,6 +11,7 @@ from typing import Any, ClassVar, Generic, TypeVar, overload
 from typing_extensions import Never
 
 _T = TypeVar("_T")
+_S = TypeVar("_S")
 
 # Used for an undocumented mypy feature. Does not exist at runtime.
 promote = object()
@@ -18,6 +19,13 @@ promote = object()
 # Fallback type providing read-only methods and attributes that appear on all `TypedDict` types.
 class TypedDictReadOnlyFallback(Mapping[str, object], metaclass=ABCMeta):
     def copy(self) -> typing_extensions.Self: ...
+    # `TypedDictTop` has no concrete class to bind as `cls`, so model this as a static method.
+    @staticmethod
+    @overload
+    def fromkeys(iterable: Iterable[_T], value: None = None, /) -> dict[_T, Any | None]: ...
+    @staticmethod
+    @overload
+    def fromkeys(iterable: Iterable[_T], value: _S, /) -> dict[_T, _S]: ...
     def items(self) -> dict_items[str, object]: ...
     def keys(self) -> dict_keys[str, object]: ...
     def values(self) -> dict_values[str, object]: ...
@@ -84,7 +92,6 @@ class NamedTupleFallback(tuple[Any, ...]):
         def __replace__(self, **kwargs: Any) -> typing_extensions.Self: ...
 
 # Non-default variations to accommodate couroutines, and `AwaitableGenerator` having a 4th type parameter.
-_S = TypeVar("_S")
 _YieldT_co = TypeVar("_YieldT_co", covariant=True)
 _SendT_nd_contra = TypeVar("_SendT_nd_contra", contravariant=True)
 _ReturnT_nd_co = TypeVar("_ReturnT_nd_co", covariant=True)

--- a/crates/ty_vendored/vendor/typeshed/stdlib/_typeshed/_type_checker_internals.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/_typeshed/_type_checker_internals.pyi
@@ -15,28 +15,9 @@ _T = TypeVar("_T")
 # Used for an undocumented mypy feature. Does not exist at runtime.
 promote = object()
 
-# Fallback type providing methods and attributes that appear on all `TypedDict` types.
-# N.B. Keep this mostly in sync with typing_extensions._TypedDict/mypy_extensions._TypedDict
-class TypedDictFallback(Mapping[str, object], metaclass=ABCMeta):
-    __total__: ClassVar[bool]
-    __required_keys__: ClassVar[frozenset[str]]
-    __optional_keys__: ClassVar[frozenset[str]]
-    # __orig_bases__ sometimes exists on <3.12, but not consistently,
-    # so we only add it to the stub on 3.12+
-    if sys.version_info >= (3, 12):
-        __orig_bases__: ClassVar[tuple[Any, ...]]
-    if sys.version_info >= (3, 13):
-        __readonly_keys__: ClassVar[frozenset[str]]
-        __mutable_keys__: ClassVar[frozenset[str]]
-
+# Fallback type providing read-only methods and attributes that appear on all `TypedDict` types.
+class TypedDictReadOnlyFallback(Mapping[str, object], metaclass=ABCMeta):
     def copy(self) -> typing_extensions.Self: ...
-    # Using Never so that only calls using mypy plugin hook that specialize the signature
-    # can go through.
-    def setdefault(self, k: Never, default: object) -> object: ...
-    # Mypy plugin hook for 'pop' expects that 'default' has a type variable type.
-    def pop(self, k: Never, default: _T = ...) -> object: ...  # pyright: ignore[reportInvalidTypeVarUse]
-    def update(self, m: typing_extensions.Self, /) -> None: ...
-    def __delitem__(self, k: Never) -> None: ...
     def items(self) -> dict_items[str, object]: ...
     def keys(self) -> dict_keys[str, object]: ...
     def values(self) -> dict_values[str, object]: ...
@@ -52,6 +33,28 @@ class TypedDictFallback(Mapping[str, object], metaclass=ABCMeta):
     def __ror__(self, value: typing_extensions.Self, /) -> typing_extensions.Self: ...
     @overload
     def __ror__(self, value: dict[str, Any], /) -> dict[str, object]: ...
+
+# Fallback type providing methods and attributes that appear on concrete `TypedDict` types.
+# N.B. Keep this mostly in sync with typing_extensions._TypedDict/mypy_extensions._TypedDict
+class TypedDictFallback(TypedDictReadOnlyFallback, metaclass=ABCMeta):
+    __total__: ClassVar[bool]
+    __required_keys__: ClassVar[frozenset[str]]
+    __optional_keys__: ClassVar[frozenset[str]]
+    # __orig_bases__ sometimes exists on <3.12, but not consistently,
+    # so we only add it to the stub on 3.12+
+    if sys.version_info >= (3, 12):
+        __orig_bases__: ClassVar[tuple[Any, ...]]
+    if sys.version_info >= (3, 13):
+        __readonly_keys__: ClassVar[frozenset[str]]
+        __mutable_keys__: ClassVar[frozenset[str]]
+
+    # Using Never so that only calls using mypy plugin hook that specialize the signature
+    # can go through.
+    def setdefault(self, k: Never, default: object) -> object: ...
+    # Mypy plugin hook for 'pop' expects that 'default' has a type variable type.
+    def pop(self, k: Never, default: _T = ...) -> object: ...  # pyright: ignore[reportInvalidTypeVarUse]
+    def update(self, m: typing_extensions.Self, /) -> None: ...
+    def __delitem__(self, k: Never) -> None: ...
 
     # supposedly incompatible definitions of __or__ and __ior__
     def __ior__(self, value: typing_extensions.Self, /) -> typing_extensions.Self: ...  # type: ignore[misc]


### PR DESCRIPTION
## Summary

This PR implements a `TypedDictTop` type that is a supertype of all `TypedDict` types, and treated as assignable to `Mapping[str, object]`.

With this type, `isinstance(x, dict)` and `isinstance(x, MutableMapping)` now generate a constraint that includes `TypedDictTop`, e.g., `Top[dict[Unknown, Unknown]] | TypedDictTop`.

Closes https://github.com/astral-sh/ty/issues/1130.

Closes https://github.com/astral-sh/ty/issues/2374.
