### PR TITLE
[ty] Remove the `extra` field from `CycleDetector`; add a `given` field to `TypeRelationChecker`

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1050,10 +1050,9 @@ impl<'db> ClassType<'db> {
         let constraints = ConstraintSetBuilder::new();
         let relation_visitor = HasRelationToVisitor::default(&constraints);
         let disjointness_visitor = IsDisjointVisitor::default(&constraints);
-        let checker = TypeRelationChecker::new(
+        let checker = TypeRelationChecker::subtyping(
             &constraints,
             InferableTypeVars::None,
-            TypeRelation::Subtyping,
             &relation_visitor,
             &disjointness_visitor,
         );

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -61,7 +61,7 @@ impl<Tag> Default for TypeTransformer<'_, Tag> {
 pub(crate) type PairVisitor<'db, Tag, C> = CycleDetector<Tag, (Type<'db>, Type<'db>), C>;
 
 #[derive(Debug)]
-pub struct CycleDetector<Tag, T, R, Extra = ()> {
+pub struct CycleDetector<Tag, T, R> {
     /// If the type we're visiting is present in `seen`, it indicates that we've hit a cycle (due
     /// to a recursive type); we need to immediately short circuit the whole operation and return
     /// the fallback value. That's why we pop items off the end of `seen` after we've visited them.
@@ -81,29 +81,22 @@ pub struct CycleDetector<Tag, T, R, Extra = ()> {
 
     fallback: R,
 
-    pub(crate) extra: Extra,
-
     _tag: PhantomData<Tag>,
 }
 
-impl<Tag, T: Hash + Eq + Clone, R: Clone, Extra: Default> CycleDetector<Tag, T, R, Extra> {
+impl<Tag, T, R> CycleDetector<Tag, T, R> {
     pub fn new(fallback: R) -> Self {
-        Self::with_extra(fallback, Extra::default())
-    }
-}
-
-impl<Tag, T: Hash + Eq + Clone, R: Clone, Extra> CycleDetector<Tag, T, R, Extra> {
-    pub(crate) fn with_extra(fallback: R, extra: Extra) -> Self {
         CycleDetector {
             seen: RefCell::new(FxIndexSet::default()),
             cache: RefCell::new(FxHashMap::default()),
             depth: Cell::new(0),
             fallback,
-            extra,
             _tag: PhantomData,
         }
     }
+}
 
+impl<Tag, T: Hash + Eq + Clone, R: Clone> CycleDetector<Tag, T, R> {
     pub fn visit(&self, item: T, func: impl FnOnce() -> R) -> R {
         if let Some(val) = self.cache.borrow().get(&item) {
             return val.clone();
@@ -133,7 +126,7 @@ impl<Tag, T: Hash + Eq + Clone, R: Clone, Extra> CycleDetector<Tag, T, R, Extra>
     }
 }
 
-impl<Tag, T: Hash + Eq + Clone, R: Default + Clone> Default for CycleDetector<Tag, T, R> {
+impl<Tag, T, R: Default> Default for CycleDetector<Tag, T, R> {
     fn default() -> Self {
         CycleDetector::new(R::default())
     }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -20,7 +20,7 @@ use crate::types::protocol_class::{
     ProtocolClass, has_all_protocol_members_defined, walk_protocol_interface,
 };
 use crate::types::relation::{
-    DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
+    DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelationChecker,
 };
 use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
 use crate::types::{
@@ -705,10 +705,9 @@ impl<'db> ProtocolInstanceType<'db> {
             let constraints = ConstraintSetBuilder::new();
             let relation_visitor = HasRelationToVisitor::default(&constraints);
             let disjointness_visitor = IsDisjointVisitor::default(&constraints);
-            let checker = TypeRelationChecker::new(
+            let checker = TypeRelationChecker::subtyping(
                 &constraints,
                 InferableTypeVars::None,
-                TypeRelation::Subtyping,
                 &relation_visitor,
                 &disjointness_visitor,
             );

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -323,7 +323,8 @@ impl<'db> Type<'db> {
             constraints,
             inferable,
             relation: TypeRelation::SubtypingAssuming,
-            relation_visitor: &HasRelationToVisitor::with_given(constraints, assuming),
+            given: assuming,
+            relation_visitor: &HasRelationToVisitor::default(constraints),
             disjointness_visitor: &IsDisjointVisitor::default(constraints),
         };
         checker.check_type_pair(db, self, target)
@@ -421,6 +422,7 @@ impl<'db> Type<'db> {
             constraints,
             inferable,
             relation,
+            given: ConstraintSet::from_bool(constraints, false),
             relation_visitor: &HasRelationToVisitor::default(constraints),
             disjointness_visitor: &IsDisjointVisitor::default(constraints),
         };
@@ -452,6 +454,7 @@ impl<'db> Type<'db> {
     ) -> ConstraintSet<'db, 'c> {
         let checker = EquivalenceChecker {
             constraints,
+            given: ConstraintSet::from_bool(constraints, false),
             relation_visitor: &HasRelationToVisitor::default(constraints),
             disjointness_visitor: &IsDisjointVisitor::default(constraints),
         };
@@ -489,6 +492,7 @@ impl<'db> Type<'db> {
         let checker = DisjointnessChecker {
             constraints,
             inferable,
+            given: ConstraintSet::from_bool(constraints, false),
             disjointness_visitor: &IsDisjointVisitor::default(constraints),
             relation_visitor: &HasRelationToVisitor::default(constraints),
         };
@@ -497,24 +501,12 @@ impl<'db> Type<'db> {
 }
 
 /// A [`PairVisitor`] that is used in `has_relation_to` methods.
-pub(crate) type HasRelationToVisitor<'db, 'c> = CycleDetector<
-    TypeRelation,
-    (Type<'db>, Type<'db>, TypeRelation),
-    ConstraintSet<'db, 'c>,
-    ConstraintSet<'db, 'c>,
->;
+pub(crate) type HasRelationToVisitor<'db, 'c> =
+    CycleDetector<TypeRelation, (Type<'db>, Type<'db>, TypeRelation), ConstraintSet<'db, 'c>>;
 
 impl<'db, 'c> HasRelationToVisitor<'db, 'c> {
     pub(crate) fn default(constraints: &'c ConstraintSetBuilder<'db>) -> Self {
-        HasRelationToVisitor::with_given(constraints, ConstraintSet::from_bool(constraints, false))
-    }
-
-    pub(crate) fn with_given(
-        constraints: &'c ConstraintSetBuilder<'db>,
-        given: ConstraintSet<'db, 'c>,
-    ) -> Self {
-        let fallback = ConstraintSet::from_bool(constraints, true);
-        HasRelationToVisitor::with_extra(fallback, given)
+        HasRelationToVisitor::new(ConstraintSet::from_bool(constraints, true))
     }
 }
 
@@ -535,6 +527,7 @@ pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
     pub(super) constraints: &'c ConstraintSetBuilder<'db>,
     pub(super) inferable: InferableTypeVars<'a, 'db>,
     pub(super) relation: TypeRelation,
+    given: ConstraintSet<'db, 'c>,
 
     // N.B. these fields are private to reduce the risk of
     // "double-visiting" a given pair of types. You should
@@ -547,17 +540,33 @@ pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
 }
 
 impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
-    pub(super) fn new(
+    pub(super) fn subtyping(
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'a, 'db>,
-        relation: TypeRelation,
         relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
         disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
     ) -> Self {
         Self {
             constraints,
             inferable,
-            relation,
+            relation: TypeRelation::Subtyping,
+            given: ConstraintSet::from_bool(constraints, false),
+            relation_visitor,
+            disjointness_visitor,
+        }
+    }
+
+    pub(super) fn constraint_set_assignability(
+        constraints: &'c ConstraintSetBuilder<'db>,
+        inferable: InferableTypeVars<'a, 'db>,
+        relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
+        disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
+    ) -> Self {
+        Self {
+            constraints,
+            inferable,
+            relation: TypeRelation::ConstraintSetAssignability,
+            given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
             disjointness_visitor,
         }
@@ -608,8 +617,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         if self.relation == TypeRelation::SubtypingAssuming
             && (source.is_type_var() || target.is_type_var())
         {
-            let given = self.relation_visitor.extra;
-            return given.implies_subtype_of(db, self.constraints, source, target);
+            return self
+                .given
+                .implies_subtype_of(db, self.constraints, source, target);
         }
 
         // Handle the constraint-set-based assignability relation next. Comparisons with a
@@ -1521,6 +1531,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     pub(super) fn as_equivalence_checker(&self) -> EquivalenceChecker<'_, 'c, 'db> {
         EquivalenceChecker {
             constraints: self.constraints,
+            given: self.given,
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
         }
@@ -1530,6 +1541,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         DisjointnessChecker {
             constraints: self.constraints,
             inferable: self.inferable,
+            given: self.given,
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
         }
@@ -1538,6 +1550,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
 pub(super) struct EquivalenceChecker<'a, 'c, 'db> {
     pub(super) constraints: &'c ConstraintSetBuilder<'db>,
+    given: ConstraintSet<'db, 'c>,
 
     // N.B. these fields are private to reduce the risk of
     // "double-visiting" a given pair of types. You should
@@ -1554,6 +1567,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
         TypeRelationChecker {
             relation: TypeRelation::Redundancy { pure: true },
             constraints: self.constraints,
+            given: self.given,
             inferable: InferableTypeVars::None,
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
@@ -1586,6 +1600,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
 pub(super) struct DisjointnessChecker<'a, 'c, 'db> {
     pub(super) constraints: &'c ConstraintSetBuilder<'db>,
     pub(super) inferable: InferableTypeVars<'a, 'db>,
+    given: ConstraintSet<'db, 'c>,
 
     // N.B. these fields are private to reduce the risk of
     // "double-visiting" a given pair of types. You should
@@ -1607,6 +1622,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         Self {
             constraints,
             inferable,
+            given: ConstraintSet::from_bool(constraints, false),
             disjointness_visitor,
             relation_visitor,
         }
@@ -1620,6 +1636,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             relation,
             constraints: self.constraints,
             inferable: self.inferable,
+            given: self.given,
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
         }
@@ -1628,6 +1645,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
     pub(super) fn as_equivalence_checker(&self) -> EquivalenceChecker<'_, 'c, 'db> {
         EquivalenceChecker {
             constraints: self.constraints,
+            given: self.given,
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
         }

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -323,10 +323,9 @@ impl<'db> CallableSignature<'db> {
     ) -> ConstraintSet<'db, 'c> {
         let relation_visitor = HasRelationToVisitor::default(constraints);
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
-        let checker = TypeRelationChecker::new(
+        let checker = TypeRelationChecker::constraint_set_assignability(
             constraints,
             inferable,
-            TypeRelation::ConstraintSetAssignability,
             &relation_visitor,
             &disjointness_visitor,
         );
@@ -786,10 +785,9 @@ impl<'db> Signature<'db> {
     ) -> ConstraintSet<'db, 'c> {
         let relation_visitor = HasRelationToVisitor::default(constraints);
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
-        let checker = TypeRelationChecker::new(
+        let checker = TypeRelationChecker::constraint_set_assignability(
             constraints,
             inferable,
-            TypeRelation::ConstraintSetAssignability,
             &relation_visitor,
             &disjointness_visitor,
         );


### PR DESCRIPTION
## Summary

Keeping this state on `TypeRelationChecker` rather than `CycleDetector` makes `TypeRelationChecker`s slightly harder to construct, but they are constructed in very few places -- nearly all sites where it is constructed are inside `relation.rs` itself. And moving the field off `CycleDetector` allows us to simplify the design of the `CycleDetector` (it can be generic over "only" 3 parameters, instead of 4!). It also makes the `CycleDetector` struct easier to understand conceptually: it's for detecting cycles; it shouldn't be holding unrelated state.

This is much easier to clean up following 2effb774b4cf68db30c25477d596c0d0a0d1f003! Prior to that refactor, cleaning this up would have required adding yet another parameter to all the many `Type::has_relation_to_impl` methods we used to have. So it was probably the right decision at the time when we added `extra` to add it as a field to the `CycleDetector`!

## Test Plan

Existing tests
