### PR TITLE
Recognize `Self` annotation and `self` assignment in SLF001

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_self/SLF001_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_self/SLF001_1.py
@@ -47,7 +47,7 @@ class M(type):
 
 # https://github.com/astral-sh/ruff/issues/24140
 
-from typing import Self
+from typing import Annotated, Self
 
 class Sit:
     def __init__(self, x: int) -> None:
@@ -59,3 +59,12 @@ class Sit:
 
     def g(self, other: Self) -> None:
         print(other._x)  # fine (annotated as Self)
+
+    def h(self, other: Annotated[Self, "meta"]) -> None:
+        print(other._x)  # fine (Annotated[Self, ...])
+
+    @staticmethod
+    def s() -> None:
+        self = object()
+        alias = self
+        print(alias._x)  # error (self is not an instance parameter)

--- a/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
@@ -202,13 +202,15 @@ impl SameClassInstanceChecker {
 }
 
 impl TypeChecker for SameClassInstanceChecker {
-    /// `C`, `C[T]`, `Annotated[C, ...]`, `Annotated[C[T], ...]`, `Self`
+    /// `C`, `C[T]`, `Annotated[C, ...]`, `Annotated[C[T], ...]`, `Self`, `Annotated[Self, ...]`
     fn match_annotation(annotation: &Expr, semantic: &SemanticModel) -> bool {
-        if semantic.match_typing_expr(annotation, "Self") {
+        let inner = unwrap_annotated(annotation, semantic);
+
+        if semantic.match_typing_expr(inner, "Self") {
             return true;
         }
 
-        let Some(class_name) = find_class_name(annotation, semantic) else {
+        let Expr::Name(class_name) = inner else {
             return false;
         };
 
@@ -217,11 +219,15 @@ impl TypeChecker for SameClassInstanceChecker {
 
     /// `cls()`, `C()`, `C[T]()`, `super().__new__()`, `self`
     fn match_initializer(initializer: &Expr, semantic: &SemanticModel) -> bool {
-        // `this = self` — a direct assignment from `self`.
-        if let Expr::Name(name) = initializer {
-            if matches!(&*name.id, "self") {
-                return true;
-            }
+        // `this = self` — a direct assignment from `self`, but only when
+        // `self` is actually a function parameter (not a local rebinding).
+        if let Expr::Name(name) = initializer
+            && name.id == "self"
+            && semantic
+                .resolve_name(name)
+                .is_some_and(|id| matches!(semantic.binding(id).kind, BindingKind::Argument))
+        {
+            return true;
         }
 
         let Expr::Call(call) = initializer else {
@@ -252,21 +258,21 @@ impl TypeChecker for SameClassInstanceChecker {
     }
 }
 
-/// Convert `Annotated[C[T], ...]` to `C` (and similar) to `C` recursively.
-fn find_class_name<'a>(expr: &'a Expr, semantic: &'a SemanticModel) -> Option<&'a ast::ExprName> {
+/// Unwrap `Annotated[X, ...]` and `C[T]` to the innermost type expression.
+fn unwrap_annotated<'a>(expr: &'a Expr, semantic: &'a SemanticModel) -> &'a Expr {
     match expr {
-        Expr::Name(name) => Some(name),
         Expr::Subscript(ast::ExprSubscript { value, slice, .. }) => {
-            if semantic.match_typing_expr(value, "Annotated") {
-                let [expr, ..] = &slice.as_tuple_expr()?.elts[..] else {
-                    return None;
-                };
-
-                return find_class_name(expr, semantic);
+            if semantic.match_typing_expr(value, "Annotated")
+                && let Some(tuple) = slice.as_tuple_expr()
+                && let [inner, ..] = &tuple.elts[..]
+            {
+                return unwrap_annotated(inner, semantic);
             }
-
-            find_class_name(value, semantic)
+            if semantic.match_typing_expr(value, "Annotated") {
+                return expr;
+            }
+            unwrap_annotated(value, semantic)
         }
-        _ => None,
+        _ => expr,
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_self/snapshots/ruff_linter__rules__flake8_self__tests__private-member-access_SLF001_1.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_self/snapshots/ruff_linter__rules__flake8_self__tests__private-member-access_SLF001_1.py.snap
@@ -1,4 +1,11 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_self/mod.rs
 ---
-
+SLF001 Private member accessed: `_x`
+  --> SLF001_1.py:70:15
+   |
+68 |         self = object()
+69 |         alias = self
+70 |         print(alias._x)  # error (self is not an instance parameter)
+   |               ^^^^^^^^
+   |


### PR DESCRIPTION
Fixes #24140

SLF001 now suppresses false positives for two additional same-class patterns:

- Variables annotated as `typing.Self` (e.g. `other: Self`)
- Variables assigned directly from `self` (e.g. `this = self`)

Both cases clearly refer to the same class instance and should not trigger a private member access warning.