### PR TITLE
Fix typo: accomodate -> accommodate

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -8825,7 +8825,7 @@ raise <CURSOR>
                 // N.B. We very much want to use the default settings
                 // here, so that our test environment matches the
                 // production environment. If a default changes, the
-                // tests should be fixed to accomodate that change
+                // tests should be fixed to accommodate that change
                 // as well. ---AG
                 settings: CompletionSettings::default(),
                 skip_builtins: false,


### PR DESCRIPTION
## Summary

Fixes a typo in a comment: "accomodate" → "accommodate"

## Test Plan

N/A - comment-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)