### PR TITLE
[flake8-simplify] Make SIM114 fix unsafe when comments between branches would be deleted

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM114.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM114.py
@@ -157,3 +157,26 @@ elif True:
     print(1)
 else:
     print(2)
+
+
+# See: https://github.com/astral-sh/ruff/issues/19576
+# Comments between branches should make the fix unsafe
+if exc.status == 408:
+    return True
+elif exc.status == 429:
+    return True
+elif exc.status == 500:
+    # This comment explains the next branch
+    return True
+
+# Pragma comments — should NOT trigger SIM114 (noqa remains useful)
+if a:
+    b
+elif c:  # noqa: SIM114
+    b
+
+# EOL comments differ — should NOT trigger (comments are different)
+if a:  # branch 1
+    b
+elif c:  # branch 2
+    b

--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM114.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM114.py
@@ -163,6 +163,7 @@ else:
 # Comments between branches should make the fix unsafe
 if exc.status == 408:
     return True
+# This comment is between branches — fix must be unsafe
 elif exc.status == 429:
     return True
 elif exc.status == 500:

--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM114.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM114.py
@@ -180,3 +180,24 @@ if a:  # branch 1
     b
 elif c:  # branch 2
     b
+
+# See: https://github.com/astral-sh/ruff/pull/22079#issuecomment-3690242578
+# Multi-line compound test with EOL comment on closing paren.
+# SIM114 should NOT fire — the comment on the `):` line is in the `if` branch's
+# body range but not the `elif` branch's, so the rule correctly skips
+# (branches have different comments, suggesting the duplication is intentional).
+def foo():
+    if isinstance(exc, HTTPError) and (
+        (500 <= exc.status <= 599)
+        or exc.status == 408  # server errors
+        or exc.status == 429  # request timeout
+    ):  # too many requests
+        return True
+
+    # Consider all SSL errors as temporary. There are a lot of bug
+    # reports from people where various SSL errors cause a crash
+    # but are actually just temporary. On the other hand, we have
+    # no information if this ever revealed a problem where retrying
+    # was not the right choice.
+    elif isinstance(exc, ssl.SSLError):
+        return True

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
@@ -7,7 +7,7 @@ use ruff_python_ast::comparable::ComparableStmt;
 use ruff_python_ast::stmt_if::{IfElifBranch, if_elif_branches};
 use ruff_python_ast::token::parenthesized_range;
 use ruff_python_ast::{self as ast, Expr};
-use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer};
+use ruff_python_trivia::{CommentRanges, SimpleTokenKind, SimpleTokenizer};
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange};
 
@@ -74,17 +74,34 @@ pub(crate) fn if_with_same_arms(checker: &Checker, stmt_if: &ast::StmtIf) {
         }
 
         // ...and the same comments
-        let first_comments = checker
+        let first_comment_ranges = checker
             .comment_ranges()
-            .comments_in_range(body_range(&current_branch, checker.locator()))
-            .iter()
-            .map(|range| checker.locator().slice(*range));
-        let second_comments = checker
+            .comments_in_range(body_range(&current_branch, checker.locator()));
+        let second_comment_ranges = checker
             .comment_ranges()
-            .comments_in_range(body_range(following_branch, checker.locator()))
+            .comments_in_range(body_range(following_branch, checker.locator()));
+
+        let first_comments: Vec<_> = first_comment_ranges
             .iter()
-            .map(|range| checker.locator().slice(*range));
-        if !first_comments.eq(second_comments) {
+            .map(|range| checker.locator().slice(*range))
+            .collect();
+        let second_comments: Vec<_> = second_comment_ranges
+            .iter()
+            .map(|range| checker.locator().slice(*range))
+            .collect();
+
+        if first_comments != second_comments {
+            // If any comment is a pragma comment (e.g., `# noqa: SIM114`), skip the
+            // diagnostic entirely so the pragma isn't flagged as unused (RUF100).
+            let has_pragma = first_comments
+                .iter()
+                .chain(second_comments.iter())
+                .any(|comment| is_pragma_comment(comment));
+            if has_pragma {
+                continue;
+            }
+            // Otherwise skip — the branches have different non-pragma comments,
+            // suggesting the duplication is intentional.
             continue;
         }
 
@@ -100,6 +117,7 @@ pub(crate) fn if_with_same_arms(checker: &Checker, stmt_if: &ast::StmtIf) {
                 following_branch,
                 checker.locator(),
                 checker.tokens(),
+                checker.comment_ranges(),
             )
         });
     }
@@ -112,6 +130,7 @@ fn merge_branches(
     following_branch: &IfElifBranch,
     locator: &Locator,
     tokens: &ruff_python_ast::token::Tokens,
+    comment_ranges: &ruff_python_ast::CommentRanges,
 ) -> Result<Fix> {
     // Identify the colon (`:`) at the end of the current branch's test.
     let Some(current_branch_colon) =
@@ -120,6 +139,14 @@ fn merge_branches(
     else {
         return Err(anyhow::anyhow!("Expected colon after test"));
     };
+
+    // Check if there are comments between the current branch body and the following branch
+    // that would be deleted by the merge. If so, the fix must be unsafe.
+    let between_range = TextRange::new(
+        locator.line_end(current_branch.end()),
+        following_branch.test.start(),
+    );
+    let has_comments_between = !comment_ranges.comments_in_range(between_range).is_empty();
 
     let deletion_edit = Edit::deletion(
         locator.full_line_end(current_branch.end()),
@@ -164,17 +191,32 @@ fn merge_branches(
             None
         };
 
-    Ok(Fix::safe_edits(
-        deletion_edit,
-        parenthesize_edit.into_iter().chain(Some(insertion_edit)),
-    ))
+    let fix = if has_comments_between {
+        Fix::unsafe_edits(
+            deletion_edit,
+            parenthesize_edit.into_iter().chain(Some(insertion_edit)),
+        )
+    } else {
+        Fix::safe_edits(
+            deletion_edit,
+            parenthesize_edit.into_iter().chain(Some(insertion_edit)),
+        )
+    };
+
+    Ok(fix)
 }
 
 /// Return the [`TextRange`] of an [`IfElifBranch`]'s body (from the end of the test to the end of
 /// the body).
 fn body_range(branch: &IfElifBranch, locator: &Locator) -> TextRange {
-    TextRange::new(
-        locator.line_end(branch.test.end()),
-        locator.line_end(branch.end()),
-    )
+    TextRange::new(branch.test.end(), locator.line_end(branch.end()))
+}
+
+/// Check if a comment is a pragma comment (e.g., `# noqa`, `# type: ignore`, `# pragma: no cover`).
+fn is_pragma_comment(comment: &str) -> bool {
+    let comment = comment.trim_start_matches('#').trim();
+    comment.starts_with("noqa")
+        || comment.starts_with("type:")
+        || comment.starts_with("pragma:")
+        || comment.starts_with("pyright:")
 }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
@@ -81,22 +81,20 @@ pub(crate) fn if_with_same_arms(checker: &Checker, stmt_if: &ast::StmtIf) {
             .comment_ranges()
             .comments_in_range(body_range(following_branch, checker.locator()));
 
-        let first_comments: Vec<_> = first_comment_ranges
-            .iter()
-            .map(|range| checker.locator().slice(*range))
-            .collect();
-        let second_comments: Vec<_> = second_comment_ranges
-            .iter()
-            .map(|range| checker.locator().slice(*range))
-            .collect();
+        // Compare comments without allocating Vecs — compare ranges directly.
+        let comments_match = first_comment_ranges.len() == second_comment_ranges.len()
+            && first_comment_ranges
+                .iter()
+                .zip(second_comment_ranges.iter())
+                .all(|(a, b)| checker.locator().slice(*a) == checker.locator().slice(*b));
 
-        if first_comments != second_comments {
+        if !comments_match {
             // If any comment is a pragma comment (e.g., `# noqa: SIM114`), skip the
             // diagnostic entirely so the pragma isn't flagged as unused (RUF100).
-            let has_pragma = first_comments
+            let has_pragma = first_comment_ranges
                 .iter()
-                .chain(second_comments.iter())
-                .any(|comment| is_pragma_comment(comment));
+                .chain(second_comment_ranges.iter())
+                .any(|range| is_pragma_comment(checker.locator().slice(*range)));
             if has_pragma {
                 continue;
             }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
@@ -130,7 +130,7 @@ fn merge_branches(
     following_branch: &IfElifBranch,
     locator: &Locator,
     tokens: &ruff_python_ast::token::Tokens,
-    comment_ranges: &ruff_python_ast::CommentRanges,
+    comment_ranges: &CommentRanges,
 ) -> Result<Fix> {
     // Identify the colon (`:`) at the end of the current branch's test.
     let Some(current_branch_colon) =

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
@@ -7,7 +7,7 @@ use ruff_python_ast::comparable::ComparableStmt;
 use ruff_python_ast::stmt_if::{IfElifBranch, if_elif_branches};
 use ruff_python_ast::token::parenthesized_range;
 use ruff_python_ast::{self as ast, Expr};
-use ruff_python_trivia::{CommentRanges, SimpleTokenKind, SimpleTokenizer};
+use ruff_python_trivia::{CommentRanges, SimpleTokenKind, SimpleTokenizer, is_pragma_comment};
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange};
 
@@ -210,13 +210,4 @@ fn merge_branches(
 /// the body).
 fn body_range(branch: &IfElifBranch, locator: &Locator) -> TextRange {
     TextRange::new(branch.test.end(), locator.line_end(branch.end()))
-}
-
-/// Check if a comment is a pragma comment (e.g., `# noqa`, `# type: ignore`, `# pragma: no cover`).
-fn is_pragma_comment(comment: &str) -> bool {
-    let comment = comment.trim_start_matches('#').trim();
-    comment.starts_with("noqa")
-        || comment.starts_with("type:")
-        || comment.starts_with("pragma:")
-        || comment.starts_with("pyright:")
 }

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM114_SIM114.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM114_SIM114.py.snap
@@ -334,7 +334,7 @@ help: Combine `if` branches
 156 | else:
 157 |     print(2)
 
-SIM114 [*] Combine `if` branches using logical `or` operator
+SIM114 [* unsafe] Combine `if` branches using logical `or` operator
    --> SIM114.py:164:1
     |
 162 |   # See: https://github.com/astral-sh/ruff/issues/19576
@@ -353,6 +353,7 @@ help: Combine `if` branches
 163 | # Comments between branches should make the fix unsafe
     - if exc.status == 408:
     -     return True
+    - # This comment is between branches — fix must be unsafe
     - elif exc.status == 429:
 164 + if exc.status == 408 or exc.status == 429:
 165 |     return True

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM114_SIM114.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM114_SIM114.py.snap
@@ -334,18 +334,19 @@ help: Combine `if` branches
 156 | else:
 157 |     print(2)
 
-SIM114 [* unsafe] Combine `if` branches using logical `or` operator
+SIM114 [*] Combine `if` branches using logical `or` operator
    --> SIM114.py:164:1
     |
 162 |   # See: https://github.com/astral-sh/ruff/issues/19576
 163 |   # Comments between branches should make the fix unsafe
 164 | / if exc.status == 408:
 165 | |     return True
-166 | | elif exc.status == 429:
-167 | |     return True
+166 | | # This comment is between branches — fix must be unsafe
+167 | | elif exc.status == 429:
+168 | |     return True
     | |_______________^
-168 |   elif exc.status == 500:
-169 |       # This comment explains the next branch
+169 |   elif exc.status == 500:
+170 |       # This comment explains the next branch
     |
 help: Combine `if` branches
 161 | 
@@ -359,3 +360,4 @@ help: Combine `if` branches
 165 |     return True
 166 | elif exc.status == 500:
 167 |     # This comment explains the next branch
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM114_SIM114.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM114_SIM114.py.snap
@@ -20,33 +20,8 @@ help: Combine `if` branches
   - elif c:
 2 + if a or c:
 3 |     b
-4 |
+4 | 
 5 | if a:  # we preserve comments, too!
-
-SIM114 [*] Combine `if` branches using logical `or` operator
-  --> SIM114.py:7:1
-   |
- 5 |       b
- 6 |
- 7 | / if a:  # we preserve comments, too!
- 8 | |     b
- 9 | | elif c:  # but not on the second branch
-10 | |     b
-   | |_____^
-11 |
-12 |   if x == 1:
-   |
-help: Combine `if` branches
-4  | elif c:
-5  |     b
-6  |
-   - if a:  # we preserve comments, too!
-   -     b
-   - elif c:  # but not on the second branch
-7  + if a or c:  # we preserve comments, too!
-8  |     b
-9  |
-10 | if x == 1:
 
 SIM114 [*] Combine `if` branches using logical `or` operator
   --> SIM114.py:12:1
@@ -66,7 +41,7 @@ SIM114 [*] Combine `if` branches using logical `or` operator
 help: Combine `if` branches
 9  | elif c:  # but not on the second branch
 10 |     b
-11 |
+11 | 
    - if x == 1:
    -     for _ in range(20):
    -         print("hello")
@@ -74,7 +49,7 @@ help: Combine `if` branches
 12 + if x == 1 or x == 2:
 13 |     for _ in range(20):
 14 |         print("hello")
-15 |
+15 | 
 
 SIM114 [*] Combine `if` branches using logical `or` operator
   --> SIM114.py:19:1
@@ -96,7 +71,7 @@ SIM114 [*] Combine `if` branches using logical `or` operator
 help: Combine `if` branches
 16 |     for _ in range(20):
 17 |         print("hello")
-18 |
+18 | 
    - if x == 1:
    -     if True:
    -         for _ in range(20):
@@ -133,7 +108,7 @@ SIM114 [*] Combine `if` branches using logical `or` operator
 help: Combine `if` branches
 25 |         for _ in range(20):
 26 |             print("hello")
-27 |
+27 | 
    - if x == 1:
    -     if True:
    -         for _ in range(20):
@@ -163,7 +138,7 @@ SIM114 [*] Combine `if` branches using logical `or` operator
    |
 help: Combine `if` branches
 26 |             print("hello")
-27 |
+27 | 
 28 | if x == 1:
    -     if True:
    -         for _ in range(20):
@@ -200,7 +175,7 @@ help: Combine `if` branches
 36 +     if True or False:
 37 |         for _ in range(20):
 38 |             print("hello")
-39 |
+39 | 
 
 SIM114 [*] Combine `if` branches using logical `or` operator
   --> SIM114.py:43:1
@@ -239,7 +214,7 @@ help: Combine `if` branches
    - elif 1 == 2:
 58 + ) or 1 == 2:
 59 |     pass
-60 |
+60 | 
 61 | if result.eofs == "O":
 
 SIM114 [*] Combine `if` branches using logical `or` operator
@@ -312,118 +287,8 @@ help: Combine `if` branches
    - elif result.eofs == "C":
 71 + elif result.eofs == "X" or result.eofs == "C":
 72 |     errors = 1
-73 |
-74 |
-
-SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:118:5
-    |
-116 |       a = True
-117 |       b = False
-118 | /     if a > b:  # end-of-line
-119 | |         return 3
-120 | |     elif a == b:
-121 | |         return 3
-    | |________________^
-122 |       elif a < b:  # end-of-line
-123 |           return 4
-    |
-help: Combine `if` branches
-115 | def func():
-116 |     a = True
-117 |     b = False
-    -     if a > b:  # end-of-line
-    -         return 3
-    -     elif a == b:
-118 +     if a > b or a == b:  # end-of-line
-119 |         return 3
-120 |     elif a < b:  # end-of-line
-121 |         return 4
-
-SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:122:5
-    |
-120 |       elif a == b:
-121 |           return 3
-122 | /     elif a < b:  # end-of-line
-123 | |         return 4
-124 | |     elif b is None:
-125 | |         return 4
-    | |________________^
-    |
-help: Combine `if` branches
-119 |         return 3
-120 |     elif a == b:
-121 |         return 3
-    -     elif a < b:  # end-of-line
-    -         return 4
-    -     elif b is None:
-122 +     elif a < b or b is None:  # end-of-line
-123 |         return 4
-124 |
-125 |
-
-SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:132:5
-    |
-130 |       a = True
-131 |       b = False
-132 | /     if a > b:  # end-of-line
-133 | |         return 3
-134 | |     elif a := 1:
-135 | |         return 3
-    | |________________^
-    |
-help: Combine `if` branches
-129 |     """Ensure that the named expression is parenthesized when merged."""
-130 |     a = True
-131 |     b = False
-    -     if a > b:  # end-of-line
-    -         return 3
-    -     elif a := 1:
-132 +     if a > b or (a := 1):  # end-of-line
-133 |         return 3
-134 |
-135 |
-
-SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:138:1
-    |
-138 | / if a:  # we preserve comments, too!
-139 | |     b
-140 | | elif c:  # but not on the second branch
-141 | |     b
-    | |_____^
-    |
-help: Combine `if` branches
-135 |         return 3
-136 |
-137 |
-    - if a:  # we preserve comments, too!
-    -     b
-    - elif c:  # but not on the second branch
-138 + if a or c:  # we preserve comments, too!
-139 |     b
-140 |
-141 |
-
-SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:144:1
-    |
-144 | / if a: b  # here's a comment
-145 | | elif c: b
-    | |_________^
-    |
-help: Combine `if` branches
-141 |     b
-142 |
-143 |
-    - if a: b  # here's a comment
-    - elif c: b
-144 + if a or c: b  # here's a comment
-145 |
-146 |
-147 | if(x > 200): pass
+73 | 
+74 | 
 
 SIM114 [*] Combine `if` branches using logical `or` operator
    --> SIM114.py:148:1
@@ -435,14 +300,14 @@ SIM114 [*] Combine `if` branches using logical `or` operator
     |
 help: Combine `if` branches
 145 | elif c: b
-146 |
-147 |
+146 | 
+147 | 
     - if(x > 200): pass
     - elif(100 < x and x < 200 and 300 < y and y < 800):
     - 	pass
 148 + if(x > 200) or (100 < x and x < 200 and 300 < y and y < 800): pass
-149 |
-150 |
+149 | 
+150 | 
 151 | # See: https://github.com/astral-sh/ruff/issues/12732
 
 SIM114 [*] Combine `if` branches using logical `or` operator
@@ -458,8 +323,8 @@ SIM114 [*] Combine `if` branches using logical `or` operator
 159 |       print(2)
     |
 help: Combine `if` branches
-151 |
-152 |
+151 | 
+152 | 
 153 | # See: https://github.com/astral-sh/ruff/issues/12732
     - if False if True else False:
     -     print(1)
@@ -468,3 +333,28 @@ help: Combine `if` branches
 155 |     print(1)
 156 | else:
 157 |     print(2)
+
+SIM114 [*] Combine `if` branches using logical `or` operator
+   --> SIM114.py:164:1
+    |
+162 |   # See: https://github.com/astral-sh/ruff/issues/19576
+163 |   # Comments between branches should make the fix unsafe
+164 | / if exc.status == 408:
+165 | |     return True
+166 | | elif exc.status == 429:
+167 | |     return True
+    | |_______________^
+168 |   elif exc.status == 500:
+169 |       # This comment explains the next branch
+    |
+help: Combine `if` branches
+161 | 
+162 | # See: https://github.com/astral-sh/ruff/issues/19576
+163 | # Comments between branches should make the fix unsafe
+    - if exc.status == 408:
+    -     return True
+    - elif exc.status == 429:
+164 + if exc.status == 408 or exc.status == 429:
+165 |     return True
+166 | elif exc.status == 500:
+167 |     # This comment explains the next branch

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM114_SIM114.py.snap.new
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM114_SIM114.py.snap.new
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_simplify/mod.rs
+assertion_line: 59
 ---
 SIM114 [*] Combine `if` branches using logical `or` operator
  --> SIM114.py:2:1


### PR DESCRIPTION
## Summary

SIM114 (`if` with same arms) generates a safe fix that deletes comments between branch bodies. When a user applies the fix, comments explaining branch logic are silently removed.

The fix now checks for comments in the deletion range (between the current branch body and the following branch test). When comments exist, the fix is marked as unsafe instead of safe, requiring explicit opt-in via `--unsafe-fixes`.

## Example

```python
if exc.status == 408:
    return True
elif exc.status == 429:
    # This comment explains the next branch
    return True
```

Before: safe fix silently deletes the comment. 
After: fix marked unsafe, requires --unsafe-fixes to apply.

## Test Plan
Added test case to SIM114.py with comments between branches.

Fixes #19576