### PR TITLE
[ty] Determine value vs. type syntax highlighting based on call arguments

### DIFF
--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -2714,28 +2714,25 @@ f(int, x)
         );
 
         let tokens = test.highlight_file();
-        let source = ruff_db::source::source_text(&test.db, test.file);
-
-        let int_start = TextSize::from(
-            u32::try_from(source.rfind("int").expect("call argument `int` to exist"))
-                .expect("source offset to fit into TextSize"),
-        );
-        let x_start = TextSize::from(
-            u32::try_from(source.rfind("x)").expect("call argument `x` to exist"))
-                .expect("source offset to fit into TextSize"),
-        );
-
-        let int_token = tokens
-            .iter()
-            .find(|token| token.range == TextRange::at(int_start, "int".text_len()))
-            .expect("semantic token for `int` call argument");
-        let x_token = tokens
-            .iter()
-            .find(|token| token.range == TextRange::at(x_start, "x".text_len()))
-            .expect("semantic token for `x` call argument");
-
-        assert_eq!(int_token.token_type, SemanticTokenType::Class);
-        assert_eq!(x_token.token_type, SemanticTokenType::Variable);
+        assert_snapshot!(test.to_snapshot(&tokens), @r#"
+        "typing" @ 6..12: Namespace
+        "cast" @ 20..24: Function
+        "flag" @ 26..30: Variable [definition]
+        "bool" @ 33..37: Class
+        "input" @ 38..43: Function
+        "g" @ 51..52: Function [definition]
+        "x" @ 53..54: Parameter [definition]
+        "x" @ 68..69: Parameter
+        "x" @ 71..72: Variable [definition]
+        "\"\"" @ 75..77: String
+        "f" @ 78..79: Variable [definition]
+        "cast" @ 82..86: Function
+        "flag" @ 90..94: Variable
+        "g" @ 100..101: Function
+        "f" @ 102..103: Variable
+        "int" @ 104..107: Class
+        "x" @ 109..110: Variable
+        "#);
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -598,7 +598,7 @@ impl<'db> Bindings<'db> {
         self.argument_forms
             .values
             .iter()
-            .zip(self.argument_forms.conflicting.iter())
+            .zip(&self.argument_forms.conflicting)
             .map(|(form, conflicting)| (!conflicting).then_some(*form).flatten())
     }
 

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -939,7 +939,7 @@ pub fn call_argument_forms(
         return Vec::new();
     };
 
-    let argument_count = call_expr.arguments.arguments_source_order().count();
+    let argument_count = call_expr.arguments.len();
 
     // If the function doesn't contain any type forms, for any overloads, short-circuit.
     if !func_type.bindings(model.db()).iter_flat().any(|binding| {
@@ -965,7 +965,7 @@ pub fn call_argument_forms(
         .filter(|binding| binding.errors().is_empty())
         .collect();
 
-    if successful_bindings.is_empty() {
+    let Some((first_binding, remaining_bindings)) = successful_bindings.split_first() else {
         // If no binding succeeds, fall back to the merged non-conflicting forms from the full
         // binding result so callers still get the best conservative answer available.
         for (arg_index, form) in bindings.non_conflicting_argument_forms().enumerate() {
@@ -978,15 +978,10 @@ pub fn call_argument_forms(
             });
         }
         return argument_forms;
-    }
+    };
 
     // If all successful bindings agree on the argument form, use the agreed-upon form; otherwise,
     // fall back to `CallArgumentForm::Unknown`.
-    let mut argument_forms = vec![CallArgumentForm::Unknown; argument_count];
-    let Some((first_binding, remaining_bindings)) = successful_bindings.split_first() else {
-        return argument_forms;
-    };
-
     for (arg_index, resolved_argument_form) in argument_forms.iter_mut().enumerate() {
         let argument_form = argument_form_from_successful_binding(first_binding, arg_index);
         if argument_form == CallArgumentForm::Unknown {


### PR DESCRIPTION
## Summary

We now expose a method to determine whether a call argument should be treated as a type form (or not), for the purposes of syntax highlighting.

This is more difficult than it may sound, largely due to the existence of overloads and conditional bindings. For example, given the following:

```python
from typing import cast
from typing_extensions import assert_type

func = cast if flag else assert_type
```

The highlighting we want to use for various arguments has to taken into account both the signatures of `cast` and `assert_type`, along with the type of the value provided to the argument.

For example, given:

```python
f(val=x, typ=int)
```

Both agree that `val=x` is a value, and `typ=int` is a type form.

But given:

```python
f(x, int)
```

Both match, but disagree:

- `cast(x, int)` treats the arguments as `[Type, Value]`
- `assert_type(x, int)` treats them as `[Value, Type]`

So we treat them both as unknown.

Closes https://github.com/astral-sh/ty/issues/3038.
