### PR TITLE
[ty] Add generic callable assignability mdtests

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -252,14 +252,17 @@ error[call-non-callable]: `NotImplemented` is not callable
 ## `map` with generic callbacks
 
 ```py
-from typing import cast
 from ty_extensions import Unknown
 import re
 
-s = cast(Unknown | str, "")
-"".join(map(re.escape, s))
+def _(s: Unknown | str):
+    escaped = map(re.escape, s)
+    reveal_type(escaped)  # revealed: map[str]
+    "".join(escaped)
 
-xs = cast(Unknown | list[str], ["a"])
-tokens: list[Unknown | str] = []
-tokens.extend(map(re.escape, xs))
+def _(xs: Unknown | list[str]):
+    escaped = map(re.escape, xs)
+    reveal_type(escaped)  # revealed: map[str]
+    tokens: list[Unknown | str] = []
+    tokens.extend(escaped)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -248,3 +248,18 @@ error[call-non-callable]: `NotImplemented` is not callable
   |           Did you mean `NotImplementedError`?
   |
 ```
+
+## `map` with generic callbacks
+
+```py
+from typing import cast
+from ty_extensions import Unknown
+import re
+
+s = cast(Unknown | str, "")
+"".join(map(re.escape, s))
+
+xs = cast(Unknown | list[str], ["a"])
+tokens: list[Unknown | str] = []
+tokens.extend(map(re.escape, xs))
+```

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -81,6 +81,33 @@ info: incompatible return types: `str` is not assignable to `int`
 info: This violates the Liskov Substitution Principle
 ```
 
+Generic class typevars bounded by the parent return type should still be valid covariant overrides.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```pyi
+class Root: ...
+
+class Base:
+    def get_parent_id(self) -> Base | Root: ...
+
+class Child[PT: Base | Root](Base):
+    parent_id: PT
+
+    def get_parent_id(self) -> PT: ...
+
+class DataArray: ...
+
+class Coordinates:
+    def __getitem__(self, key: object) -> DataArray: ...
+
+class DataArrayCoordinates[T_DataArray: DataArray](Coordinates):
+    def __getitem__(self, key: object) -> T_DataArray: ...
+```
+
 ## Method parameters
 
 A subclass method may provide a different parameter list to the superclass method, but all

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1314,7 +1314,7 @@ specializations. That means that a generic callable is assignable to any particu
 the generic callable.)
 
 ```py
-from typing import Callable
+from typing import Callable, Self
 from ty_extensions import RegularCallableTypeOf, TypeOf, is_assignable_to, static_assert
 
 def identity[T](t: T) -> T:
@@ -1322,15 +1322,89 @@ def identity[T](t: T) -> T:
 
 static_assert(is_assignable_to(TypeOf[identity], Callable[[int], int]))
 static_assert(is_assignable_to(TypeOf[identity], Callable[[str], str]))
-# TODO: no error
+# TODO: This should not be assignable. A generic callable must use one coherent specialization.
 # error: [static-assert-error]
 static_assert(not is_assignable_to(TypeOf[identity], Callable[[str], int]))
 
 static_assert(is_assignable_to(RegularCallableTypeOf[identity], Callable[[int], int]))
 static_assert(is_assignable_to(RegularCallableTypeOf[identity], Callable[[str], str]))
-# TODO: no error
 # error: [static-assert-error]
 static_assert(not is_assignable_to(RegularCallableTypeOf[identity], Callable[[str], int]))
+
+def bounded[T_bound: object](t: T_bound) -> T_bound:
+    return t
+
+static_assert(is_assignable_to(TypeOf[bounded], Callable[[str], str]))
+# error: [static-assert-error]
+static_assert(not is_assignable_to(TypeOf[bounded], Callable[[str], int]))
+
+static_assert(is_assignable_to(RegularCallableTypeOf[bounded], Callable[[str], str]))
+# error: [static-assert-error]
+static_assert(not is_assignable_to(RegularCallableTypeOf[bounded], Callable[[str], int]))
+
+def constrained[T_constrained: (str, bytes)](t: T_constrained) -> T_constrained:
+    return t
+
+static_assert(is_assignable_to(TypeOf[constrained], Callable[[str], str]))
+static_assert(is_assignable_to(TypeOf[constrained], Callable[[bytes], bytes]))
+# error: [static-assert-error]
+static_assert(not is_assignable_to(TypeOf[constrained], Callable[[str], int]))
+
+static_assert(is_assignable_to(RegularCallableTypeOf[constrained], Callable[[str], str]))
+static_assert(is_assignable_to(RegularCallableTypeOf[constrained], Callable[[bytes], bytes]))
+# error: [static-assert-error]
+static_assert(not is_assignable_to(RegularCallableTypeOf[constrained], Callable[[str], int]))
+
+# This exercises the case where a method's inferable set includes an outer class typevar in
+# addition to the typevars directly bound by the method's own generic context.
+class MethodCarrier[A_method]:
+    def method[T_method: str](self: "MethodCarrier[A_method]", t: T_method) -> tuple[A_method, T_method]:
+        raise NotImplementedError
+
+static_assert(
+    is_assignable_to(
+        TypeOf[MethodCarrier.method],
+        Callable[[MethodCarrier[int], str], tuple[int, str]],
+    )
+)
+static_assert(
+    is_assignable_to(
+        RegularCallableTypeOf[MethodCarrier.method],
+        Callable[[MethodCarrier[int], str], tuple[int, str]],
+    )
+)
+static_assert(
+    not is_assignable_to(
+        TypeOf[MethodCarrier.method],
+        Callable[[MethodCarrier[int], int], tuple[int, int]],
+    )
+)
+static_assert(
+    not is_assignable_to(
+        RegularCallableTypeOf[MethodCarrier.method],
+        Callable[[MethodCarrier[int], int], tuple[int, int]],
+    )
+)
+
+class SelfCarrier[A_self]:
+    def method[T_self: str](self: Self, t: T_self) -> tuple[A_self, T_self]:
+        raise NotImplementedError
+
+# TODO: This should be assignable. The unbound method type currently loses the outer class type
+# argument carried through `Self`, so the return type degrades to `tuple[Unknown, T_self]` before
+# the generic-callable assignability logic runs.
+static_assert(
+    is_assignable_to(
+        TypeOf[SelfCarrier.method],
+        Callable[[SelfCarrier[int], str], tuple[int, str]],
+    )
+)
+static_assert(
+    is_assignable_to(
+        RegularCallableTypeOf[SelfCarrier.method],
+        Callable[[SelfCarrier[int], str], tuple[int, str]],
+    )
+)
 ```
 
 The reverse is not true — if someone expects a generic function that can be called with any


### PR DESCRIPTION
## Summary

Adds mdtest coverage for generic callable assignability behavior that should be preserved while the underlying implementation work moves through the `SpecializationBuilder` constraint-set path.

The generic callable cases document the expected behavior for unconstrained, bounded, and constrained type variables. The unbound-method case also covers an outer class type variable participating in the method signature.

This also adds regression coverage for two related cases that now pass on `main`: bounded generic return overrides in Liskov checks, and the `map(re.escape, ...)` ecosystem case involving `Unknown` unions.

## Test Plan

The targeted mdtests cover generic callable assignability with unconstrained, bounded, and constrained type variables, unbound generic methods that include outer class type variables, bounded generic return overrides, and the `map(re.escape, ...)` ecosystem case involving `Unknown` unions.