### PR TITLE
[flake8-bandit] Treat sys.executable as trusted input in S603

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S603.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S603.py
@@ -45,3 +45,12 @@ run(e)
 # Tuple literals are trusted
 check_output(("literal", "cmd", "using", "tuple"), text=True)
 Popen(("literal", "cmd", "using", "tuple"))
+
+# https://github.com/astral-sh/ruff/issues/24084
+# sys.executable is trusted
+import sys
+
+run([sys.executable, "-m", "pip", "install", "ruff"], check=True)
+Popen([sys.executable, "-m", "pip"])
+run(sys.executable)
+check_output((sys.executable, "-m", "pip"))

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -294,16 +294,27 @@ impl Violation for UnixCommandWildcardInjection {
     }
 }
 
-/// Check if an expression is a trusted input for subprocess.run.
-/// We assume that any str, list[str] or tuple[str] literal can be trusted.
-fn is_trusted_input(arg: &Expr) -> bool {
-    match arg {
+/// Check if a single expression element is trusted input.
+/// String literals and `sys.executable` are considered trusted.
+fn is_trusted_element(expr: &Expr, semantic: &SemanticModel) -> bool {
+    match expr {
         Expr::StringLiteral(_) => true,
+        _ => semantic
+            .resolve_qualified_name(expr)
+            .is_some_and(|name| matches!(name.segments(), ["sys", "executable"])),
+    }
+}
+
+/// Check if an expression is a trusted input for subprocess calls.
+/// We assume that any str, list[str] or tuple[str] literal can be trusted,
+/// as well as `sys.executable`.
+fn is_trusted_input(arg: &Expr, semantic: &SemanticModel) -> bool {
+    match arg {
         Expr::List(ast::ExprList { elts, .. }) | Expr::Tuple(ast::ExprTuple { elts, .. }) => {
-            elts.iter().all(|elt| matches!(elt, Expr::StringLiteral(_)))
+            elts.iter().all(|elt| is_trusted_element(elt, semantic))
         }
-        Expr::Named(named) => is_trusted_input(&named.value),
-        _ => false,
+        Expr::Named(named) => is_trusted_input(&named.value, semantic),
+        _ => is_trusted_element(arg, semantic),
     }
 }
 
@@ -329,7 +340,7 @@ pub(crate) fn shell_injection(checker: &Checker, call: &ast::ExprCall) {
                 }
                 // S603
                 _ => {
-                    if !is_trusted_input(arg) {
+                    if !is_trusted_input(arg, checker.semantic()) {
                         checker.report_diagnostic_if_enabled(
                             SubprocessWithoutShellEqualsTrue,
                             call.func.range(),


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary
Treat `sys.executable` as trusted input in `S603`. `sys.executable` is the path to the running Python interpreter and is not user-controlled. Subprocess calls like `subprocess.run([sys.executable, "-m", "pip"])` should not be flagged as untrusted input.

Closes #24084

## Test plan
- Added `sys.executable` test cases to `S603.py` fixture (standalone, in list, in tuple)
- Verified no S603 diagnostics emitted for `sys.executable` calls
- Existing snapshot unchanged

<!-- How was it tested? -->
