### PR TITLE
[ruff] Stabilize fix diffs in full check output

### DIFF
--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -241,7 +241,7 @@ impl Printer {
             .color(!cfg!(test) && colored::control::SHOULD_COLORIZE.should_colorize())
             .with_show_fix_status(show_fix_status(self.fix_mode, fixables.as_ref()))
             .with_fix_applicability(self.unsafe_fixes.required_applicability())
-            .show_fix_diff(preview.is_enabled());
+            .show_fix_diff(self.format == OutputFormat::Full);
 
         render_diagnostics(writer, self.format, config, &context, &diagnostics.inner)?;
 
@@ -415,7 +415,7 @@ impl Printer {
                 .color(!cfg!(test) && colored::control::SHOULD_COLORIZE.should_colorize())
                 .with_show_fix_status(show_fix_status(self.fix_mode, fixables.as_ref()))
                 .with_fix_applicability(self.unsafe_fixes.required_applicability())
-                .show_fix_diff(preview.is_enabled());
+                .show_fix_diff(self.format == OutputFormat::Full);
             render_diagnostics(writer, self.format, config, &context, &diagnostics.inner)?;
         }
         writer.flush()?;

--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -3733,10 +3733,41 @@ nested_optional: Optional[Optional[Optional[str]]] = None
 }
 
 #[test]
+fn show_fix_diff_in_full_output_without_preview() {
+    assert_cmd_snapshot!(
+        Command::new(get_cargo_bin(BIN_NAME))
+            .args(["check", "--no-cache", "--color", "never"])
+            .args(["--output-format", "full"])
+            .args(["--select", "F401"])
+            .arg("-")
+            .pass_stdin("import math"),
+        @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    F401 [*] `math` imported but unused
+     --> -:1:8
+      |
+    1 | import math
+      |        ^^^^
+      |
+    help: Remove unused import: `math`
+      - import math
+
+    Found 1 error.
+    [*] 1 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "###,
+    );
+}
+
+#[test]
 fn show_fixes_in_full_output_with_preview_enabled() {
     assert_cmd_snapshot!(
         Command::new(get_cargo_bin(BIN_NAME))
-            .args(["check", "--no-cache", "--output-format", "full"])
+            .args(["check", "--no-cache", "--color", "never"])
+            .args(["--output-format", "full"])
             .args(["--select", "F401"])
             .arg("--preview")
             .arg("-")

--- a/crates/ruff/tests/cli/snapshots/cli__lint__output_format_full.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__output_format_full.snap
@@ -25,6 +25,10 @@ F401 [*] `os` imported but unused
 3 | match 42:  # invalid-syntax
   |
 help: Remove unused import: `os`
+  - import os  # F401
+1 | x = y      # F821
+2 | match 42:  # invalid-syntax
+3 |     case _: ...
 
 F821 Undefined name `y`
  --> input.py:2:5


### PR DESCRIPTION
## What / why
`ruff check --output-format full` only showed inline fix diffs when `--preview` was on. #22946 is about stabilizing that for stable full output.

## Change
In `crates/ruff/src/printer.rs`, `show_fix_diff` is now tied to `OutputFormat::Full` instead of preview, in both normal and `--watch` printing (`write_once` / `write_continuously`). Rendering logic in `ruff_db` is unchanged; preview still affects other diagnostic options.

Closes #22946
