### PR TITLE
Fix incorrect path for ty_python_semantic in fuzzer

### DIFF
--- a/fuzz/init-fuzzer.sh
+++ b/fuzz/init-fuzzer.sh
@@ -33,7 +33,7 @@ if [ ! -d corpus/common ]; then
     # Build a smaller corpus in addition to the (optional) larger corpus
     echo "Building a smaller corpus dataset..."
     curl -L 'https://github.com/python/cpython/archive/refs/tags/v3.13.0.tar.gz' | tar xz
-    cp -r "../../../crates/ty_project/resources/test/corpus" "ty_project"
+    cp -r "../../../crates/ty_python_semantic/resources/corpus" "ty_python_semantic"
     cp -r "../../../crates/ruff_linter/resources/test/fixtures" "ruff_linter"
     cp -r "../../../crates/ruff_python_formatter/resources/test/fixtures" "ruff_python_formatter"
     cp -r "../../../crates/ruff_python_parser/resources" "ruff_python_parser"


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

The `init-fuzzer.sh` script was failing for me with:

```
cp: cannot stat '../../../crates/ty_project/resources/test/corpus': No such file or directory
```

I guess the said corpus was moved to ty_python_semantic in https://github.com/astral-sh/ruff/pull/18609


<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
I ran it on my computer. Do you want this to run as part of CI to not break it in the future?