### PR TITLE
[ty] Add fast path for unreachable class subtype checks

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1842,6 +1842,24 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: ClassType<'db>,
         target: ClassType<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        // Fast path: check if the target's class literal is reachable from the source's
+        // unspecialized MRO. If it's not (and there are no dynamic bases that could match
+        // anything), we can return `never()` immediately, avoiding expensive specialization
+        // checks and constraint-set operations in the `when_any` below.
+        let target_literal = target.class_literal(db);
+        let target_reachable = source
+            .class_literal(db)
+            .iter_mro(db)
+            .any(|base| match base {
+                ClassBase::Class(class) => class.class_literal(db) == target_literal,
+                ClassBase::Dynamic(_) => true,
+                ClassBase::Protocol | ClassBase::Generic | ClassBase::TypedDict => false,
+            });
+
+        if !target_reachable {
+            return self.never();
+        }
+
         source.iter_mro(db).when_any(db, self.constraints, |base| {
             match base {
                 ClassBase::Dynamic(_) => match self.relation {


### PR DESCRIPTION
## Summary

Optimize `TypeRelationChecker::check_class_subtype` by adding a fast path that checks if the target class is reachable from the source class's unspecialized MRO before performing expensive specialization checks and constraint-set operations.

The optimization checks if the target's class literal appears in the source's MRO. If it's not reachable and there are no dynamic bases that could match, we immediately return `never()` without proceeding to the more expensive `when_any` constraint-set operations below.

This avoids unnecessary work for cases where the subtype relationship is impossible, improving performance for type checking operations that frequently check class compatibility.

## Test Plan

Existing tests