### PR TITLE
[ty] Avoid unnecessarily allocating Union/IntersectionBuilder

### DIFF
--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -598,28 +598,16 @@ impl<'db> Bindings<'db> {
         if let Some(return_ty) = self.constructor_return_type(db) {
             return return_ty;
         }
-        // If there's a single binding, return its type directly
-        if let Some(binding) = self.single_element() {
-            return binding.return_type();
-        }
 
-        // For each element (union variant), compute its return type:
-        // - Single binding: use that binding's return type
-        // - Multiple bindings (intersection): for intersections, only include
-        //   successful bindings (failed ones have been filtered out by retain_successful)
+        // For each element (union variant), intersect the return types of its surviving bindings.
         let element_return_types = self.elements.iter().map(|element| {
-            if let [single_binding] = &*element.bindings {
-                single_binding.return_type()
-            } else {
-                // For intersections, intersect the return types of remaining bindings
-                IntersectionType::from_elements(
-                    db,
-                    element.bindings.iter().map(CallableBinding::return_type),
-                )
-            }
+            IntersectionType::from_elements(
+                db,
+                element.bindings.iter().map(CallableBinding::return_type),
+            )
         });
 
-        // Union the return types of all elements
+        // Union the return types of all elements.
         UnionType::from_elements(db, element_return_types)
     }
 

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -479,11 +479,8 @@ impl<'db> CallableTypes<'db> {
     }
 
     pub(crate) fn into_type(self, db: &'db dyn Db) -> Type<'db> {
-        match self.0.as_slice() {
-            [] => unreachable!("CallableTypes should not be empty"),
-            [single] => Type::Callable(*single),
-            slice => UnionType::from_elements(db, slice.iter().copied().map(Type::Callable)),
-        }
+        assert!(!self.0.is_empty(), "CallableTypes should not be empty");
+        UnionType::from_elements(db, self.0.into_iter().map(Type::Callable))
     }
 
     pub(crate) fn map(self, mut f: impl FnMut(CallableType<'db>) -> CallableType<'db>) -> Self {

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -45,12 +45,20 @@ impl<'db> UnionType<'db> {
         I: IntoIterator<Item = T>,
         T: Into<Type<'db>>,
     {
-        elements
-            .into_iter()
-            .fold(UnionBuilder::new(db), |builder, element| {
-                builder.add(element.into())
-            })
-            .build()
+        let mut iter_elements = elements.into_iter();
+
+        if let Some(first) = iter_elements.next() {
+            if let Some(second) = iter_elements.next() {
+                let builder = UnionBuilder::new(db).add(first.into()).add(second.into());
+                iter_elements
+                    .fold(builder, |builder, element| builder.add(element.into()))
+                    .build()
+            } else {
+                first.into()
+            }
+        } else {
+            Type::Never
+        }
     }
 
     /// Create a union type `A | B` from two elements `A` and `B`.
@@ -632,9 +640,23 @@ impl<'db> IntersectionType<'db> {
         I: IntoIterator<Item = T>,
         T: Into<Type<'db>>,
     {
-        IntersectionBuilder::new(db)
-            .positive_elements(elements)
-            .build()
+        let mut elements_iter = elements.into_iter();
+
+        if let Some(first) = elements_iter.next() {
+            if let Some(second) = elements_iter.next() {
+                let builder =
+                    IntersectionBuilder::new(db).positive_elements([first.into(), second.into()]);
+                elements_iter
+                    .fold(builder, |builder, element| {
+                        builder.add_positive(element.into())
+                    })
+                    .build()
+            } else {
+                first.into()
+            }
+        } else {
+            Type::object()
+        }
     }
 
     /// Create an intersection type `A & B` from two elements `A` and `B`.

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1145,18 +1145,13 @@ impl<'db> IntersectionBuilder<'db> {
         self
     }
 
-    pub(crate) fn build(mut self) -> Type<'db> {
-        // Avoid allocating the UnionBuilder unnecessarily if we have just one intersection:
-        if self.intersections.len() == 1 {
-            self.intersections.pop().unwrap().build(self.db)
-        } else {
-            UnionType::from_elements(
-                self.db,
-                self.intersections
-                    .into_iter()
-                    .map(|inner| inner.build(self.db)),
-            )
-        }
+    pub(crate) fn build(self) -> Type<'db> {
+        UnionType::from_elements(
+            self.db,
+            self.intersections
+                .into_iter()
+                .map(|inner| inner.build(self.db)),
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

We have several places where we optimize the just-one-type case in order to avoid calling `UnionType::from_elements` or `IntersectionType::from_elements`. Rather than implementing this optimization ad-hoc at various call sites, implement it inside the two `from_elements` methods, so callers never need to worry about just calling them.

This PR is perf-neutral, but removing the existing optimizations causes meaningful regression. This just consolidates those existing necessary optimizations so that all callers get them.

This is not _purely_ a refactor, as passing a type through union/intersection building can unpack a type alias, but I consider that a neutral or positive change. There's no need to unpack an alias if we aren't actually unioning or intersecting it with anything.

One downside of this change is that we have to repeat the fact that an empty union is `Never` and an empty intersection is `object` in a second place. But this is not a fact that is likely to change, so I think that's worth the optimization.

## Test Plan

Existing CI.
