### PR TITLE
[ty] Include CPython projects in ecosystem-analyzer runs

### DIFF
--- a/crates/ty/docs/mypy_primer.md
+++ b/crates/ty/docs/mypy_primer.md
@@ -31,7 +31,7 @@ mypy_primer \
 ```
 
 This will show the diagnostics diff for the `black` project between the `main` branch and your `my/feature` branch. To run the
-diff for all projects we currently enable in CI, use `--project-selector "/($(paste -s -d'|' crates/ty_python_semantic/resources/primer/good.txt))\$"`.
+diff for all projects we currently enable in CI, use `--project-selector "$(uv run scripts/mypy_primer_selector.py crates/ty_python_semantic/resources/primer/good.txt)"`.
 
 You can also take a look at the [full list of ecosystem projects]. Note that some of them might still need a `ty_paths` configuration
 option to work correctly.

--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -35,7 +35,9 @@ colour
 com2ann
 comtypes
 core
-cpython
+CPython (Argument Clinic)
+CPython (cases_generator)
+CPython (peg_generator)
 cryptography
 cwltool
 dacite

--- a/scripts/mypy_primer.sh
+++ b/scripts/mypy_primer.sh
@@ -5,7 +5,7 @@ echo "Enabling mypy primer specific configuration overloads (see .github/mypy-pr
 mkdir -p ~/.config/ty
 cp .github/mypy-primer-ty.toml ~/.config/ty/ty.toml
 
-PRIMER_SELECTOR="$(paste -s -d'|' "${PRIMER_SELECTOR}")"
+PRIMER_SELECTOR="$(uv run scripts/mypy_primer_selector.py "${PRIMER_SELECTOR}")"
 
 echo "new commit"
 git rev-list --format=%s --max-count=1 "${GITHUB_SHA}"
@@ -29,7 +29,7 @@ uvx \
   --cargo-profile profiling \
   --old base_commit \
   --new "${GITHUB_SHA}" \
-  --project-selector "/($PRIMER_SELECTOR)\$" \
+  --project-selector "${PRIMER_SELECTOR}" \
   --output concise \
   --debug > "${DIFF_FILE}" || [ $? -eq 1 ]
 

--- a/scripts/mypy_primer_selector.py
+++ b/scripts/mypy_primer_selector.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CPYTHON_PROJECTS = {
+    "CPython (Argument Clinic)": "cpython",
+    "CPython (cases_generator)": "cpython",
+    "CPython (peg_generator)": "cpython",
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build a mypy_primer project-selector regex from a project list."
+    )
+    parser.add_argument("project_list", type=Path)
+    args = parser.parse_args()
+
+    projects: list[str] = []
+    seen: set[str] = set()
+
+    for line in args.project_list.read_text().splitlines():
+        project = line.strip()
+        if not project:
+            continue
+
+        selector = CPYTHON_PROJECTS.get(project, project)
+        if selector not in seen:
+            projects.append(re.escape(selector))
+            seen.add(selector)
+
+    print(f"/({'|'.join(projects)})$")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

There are three special projects in mypy_primer's list: they are all part of the cpython repository, but in different subfolders. Previously, `good.txt` only included the pattern "cpython" to include all of them for mypy_primer runs. However, ecosystem-analyzer expects an exact match. I don't really want to change that behavior in ecosystem-analyzer, so instead, we now include the full project names, and map those back to "cpython" for mypy_primer (which matches the regex against the projects URL, not the name).

## Test Plan

- Made sure that mypy_primer still runs as expected, with the new selector (regex-escaping leads to a slightly different project selector)
- Made sure that CPython projects are now included in ecosystem-analyzer runs