### PR TITLE
[ty] Remove unnecessary `parsed_module()` calls

### DIFF
--- a/crates/ty_python_semantic/src/semantic_index/ast_ids.rs
+++ b/crates/ty_python_semantic/src/semantic_index/ast_ids.rs
@@ -120,7 +120,7 @@ impl AstIdsBuilder {
 pub(crate) mod node_key {
     use ruff_python_ast as ast;
 
-    use crate::node_key::NodeKey;
+    use crate::{ast_node_ref::AstNodeRef, node_key::NodeKey};
 
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, salsa::Update, get_size2::GetSize)]
     pub(crate) struct ExpressionNodeKey(NodeKey);
@@ -158,6 +158,12 @@ pub(crate) mod node_key {
     impl From<&ast::Keyword> for ExpressionNodeKey {
         fn from(value: &ast::Keyword) -> Self {
             Self(NodeKey::from_node(value))
+        }
+    }
+
+    impl<T> From<&AstNodeRef<T>> for ExpressionNodeKey {
+        fn from(value: &AstNodeRef<T>) -> Self {
+            Self(NodeKey::from_node_ref(value))
         }
     }
 }

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -1048,8 +1048,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                 match pred.node {
                     PredicateNode::Expression(expression) => {
-                        let module = self.module;
-                        let expression_node = expression.node_ref(self.db, module);
+                        let expression_node = expression.node_ref(self.db).node(self.module);
                         PossiblyNarrowedPlacesBuilder::new(self.db, place_table)
                             .expression(expression_node)
                     }

--- a/crates/ty_python_semantic/src/semantic_index/expression.rs
+++ b/crates/ty_python_semantic/src/semantic_index/expression.rs
@@ -2,7 +2,6 @@ use crate::ast_node_ref::AstNodeRef;
 use crate::db::Db;
 use crate::semantic_index::scope::{FileScopeId, ScopeId};
 use ruff_db::files::File;
-use ruff_db::parsed::ParsedModuleRef;
 use ruff_python_ast as ast;
 use salsa;
 
@@ -43,7 +42,7 @@ pub(crate) struct Expression<'db> {
     #[no_eq]
     #[tracked]
     #[returns(ref)]
-    pub(crate) _node_ref: AstNodeRef<ast::Expr>,
+    pub(crate) node_ref: AstNodeRef<ast::Expr>,
 
     /// An assignment statement, if this expression is immediately used as the rhs of that
     /// assignment.
@@ -64,14 +63,6 @@ pub(crate) struct Expression<'db> {
 impl get_size2::GetSize for Expression<'_> {}
 
 impl<'db> Expression<'db> {
-    pub(crate) fn node_ref<'ast>(
-        self,
-        db: &'db dyn Db,
-        parsed: &'ast ParsedModuleRef,
-    ) -> &'ast ast::Expr {
-        self._node_ref(db).node(parsed)
-    }
-
     pub(crate) fn scope(self, db: &'db dyn Db) -> ScopeId<'db> {
         self.file_scope(db).to_scope_id(db, self.file(db))
     }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -36,7 +36,7 @@
 //! of iterations, so if we fail to converge, Salsa will eventually panic. (This should of course
 //! be considered a bug.)
 
-use ruff_db::parsed::{ParsedModuleRef, parsed_module};
+use ruff_db::parsed::parsed_module;
 use ruff_text_size::Ranged;
 use rustc_hash::{FxHashMap, FxHashSet};
 use salsa;
@@ -240,7 +240,7 @@ pub(super) fn infer_expression_types_impl<'db>(
     let _span = tracing::trace_span!(
         "infer_expression_types",
         expression = ?expression.as_id(),
-        range = ?expression.node_ref(db, &module).range(),
+        range = ?expression.node_ref(db).node(&module).range(),
         ?file
     )
     .entered();
@@ -275,10 +275,9 @@ pub(crate) fn infer_same_file_expression_type<'db>(
     db: &'db dyn Db,
     expression: Expression<'db>,
     tcx: TypeContext<'db>,
-    parsed: &ParsedModuleRef,
 ) -> Type<'db> {
     let inference = infer_expression_types(db, expression, tcx);
-    inference.expression_type(expression.node_ref(db, parsed))
+    inference.expression_type(expression.node_ref(db))
 }
 
 /// Infers the type of an expression where the expression might come from another file.
@@ -306,13 +305,10 @@ pub(crate) fn infer_expression_type<'db>(
 fn infer_expression_type_impl<'db>(db: &'db dyn Db, input: InferExpression<'db>) -> Type<'db> {
     let (expression, _) = input.into_inner(db);
 
-    let file = expression.file(db);
-    let module = parsed_module(db, file).load(db);
-
     // It's okay to call the "same file" version here because we're inside a salsa query.
     let inference = infer_expression_types_impl(db, input);
 
-    inference.expression_type(expression.node_ref(db, &module))
+    inference.expression_type(expression.node_ref(db))
 }
 
 /// An `Expression` with an optional `TypeContext`.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -867,10 +867,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         match expression.kind(self.db()) {
             ExpressionKind::Normal => {
-                self.infer_expression_impl(expression.node_ref(self.db(), self.module()), tcx);
+                self.infer_expression_impl(expression.node_ref(self.db()).node(self.module()), tcx);
             }
             ExpressionKind::TypeExpression => {
-                self.infer_type_expression(expression.node_ref(self.db(), self.module()));
+                self.infer_type_expression(expression.node_ref(self.db()).node(self.module()));
             }
         }
     }
@@ -6463,12 +6463,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             //  but only if the target is a name. We should report a diagnostic here if the target isn't a name:
             //  `[... for a.x in not_iterable]
             if is_first {
-                infer_same_file_expression_type(
-                    builder.db(),
-                    builder.index.expression(iter),
-                    tcx,
-                    builder.module(),
-                )
+                infer_same_file_expression_type(builder.db(), builder.index.expression(iter), tcx)
             } else {
                 builder.infer_maybe_standalone_expression(iter, tcx)
             }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -617,7 +617,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         expression: Expression<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
-        let expression_node = expression.node_ref(self.db, self.module);
+        let expression_node = expression.node_ref(self.db).node(self.module);
         self.evaluate_expression_node_predicate(expression_node, expression, is_positive)
     }
 
@@ -1651,7 +1651,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         singleton: ast::Singleton,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
-        let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db, self.module))?;
+        let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
         let place = self.expect_place(&subject);
 
         let ty = match singleton {
@@ -1680,11 +1680,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             return None;
         }
 
-        let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db, self.module))?;
+        let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
         let place = self.expect_place(&subject);
 
-        let class_type =
-            infer_same_file_expression_type(self.db, cls, TypeContext::default(), self.module);
+        let class_type = infer_same_file_expression_type(self.db, cls, TypeContext::default());
 
         let narrowed_type = match class_type {
             Type::ClassLiteral(class) => {
@@ -1711,7 +1710,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             return None;
         }
 
-        let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db, self.module))?;
+        let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
         let place = self.expect_place(&subject);
 
         let mapping_type = ClassInfoConstraintFunction::IsInstance
@@ -1734,16 +1733,13 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         value: Expression<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
-        let subject_node = subject.node_ref(self.db, self.module);
+        let subject_node = subject.node_ref(self.db).node(self.module);
         let place = {
             let subject = PlaceExpr::try_from_expr(subject_node)?;
             self.expect_place(&subject)
         };
-        let subject_ty =
-            infer_same_file_expression_type(self.db, subject, TypeContext::default(), self.module);
-
-        let value_ty =
-            infer_same_file_expression_type(self.db, value, TypeContext::default(), self.module);
+        let subject_ty = infer_same_file_expression_type(self.db, subject, TypeContext::default());
+        let value_ty = infer_same_file_expression_type(self.db, value, TypeContext::default());
 
         let mut constraints = self
             .evaluate_expr_compare_op(subject_ty, value_ty, ast::CmpOp::Eq, is_positive)
@@ -2353,7 +2349,7 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
         let mut places = PossiblyNarrowedPlaces::default();
 
         // The match subject can always be narrowed by a pattern
-        let subject_node = subject.node_ref(self.db, module);
+        let subject_node = subject.node_ref(self.db).node(module);
         if let Some(subject_place_expr) = PlaceExpr::try_from_expr(subject_node) {
             if let Some(place) = self.places.place_id((&subject_place_expr).into()) {
                 places.insert(place);

--- a/crates/ty_python_semantic/src/types/unpacker.rs
+++ b/crates/ty_python_semantic/src/types/unpacker.rs
@@ -51,7 +51,7 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
 
         let value_inference =
             infer_expression_types(self.db(), value.expression(), TypeContext::default());
-        let value_expr = value.expression().node_ref(self.db(), self.module());
+        let value_expr = value.expression().node_ref(self.db()).node(self.module());
 
         if matches!(value.kind(), UnpackKind::Assign)
             && self.unpack_assignment_sequence_from_inference(target, value_expr, value_inference)

--- a/crates/ty_python_semantic/src/unpack.rs
+++ b/crates/ty_python_semantic/src/unpack.rs
@@ -95,7 +95,7 @@ impl<'db> UnpackValue<'db> {
         db: &'db dyn Db,
         module: &'ast ParsedModuleRef,
     ) -> AnyNodeRef<'ast> {
-        self.expression().node_ref(db, module).into()
+        self.expression().node_ref(db).node(module).into()
     }
 
     pub(crate) const fn kind(self) -> UnpackKind {


### PR DESCRIPTION
## Summary

By implementing `From<AstNodeRef>` for `ExpressionNodeKey`, we can reduce the number of places we need to call `parsed_module()`, simplifying the code and slightly reducing memory usage.

## Test Plan

Existing tests
