### PR TITLE
Avoid panic on invalid IPython escape commands in expressions

### DIFF
--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -2792,7 +2792,6 @@ impl<'src> Parser<'src> {
     /// # Panics
     ///
     /// If the parser isn't positioned at a `IpyEscapeCommand` token.
-    /// If the escape command kind is not `%` or `!`.
     fn parse_ipython_escape_command_expression(&mut self) -> ast::ExprIpyEscapeCommand {
         let start = self.node_start();
 
@@ -2802,13 +2801,19 @@ impl<'src> Parser<'src> {
             unreachable!()
         };
 
+        let range = self.node_range(start);
+
         if !matches!(kind, IpyEscapeKind::Magic | IpyEscapeKind::Shell) {
-            // This should never occur as the lexer won't allow it.
-            unreachable!("IPython escape command expression is only allowed for % and !");
+            self.add_error(
+                ParseErrorType::OtherError(
+                    "IPython escape command expression is only allowed for % and !".to_string(),
+                ),
+                range,
+            );
         }
 
         let command = ast::ExprIpyEscapeCommand {
-            range: self.node_range(start),
+            range,
             node_index: AtomicNodeIndex::NONE,
             kind,
             value,

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -1,4 +1,6 @@
-use crate::{Mode, ParseOptions, parse, parse_expression, parse_module};
+use crate::{
+    Mode, ParseErrorType, ParseOptions, parse, parse_expression, parse_module, parse_unchecked,
+};
 
 #[test]
 fn test_modes() {
@@ -135,6 +137,20 @@ foo.bar[0].baz[2].egg??
     )
     .unwrap();
     insta::assert_debug_snapshot!(parsed.syntax());
+}
+
+#[test]
+fn test_ipython_quote_escape_command_as_expression() {
+    let parsed = parse_unchecked("{]\n,", ParseOptions::from(Mode::Ipython));
+
+    assert!(parsed.has_invalid_syntax());
+    assert!(parsed.errors().iter().any(|error| {
+        matches!(
+            &error.error,
+            ParseErrorType::OtherError(message)
+                if message == "IPython escape command expression is only allowed for % and !"
+        )
+    }));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Turns out the lexer can emit these.

Closes https://github.com/astral-sh/ruff/issues/21705.
