### PR TITLE
[ty] Fix subtyping of intersections containing newtypes of unions vs unions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
@@ -20,7 +20,7 @@ type (i.e. not an alias).
 
 ```py
 from typing_extensions import NewType
-from ty_extensions import static_assert, is_subtype_of, is_equivalent_to
+from ty_extensions import static_assert, is_subtype_of, is_equivalent_to, Not, Intersection, AlwaysFalsy, is_assignable_to
 
 Foo = NewType("Foo", int)
 Bar = NewType("Bar", Foo)
@@ -53,6 +53,21 @@ g(Bar(Foo(42)))
 h(42)  # error: [invalid-argument-type] "Argument to function `h` is incorrect: Expected `Bar`, found `Literal[42]`"
 h(Foo(42))  # error: [invalid-argument-type] "Argument to function `h` is incorrect: Expected `Bar`, found `Foo`"
 h(Bar(Foo(42)))
+
+FloatNewType = NewType("FloatNewType", float)
+
+static_assert(is_subtype_of(FloatNewType, float))
+static_assert(is_subtype_of(Intersection[FloatNewType, AlwaysFalsy], float))
+static_assert(is_subtype_of(Intersection[FloatNewType, Not[AlwaysFalsy]], float))
+
+ComplexNewType = NewType("ComplexNewType", complex)
+
+static_assert(is_subtype_of(ComplexNewType, complex))
+static_assert(is_subtype_of(Intersection[ComplexNewType, AlwaysFalsy], complex))
+static_assert(is_subtype_of(Intersection[ComplexNewType, Not[AlwaysFalsy]], complex))
+static_assert(not is_assignable_to(ComplexNewType, float))
+static_assert(not is_assignable_to(Intersection[ComplexNewType, AlwaysFalsy], float))
+static_assert(not is_assignable_to(Intersection[ComplexNewType, Not[AlwaysFalsy]], float))
 ```
 
 ## Member and method lookup work

--- a/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -489,3 +489,24 @@ def test() -> None:
     # error: [invalid-key] "Unknown key "nonexistent" for TypedDict `Person`"
     print(p["nonexistent"])
 ```
+
+## Truthiness narrowing of `NewType`s
+
+```py
+from typing import NewType
+
+FloatNewType = NewType("FloatNewType", float)
+ComplexNewType = NewType("ComplexNewType", complex)
+
+def expects_float(x: float): ...
+def expects_complex(x: complex): ...
+def f(floaty: FloatNewType, complexy: ComplexNewType):
+    if floaty:
+        reveal_type(floaty)  # revealed:FloatNewType & ~AlwaysFalsy
+        expects_float(floaty)  # fine
+
+    if complexy:
+        reveal_type(complexy)  # revealed: ComplexNewType & ~AlwaysFalsy
+        expects_complex(complexy)  # fine
+        expects_float(complexy)  # error: [invalid-argument-type]
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1188,6 +1188,13 @@ impl<'db> Type<'db> {
         }
     }
 
+    pub(crate) const fn as_new_type(self) -> Option<NewType<'db>> {
+        match self {
+            Type::NewTypeInstance(new_type) => Some(new_type),
+            _ => None,
+        }
+    }
+
     /// If this type is a `Type::TypeAlias`, recursively resolves it to its
     /// underlying value type. Otherwise, returns `self` unchanged.
     pub(crate) fn resolve_type_alias(self, db: &'db dyn Db) -> Type<'db> {

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -10,9 +10,10 @@ use crate::types::cyclic::PairVisitor;
 use crate::types::enums::is_single_member_enum;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::{
-    CallableType, ClassBase, ClassType, CycleDetector, DynamicType, KnownBoundMethodType,
-    KnownClass, KnownInstanceType, LiteralValueTypeKind, MemberLookupPolicy, PropertyInstanceType,
-    ProtocolInstanceType, SubclassOfInner, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
+    CallableType, ClassBase, ClassType, CycleDetector, DynamicType, IntersectionBuilder,
+    KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind, MemberLookupPolicy,
+    PropertyInstanceType, ProtocolInstanceType, SubclassOfInner, TypeVarBoundOrConstraints,
+    UnionType, UpcastPolicy,
 };
 use crate::{
     Db,
@@ -597,6 +598,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             .visit((source, target, self.relation), work)
     }
 
+    /// Return a constraint set indicating the conditions under which `self.relation` holds between `source` and `target`.
     pub(super) fn check_type_pair(
         &self,
         db: &'db dyn Db,
@@ -900,6 +902,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             (Type::NewTypeInstance(source_newtype), Type::NewTypeInstance(target_newtype)) => {
                 self.check_newtype_pair(db, source_newtype, target_newtype)
             }
+
             // In the special cases of `NewType`s of `float` or `complex`, the concrete base type
             // can be a union (`int | float` or `int | float | complex`). For that reason,
             // `NewType` assignability to a union needs to consider two different cases. It could
@@ -942,6 +945,40 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         } else {
                             self.never()
                         }
+                    })
+            }
+
+            // Similar to above, another somewhat unfortunate special case for
+            // intersections of newtypes of unions vs unions.
+            (Type::Intersection(intersection), Type::Union(union))
+                if intersection.positive(db).iter().any(|element| {
+                    element
+                        .as_new_type()
+                        .is_some_and(|newtype| newtype.concrete_base_type(db).is_union())
+                }) =>
+            {
+                // First the normal "assign to union" case, unfortunately duplicated from below (and above :().
+                union
+                    .elements(db)
+                    .iter()
+                    .when_any(db, self.constraints, |&elem_ty| {
+                        self.check_type_pair(db, source, elem_ty)
+                    })
+                    // Construct a new intersection with every newtype mapped to its concrete base
+                    // type and check that.
+                    .or(db, self.constraints, || {
+                        let mut builder = IntersectionBuilder::new(db);
+                        for &pos in intersection.positive(db) {
+                            if let Some(newtype) = pos.as_new_type() {
+                                builder = builder.add_positive(newtype.concrete_base_type(db));
+                            } else {
+                                builder = builder.add_positive(pos);
+                            }
+                        }
+                        for &neg in intersection.negative(db) {
+                            builder = builder.add_negative(neg);
+                        }
+                        self.check_type_pair(db, builder.build(), target)
                     })
             }
 


### PR DESCRIPTION
## Summary

We recognise a newtype as a subtype of its concrete base type, and we even recognise newtypes of unions as a subtype of their concrete base type, but we do not currently recognise intersections of newtypes of unions as subtypes of the newtype's concrete base type. This PR fixes that.

Fixes https://github.com/astral-sh/ty/issues/2940

Co-authored-by: Brent Westbrook <brentrwestbrook@gmail.com>

## Test Plan

added mdtests that fail on `main`
