### PR TITLE
[flake8-self] Recognize `Self`-typed expressions in SLF001

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_self/SLF001_self.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_self/SLF001_self.py
@@ -1,0 +1,27 @@
+from typing import Self
+
+
+class Foo:
+    def __init__(self, x: int) -> None:
+        self._x = x
+
+    def foo(self) -> None:
+        this: Self = self
+        print(this._x)  # OK (Self annotation)
+        print(self._x)  # OK (self)
+
+    @classmethod
+    def bar(cls) -> None:
+        inst: Self = cls()
+        print(inst._x)  # OK (Self annotation)
+
+    def other(self, other: Self) -> None:
+        print(other._x)  # OK (Self annotation)
+
+
+class Bar:
+    def __init__(self, y: int) -> None:
+        self._y = y
+
+    def baz(self, other: Foo) -> None:
+        print(other._x)  # SLF001 (not Self, different class)

--- a/crates/ruff_linter/src/rules/flake8_self/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_self/mod.rs
@@ -16,6 +16,7 @@ mod tests {
 
     #[test_case(Rule::PrivateMemberAccess, Path::new("SLF001.py"))]
     #[test_case(Rule::PrivateMemberAccess, Path::new("SLF001_1.py"))]
+    #[test_case(Rule::PrivateMemberAccess, Path::new("SLF001_self.py"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.name(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
@@ -202,8 +202,13 @@ impl SameClassInstanceChecker {
 }
 
 impl TypeChecker for SameClassInstanceChecker {
-    /// `C`, `C[T]`, `Annotated[C, ...]`, `Annotated[C[T], ...]`
+    /// `C`, `C[T]`, `Annotated[C, ...]`, `Annotated[C[T], ...]`, `Self`, `typing.Self`
     fn match_annotation(annotation: &Expr, semantic: &SemanticModel) -> bool {
+        // Check for `Self` (from typing or typing_extensions)
+        if semantic.match_typing_expr(annotation, "Self") {
+            return true;
+        }
+
         let Some(class_name) = find_class_name(annotation, semantic) else {
             return false;
         };


### PR DESCRIPTION
## Summary

Fixes #24140

Variables annotated with `Self` (from `typing` or `typing_extensions`) are now recognized as same-class instances and no longer trigger SLF001 for private member access.

```python
from typing import Self

class Foo:
    def __init__(self, x: int) -> None:
        self._x = x

    def foo(self) -> None:
        this: Self = self
        print(this._x)  # previously SLF001, now OK
```
## Changes
Added Self type check in SameClassInstanceChecker::match_annotation using semantic.match_typing_expr(annotation, "Self")
Added test fixture SLF001_self.py covering: Self annotation on variable, Self annotation on parameter, Self in classmethod, and cross-class access (still flagged)

## Test Plan
this: Self = self accessing this._private -> no diagnostic
other: Self as parameter accessing other._private -> no diagnostic
other: DifferentClass accessing other._private -> SLF001 still flagged