### PR TITLE
[ty] ecosystem-analyzer: Inline diffs and panic messages

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -87,7 +87,7 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@3b27e0b28a5314240c218e939bde0c6c02a39652"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@2907323c61016ffd2cab9c25fb255f3dab8ec256"
 
           ecosystem-analyzer \
             --repository ruff \

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -56,7 +56,7 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@3b27e0b28a5314240c218e939bde0c6c02a39652"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@2907323c61016ffd2cab9c25fb255f3dab8ec256"
 
           ecosystem-analyzer \
             --verbose \


### PR DESCRIPTION
## Summary

Pulls in some ecosystem analyzer changes that allow us to see diagnostic diffs inline (will be collapsed into a `<details>` block if there are more of them, and will be randomly sampled if there are too many of them to fit inside a comment; will skip all diagnostics of flaky projects):

<img width="833" height="934" alt="image" src="https://github.com/user-attachments/assets/c66cd458-5328-4e1e-a86d-d54ab3ca2005" />

And we can now see panic messages in the HTML report:

<img width="1003" height="310" alt="image" src="https://github.com/user-attachments/assets/421f94c1-568b-4a07-9c8c-2300b7f233e7" />



## Test Plan

Various test runs on dummy PRs
