### PR TITLE
Clarify `extend-ignore` and `extend-select` settings documentation

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -677,6 +677,14 @@ pub struct LintCommonOptions {
 
     /// A list of rule codes or prefixes to ignore, in addition to those
     /// specified by `ignore`.
+    ///
+    /// This option is deprecated because it is now interchangeable with
+    /// [`ignore`](#lint_ignore). In earlier versions of Ruff, `ignore` would
+    /// _replace_ the set of ignored rules when using configuration inheritance
+    /// (via the top-level [`extend`](https://docs.astral.sh/ruff/settings/#extend)
+    /// setting), while `extend-ignore` would _add_ to the inherited set. Ruff
+    /// now merges both `ignore` and `extend-ignore` into a single set, so the
+    /// distinction no longer applies. Use [`ignore`](#lint_ignore) instead.
     #[option(
         default = "[]",
         value_type = "list[RuleSelector]",
@@ -692,6 +700,23 @@ pub struct LintCommonOptions {
 
     /// A list of rule codes or prefixes to enable, in addition to those
     /// specified by [`select`](#lint_select).
+    ///
+    /// Unlike [`select`](#lint_select), which _replaces_ the default rule set
+    /// when specified, `extend-select` _adds_ to whatever rules are already
+    /// active. This makes `extend-select` the preferred option when you want
+    /// to enable additional rules on top of the defaults without having to
+    /// enumerate them.
+    ///
+    /// For example, to enable the defaults plus flake8-bugbear:
+    ///
+    /// ```toml
+    /// [tool.ruff.lint]
+    /// # Adds flake8-bugbear on top of the default rules (E4, E7, E9, F).
+    /// extend-select = ["B"]
+    /// ```
+    ///
+    /// Using `select = ["B"]` instead would _replace_ the defaults, enabling
+    /// only flake8-bugbear.
     #[option(
         default = "[]",
         value_type = "list[RuleSelector]",

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -99,7 +99,7 @@
       }
     },
     "extend-ignore": {
-      "description": "A list of rule codes or prefixes to ignore, in addition to those\nspecified by `ignore`.",
+      "description": "A list of rule codes or prefixes to ignore, in addition to those\nspecified by `ignore`.\n\nThis option is deprecated because it is now interchangeable with\n[`ignore`](#lint_ignore). In earlier versions of Ruff, `ignore` would\n_replace_ the set of ignored rules when using configuration inheritance\n(via the top-level [`extend`](https://docs.astral.sh/ruff/settings/#extend)\nsetting), while `extend-ignore` would _add_ to the inherited set. Ruff\nnow merges both `ignore` and `extend-ignore` into a single set, so the\ndistinction no longer applies. Use [`ignore`](#lint_ignore) instead.",
       "type": [
         "array",
         "null"
@@ -145,7 +145,7 @@
       }
     },
     "extend-select": {
-      "description": "A list of rule codes or prefixes to enable, in addition to those\nspecified by [`select`](#lint_select).",
+      "description": "A list of rule codes or prefixes to enable, in addition to those\nspecified by [`select`](#lint_select).\n\nUnlike [`select`](#lint_select), which _replaces_ the default rule set\nwhen specified, `extend-select` _adds_ to whatever rules are already\nactive. This makes `extend-select` the preferred option when you want\nto enable additional rules on top of the defaults without having to\nenumerate them.\n\nFor example, to enable the defaults plus flake8-bugbear:\n\n```toml\n[tool.ruff.lint]\n# Adds flake8-bugbear on top of the default rules (E4, E7, E9, F).\nextend-select = [\"B\"]\n```\n\nUsing `select = [\"B\"]` instead would _replace_ the defaults, enabling\nonly flake8-bugbear.",
       "type": [
         "array",
         "null"
@@ -2154,7 +2154,7 @@
           }
         },
         "extend-ignore": {
-          "description": "A list of rule codes or prefixes to ignore, in addition to those\nspecified by `ignore`.",
+          "description": "A list of rule codes or prefixes to ignore, in addition to those\nspecified by `ignore`.\n\nThis option is deprecated because it is now interchangeable with\n[`ignore`](#lint_ignore). In earlier versions of Ruff, `ignore` would\n_replace_ the set of ignored rules when using configuration inheritance\n(via the top-level [`extend`](https://docs.astral.sh/ruff/settings/#extend)\nsetting), while `extend-ignore` would _add_ to the inherited set. Ruff\nnow merges both `ignore` and `extend-ignore` into a single set, so the\ndistinction no longer applies. Use [`ignore`](#lint_ignore) instead.",
           "type": [
             "array",
             "null"
@@ -2188,7 +2188,7 @@
           }
         },
         "extend-select": {
-          "description": "A list of rule codes or prefixes to enable, in addition to those\nspecified by [`select`](#lint_select).",
+          "description": "A list of rule codes or prefixes to enable, in addition to those\nspecified by [`select`](#lint_select).\n\nUnlike [`select`](#lint_select), which _replaces_ the default rule set\nwhen specified, `extend-select` _adds_ to whatever rules are already\nactive. This makes `extend-select` the preferred option when you want\nto enable additional rules on top of the defaults without having to\nenumerate them.\n\nFor example, to enable the defaults plus flake8-bugbear:\n\n```toml\n[tool.ruff.lint]\n# Adds flake8-bugbear on top of the default rules (E4, E7, E9, F).\nextend-select = [\"B\"]\n```\n\nUsing `select = [\"B\"]` instead would _replace_ the defaults, enabling\nonly flake8-bugbear.",
           "type": [
             "array",
             "null"


### PR DESCRIPTION
Closes #18884

## Summary

Clarifies the documentation for `lint.extend-ignore` and `lint.extend-select` to address confusion about when to use each variant:

- **`extend-ignore`**: Explains that the deprecation exists because the option is now interchangeable with `ignore` - in earlier Ruff versions, `ignore` would replace the ignored set during config inheritance while `extend-ignore` would add to it, but this distinction no longer applies.
- **`extend-select`**: Adds a clear explanation of the additive behavior vs `select`'s replacement behavior, with a concrete TOML example showing the difference.

## Test Plan

- `cargo dev generate-all` regenerates the schema successfully
- `cargo fmt -- --check` passes
- Documentation-only change - no runtime behavior affected