### PR TITLE
[`ruff`] Remove division special case to fix false positives (`RUF069`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF069.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF069.py
@@ -32,8 +32,10 @@ assert (y := x + 1.0) == 2.0
 [i for i in range(10) if i == 1.0]
 {i for i in range(10) if i != 2.0}
 
+# ok: division without a known float operand (see https://github.com/astral-sh/ruff/issues/23281)
 assert x / 2 == 1
 assert (x / 2) == (y / 3)
+assert (y := x / 2) == 1
 
 # ok
 assert Path(__file__).parent / ".txt" == 1
@@ -42,8 +44,6 @@ def foo(a, b):
     return a == b * float("2")
 
 assert complex(0.3, 0.2) == complex(0.1 + 0.2, 0.1 + 0.1)
-
-assert (y := x / 2) == 1
 
 assert (0.3 if x > 0 else 1) == 0.1 + 0.2
 

--- a/crates/ruff_linter/src/rules/ruff/rules/float_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/float_equality_comparison.rs
@@ -160,36 +160,19 @@ fn has_float(expr: &Expr, semantic: &SemanticModel) -> bool {
                 Expr::Call(ast::ExprCall { func, .. }) => ["float", "complex"]
                     .iter()
                     .any(|s| semantic.match_builtin_expr(func, s)),
-                Expr::BinOp(ast::ExprBinOp {
-                    left, right, op, ..
-                }) => {
-                    // Division always returns float in Python
-                    // https://docs.python.org/3/tutorial/introduction.html#numbers
-                    match op {
-                        ast::Operator::Div => {
-                            // Only trigger for numeric divisions, not path operations
-                            // Ex) `Path(__file__).parents[2] / "text.txt"`
-                            is_numeric_expr(left) || is_numeric_expr(right)
-                        }
-                        _ => has_float(left, semantic) || has_float(right, semantic),
-                    }
+                // Division (`/`) in Python always returns a float for built-in
+                // numeric types, but without type inference we can't distinguish
+                // built-in `/` from overloaded `/` (e.g. `Decimal`, `pathlib.Path`,
+                // astropy units). To avoid false positives we only flag when an
+                // operand is already known to be a float.
+                // See: https://github.com/astral-sh/ruff/issues/23281
+                Expr::BinOp(ast::ExprBinOp { left, right, .. }) => {
+                    has_float(left, semantic) || has_float(right, semantic)
                 }
                 Expr::Named(ast::ExprNamed { value, .. }) => has_float(value, semantic),
                 _ => false,
             }
         }
-    }
-}
-
-fn is_numeric_expr(expr: &Expr) -> bool {
-    match expr {
-        Expr::NumberLiteral(_) => true,
-        Expr::BinOp(ast::ExprBinOp { left, right, .. }) => {
-            is_numeric_expr(left) || is_numeric_expr(right)
-        }
-        Expr::UnaryOp(ast::ExprUnaryOp { operand, .. }) => is_numeric_expr(operand),
-        Expr::Named(ast::ExprNamed { value, .. }) => is_numeric_expr(value),
-        _ => false,
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF069_RUF069.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF069_RUF069.py.snap
@@ -173,57 +173,26 @@ RUF069 Unreliable floating point equality comparison `i != 2.0`
 33 | {i for i in range(10) if i != 2.0}
    |                          ^^^^^^^^
 34 |
-35 | assert x / 2 == 1
-   |
-
-RUF069 Unreliable floating point equality comparison `x / 2 == 1`
-  --> RUF069.py:35:8
-   |
-33 | {i for i in range(10) if i != 2.0}
-34 |
-35 | assert x / 2 == 1
-   |        ^^^^^^^^^^
-36 | assert (x / 2) == (y / 3)
-   |
-
-RUF069 Unreliable floating point equality comparison `x / 2 == y / 3`
-  --> RUF069.py:36:9
-   |
-35 | assert x / 2 == 1
-36 | assert (x / 2) == (y / 3)
-   |         ^^^^^^^^^^^^^^^^
-37 |
-38 | # ok
+35 | # ok: division without a known float operand (see https://github.com/astral-sh/ruff/issues/23281)
    |
 
 RUF069 Unreliable floating point equality comparison `a == b * float("2")`
-  --> RUF069.py:42:12
+  --> RUF069.py:44:12
    |
-41 | def foo(a, b):
-42 |     return a == b * float("2")
+43 | def foo(a, b):
+44 |     return a == b * float("2")
    |            ^^^^^^^^^^^^^^^^^^^
-43 |
-44 | assert complex(0.3, 0.2) == complex(0.1 + 0.2, 0.1 + 0.1)
+45 |
+46 | assert complex(0.3, 0.2) == complex(0.1 + 0.2, 0.1 + 0.1)
    |
 
 RUF069 Unreliable floating point equality comparison `complex(0.3, 0.2) == complex(0.1 + 0.2, 0.1 + 0.1)`
-  --> RUF069.py:44:8
+  --> RUF069.py:46:8
    |
-42 |     return a == b * float("2")
-43 |
-44 | assert complex(0.3, 0.2) == complex(0.1 + 0.2, 0.1 + 0.1)
+44 |     return a == b * float("2")
+45 |
+46 | assert complex(0.3, 0.2) == complex(0.1 + 0.2, 0.1 + 0.1)
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-45 |
-46 | assert (y := x / 2) == 1
-   |
-
-RUF069 Unreliable floating point equality comparison `y := x / 2 == 1`
-  --> RUF069.py:46:9
-   |
-44 | assert complex(0.3, 0.2) == complex(0.1 + 0.2, 0.1 + 0.1)
-45 |
-46 | assert (y := x / 2) == 1
-   |         ^^^^^^^^^^^^^^^^
 47 |
 48 | assert (0.3 if x > 0 else 1) == 0.1 + 0.2
    |
@@ -231,7 +200,7 @@ RUF069 Unreliable floating point equality comparison `y := x / 2 == 1`
 RUF069 Unreliable floating point equality comparison `0.3 if x > 0 else 1 == 0.1 + 0.2`
   --> RUF069.py:48:9
    |
-46 | assert (y := x / 2) == 1
+46 | assert complex(0.3, 0.2) == complex(0.1 + 0.2, 0.1 + 0.1)
 47 |
 48 | assert (0.3 if x > 0 else 1) == 0.1 + 0.2
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

Fixes #23281

`RUF069` was incorrectly flagging `Decimal` divisions, astropy unit operations, and other types that override `/` as float comparisons. The root cause was a special case in `has_float()` that treated *any* division involving numeric-looking expressions as producing a float — but without type inference, we can't distinguish built-in `/` (which does return `float`) from overloaded `/` on types like `Decimal` or astropy units.

As suggested by @ntBre in [the issue](https://github.com/astral-sh/ruff/issues/23281#issuecomment-3927447249), this removes the `Operator::Div` special case and the now-unused `is_numeric_expr` helper. Division is now treated the same as all other binary operators: only flagged when an operand is already *known* to be a float (literal, `float()` call, etc.).

This biases toward false negatives over false positives, which is the right tradeoff until proper type inference is available.

## Test Plan

Updated snapshot tests for `RUF069`. The three previously-false-positive cases (`x / 2 == 1`, `(x / 2) == (y / 3)`, `(y := x / 2) == 1`) are now correctly not flagged, while cases where one side is a known float (`x / 2 == 1.5`) are still caught.

```
cargo nextest run ruf069
```