### PR TITLE
[ty] Move ruffen-docs formatting config to a `ruff.toml` config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -126,14 +126,6 @@ repos:
     hooks:
       - id: ruff-format
         name: mdtest format
-        args:
-          [
-            "--preview",
-            "--line-length",
-            "130",
-            "--extension",
-            "py:pyi,python:pyi",
-          ]
         types_or: [markdown]
         files: '^crates/.*/resources/mdtest/.*\.md$'
         pass_filenames: true

--- a/crates/ty_python_semantic/resources/mdtest/ruff.toml
+++ b/crates/ty_python_semantic/resources/mdtest/ruff.toml
@@ -1,0 +1,10 @@
+# Formatting configuration for Python codeblocks in mdtests
+
+line-length = 130
+
+[extension]
+py = "pyi"
+python = "pyi"
+
+[format]
+preview = true


### PR DESCRIPTION
## Summary

Moving these configuration settings to a config file means I can enable format-on-save for the Ruff formatter on MarkDown files in VSCode, and it will instantly reformat my mdtests with the correct settings.

## Test Plan

I enabled format-on-save for the Ruff formatter on MarkDown files by adjusting my user settings in VSCode as follows:

```json
{
    "ruff.format.preview": true,
    "[markdown]": {
        "editor.formatOnSave": true,
        "editor.formatOnType": true,
        "editor.defaultFormatter": "charliermarsh.ruff"
    }
}
```

After having done so, I verified that all Python codeblocks in the mdtest I was working on were formatted on save by Ruff -- but they were formatted using the default settings (line length of 88, more verbose `.py`-style formatting with more line breaks) rather than using the configuration in our pre-commit file. After moving the configuration to the `ruff.toml` file, I verified that format-on-save now respects this formatting, and `uvx prek run -a` also still works as expected.