### PR TITLE
[ty] Fix folding ranges of comments separated by statements

### DIFF
--- a/crates/ty_ide/src/folding_range.rs
+++ b/crates/ty_ide/src/folding_range.rs
@@ -244,7 +244,7 @@ impl FoldingRangeVisitor<'_> {
                 !text.starts_with("region") && !text.starts_with("endregion");
 
             if is_non_region_comment {
-                // Extend the current comment block unless a blank line or a statement separates the comments r
+                // Extend the current comment block unless a blank line or a statement separates the comments.
                 if let Some(ref mut comment_block_range) = comment_block_range {
                     let has_text_between = !self.source
                         [TextRange::new(comment_block_range.end(), comment_range.start())]


### PR DESCRIPTION
## Summary

I rewrote the comment folding in #23831 to use comment ranges instead of iterating over the file's range. 
However, I failed to account for the case where two comments are separated by statements. 

This PR groups comments together only when they're separated by whitespace. 

Fixes https://github.com/astral-sh/ty/issues/3106

## Test Plan

Added regression test

https://github.com/user-attachments/assets/093a7076-8885-4053-8779-d5fc6848371a

