### PR TITLE
fix(formatter): preserve parentheses in except handler tuples for Python 3.14+

### DIFF
--- a/crates/ruff_python_formatter/src/other/except_handler_except_handler.rs
+++ b/crates/ruff_python_formatter/src/other/except_handler_except_handler.rs
@@ -103,11 +103,13 @@ impl FormatNodeRule<ExceptHandlerExceptHandler> for FormatExceptHandlerExceptHan
                                 && name.is_none()
                                 && !tuple.iter().any(Expr::is_starred_expr) =>
                         {
+                            // In Python 3.14+, parentheses around exception tuples are optional.
+                            // Use Preserve to keep existing parentheses if present, otherwise omit them.
                             write!(
                                 f,
                                 [
                                     space(),
-                                    tuple.format().with_options(TupleParentheses::NeverPreserve)
+                                    tuple.format().with_options(TupleParentheses::Preserve)
                                 ]
                             )?;
                         }


### PR DESCRIPTION
## Summary

In Python 3.14, parentheses around exception tuples in `except` handlers are optional, but they are still valid syntax. The formatter was incorrectly removing existing parentheses using `TupleParentheses::NeverPreserve`, which produces invalid Python code.

## Fix

Changed `TupleParentheses::NeverPreserve` to `TupleParentheses::Preserve` to keep existing parentheses while still allowing them to be omitted when formatting from scratch.

## Example

Before (broken in 0.15.0+ with `--target-version py314`):
```python
# Input
try:
    int("a")
except (ValueError, IndexError):
    pass

# Output (incorrect - syntax error)
except ValueError, IndexError:
    pass
```

After (preserves parentheses):
```python
# Input
try:
    int("a")
except (ValueError, IndexError):
    pass

# Output (correct - preserves parentheses)
except (ValueError, IndexError):
    pass
```

Fixes #24041