### PR TITLE
Fix `%foo?` parsing in IPython assignment expressions

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -434,7 +434,10 @@ impl<'src> Lexer<'src> {
                     && self.nesting == 0 =>
             {
                 // SAFETY: Safe because `c` has been matched against one of the possible escape command token
-                self.lex_ipython_escape_command(IpyEscapeKind::try_from(c).unwrap())
+                self.lex_ipython_escape_command(
+                    IpyEscapeKind::try_from(c).unwrap(),
+                    IpyEscapeLexContext::Assignment,
+                )
             }
 
             c @ ('%' | '!' | '?' | '/' | ';' | ',')
@@ -448,7 +451,7 @@ impl<'src> Lexer<'src> {
                     IpyEscapeKind::try_from(c).unwrap()
                 };
 
-                self.lex_ipython_escape_command(kind)
+                self.lex_ipython_escape_command(kind, IpyEscapeLexContext::LogicalLineStart)
             }
 
             '?' if self.mode == Mode::Ipython => TokenKind::Question,
@@ -1262,7 +1265,11 @@ impl<'src> Lexer<'src> {
     }
 
     /// Lex a single IPython escape command.
-    fn lex_ipython_escape_command(&mut self, escape_kind: IpyEscapeKind) -> TokenKind {
+    fn lex_ipython_escape_command(
+        &mut self,
+        escape_kind: IpyEscapeKind,
+        context: IpyEscapeLexContext,
+    ) -> TokenKind {
         let mut value = String::new();
 
         loop {
@@ -1308,6 +1315,27 @@ impl<'src> Lexer<'src> {
                     let mut question_count = 1u32;
                     while self.cursor.eat_char('?') {
                         question_count += 1;
+                    }
+
+                    // Help end tokens (`?` / `??`) are only valid in certain contexts
+                    // (e.g., not within f-strings or parenthesized expressions), and only
+                    // for escape kinds that IPython recognizes as supporting a trailing `?`
+                    // (i.e., `%`, `%%`, `?`, and `??`). For other escape kinds like `!` or
+                    // `/`, the `?` is just part of the command value.
+                    if !context.allows_help_end()
+                        || !matches!(
+                            escape_kind,
+                            IpyEscapeKind::Magic
+                                | IpyEscapeKind::Magic2
+                                | IpyEscapeKind::Help
+                                | IpyEscapeKind::Help2
+                        )
+                    {
+                        value.reserve(question_count as usize);
+                        for _ in 0..question_count {
+                            value.push('?');
+                        }
+                        continue;
                     }
 
                     // The original implementation in the IPython codebase is based on regex which
@@ -1749,6 +1777,18 @@ impl State {
 }
 
 #[derive(Copy, Clone, Debug)]
+enum IpyEscapeLexContext {
+    Assignment,
+    LogicalLineStart,
+}
+
+impl IpyEscapeLexContext {
+    const fn allows_help_end(self) -> bool {
+        matches!(self, Self::LogicalLineStart)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
 enum Radix {
     Binary,
     Octal,
@@ -2108,7 +2148,9 @@ pwd = !pwd
 foo = %timeit a = b
 bar = %timeit a % 3
 baz = %matplotlib \
-        inline"
+        inline
+qux = %foo?
+quux = !pwd?"
             .trim();
         assert_snapshot!(lex_jupyter_source(source));
     }

--- a/crates/ruff_python_parser/src/parser/snapshots/ruff_python_parser__parser__tests__ipython_escape_commands.snap
+++ b/crates/ruff_python_parser/src/parser/snapshots/ruff_python_parser__parser__tests__ipython_escape_commands.snap
@@ -5,7 +5,7 @@ expression: parsed.syntax()
 Module(
     ModModule {
         node_index: NodeIndex(None),
-        range: 0..929,
+        range: 0..953,
         body: [
             Expr(
                 StmtExpr {
@@ -362,10 +362,58 @@ Module(
                     ),
                 },
             ),
+            Assign(
+                StmtAssign {
+                    node_index: NodeIndex(None),
+                    range: 785..796,
+                    targets: [
+                        Name(
+                            ExprName {
+                                node_index: NodeIndex(None),
+                                range: 785..788,
+                                id: Name("bar"),
+                                ctx: Store,
+                            },
+                        ),
+                    ],
+                    value: IpyEscapeCommand(
+                        ExprIpyEscapeCommand {
+                            node_index: NodeIndex(None),
+                            range: 791..796,
+                            kind: Magic,
+                            value: "foo?",
+                        },
+                    ),
+                },
+            ),
+            Assign(
+                StmtAssign {
+                    node_index: NodeIndex(None),
+                    range: 797..808,
+                    targets: [
+                        Name(
+                            ExprName {
+                                node_index: NodeIndex(None),
+                                range: 797..800,
+                                id: Name("baz"),
+                                ctx: Store,
+                            },
+                        ),
+                    ],
+                    value: IpyEscapeCommand(
+                        ExprIpyEscapeCommand {
+                            node_index: NodeIndex(None),
+                            range: 803..808,
+                            kind: Shell,
+                            value: "pwd?",
+                        },
+                    ),
+                },
+            ),
             IpyEscapeCommand(
                 StmtIpyEscapeCommand {
                     node_index: NodeIndex(None),
-                    range: 786..791,
+                    range: 810..815,
                     kind: Magic,
                     value: " foo",
                 },
@@ -373,12 +421,12 @@ Module(
             Assign(
                 StmtAssign {
                     node_index: NodeIndex(None),
-                    range: 792..813,
+                    range: 816..837,
                     targets: [
                         Name(
                             ExprName {
                                 node_index: NodeIndex(None),
-                                range: 792..795,
+                                range: 816..819,
                                 id: Name("foo"),
                                 ctx: Store,
                             },
@@ -387,7 +435,7 @@ Module(
                     value: IpyEscapeCommand(
                         ExprIpyEscapeCommand {
                             node_index: NodeIndex(None),
-                            range: 798..813,
+                            range: 822..837,
                             kind: Magic,
                             value: "foo  # comment",
                         },
@@ -397,7 +445,7 @@ Module(
             IpyEscapeCommand(
                 StmtIpyEscapeCommand {
                     node_index: NodeIndex(None),
-                    range: 838..842,
+                    range: 862..866,
                     kind: Help,
                     value: "foo",
                 },
@@ -405,7 +453,7 @@ Module(
             IpyEscapeCommand(
                 StmtIpyEscapeCommand {
                     node_index: NodeIndex(None),
-                    range: 843..852,
+                    range: 867..876,
                     kind: Help2,
                     value: "foo.bar",
                 },
@@ -413,7 +461,7 @@ Module(
             IpyEscapeCommand(
                 StmtIpyEscapeCommand {
                     node_index: NodeIndex(None),
-                    range: 853..865,
+                    range: 877..889,
                     kind: Help,
                     value: "foo.bar.baz",
                 },
@@ -421,7 +469,7 @@ Module(
             IpyEscapeCommand(
                 StmtIpyEscapeCommand {
                     node_index: NodeIndex(None),
-                    range: 866..874,
+                    range: 890..898,
                     kind: Help2,
                     value: "foo[0]",
                 },
@@ -429,7 +477,7 @@ Module(
             IpyEscapeCommand(
                 StmtIpyEscapeCommand {
                     node_index: NodeIndex(None),
-                    range: 875..885,
+                    range: 899..909,
                     kind: Help,
                     value: "foo[0][1]",
                 },
@@ -437,7 +485,7 @@ Module(
             IpyEscapeCommand(
                 StmtIpyEscapeCommand {
                     node_index: NodeIndex(None),
-                    range: 886..905,
+                    range: 910..929,
                     kind: Help2,
                     value: "foo.bar[0].baz[1]",
                 },
@@ -445,7 +493,7 @@ Module(
             IpyEscapeCommand(
                 StmtIpyEscapeCommand {
                     node_index: NodeIndex(None),
-                    range: 906..929,
+                    range: 930..953,
                     kind: Help2,
                     value: "foo.bar[0].baz[2].egg",
                 },

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -115,6 +115,8 @@ p1 = !pwd
 p2: str = !pwd
 foo = %foo \
     bar
+bar = %foo?
+baz = !pwd?
 
 % foo
 foo = %foo  # comment

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_assignment.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_assignment.snap
@@ -87,7 +87,49 @@ expression: lex_jupyter_source(source)
     ),
     (
         Newline,
-        85..85,
+        85..86,
+    ),
+    (
+        Name(
+            Name("qux"),
+        ),
+        86..89,
+    ),
+    (
+        Equal,
+        90..91,
+    ),
+    (
+        IpyEscapeCommand {
+            value: "foo?",
+            kind: Magic,
+        },
+        92..97,
+    ),
+    (
+        Newline,
+        97..98,
+    ),
+    (
+        Name(
+            Name("quux"),
+        ),
+        98..102,
+    ),
+    (
+        Equal,
+        103..104,
+    ),
+    (
+        IpyEscapeCommand {
+            value: "pwd?",
+            kind: Shell,
+        },
+        105..110,
+    ),
+    (
+        Newline,
+        110..110,
     ),
 ]
 ```

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_help_end_escape_command.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_help_end_escape_command.snap
@@ -172,8 +172,8 @@ expression: lex_jupyter_source(source)
     ),
     (
         IpyEscapeCommand {
-            value: "pwd",
-            kind: Help,
+            value: "pwd?",
+            kind: Shell,
         },
         127..132,
     ),


### PR DESCRIPTION
## Summary

We now distinguish between IPython escape commands lexed after an `=` sign from those at the start of a logical line, which allows `x = %foo?` to be interpreted as "assign the result of running a line magic named `foo?`", matching the IPython assignment-magic transform.

See: https://github.com/astral-sh/ruff/issues/21705#issuecomment-4085099342.
