### PR TITLE
[ty] Introduce fast path for protocol non-assignability

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3096,6 +3096,42 @@ indexed_data = {k: v[0:10] for k, v in data.items()}
 reveal_type(indexed_data)  # revealed: dict[str, IntArray]
 ```
 
+### Regression test: `dict()` overloads with tuple-of-tuples input
+
+This is a regression test for [ty#3026](https://github.com/astral-sh/ty/issues/3026). Matching the
+`dict()` overloads that accept `_typeshed.SupportsKeysAndGetItem` against a tuple of tuples used to
+trigger exponential behavior before we rejected the protocol candidates.
+
+```py
+output = dict((
+    ("0", 0),
+    ("1", 1),
+    ("2", 2),
+    ("3", 3),
+    ("4", 4),
+    ("5", 5),
+    ("6", 6),
+    ("7", 7),
+    ("8", 8),
+    ("9", 9),
+    ("10", 10),
+    ("11", 11),
+    ("12", 12),
+    ("13", 13),
+    ("14", 14),
+    ("15", 15),
+    ("16", 16),
+    ("17", 17),
+    ("18", 18),
+    ("19", 19),
+    ("20", 20),
+    ("21", 21),
+    ("22", 22),
+    ("23", 23),
+))
+reveal_type(output)  # revealed: dict[str, int]
+```
+
 ### Regression test: narrowing with self-referential protocols
 
 This snippet caused us to panic on an early version of the implementation for protocols.

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -9,14 +9,16 @@ use ty_module_resolver::{ModuleName, file_to_module};
 
 use super::protocol_class::ProtocolInterface;
 use super::{BoundTypeVarInstance, ClassType, KnownClass, SubclassOfType, Type, TypeVarVariance};
-use crate::place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers};
+use crate::place::PlaceAndQualifiers;
 use crate::semantic_index::definition::Definition;
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
 };
 use crate::types::enums::is_single_member_enum;
 use crate::types::generics::{InferableTypeVars, walk_specialization};
-use crate::types::protocol_class::{ProtocolClass, walk_protocol_interface};
+use crate::types::protocol_class::{
+    ProtocolClass, has_all_protocol_members_defined, walk_protocol_interface,
+};
 use crate::types::relation::{
     DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
 };
@@ -428,34 +430,6 @@ impl<'db> From<NominalInstanceType<'db>> for Type<'db> {
 }
 
 impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
-    /// Protocol compatibility can only succeed if every required member is present. Check that
-    /// necessary condition up front so we can avoid expensive per-member type comparisons and
-    /// generic protocol solving when the actual type is plainly missing a member.
-    fn has_all_protocol_members_defined(
-        db: &'db dyn Db,
-        ty: Type<'db>,
-        protocol: ProtocolInstanceType<'db>,
-    ) -> bool {
-        let target_interface = protocol.inner.interface(db);
-
-        match ty {
-            Type::ProtocolInstance(source_protocol) => target_interface.members(db).all(|member| {
-                source_protocol
-                    .interface(db)
-                    .includes_member(db, member.name())
-            }),
-            _ => target_interface.members(db).all(|member| {
-                matches!(
-                    ty.member(db, member.name()).place,
-                    Place::Defined(DefinedPlace {
-                        definedness: Definedness::AlwaysDefined,
-                        ..
-                    })
-                )
-            }),
-        }
-    }
-
     /// Return `true` if `ty` conforms to the interface described by `protocol`.
     pub(super) fn check_type_satisfies_protocol(
         &self,
@@ -505,7 +479,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return result;
         }
 
-        if !Self::has_all_protocol_members_defined(db, ty, protocol) {
+        if !has_all_protocol_members_defined(db, ty, protocol) {
             return result;
         }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -9,7 +9,7 @@ use ty_module_resolver::{ModuleName, file_to_module};
 
 use super::protocol_class::ProtocolInterface;
 use super::{BoundTypeVarInstance, ClassType, KnownClass, SubclassOfType, Type, TypeVarVariance};
-use crate::place::PlaceAndQualifiers;
+use crate::place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers};
 use crate::semantic_index::definition::Definition;
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
@@ -428,6 +428,34 @@ impl<'db> From<NominalInstanceType<'db>> for Type<'db> {
 }
 
 impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
+    /// Protocol compatibility can only succeed if every required member is present. Check that
+    /// necessary condition up front so we can avoid expensive per-member type comparisons and
+    /// generic protocol solving when the actual type is plainly missing a member.
+    fn has_all_protocol_members_defined(
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        protocol: ProtocolInstanceType<'db>,
+    ) -> bool {
+        let target_interface = protocol.inner.interface(db);
+
+        match ty {
+            Type::ProtocolInstance(source_protocol) => target_interface.members(db).all(|member| {
+                source_protocol
+                    .interface(db)
+                    .includes_member(db, member.name())
+            }),
+            _ => target_interface.members(db).all(|member| {
+                matches!(
+                    ty.member(db, member.name()).place,
+                    Place::Defined(DefinedPlace {
+                        definedness: Definedness::AlwaysDefined,
+                        ..
+                    })
+                )
+            }),
+        }
+    }
+
     /// Return `true` if `ty` conforms to the interface described by `protocol`.
     pub(super) fn check_type_satisfies_protocol(
         &self,
@@ -474,6 +502,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             && proto_class.is_known(db, KnownClass::Generator)
             && Program::get(db).python_version(db) < PythonVersion::PY313
         {
+            return result;
+        }
+
+        if !Self::has_all_protocol_members_defined(db, ty, protocol) {
             return result;
         }
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -19,8 +19,8 @@ use crate::{
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarInstance, CallableType, ClassBase, ClassType,
         FindLegacyTypeVarsVisitor, InstanceFallbackShadowsNonDataDescriptor, KnownFunction,
-        MemberLookupPolicy, PropertyInstanceType, Signature, StaticClassLiteral, Type, TypeMapping,
-        TypeQualifiers, TypeVarVariance, VarianceInferable,
+        MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType, Signature,
+        StaticClassLiteral, Type, TypeMapping, TypeQualifiers, TypeVarVariance, VarianceInferable,
         constraints::{ConstraintSet, IteratorConstraintsExtension, OptionConstraintsExtension},
         context::InferContext,
         diagnostic::report_undeclared_protocol_member,
@@ -965,4 +965,33 @@ fn protocol_bind_self<'db>(
         callable.signatures(db).bind_self(db, self_type),
         CallableTypeKind::Regular,
     )
+}
+
+/// Protocol compatibility can only succeed if every required member is present.
+///
+/// Check that necessary condition up front so we can avoid expensive per-member type
+/// comparisons and generic protocol solving when the actual type is plainly missing a member.
+pub(super) fn has_all_protocol_members_defined<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    protocol: ProtocolInstanceType<'db>,
+) -> bool {
+    let target_interface = protocol.interface(db);
+
+    match ty {
+        Type::ProtocolInstance(source_protocol) => target_interface.members(db).all(|member| {
+            source_protocol
+                .interface(db)
+                .includes_member(db, member.name())
+        }),
+        _ => target_interface.members(db).all(|member| {
+            matches!(
+                ty.member(db, member.name()).place,
+                Place::Defined(DefinedPlace {
+                    definedness: Definedness::AlwaysDefined,
+                    ..
+                })
+            )
+        }),
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds a fast path to first verify that every required protocol member is definitely present.

Closes https://github.com/astral-sh/ty/issues/3026.
