### PR TITLE
[ty] Avoid widening exact operations during `is` narrowing

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -164,24 +164,29 @@ def _(a: Literal[1], b: Literal[1, 2], c: Literal[1, 2, 3]):
         reveal_type(c)  # revealed: Literal[1]
 ```
 
-Identity narrowing should not widen an operand that is already more precise than the compared type:
+Identity narrowing should preserve singleton information on the compared class object:
+
+```toml
+[environment]
+python-version = "3.12"
+```
 
 ```py
-from typing import TypeVar
-
 class Y:
     def __init__(self) -> None: ...
 
 class Z(Y):
     def __init__(self, x: int) -> None: ...
 
-T = TypeVar("T", Y, Z)
-
-def f(klass: type[T]) -> None:
+def f[T: (Y, Z)](klass: type[T]) -> None:
     reveal_type(Y)  # revealed: <class 'Y'>
     if klass is Y:
-        reveal_type(Y)  # revealed: <class 'Y'>
+        reveal_type(klass)  # revealed: type[T@f] & <class 'Y'>
+        reveal_type(Y)  # revealed: <class 'Y'> & type[T@f]
         Y()
+    if klass is Z:
+        reveal_type(klass)  # revealed: <class 'Z'>
+        reveal_type(Z)  # revealed: <class 'Z'>
 ```
 
 ## `is` where the other operand is a call expression

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -164,6 +164,26 @@ def _(a: Literal[1], b: Literal[1, 2], c: Literal[1, 2, 3]):
         reveal_type(c)  # revealed: Literal[1]
 ```
 
+Identity narrowing should not widen an operand that is already more precise than the compared type:
+
+```py
+from typing import TypeVar
+
+class Y:
+    def __init__(self) -> None: ...
+
+class Z(Y):
+    def __init__(self, x: int) -> None: ...
+
+T = TypeVar("T", Y, Z)
+
+def f(klass: type[T]) -> None:
+    reveal_type(Y)  # revealed: <class 'Y'>
+    if klass is Y:
+        reveal_type(Y)  # revealed: <class 'Y'>
+        Y()
+```
+
 ## `is` where the other operand is a call expression
 
 ```py

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1132,18 +1132,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     None
                 }
             }
-            ast::CmpOp::Is => {
-                let rhs_ty = rhs_ty.resolve_type_alias(self.db);
-
-                // Identity checks should not feed a new constraint back into an operand that is
-                // already single-valued. For example, `klass is Y` should narrow `klass: type[T]`,
-                // but it must not widen `Y` to `type[T]`.
-                if lhs_ty.is_single_valued(self.db) {
-                    None
-                } else {
-                    Some(rhs_ty)
-                }
-            }
+            ast::CmpOp::Is => Some(rhs_ty.resolve_type_alias(self.db)),
             ast::CmpOp::Eq => self.evaluate_expr_eq(lhs_ty, rhs_ty),
             ast::CmpOp::NotEq => self.evaluate_expr_ne(lhs_ty, rhs_ty),
             ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty),

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1132,7 +1132,18 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     None
                 }
             }
-            ast::CmpOp::Is => Some(rhs_ty),
+            ast::CmpOp::Is => {
+                let rhs_ty = rhs_ty.resolve_type_alias(self.db);
+
+                // Identity checks should not feed a new constraint back into an operand that is
+                // already single-valued. For example, `klass is Y` should narrow `klass: type[T]`,
+                // but it must not widen `Y` to `type[T]`.
+                if lhs_ty.is_single_valued(self.db) {
+                    None
+                } else {
+                    Some(rhs_ty)
+                }
+            }
             ast::CmpOp::Eq => self.evaluate_expr_eq(lhs_ty, rhs_ty),
             ast::CmpOp::NotEq => self.evaluate_expr_ne(lhs_ty, rhs_ty),
             ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty),

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -605,6 +605,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         source: Type<'db>,
         target: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let is_exact_class_object =
+            |ty: Type<'db>| matches!(ty, Type::ClassLiteral(_) | Type::GenericAlias(_));
+
         // Subtyping implies assignability, so if subtyping is reflexive and the two types are
         // equal, it is both a subtype and assignable. Assignability is always reflexive.
         //
@@ -781,16 +784,19 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.never()
             }
 
-            // `type[T]` is a subtype of the class object `A` if every instance of `T` is a subtype of an instance
-            // of `A`, and vice versa.
+            // For non-exact-class-object targets with an instance view, `type[T]` can inherit
+            // subtype facts from `T`. Exact class-object targets are handled by dedicated branches
+            // below; collapsing them to instances would incorrectly make `type[T] <: <class 'Y'>`
+            // hold whenever `T <: Y`.
             (Type::SubclassOf(subclass_of), _)
-                if !subclass_of
-                    .into_type_var()
-                    .zip(target.to_instance(db))
-                    .when_some_and(db, self.constraints, |(source_i, target_i)| {
-                        self.check_type_pair(db, Type::TypeVar(source_i), target_i)
-                    })
-                    .is_never_satisfied(db) =>
+                if !is_exact_class_object(target)
+                    && !subclass_of
+                        .into_type_var()
+                        .zip(target.to_instance(db))
+                        .when_some_and(db, self.constraints, |(source_i, target_i)| {
+                            self.check_type_pair(db, Type::TypeVar(source_i), target_i)
+                        })
+                        .is_never_satisfied(db) =>
             {
                 // TODO: The repetition here isn't great, but we need the fallthrough logic.
                 subclass_of
@@ -802,13 +808,14 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
 
             (_, Type::SubclassOf(subclass_of))
-                if !subclass_of
-                    .into_type_var()
-                    .zip(source.to_instance(db))
-                    .when_some_and(db, self.constraints, |(target_i, source_i)| {
-                        self.check_type_pair(db, source_i, Type::TypeVar(target_i))
-                    })
-                    .is_never_satisfied(db) =>
+                if !is_exact_class_object(source)
+                    && !subclass_of
+                        .into_type_var()
+                        .zip(source.to_instance(db))
+                        .when_some_and(db, self.constraints, |(target_i, source_i)| {
+                            self.check_type_pair(db, source_i, Type::TypeVar(target_i))
+                        })
+                        .is_never_satisfied(db) =>
             {
                 // TODO: The repetition here isn't great, but we need the fallthrough logic.
                 subclass_of
@@ -1407,6 +1414,26 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             (Type::BoundSuper(_), _) => {
                 self.check_type_pair(db, KnownClass::Super.to_instance(db), target)
+            }
+
+            (Type::ClassLiteral(source_cls), Type::SubclassOf(target_subclass_ty))
+                if target_subclass_ty.is_type_var() =>
+            {
+                self.check_type_pair(
+                    db,
+                    Type::instance(db, source_cls.default_specialization(db)),
+                    Type::TypeVar(target_subclass_ty.subclass_of().into_type_var().unwrap()),
+                )
+            }
+
+            (Type::GenericAlias(source_alias), Type::SubclassOf(target_subclass_ty))
+                if target_subclass_ty.is_type_var() =>
+            {
+                self.check_type_pair(
+                    db,
+                    Type::instance(db, ClassType::Generic(source_alias)),
+                    Type::TypeVar(target_subclass_ty.subclass_of().into_type_var().unwrap()),
+                )
             }
 
             (Type::SubclassOf(subclass_of), _) | (_, Type::SubclassOf(subclass_of))


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ty/issues/3074.
