### PR TITLE
[`pyupgrade`] UP018 should detect more unnecessarily wrapped literals (UP018)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP018.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP018.py
@@ -97,6 +97,7 @@ str(t"hey")
 
 # UP018 - Extended detections
 str("A" "B")
+str("A" "B").lower()
 str(
     "A"
     "B"

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
@@ -173,6 +173,9 @@ fn is_redundant_keyword(builtin: &str, keyword: &ast::Keyword) -> bool {
     };
     match builtin {
         "str" => arg == "object",
+        // Python 3.14 emits a `SyntaxWarning` for `complex(real=1j)`. While this
+        // does change the behavior, upgrading it to 1j is very much in the spirit of this rule
+        // and removing the `SyntaxWarning` is a nice side effect.
         "complex" => arg == "real",
         _ => false,
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP018.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP018.py.snap
@@ -736,8 +736,8 @@ UP018 [*] Unnecessary `str` call (rewrite as a literal)
  98 | # UP018 - Extended detections
  99 | str("A" "B")
     | ^^^^^^^^^^^^
-100 | str(
-101 |     "A"
+100 | str("A" "B").lower()
+101 | str(
     |
 help: Replace with string literal
 96  | str(t"hey")
@@ -745,204 +745,224 @@ help: Replace with string literal
 98  | # UP018 - Extended detections
     - str("A" "B")
 99  + "A" "B"
-100 | str(
-101 |     "A"
-102 |     "B"
+100 | str("A" "B").lower()
+101 | str(
+102 |     "A"
 
 UP018 [*] Unnecessary `str` call (rewrite as a literal)
    --> UP018.py:100:1
     |
- 98 |   # UP018 - Extended detections
- 99 |   str("A" "B")
-100 | / str(
-101 | |     "A"
-102 | |     "B"
-103 | | )
-    | |_^
-104 |   str(object="!")
-105 |   complex(1j)
+ 98 | # UP018 - Extended detections
+ 99 | str("A" "B")
+100 | str("A" "B").lower()
+    | ^^^^^^^^^^^^
+101 | str(
+102 |     "A"
     |
 help: Replace with string literal
 97  | 
 98  | # UP018 - Extended detections
 99  | str("A" "B")
+    - str("A" "B").lower()
+100 + "A" "B".lower()
+101 | str(
+102 |     "A"
+103 |     "B"
+
+UP018 [*] Unnecessary `str` call (rewrite as a literal)
+   --> UP018.py:101:1
+    |
+ 99 |   str("A" "B")
+100 |   str("A" "B").lower()
+101 | / str(
+102 | |     "A"
+103 | |     "B"
+104 | | )
+    | |_^
+105 |   str(object="!")
+106 |   complex(1j)
+    |
+help: Replace with string literal
+98  | # UP018 - Extended detections
+99  | str("A" "B")
+100 | str("A" "B").lower()
     - str(
     -     "A"
     -     "B"
     - )
-100 + ("A"
-101 +     "B")
-102 | str(object="!")
-103 | complex(1j)
-104 | complex(real=1j)
+101 + ("A"
+102 +     "B")
+103 | str(object="!")
+104 | complex(1j)
+105 | complex(real=1j)
 
 UP018 [*] Unnecessary `str` call (rewrite as a literal)
-   --> UP018.py:104:1
-    |
-102 |     "B"
-103 | )
-104 | str(object="!")
-    | ^^^^^^^^^^^^^^^
-105 | complex(1j)
-106 | complex(real=1j)
-    |
-help: Replace with string literal
-101 |     "A"
-102 |     "B"
-103 | )
-    - str(object="!")
-104 + "!"
-105 | complex(1j)
-106 | complex(real=1j)
-107 | complex()
-
-UP018 [*] Unnecessary `complex` call (rewrite as a literal)
    --> UP018.py:105:1
     |
-103 | )
-104 | str(object="!")
-105 | complex(1j)
-    | ^^^^^^^^^^^
-106 | complex(real=1j)
-107 | complex()
+103 |     "B"
+104 | )
+105 | str(object="!")
+    | ^^^^^^^^^^^^^^^
+106 | complex(1j)
+107 | complex(real=1j)
     |
-help: Replace with complex literal
-102 |     "B"
-103 | )
-104 | str(object="!")
-    - complex(1j)
-105 + 1j
-106 | complex(real=1j)
-107 | complex()
-108 | complex(0j)
+help: Replace with string literal
+102 |     "A"
+103 |     "B"
+104 | )
+    - str(object="!")
+105 + "!"
+106 | complex(1j)
+107 | complex(real=1j)
+108 | complex()
 
 UP018 [*] Unnecessary `complex` call (rewrite as a literal)
    --> UP018.py:106:1
     |
-104 | str(object="!")
-105 | complex(1j)
-106 | complex(real=1j)
-    | ^^^^^^^^^^^^^^^^
-107 | complex()
-108 | complex(0j)
+104 | )
+105 | str(object="!")
+106 | complex(1j)
+    | ^^^^^^^^^^^
+107 | complex(real=1j)
+108 | complex()
     |
 help: Replace with complex literal
-103 | )
-104 | str(object="!")
-105 | complex(1j)
-    - complex(real=1j)
+103 |     "B"
+104 | )
+105 | str(object="!")
+    - complex(1j)
 106 + 1j
-107 | complex()
-108 | complex(0j)
-109 | complex(real=0j)
+107 | complex(real=1j)
+108 | complex()
+109 | complex(0j)
 
 UP018 [*] Unnecessary `complex` call (rewrite as a literal)
    --> UP018.py:107:1
     |
-105 | complex(1j)
-106 | complex(real=1j)
-107 | complex()
-    | ^^^^^^^^^
-108 | complex(0j)
-109 | complex(real=0j)
+105 | str(object="!")
+106 | complex(1j)
+107 | complex(real=1j)
+    | ^^^^^^^^^^^^^^^^
+108 | complex()
+109 | complex(0j)
     |
 help: Replace with complex literal
-104 | str(object="!")
-105 | complex(1j)
-106 | complex(real=1j)
-    - complex()
-107 + 0j
-108 | complex(0j)
-109 | complex(real=0j)
-110 | (complex(0j)).real
+104 | )
+105 | str(object="!")
+106 | complex(1j)
+    - complex(real=1j)
+107 + 1j
+108 | complex()
+109 | complex(0j)
+110 | complex(real=0j)
 
 UP018 [*] Unnecessary `complex` call (rewrite as a literal)
    --> UP018.py:108:1
     |
-106 | complex(real=1j)
-107 | complex()
-108 | complex(0j)
-    | ^^^^^^^^^^^
-109 | complex(real=0j)
-110 | (complex(0j)).real
+106 | complex(1j)
+107 | complex(real=1j)
+108 | complex()
+    | ^^^^^^^^^
+109 | complex(0j)
+110 | complex(real=0j)
     |
 help: Replace with complex literal
-105 | complex(1j)
-106 | complex(real=1j)
-107 | complex()
-    - complex(0j)
+105 | str(object="!")
+106 | complex(1j)
+107 | complex(real=1j)
+    - complex()
 108 + 0j
-109 | complex(real=0j)
-110 | (complex(0j)).real
-111 | complex(1j).real
+109 | complex(0j)
+110 | complex(real=0j)
+111 | (complex(0j)).real
 
 UP018 [*] Unnecessary `complex` call (rewrite as a literal)
    --> UP018.py:109:1
     |
-107 | complex()
-108 | complex(0j)
-109 | complex(real=0j)
-    | ^^^^^^^^^^^^^^^^
-110 | (complex(0j)).real
-111 | complex(1j).real
-    |
-help: Replace with complex literal
-106 | complex(real=1j)
-107 | complex()
-108 | complex(0j)
-    - complex(real=0j)
-109 + 0j
-110 | (complex(0j)).real
-111 | complex(1j).real
-112 | complex(real=1j).real
-
-UP018 [*] Unnecessary `complex` call (rewrite as a literal)
-   --> UP018.py:110:2
-    |
-108 | complex(0j)
-109 | complex(real=0j)
-110 | (complex(0j)).real
-    |  ^^^^^^^^^^^
-111 | complex(1j).real
-112 | complex(real=1j).real
-    |
-help: Replace with complex literal
-107 | complex()
-108 | complex(0j)
-109 | complex(real=0j)
-    - (complex(0j)).real
-110 + (0j).real
-111 | complex(1j).real
-112 | complex(real=1j).real
-
-UP018 [*] Unnecessary `complex` call (rewrite as a literal)
-   --> UP018.py:111:1
-    |
-109 | complex(real=0j)
-110 | (complex(0j)).real
-111 | complex(1j).real
+107 | complex(real=1j)
+108 | complex()
+109 | complex(0j)
     | ^^^^^^^^^^^
-112 | complex(real=1j).real
+110 | complex(real=0j)
+111 | (complex(0j)).real
     |
 help: Replace with complex literal
-108 | complex(0j)
-109 | complex(real=0j)
-110 | (complex(0j)).real
-    - complex(1j).real
-111 + 1j.real
-112 | complex(real=1j).real
+106 | complex(1j)
+107 | complex(real=1j)
+108 | complex()
+    - complex(0j)
+109 + 0j
+110 | complex(real=0j)
+111 | (complex(0j)).real
+112 | complex(1j).real
+
+UP018 [*] Unnecessary `complex` call (rewrite as a literal)
+   --> UP018.py:110:1
+    |
+108 | complex()
+109 | complex(0j)
+110 | complex(real=0j)
+    | ^^^^^^^^^^^^^^^^
+111 | (complex(0j)).real
+112 | complex(1j).real
+    |
+help: Replace with complex literal
+107 | complex(real=1j)
+108 | complex()
+109 | complex(0j)
+    - complex(real=0j)
+110 + 0j
+111 | (complex(0j)).real
+112 | complex(1j).real
+113 | complex(real=1j).real
+
+UP018 [*] Unnecessary `complex` call (rewrite as a literal)
+   --> UP018.py:111:2
+    |
+109 | complex(0j)
+110 | complex(real=0j)
+111 | (complex(0j)).real
+    |  ^^^^^^^^^^^
+112 | complex(1j).real
+113 | complex(real=1j).real
+    |
+help: Replace with complex literal
+108 | complex()
+109 | complex(0j)
+110 | complex(real=0j)
+    - (complex(0j)).real
+111 + (0j).real
+112 | complex(1j).real
+113 | complex(real=1j).real
 
 UP018 [*] Unnecessary `complex` call (rewrite as a literal)
    --> UP018.py:112:1
     |
-110 | (complex(0j)).real
-111 | complex(1j).real
-112 | complex(real=1j).real
+110 | complex(real=0j)
+111 | (complex(0j)).real
+112 | complex(1j).real
+    | ^^^^^^^^^^^
+113 | complex(real=1j).real
+    |
+help: Replace with complex literal
+109 | complex(0j)
+110 | complex(real=0j)
+111 | (complex(0j)).real
+    - complex(1j).real
+112 + 1j.real
+113 | complex(real=1j).real
+
+UP018 [*] Unnecessary `complex` call (rewrite as a literal)
+   --> UP018.py:113:1
+    |
+111 | (complex(0j)).real
+112 | complex(1j).real
+113 | complex(real=1j).real
     | ^^^^^^^^^^^^^^^^
     |
 help: Replace with complex literal
-109 | complex(real=0j)
-110 | (complex(0j)).real
-111 | complex(1j).real
+110 | complex(real=0j)
+111 | (complex(0j)).real
+112 | complex(1j).real
     - complex(real=1j).real
-112 + 1j.real
+113 + 1j.real


### PR DESCRIPTION
## Summary
This PR extends `UP018` (`native-literals`) to detect more unnecessarily wrapped literals

Closes #19864.

## Problem
Currently, `UP018` misses several cases of redundant literal constructors:
1. `int().denominator` and similar attribute accesses on zero-value calls.
2. Implicitly concatenated string/bytes literals.
3. `str()` and `complex()` calls with redundant keyword arguments like `object=` or `real=`.
4. `complex()` calls with complex literals.

## Approach
1. Added `Complex` to `LiteralType` enum and supported `complex` in `LiteralType::from_str`.
2. Updated `LiteralType::as_zero_value_expr` to return `0j` for `Complex`.
3. Updated `native_literals` to:
    - Support redundant keyword arguments (`object` for `str`, `real` for `complex`).
    - Remove the check that skipped implicitly concatenated strings.
    - Wrap implicitly concatenated strings/bytes in parentheses if they span multiple lines to maintain valid syntax.
    - Wrap zero-value `int` in parentheses when followed by an attribute access (e.g., `(0).denominator`).

## Test Plan
- Added new test cases to `crates/ruff_linter/resources/test/fixtures/pyupgrade/UP018.py`.
- Verified existing and new tests pass with `cargo test -p ruff_linter pyupgrade::tests`.
- Manually verified with a reproduction script.
- Verified with `cargo clippy`.