### PR TITLE
replace deprecated `std::f64::EPSILON` with `f64::EPSILON`

### DIFF
--- a/crates/ruff_python_literal/src/float.rs
+++ b/crates/ruff_python_literal/src/float.rs
@@ -1,5 +1,3 @@
-use std::f64;
-
 fn is_integer(v: f64) -> bool {
     (v - v.round()).abs() < f64::EPSILON
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Replaces usage of the deprecated `std::f64::EPSILON` constant with the modern associated constant introduced in Rust 1.43.0.
Sources:

- [std::f64::EPSILON docs stating deprecation](https://doc.rust-lang.org/std/f64/constant.EPSILON.html)
- [f64 primitive associated constant EPSILON docs](https://doc.rust-lang.org/std/primitive.f64.html#associatedconstant.EPSILON)
- [Relevant Rust 1.43.0 release notes section](https://blog.rust-lang.org/2020/04/23/Rust-1.43.0/#library-changes)

## Test Plan

<!-- How was it tested? -->
Ran Ruff's test suite using `CONTRIBUTING.md` as a guide.
