### PR TITLE
[ty] Fix compiler warning about unused variable

### DIFF
--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -675,7 +675,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // Pretend that instances of `dataclasses.Field` are assignable to their default type.
             // This allows field definitions like `name: str = field(default="")` in dataclasses
             // to pass the assignability check of the inferred type to the declared type.
-            (Type::KnownInstance(KnownInstanceType::Field(field)), right)
+            (Type::KnownInstance(KnownInstanceType::Field(field)), _)
                 if self.relation.is_assignability() =>
             {
                 field


### PR DESCRIPTION
## Summary

Fix this warning when compiling ty:

```
warning: unused variable: `right`
   --> crates/ty_python_semantic/src/types/relation.rs:678:68
    |
678 |             (Type::KnownInstance(KnownInstanceType::Field(field)), right)
    |                                                                    ^^^^^ help: if this is intentional, prefix it with an underscore: `_right`
    |
    = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
```

For some reason, this warning doesn't appear for `cargo build -p ty`, but does for other commands such as if I navigate to another directory and then run `cargo build --manifest-path ../ruff/Cargo.toml -p ty`. Anyway, it's a valid complaint, so this PR fixes it.
