### PR TITLE
[ty] Compare generic callables modulo owned type parameter renaming

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -1326,8 +1326,7 @@ class ChildOfParentDataclass[T](ParentDataclass[T]): ...
 def uses_dataclass[T](x: T) -> ChildOfParentDataclass[T]:
     return ChildOfParentDataclass(x)
 
-# TODO: ParentDataclass.__init__ should show generic types, not Unknown
-# revealed: (self: ParentDataclass[Unknown], value: Unknown) -> None
+# revealed: [T](self: ParentDataclass[T], value: T) -> None
 reveal_type(ParentDataclass.__init__)
 
 # revealed: [T](self: ParentDataclass[T], value: T) -> None

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -825,7 +825,7 @@ class C(Generic[T]):
 reveal_type(generic_context(C))
 # revealed: ty_extensions.GenericContext[Self@method]
 reveal_type(generic_context(C.method))
-# revealed: ty_extensions.GenericContext[Self@generic_method, U@generic_method]
+# revealed: ty_extensions.GenericContext[Self@generic_method, U@generic_method, T@C]
 reveal_type(generic_context(C.generic_method))
 # revealed: None
 reveal_type(generic_context(C[int]))

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -669,7 +669,7 @@ class C[T]:
 reveal_type(generic_context(C))
 # revealed: ty_extensions.GenericContext[Self@method]
 reveal_type(generic_context(C.method))
-# revealed: ty_extensions.GenericContext[Self@generic_method, U@generic_method]
+# revealed: ty_extensions.GenericContext[Self@generic_method, U@generic_method, T@C]
 reveal_type(generic_context(C.generic_method))
 # revealed: None
 reveal_type(generic_context(C[int]))
@@ -898,9 +898,9 @@ class Impl[S, R](A[S, R]):
     def foo(self, s: S) -> S:
         return self.set(s, self.get(s))
 
-reveal_type(generic_context(A.get))  # revealed: ty_extensions.GenericContext[Self@get]
-reveal_type(generic_context(A.merge))  # revealed: ty_extensions.GenericContext[Self@merge, R2@merge]
-reveal_type(generic_context(Impl.foo))  # revealed: ty_extensions.GenericContext[Self@foo]
+reveal_type(generic_context(A.get))  # revealed: ty_extensions.GenericContext[Self@get, S@A, R@A]
+reveal_type(generic_context(A.merge))  # revealed: ty_extensions.GenericContext[Self@merge, R2@merge, S@A, R@A]
+reveal_type(generic_context(Impl.foo))  # revealed: ty_extensions.GenericContext[Self@foo, S@Impl]
 ```
 
 ## Tuple as a PEP-695 generic class

--- a/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
@@ -152,9 +152,12 @@ already solved and specialized when the class was specialized:
 from ty_extensions import generic_context
 
 legacy.m("string", None)  # error: [invalid-argument-type]
+reveal_type(Legacy.m)  # revealed: def m[S, T](self, x: T, y: S) -> S
 reveal_type(legacy.m)  # revealed: bound method Legacy[int].m[S](x: int, y: S) -> S
 # revealed: ty_extensions.GenericContext[T@Legacy]
 reveal_type(generic_context(Legacy))
+# revealed: ty_extensions.GenericContext[Self@m, S@m, T@Legacy]
+reveal_type(generic_context(Legacy.m))
 # revealed: ty_extensions.GenericContext[Self@m, S@m]
 reveal_type(generic_context(legacy.m))
 ```
@@ -162,11 +165,16 @@ reveal_type(generic_context(legacy.m))
 With PEP 695 syntax, it is clearer that the method uses a separate typevar:
 
 ```py
+from ty_extensions import generic_context
+
 class C[T]:
     def m[S](self, x: T, y: S) -> S:
         return y
 
 c: C[int] = C()
+reveal_type(C.m)  # revealed: def m[S, T](self, x: T, y: S) -> S
+# revealed: ty_extensions.GenericContext[Self@m, S@m, T@C]
+reveal_type(generic_context(C.m))
 reveal_type(c.m(1, "string"))  # revealed: Literal["string"]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -1084,7 +1084,7 @@ class Property[T](NamedTuple):
 
 reveal_type(Property("height", 3.4))  # revealed: Property[float]
 reveal_type(Property.value)  # revealed: property
-reveal_type(Property.value.fget)  # revealed: (self, /) -> Unknown
+reveal_type(Property.value.fget)  # revealed: (self, /) -> T@Property
 reveal_type(Property[str].value.fget)  # revealed: (self, /) -> str
 reveal_type(Property("height", 3.4).value)  # revealed: float
 
@@ -1096,7 +1096,7 @@ class LegacyProperty(NamedTuple, Generic[T]):
 
 reveal_type(LegacyProperty("height", 42))  # revealed: LegacyProperty[int]
 reveal_type(LegacyProperty.value)  # revealed: property
-reveal_type(LegacyProperty.value.fget)  # revealed: (self, /) -> Unknown
+reveal_type(LegacyProperty.value.fget)  # revealed: (self, /) -> T@LegacyProperty
 reveal_type(LegacyProperty[str].value.fget)  # revealed: (self, /) -> str
 reveal_type(LegacyProperty("height", 3.4).value)  # revealed: int | float
 ```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1314,7 +1314,7 @@ specializations. That means that a generic callable is assignable to any particu
 the generic callable.)
 
 ```py
-from typing import Callable
+from typing import Callable, TypeVar
 from ty_extensions import RegularCallableTypeOf, TypeOf, is_assignable_to, static_assert
 
 def identity[T](t: T) -> T:
@@ -1331,6 +1331,12 @@ static_assert(is_assignable_to(RegularCallableTypeOf[identity], Callable[[str], 
 # TODO: no error
 # error: [static-assert-error]
 static_assert(not is_assignable_to(RegularCallableTypeOf[identity], Callable[[str], int]))
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+static_assert(is_assignable_to(Callable[[T], T], Callable[[U], U]))
+static_assert(is_assignable_to(Callable[[U], U], Callable[[T], T]))
 ```
 
 The reverse is not true — if someone expects a generic function that can be called with any

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -278,6 +278,22 @@ static_assert(
 )
 ```
 
+Generic callables are equivalent modulo renaming of their own type parameters:
+
+```py
+from typing import Callable, TypeVar
+from ty_extensions import is_assignable_to, is_equivalent_to, is_subtype_of, static_assert
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+static_assert(is_assignable_to(Callable[[T], T], Callable[[U], U]))
+static_assert(is_assignable_to(Callable[[U], U], Callable[[T], T]))
+static_assert(is_subtype_of(Callable[[T], T], Callable[[U], U]))
+static_assert(is_subtype_of(Callable[[U], U], Callable[[T], T]))
+static_assert(is_equivalent_to(Callable[[T], T], Callable[[U], U]))
+```
+
 ### Not equivalent
 
 There are multiple cases when two callable types are not equivalent which are enumerated below.

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -2204,7 +2204,7 @@ specializations. That means that a generic callable is a subtype of any particul
 the generic callable.)
 
 ```py
-from typing import Callable
+from typing import Callable, Generic, TypeVar
 from ty_extensions import RegularCallableTypeOf, TypeOf, is_subtype_of, static_assert
 
 def identity[T](t: T) -> T:
@@ -2229,6 +2229,23 @@ static_assert(is_subtype_of(RegularCallableTypeOf[identity], Callable[[int], int
 # error: [static-assert-error]
 static_assert(is_subtype_of(RegularCallableTypeOf[identity], Callable[[str], str]))
 static_assert(not is_subtype_of(RegularCallableTypeOf[identity], Callable[[str], int]))
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+static_assert(is_subtype_of(Callable[[T], T], Callable[[U], U]))
+static_assert(is_subtype_of(Callable[[U], U], Callable[[T], T]))
+
+class A(Generic[T]):
+    def m(self, x: T) -> T:
+        return x
+
+class B(Generic[U]):
+    def m(self, x: U) -> U:
+        return x
+
+static_assert(is_subtype_of(RegularCallableTypeOf[A.m], RegularCallableTypeOf[B.m]))
+static_assert(is_subtype_of(RegularCallableTypeOf[B.m], RegularCallableTypeOf[A.m]))
 ```
 
 The reverse is not true — if someone expects a generic function that can be called with any

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3256,9 +3256,76 @@ impl<'db> Type<'db> {
                     .into();
                 }
 
-                let class_attr_plain = self.find_name_in_mro_with_policy(db, name_str, policy).expect(
-                    "Calling `find_name_in_mro` on class literals and subclass-of types should always return `Some`",
-                );
+                let class_attr_plain = if let Type::ClassLiteral(ClassLiteral::Static(class)) = self
+                {
+                    if let Some(class_generic_context) = class.generic_context(db) {
+                        let class_attr_plain = Type::from(class.identity_specialization(db))
+                            .find_name_in_mro_with_policy(db, name_str, policy)
+                            .expect(
+                                "Calling `find_name_in_mro` on class literals and subclass-of types should always return `Some`",
+                            );
+
+                        class_attr_plain.map_type(|ty| {
+                            if let Type::FunctionLiteral(function) = ty
+                                && !function.is_staticmethod(db)
+                                && !function.is_classmethod(db)
+                            {
+                                let signature_mentions_typevar =
+                                    |signature: &Signature<'db>, typevar| {
+                                        GenericContext::from_signature_types(
+                                            db,
+                                            signature.parameters(),
+                                            signature.return_ty,
+                                        )
+                                        .is_some_and(
+                                            |generic_context| {
+                                                generic_context.binds_typevar(db, typevar).is_some()
+                                            },
+                                        )
+                                    };
+                                let function_signature = function.signature(db);
+                                let last_definition_signature =
+                                    function.last_definition_signature(db);
+                                let mut mentioned_inherited_typevars = class_generic_context
+                                    .variables(db)
+                                    .filter(|bound_typevar| {
+                                        let typevar = bound_typevar.typevar(db);
+                                        function_signature.iter().any(|signature| {
+                                            signature_mentions_typevar(signature, typevar)
+                                        }) || signature_mentions_typevar(
+                                            last_definition_signature,
+                                            typevar,
+                                        )
+                                    })
+                                    .peekable();
+
+                                if mentioned_inherited_typevars.peek().is_some() {
+                                    Type::FunctionLiteral(function.with_inherited_generic_context(
+                                        db,
+                                        GenericContext::from_typevar_instances(
+                                            db,
+                                            mentioned_inherited_typevars,
+                                        ),
+                                    ))
+                                } else {
+                                    ty
+                                }
+                            } else {
+                                ty
+                            }
+                        })
+                    } else {
+                        self.find_name_in_mro_with_policy(db, name_str, policy)
+                            .expect(
+                                "Calling `find_name_in_mro` on class literals and subclass-of types should always return `Some`",
+                            )
+                    }
+                } else {
+                    self.find_name_in_mro_with_policy(db, name_str, policy)
+                        .expect(
+                            "Calling `find_name_in_mro` on class literals and subclass-of types should always return `Some`",
+                        )
+                };
 
                 let self_instance = self
                     .to_instance(db)

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -556,6 +556,52 @@ impl<'db> GenericContext<'db> {
         Some(Self::from_typevar_instances(db, variables))
     }
 
+    /// Creates a generic context from the bound type variables that appear directly in a callable
+    /// signature's parameter and return types.
+    pub(crate) fn from_signature_types(
+        db: &'db dyn Db,
+        parameters: &Parameters<'db>,
+        return_type: Type<'db>,
+    ) -> Option<Self> {
+        #[derive(Default)]
+        struct CollectTypeVars<'db> {
+            typevars: RefCell<FxOrderSet<BoundTypeVarInstance<'db>>>,
+            recursion_guard: TypeCollector<'db>,
+        }
+
+        impl<'db> TypeVisitor<'db> for CollectTypeVars<'db> {
+            fn should_visit_lazy_type_attributes(&self) -> bool {
+                false
+            }
+
+            fn visit_bound_type_var_type(
+                &self,
+                db: &'db dyn Db,
+                bound_typevar: BoundTypeVarInstance<'db>,
+            ) {
+                let bound_typevar = if bound_typevar.is_paramspec(db) {
+                    bound_typevar.without_paramspec_attr(db)
+                } else {
+                    bound_typevar
+                };
+                self.typevars.borrow_mut().insert(bound_typevar);
+            }
+
+            fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+            }
+        }
+
+        let visitor = CollectTypeVars::default();
+        for parameter in parameters {
+            visitor.visit_type(db, parameter.annotated_type());
+        }
+        visitor.visit_type(db, return_type);
+
+        let typevars = visitor.typevars.into_inner();
+        (!typevars.is_empty()).then(|| Self::from_typevar_instances(db, typevars))
+    }
+
     pub(crate) fn remove_callable_only_typevars(
         db: &'db dyn Db,
         generic_context: Option<Self>,

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -15,12 +15,13 @@ use crate::types::special_form::{AliasSpec, LegacyStdlibAlias};
 use crate::types::string_annotation::parse_string_annotation;
 use crate::types::tuple::{TupleSpecBuilder, TupleType};
 use crate::types::{
-    BindingContext, CallableType, DynamicType, GenericContext, IntersectionBuilder, KnownClass,
-    KnownInstanceType, LintDiagnosticGuard, LiteralValueTypeKind, Parameter, Parameters,
-    SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeContext, TypeGuardType, TypeIsType,
-    TypeMapping, TypeVarKind, UnionBuilder, UnionType, any_over_type, todo_type,
+    ApplyTypeMappingVisitor, BindingContext, CallableType, DynamicType, GenericContext,
+    IntersectionBuilder, KnownClass, KnownInstanceType, LintDiagnosticGuard, LiteralValueTypeKind,
+    Parameter, Parameters, SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeContext,
+    TypeGuardType, TypeIsType, TypeMapping, TypeVarKind, UnionBuilder, UnionType, any_over_type,
+    todo_type,
 };
-use crate::{FxOrderSet, Program, add_inferred_python_version_hint_to_diagnostic};
+use crate::{Db, FxOrderSet, Program, add_inferred_python_version_hint_to_diagnostic};
 
 /// Type expressions
 impl<'db> TypeInferenceBuilder<'db, '_> {
@@ -1475,8 +1476,61 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         fn inner<'db>(
             builder: &mut TypeInferenceBuilder<'db, '_>,
             subscript: &ast::ExprSubscript,
+            allow_implicit_generic_context: bool,
         ) -> Type<'db> {
+            fn callable_type_expression<'db>(
+                db: &'db dyn Db,
+                should_bind_standalone_legacy_typevars: bool,
+                parameters: Parameters<'db>,
+                return_type: Type<'db>,
+            ) -> Type<'db> {
+                if should_bind_standalone_legacy_typevars {
+                    // A standalone raw `Callable[[T], T]` type expression outside annotation
+                    // contexts implicitly binds otherwise-unbound legacy `TypeVar`s to the
+                    // callable itself so relation checking can treat the whole signature as
+                    // generic instead of comparing those typevars by raw identity. In
+                    // annotations, or when an enclosing definition already owns the typevars,
+                    // we keep the callable nongeneric so existing scoping rules are preserved.
+                    let signature = Signature::new(parameters, return_type)
+                        .apply_type_mapping_impl(
+                            db,
+                            &TypeMapping::BindLegacyTypevars(BindingContext::Synthetic),
+                            TypeContext::default(),
+                            &ApplyTypeMappingVisitor::default(),
+                        );
+                    let generic_context = GenericContext::from_signature_types(
+                        db,
+                        signature.parameters(),
+                        signature.return_ty,
+                    )
+                    .and_then(|context| {
+                        let mut synthetic_typevars = context
+                            .variables(db)
+                            .filter(|bound_typevar| {
+                                bound_typevar.binding_context(db) == BindingContext::Synthetic
+                            })
+                            .peekable();
+                        synthetic_typevars
+                            .peek()
+                            .is_some()
+                            .then(|| GenericContext::from_typevar_instances(db, synthetic_typevars))
+                    });
+                    Type::single_callable(
+                        db,
+                        Signature::new_generic(
+                            generic_context,
+                            signature.parameters().clone(),
+                            signature.return_ty,
+                        ),
+                    )
+                } else {
+                    Type::single_callable(db, Signature::new(parameters, return_type))
+                }
+            }
+
             let db = builder.db();
+            let should_bind_standalone_legacy_typevars =
+                allow_implicit_generic_context && builder.typevar_binding_context.is_none();
 
             let arguments_slice = &*subscript.slice;
 
@@ -1515,12 +1569,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         ));
                     }
                 }
-                Type::single_callable(
+                callable_type_expression(
                     db,
-                    Signature::new(
-                        Parameters::unknown(),
-                        return_type.unwrap_or_else(Type::unknown),
-                    ),
+                    should_bind_standalone_legacy_typevars,
+                    Parameters::unknown(),
+                    return_type.unwrap_or_else(Type::unknown),
                 )
             } else {
                 let correct_argument_number = if let Some(third_argument) = arguments.next() {
@@ -1540,7 +1593,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 if correct_argument_number
                     && let (Some(parameters), Some(return_type)) = (parameters, return_type)
                 {
-                    Type::single_callable(db, Signature::new(parameters, return_type))
+                    callable_type_expression(
+                        db,
+                        should_bind_standalone_legacy_typevars,
+                        parameters,
+                        return_type,
+                    )
                 } else {
                     Type::Callable(CallableType::unknown(db))
                 }
@@ -1560,10 +1618,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // in the global scope or similar should be considered to create an implicit generic context.
         // For now, we do not report unbound type variables in any `Callable` contexts, but we may
         // decide to revisit this in the future.
+        let allow_implicit_generic_context = !self
+            .inference_flags
+            .contains(InferenceFlags::CHECK_UNBOUND_TYPEVARS);
         let previous_check_unbound_typevars = self
             .inference_flags
             .replace(InferenceFlags::CHECK_UNBOUND_TYPEVARS, false);
-        let result = inner(self, subscript);
+        let result = inner(self, subscript, allow_implicit_generic_context);
         self.inference_flags.set(
             InferenceFlags::CHECK_UNBOUND_TYPEVARS,
             previous_check_unbound_typevars,


### PR DESCRIPTION
## Summary

Fixes #1872

Relates to: https://github.com/astral-sh/ty/issues/95

Compare generic callables modulo renaming of their owned type parameters.

On `main`, some generic callables still lose the binder that owns the type parameters they mention. That makes alpha-equivalent callable shapes compare too literally, so cases like `Callable[[T], T]` vs `Callable[[U], U]` and `RegularCallableTypeOf[A.m]` vs `RegularCallableTypeOf[B.m]` can fail even though they have the same generic shape.

This PR fixes that in the two remaining construction sites that mattered here:

- raw standalone `Callable[...]` type expressions now synthesize a callable-owned generic context when they mention otherwise-unbound legacy typevars
- unbound generic members on generic classes now retain the inherited class type parameters they actually mention instead of degrading them to `Unknown`

In `type_expression.rs`, raw `Callable[[T], T]` expressions outside annotation-scoping contexts now bind their mentioned legacy typevars to the callable itself before relation checks. In `types.rs`, bare static generic class lookup now constructs unbound function members from the class identity specialization and reattaches only the inherited class typevars that appear in the member signature.

## Test Plan

- raw `Callable[[T], T]` and `Callable[[U], U]` compare as assignable, subtype-related, and equivalent
- unbound generic methods of generic classes compare as the same generic callable shape modulo
  renaming
- unbound generic members keep inherited class type parameters in their displayed generic context instead of degrading them to `Unknown`
- generic dataclass `__init__` and generic named-tuple property getters preserve their outer class type parameters on unbound access
