### PR TITLE
[ty] Fix untracked reads in Salsa queries that can lead to backdating panics

### DIFF
--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -33,6 +33,15 @@ pub trait Db: SemanticDb {
 #[salsa::db]
 #[derive(Clone)]
 pub struct ProjectDatabase {
+    // This handle must remain stable for the lifetime of the database.
+    //
+    // Many tracked queries branch on the untracked `db.project()` read before
+    // consulting tracked `Project` fields. Replacing the handle during reload
+    // therefore changes query behavior outside salsa's dependency graph and can
+    // trigger stale results.
+    //
+    // Structural reloads must update the existing `Project` in place via salsa
+    // setters instead of swapping in a freshly constructed handle.
     project: Option<Project>,
     files: Files,
 

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -1,7 +1,7 @@
+use crate::ProjectMetadata;
 use crate::db::{Db, ProjectDatabase};
 use crate::metadata::options::ProjectOptionsOverrides;
 use crate::watch::{ChangeEvent, CreatedKind, DeletedKind};
-use crate::{Project, ProjectMetadata};
 use std::collections::BTreeSet;
 
 use crate::walk::ProjectFilesWalker;
@@ -38,7 +38,7 @@ impl ProjectDatabase {
         changes: Vec<ChangeEvent>,
         project_options_overrides: Option<&ProjectOptionsOverrides>,
     ) -> ChangeResult {
-        let mut project = self.project();
+        let project = self.project();
         let project_root = project.root(self).to_path_buf();
         let config_file_override =
             project_options_overrides.and_then(|options| options.config_file_override.clone());
@@ -59,11 +59,12 @@ impl ProjectDatabase {
         let mut sync_recursively = BTreeSet::default();
 
         for change in changes {
-            tracing::trace!("Handle change: {:?}", change);
+            tracing::debug!("Handling file watcher change event: {:?}", change);
 
             if let Some(path) = change.system_path() {
                 if let Some(config_file) = &config_file_override {
                     if config_file.as_path() == path {
+                        File::sync_path(self, path);
                         result.project_changed = true;
 
                         continue;
@@ -74,6 +75,7 @@ impl ProjectDatabase {
                     path.file_name(),
                     Some(".gitignore" | ".ignore" | "ty.toml" | "pyproject.toml")
                 ) {
+                    File::sync_path(self, path);
                     // Changes to ignore files or settings can change the project structure or add/remove files.
                     result.project_changed = true;
 
@@ -279,28 +281,8 @@ impl ProjectDatabase {
                         }
                     }
 
-                    if metadata.root() == project.root(self) {
-                        tracing::debug!("Reloading project after structural change");
-                        project.reload(self, metadata);
-                    } else {
-                        match Project::from_metadata(self, metadata, &FallibleStrategy) {
-                            Ok(new_project) => {
-                                tracing::debug!("Replace project after structural change");
-                                project = new_project;
-                            }
-                            Err(error) => {
-                                tracing::error!(
-                                    "Keeping old project configuration because loading the new settings failed with: {error}"
-                                );
-
-                                project
-                                    .set_settings_diagnostics(self)
-                                    .to(vec![error.into_diagnostic()]);
-                            }
-                        }
-
-                        self.project = Some(project);
-                    }
+                    tracing::debug!("Reloading project after structural change");
+                    project.reload(self, metadata);
                 }
                 Err(error) => {
                     tracing::error!(

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -184,20 +184,24 @@ impl Project {
                 .options()
                 .to_settings(db, metadata.root(), strategy)?;
 
-        // This adds a file root for the project itself. This enables
-        // tracking of when changes are made to the files in a project
-        // at the directory level. At time of writing (2025-07-17),
-        // this is used for caching completions for submodules.
-        db.files()
-            .try_add_root(db, metadata.root(), FileRootKind::Project);
-
         let project = Project::builder(Box::new(metadata), Box::new(settings), diagnostics)
             .durability(Durability::MEDIUM)
             .open_fileset_durability(Durability::LOW)
             .file_set_durability(Durability::LOW)
             .new(db);
 
+        project.try_add_file_root(db);
+
         Ok(project)
+    }
+
+    fn try_add_file_root(self, db: &dyn Db) {
+        // This adds a file root for the project itself. This enables
+        // tracking of when changes are made to the files in a project
+        // at the directory level. At time of writing (2025-07-17),
+        // this is used for caching completions for submodules.
+        db.files()
+            .try_add_root(db, self.root(db), FileRootKind::Project);
     }
 
     pub fn root(self, db: &dyn Db) -> &SystemPath {
@@ -242,32 +246,37 @@ impl Project {
 
     pub fn reload(self, db: &mut dyn Db, metadata: ProjectMetadata) {
         tracing::debug!("Reloading project");
-        assert_eq!(self.root(db), metadata.root());
-
-        if &metadata != self.metadata(db) {
-            match metadata
-                .options()
-                .to_settings(db, metadata.root(), &FallibleStrategy)
-            {
-                Ok((settings, settings_diagnostics)) => {
-                    if self.settings(db) != &settings {
-                        self.set_settings(db).to(Box::new(settings));
-                    }
-
-                    if self.settings_diagnostics(db) != settings_diagnostics {
-                        self.set_settings_diagnostics(db).to(settings_diagnostics);
-                    }
-                }
-                Err(error) => {
-                    self.set_settings_diagnostics(db)
-                        .to(vec![error.into_diagnostic()]);
-                }
-            }
-
-            self.set_metadata(db).to(Box::new(metadata));
-        }
 
         self.reload_files(db);
+
+        if &metadata == self.metadata(db) {
+            return;
+        }
+
+        match metadata
+            .options()
+            .to_settings(db, metadata.root(), &FallibleStrategy)
+        {
+            Ok((settings, settings_diagnostics)) => {
+                if self.settings(db) != &settings {
+                    self.set_settings(db).to(Box::new(settings));
+                }
+
+                if self.settings_diagnostics(db) != settings_diagnostics {
+                    self.set_settings_diagnostics(db).to(settings_diagnostics);
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    "Keeping old project configuration because loading the new settings failed with: {error}"
+                );
+                self.set_settings_diagnostics(db)
+                    .to(vec![error.into_diagnostic()]);
+            }
+        }
+
+        self.set_metadata(db).to(Box::new(metadata));
+        self.try_add_file_root(db);
     }
 
     /// Checks the project and its dependencies according to the project's check mode.


### PR DESCRIPTION
## Summary

This PR fixes two cases that could lead to the panics reported in https://github.com/astral-sh/ty/issues/1565. 

After a change to an input (e.g., a file was modified), Salsa re-executes all queries that read that input or depend on any such query. To limit invalidation, Salsa can backdate a query. If a query computes to the same value as in the previous revision, Salsa considers it unchanged and skips re-executing dependent queries. This is called backdating a query. The reason it's called backdating is that Salsa tracks the revision in which a query was last changed; backdating sets the last-changed revision "back" to the revision from before the input change. During backdating, Salsa enforces that the revision is indeed going backwards. That is, the revision Salsa backdates to (or the last changed revision from the previous query run) must be smaller (older) than the last changed revision from the current run. 

Under normal circumstances, this invariant should always hold because for a query result to change, the query has to read some input that was changed in the current revision (at least in a revision newer than the last run). This ensures that the last changed revision from the new run is never older than that from the previous run. However, this invariant can be violated if a query branches on a state that isn't tracked in Salsa. Salsa will rerun the query because one of its inputs changed, but the query branches on some untracked state before reading that input, so that the query's last changed revision might be earlier than when the input changed.

Reading an untracked state in a query is always a bug (unless you call `db.untracked_read`), and it can lead to stale results. But I don't think it's an error severe enough to warrant Salsa panicking. I plan to PR a change to Salsa to panic only in debug builds and otherwise log a warning, notifying users about the untracked read.

The change in this PR is to fix two cases where we ended up with reading untracked global state or failed to correctly invalidate all query dependencies:

* `Project` is a Salsa input, but `db.project` isn't a Salsa tracked field. Therefore, it's important that we never reassign `db.project` during a DB's lifetime. This PR fixes the one place where we did replace `db.project` with a new `Project`
* There were a few instances where we didn't call `File::sync` where we should. This can lead to stale results and potentially panic within `absolute_desperate_search_paths` because the query branches on whether something is a file.


## Test Plan

I wrote three integration tests with Codex that all panicked before making the above changes. I decided not to commit them because they all feel a bit artificial and I didn't manage to come up with more real-world tests that reproduce the panic. All tests now pass without panicking. 

<details><summary>Tests</summary>

```rust
use ruff_db::files::{File, system_path_to_file};
use ruff_db::system::{SystemPath, SystemPathBuf, TestSystem};
use ty_module_resolver::UseDefaultStrategy;
use ty_module_resolver::{ModuleName, resolve_module};
use ty_project::metadata::options::{AnalysisOptions, Options};
use ty_project::watch::{ChangeEvent, CreatedKind};
use ty_project::{Db as _, ProjectDatabase, ProjectMetadata};

#[salsa::tracked]
fn dep_a(db: &dyn ty_project::Db, file: File) -> u32 {
    file.read_to_string(db)
        .ok()
        .and_then(|contents| contents.trim().parse().ok())
        .unwrap_or(0)
}

#[salsa::tracked]
fn dep_b(db: &dyn ty_project::Db, file: File) -> u32 {
    file.read_to_string(db)
        .ok()
        .and_then(|contents| contents.trim().parse().ok())
        .unwrap_or(0)
}

#[salsa::tracked]
fn branch_on_project_identity(
    db: &dyn ty_project::Db,
    expected_project: ty_project::Project,
    file_a: File,
    file_b: File,
) -> u32 {
    if db.project() == expected_project {
        dep_a(db, file_a)
    } else {
        dep_b(db, file_b)
    }
}

/// Minimal model of `absolute_desperate_search_paths`' invalidation strategy.
///
/// The real resolver query:
/// - tracks only the enclosing project root revision
/// - then branches on `system.is_file(.../pyproject.toml)`
///
/// Calling the real tracked query here would only reproduce the stale-cache bug:
/// after creating `pyproject.toml`, the query would keep returning its old memo and
/// the outer query's branch would not change. This distilled query keeps the same
/// dependency shape while allowing the branch flip to remain visible, which is what
/// exposes the backdating assertion.
#[salsa::tracked]
fn branch_like_absolute_desperate_search_paths_without_root_invalidation(
    db: &dyn ty_project::Db,
    importing_file: File,
    file_a: File,
    file_b: File,
) -> u32 {
    let importing_path = importing_file.path(db).as_system_path().unwrap();
    let package_path = importing_path.parent().unwrap().parent().unwrap();
    let pyproject_path = package_path.join("pyproject.toml");

    let root = db.files().root(db, package_path).unwrap();
    let _ = root.revision(db);

    if db.system().is_file(&pyproject_path) {
        dep_a(db, file_a)
    } else {
        dep_b(db, file_b)
    }
}

#[test]
#[should_panic(expected = "old_memo.revisions.changed_at <= revisions.changed_at")]
fn project_reload_via_apply_changes_synthetic_write_does_not_avoid_backdating_panic() {
    let system = TestSystem::default();

    let a_path = SystemPath::new("/project/subpkg/a.txt");
    let b_path = SystemPath::new("/project/subpkg/b.txt");

    system
        .memory_file_system()
        .create_directory_all(SystemPath::new("/project/subpkg"))
        .unwrap();
    system.memory_file_system().write_file(a_path, "0").unwrap();
    system.memory_file_system().write_file(b_path, "0").unwrap();

    let metadata = ProjectMetadata::from_options(
        Options {
            analysis: Some(AnalysisOptions {
                respect_type_ignore_comments: Some(true),
                ..AnalysisOptions::default()
            }),
            ..Options::default()
        },
        SystemPathBuf::from("/project/subpkg"),
        None,
        &UseDefaultStrategy,
    )
    .unwrap();

    let mut db = ProjectDatabase::use_defaults(metadata, system.clone());

    let a_file = system_path_to_file(&db, a_path).expect("a.txt to exist");
    let b_file = system_path_to_file(&db, b_path).expect("b.txt to exist");

    let initial_project = db.project();

    assert_eq!(
        branch_on_project_identity(&db, initial_project, a_file, b_file),
        0
    );

    system
        .memory_file_system()
        .write_file(a_path, "1")
        .expect("update a.txt");

    db.apply_changes(
        vec![ChangeEvent::file_content_changed(a_path.to_path_buf())],
        None,
    );
    assert_eq!(
        branch_on_project_identity(&db, initial_project, a_file, b_file),
        1
    );

    system
        .memory_file_system()
        .write_file(a_path, "0")
        .expect("update a.txt");
    db.apply_changes(
        vec![ChangeEvent::file_content_changed(a_path.to_path_buf())],
        None,
    );
    assert_eq!(
        branch_on_project_identity(&db, initial_project, a_file, b_file),
        0
    );

    // Trigger a change that forces the project to reload.
    system
        .memory_file_system()
        .write_file(
            SystemPath::new("/project/ty.toml"),
            "[analysis]\nrespect-type-ignore-comments = false\n",
        )
        .expect("write ty.toml");
    db.apply_changes(
        vec![ChangeEvent::Created {
            path: SystemPathBuf::from("/project/ty.toml"),
            kind: CreatedKind::File,
        }],
        None,
    );

    // assert_ne!(db.project(), initial_project);

    system
        .memory_file_system()
        .write_file(a_path, "1")
        .expect("update a.txt");
    db.apply_changes(
        vec![ChangeEvent::file_content_changed(a_path.to_path_buf())],
        None,
    );

    let _ = branch_on_project_identity(&db, initial_project, a_file, b_file);
}

#[test]
fn nested_pyproject_creation_invalidates_desperate_resolution() {
    let system = TestSystem::default();

    let importing_path = SystemPath::new("/project/subpkg/tests/test.py");
    let nested_package_init = SystemPath::new("/project/subpkg/__init__.py");
    let nested_module_path = SystemPath::new("/project/subpkg/foo.py");

    system
        .memory_file_system()
        .create_directory_all(SystemPath::new("/project/subpkg/tests"))
        .unwrap();
    system
        .memory_file_system()
        .write_file(importing_path, "")
        .unwrap();
    system
        .memory_file_system()
        .write_file(nested_package_init, "")
        .unwrap();
    system
        .memory_file_system()
        .write_file(nested_module_path, "x = 1")
        .unwrap();

    let metadata = ProjectMetadata::new("project".into(), SystemPathBuf::from("/project"));
    let mut db = ProjectDatabase::use_defaults(metadata, system.clone());

    let importing_file = system_path_to_file(&db, importing_path).expect("test.py to exist");
    let nested_module_file = system_path_to_file(&db, nested_module_path).expect("foo.py to exist");
    let foo = ModuleName::new_static("foo").unwrap();

    assert_eq!(resolve_module(&db, importing_file, &foo), None);

    system
        .memory_file_system()
        .write_file(
            SystemPath::new("/project/subpkg/pyproject.toml"),
            "[tool.ty]\n",
        )
        .unwrap();
    db.apply_changes(
        vec![ChangeEvent::Created {
            path: SystemPathBuf::from("/project/subpkg/pyproject.toml"),
            kind: CreatedKind::File,
        }],
        None,
    );

    assert_eq!(
        resolve_module(&db, importing_file, &foo).map(|module| module.file(&db).unwrap()),
        Some(nested_module_file),
        "nested pyproject.toml should invalidate desperate resolution",
    );
}

#[test]
fn project_root_invalidation_prevents_backdate_assertion() {
    let system = TestSystem::default();

    let importing_path = SystemPath::new("/project/subpkg/tests/test.py");
    let a_path = SystemPath::new("/project/subpkg/a.txt");
    let b_path = SystemPath::new("/project/subpkg/b.txt");

    system
        .memory_file_system()
        .create_directory_all(SystemPath::new("/project/subpkg/tests"))
        .unwrap();
    system
        .memory_file_system()
        .write_file(importing_path, "")
        .unwrap();
    system.memory_file_system().write_file(a_path, "0").unwrap();
    system.memory_file_system().write_file(b_path, "0").unwrap();

    let metadata = ProjectMetadata::new("project".into(), SystemPathBuf::from("/project"));
    let mut db = ProjectDatabase::use_defaults(metadata, system.clone());

    let importing_file = system_path_to_file(&db, importing_path).expect("test.py to exist");
    let a_file = system_path_to_file(&db, a_path).expect("a.txt to exist");
    let b_file = system_path_to_file(&db, b_path).expect("b.txt to exist");

    assert_eq!(
        branch_like_absolute_desperate_search_paths_without_root_invalidation(
            &db,
            importing_file,
            a_file,
            b_file,
        ),
        0
    );

    system.memory_file_system().write_file(b_path, "1").unwrap();
    db.apply_changes(
        vec![ChangeEvent::file_content_changed(b_path.to_path_buf())],
        None,
    );
    assert_eq!(
        branch_like_absolute_desperate_search_paths_without_root_invalidation(
            &db,
            importing_file,
            a_file,
            b_file,
        ),
        1
    );

    system.memory_file_system().write_file(b_path, "0").unwrap();
    db.apply_changes(
        vec![ChangeEvent::file_content_changed(b_path.to_path_buf())],
        None,
    );
    assert_eq!(
        branch_like_absolute_desperate_search_paths_without_root_invalidation(
            &db,
            importing_file,
            a_file,
            b_file,
        ),
        0
    );

    system
        .memory_file_system()
        .write_file(
            SystemPath::new("/project/subpkg/pyproject.toml"),
            "[tool.ty]\n",
        )
        .unwrap();
    db.apply_changes(
        vec![ChangeEvent::Created {
            path: SystemPathBuf::from("/project/subpkg/pyproject.toml"),
            kind: CreatedKind::File,
        }],
        None,
    );

    system.memory_file_system().write_file(b_path, "1").unwrap();
    db.apply_changes(
        vec![ChangeEvent::file_content_changed(b_path.to_path_buf())],
        None,
    );

    assert_eq!(
        branch_like_absolute_desperate_search_paths_without_root_invalidation(
            &db,
            importing_file,
            a_file,
            b_file,
        ),
        0
    );
}

```
</details>
