### PR TITLE
[ty] Add `NewType`s to the property tests

### DIFF
--- a/crates/ty_python_semantic/src/types/property_tests/setup.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/setup.rs
@@ -1,9 +1,30 @@
-use crate::db::tests::{TestDb, setup_db};
+use crate::db::tests::{TestDb, TestDbBuilder};
 use std::sync::{Arc, Mutex, OnceLock};
 
 static CACHED_DB: OnceLock<Arc<Mutex<TestDb>>> = OnceLock::new();
 
+/// The path to the module containing definitions for property testing.
+pub(crate) const PROPERTY_TEST_MODULE_PATH: &str = "/src/type_candidates.py";
+
 pub(crate) fn get_cached_db() -> TestDb {
-    let db = CACHED_DB.get_or_init(|| Arc::new(Mutex::new(setup_db())));
+    let db = CACHED_DB.get_or_init(|| {
+        let db = TestDbBuilder::new()
+            .with_file(
+                PROPERTY_TEST_MODULE_PATH,
+                "\
+from typing import NewType
+
+NewTypeOfInt = NewType('NewTypeOfInt', int)
+SubNewTypeOfInt = NewType('SubNewTypeOfInt', NewTypeOfInt)
+SubSubNewTypeOfInt = NewType('SubSubNewTypeOfInt', SubNewTypeOfInt)
+NewTypeOfFloat = NewType('NewTypeOfFloat', float)
+SubNewTypeOfFloat = NewType('SubNewTypeOfFloat', NewTypeOfFloat)
+NewTypeOfComplex = NewType('NewTypeOfComplex', complex)
+NewTypeOfStr = NewType('NewTypeOfStr', str)",
+            )
+            .build()
+            .unwrap();
+        Arc::new(Mutex::new(db))
+    });
     db.lock().unwrap().clone()
 }

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -1,13 +1,15 @@
 use crate::Db;
 use crate::db::tests::TestDb;
-use crate::place::{builtins_symbol, known_module_symbol};
+use crate::place::{DefinedPlace, Place, builtins_symbol, global_symbol, known_module_symbol};
 use crate::types::enums::is_single_member_enum;
+use crate::types::known_instance::KnownInstanceType;
 use crate::types::tuple::TupleType;
 use crate::types::{
     BoundMethodType, EnumLiteralType, IntersectionBuilder, IntersectionType, KnownClass, Parameter,
     Parameters, Signature, SpecialFormType, SubclassOfType, Type, UnionType,
 };
 use quickcheck::{Arbitrary, Gen};
+use ruff_db::files::system_path_to_file;
 use ruff_python_ast::name::Name;
 use rustc_hash::FxHashSet;
 use ty_module_resolver::KnownModule;
@@ -65,6 +67,16 @@ pub(crate) enum Ty {
     /// where the class has `Any` in its MRO
     UnittestMockInstance,
     UnittestMockLiteral,
+    /// Instances of various `NewType`s that we construct in `setup.rs`.
+    /// `FloatNewType` and `ComplexNewType` are interesting because they are the only
+    /// kinds of `NewType`s that can have unions as their concrete base types.
+    IntNewtypeInstance,
+    StrNewtypeInstance,
+    FloatNewtypeInstance,
+    ComplexNewtypeInstance,
+    SubNewTypeOfIntInstance,
+    SubSubNewTypeOfIntInstance,
+    SubNewTypeOfFloatInstance,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -235,7 +247,28 @@ impl Ty {
                 db,
                 Signature::new(params.into_parameters(db), returns.into_type(db)),
             ),
+            Ty::FloatNewtypeInstance => newtype_instance(db, "NewTypeOfFloat"),
+            Ty::IntNewtypeInstance => newtype_instance(db, "NewTypeOfInt"),
+            Ty::StrNewtypeInstance => newtype_instance(db, "NewTypeOfStr"),
+            Ty::ComplexNewtypeInstance => newtype_instance(db, "NewTypeOfComplex"),
+            Ty::SubNewTypeOfIntInstance => newtype_instance(db, "SubNewTypeOfInt"),
+            Ty::SubSubNewTypeOfIntInstance => newtype_instance(db, "SubSubNewTypeOfInt"),
+            Ty::SubNewTypeOfFloatInstance => newtype_instance(db, "SubNewTypeOfFloat"),
         }
+    }
+}
+
+fn newtype_instance<'db>(db: &'db dyn Db, name: &str) -> Type<'db> {
+    let file = system_path_to_file(db, super::setup::PROPERTY_TEST_MODULE_PATH)
+        .expect("Property-test module must exist");
+    let Place::Defined(DefinedPlace { ty, .. }) = global_symbol(db, file, name).place else {
+        panic!(
+            "Expected a global symbol for `{name}` in the property test module, but it was not found"
+        );
+    };
+    match ty {
+        Type::KnownInstance(KnownInstanceType::NewType(newtype)) => Type::NewTypeInstance(newtype),
+        _ => panic!("Expected NewType symbol for `{name}`, got {ty:?}"),
     }
 }
 
@@ -280,6 +313,8 @@ fn arbitrary_core_type(g: &mut Gen, fully_static: bool) -> Ty {
         Ty::KnownClassInstance(KnownClass::Object),
         Ty::KnownClassInstance(KnownClass::Str),
         Ty::KnownClassInstance(KnownClass::Int),
+        Ty::KnownClassInstance(KnownClass::Float),
+        Ty::KnownClassInstance(KnownClass::Complex),
         Ty::KnownClassInstance(KnownClass::Bool),
         Ty::KnownClassInstance(KnownClass::FunctionType),
         Ty::KnownClassInstance(KnownClass::SpecialForm),
@@ -313,6 +348,13 @@ fn arbitrary_core_type(g: &mut Gen, fully_static: bool) -> Ty {
             class: "int",
             method: "bit_length",
         },
+        Ty::IntNewtypeInstance,
+        Ty::StrNewtypeInstance,
+        Ty::FloatNewtypeInstance,
+        Ty::ComplexNewtypeInstance,
+        Ty::SubNewTypeOfIntInstance,
+        Ty::SubSubNewTypeOfIntInstance,
+        Ty::SubNewTypeOfFloatInstance,
     ];
     let types = if fully_static {
         &types[fully_static_index..]


### PR DESCRIPTION
## Summary

This should give us more confidence when refactoring `NewType`-related code in `relation.rs`

## Test Plan

I ran `QUICKCHECK_TESTS=1000000 cargo test --profile=profiling -p ty_python_semantic -- --ignored types::property_tests::stable` and didn't observe any failures
