### PR TITLE
Add TC009: flag TYPE_CHECKING blocks before imports

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC009.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC009.py
@@ -1,0 +1,27 @@
+"""Tests for TC009 - TYPE_CHECKING block before imports."""
+
+# Error: TYPE_CHECKING block before regular imports
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # TC009
+    from collections.abc import Sequence
+
+from mylib import MyClass
+
+# OK: TYPE_CHECKING block after all imports
+import os
+from typing import TYPE_CHECKING as TC
+
+from another_lib import AnotherClass
+
+if TC:
+    from collections.abc import Mapping
+
+
+# OK: no imports after TYPE_CHECKING block
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Set

--- a/crates/ruff_linter/src/checkers/ast/analyze/module.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/module.rs
@@ -2,7 +2,7 @@ use ruff_python_ast::Suite;
 
 use crate::checkers::ast::Checker;
 use crate::codes::Rule;
-use crate::rules::{flake8_bugbear, ruff};
+use crate::rules::{flake8_bugbear, flake8_type_checking, ruff};
 
 /// Run lint rules over a module.
 pub(crate) fn module(suite: &Suite, checker: &Checker) {
@@ -11,5 +11,8 @@ pub(crate) fn module(suite: &Suite, checker: &Checker) {
     }
     if checker.is_rule_enabled(Rule::InvalidFormatterSuppressionComment) {
         ruff::rules::ignored_formatter_suppression_comment(checker, suite);
+    }
+    if checker.is_rule_enabled(Rule::TypeCheckingBlockBeforeImports) {
+        flake8_type_checking::rules::type_checking_block_before_imports(checker, suite);
     }
 }

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -916,6 +916,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Flake8TypeChecking, "006") => rules::flake8_type_checking::rules::RuntimeCastValue,
         (Flake8TypeChecking, "007") => rules::flake8_type_checking::rules::UnquotedTypeAlias,
         (Flake8TypeChecking, "008") => rules::flake8_type_checking::rules::QuotedTypeAlias,
+        (Flake8TypeChecking, "009") => rules::flake8_type_checking::rules::TypeCheckingBlockBeforeImports,
         (Flake8TypeChecking, "010") => rules::flake8_type_checking::rules::RuntimeStringUnion,
 
         // tryceratops

--- a/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
@@ -19,6 +19,7 @@ mod tests {
 
     #[test_case(Rule::EmptyTypeCheckingBlock, Path::new("TC005.py"))]
     #[test_case(Rule::RuntimeCastValue, Path::new("TC006.py"))]
+    #[test_case(Rule::TypeCheckingBlockBeforeImports, Path::new("TC009.py"))]
     #[test_case(Rule::RuntimeImportInTypeCheckingBlock, Path::new("TC004_1.py"))]
     #[test_case(Rule::RuntimeImportInTypeCheckingBlock, Path::new("TC004_10.py"))]
     #[test_case(Rule::RuntimeImportInTypeCheckingBlock, Path::new("TC004_11.py"))]

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/mod.rs
@@ -3,6 +3,7 @@ pub(crate) use runtime_cast_value::*;
 pub(crate) use runtime_import_in_type_checking_block::*;
 pub(crate) use runtime_string_union::*;
 pub(crate) use type_alias_quotes::*;
+pub(crate) use type_checking_block_before_imports::*;
 pub(crate) use typing_only_runtime_import::*;
 
 mod empty_type_checking_block;
@@ -10,4 +11,5 @@ mod runtime_cast_value;
 mod runtime_import_in_type_checking_block;
 mod runtime_string_union;
 mod type_alias_quotes;
+mod type_checking_block_before_imports;
 mod typing_only_runtime_import;

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/type_checking_block_before_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/type_checking_block_before_imports.rs
@@ -1,0 +1,90 @@
+use ruff_python_ast::{self as ast, Expr, Stmt};
+
+use ruff_macros::{ViolationMetadata, derive_message_formats};
+use ruff_text_size::Ranged;
+
+use crate::Violation;
+use crate::checkers::ast::Checker;
+
+/// ## What it does
+/// Checks for `if TYPE_CHECKING:` blocks that appear before regular
+/// top-level import statements.
+///
+/// ## Why is this bad?
+/// By convention, `if TYPE_CHECKING:` blocks should be placed after all
+/// regular (runtime) imports. Placing them before regular imports makes it
+/// harder to distinguish between runtime dependencies and type-only
+/// dependencies at a glance.
+///
+/// Note that while no PEP mandates this ordering, it is a widely adopted
+/// convention and is the placement used by the `TC001`–`TC003` autofixes
+/// when they introduce a `TYPE_CHECKING` block.
+///
+/// ## Example
+/// ```python
+/// from typing import TYPE_CHECKING
+///
+/// if TYPE_CHECKING:
+///     from collections.abc import Sequence
+///
+/// from mylib import MyClass
+/// ```
+///
+/// Use instead:
+/// ```python
+/// from typing import TYPE_CHECKING
+///
+/// from mylib import MyClass
+///
+/// if TYPE_CHECKING:
+///     from collections.abc import Sequence
+/// ```
+///
+/// ## References
+/// - [PEP 563: Runtime annotation resolution and `TYPE_CHECKING`](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
+#[derive(ViolationMetadata)]
+#[violation_metadata(preview_since = "0.14.15")]
+pub(crate) struct TypeCheckingBlockBeforeImports;
+
+impl Violation for TypeCheckingBlockBeforeImports {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        "`if TYPE_CHECKING:` block should be after all top-level imports".to_string()
+    }
+}
+
+/// Returns `true` if the given `if` statement is an `if TYPE_CHECKING:` block.
+///
+/// This is a syntactic check that does not require the semantic model,
+/// handling the two common forms:
+/// - `if TYPE_CHECKING:`
+/// - `if typing.TYPE_CHECKING:`
+fn is_type_checking_block_syntactic(stmt: &ast::StmtIf) -> bool {
+    match stmt.test.as_ref() {
+        Expr::Name(ast::ExprName { id, .. }) => id == "TYPE_CHECKING",
+        Expr::Attribute(ast::ExprAttribute { attr, .. }) => attr == "TYPE_CHECKING",
+        _ => false,
+    }
+}
+
+/// TC009
+pub(crate) fn type_checking_block_before_imports(checker: &Checker, suite: &[Stmt]) {
+    // Find the index of the last top-level import statement.
+    let last_import_index = suite
+        .iter()
+        .rposition(|stmt| matches!(stmt, Stmt::Import(_) | Stmt::ImportFrom(_)));
+
+    let Some(last_import_index) = last_import_index else {
+        // No imports at all — nothing to check.
+        return;
+    };
+
+    // Flag any `if TYPE_CHECKING:` block that appears before the last import.
+    for stmt in &suite[..last_import_index] {
+        if let Stmt::If(if_stmt) = stmt {
+            if is_type_checking_block_syntactic(if_stmt) {
+                checker.report_diagnostic(TypeCheckingBlockBeforeImports, if_stmt.range());
+            }
+        }
+    }
+}

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__type-checking-block-before-imports_TC009.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__type-checking-block-before-imports_TC009.py.snap
@@ -1,0 +1,15 @@
+---
+source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
+assertion_line: 65
+---
+TC009 `if TYPE_CHECKING:` block should be after all top-level imports
+  --> TC009.py:7:1
+   |
+ 5 |   from typing import TYPE_CHECKING
+ 6 |
+ 7 | / if TYPE_CHECKING:  # TC009
+ 8 | |     from collections.abc import Sequence
+   | |________________________________________^
+ 9 |
+10 |   from mylib import MyClass
+   |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

This patch adds a new preview rule TC009 (type-checking-block-before-imports) to the flake8-type-checking linter. The rule flags `if TYPE_CHECKING:` blocks that appear before regular top-level import statements.

By convention, TYPE_CHECKING blocks should be placed after all runtime imports. This makes it easier to distinguish runtime dependencies from type-only dependencies at a glance, and is consistent with the placement used by TC001-TC003 autofixes.

Closes https://github.com/astral-sh/ruff/issues/13976.

## Test Plan

New tests added to cover the desired rule.
