### PR TITLE
[ty] Simplify an intersection of `N & ~T` to `Never` if `B & ~T` would simplify to `Never`, where `B` is the concrete base type of a `NewType` `N`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
@@ -414,6 +414,17 @@ def _(x: Foo | float, y: Bar | complex):
     reveal_type(not y)  # revealed: bool
 ```
 
+Intersections with `NewType`s solve to `Never` if the intersection with the `NewType`'s concrete
+base type would also solve to `Never`:
+
+```py
+TFloat = NewType("TFloat", float)
+
+def f(x: TFloat) -> None:
+    if not isinstance(x, float | int):
+        reveal_type(x)  # revealed: Never
+```
+
 ## A `NewType` definition must be a simple variable assignment
 
 ```py

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1516,7 +1516,11 @@ impl<'db> InnerIntersectionBuilder<'db> {
         // to their upper bound and all constrained type variables to the union of their constraints.
         // If that speculative intersection simplifies to `Never`, this intersection must also simplify
         // to `Never`.
-        if self.positive.iter().any(|ty| ty.is_type_var()) {
+        if self
+            .positive
+            .iter()
+            .any(|ty| matches!(ty, Type::TypeVar(_) | Type::NewTypeInstance(_)))
+        {
             let mut speculative = IntersectionBuilder::new(db);
             for pos in &self.positive {
                 match pos {
@@ -1532,6 +1536,9 @@ impl<'db> InnerIntersectionBuilder<'db> {
                             // upper bound, and it is always a no-op to add `object` to an intersection.
                             None => {}
                         }
+                    }
+                    Type::NewTypeInstance(newtype) => {
+                        speculative = speculative.add_positive(newtype.concrete_base_type(db));
                     }
                     _ => speculative = speculative.add_positive(*pos),
                 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/2941

Co-authored-by: Brent Westbrook <brentrwestbrook@gmail.com>

## Test Plan

added an mdtest
