### PR TITLE
Allow extra characters on next line for TD003

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -241,8 +241,8 @@ impl Violation for MissingSpaceAfterTodoColon {
 static ISSUE_LINK_OWN_LINE_REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     RegexSet::new([
         r"^#\s*(http|https)://.*", // issue link
-        r"^#\s*\d+$",              // issue code - like "003"
-        r"^#\s*[A-Z]+\-?\d+$",     // issue code - like "TD003"
+        r"^#\s*\d+.*",              // issue code - like "003"
+        r"^#\s*[A-Z]+\-?\d+.*",     // issue code - like "TD003"
     ])
     .unwrap()
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Rationale: rule https://docs.astral.sh/ruff/rules/missing-todo-link/ is not violated only when an identifier `123` or `ABC-123` is found on the next line AND is the only text found, while for URLs this is not the case, and anything like `https://foo/bar and something else` will be matched, thus the rule won't be violated.

## Test Plan

Was not (yet)