### PR TITLE
fix: suppress SIM105 for except* (fixes #23798)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM105_5.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM105_5.py
@@ -1,0 +1,19 @@
+# OK: `except*` should not trigger SIM105 because `contextlib.suppress` doesn't
+# support `BaseExceptionGroup` until Python 3.12, so the fix would be incorrect
+# for Python 3.11. See https://github.com/astral-sh/ruff/issues/23798
+
+
+def foo():
+    pass
+
+
+try:
+    foo()
+except* ValueError:
+    pass
+
+
+try:
+    foo()
+except* (ValueError, OSError):
+    pass

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -1316,7 +1316,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 handlers,
                 orelse,
                 finalbody,
-                ..
+                is_star,
             },
         ) => {
             if checker.is_rule_enabled(Rule::TooManyNestedBlocks) {
@@ -1355,7 +1355,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             }
             if checker.is_rule_enabled(Rule::SuppressibleException) {
                 flake8_simplify::rules::suppressible_exception(
-                    checker, stmt, body, handlers, orelse, finalbody,
+                    checker, stmt, body, handlers, orelse, finalbody, *is_star,
                 );
             }
             if checker.is_rule_enabled(Rule::ReturnInTryExceptFinally) {

--- a/crates/ruff_linter/src/rules/flake8_simplify/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/mod.rs
@@ -22,6 +22,7 @@ mod tests {
     #[test_case(Rule::SuppressibleException, Path::new("SIM105_2.py"))]
     #[test_case(Rule::SuppressibleException, Path::new("SIM105_3.py"))]
     #[test_case(Rule::SuppressibleException, Path::new("SIM105_4.py"))]
+    #[test_case(Rule::SuppressibleException, Path::new("SIM105_5.py"))]
     #[test_case(Rule::ReturnInTryExceptFinally, Path::new("SIM107.py"))]
     #[test_case(Rule::IfElseBlockInsteadOfIfExp, Path::new("SIM108.py"))]
     #[test_case(Rule::CompareWithTuple, Path::new("SIM109.py"))]

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/suppressible_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/suppressible_exception.rs
@@ -87,7 +87,11 @@ pub(crate) fn suppressible_exception(
     handlers: &[ExceptHandler],
     orelse: &[Stmt],
     finalbody: &[Stmt],
+    is_star: bool,
 ) {
+    if is_star {
+        return;
+    }
     if !matches!(
         try_body,
         [Stmt::Delete(_)

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM105_SIM105_5.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM105_SIM105_5.py.snap
@@ -1,0 +1,3 @@
+---
+source: crates/ruff_linter/src/rules/flake8_simplify/mod.rs
+---


### PR DESCRIPTION
## Summary

Fixes #23798.

SIM105 suggests replacing `except* ...: pass` with `contextlib.suppress()`, but `contextlib.suppress` only gained support for `BaseExceptionGroup` in Python 3.12. This means the suggested fix is incorrect for Python 3.11 when using `except*` syntax.

## Changes

- Added `is_star` parameter to `suppressible_exception()` function
- When the try statement uses `except*`, skip the SIM105 rule entirely
- Added test fixture `SIM105_5.py` to verify `except*` cases are not flagged

## Rationale

As described in the issue, `except*` handles `BaseExceptionGroup`, and `contextlib.suppress` did not support exception groups until Python 3.12. Even when targeting Python 3.12+, the semantic equivalence is not guaranteed, so it's safest to suppress SIM105 for all `except*` cases.