### PR TITLE
[ty] ecosystem-analyzer: Fail on newly panicking projects

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -64,6 +64,7 @@ jobs:
         run: rustup show
 
       - name: Compute diagnostic diff
+        id: compute-diagnostic-diff
         shell: bash
         run: |
           cd ruff
@@ -86,7 +87,7 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@2907323c61016ffd2cab9c25fb255f3dab8ec256"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@cc6b94ac6d40d7c1cbf891ce48245d6b69e5631b"
 
           ecosystem-analyzer \
             --repository ruff \
@@ -111,13 +112,17 @@ jobs:
             --new-name "$REF_NAME" \
             --output-html dist/diff.html
 
+          set +e
           ecosystem-analyzer \
             generate-diff-statistics \
             diagnostics-old.json \
             diagnostics-new.json \
+            --fail-on-new-abnormal-exits \
             --old-name "main (merge base)" \
             --new-name "$REF_NAME" \
             --output diff-statistics.md
+          DIFF_STATISTICS_EXIT_CODE=$?
+          set -e
 
           ecosystem-analyzer \
             generate-timing-diff \
@@ -132,6 +137,8 @@ jobs:
           cat diff-statistics.md >> comment.md
 
           cat diff-statistics.md >> "$GITHUB_STEP_SUMMARY"
+
+          echo "diff_statistics_exit_code=$DIFF_STATISTICS_EXIT_CODE" >> "$GITHUB_OUTPUT"
 
       # NOTE: astral-sh-bot uses this artifact to post comments on PRs.
       # Make sure to update the bot if you rename the artifact.
@@ -160,3 +167,7 @@ jobs:
         with:
           name: timing.html
           path: dist/timing.html
+
+      - name: Fail on new abnormal exits
+        if: steps.compute-diagnostic-diff.outputs.diff_statistics_exit_code != '0'
+        run: exit 1

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -56,7 +56,7 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@2907323c61016ffd2cab9c25fb255f3dab8ec256"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@cc6b94ac6d40d7c1cbf891ce48245d6b69e5631b"
 
           ecosystem-analyzer \
             --verbose \


### PR DESCRIPTION
## Summary

* Fail the ecosystem-analyzer CI run if new projects result in a ty panic
* Add a new table to the PR comment if there are projects with large timing diffs (> 50%)

## Test Plan

- [x] Clean CI runs on this PR
- [x] Failing CI run on [this test PR](https://github.com/astral-sh/ruff/pull/24046)
