### PR TITLE
[ty] Add precisely-typed overloads for `TypedDict` update

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -55,9 +55,15 @@ class NamePatch(TypedDict, total=False):
     name: str
 
 name_update: NamePatch = {"name": "Bobby"}
+string_key_updates: list[tuple[str, str]] = [("name", "Bobby")]
+bad_key_updates: list[tuple[int, str]] = [(1, "Bobby")]
 
 bob.update(name_update)
 bob.update({"name": "Robert"})
+bob.update([("name", "Bobby")])
+bob.update([("age", 27)])
+bob.update(name_update, age=26)
+bob.update([("name", "Bobby")], age=26)
 
 # error: [invalid-argument-type]
 bob.update(age="bad")
@@ -66,12 +72,27 @@ bob.update(age="bad")
 bob.update(other=1)
 
 # error: [invalid-argument-type]
+bob.update(name_update, age="bad")
+
+# error: [no-matching-overload]
+bob.update(name_update, other=1)
+
+# error: [invalid-argument-type]
 # error: [invalid-key]
 bob.update({"other": 1})
 
 # error: [invalid-argument-type]
 # error: [invalid-argument-type]
 bob.update({"age": "bad"})
+
+bob.update([("other", 1)])
+
+bob.update([("age", "bad")])
+
+bob.update(string_key_updates)
+
+# error: [invalid-argument-type]
+bob.update(bad_key_updates)
 ```
 
 `update()` treats the patch operand as partial even when the target `TypedDict` uses `Required` and

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -49,6 +49,17 @@ Methods that are available on `dict`s are also available on `TypedDict`s:
 
 ```py
 bob.update(age=26)
+bob.update({"age": 27})
+
+# error: [invalid-argument-type]
+bob.update(age="bad")
+
+# error: [no-matching-overload]
+bob.update(other=1)
+
+# error: [invalid-argument-type]
+# error: [invalid-argument-type]
+bob.update({"age": "bad"})
 ```
 
 PEP 584-style immutable updates preserve the `TypedDict` type when the other operand is compatible:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -51,11 +51,23 @@ Methods that are available on `dict`s are also available on `TypedDict`s:
 bob.update(age=26)
 bob.update({"age": 27})
 
+class NamePatch(TypedDict, total=False):
+    name: str
+
+name_update: NamePatch = {"name": "Bobby"}
+
+bob.update(name_update)
+bob.update({"name": "Robert"})
+
 # error: [invalid-argument-type]
 bob.update(age="bad")
 
 # error: [no-matching-overload]
 bob.update(other=1)
+
+# error: [invalid-argument-type]
+# error: [invalid-key]
+bob.update({"other": 1})
 
 # error: [invalid-argument-type]
 # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -68,13 +68,13 @@ bob.update([("name", "Bobby")], age=26)
 # error: [invalid-argument-type]
 bob.update(age="bad")
 
-# error: [no-matching-overload]
+# error: [unknown-argument]
 bob.update(other=1)
 
 # error: [invalid-argument-type]
 bob.update(name_update, age="bad")
 
-# error: [no-matching-overload]
+# error: [unknown-argument]
 bob.update(name_update, other=1)
 
 # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -74,6 +74,37 @@ bob.update({"other": 1})
 bob.update({"age": "bad"})
 ```
 
+`update()` treats the patch operand as partial even when the target `TypedDict` uses `Required` and
+`NotRequired`:
+
+```py
+from typing_extensions import NotRequired, Required
+
+class Movie(TypedDict, total=False):
+    title: Required[str]
+    year: int
+    director: NotRequired[str]
+
+class MissingRequiredTitle(TypedDict, total=False):
+    year: int
+
+movie: Movie = {"title": "Alien"}
+missing_required_title: MissingRequiredTitle = {"year": 1986}
+
+movie.update(year=1986)
+movie.update(director="Cameron")
+movie.update({"title": "Aliens"})
+movie.update({"director": "Cameron"})
+movie.update(missing_required_title)
+
+# error: [invalid-argument-type]
+movie.update(title=1986)
+
+# error: [invalid-argument-type]
+# error: [invalid-argument-type]
+movie.update({"director": 1986})
+```
+
 PEP 584-style immutable updates preserve the `TypedDict` type when the other operand is compatible:
 
 ```py

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2004,14 +2004,11 @@ impl<'db> VarianceInferable<'db> for ClassLiteral<'db> {
     }
 }
 
-pub(super) fn synthesize_typed_dict_update_member<'db, I>(
+pub(super) fn synthesize_typed_dict_update_member<'db>(
     db: &'db dyn Db,
     instance_ty: Type<'db>,
-    fields: I,
-) -> Type<'db>
-where
-    I: IntoIterator<Item = (Name, Type<'db>)>,
-{
+    keyword_parameters: &[Parameter<'db>],
+) -> Type<'db> {
     let partial_ty = if let Type::TypedDict(typed_dict) = instance_ty {
         Type::TypedDict(typed_dict.to_partial(db))
     } else {
@@ -2024,23 +2021,36 @@ where
             [
                 Parameter::positional_only(Some(Name::new_static("self")))
                     .with_annotated_type(instance_ty),
-                Parameter::positional_only(Some(Name::new_static("value")))
-                    .with_annotated_type(partial_ty),
-            ],
+                Parameter::positional_only(Some(Name::new_static("value"))).with_annotated_type(
+                    UnionBuilder::new(db)
+                        .add(partial_ty)
+                        .add(KnownClass::Iterable.to_specialized_instance(
+                            db,
+                            &[Type::heterogeneous_tuple(
+                                db,
+                                [KnownClass::Str.to_instance(db), Type::object()],
+                            )],
+                        ))
+                        .build(),
+                ),
+            ]
+            .into_iter()
+            .chain(keyword_parameters.iter().cloned()),
         ),
         Type::none(db),
     );
 
-    let keyword_parameters = std::iter::once(
-        Parameter::positional_only(Some(Name::new_static("self"))).with_annotated_type(instance_ty),
-    )
-    .chain(fields.into_iter().map(|(field_name, field_ty)| {
-        Parameter::keyword_only(field_name)
-            .with_annotated_type(field_ty)
-            .with_default_type(field_ty)
-    }));
-
-    let keyword_update = Signature::new(Parameters::new(db, keyword_parameters), Type::none(db));
+    let keyword_update = Signature::new(
+        Parameters::new(
+            db,
+            std::iter::once(
+                Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(instance_ty),
+            )
+            .chain(keyword_parameters.iter().cloned()),
+        ),
+        Type::none(db),
+    );
 
     Type::Callable(CallableType::new(
         db,

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2015,24 +2015,26 @@ pub(super) fn synthesize_typed_dict_update_member<'db>(
         instance_ty
     };
 
-    let positional_update = Signature::new(
+    let value_ty = UnionBuilder::new(db)
+        .add(partial_ty)
+        .add(KnownClass::Iterable.to_specialized_instance(
+            db,
+            &[Type::heterogeneous_tuple(
+                db,
+                [KnownClass::Str.to_instance(db), Type::object()],
+            )],
+        ))
+        .build();
+
+    let update_signature = Signature::new(
         Parameters::new(
             db,
             [
                 Parameter::positional_only(Some(Name::new_static("self")))
                     .with_annotated_type(instance_ty),
-                Parameter::positional_only(Some(Name::new_static("value"))).with_annotated_type(
-                    UnionBuilder::new(db)
-                        .add(partial_ty)
-                        .add(KnownClass::Iterable.to_specialized_instance(
-                            db,
-                            &[Type::heterogeneous_tuple(
-                                db,
-                                [KnownClass::Str.to_instance(db), Type::object()],
-                            )],
-                        ))
-                        .build(),
-                ),
+                Parameter::positional_only(Some(Name::new_static("value")))
+                    .with_annotated_type(value_ty)
+                    .with_default_type(Type::none(db)),
             ]
             .into_iter()
             .chain(keyword_parameters.iter().cloned()),
@@ -2040,23 +2042,7 @@ pub(super) fn synthesize_typed_dict_update_member<'db>(
         Type::none(db),
     );
 
-    let keyword_update = Signature::new(
-        Parameters::new(
-            db,
-            std::iter::once(
-                Parameter::positional_only(Some(Name::new_static("self")))
-                    .with_annotated_type(instance_ty),
-            )
-            .chain(keyword_parameters.iter().cloned()),
-        ),
-        Type::none(db),
-    );
-
-    Type::Callable(CallableType::new(
-        db,
-        CallableSignature::from_overloads([positional_update, keyword_update]),
-        CallableTypeKind::FunctionLike,
-    ))
+    Type::function_like_callable(db, update_signature)
 }
 
 /// Performs member lookups over an MRO (Method Resolution Order).

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2004,6 +2004,51 @@ impl<'db> VarianceInferable<'db> for ClassLiteral<'db> {
     }
 }
 
+pub(super) fn synthesize_typed_dict_update_member<'db, I>(
+    db: &'db dyn Db,
+    instance_ty: Type<'db>,
+    fields: I,
+) -> Type<'db>
+where
+    I: IntoIterator<Item = (Name, Type<'db>)>,
+{
+    let partial_ty = if let Type::TypedDict(typed_dict) = instance_ty {
+        Type::TypedDict(typed_dict.to_partial(db))
+    } else {
+        instance_ty
+    };
+
+    let positional_update = Signature::new(
+        Parameters::new(
+            db,
+            [
+                Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(instance_ty),
+                Parameter::positional_only(Some(Name::new_static("value")))
+                    .with_annotated_type(partial_ty),
+            ],
+        ),
+        Type::none(db),
+    );
+
+    let keyword_parameters = std::iter::once(
+        Parameter::positional_only(Some(Name::new_static("self"))).with_annotated_type(instance_ty),
+    )
+    .chain(fields.into_iter().map(|(field_name, field_ty)| {
+        Parameter::keyword_only(field_name)
+            .with_annotated_type(field_ty)
+            .with_default_type(field_ty)
+    }));
+
+    let keyword_update = Signature::new(Parameters::new(db, keyword_parameters), Type::none(db));
+
+    Type::Callable(CallableType::new(
+        db,
+        CallableSignature::from_overloads([positional_update, keyword_update]),
+        CallableTypeKind::FunctionLike,
+    ))
+}
+
 /// Performs member lookups over an MRO (Method Resolution Order).
 ///
 /// This struct encapsulates the shared logic for looking up class and instance

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1977,13 +1977,23 @@ impl<'db> StaticClassLiteral<'db> {
                     CallableTypeKind::FunctionLike,
                 )))
             }
-            (CodeGeneratorKind::TypedDict, "update") => Some(synthesize_typed_dict_update_member(
-                db,
-                instance_ty,
-                self.fields(db, specialization, field_policy)
+            (CodeGeneratorKind::TypedDict, "update") => {
+                let keyword_parameters: Vec<_> = self
+                    .fields(db, specialization, field_policy)
                     .iter()
-                    .map(|(name, field)| (name.clone(), field.declared_ty)),
-            )),
+                    .map(|(name, field)| {
+                        Parameter::keyword_only(name.clone())
+                            .with_annotated_type(field.declared_ty)
+                            .with_default_type(field.declared_ty)
+                    })
+                    .collect();
+
+                Some(synthesize_typed_dict_update_member(
+                    db,
+                    instance_ty,
+                    &keyword_parameters,
+                ))
+            }
             _ => None,
         }
     }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -37,6 +37,7 @@ use crate::{
             ClassMemberResult, CodeGeneratorKind, DisjointBase, Field, FieldKind,
             InstanceMemberResult, MetaclassError, MetaclassErrorKind, MethodDecorator, MroLookup,
             NamedTupleField, SlotsKind, synthesize_namedtuple_class_member,
+            synthesize_typed_dict_update_member,
         },
         context::InferContext,
         declaration_type, definition_expression_type, determine_upper_bound,
@@ -1976,23 +1977,13 @@ impl<'db> StaticClassLiteral<'db> {
                     CallableTypeKind::FunctionLike,
                 )))
             }
-            (CodeGeneratorKind::TypedDict, "update") => {
-                // TODO: synthesize a set of overloads with precise types
-                let signature = Signature::new(
-                    Parameters::new(
-                        db,
-                        [
-                            Parameter::positional_only(Some(Name::new_static("self")))
-                                .with_annotated_type(instance_ty),
-                            Parameter::variadic(Name::new_static("args")),
-                            Parameter::keyword_variadic(Name::new_static("kwargs")),
-                        ],
-                    ),
-                    Type::none(db),
-                );
-
-                Some(Type::function_like_callable(db, signature))
-            }
+            (CodeGeneratorKind::TypedDict, "update") => Some(synthesize_typed_dict_update_member(
+                db,
+                instance_ty,
+                self.fields(db, specialization, field_policy)
+                    .iter()
+                    .map(|(name, field)| (name.clone(), field.declared_ty)),
+            )),
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary

This TODO led to some false positives in https://github.com/astral-sh/ruff/pull/24092, so putting this up separately.

I believe the ecosystem diagnostics are false positives (and the Pydantic diagnostics in particular already have `# pyright: ignore`).