### PR TITLE
[ty] Improve `isinstance()` reachability analysis

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -497,16 +497,82 @@ infrastructure!
 class A: ...
 class B: ...
 
-def f[T: A | B](x: T) -> bool:
+def j[T: A | B](x: T) -> bool:
     if isinstance(x, A):
         return True
     elif isinstance(x, B):
         return False
 
-def g[T: A | B](x: T) -> bool:
+def k[T: (A, B)](x: T) -> bool:
+    if isinstance(x, A):
+        return True
+    elif isinstance(x, B):
+        return False
+
+def l[T](x: T) -> bool:
+    if isinstance(x, int):
+        return True
+    elif not isinstance(x, int):
+        return False
+
+def m[T: A | B](x: T) -> bool:
     match x:
         case A():
             return True
         case B():
             return False
+
+def n[T: (A, B)](x: T) -> bool:
+    match x:
+        case A():
+            return True
+        case B():
+            return False
+```
+
+## Exhaustiveness checking for `NewType`s of `float` and `complex`
+
+```py
+from typing_extensions import NewType, assert_never
+
+FloatN = NewType("FloatN", float)
+ComplexN = NewType("ComplexN", complex)
+
+def f(x: FloatN) -> bool:
+    if isinstance(x, int):
+        return True
+    elif isinstance(x, float):
+        return False
+    else:
+        assert_never(x)
+
+def g(x: ComplexN) -> bool:
+    if isinstance(x, int):
+        return True
+    elif isinstance(x, float):
+        return True
+    elif isinstance(x, complex):
+        return False
+    else:
+        assert_never(x)
+
+# the same version of the above tests, but isolated
+# from the fact that `assert_never` creates its own
+# reachability constraint:
+
+# no `invalid-return-type` diagnostic
+def h(x: FloatN) -> bool:
+    if isinstance(x, int):
+        return True
+    elif isinstance(x, float):
+        return False
+
+# no `invalid-return-type` diagnostic
+def i(x: ComplexN) -> bool:
+    if isinstance(x, int):
+        return True
+    elif isinstance(x, float):
+        return True
+    elif isinstance(x, complex):
+        return False
 ```

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1474,27 +1474,40 @@ fn is_instance_truthiness<'db>(
         // that is always true.
         Type::Intersection(intersection) => {
             let mut effective = IntersectionBuilder::new(db);
-            let mut found_positive_tvars = false;
+            let mut found_tvars_or_newtypes = false;
 
             for &positive in intersection.positive(db) {
                 if is_instance_truthiness(db, positive, class).is_always_true() {
                     return Truthiness::AlwaysTrue;
-                } else if let Type::TypeVar(tvar) = positive
-                    && let Some(TypeVarBoundOrConstraints::UpperBound(bound)) =
-                        tvar.typevar(db).bound_or_constraints(db)
-                {
-                    effective = effective.add_positive(bound);
-                    found_positive_tvars = true;
+                } else if let Type::TypeVar(tvar) = positive {
+                    match tvar.typevar(db).bound_or_constraints(db) {
+                        Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                            effective = effective.add_positive(bound);
+                        }
+                        Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                            effective = effective.add_positive(constraints.as_type(db));
+                        }
+                        // A typevar without bounds/constraints has `object` as its implicit upper bound,
+                        // and adding `object` to an intersection is a no-op
+                        None => {}
+                    }
+                    found_tvars_or_newtypes = true;
+                } else if let Type::NewTypeInstance(newtype) = positive {
+                    found_tvars_or_newtypes = true;
+                    effective = effective.add_positive(newtype.concrete_base_type(db));
                 } else {
                     effective = effective.add_positive(positive);
                 }
             }
 
-            if !found_positive_tvars {
+            if !found_tvars_or_newtypes {
                 return Truthiness::Ambiguous;
             }
 
             for &negative in intersection.negative(db) {
+                if is_instance_truthiness(db, negative, class).is_always_true() {
+                    return Truthiness::AlwaysFalse;
+                }
                 effective = effective.add_negative(negative);
             }
 


### PR DESCRIPTION
## Summary

Our reachability analysis for `isinstance()` constraints currently doesn't match the sophistication of our type narrowing in this situation. This was obscured in our tests by the fact that `assert_never()`, `reveal_type` and `assert_type` calls can in fact create their own reachability constraints!

`assert_type`, `reveal_type` and `assert_never` are all generic functions that return an object of the same type as the object passed into the function. Following https://github.com/astral-sh/ruff/pull/23419, that means that if you pass an object inferred as having the type `Never` into one of these functions, all code following that call will be inferred as being unreachable. In other words, this test was passing entirely by accident, because of additional reachability constraints introduced by the `reveal-type` and `assert_never` calls!

https://github.com/astral-sh/ruff/blob/1aabbbc89160251cf13d3282a4963db84419a3bb/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md?plain=1#L470-L477

Remove the `else` branch from that test, and you get a false-positive `invalid-return-type` diagnostic complaining that the function can implicitly return `None` -- which is clearly not the case:

```py
def h[T: int | str](x: T) -> T:
    if isinstance(x, int):
        return x
    elif isinstance(x, str):
        return x
```

The fix is to adapt our `isinstance()` special casing so that it has the same sophistication as our type narrowing machinery here, where we understand that `T & ~U & ~S` must resolve to `Never` if `T` is a type variable bound to the union `S | U`. In a similar way, an `else` branch (explicit or implicit) can never be taken in either of the `h` functions above.

## Test Plan

Added mdtests that fail on `main`
