### PR TITLE
[flake8-implicit-str-concat] Implement fix for multi-line implicit string concatenation (ISC002)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
@@ -96,9 +96,15 @@ impl Violation for SingleLineImplicitStringConcatenation {
 pub(crate) struct MultiLineImplicitStringConcatenation;
 
 impl Violation for MultiLineImplicitStringConcatenation {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         "Implicitly concatenated string literals over multiple lines".to_string()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Replace with explicit concatenation".to_string())
     }
 }
 
@@ -159,10 +165,12 @@ pub(crate) fn implicit(
         };
 
         if locator.contains_line_break(TextRange::new(a_range.end(), b_range.start())) {
-            context.report_diagnostic_if_enabled(
+            if let Some(mut diagnostic) = context.report_diagnostic_if_enabled(
                 MultiLineImplicitStringConcatenation,
                 TextRange::new(a_range.start(), b_range.end()),
-            );
+            ) {
+                diagnostic.set_fix(fix_multiline(a_range, b_range, locator));
+            }
         } else {
             if let Some(mut diagnostic) = context.report_diagnostic_if_enabled(
                 SingleLineImplicitStringConcatenation,
@@ -267,4 +275,46 @@ fn has_odd_consecutive_backslashes(mut itr: impl Iterator<Item = u8>) -> bool {
         odd_backslashes = !odd_backslashes;
     }
     odd_backslashes
+}
+
+/// Generate a fix for multi-line implicit string concatenation (ISC002).
+///
+/// For backslash-continued strings, removes the backslash and wraps the
+/// concatenation in parentheses. For strings already in parentheses (when
+/// `allow-multiline = false`), converts to explicit `+` concatenation.
+fn fix_multiline(
+    a_range: TextRange,
+    b_range: TextRange,
+    locator: &Locator,
+) -> Fix {
+    let between = locator.slice(TextRange::new(a_range.end(), b_range.start()));
+
+    if let Some(backslash_offset) = between.find('\\') {
+        // Backslash continuation: remove the `\` and wrap in parentheses.
+        // Also consume any whitespace before the backslash.
+        let before_backslash = &between[..backslash_offset];
+        let trimmed_len = before_backslash.trim_end().len();
+        let replace_start = a_range.end() + TextLen::text_len(&between[..trimmed_len]);
+
+        let b_line_start = locator.line_start(b_range.start());
+        let indent = locator.slice(TextRange::new(b_line_start, b_range.start()));
+
+        Fix::unsafe_edits(
+            Edit::insertion("(".to_string(), a_range.start()),
+            [
+                Edit::range_replacement(
+                    format!("\n{indent}"),
+                    TextRange::new(replace_start, b_range.start()),
+                ),
+                Edit::insertion(")".to_string(), b_range.end()),
+            ],
+        )
+    } else {
+        // No backslash (allow-multiline = false): insert ` +` after the first
+        // string to make the concatenation explicit.
+        Fix::unsafe_edit(Edit::insertion(
+            " +".to_string(),
+            a_range.end(),
+        ))
+    }
 }

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/snapshots/ruff_linter__rules__flake8_implicit_str_concat__tests__ISC002_ISC.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/snapshots/ruff_linter__rules__flake8_implicit_str_concat__tests__ISC002_ISC.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_implicit_str_concat/mod.rs
 ---
-ISC002 Implicitly concatenated string literals over multiple lines
+ISC002 [*] Implicitly concatenated string literals over multiple lines
  --> ISC.py:5:5
   |
 3 |   _ = "abc" + "def"
@@ -13,8 +13,20 @@ ISC002 Implicitly concatenated string literals over multiple lines
 7 |
 8 |   _ = (
   |
+help: Replace with explicit concatenation
+2 | 
+3 | _ = "abc" + "def"
+4 | 
+  - _ = "abc" \
+  -     "def"
+5 + _ = ("abc"
+6 +     "def")
+7 | 
+8 | _ = (
+9 |   "abc" +
+note: This is an unsafe fix and may change runtime behavior
 
-ISC002 Implicitly concatenated string literals over multiple lines
+ISC002 [*] Implicitly concatenated string literals over multiple lines
   --> ISC.py:74:10
    |
 72 |   _ = "a" f"b {f"c" f"d"} e" "f"
@@ -26,8 +38,20 @@ ISC002 Implicitly concatenated string literals over multiple lines
 76 |
 77 |   # Explicitly concatenated nested f-strings
    |
+help: Replace with explicit concatenation
+71 | # Nested f-strings
+72 | _ = "a" f"b {f"c" f"d"} e" "f"
+73 | _ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+   - _ = f"b {f"abc" \
+   -     f"def"} g"
+74 + _ = f"b {(f"abc"
+75 +     f"def")} g"
+76 | 
+77 | # Explicitly concatenated nested f-strings
+78 | _ = f"a {f"first"
+note: This is an unsafe fix and may change runtime behavior
 
-ISC002 Implicitly concatenated string literals over multiple lines
+ISC002 [*] Implicitly concatenated string literals over multiple lines
    --> ISC.py:196:1
     |
 195 |   # ISC002
@@ -37,8 +61,20 @@ ISC002 Implicitly concatenated string literals over multiple lines
 198 |
 199 |   # ISC003
     |
+help: Replace with explicit concatenation
+193 | t"The quick " t"brown fox."
+194 | 
+195 | # ISC002
+    - t"The quick brown fox jumps over the lazy "\
+    - t"dog."
+196 + (t"The quick brown fox jumps over the lazy "
+197 + t"dog.")
+198 | 
+199 | # ISC003
+200 | (
+note: This is an unsafe fix and may change runtime behavior
 
-ISC002 Implicitly concatenated string literals over multiple lines
+ISC002 [*] Implicitly concatenated string literals over multiple lines
    --> ISC.py:208:10
     |
 206 |   _ = "a" f"b {t"c" t"d"} e" "f"
@@ -48,3 +84,15 @@ ISC002 Implicitly concatenated string literals over multiple lines
 209 | |     t"def"} g"
     | |__________^
     |
+help: Replace with explicit concatenation
+205 | # nested examples with both t and f-strings
+206 | _ = "a" f"b {t"c" t"d"} e" "f"
+207 | _ = t"b {f"c" f"d {t"e" t"f"} g"} h"
+    - _ = f"b {t"abc" \
+    -     t"def"} g"
+208 + _ = f"b {(t"abc"
+209 +     t"def")} g"
+210 | 
+211 | 
+212 | # Explicit concatenation with either operand being
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/snapshots/ruff_linter__rules__flake8_implicit_str_concat__tests__multiline_ISC002_ISC.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/snapshots/ruff_linter__rules__flake8_implicit_str_concat__tests__multiline_ISC002_ISC.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_implicit_str_concat/mod.rs
 ---
-ISC002 Implicitly concatenated string literals over multiple lines
+ISC002 [*] Implicitly concatenated string literals over multiple lines
  --> ISC.py:5:5
   |
 3 |   _ = "abc" + "def"
@@ -13,8 +13,20 @@ ISC002 Implicitly concatenated string literals over multiple lines
 7 |
 8 |   _ = (
   |
+help: Replace with explicit concatenation
+2 | 
+3 | _ = "abc" + "def"
+4 | 
+  - _ = "abc" \
+  -     "def"
+5 + _ = ("abc"
+6 +     "def")
+7 | 
+8 | _ = (
+9 |   "abc" +
+note: This is an unsafe fix and may change runtime behavior
 
-ISC002 Implicitly concatenated string literals over multiple lines
+ISC002 [*] Implicitly concatenated string literals over multiple lines
   --> ISC.py:24:3
    |
 23 |   _ = (
@@ -23,8 +35,18 @@ ISC002 Implicitly concatenated string literals over multiple lines
    | |_______^
 26 |   )
    |
+help: Replace with explicit concatenation
+21 | )
+22 | 
+23 | _ = (
+   -   "abc"
+24 +   "abc" +
+25 |   "def"
+26 | )
+27 | 
+note: This is an unsafe fix and may change runtime behavior
 
-ISC002 Implicitly concatenated string literals over multiple lines
+ISC002 [*] Implicitly concatenated string literals over multiple lines
   --> ISC.py:29:3
    |
 28 |   _ = (
@@ -33,8 +55,18 @@ ISC002 Implicitly concatenated string literals over multiple lines
    | |_______^
 31 |   )
    |
+help: Replace with explicit concatenation
+26 | )
+27 | 
+28 | _ = (
+   -   f"abc"
+29 +   f"abc" +
+30 |   "def"
+31 | )
+32 | 
+note: This is an unsafe fix and may change runtime behavior
 
-ISC002 Implicitly concatenated string literals over multiple lines
+ISC002 [*] Implicitly concatenated string literals over multiple lines
   --> ISC.py:34:3
    |
 33 |   _ = (
@@ -43,8 +75,18 @@ ISC002 Implicitly concatenated string literals over multiple lines
    | |________^
 36 |   )
    |
+help: Replace with explicit concatenation
+31 | )
+32 | 
+33 | _ = (
+   -   b"abc"
+34 +   b"abc" +
+35 |   b"def"
+36 | )
+37 | 
+note: This is an unsafe fix and may change runtime behavior
 
-ISC002 Implicitly concatenated string literals over multiple lines
+ISC002 [*] Implicitly concatenated string literals over multiple lines
   --> ISC.py:67:5
    |
 65 |   _ = f"""abc {"def" "ghi"} jkl"""
@@ -54,8 +96,18 @@ ISC002 Implicitly concatenated string literals over multiple lines
    | |_________^
 69 |   } jkl"""
    |
+help: Replace with explicit concatenation
+64 | _ = f"a {'b' 'c' 'd'} e"
+65 | _ = f"""abc {"def" "ghi"} jkl"""
+66 | _ = f"""abc {
+   -     "def"
+67 +     "def" +
+68 |     "ghi"
+69 | } jkl"""
+70 | 
+note: This is an unsafe fix and may change runtime behavior
 
-ISC002 Implicitly concatenated string literals over multiple lines
+ISC002 [*] Implicitly concatenated string literals over multiple lines
   --> ISC.py:74:10
    |
 72 |   _ = "a" f"b {f"c" f"d"} e" "f"
@@ -67,8 +119,20 @@ ISC002 Implicitly concatenated string literals over multiple lines
 76 |
 77 |   # Explicitly concatenated nested f-strings
    |
+help: Replace with explicit concatenation
+71 | # Nested f-strings
+72 | _ = "a" f"b {f"c" f"d"} e" "f"
+73 | _ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+   - _ = f"b {f"abc" \
+   -     f"def"} g"
+74 + _ = f"b {(f"abc"
+75 +     f"def")} g"
+76 | 
+77 | # Explicitly concatenated nested f-strings
+78 | _ = f"a {f"first"
+note: This is an unsafe fix and may change runtime behavior
 
-ISC002 Implicitly concatenated string literals over multiple lines
+ISC002 [*] Implicitly concatenated string literals over multiple lines
    --> ISC.py:196:1
     |
 195 |   # ISC002
@@ -78,8 +142,20 @@ ISC002 Implicitly concatenated string literals over multiple lines
 198 |
 199 |   # ISC003
     |
+help: Replace with explicit concatenation
+193 | t"The quick " t"brown fox."
+194 | 
+195 | # ISC002
+    - t"The quick brown fox jumps over the lazy "\
+    - t"dog."
+196 + (t"The quick brown fox jumps over the lazy "
+197 + t"dog.")
+198 | 
+199 | # ISC003
+200 | (
+note: This is an unsafe fix and may change runtime behavior
 
-ISC002 Implicitly concatenated string literals over multiple lines
+ISC002 [*] Implicitly concatenated string literals over multiple lines
    --> ISC.py:208:10
     |
 206 |   _ = "a" f"b {t"c" t"d"} e" "f"
@@ -89,8 +165,20 @@ ISC002 Implicitly concatenated string literals over multiple lines
 209 | |     t"def"} g"
     | |__________^
     |
+help: Replace with explicit concatenation
+205 | # nested examples with both t and f-strings
+206 | _ = "a" f"b {t"c" t"d"} e" "f"
+207 | _ = t"b {f"c" f"d {t"e" t"f"} g"} h"
+    - _ = f"b {t"abc" \
+    -     t"def"} g"
+208 + _ = f"b {(t"abc"
+209 +     t"def")} g"
+210 | 
+211 | 
+212 | # Explicit concatenation with either operand being
+note: This is an unsafe fix and may change runtime behavior
 
-ISC002 Implicitly concatenated string literals over multiple lines
+ISC002 [*] Implicitly concatenated string literals over multiple lines
    --> ISC.py:217:5
     |
 215 |   # See https://github.com/astral-sh/ruff/issues/19757
@@ -100,8 +188,18 @@ ISC002 Implicitly concatenated string literals over multiple lines
     | |_________^
 219 |   )
     |
+help: Replace with explicit concatenation
+214 | # reports diagnostic - no autofix.
+215 | # See https://github.com/astral-sh/ruff/issues/19757
+216 | _ = "abc" + (
+    -     "def"
+217 +     "def" +
+218 |     "ghi"
+219 | )
+220 | 
+note: This is an unsafe fix and may change runtime behavior
 
-ISC002 Implicitly concatenated string literals over multiple lines
+ISC002 [*] Implicitly concatenated string literals over multiple lines
    --> ISC.py:222:5
     |
 221 |   _ = (
@@ -110,3 +208,12 @@ ISC002 Implicitly concatenated string literals over multiple lines
     | |_________^
 224 |   ) + "ghi"
     |
+help: Replace with explicit concatenation
+219 | )
+220 | 
+221 | _ = (
+    -     "abc"
+222 +     "abc" +
+223 |     "def"
+224 | ) + "ghi"
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Closes #23887

## Summary

Implements an autofix for ISC002 (multi-line implicit string concatenation), handling two cases based on the `allow-multiline` setting:

**Backslash continuation (`allow-multiline = true`, default):** Wraps the concatenated strings in parentheses and removes the backslash continuation. This converts the backslash-based line continuation into the parenthesized form recommended by PEP 8.

```python
# Before
z = "The quick brown fox jumps over the lazy "\
    "dog."
# After
z = ("The quick brown fox jumps over the lazy "
    "dog.")
```

**Parenthesized implicit concatenation (`allow-multiline = false`):** Inserts explicit `+` concatenation between the strings, since implicit concatenation is disallowed entirely in this mode.

```python
# Before
z = (
    "The quick brown fox jumps over the lazy "
    "dog."
)
# After
z = (
    "The quick brown fox jumps over the lazy " +
    "dog."
)
```

The fix is marked as unsafe due to potential interactions with the formatter.

## Test Plan

- Updated snapshot tests for both `allow-multiline` settings
- All existing ISC tests pass (`cargo test -p ruff_linter -- flake8_implicit_str_concat`)
- `cargo clippy -p ruff_linter -- -D warnings` passes
- `cargo dev generate-all` produces no changes