### PR TITLE
[ty] Specialize known-key `TypedDict` methods

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1782,6 +1782,39 @@ def _(u: IntX | StrX, v: OptionalX | RequiredX) -> None:
     reveal_type(v.pop("x"))  # revealed: Unknown
 ```
 
+Known-key specialization on unions falls back to generic resolution when a key is missing from one
+arm:
+
+```py
+from typing import TypedDict
+from typing_extensions import NotRequired
+
+class HasX(TypedDict):
+    x: int
+
+class NoX(TypedDict):
+    y: str
+
+class OptX(TypedDict):
+    x: NotRequired[int]
+
+class OptStrX(TypedDict):
+    x: NotRequired[str]
+
+def _(u: HasX | NoX) -> None:
+    # Key "x" is missing from `NoX`, so specialization does not apply.
+    reveal_type(u.get("x"))  # revealed: int | Unknown | None
+
+def union_get(u: HasX | OptX) -> None:
+    # `HasX.x` is required (returns `int`), `OptX.x` is not (returns `int | None`).
+    reveal_type(u.get("x"))  # revealed: int | None
+
+def union_pop_with_default(u: OptX | OptStrX) -> None:
+    # `Literal[0]` is assignable to `int`, so `OptX` arm returns `int`; `OptStrX` arm
+    # returns `str | Literal[0]`.
+    reveal_type(u.pop("x", 0))  # revealed: int | str
+```
+
 Known-key `get()` calls also use the field type as bidirectional context when that produces a valid
 default:
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6978,30 +6978,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // TypedDict method specialization: for known-key calls like `td.get("key")`, replace
         // the generic callable with a specialized signature that encodes the field type.
         let mut callable_type = callable_type;
-        if let ast::Expr::Attribute(ast::ExprAttribute { value, attr, .. }) = func.as_ref() {
+        if let ast::Expr::Attribute(ast::ExprAttribute { value, attr, .. }) = func.as_ref()
+            && matches!(attr.id.as_str(), "get" | "pop" | "setdefault")
+        {
             let value_type = self.expression_type(value);
 
-            if let Type::TypedDict(typed_dict_ty) = value_type
-                && matches!(attr.id.as_str(), "pop" | "setdefault")
-                && !arguments.args.is_empty()
-                && let Some(ty) = self.check_typed_dict_pop_or_setdefault_call(
-                    typed_dict_ty,
-                    attr.id.as_str(),
-                    arguments,
-                )
-            {
-                return ty;
-            }
-
-            if matches!(attr.id.as_str(), "get" | "pop" | "setdefault")
-                && let Some(specialized_callable) = self
-                    .specialize_typed_dict_known_key_method_call(
-                        value_type,
-                        attr.id.as_str(),
-                        arguments,
-                    )
-            {
-                callable_type = specialized_callable;
+            if let Some(result) = self.specialize_typed_dict_known_key_method_call(
+                value_type,
+                attr.id.as_str(),
+                arguments,
+            ) {
+                match result {
+                    typed_dict::TypedDictMethodSpecialization::Callable(ty) => {
+                        callable_type = ty;
+                    }
+                    typed_dict::TypedDictMethodSpecialization::Diagnosed(ty) => {
+                        return ty;
+                    }
+                }
             }
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -9,7 +9,23 @@ use crate::types::{
     UnionType, callable::CallableTypeKind, signatures::CallableSignature,
 };
 
+/// Result of attempting to specialize a `TypedDict` method call for a known literal key.
+pub(super) enum TypedDictMethodSpecialization<'db> {
+    /// A specialized callable that should replace the generic method type for normal call
+    /// resolution.
+    Callable(Type<'db>),
+
+    /// A diagnostic was emitted (e.g. invalid key, pop on required field). The caller should
+    /// return the contained type directly, bypassing normal call resolution.
+    Diagnosed(Type<'db>),
+}
+
 impl<'db> TypeInferenceBuilder<'db, '_> {
+    /// Return an empty function-like callable to model a `TypedDict` method that is statically
+    /// unavailable for the current key shape.
+    ///
+    /// A callable with zero overloads will fail at every call site with a `call-non-callable`
+    /// diagnostic, which is the desired behavior for e.g. `pop()` on a required field.
     fn non_callable_typed_dict_method(&self) -> Type<'db> {
         Type::Callable(CallableType::new(
             self.db(),
@@ -18,6 +34,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         ))
     }
 
+    /// Build a field-specific callable signature for a known-key `TypedDict` method call.
+    ///
+    /// Returns `None` if the method name or arity is unsupported, or if a required default type
+    /// was not provided.
     fn specialize_typed_dict_known_key_method_for_field(
         &self,
         key: &str,
@@ -104,11 +124,19 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 ),
             ),
             ("pop", 1 | 2) => self.non_callable_typed_dict_method(),
+            // Unsupported method or arity — fall back to generic overload resolution, which
+            // will produce the appropriate arity/type errors.
             _ => return None,
         })
     }
 
-    pub(super) fn known_typed_dict_field_for_key(
+    /// Resolve the field type for a literal key on a `TypedDict` or union of
+    /// `TypedDict` instances.
+    ///
+    /// For unions, every arm must contain the key; the resulting field type is the union of the
+    /// per-arm field types, and the field is treated as required only if it is required in every
+    /// arm.
+    fn known_typed_dict_field_for_key(
         &self,
         value_type: Type<'db>,
         key: &str,
@@ -135,7 +163,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
     }
 
-    pub(super) fn infer_typed_dict_known_key_default(
+    /// Infer a known-key `get()` or `pop()` default, optionally trying the field type as
+    /// bidirectional context and keeping it only if that inference remains assignable.
+    fn infer_typed_dict_known_key_default(
         &mut self,
         default_arg: &ast::Expr,
         field_ty: Type<'db>,
@@ -144,29 +174,32 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // We use speculative inference here because we only need the *type* of the default
         // argument to construct the specialized callable. The expression type will be properly
         // stored during normal argument inference (with the correct type context from the
-        // specialized callable's parameter annotation).
-        if !use_field_context {
-            return self.speculate().infer_expression(default_arg, TypeContext::default());
+        // specialized callable's parameter annotation). `speculate()` calls `context.defuse()`,
+        // so no diagnostics leak from these trial inferences.
+        let infer_speculatively =
+            |builder: &mut Self, tcx| builder.speculate().infer_expression(default_arg, tcx);
+
+        if use_field_context {
+            let inferred_ty = infer_speculatively(self, TypeContext::new(Some(field_ty)));
+            if inferred_ty.is_assignable_to(self.db(), field_ty) {
+                return inferred_ty;
+            }
         }
 
-        let inferred_ty = self
-            .speculate()
-            .infer_expression(default_arg, TypeContext::new(Some(field_ty)));
-
-        if inferred_ty.is_assignable_to(self.db(), field_ty) {
-            inferred_ty
-        } else {
-            self.speculate()
-                .infer_expression(default_arg, TypeContext::default())
-        }
+        infer_speculatively(self, TypeContext::default())
     }
 
+    /// Specialize a `TypedDict` method call for a known literal key.
+    ///
+    /// For concrete `TypedDict`s, this validates key existence and required-field constraints
+    /// (emitting diagnostics as needed) and builds a field-specific callable signature. For unions
+    /// of `TypedDict`s, it builds per-arm specialized callables when all arms define the key.
     pub(super) fn specialize_typed_dict_known_key_method_call(
         &mut self,
         value_type: Type<'db>,
         method_name: &str,
         arguments: &ast::Arguments,
-    ) -> Option<Type<'db>> {
+    ) -> Option<TypedDictMethodSpecialization<'db>> {
         if !arguments.keywords.is_empty() {
             return None;
         }
@@ -180,6 +213,23 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         };
 
         let key = key_literal.to_str();
+
+        // For concrete TypedDicts, validate key existence and required-field constraints for
+        // `pop`/`setdefault` before attempting specialization. These produce definitive
+        // diagnostics that should short-circuit normal call resolution.
+        if let Type::TypedDict(typed_dict_ty) = value_type
+            && matches!(method_name, "pop" | "setdefault")
+        {
+            if let Some(diagnosed) =
+                self.check_typed_dict_key_constraints(typed_dict_ty, method_name, key, first_arg)
+            {
+                return Some(diagnosed);
+            }
+        }
+
+        // Compute the default type for the default argument, if present. For `get()` and `pop()`
+        // two-arg forms, we use the aggregate field type as bidirectional context so that literals
+        // like `{}` can be inferred as the declared field type.
         let default_ty = match (method_name, &*arguments.args) {
             ("get", [_, default_arg]) => {
                 let (field_ty, field_is_required) =
@@ -198,7 +248,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             _ => return None,
         };
 
-        match value_type {
+        let specialized = match value_type {
             Type::TypedDict(typed_dict_ty) => {
                 let field = typed_dict_ty.items(self.db()).get(key)?;
                 self.specialize_typed_dict_known_key_method_for_field(
@@ -226,24 +276,22 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }),
             ),
             _ => None,
-        }
+        };
+
+        specialized.map(TypedDictMethodSpecialization::Callable)
     }
 
-    pub(super) fn check_typed_dict_pop_or_setdefault_call(
+    /// Validate literal-key constraints for `pop()` and `setdefault()` on a concrete `TypedDict`.
+    ///
+    /// Returns `Some(Diagnosed(Unknown))` when a definitive diagnostic is emitted (invalid key,
+    /// or pop on a required field); otherwise returns `None` to continue with specialization.
+    fn check_typed_dict_key_constraints(
         &mut self,
         typed_dict_ty: TypedDictType<'db>,
         method_name: &str,
-        arguments: &ast::Arguments,
-    ) -> Option<Type<'db>> {
-        let first_arg = arguments.args.first()?;
-        let ast::Expr::StringLiteral(ast::ExprStringLiteral {
-            value: key_literal, ..
-        }) = first_arg
-        else {
-            return None;
-        };
-
-        let key = key_literal.to_str();
+        key: &str,
+        key_expr: &ast::Expr,
+    ) -> Option<TypedDictMethodSpecialization<'db>> {
         let items = typed_dict_ty.items(self.db());
 
         if let Some((_, field)) = items
@@ -253,11 +301,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             if method_name == "pop" && field.is_required() {
                 report_cannot_pop_required_field_on_typed_dict(
                     &self.context,
-                    first_arg.into(),
+                    key_expr.into(),
                     Type::TypedDict(typed_dict_ty),
                     key,
                 );
-                return Some(Type::unknown());
+                return Some(TypedDictMethodSpecialization::Diagnosed(Type::unknown()));
             }
 
             return None;
@@ -266,8 +314,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let key_ty = Type::string_literal(self.db(), key);
         report_invalid_key_on_typed_dict(
             &self.context,
-            first_arg.into(),
-            first_arg.into(),
+            key_expr.into(),
+            key_expr.into(),
             Type::TypedDict(typed_dict_ty),
             None,
             key_ty,
@@ -275,6 +323,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         );
 
         // Return `Unknown` to prevent the overload system from generating its own error.
-        Some(Type::unknown())
+        Some(TypedDictMethodSpecialization::Diagnosed(Type::unknown()))
     }
 }


### PR DESCRIPTION
## Summary

This PR specializes TypedDict method calls when the key argument is a known string literal. Specifically, for `get`, `pop`, and `setdefault`, we now replace the generic method type with a field-specific signature based on the matching TypedDict item.

This is motivated by changes that came up in fixing ecosystem fallout from https://github.com/astral-sh/ruff/pull/23946.
