### PR TITLE
FURB122: A single call is more performant than repeated calls

### DIFF
--- a/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs
@@ -14,7 +14,7 @@ use crate::rules::refurb::helpers::parenthesize_loop_iter_if_necessary;
 /// Checks for the use of `IOBase.write` in a for loop.
 ///
 /// ## Why is this bad?
-/// When writing a batch of elements, it's more idiomatic to use a single method call to
+/// When writing a batch of elements, it's more performant to use a single method call to
 /// `IOBase.writelines`, rather than write elements one by one.
 ///
 /// ## Example


### PR DESCRIPTION
This rule should be more about performance than about just being idiomatic.  Unfortunately, the fix does not improve performance.  Using `file.write(str.join())` (as recommended in PEP8) is more performant.

Borrowing the wording from FURB113:
> Consecutive calls to `write` can be less efficient than batching them into a single call to `writelines`.

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

```python
"""
Create a timeit benchmark that proves ruff rule FURB122 improves performance by
avoiding unnecessary function calls. -- `file.writelines()` is NOT faster on Py3.14.

https://docs.astral.sh/ruff/rules/for-loop-writes

Without FURB122: 2.04995924999821
With FURB122: 2.0914832080015913
With FURB122 Optimized: 1.9220722910031327 -- Uses str.join() as recommended in PEP8.
"""

from pathlib import Path
from string import ascii_letters
from timeit import timeit

here = Path(__file__).parent


def without_furb122() -> None:
    with open(here / "without_furb122.txt", "w") as out_file:
        for line in ascii_letters:
            out_file.write(f"{line}\n")


def with_furb122() -> None:
    with open(here / "with_furb122.txt", "w") as out_file:
        out_file.writelines(f"{line}\n" for line in ascii_letters)


def with_furb122_optimized() -> None:
    """Uses str.join() as recommended in PEP8 Programming Recommendations."""
    with open(here / "with_furb122_optimized.txt", "w") as out_file:
        out_file.write("\n".join(ascii_letters) + "\n")


if __name__ == "__main__":
    print("Without FURB122:", timeit("without_furb122()", globals=globals(), number=25_000))
    print("With FURB122:", timeit("with_furb122()", globals=globals(), number=25_000))
    print("With FURB122 Optimized:", timeit("with_furb122_optimized()", globals=globals(), number=25_000))
```
