### PR TITLE
[cli] Add block-layout terminal UI for help, diagnostics, and summaries

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -110,12 +110,21 @@ const STYLES: Styles = Styles::styled()
     .literal(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
     .placeholder(AnsiColor::Cyan.on_default());
 
+const HELP_TEMPLATE: &str = "\
+{before-help}{about-with-newline}\n\
+╭─ Usage\n\
+│ {usage}\n\
+╰─\n\n\
+{all-args}\n\
+{after-help}";
+
 #[derive(Debug, Parser)]
 #[command(
     author,
     name = "ruff",
     about = "Ruff: An extremely fast Python linter and code formatter.",
-    after_help = "For help with a specific command, see: `ruff help <command>`."
+    after_help = "For help with a specific command, see: `ruff help <command>`.",
+    help_template = HELP_TEMPLATE
 )]
 #[command(version)]
 #[command(styles = STYLES)]
@@ -190,6 +199,7 @@ pub enum AnalyzeCommand {
 }
 
 #[derive(Clone, Debug, clap::Parser)]
+#[command(help_template = HELP_TEMPLATE)]
 #[expect(clippy::struct_excessive_bools)]
 pub struct AnalyzeGraphCommand {
     /// List of files or directories to include.
@@ -227,6 +237,7 @@ pub struct AnalyzeGraphCommand {
 
 // The `Parser` derive is for ruff_dev, for ruff `Args` would be sufficient
 #[derive(Clone, Debug, clap::Parser)]
+#[command(help_template = HELP_TEMPLATE)]
 #[expect(clippy::struct_excessive_bools)]
 pub struct CheckCommand {
     /// List of files or directories to check.
@@ -495,6 +506,7 @@ pub struct CheckCommand {
 }
 
 #[derive(Clone, Debug, clap::Parser)]
+#[command(help_template = HELP_TEMPLATE)]
 #[expect(clippy::struct_excessive_bools)]
 pub struct FormatCommand {
     /// List of files or directories to format.

--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -43,6 +43,7 @@ use ruff_workspace::resolver::{
 
 use crate::args::{ConfigArguments, FormatArguments, FormatRange};
 use crate::cache::{Cache, FileCacheKey, PackageCacheMap, PackageCaches};
+use crate::output_ui::write_two_col_block;
 use crate::{ExitStatus, resolve_default_files};
 
 #[derive(Debug, Copy, Clone, is_macro::Is)]
@@ -650,48 +651,42 @@ impl<'a> FormatResults<'a> {
             }
         }
 
-        // Write out a summary of the formatting results.
-        if changed > 0 && unchanged > 0 {
-            writeln!(
-                f,
-                "{} file{} {}, {} file{} {}",
-                changed,
-                if changed == 1 { "" } else { "s" },
-                match self.mode {
-                    FormatMode::Write => "reformatted",
-                    FormatMode::Check | FormatMode::Diff => "would be reformatted",
-                },
-                unchanged,
-                if unchanged == 1 { "" } else { "s" },
-                match self.mode {
-                    FormatMode::Write => "left unchanged",
-                    FormatMode::Check | FormatMode::Diff => "already formatted",
-                },
-            )
-        } else if changed > 0 {
-            writeln!(
-                f,
-                "{} file{} {}",
-                changed,
-                if changed == 1 { "" } else { "s" },
-                match self.mode {
-                    FormatMode::Write => "reformatted",
-                    FormatMode::Check | FormatMode::Diff => "would be reformatted",
-                }
-            )
-        } else if unchanged > 0 {
-            writeln!(
-                f,
-                "{} file{} {}",
-                unchanged,
-                if unchanged == 1 { "" } else { "s" },
-                match self.mode {
-                    FormatMode::Write => "left unchanged",
-                    FormatMode::Check | FormatMode::Diff => "already formatted",
-                },
-            )
-        } else {
+        let mut rows = Vec::new();
+        if changed > 0 {
+            rows.push((
+                "Changed".to_string(),
+                format!(
+                    "{changed} file{} {}",
+                    if changed == 1 { "" } else { "s" },
+                    match self.mode {
+                        FormatMode::Write => "reformatted",
+                        FormatMode::Check | FormatMode::Diff => "would be reformatted",
+                    }
+                ),
+            ));
+        }
+        if unchanged > 0 {
+            rows.push((
+                "Unchanged".to_string(),
+                format!(
+                    "{unchanged} file{} {}",
+                    if unchanged == 1 { "" } else { "s" },
+                    match self.mode {
+                        FormatMode::Write => "left unchanged",
+                        FormatMode::Check | FormatMode::Diff => "already formatted",
+                    }
+                ),
+            ));
+        }
+        if rows.is_empty() {
             Ok(())
+        } else {
+            write_two_col_block(
+                f,
+                "Format Summary",
+                &rows,
+                colored::control::SHOULD_COLORIZE.should_colorize(),
+            )
         }
     }
 

--- a/crates/ruff/src/help_ui.rs
+++ b/crates/ruff/src/help_ui.rs
@@ -1,0 +1,213 @@
+use std::ffi::{OsStr, OsString};
+use std::io::Write;
+
+use anyhow::Result;
+use clap::CommandFactory;
+use colored::Colorize;
+
+use crate::args::Args;
+use crate::output_ui::{write_text_block, write_three_col_block};
+
+#[derive(Default)]
+struct Section {
+    title: String,
+    lines: Vec<String>,
+}
+
+fn parse_section_title(line: &str) -> Option<String> {
+    if !line.ends_with(':') {
+        return None;
+    }
+    let title = line.trim_end_matches(':').trim();
+    if title.is_empty() || title.starts_with(' ') {
+        return None;
+    }
+    Some(title.to_string())
+}
+
+fn split_columns(line: &str) -> Option<(String, String, String)> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let first_split = trimmed.find("  ")?;
+    let left = trimmed[..first_split].trim().to_string();
+    let mut rest = trimmed[first_split..].trim().to_string();
+    if left.is_empty() || rest.is_empty() {
+        return None;
+    }
+
+    let mut middle = String::new();
+    if let Some(second_split) = rest.find("  ") {
+        middle = rest[..second_split].trim().to_string();
+        rest = rest[second_split..].trim().to_string();
+    }
+    Some((left, middle, rest))
+}
+
+fn split_flag_and_type(flag: &str) -> (String, String) {
+    if let Some(start) = flag.rfind(" <")
+        && flag.ends_with('>')
+    {
+        let left = flag[..start].trim().to_string();
+        let ty = flag[start + 1..].trim().to_string();
+        return (left, ty);
+    }
+    (flag.to_string(), String::new())
+}
+
+/// `ruff help` / `ruff help check` / `ruff help analyze graph`
+fn resolve_help_subcommand_path(args: &[OsString]) -> Option<Vec<String>> {
+    if args.get(1).map(OsString::as_os_str) != Some(OsStr::new("help")) {
+        return None;
+    }
+    let mut path = Vec::new();
+    for arg in args.iter().skip(2) {
+        let Some(value) = arg.to_str() else {
+            return None;
+        };
+        if value.starts_with('-') {
+            break;
+        }
+        path.push(value.to_string());
+    }
+    Some(path)
+}
+
+/// `ruff -h`, `ruff check -h`, `ruff --help`, etc.
+fn resolve_help_flag_path(args: &[OsString]) -> Option<Vec<String>> {
+    if !args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        return None;
+    }
+
+    let mut path = Vec::new();
+    for arg in args.iter().skip(1) {
+        if arg == "-h" || arg == "--help" {
+            break;
+        }
+        let Some(value) = arg.to_str() else {
+            continue;
+        };
+        if value.starts_with('-') {
+            break;
+        }
+        path.push(value.to_string());
+    }
+    Some(path)
+}
+
+fn resolve_block_help_path(args: &[OsString]) -> Option<Vec<String>> {
+    if let Some(path) = resolve_help_subcommand_path(args) {
+        return Some(path);
+    }
+    resolve_help_flag_path(args)
+}
+
+pub(crate) fn render_help_if_requested(args: &[OsString], writer: &mut dyn Write) -> Result<bool> {
+    let Some(path) = resolve_block_help_path(args) else {
+        return Ok(false);
+    };
+
+    let mut command = Args::command();
+    for part in &path {
+        let Some(next) = command.find_subcommand_mut(part) else {
+            return Ok(false);
+        };
+        command = next.clone();
+    }
+
+    let usage_rendered = command.render_usage().to_string();
+    let usage = usage_rendered
+        .trim()
+        .strip_prefix("Usage:")
+        .map(str::trim)
+        .unwrap_or(usage_rendered.trim())
+        .to_string();
+    let rendered = command.render_help().to_string();
+    let use_color = colored::control::SHOULD_COLORIZE.should_colorize();
+
+    let mut lines = rendered.lines();
+    let mut about_lines = Vec::new();
+    for line in lines.by_ref() {
+        if line.trim().is_empty() {
+            break;
+        }
+        about_lines.push(line.to_string());
+    }
+
+    for about in &about_lines {
+        if use_color {
+            writeln!(writer, "{}", about.green().bold())?;
+        } else {
+            writeln!(writer, "{about}")?;
+        }
+    }
+    writeln!(writer)?;
+    write_text_block(writer, "Usage", usage.trim(), use_color, true)?;
+    writeln!(writer)?;
+
+    let mut sections = Vec::new();
+    let mut current = Section::default();
+    for line in rendered.lines() {
+        if line.starts_with("Usage:") || line.starts_with("For help with") {
+            continue;
+        }
+        if let Some(title) = parse_section_title(line) {
+            if !current.title.is_empty() {
+                sections.push(current);
+            }
+            current = Section {
+                title,
+                lines: Vec::new(),
+            };
+            continue;
+        }
+        if !current.title.is_empty() {
+            current.lines.push(line.to_string());
+        }
+    }
+    if !current.title.is_empty() {
+        sections.push(current);
+    }
+
+    for section in sections {
+        let mut rows: Vec<(String, String, String)> = Vec::new();
+        for raw in section.lines {
+            if raw.trim().is_empty() {
+                continue;
+            }
+            if let Some((first, middle, third)) = split_columns(&raw) {
+                let (first, extra_type) = split_flag_and_type(&first);
+                let typ = if middle.is_empty() {
+                    extra_type
+                } else {
+                    middle
+                };
+                rows.push((first, typ, third));
+            } else if raw.trim_start().starts_with('-') || raw.trim_start().starts_with('[') {
+                let (first, typ) = split_flag_and_type(raw.trim());
+                rows.push((first, typ, String::new()));
+            } else if let Some((_, _, last)) = rows.last_mut() {
+                if !last.is_empty() {
+                    last.push(' ');
+                }
+                last.push_str(raw.trim());
+            }
+        }
+        if !rows.is_empty() {
+            write_three_col_block(writer, &section.title, &rows, use_color)?;
+            writeln!(writer)?;
+        }
+    }
+
+    if path.is_empty() {
+        let footer = "For help with a specific command, see: `ruff help <command>`.";
+        if use_color {
+            writeln!(writer, "{}", footer.green().bold())?;
+        } else {
+            writeln!(writer, "{footer}")?;
+        }
+    }
+
+    Ok(true)
+}

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -29,6 +29,8 @@ pub mod args;
 mod cache;
 mod commands;
 mod diagnostics;
+mod help_ui;
+mod output_ui;
 mod printer;
 pub mod resolve;
 mod stdin;
@@ -209,6 +211,14 @@ pub fn run(
         Command::Server(args) => server(args),
         Command::Analyze(AnalyzeCommand::Graph(args)) => analyze_graph(args, global_options),
     }
+}
+
+/// Hook for the `ruff` binary only: unified block-style help for `-h`, `--help`, and `ruff help …`
+/// before Clap parsing (so every entry point matches).
+#[doc(hidden)]
+pub fn render_block_help_if_requested(args: &[OsString]) -> Result<bool> {
+    let mut stdout = io::stdout().lock();
+    help_ui::render_help_if_requested(args, &mut stdout)
 }
 
 fn format(args: FormatCommand, global_options: GlobalConfigArgs) -> Result<ExitStatus> {

--- a/crates/ruff/src/main.rs
+++ b/crates/ruff/src/main.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use colored::Colorize;
 
 use ruff::args::Args;
-use ruff::{ExitStatus, run};
+use ruff::{ExitStatus, render_block_help_if_requested, run};
 
 #[cfg(target_os = "windows")]
 #[global_allocator]
@@ -39,6 +39,12 @@ pub fn main() -> ExitCode {
         Ok(args) => args,
         Err(err) => return report_error(&err),
     };
+
+    match render_block_help_if_requested(&args) {
+        Ok(true) => return ExitStatus::Success.into(),
+        Ok(false) => {}
+        Err(err) => return report_error(&err),
+    }
 
     let args = Args::parse_from(args);
 

--- a/crates/ruff/src/output_ui.rs
+++ b/crates/ruff/src/output_ui.rs
@@ -1,0 +1,387 @@
+use std::borrow::Cow;
+use std::io::{self, Write};
+
+use colored::Colorize;
+
+#[derive(Copy, Clone)]
+struct Borders {
+    top_left: char,
+    top_right: char,
+    bottom_left: char,
+    bottom_right: char,
+    horizontal: char,
+    vertical: char,
+}
+
+const UNICODE_BORDERS: Borders = Borders {
+    top_left: '╭',
+    top_right: '╮',
+    bottom_left: '╰',
+    bottom_right: '╯',
+    horizontal: '─',
+    vertical: '│',
+};
+
+const ASCII_BORDERS: Borders = Borders {
+    top_left: '+',
+    top_right: '+',
+    bottom_left: '+',
+    bottom_right: '+',
+    horizontal: '-',
+    vertical: '|',
+};
+
+fn terminal_width() -> usize {
+    std::env::var("COLUMNS")
+        .ok()
+        .and_then(|columns| columns.parse::<usize>().ok())
+        .map(|columns| columns.clamp(72, 140))
+        .unwrap_or(100)
+}
+
+/// Visible width of a string, ignoring common ANSI SGR sequences (help text is ASCII-heavy).
+fn visible_width(s: &str) -> usize {
+    let mut width = 0;
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            if chars.peek() == Some(&'[') {
+                chars.next();
+                while let Some(ch) = chars.next() {
+                    if ch == 'm' {
+                        break;
+                    }
+                }
+            }
+            continue;
+        }
+        width += unicode_column_width(c);
+    }
+    width
+}
+
+fn unicode_column_width(c: char) -> usize {
+    usize::from(!c.is_control())
+}
+
+fn pad_to_visible_width(s: &str, target: usize) -> String {
+    let pad = target.saturating_sub(visible_width(s));
+    format!("{s}{}", " ".repeat(pad))
+}
+
+fn wrap_text(value: &str, width: usize) -> Vec<Cow<'_, str>> {
+    if width == 0 || value.len() <= width {
+        return vec![Cow::Borrowed(value)];
+    }
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in value.split_whitespace() {
+        let separator = usize::from(!current.is_empty());
+        if current.len() + separator + word.len() > width && !current.is_empty() {
+            lines.push(Cow::Owned(current));
+            current = String::new();
+        }
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        current.push_str(word);
+    }
+    if !current.is_empty() {
+        lines.push(Cow::Owned(current));
+    }
+    if lines.is_empty() {
+        vec![Cow::Borrowed("")]
+    } else {
+        lines
+    }
+}
+
+fn write_border(
+    writer: &mut dyn Write,
+    left: char,
+    fill: char,
+    right: char,
+    width: usize,
+    colored: bool,
+) -> io::Result<()> {
+    let border = format!(
+        "{left}{}{right}",
+        fill.to_string().repeat(width.saturating_sub(2))
+    );
+    if colored {
+        writeln!(writer, "{}", border.cyan())
+    } else {
+        writeln!(writer, "{border}")
+    }
+}
+
+fn write_inner_line(
+    writer: &mut dyn Write,
+    left: char,
+    right: char,
+    content: &str,
+    inner_width: usize,
+    colored: bool,
+) -> io::Result<()> {
+    let rendered = pad_to_visible_width(content, inner_width);
+    if colored {
+        writeln!(
+            writer,
+            "{}{}{}",
+            left.to_string().cyan(),
+            rendered,
+            right.to_string().cyan()
+        )
+    } else {
+        writeln!(writer, "{left}{rendered}{right}")
+    }
+}
+
+pub(crate) fn write_text_block(
+    writer: &mut dyn Write,
+    title: &str,
+    body: &str,
+    colored: bool,
+    color_body: bool,
+) -> io::Result<()> {
+    let width = terminal_width();
+    let borders = if colored {
+        UNICODE_BORDERS
+    } else {
+        ASCII_BORDERS
+    };
+    let inner_width = width.saturating_sub(2);
+
+    write_border(
+        writer,
+        borders.top_left,
+        borders.horizontal,
+        borders.top_right,
+        width,
+        colored,
+    )?;
+    let title_line = if colored {
+        format!(" {}", title.green().bold())
+    } else {
+        format!(" {title}")
+    };
+    write_inner_line(
+        writer,
+        borders.vertical,
+        borders.vertical,
+        &title_line,
+        inner_width,
+        colored,
+    )?;
+    write_inner_line(
+        writer,
+        borders.vertical,
+        borders.vertical,
+        "",
+        inner_width,
+        colored,
+    )?;
+    for line in body.lines() {
+        for wrapped in wrap_text(line, inner_width.saturating_sub(1)) {
+            let body_line = if colored && color_body {
+                format!(" {}", wrapped.green().bold())
+            } else {
+                format!(" {wrapped}")
+            };
+            write_inner_line(
+                writer,
+                borders.vertical,
+                borders.vertical,
+                &body_line,
+                inner_width,
+                colored,
+            )?;
+        }
+    }
+    write_border(
+        writer,
+        borders.bottom_left,
+        borders.horizontal,
+        borders.bottom_right,
+        width,
+        colored,
+    )
+}
+
+pub(crate) fn write_two_col_block(
+    writer: &mut dyn Write,
+    title: &str,
+    rows: &[(String, String)],
+    colored: bool,
+) -> io::Result<()> {
+    let width = terminal_width();
+    let borders = if colored {
+        UNICODE_BORDERS
+    } else {
+        ASCII_BORDERS
+    };
+    let inner_width = width.saturating_sub(2);
+    let key_width = rows
+        .iter()
+        .map(|(key, _)| key.len())
+        .max()
+        .unwrap_or(0)
+        .min(28);
+    let value_width = inner_width.saturating_sub(key_width + 4);
+
+    write_border(
+        writer,
+        borders.top_left,
+        borders.horizontal,
+        borders.top_right,
+        width,
+        colored,
+    )?;
+    let title_line = if colored {
+        format!(" {}", title.green().bold())
+    } else {
+        format!(" {title}")
+    };
+    write_inner_line(
+        writer,
+        borders.vertical,
+        borders.vertical,
+        &title_line,
+        inner_width,
+        colored,
+    )?;
+    write_inner_line(
+        writer,
+        borders.vertical,
+        borders.vertical,
+        "",
+        inner_width,
+        colored,
+    )?;
+    for (key, value) in rows {
+        let wrapped = wrap_text(value, value_width);
+        for (index, line) in wrapped.into_iter().enumerate() {
+            let key_cell = if index == 0 {
+                if colored {
+                    pad_to_visible_width(&format!("{}", key.cyan().bold()), key_width)
+                } else {
+                    format!("{key:<key_width$}")
+                }
+            } else {
+                " ".repeat(key_width)
+            };
+            write_inner_line(
+                writer,
+                borders.vertical,
+                borders.vertical,
+                &format!(" {}  {line}", key_cell),
+                inner_width,
+                colored,
+            )?;
+        }
+    }
+    write_border(
+        writer,
+        borders.bottom_left,
+        borders.horizontal,
+        borders.bottom_right,
+        width,
+        colored,
+    )
+}
+
+pub(crate) fn write_three_col_block(
+    writer: &mut dyn Write,
+    title: &str,
+    rows: &[(String, String, String)],
+    colored: bool,
+) -> io::Result<()> {
+    let width = terminal_width();
+    let borders = if colored {
+        UNICODE_BORDERS
+    } else {
+        ASCII_BORDERS
+    };
+    let inner_width = width.saturating_sub(2);
+    let first_width = rows
+        .iter()
+        .map(|(first, _, _)| first.len())
+        .max()
+        .unwrap_or(0)
+        .min(28);
+    let second_width = rows
+        .iter()
+        .map(|(_, second, _)| second.len())
+        .max()
+        .unwrap_or(0)
+        .min(14);
+    let third_width = inner_width.saturating_sub(first_width + second_width + 6);
+
+    write_border(
+        writer,
+        borders.top_left,
+        borders.horizontal,
+        borders.top_right,
+        width,
+        colored,
+    )?;
+    let title_line = if colored {
+        format!(" {}", title.green().bold())
+    } else {
+        format!(" {title}")
+    };
+    write_inner_line(
+        writer,
+        borders.vertical,
+        borders.vertical,
+        &title_line,
+        inner_width,
+        colored,
+    )?;
+    write_inner_line(
+        writer,
+        borders.vertical,
+        borders.vertical,
+        "",
+        inner_width,
+        colored,
+    )?;
+
+    for (first, second, third) in rows {
+        let wrapped = wrap_text(third, third_width);
+        for (index, line) in wrapped.into_iter().enumerate() {
+            let first_value = if index == 0 { first.as_str() } else { "" };
+            let second_value = if index == 0 { second.as_str() } else { "" };
+            let first_cell = if first_value.is_empty() {
+                " ".repeat(first_width)
+            } else if colored {
+                pad_to_visible_width(&format!("{}", first_value.cyan().bold()), first_width)
+            } else {
+                format!("{first_value:<first_width$}")
+            };
+            let second_cell = if second_value.is_empty() {
+                " ".repeat(second_width)
+            } else if colored {
+                pad_to_visible_width(&format!("{}", second_value.yellow()), second_width)
+            } else {
+                format!("{second_value:<second_width$}")
+            };
+            write_inner_line(
+                writer,
+                borders.vertical,
+                borders.vertical,
+                &format!(" {}  {}  {}", first_cell, second_cell, line),
+                inner_width,
+                colored,
+            )?;
+        }
+    }
+    write_border(
+        writer,
+        borders.bottom_left,
+        borders.horizontal,
+        borders.bottom_right,
+        width,
+        colored,
+    )
+}

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -19,6 +19,7 @@ use ruff_linter::settings::flags::{self};
 use ruff_linter::settings::types::{OutputFormat, PreviewMode, UnsafeFixes};
 
 use crate::diagnostics::{Diagnostics, FixMap};
+use crate::output_ui::{write_text_block, write_two_col_block};
 
 bitflags! {
     #[derive(Default, Debug, Copy, Clone)]
@@ -81,7 +82,11 @@ impl Printer {
         }
     }
 
-    fn write_summary_text(&self, writer: &mut dyn Write, diagnostics: &Diagnostics) -> Result<()> {
+    fn write_summary_text_plain(
+        &self,
+        writer: &mut dyn Write,
+        diagnostics: &Diagnostics,
+    ) -> Result<()> {
         if self.log_level >= LogLevel::Default {
             let fixables = FixableStatistics::try_from(diagnostics, self.unsafe_fixes);
 
@@ -205,6 +210,30 @@ impl Printer {
         Ok(())
     }
 
+    fn should_use_block_ui(&self) -> bool {
+        self.format.is_human_readable()
+    }
+
+    fn write_summary_text(&self, writer: &mut dyn Write, diagnostics: &Diagnostics) -> Result<()> {
+        if !self.should_use_block_ui() {
+            return self.write_summary_text_plain(writer, diagnostics);
+        }
+        let mut buffer = Vec::new();
+        self.write_summary_text_plain(&mut buffer, diagnostics)?;
+        let body = String::from_utf8(buffer)?;
+        if body.trim().is_empty() {
+            return Ok(());
+        }
+        write_text_block(
+            writer,
+            "Summary",
+            body.trim_end(),
+            colored::control::SHOULD_COLORIZE.should_colorize(),
+            false,
+        )?;
+        Ok(())
+    }
+
     pub(crate) fn write_once(
         &self,
         diagnostics: &Diagnostics,
@@ -243,7 +272,27 @@ impl Printer {
             .with_fix_applicability(self.unsafe_fixes.required_applicability())
             .show_fix_diff(preview.is_enabled());
 
-        render_diagnostics(writer, self.format, config, &context, &diagnostics.inner)?;
+        if self.should_use_block_ui() {
+            let mut rendered = Vec::new();
+            render_diagnostics(
+                &mut rendered,
+                self.format,
+                config,
+                &context,
+                &diagnostics.inner,
+            )?;
+            let body = String::from_utf8(rendered)?;
+            write_text_block(
+                writer,
+                "Diagnostics",
+                body.trim_end(),
+                colored::control::SHOULD_COLORIZE.should_colorize(),
+                false,
+            )?;
+            writeln!(writer)?;
+        } else {
+            render_diagnostics(writer, self.format, config, &context, &diagnostics.inner)?;
+        }
 
         if matches!(
             self.format,
@@ -334,30 +383,64 @@ impl Printer {
                 let unfixable = "[ ] ";
 
                 // By default, we mimic Flake8's `--statistics` format.
-                for statistic in &statistics {
-                    writeln!(
-                        writer,
-                        "{:>count_width$}\t{:<code_width$}\t{}{}",
-                        statistic.count.to_string().bold(),
-                        statistic
-                            .code
-                            .map(SecondaryCode::as_str)
-                            .unwrap_or_default()
-                            .red()
-                            .bold(),
-                        if any_fixable {
-                            if statistic.all_fixable {
-                                &all_fixable
-                            } else if statistic.any_fixable() {
-                                &partially_fixable
+                if self.should_use_block_ui() {
+                    let rows: Vec<(String, String)> = statistics
+                        .iter()
+                        .map(|statistic| {
+                            let code = statistic
+                                .code
+                                .map(SecondaryCode::as_str)
+                                .unwrap_or_default();
+                            let fix_status = if any_fixable {
+                                if statistic.all_fixable {
+                                    &all_fixable
+                                } else if statistic.any_fixable() {
+                                    &partially_fixable
+                                } else {
+                                    unfixable
+                                }
                             } else {
-                                unfixable
-                            }
-                        } else {
-                            ""
-                        },
-                        statistic.name,
+                                ""
+                            };
+                            (
+                                format!("{:>count_width$} {:<code_width$}", statistic.count, code),
+                                format!("{fix_status}{}", statistic.name),
+                            )
+                        })
+                        .collect();
+                    write_two_col_block(
+                        writer,
+                        "Statistics",
+                        &rows,
+                        colored::control::SHOULD_COLORIZE.should_colorize(),
                     )?;
+                    writeln!(writer)?;
+                } else {
+                    for statistic in &statistics {
+                        writeln!(
+                            writer,
+                            "{:>count_width$}\t{:<code_width$}\t{}{}",
+                            statistic.count.to_string().bold(),
+                            statistic
+                                .code
+                                .map(SecondaryCode::as_str)
+                                .unwrap_or_default()
+                                .red()
+                                .bold(),
+                            if any_fixable {
+                                if statistic.all_fixable {
+                                    &all_fixable
+                                } else if statistic.any_fixable() {
+                                    &partially_fixable
+                                } else {
+                                    unfixable
+                                }
+                            } else {
+                                ""
+                            },
+                            statistic.name,
+                        )?;
+                    }
                 }
 
                 self.write_summary_text(writer, diagnostics)?;
@@ -416,7 +499,26 @@ impl Printer {
                 .with_show_fix_status(show_fix_status(self.fix_mode, fixables.as_ref()))
                 .with_fix_applicability(self.unsafe_fixes.required_applicability())
                 .show_fix_diff(preview.is_enabled());
-            render_diagnostics(writer, self.format, config, &context, &diagnostics.inner)?;
+            if self.should_use_block_ui() {
+                let mut rendered = Vec::new();
+                render_diagnostics(
+                    &mut rendered,
+                    self.format,
+                    config,
+                    &context,
+                    &diagnostics.inner,
+                )?;
+                let body = String::from_utf8(rendered)?;
+                write_text_block(
+                    writer,
+                    "Diagnostics",
+                    body.trim_end(),
+                    colored::control::SHOULD_COLORIZE.should_colorize(),
+                    false,
+                )?;
+            } else {
+                render_diagnostics(writer, self.format, config, &context, &diagnostics.inner)?;
+            }
         }
         writer.flush()?;
 
@@ -461,27 +563,32 @@ fn print_fix_summary(writer: &mut dyn Write, fixed: &FixMap) -> Result<()> {
             .unwrap(),
     );
 
-    let s = if total == 1 { "" } else { "s" };
-    let label = format!("Fixed {total} error{s}:");
-    writeln!(writer, "{}", label.bold().green())?;
-
+    let mut rows: Vec<(String, String)> = Vec::new();
     for (filename, table) in fixed
         .iter()
         .sorted_by_key(|(filename, ..)| filename.as_str())
     {
-        writeln!(
-            writer,
-            "{} {}{}",
-            "-".cyan(),
-            relativize_path(filename).bold(),
-            ":".cyan()
-        )?;
+        let mut details = String::new();
         for (code, name, count) in table.iter().sorted_by_key(|(.., count)| Reverse(*count)) {
-            writeln!(
-                writer,
-                "    {count:>num_digits$} × {code} ({name})",
-                code = code.to_string().red().bold(),
-            )?;
+            if !details.is_empty() {
+                details.push_str(", ");
+            }
+            details.push_str(&format!(
+                "{count:>num_digits$} × {} ({name})",
+                code.to_string().red().bold()
+            ));
+        }
+        rows.push((relativize_path(filename).to_string(), details));
+    }
+    if colored::control::SHOULD_COLORIZE.should_colorize() {
+        let s = if total == 1 { "" } else { "s" };
+        let title = format!("Fixed {total} error{s}");
+        write_two_col_block(writer, &title, &rows, true)?;
+    } else {
+        let s = if total == 1 { "" } else { "s" };
+        writeln!(writer, "Fixed {total} error{s}:")?;
+        for (filename, details) in rows {
+            writeln!(writer, "- {filename}: {details}")?;
         }
     }
     Ok(())


### PR DESCRIPTION
## Summary

This PR refreshes Ruff’s **human-facing** terminal output into a **consistent block-style layout** (boxed sections, aligned columns, restored semantic colors aligned with existing Clap styling) while **leaving behavior unchanged**: parsing, linting, fixing, formatting, exit codes, and **machine-readable** output formats (`json`, `sarif`, CI formats, etc.) are unaffected.

Concretely:

- **Unified help**: `-h` / `--help` and `ruff help …` are handled through the **same** pre-parse help renderer, so help output is consistent across entry points. Unknown `ruff help <cmd>` paths still defer to Clap for the standard error.
- **Shared UI layer**: Small drawing helpers for bordered blocks and multi-column rows, with width padding that tolerates ANSI (so colors don’t break alignment).
- **Lint output**: For human-readable `OutputFormat`s only (`full` / `concise` / `grouped`), diagnostics and end-of-run summaries can be wrapped in labeled blocks; **JSON/statistics JSON** and other non-human paths stay as before.
- **Formatter**: Human “format summary” uses the same block/column presentation; logic for counts/modes is unchanged.

## Motivation

CLI help and human diagnostics were a mix of plain Clap layouts and ad hoc lines, which made the tool feel inconsistent and harder to scan—especially next to modern CLIs that use clear sections and columns. This change **standardizes presentation** without changing what Ruff computes or emits for structured consumers.

## Test plan

- [x] `cargo check -p ruff`
- [x] `cargo clippy -p ruff --all-targets -- -D warnings` (or full workspace per CONTRIBUTING if you prefer)
- [x] `uvx prek run -a`
- [x] **Help / entry points** (local `target/debug/ruff` or your `CARGO_TARGET_DIR`):
  - [x] `ruff -h` and `ruff --help`
  - [x] `ruff help`, `ruff help check`, `ruff help format`, `ruff help analyze graph`
  - [x] `ruff check -h`, `ruff format -h`
  - [x] Invalid: `ruff help not-a-command` → expect normal Clap error
- [x] **Color on/off**: `ruff -h` with `--color never` / `always` (and `NO_COLOR` if you use it) — borders fall back to ASCII where appropriate
- [x] **Lint human output**: run `ruff check` on a small file with violations — `full` / `concise` / `grouped`
- [x] **Lint machine output**: `ruff check --output-format json` (and one other e.g. `github`) — confirm **no** block wrapper / no accidental extra framing
- [x] **Statistics**: `ruff check --statistics` (text + `json`) — block only on human path
- [x] **Formatter**: `ruff format --check` on a file that would change — summary block appears where expected
- [x] **Regression sanity**: `ruff -v` still errors for missing subcommand (unchanged semantics)

Before:
<img width="1100" height="705" alt="image" src="https://github.com/user-attachments/assets/2375bcab-91bf-4488-b220-c11c40eebda1" />


After:
<img width="1154" height="818" alt="image" src="https://github.com/user-attachments/assets/5a31bd9e-7fbc-40d7-ba43-d7a296c4cb94" />
<img width="1047" height="830" alt="image" src="https://github.com/user-attachments/assets/5ca5714a-b61b-4c99-91c2-70327bcffda3" />
<img width="940" height="455" alt="image" src="https://github.com/user-attachments/assets/02e3608e-e585-4133-8193-67e5cf8eda0e" />
