### PR TITLE
[ty] Expand bounded typevars to their upper bounds when evaluating truthiness comparisons between intersections and literal types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -486,6 +486,37 @@ def i[T: (int, str)](x: T) -> T:
             assert_never(x)
 
     return x
+
+def eq_narrow_match_constrained[T: (Literal["foo"], Literal["bar"])](x: T) -> T:
+    match x:
+        case "foo":
+            pass
+        case "bar":
+            pass
+        case _:
+            assert_never(x)
+
+    return x
+
+def eq_narrow_if_bounded[T: Literal["foo", "bar"]](x: T) -> T:
+    if x == "foo":
+        pass
+    elif x == "bar":
+        pass
+    else:
+        assert_never(x)
+
+    return x
+
+def eq_narrow_if_constrained[T: (Literal["foo"], Literal["bar"])](x: T) -> T:
+    if x == "foo":
+        pass
+    elif x == "bar":
+        pass
+    else:
+        assert_never(x)
+
+    return x
 ```
 
 In these examples, no `invalid-return-type` diagnostics are emitted, despite the fact there are no
@@ -494,8 +525,6 @@ In these examples, no `invalid-return-type` diagnostics are emitted, despite the
 predicates in our reachability infrastructure!
 
 ```py
-from typing import Literal
-
 class A: ...
 class B: ...
 
@@ -531,13 +560,26 @@ def n[T: (A, B)](x: T) -> bool:
         case B():
             return False
 
-def h[T: Literal["foo", "bar"]](x: T) -> bool:
+def o[T: Literal["foo", "bar"]](x: T) -> bool:
     if x == "foo":
         return True
     elif x == "bar":
         return False
 
-def i[T: Literal["foo", "bar"]](x: T) -> bool:
+def p[T: Literal["foo", "bar"]](x: T) -> bool:
+    match x:
+        case "foo":
+            return True
+        case "bar":
+            return False
+
+def q[T: (Literal["foo"], Literal["bar"])](x: T) -> bool:
+    if x == "foo":
+        return True
+    elif x == "bar":
+        return False
+
+def r[T: (Literal["foo"], Literal["bar"])](x: T) -> bool:
     match x:
         case "foo":
             return True

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -188,6 +188,31 @@ pub(super) fn infer_binary_type_comparison<'db>(
             Some(Ok(builder.build()))
         }
 
+        (Type::Intersection(intersection), right)
+            if intersection.positive(db).iter().copied().any(Type::is_type_var) =>
+        {
+            Some(infer_binary_type_comparison(
+                context,
+                intersection.with_expanded_typevars_and_newtypes(db),
+                op,
+                right,
+                range,
+                visitor
+            ))
+        }
+        (left, Type::Intersection(intersection))
+            if intersection.positive(db).iter().copied().any(Type::is_type_var) =>
+        {
+            Some(infer_binary_type_comparison(
+                context,
+                left,
+                op,
+                intersection.with_expanded_typevars_and_newtypes(db),
+                range,
+                visitor
+            ))
+        }
+
         (Type::Intersection(intersection), right) => {
             Some(
                 infer_binary_intersection_type_comparison(
@@ -654,31 +679,13 @@ fn infer_binary_intersection_type_comparison<'db>(
     // If a comparison yields a definitive true/false answer on a (positive) part
     // of an intersection type, it will also yield a definitive answer on the full
     // intersection type, which is even more specific.
-    for &pos in intersection.positive(db) {
-        // If the positive element is a TypeVar with a bound, try expanding the
-        // TypeVar to its bound and applying the intersection's negative elements.
-        // This handles cases like `(T & ~Literal["foo"]) == Literal["bar"]` where
-        // `T: Literal["foo", "bar"]`: expanding to the bound and excluding
-        // `Literal["foo"]` simplifies to `Literal["bar"]`, giving a definitive result.
-        let pos = if let Type::TypeVar(tvar) = pos
-            && let Some(TypeVarBoundOrConstraints::UpperBound(bound)) =
-                tvar.typevar(db).bound_or_constraints(db)
-        {
-            let mut builder = IntersectionBuilder::new(db).add_positive(bound);
-            for neg in intersection.negative(db) {
-                builder = builder.add_negative(*neg);
-            }
-            builder.build()
-        } else {
-            pos
-        };
-
+    for pos in intersection.positive(db) {
         let result = match intersection_on {
             IntersectionOn::Left => {
-                infer_binary_type_comparison(context, pos, op, other, range, visitor)
+                infer_binary_type_comparison(context, *pos, op, other, range, visitor)
             }
             IntersectionOn::Right => {
-                infer_binary_type_comparison(context, other, op, pos, range, visitor)
+                infer_binary_type_comparison(context, other, op, *pos, range, visitor)
             }
         };
 

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -2,8 +2,8 @@ use itertools::Either;
 
 use crate::place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers, TypeOrigin, Widening};
 use crate::types::class::KnownClass;
-use crate::types::visitor;
 use crate::types::{Type, TypeQualifiers};
+use crate::types::{TypeVarBoundOrConstraints, visitor};
 use crate::{Db, FxOrderSet};
 
 pub(crate) mod builder;
@@ -839,6 +839,13 @@ impl<'db> IntersectionType<'db> {
         }
     }
 
+    /// Return a version of this intersection type where any type variables in the positive elements
+    /// have been replaced by their bounds or constraints, and where any newtypes in the positive elements
+    /// have been replaced by their concrete base types.
+    pub(crate) fn with_expanded_typevars_and_newtypes(self, db: &'db dyn Db) -> Type<'db> {
+        expand_intersection_typevars_and_newtypes(db, self.positive(db), self.negative(db))
+    }
+
     pub fn iter_positive(self, db: &'db dyn Db) -> impl Iterator<Item = Type<'db>> {
         self.positive(db).iter().copied()
     }
@@ -854,6 +861,41 @@ impl<'db> IntersectionType<'db> {
     pub(crate) fn is_simple_negation(self, db: &'db dyn Db) -> bool {
         self.positive(db).is_empty() && self.negative(db).len() == 1
     }
+}
+
+fn expand_intersection_typevars_and_newtypes<'db>(
+    db: &'db dyn Db,
+    positive: &FxOrderSet<Type<'db>>,
+    negative: &NegativeIntersectionElements<'db>,
+) -> Type<'db> {
+    let mut builder = IntersectionBuilder::new(db);
+    for &element in positive {
+        match element {
+            Type::TypeVar(tvar) => {
+                match tvar.typevar(db).bound_or_constraints(db) {
+                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                        builder = builder.add_positive(bound);
+                    }
+                    Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                        builder = builder.add_positive(constraints.as_type(db));
+                    }
+                    // Type variables without bounds or constraints implicitly have `object`
+                    // as their upper bound, and adding `object` to an intersection is always a no-op
+                    None => {}
+                }
+            }
+            Type::NewTypeInstance(newtype) => {
+                builder = builder.add_positive(newtype.concrete_base_type(db));
+            }
+            _ => builder = builder.add_positive(element),
+        }
+    }
+
+    for &element in negative {
+        builder = builder.add_negative(element);
+    }
+
+    builder.build()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize)]

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -38,6 +38,7 @@
 
 use super::RecursivelyDefined;
 use crate::types::enums::{enum_member_literals, enum_metadata};
+use crate::types::set_theoretic::expand_intersection_typevars_and_newtypes;
 use crate::types::{
     BytesLiteralType, ClassLiteral, EnumLiteralType, IntersectionType, KnownClass,
     LiteralValueType, LiteralValueTypeKind, NegativeIntersectionElements, StringLiteralType, Type,
@@ -1516,32 +1517,9 @@ impl<'db> InnerIntersectionBuilder<'db> {
             .iter()
             .any(|ty| matches!(ty, Type::TypeVar(_) | Type::NewTypeInstance(_)))
         {
-            let mut speculative = IntersectionBuilder::new(db);
-            for pos in &self.positive {
-                match pos {
-                    Type::TypeVar(type_var) => {
-                        match type_var.typevar(db).bound_or_constraints(db) {
-                            Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                                speculative = speculative.add_positive(bound);
-                            }
-                            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                                speculative = speculative.add_positive(constraints.as_type(db));
-                            }
-                            // TypeVars without a bound or constraint implicitly have `object` as their
-                            // upper bound, and it is always a no-op to add `object` to an intersection.
-                            None => {}
-                        }
-                    }
-                    Type::NewTypeInstance(newtype) => {
-                        speculative = speculative.add_positive(newtype.concrete_base_type(db));
-                    }
-                    _ => speculative = speculative.add_positive(*pos),
-                }
-            }
-            for neg in &self.negative {
-                speculative = speculative.add_negative(*neg);
-            }
-            if speculative.build().is_never() {
+            let speculative =
+                expand_intersection_typevars_and_newtypes(db, &self.positive, &self.negative);
+            if speculative.is_never() {
                 return Type::Never;
             }
         }


### PR DESCRIPTION
## Summary

Similar to https://github.com/astral-sh/ruff/pull/24077, but for equality-derived reachability constraints rather than `isinstance()`-derived reachability constraints.

This function currently causes us to emit a false-positive `invalid-return-type` diagnostic saying that it could return `None`, but it cannot:

```py
from typing import Literal

def h[T: Literal["foo", "bar"]](x: T) -> bool:
    if x == "foo":
        return True
    elif x == "bar":
        return False
```

## Test Plan

Added new mdtests that fail on `main`.
