### PR TITLE
[parser] Reset lexer state at notebook cell boundaries

### DIFF
--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -776,23 +776,21 @@ fn parse_unchecked_source(
 ) -> Parsed<ModModule> {
     let options = ParseOptions::from(source_type).with_target_version(target_version);
 
-    // For notebooks, pass cell offsets so the lexer can reset indent state at cell boundaries.
-    let empty_offsets = Vec::new();
-    let cell_offsets: &[ruff_text_size::TextSize] = source_kind
-        .as_ipy_notebook()
-        .map(|nb| nb.cell_offsets().as_ref())
-        .unwrap_or(&empty_offsets);
+    let source = source_kind.source_code();
+    let mut parser = ruff_python_parser::Parser::new(source, options);
+
+    // For notebooks, set cell offsets so the lexer can reset indent state at cell boundaries.
+    if let Some(nb) = source_kind.as_ipy_notebook() {
+        parser.set_cell_offsets(nb.cell_offsets().as_ref());
+    }
 
     // SAFETY: Safe because `PySourceType` always parses to a `ModModule`. See
-    // `ruff_python_parser::parse_unchecked_source`. We use `parse_unchecked` (and thus
+    // `ruff_python_parser::parse_unchecked_source`. We use `Parser::new` (and thus
     // have to unwrap) in order to pass the `PythonVersion` via `ParseOptions`.
-    ruff_python_parser::parse_unchecked_with_cell_offsets(
-        source_kind.source_code(),
-        options,
-        cell_offsets,
-    )
-    .try_into_module()
-    .expect("PySourceType always parses into a module")
+    parser
+        .parse()
+        .try_into_module()
+        .expect("PySourceType always parses into a module")
 }
 
 #[cfg(test)]

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -777,15 +777,19 @@ fn parse_unchecked_source(
     let options = ParseOptions::from(source_type).with_target_version(target_version);
 
     let source = source_kind.source_code();
-    let mut parser = ruff_python_parser::Parser::new(source, options);
-
-    // For notebooks, set cell offsets so the lexer can reset indent state at cell boundaries.
-    if let Some(nb) = source_kind.as_ipy_notebook() {
-        parser.set_cell_offsets(nb.cell_offsets().as_ref());
-    }
+    let cell_offsets = source_kind
+        .as_ipy_notebook()
+        .map(|nb| nb.cell_offsets().as_ref())
+        .unwrap_or(&[]);
+    let parser = ruff_python_parser::Parser::new_starts_at(
+        source,
+        ruff_text_size::TextSize::new(0),
+        options,
+        cell_offsets,
+    );
 
     // SAFETY: Safe because `PySourceType` always parses to a `ModModule`. See
-    // `ruff_python_parser::parse_unchecked_source`. We use `Parser::new` (and thus
+    // `ruff_python_parser::parse_unchecked_source`. We use `Parser::new_starts_at` (and thus
     // have to unwrap) in order to pass the `PythonVersion` via `ParseOptions`.
     parser
         .parse()

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -781,8 +781,7 @@ fn parse_unchecked_source(
         .as_ipy_notebook()
         .map(|nb| nb.cell_offsets().as_ref())
         .unwrap_or(&[]);
-    let parser =
-        ruff_python_parser::Parser::new_with_cell_offsets(source, options, cell_offsets);
+    let parser = ruff_python_parser::Parser::new_with_cell_offsets(source, options, cell_offsets);
 
     // SAFETY: Safe because `PySourceType` always parses to a `ModModule`. See
     // `ruff_python_parser::parse_unchecked_source`. We use `Parser::new_with_cell_offsets` (and thus

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -781,15 +781,11 @@ fn parse_unchecked_source(
         .as_ipy_notebook()
         .map(|nb| nb.cell_offsets().as_ref())
         .unwrap_or(&[]);
-    let parser = ruff_python_parser::Parser::new_starts_at(
-        source,
-        ruff_text_size::TextSize::new(0),
-        options,
-        cell_offsets,
-    );
+    let parser =
+        ruff_python_parser::Parser::new_with_cell_offsets(source, options, cell_offsets);
 
     // SAFETY: Safe because `PySourceType` always parses to a `ModModule`. See
-    // `ruff_python_parser::parse_unchecked_source`. We use `Parser::new_starts_at` (and thus
+    // `ruff_python_parser::parse_unchecked_source`. We use `Parser::new_with_cell_offsets` (and thus
     // have to unwrap) in order to pass the `PythonVersion` via `ParseOptions`.
     parser
         .parse()

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -768,19 +768,31 @@ impl ParseSource {
 }
 
 /// Like [`ruff_python_parser::parse_unchecked_source`] but with an additional [`PythonVersion`]
-/// argument.
+/// argument and notebook cell boundary support.
 fn parse_unchecked_source(
     source_kind: &SourceKind,
     source_type: PySourceType,
     target_version: PythonVersion,
 ) -> Parsed<ModModule> {
     let options = ParseOptions::from(source_type).with_target_version(target_version);
+
+    // For notebooks, pass cell offsets so the lexer can reset indent state at cell boundaries.
+    let empty_offsets = Vec::new();
+    let cell_offsets: &[ruff_text_size::TextSize] = source_kind
+        .as_ipy_notebook()
+        .map(|nb| nb.cell_offsets().as_ref())
+        .unwrap_or(&empty_offsets);
+
     // SAFETY: Safe because `PySourceType` always parses to a `ModModule`. See
     // `ruff_python_parser::parse_unchecked_source`. We use `parse_unchecked` (and thus
     // have to unwrap) in order to pass the `PythonVersion` via `ParseOptions`.
-    ruff_python_parser::parse_unchecked(source_kind.source_code(), options)
-        .try_into_module()
-        .expect("PySourceType always parses into a module")
+    ruff_python_parser::parse_unchecked_with_cell_offsets(
+        source_kind.source_code(),
+        options,
+        cell_offsets,
+    )
+    .try_into_module()
+    .expect("PySourceType always parses into a module")
 }
 
 #[cfg(test)]

--- a/crates/ruff_python_index/src/indexer.rs
+++ b/crates/ruff_python_index/src/indexer.rs
@@ -42,6 +42,16 @@ impl Indexer {
         let mut line_start = TextSize::default();
 
         for token in tokens {
+            if token.start() < prev_end {
+                eprintln!(
+                    "OVERLAPPING TOKEN: prev_end={:?} token.start={:?} kind={:?}",
+                    prev_end,
+                    token.start(),
+                    token.kind()
+                );
+                // Show all tokens so far
+                break;
+            }
             let trivia = &source[TextRange::new(prev_end, token.start())];
 
             // Get the trivia between the previous and the current token and detect any newlines.

--- a/crates/ruff_python_index/src/indexer.rs
+++ b/crates/ruff_python_index/src/indexer.rs
@@ -42,16 +42,6 @@ impl Indexer {
         let mut line_start = TextSize::default();
 
         for token in tokens {
-            if token.start() < prev_end {
-                eprintln!(
-                    "OVERLAPPING TOKEN: prev_end={:?} token.start={:?} kind={:?}",
-                    prev_end,
-                    token.start(),
-                    token.kind()
-                );
-                // Show all tokens so far
-                break;
-            }
             let trivia = &source[TextRange::new(prev_end, token.start())];
 
             // Get the trivia between the previous and the current token and detect any newlines.

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -159,7 +159,14 @@ impl<'src> Lexer<'src> {
     /// When the lexer crosses a cell boundary and the indent stack is not at root level,
     /// it will emit `Dedent` tokens to flush the stack.
     pub(crate) fn set_cell_offsets(&mut self, cell_offsets: &'src [TextSize]) {
-        self.has_cells = !cell_offsets.is_empty();
+        // The notebook always appends a trailing offset at source.len() for the
+        // separator newline.  Trim it so we don't emit a spurious Dedent at EOF.
+        let source_end = self.source.text_len();
+        let end = cell_offsets.partition_point(|&offset| offset < source_end);
+        let cell_offsets = &cell_offsets[..end];
+
+        // Need at least two offsets for a cell boundary to exist.
+        self.has_cells = cell_offsets.len() > 1;
         self.cell_offsets = cell_offsets;
 
         if self.has_cells {
@@ -1527,6 +1534,17 @@ impl<'src> Lexer<'src> {
         }
 
         // Then flush to a logical line boundary (newline + dedents).
+        // At a cell boundary with the indent stack at root level, just advance
+        // to the next cell and re-enter lex_token.  No token is emitted — the
+        // parser sees a continuous token stream across cell boundaries.
+        if at_cell_boundary && *self.indentations.current() == Indentation::root() {
+            self.range_from_consume_end = Some(self.token_range());
+            self.advance_to_next_cell();
+            // Re-enter lex_token to lex the next cell's first token.
+            // The cursor is no longer empty, so it won't hit end-of-input.
+            return self.lex_token();
+        }
+
         let end_token = if at_cell_boundary {
             TokenKind::Dedent
         } else {
@@ -1537,7 +1555,9 @@ impl<'src> Lexer<'src> {
 
         // When all dedents are flushed at a cell boundary, advance past it.
         // Save the range BEFORE advancing since the cursor will be replaced.
-        if at_cell_boundary && token == end_token {
+        // This triggers when flush returns the expected end_token OR when it
+        // collapses a boundary Dedent to EndOfFile (stack already at root).
+        if at_cell_boundary && (token == end_token || token == TokenKind::EndOfFile) {
             self.range_from_consume_end = Some(self.token_range());
             self.advance_to_next_cell();
         }

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -79,16 +79,6 @@ pub struct Lexer<'src> {
     /// Cell offsets for Jupyter notebook sources. This tracks the byte offsets where each
     /// cell begins in the concatenated source. Empty slice for non-notebook sources.
     cell_offsets: &'src [TextSize],
-
-    /// Index into `cell_offsets` indicating the current cell the lexer is in.
-    current_cell: usize,
-
-    /// When true, the next call to `next_token()` should emit a Dedent token to flush
-    /// the indent stack at a cell boundary.
-    pending_cell_dedent: bool,
-
-    /// The byte offset of the cell boundary that triggered the pending dedent.
-    pending_cell_dedent_offset: TextSize,
 }
 
 impl<'src> Lexer<'src> {
@@ -124,9 +114,6 @@ impl<'src> Lexer<'src> {
             interpolated_strings: InterpolatedStrings::default(),
             errors: Vec::new(),
             cell_offsets: &[],
-            current_cell: 0,
-            pending_cell_dedent: false,
-            pending_cell_dedent_offset: TextSize::new(0),
         };
 
         if start_offset == TextSize::new(0) {
@@ -145,6 +132,7 @@ impl<'src> Lexer<'src> {
     /// it will emit `Dedent` tokens to flush the stack.
     pub(crate) fn set_cell_offsets(&mut self, cell_offsets: &'src [TextSize]) {
         self.cell_offsets = cell_offsets;
+        self.cursor.set_cell_offsets(cell_offsets);
     }
 
     /// Returns the kind of the current token.
@@ -181,45 +169,6 @@ impl<'src> Lexer<'src> {
 
     /// Lex the next token.
     pub fn next_token(&mut self) -> TokenKind {
-        // Handle pending cell boundary cleanup before lexing the next token.
-        // This shares logic with `consume_end()` at EOF to ensure consistent
-        // handling of nesting, interpolated strings, and indentation.
-        if self.pending_cell_dedent {
-            // Finish any unterminated interpolated-strings at the cell boundary.
-            while let Some(interpolated_string) = self.interpolated_strings.pop() {
-                self.nesting = interpolated_string.nesting();
-                self.push_error(LexicalError::new(
-                    LexicalErrorType::from_interpolated_string_error(
-                        InterpolatedStringErrorType::UnterminatedString,
-                        interpolated_string.kind(),
-                    ),
-                    self.token_range(),
-                ));
-            }
-
-            // Report errors for unclosed nesting at the cell boundary.
-            let init_nesting = u32::from(self.mode == Mode::ParenthesizedExpression);
-            if self.nesting > init_nesting {
-                self.nesting = 0;
-                self.push_error(LexicalError::new(
-                    LexicalErrorType::Eof,
-                    self.token_range(),
-                ));
-            }
-
-            // Flush to logical line start (newline + dedents).
-            let token = self.flush_to_logical_line_start(TokenKind::Dedent);
-            if token == TokenKind::Dedent {
-                self.current_kind = TokenKind::Dedent;
-                self.current_range =
-                    TextRange::empty(self.pending_cell_dedent_offset);
-                return TokenKind::Dedent;
-            }
-            // All dedents emitted, clear the flag and continue lexing normally.
-            self.pending_cell_dedent = false;
-            self.state = State::AfterNewline;
-        }
-
         self.cursor.start_token();
         self.current_value = TokenValue::None;
         self.current_flags = TokenFlags::empty();
@@ -228,10 +177,6 @@ impl<'src> Lexer<'src> {
         if !matches!(self.current_kind, TokenKind::Unknown) {
             self.current_range = self.token_range();
         }
-
-        // After lexing a token, check if we've crossed into a new notebook cell.
-        // If so, and the indent stack is not empty, schedule dedent emission.
-        self.check_cell_boundary();
 
         self.current_kind
     }
@@ -1478,6 +1423,8 @@ impl<'src> Lexer<'src> {
     }
 
     fn consume_end(&mut self) -> TokenKind {
+        let is_cell_boundary = self.cursor.is_at_cell_boundary();
+
         // First, finish any unterminated interpolated-strings.
         while let Some(interpolated_string) = self.interpolated_strings.pop() {
             self.nesting = interpolated_string.nesting();
@@ -1498,11 +1445,33 @@ impl<'src> Lexer<'src> {
         if self.nesting > init_nesting {
             // Reset the nesting to avoid going into infinite loop.
             self.nesting = 0;
+            if is_cell_boundary {
+                // At a cell boundary, report the nesting error and advance past the boundary.
+                // Remaining dedents will be flushed on subsequent next_token() calls.
+                self.cursor.next_cell();
+                return self.push_error(LexicalError::new(
+                    LexicalErrorType::Eof,
+                    self.token_range(),
+                ));
+            }
             return self.push_error(LexicalError::new(LexicalErrorType::Eof, self.token_range()));
         }
 
         // Then flush to a logical line boundary (newline + dedents).
-        self.flush_to_logical_line_start(TokenKind::EndOfFile)
+        let end_token = if is_cell_boundary {
+            TokenKind::Dedent
+        } else {
+            TokenKind::EndOfFile
+        };
+
+        let token = self.flush_to_logical_line_start(end_token);
+
+        // When all dedents are flushed at a cell boundary, advance past it.
+        if is_cell_boundary && token == end_token {
+            self.cursor.next_cell();
+        }
+
+        token
     }
 
     /// Flush the lexer state to a logical line boundary by emitting a trailing newline
@@ -1526,44 +1495,6 @@ impl<'src> Lexer<'src> {
             TokenKind::Dedent
         } else {
             end_token
-        }
-    }
-
-    /// Check if the lexer has crossed a notebook cell boundary. If so, and if the indent
-    /// stack is not empty, schedule dedent emission on the next call to `next_token()`.
-    ///
-    /// This forces the lexer to close all open indent levels at cell boundaries,
-    /// similar to what happens at EOF. The parser will then report "expected indented block"
-    /// for compound statements whose bodies span cells.
-    fn check_cell_boundary(&mut self) {
-        if self.cell_offsets.is_empty() {
-            return;
-        }
-
-        let current_offset = self.offset();
-
-        // Find which cell we're in by searching for the last cell offset <= current position.
-        // cell_offsets contains the start offsets of each cell, so we need to find the
-        // highest index i where cell_offsets[i] <= current_offset.
-        let new_cell = self
-            .cell_offsets
-            .partition_point(|&offset| offset <= current_offset)
-            .saturating_sub(1);
-
-        // Clamp to valid range (should already be, but safety check)
-        let new_cell = new_cell.min(self.cell_offsets.len().saturating_sub(1));
-
-        if new_cell > self.current_cell {
-            self.current_cell = new_cell;
-
-            // Only emit dedents if the indent stack is not at root level
-            if self.indentations.current() != &Indentation::root() {
-                self.pending_cell_dedent = true;
-                // Use the start of the new cell as the dedent token's position
-                if let Some(&cell_start) = self.cell_offsets.get(new_cell) {
-                    self.pending_cell_dedent_offset = cell_start;
-                }
-            }
         }
     }
 
@@ -1812,9 +1743,7 @@ impl<'src> Lexer<'src> {
             pending_indentation: self.pending_indentation,
             interpolated_strings_checkpoint: self.interpolated_strings.checkpoint(),
             errors_position: self.errors.len(),
-            current_cell: self.current_cell,
-            pending_cell_dedent: self.pending_cell_dedent,
-            pending_cell_dedent_offset: self.pending_cell_dedent_offset,
+            current_cell: self.cursor.current_cell(),
         }
     }
 
@@ -1833,13 +1762,14 @@ impl<'src> Lexer<'src> {
             interpolated_strings_checkpoint,
             errors_position,
             current_cell,
-            pending_cell_dedent,
-            pending_cell_dedent_offset,
         } = checkpoint;
 
         let mut cursor = Cursor::new(self.source);
         // We preserve the previous char using this method.
         cursor.skip_bytes(cursor_offset.to_usize());
+        // Restore cell-awareness on the reconstructed cursor.
+        cursor.set_cell_offsets(self.cell_offsets);
+        cursor.set_current_cell(current_cell);
 
         self.current_value = value;
         self.current_kind = current_kind;
@@ -1853,9 +1783,6 @@ impl<'src> Lexer<'src> {
         self.interpolated_strings
             .rewind(interpolated_strings_checkpoint);
         self.errors.truncate(errors_position);
-        self.current_cell = current_cell;
-        self.pending_cell_dedent = pending_cell_dedent;
-        self.pending_cell_dedent_offset = pending_cell_dedent_offset;
     }
 
     pub fn finish(self) -> Vec<LexicalError> {
@@ -1876,8 +1803,6 @@ pub(crate) struct LexerCheckpoint {
     interpolated_strings_checkpoint: InterpolatedStringsCheckpoint,
     errors_position: usize,
     current_cell: usize,
-    pending_cell_dedent: bool,
-    pending_cell_dedent_offset: TextSize,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -234,13 +234,6 @@ impl<'src> Lexer<'src> {
             self.current_range = self.token_range();
         }
 
-        if !self.current_kind.is_trivia() || self.current_kind.is_eof() {
-            eprintln!(
-                "TOKEN: kind={:?} range={:?} has_cells={} cell_start={:?}",
-                self.current_kind, self.current_range, self.has_cells, self.cell_start_offset
-            );
-        }
-
         self.current_kind
     }
 

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1526,6 +1526,26 @@ impl<'src> Lexer<'src> {
             return self.push_error(LexicalError::new(LexicalErrorType::Eof, self.token_range()));
         }
 
+        // At a cell boundary with open indent levels, clear the stack silently and
+        // advance to the next cell. Do NOT emit Dedent tokens — they would tell the
+        // parser the block is properly closed when it isn't. The parser should see
+        // the compound statement as having no body (it will recover when it encounters
+        // the next token from the new cell).
+        if at_cell_boundary && *self.indentations.current() != Indentation::root() {
+            while self.indentations.dedent().is_some() {
+                // Silently discard all dedents.
+            }
+            // Also discard the pending newline if we haven't flushed it yet.
+            if self.state.is_after_newline() {
+                // Already at a logical line start, no newline to discard.
+            } else {
+                self.state = State::AfterNewline;
+            }
+            self.range_from_consume_end = Some(self.token_range());
+            self.advance_to_next_cell();
+            return self.lex_token();
+        }
+
         let end_token = if at_cell_boundary {
             TokenKind::Dedent
         } else {

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1786,7 +1786,6 @@ impl<'src> Lexer<'src> {
             pending_indentation: self.pending_indentation,
             interpolated_strings_checkpoint: self.interpolated_strings.checkpoint(),
             errors_position: self.errors.len(),
-            current_cell: self.current_cell,
         }
     }
 
@@ -1804,7 +1803,6 @@ impl<'src> Lexer<'src> {
             pending_indentation,
             interpolated_strings_checkpoint,
             errors_position,
-            current_cell: _,
         } = checkpoint;
 
         if self.has_cells {

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1760,8 +1760,6 @@ impl<'src> Lexer<'src> {
     }
 
     /// Retrieves the current offset of the cursor within the source code.
-    // SAFETY: Lexer doesn't allow files larger than 4GB
-    #[expect(clippy::cast_possible_truncation)]
     #[inline]
     fn offset(&self) -> TextSize {
         self.cell_start_offset + self.cell_text_len - self.cursor.text_len()

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1526,19 +1526,6 @@ impl<'src> Lexer<'src> {
             return self.push_error(LexicalError::new(LexicalErrorType::Eof, self.token_range()));
         }
 
-        // Then flush to a logical line boundary (newline + dedents).
-        // At a cell boundary with the indent stack at root level, just advance
-        // to the next cell and re-enter lex_token.  No token is emitted — the
-        // parser sees a continuous token stream across cell boundaries.
-        // Note: do NOT set range_from_consume_end here — the next cell's
-        // consume_end would pick it up and corrupt the EndOfFile token range.
-        if at_cell_boundary && *self.indentations.current() == Indentation::root() {
-            self.advance_to_next_cell();
-            // Re-enter lex_token to lex the next cell's first token.
-            // The cursor is no longer empty, so it won't hit end-of-input.
-            return self.lex_token();
-        }
-
         let end_token = if at_cell_boundary {
             TokenKind::Dedent
         } else {
@@ -1552,6 +1539,13 @@ impl<'src> Lexer<'src> {
         // This triggers when flush returns the expected end_token OR when it
         // collapses a boundary Dedent to EndOfFile (stack already at root).
         if at_cell_boundary && (token == end_token || token == TokenKind::EndOfFile) {
+            // At root level, the flush returned a spurious Dedent (no actual
+            // dedent happened).  Skip it — re-enter lex_token for the next
+            // cell instead of emitting a Dedent the parser can't handle.
+            if token == TokenKind::Dedent && *self.indentations.current() == Indentation::root() {
+                self.advance_to_next_cell();
+                return self.lex_token();
+            }
             self.range_from_consume_end = Some(self.token_range());
             self.advance_to_next_cell();
         }

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1449,10 +1449,8 @@ impl<'src> Lexer<'src> {
                 // At a cell boundary, report the nesting error and advance past the boundary.
                 // Remaining dedents will be flushed on subsequent next_token() calls.
                 self.cursor.next_cell();
-                return self.push_error(LexicalError::new(
-                    LexicalErrorType::Eof,
-                    self.token_range(),
-                ));
+                return self
+                    .push_error(LexicalError::new(LexicalErrorType::Eof, self.token_range()));
             }
             return self.push_error(LexicalError::new(LexicalErrorType::Eof, self.token_range()));
         }

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -86,6 +86,10 @@ pub struct Lexer<'src> {
     /// The absolute byte offset where the current cell starts in the full source.
     cell_start_offset: TextSize,
 
+    /// Precomputed `cell_start_offset + cell_text_len`. Used by `offset()` to avoid
+    /// an extra addition per token compared to the original `source.len()` - `cursor.text_len()`.
+    cell_end_offset: TextSize,
+
     /// Whether cell offsets are set (non-empty). Used to skip cell logic for regular files.
     has_cells: bool,
 
@@ -134,6 +138,7 @@ impl<'src> Lexer<'src> {
             cell_offsets: &[],
             current_cell: 0,
             cell_start_offset: TextSize::new(0),
+            cell_end_offset: source.text_len(),
             has_cells: false,
             cell_text_len: source.text_len(),
             range_from_consume_end: None,
@@ -165,6 +170,7 @@ impl<'src> Lexer<'src> {
                 .unwrap_or_else(|| self.source.text_len());
             let first_cell_text = &self.source[..first_cell_end.to_usize()];
             self.cell_text_len = first_cell_text.text_len();
+            self.cell_end_offset = self.cell_text_len;
             self.cursor = Cursor::new(first_cell_text);
             self.current_cell = 0;
             self.cell_start_offset = TextSize::new(0);
@@ -183,6 +189,7 @@ impl<'src> Lexer<'src> {
         let cell_text = &self.source[cell_start.to_usize()..cell_end.to_usize()];
         self.cell_start_offset = cell_start;
         self.cell_text_len = cell_text.text_len();
+        self.cell_end_offset = cell_start + self.cell_text_len;
         self.cursor = Cursor::new(cell_text);
     }
 
@@ -1776,7 +1783,7 @@ impl<'src> Lexer<'src> {
     /// Retrieves the current offset of the cursor within the source code.
     #[inline]
     fn offset(&self) -> TextSize {
-        self.cell_start_offset + self.cell_text_len - self.cursor.text_len()
+        self.cell_end_offset - self.cursor.text_len()
     }
 
     #[inline]
@@ -1842,11 +1849,13 @@ impl<'src> Lexer<'src> {
             self.current_cell = cell_idx;
             self.cell_start_offset = cell_start;
             self.cell_text_len = cell_text.text_len();
+            self.cell_end_offset = cell_start + self.cell_text_len;
             self.cursor = cursor;
         } else {
             let mut cursor = Cursor::new(self.source);
             cursor.skip_bytes(cursor_offset.to_usize());
             self.cursor = cursor;
+            self.cell_end_offset = self.source.text_len();
         }
 
         self.current_value = value;

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -97,12 +97,7 @@ impl<'src> Lexer<'src> {
     /// If the start offset is greater than 0, the cursor is moved ahead that many bytes.
     /// This means that the input source should be the complete source code and not the
     /// sliced version.
-    pub(crate) fn new(
-        source: &'src str,
-        mode: Mode,
-        start_offset: TextSize,
-        cell_offsets: &'src [TextSize],
-    ) -> Self {
+    pub(crate) fn new(source: &'src str, mode: Mode, start_offset: TextSize) -> Self {
         assert!(
             u32::try_from(source.len()).is_ok(),
             "Lexer only supports files with a size up to 4GB"
@@ -128,7 +123,7 @@ impl<'src> Lexer<'src> {
             mode,
             interpolated_strings: InterpolatedStrings::default(),
             errors: Vec::new(),
-            cell_offsets,
+            cell_offsets: &[],
             current_cell: 0,
             pending_cell_dedent: false,
             pending_cell_dedent_offset: TextSize::new(0),
@@ -142,6 +137,14 @@ impl<'src> Lexer<'src> {
         }
 
         lexer
+    }
+
+    /// Set cell offsets for notebook cell boundary awareness.
+    ///
+    /// When the lexer crosses a cell boundary and the indent stack is not at root level,
+    /// it will emit `Dedent` tokens to flush the stack.
+    pub(crate) fn set_cell_offsets(&mut self, cell_offsets: &'src [TextSize]) {
+        self.cell_offsets = cell_offsets;
     }
 
     /// Returns the kind of the current token.
@@ -178,17 +181,41 @@ impl<'src> Lexer<'src> {
 
     /// Lex the next token.
     pub fn next_token(&mut self) -> TokenKind {
-        // Handle pending cell boundary dedent before lexing the next token.
-        // This flushes the indent stack at cell boundaries, similar to what
-        // `consume_end()` does at EOF.
+        // Handle pending cell boundary cleanup before lexing the next token.
+        // This shares logic with `consume_end()` at EOF to ensure consistent
+        // handling of nesting, interpolated strings, and indentation.
         if self.pending_cell_dedent {
-            if let Some(_indent) = self.indentations.dedent() {
+            // Finish any unterminated interpolated-strings at the cell boundary.
+            while let Some(interpolated_string) = self.interpolated_strings.pop() {
+                self.nesting = interpolated_string.nesting();
+                self.push_error(LexicalError::new(
+                    LexicalErrorType::from_interpolated_string_error(
+                        InterpolatedStringErrorType::UnterminatedString,
+                        interpolated_string.kind(),
+                    ),
+                    self.token_range(),
+                ));
+            }
+
+            // Report errors for unclosed nesting at the cell boundary.
+            let init_nesting = u32::from(self.mode == Mode::ParenthesizedExpression);
+            if self.nesting > init_nesting {
+                self.nesting = 0;
+                self.push_error(LexicalError::new(
+                    LexicalErrorType::Eof,
+                    self.token_range(),
+                ));
+            }
+
+            // Flush to logical line start (newline + dedents).
+            let token = self.flush_to_logical_line_start(TokenKind::Dedent);
+            if token == TokenKind::Dedent {
                 self.current_kind = TokenKind::Dedent;
                 self.current_range =
                     TextRange::empty(self.pending_cell_dedent_offset);
                 return TokenKind::Dedent;
             }
-            // Stack is empty, clear the flag and continue lexing normally.
+            // All dedents emitted, clear the flag and continue lexing normally.
             self.pending_cell_dedent = false;
             self.state = State::AfterNewline;
         }
@@ -1451,8 +1478,6 @@ impl<'src> Lexer<'src> {
     }
 
     fn consume_end(&mut self) -> TokenKind {
-        // We reached end of file.
-
         // First, finish any unterminated interpolated-strings.
         while let Some(interpolated_string) = self.interpolated_strings.pop() {
             self.nesting = interpolated_string.nesting();
@@ -1476,16 +1501,31 @@ impl<'src> Lexer<'src> {
             return self.push_error(LexicalError::new(LexicalErrorType::Eof, self.token_range()));
         }
 
-        // Next, insert a trailing newline, if required.
+        // Then flush to a logical line boundary (newline + dedents).
+        self.flush_to_logical_line_start(TokenKind::EndOfFile)
+    }
+
+    /// Flush the lexer state to a logical line boundary by emitting a trailing newline
+    /// (if needed) and then dedenting the indent stack to zero.
+    ///
+    /// This is shared between EOF handling (`consume_end`) and notebook cell boundary
+    /// handling to ensure consistent cleanup of nesting, interpolated strings, and
+    /// indentation state.
+    ///
+    /// `end_token` is returned when the indent stack is fully flushed (typically
+    /// `TokenKind::EndOfFile` at EOF or `TokenKind::Dedent` at cell boundaries where
+    /// the caller will continue lexing).
+    fn flush_to_logical_line_start(&mut self, end_token: TokenKind) -> TokenKind {
+        // Insert a trailing newline, if required.
         if !self.state.is_new_logical_line() {
             self.state = State::AfterNewline;
             TokenKind::Newline
         }
-        // Next, flush the indentation stack to zero.
+        // Flush the indentation stack to zero.
         else if self.indentations.dedent().is_some() {
             TokenKind::Dedent
         } else {
-            TokenKind::EndOfFile
+            end_token
         }
     }
 
@@ -1985,7 +2025,7 @@ impl<'a> LexedText<'a> {
 
 /// Create a new [`Lexer`] for the given source code and [`Mode`].
 pub fn lex(source: &str, mode: Mode) -> Lexer<'_> {
-    Lexer::new(source, mode, TextSize::default(), &[])
+    Lexer::new(source, mode, TextSize::default())
 }
 
 #[cfg(test)]
@@ -2043,7 +2083,7 @@ mod tests {
     }
 
     fn lex(source: &str, mode: Mode, start_offset: TextSize) -> LexerOutput {
-        let mut lexer = Lexer::new(source, mode, start_offset, &[]);
+        let mut lexer = Lexer::new(source, mode, start_offset);
         let mut tokens = Vec::new();
         loop {
             let kind = lexer.next_token();

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -79,6 +79,19 @@ pub struct Lexer<'src> {
     /// Cell offsets for Jupyter notebook sources. This tracks the byte offsets where each
     /// cell begins in the concatenated source. Empty slice for non-notebook sources.
     cell_offsets: &'src [TextSize],
+
+    /// The index of the current cell being lexed.
+    current_cell: usize,
+
+    /// The absolute byte offset where the current cell starts in the full source.
+    cell_start_offset: TextSize,
+
+    /// Whether cell offsets are set (non-empty). Used to skip cell logic for regular files.
+    has_cells: bool,
+
+    /// The text length of the current cell. Used to compute absolute cursor offset
+    /// since `cursor.source_length` is modified by `start_token()`.
+    cell_text_len: TextSize,
 }
 
 impl<'src> Lexer<'src> {
@@ -114,6 +127,10 @@ impl<'src> Lexer<'src> {
             interpolated_strings: InterpolatedStrings::default(),
             errors: Vec::new(),
             cell_offsets: &[],
+            current_cell: 0,
+            cell_start_offset: TextSize::new(0),
+            has_cells: false,
+            cell_text_len: source.text_len(),
         };
 
         if start_offset == TextSize::new(0) {
@@ -131,8 +148,36 @@ impl<'src> Lexer<'src> {
     /// When the lexer crosses a cell boundary and the indent stack is not at root level,
     /// it will emit `Dedent` tokens to flush the stack.
     pub(crate) fn set_cell_offsets(&mut self, cell_offsets: &'src [TextSize]) {
+        self.has_cells = !cell_offsets.is_empty();
         self.cell_offsets = cell_offsets;
-        self.cursor.set_cell_offsets(cell_offsets);
+
+        if self.has_cells {
+            // Create a cursor for the first cell.
+            let first_cell_end = cell_offsets
+                .get(1)
+                .copied()
+                .unwrap_or_else(|| self.source.text_len());
+            let first_cell_text = &self.source[..first_cell_end.to_usize()];
+            self.cell_text_len = first_cell_text.text_len();
+            self.cursor = Cursor::new(first_cell_text);
+            self.current_cell = 0;
+            self.cell_start_offset = TextSize::new(0);
+        }
+    }
+
+    /// Advance to the next notebook cell by creating a new cursor for it.
+    fn advance_to_next_cell(&mut self) {
+        self.current_cell += 1;
+        let cell_start = self.cell_offsets[self.current_cell];
+        let cell_end = self
+            .cell_offsets
+            .get(self.current_cell + 1)
+            .copied()
+            .unwrap_or_else(|| self.source.text_len());
+        let cell_text = &self.source[cell_start.to_usize()..cell_end.to_usize()];
+        self.cell_start_offset = cell_start;
+        self.cell_text_len = cell_text.text_len();
+        self.cursor = Cursor::new(cell_text);
     }
 
     /// Returns the kind of the current token.
@@ -1423,7 +1468,7 @@ impl<'src> Lexer<'src> {
     }
 
     fn consume_end(&mut self) -> TokenKind {
-        let is_cell_boundary = self.cursor.is_at_cell_boundary();
+        let at_cell_boundary = self.has_cells && self.current_cell + 1 < self.cell_offsets.len();
 
         // First, finish any unterminated interpolated-strings.
         while let Some(interpolated_string) = self.interpolated_strings.pop() {
@@ -1445,10 +1490,10 @@ impl<'src> Lexer<'src> {
         if self.nesting > init_nesting {
             // Reset the nesting to avoid going into infinite loop.
             self.nesting = 0;
-            if is_cell_boundary {
+            if at_cell_boundary {
                 // At a cell boundary, report the nesting error and advance past the boundary.
                 // Remaining dedents will be flushed on subsequent next_token() calls.
-                self.cursor.next_cell();
+                self.advance_to_next_cell();
                 return self
                     .push_error(LexicalError::new(LexicalErrorType::Eof, self.token_range()));
             }
@@ -1456,7 +1501,7 @@ impl<'src> Lexer<'src> {
         }
 
         // Then flush to a logical line boundary (newline + dedents).
-        let end_token = if is_cell_boundary {
+        let end_token = if at_cell_boundary {
             TokenKind::Dedent
         } else {
             TokenKind::EndOfFile
@@ -1465,8 +1510,8 @@ impl<'src> Lexer<'src> {
         let token = self.flush_to_logical_line_start(end_token);
 
         // When all dedents are flushed at a cell boundary, advance past it.
-        if is_cell_boundary && token == end_token {
-            self.cursor.next_cell();
+        if at_cell_boundary && token == end_token {
+            self.advance_to_next_cell();
         }
 
         token
@@ -1719,7 +1764,7 @@ impl<'src> Lexer<'src> {
     #[expect(clippy::cast_possible_truncation)]
     #[inline]
     fn offset(&self) -> TextSize {
-        TextSize::new(self.source.len() as u32) - self.cursor.text_len()
+        self.cell_start_offset + self.cell_text_len - self.cursor.text_len()
     }
 
     #[inline]
@@ -1741,7 +1786,7 @@ impl<'src> Lexer<'src> {
             pending_indentation: self.pending_indentation,
             interpolated_strings_checkpoint: self.interpolated_strings.checkpoint(),
             errors_position: self.errors.len(),
-            current_cell: self.cursor.current_cell(),
+            current_cell: self.current_cell,
         }
     }
 
@@ -1759,21 +1804,45 @@ impl<'src> Lexer<'src> {
             pending_indentation,
             interpolated_strings_checkpoint,
             errors_position,
-            current_cell,
+            current_cell: _,
         } = checkpoint;
 
-        let mut cursor = Cursor::new(self.source);
-        // We preserve the previous char using this method.
-        cursor.skip_bytes(cursor_offset.to_usize());
-        // Restore cell-awareness on the reconstructed cursor.
-        cursor.set_cell_offsets(self.cell_offsets);
-        cursor.set_current_cell(current_cell);
+        if self.has_cells {
+            // Use bisection to find the cell containing the target offset.
+            // cell_offsets[current_cell] <= cursor_offset
+            let cell_idx = self
+                .cell_offsets
+                .partition_point(|&offset| offset <= cursor_offset)
+                .saturating_sub(1);
+
+            let cell_start = self.cell_offsets[cell_idx];
+            let cell_end = self
+                .cell_offsets
+                .get(cell_idx + 1)
+                .copied()
+                .unwrap_or_else(|| self.source.text_len());
+            let cell_text = &self.source[cell_start.to_usize()..cell_end.to_usize()];
+
+            let mut cursor = Cursor::new(cell_text);
+            let relative_offset = (cursor_offset - cell_start).to_usize();
+            if relative_offset > 0 {
+                cursor.skip_bytes(relative_offset);
+            }
+
+            self.current_cell = cell_idx;
+            self.cell_start_offset = cell_start;
+            self.cell_text_len = cell_text.text_len();
+            self.cursor = cursor;
+        } else {
+            let mut cursor = Cursor::new(self.source);
+            cursor.skip_bytes(cursor_offset.to_usize());
+            self.cursor = cursor;
+        }
 
         self.current_value = value;
         self.current_kind = current_kind;
         self.current_range = current_range;
         self.current_flags = current_flags;
-        self.cursor = cursor;
         self.state = state;
         self.nesting = nesting;
         self.indentations.rewind(indentations_checkpoint);
@@ -1800,7 +1869,6 @@ pub(crate) struct LexerCheckpoint {
     pending_indentation: Option<Indentation>,
     interpolated_strings_checkpoint: InterpolatedStringsCheckpoint,
     errors_position: usize,
-    current_cell: usize,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -75,6 +75,20 @@ pub struct Lexer<'src> {
 
     /// Errors encountered while lexing.
     errors: Vec<LexicalError>,
+
+    /// Cell offsets for Jupyter notebook sources. This tracks the byte offsets where each
+    /// cell begins in the concatenated source. Empty slice for non-notebook sources.
+    cell_offsets: &'src [TextSize],
+
+    /// Index into `cell_offsets` indicating the current cell the lexer is in.
+    current_cell: usize,
+
+    /// When true, the next call to `next_token()` should emit a Dedent token to flush
+    /// the indent stack at a cell boundary.
+    pending_cell_dedent: bool,
+
+    /// The byte offset of the cell boundary that triggered the pending dedent.
+    pending_cell_dedent_offset: TextSize,
 }
 
 impl<'src> Lexer<'src> {
@@ -83,7 +97,12 @@ impl<'src> Lexer<'src> {
     /// If the start offset is greater than 0, the cursor is moved ahead that many bytes.
     /// This means that the input source should be the complete source code and not the
     /// sliced version.
-    pub(crate) fn new(source: &'src str, mode: Mode, start_offset: TextSize) -> Self {
+    pub(crate) fn new(
+        source: &'src str,
+        mode: Mode,
+        start_offset: TextSize,
+        cell_offsets: &'src [TextSize],
+    ) -> Self {
         assert!(
             u32::try_from(source.len()).is_ok(),
             "Lexer only supports files with a size up to 4GB"
@@ -109,6 +128,10 @@ impl<'src> Lexer<'src> {
             mode,
             interpolated_strings: InterpolatedStrings::default(),
             errors: Vec::new(),
+            cell_offsets,
+            current_cell: 0,
+            pending_cell_dedent: false,
+            pending_cell_dedent_offset: TextSize::new(0),
         };
 
         if start_offset == TextSize::new(0) {
@@ -155,6 +178,21 @@ impl<'src> Lexer<'src> {
 
     /// Lex the next token.
     pub fn next_token(&mut self) -> TokenKind {
+        // Handle pending cell boundary dedent before lexing the next token.
+        // This flushes the indent stack at cell boundaries, similar to what
+        // `consume_end()` does at EOF.
+        if self.pending_cell_dedent {
+            if let Some(_indent) = self.indentations.dedent() {
+                self.current_kind = TokenKind::Dedent;
+                self.current_range =
+                    TextRange::empty(self.pending_cell_dedent_offset);
+                return TokenKind::Dedent;
+            }
+            // Stack is empty, clear the flag and continue lexing normally.
+            self.pending_cell_dedent = false;
+            self.state = State::AfterNewline;
+        }
+
         self.cursor.start_token();
         self.current_value = TokenValue::None;
         self.current_flags = TokenFlags::empty();
@@ -163,6 +201,11 @@ impl<'src> Lexer<'src> {
         if !matches!(self.current_kind, TokenKind::Unknown) {
             self.current_range = self.token_range();
         }
+
+        // After lexing a token, check if we've crossed into a new notebook cell.
+        // If so, and the indent stack is not empty, schedule dedent emission.
+        self.check_cell_boundary();
+
         self.current_kind
     }
 
@@ -1446,6 +1489,44 @@ impl<'src> Lexer<'src> {
         }
     }
 
+    /// Check if the lexer has crossed a notebook cell boundary. If so, and if the indent
+    /// stack is not empty, schedule dedent emission on the next call to `next_token()`.
+    ///
+    /// This forces the lexer to close all open indent levels at cell boundaries,
+    /// similar to what happens at EOF. The parser will then report "expected indented block"
+    /// for compound statements whose bodies span cells.
+    fn check_cell_boundary(&mut self) {
+        if self.cell_offsets.is_empty() {
+            return;
+        }
+
+        let current_offset = self.offset();
+
+        // Find which cell we're in by searching for the last cell offset <= current position.
+        // cell_offsets contains the start offsets of each cell, so we need to find the
+        // highest index i where cell_offsets[i] <= current_offset.
+        let new_cell = self
+            .cell_offsets
+            .partition_point(|&offset| offset <= current_offset)
+            .saturating_sub(1);
+
+        // Clamp to valid range (should already be, but safety check)
+        let new_cell = new_cell.min(self.cell_offsets.len().saturating_sub(1));
+
+        if new_cell > self.current_cell {
+            self.current_cell = new_cell;
+
+            // Only emit dedents if the indent stack is not at root level
+            if self.indentations.current() != &Indentation::root() {
+                self.pending_cell_dedent = true;
+                // Use the start of the new cell as the dedent token's position
+                if let Some(&cell_start) = self.cell_offsets.get(new_cell) {
+                    self.pending_cell_dedent_offset = cell_start;
+                }
+            }
+        }
+    }
+
     /// Re-lex the [`NonLogicalNewline`] token at the given position in the context of a logical
     /// line.
     ///
@@ -1691,6 +1772,9 @@ impl<'src> Lexer<'src> {
             pending_indentation: self.pending_indentation,
             interpolated_strings_checkpoint: self.interpolated_strings.checkpoint(),
             errors_position: self.errors.len(),
+            current_cell: self.current_cell,
+            pending_cell_dedent: self.pending_cell_dedent,
+            pending_cell_dedent_offset: self.pending_cell_dedent_offset,
         }
     }
 
@@ -1708,6 +1792,9 @@ impl<'src> Lexer<'src> {
             pending_indentation,
             interpolated_strings_checkpoint,
             errors_position,
+            current_cell,
+            pending_cell_dedent,
+            pending_cell_dedent_offset,
         } = checkpoint;
 
         let mut cursor = Cursor::new(self.source);
@@ -1726,6 +1813,9 @@ impl<'src> Lexer<'src> {
         self.interpolated_strings
             .rewind(interpolated_strings_checkpoint);
         self.errors.truncate(errors_position);
+        self.current_cell = current_cell;
+        self.pending_cell_dedent = pending_cell_dedent;
+        self.pending_cell_dedent_offset = pending_cell_dedent_offset;
     }
 
     pub fn finish(self) -> Vec<LexicalError> {
@@ -1745,6 +1835,9 @@ pub(crate) struct LexerCheckpoint {
     pending_indentation: Option<Indentation>,
     interpolated_strings_checkpoint: InterpolatedStringsCheckpoint,
     errors_position: usize,
+    current_cell: usize,
+    pending_cell_dedent: bool,
+    pending_cell_dedent_offset: TextSize,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -1892,7 +1985,7 @@ impl<'a> LexedText<'a> {
 
 /// Create a new [`Lexer`] for the given source code and [`Mode`].
 pub fn lex(source: &str, mode: Mode) -> Lexer<'_> {
-    Lexer::new(source, mode, TextSize::default())
+    Lexer::new(source, mode, TextSize::default(), &[])
 }
 
 #[cfg(test)]
@@ -1950,7 +2043,7 @@ mod tests {
     }
 
     fn lex(source: &str, mode: Mode, start_offset: TextSize) -> LexerOutput {
-        let mut lexer = Lexer::new(source, mode, start_offset);
+        let mut lexer = Lexer::new(source, mode, start_offset, &[]);
         let mut tokens = Vec::new();
         loop {
             let kind = lexer.next_token();

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -159,12 +159,6 @@ impl<'src> Lexer<'src> {
     /// When the lexer crosses a cell boundary and the indent stack is not at root level,
     /// it will emit `Dedent` tokens to flush the stack.
     pub(crate) fn set_cell_offsets(&mut self, cell_offsets: &'src [TextSize]) {
-        // The notebook always appends a trailing offset at source.len() for the
-        // separator newline.  Trim it so we don't emit a spurious Dedent at EOF.
-        let source_end = self.source.text_len();
-        let end = cell_offsets.partition_point(|&offset| offset < source_end);
-        let cell_offsets = &cell_offsets[..end];
-
         self.has_cells = !cell_offsets.is_empty();
         self.cell_offsets = cell_offsets;
 
@@ -1536,8 +1530,9 @@ impl<'src> Lexer<'src> {
         // At a cell boundary with the indent stack at root level, just advance
         // to the next cell and re-enter lex_token.  No token is emitted — the
         // parser sees a continuous token stream across cell boundaries.
+        // Note: do NOT set range_from_consume_end here — the next cell's
+        // consume_end would pick it up and corrupt the EndOfFile token range.
         if at_cell_boundary && *self.indentations.current() == Indentation::root() {
-            self.range_from_consume_end = Some(self.token_range());
             self.advance_to_next_cell();
             // Re-enter lex_token to lex the next cell's first token.
             // The cursor is no longer empty, so it won't hit end-of-input.

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -92,6 +92,11 @@ pub struct Lexer<'src> {
     /// The text length of the current cell. Used to compute absolute cursor offset
     /// since `cursor.source_length` is modified by `start_token()`.
     cell_text_len: TextSize,
+
+    /// When set, `next_token()` uses this range instead of computing it from the cursor.
+    /// Used when `consume_end()` advances to a new cell, since `token_range()` would then
+    /// use the new cell's cursor coordinates.
+    range_from_consume_end: Option<TextRange>,
 }
 
 impl<'src> Lexer<'src> {
@@ -131,6 +136,7 @@ impl<'src> Lexer<'src> {
             cell_start_offset: TextSize::new(0),
             has_cells: false,
             cell_text_len: source.text_len(),
+            range_from_consume_end: None,
         };
 
         if start_offset == TextSize::new(0) {
@@ -219,8 +225,20 @@ impl<'src> Lexer<'src> {
         self.current_flags = TokenFlags::empty();
         self.current_kind = self.lex_token();
         // For `Unknown` token, the `push_error` method updates the current range.
-        if !matches!(self.current_kind, TokenKind::Unknown) {
+        // Clear range_from_consume_end since it's not for this token.
+        if matches!(self.current_kind, TokenKind::Unknown) {
+            self.range_from_consume_end = None;
+        } else if let Some(range) = self.range_from_consume_end.take() {
+            self.current_range = range;
+        } else {
             self.current_range = self.token_range();
+        }
+
+        if !self.current_kind.is_trivia() || self.current_kind.is_eof() {
+            eprintln!(
+                "TOKEN: kind={:?} range={:?} has_cells={} cell_start={:?}",
+                self.current_kind, self.current_range, self.has_cells, self.cell_start_offset
+            );
         }
 
         self.current_kind
@@ -1492,7 +1510,8 @@ impl<'src> Lexer<'src> {
             self.nesting = 0;
             if at_cell_boundary {
                 // At a cell boundary, report the nesting error and advance past the boundary.
-                // Remaining dedents will be flushed on subsequent next_token() calls.
+                // Save the range BEFORE advancing since the cursor will be replaced.
+                self.range_from_consume_end = Some(self.token_range());
                 self.advance_to_next_cell();
                 return self
                     .push_error(LexicalError::new(LexicalErrorType::Eof, self.token_range()));
@@ -1510,7 +1529,9 @@ impl<'src> Lexer<'src> {
         let token = self.flush_to_logical_line_start(end_token);
 
         // When all dedents are flushed at a cell boundary, advance past it.
+        // Save the range BEFORE advancing since the cursor will be replaced.
         if at_cell_boundary && token == end_token {
+            self.range_from_consume_end = Some(self.token_range());
             self.advance_to_next_cell();
         }
 
@@ -3005,6 +3026,52 @@ t"{(lambda x:{x})}"
     case bar:
         pass";
         assert_snapshot!(lex_jupyter_source(source));
+    }
+
+    #[test]
+    fn test_notebook_single_cell_token_ranges() {
+        use ruff_text_size::TextSize;
+        let source = "import random\n";
+        let cell_offsets = [TextSize::new(0)];
+        let mut lexer = Lexer::new(source, Mode::Ipython, TextSize::default());
+        lexer.set_cell_offsets(&cell_offsets);
+        loop {
+            let kind = lexer.next_token();
+            if kind.is_eof() {
+                break;
+            }
+            let range = lexer.current_range();
+            assert!(
+                range.start() <= range.end(),
+                "Token {:?} has invalid range: start={:?} > end={:?}",
+                kind,
+                range.start(),
+                range.end()
+            );
+        }
+    }
+
+    #[test]
+    fn test_notebook_multi_cell_token_ranges() {
+        use ruff_text_size::TextSize;
+        let source = "import random\nx = 1\n";
+        let cell_offsets = [TextSize::new(0), TextSize::new(14)];
+        let mut lexer = Lexer::new(source, Mode::Ipython, TextSize::default());
+        lexer.set_cell_offsets(&cell_offsets);
+        loop {
+            let kind = lexer.next_token();
+            if kind.is_eof() {
+                break;
+            }
+            let range = lexer.current_range();
+            assert!(
+                range.start() <= range.end(),
+                "Token {:?} has invalid range: start={:?} > end={:?}",
+                kind,
+                range.start(),
+                range.end()
+            );
+        }
     }
 
     fn lex_fstring_error(source: &str) -> InterpolatedStringErrorType {

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -165,8 +165,7 @@ impl<'src> Lexer<'src> {
         let end = cell_offsets.partition_point(|&offset| offset < source_end);
         let cell_offsets = &cell_offsets[..end];
 
-        // Need at least two offsets for a cell boundary to exist.
-        self.has_cells = cell_offsets.len() > 1;
+        self.has_cells = !cell_offsets.is_empty();
         self.cell_offsets = cell_offsets;
 
         if self.has_cells {

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -178,6 +178,8 @@ impl<'src> Lexer<'src> {
     }
 
     /// Advance to the next notebook cell by creating a new cursor for it.
+    #[cold]
+    #[inline(never)]
     fn advance_to_next_cell(&mut self) {
         self.current_cell += 1;
         let cell_start = self.cell_offsets[self.current_cell];
@@ -1488,6 +1490,8 @@ impl<'src> Lexer<'src> {
         }
     }
 
+    #[cold]
+    #[inline(never)]
     fn consume_end(&mut self) -> TokenKind {
         let at_cell_boundary = self.has_cells && self.current_cell + 1 < self.cell_offsets.len();
 

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -232,13 +232,16 @@ impl<'src> Lexer<'src> {
         self.current_flags = TokenFlags::empty();
         self.current_kind = self.lex_token();
         // For `Unknown` token, the `push_error` method updates the current range.
-        // Clear range_from_consume_end since it's not for this token.
-        if matches!(self.current_kind, TokenKind::Unknown) {
-            self.range_from_consume_end = None;
-        } else if let Some(range) = self.range_from_consume_end.take() {
-            self.current_range = range;
-        } else {
+        if !matches!(self.current_kind, TokenKind::Unknown) {
             self.current_range = self.token_range();
+        }
+        // Cell-boundary fixup: if consume_end() advanced to a new cell, the cursor
+        // range would be wrong. Only check on EOF/Dedent (the only kinds that can
+        // appear at cell boundaries) to avoid overhead on every token.
+        if self.current_kind.is_eof() || self.current_kind == TokenKind::Dedent {
+            if let Some(range) = self.range_from_consume_end.take() {
+                self.current_range = range;
+            }
         }
 
         self.current_kind

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -3021,52 +3021,6 @@ t"{(lambda x:{x})}"
         assert_snapshot!(lex_jupyter_source(source));
     }
 
-    #[test]
-    fn test_notebook_single_cell_token_ranges() {
-        use ruff_text_size::TextSize;
-        let source = "import random\n";
-        let cell_offsets = [TextSize::new(0)];
-        let mut lexer = Lexer::new(source, Mode::Ipython, TextSize::default());
-        lexer.set_cell_offsets(&cell_offsets);
-        loop {
-            let kind = lexer.next_token();
-            if kind.is_eof() {
-                break;
-            }
-            let range = lexer.current_range();
-            assert!(
-                range.start() <= range.end(),
-                "Token {:?} has invalid range: start={:?} > end={:?}",
-                kind,
-                range.start(),
-                range.end()
-            );
-        }
-    }
-
-    #[test]
-    fn test_notebook_multi_cell_token_ranges() {
-        use ruff_text_size::TextSize;
-        let source = "import random\nx = 1\n";
-        let cell_offsets = [TextSize::new(0), TextSize::new(14)];
-        let mut lexer = Lexer::new(source, Mode::Ipython, TextSize::default());
-        lexer.set_cell_offsets(&cell_offsets);
-        loop {
-            let kind = lexer.next_token();
-            if kind.is_eof() {
-                break;
-            }
-            let range = lexer.current_range();
-            assert!(
-                range.start() <= range.end(),
-                "Token {:?} has invalid range: start={:?} > end={:?}",
-                kind,
-                range.start(),
-                range.end()
-            );
-        }
-    }
-
     fn lex_fstring_error(source: &str) -> InterpolatedStringErrorType {
         let output = lex(source, Mode::Module, TextSize::default());
         match output

--- a/crates/ruff_python_parser/src/lexer/cursor.rs
+++ b/crates/ruff_python_parser/src/lexer/cursor.rs
@@ -30,6 +30,10 @@ pub(super) struct Cursor<'src> {
 
     /// Index into `cell_offsets` indicating the current cell the cursor is in.
     current_cell: usize,
+
+    /// Whether cell offsets are set. Used to skip cell boundary checks on the hot path
+    /// for non-notebook sources, avoiding function call overhead on every token.
+    has_cells: bool,
 }
 
 impl<'src> Cursor<'src> {
@@ -42,11 +46,13 @@ impl<'src> Cursor<'src> {
             prev_char: EOF_CHAR,
             cell_offsets: &[],
             current_cell: 0,
+            has_cells: false,
         }
     }
 
     /// Set cell offsets for notebook cell boundary awareness.
     pub(crate) fn set_cell_offsets(&mut self, cell_offsets: &'src [TextSize]) {
+        self.has_cells = !cell_offsets.is_empty();
         self.cell_offsets = cell_offsets;
     }
 
@@ -101,7 +107,7 @@ impl<'src> Cursor<'src> {
     /// Peeks the next character from the input stream without consuming it.
     /// Returns [`EOF_CHAR`] if the position is past the end of the file or at a cell boundary.
     pub(super) fn first(&self) -> char {
-        if self.is_at_cell_boundary() {
+        if self.has_cells && self.is_at_cell_boundary() {
             return EOF_CHAR;
         }
         self.chars.clone().next().unwrap_or(EOF_CHAR)
@@ -149,13 +155,13 @@ impl<'src> Cursor<'src> {
 
     /// Returns `true` if the cursor is at the end of file or at a cell boundary.
     pub(super) fn is_eof(&self) -> bool {
-        self.chars.as_str().is_empty() || self.is_at_cell_boundary()
+        self.chars.as_str().is_empty() || (self.has_cells && self.is_at_cell_boundary())
     }
 
     /// Moves the cursor to the next character, returning the previous character.
     /// Returns [`None`] if there is no next character or at a cell boundary.
     pub(super) fn bump(&mut self) -> Option<char> {
-        if self.is_at_cell_boundary() {
+        if self.has_cells && self.is_at_cell_boundary() {
             return None;
         }
 

--- a/crates/ruff_python_parser/src/lexer/cursor.rs
+++ b/crates/ruff_python_parser/src/lexer/cursor.rs
@@ -7,6 +7,10 @@ pub(crate) const EOF_CHAR: char = '\0';
 /// A cursor represents a pointer in the source code.
 ///
 /// Based on [`rustc`'s `Cursor`](https://github.com/rust-lang/rust/blob/d1b7355d3d7b4ead564dbecb1d240fcc74fff21b/compiler/rustc_lexer/src/cursor.rs)
+///
+/// The cursor holds only the text of a single cell. For regular Python files,
+/// this is the entire source. For Jupyter notebooks, the lexer creates a new
+/// cursor for each cell when transitioning between cells.
 #[derive(Clone, Debug)]
 pub(super) struct Cursor<'src> {
     /// An iterator over the [`char`]'s of the source code.
@@ -16,85 +20,18 @@ pub(super) struct Cursor<'src> {
     /// token which is being lexed.
     source_length: TextSize,
 
-    /// Total length of the original source. Used to compute absolute cursor position
-    /// for cell boundary checks.
-    total_source_length: TextSize,
-
     /// Stores the previous character for debug assertions.
     #[cfg(debug_assertions)]
     prev_char: char,
-
-    /// Cell offsets for Jupyter notebook sources. Tracks the byte offsets where each cell
-    /// begins in the concatenated source. Empty slice for non-notebook sources.
-    cell_offsets: &'src [TextSize],
-
-    /// Index into `cell_offsets` indicating the current cell the cursor is in.
-    current_cell: usize,
-
-    /// Whether cell offsets are set. Used to skip cell boundary checks on the hot path
-    /// for non-notebook sources, avoiding function call overhead on every token.
-    has_cells: bool,
 }
 
 impl<'src> Cursor<'src> {
     pub(crate) fn new(source: &'src str) -> Self {
         Self {
             source_length: source.text_len(),
-            total_source_length: source.text_len(),
             chars: source.chars(),
             #[cfg(debug_assertions)]
             prev_char: EOF_CHAR,
-            cell_offsets: &[],
-            current_cell: 0,
-            has_cells: false,
-        }
-    }
-
-    /// Set cell offsets for notebook cell boundary awareness.
-    pub(crate) fn set_cell_offsets(&mut self, cell_offsets: &'src [TextSize]) {
-        self.has_cells = !cell_offsets.is_empty();
-        self.cell_offsets = cell_offsets;
-    }
-
-    /// Returns the current cell index.
-    pub(crate) fn current_cell(&self) -> usize {
-        self.current_cell
-    }
-
-    /// Set the current cell index (used during checkpoint/rewind).
-    pub(crate) fn set_current_cell(&mut self, cell: usize) {
-        self.current_cell = cell;
-    }
-
-    /// Returns `true` if the cursor is positioned at a notebook cell boundary.
-    ///
-    /// A cell boundary occurs when the cursor position equals the start offset
-    /// of the next cell (i.e., `cell_offsets[current_cell + 1]`).
-    pub(crate) fn is_at_cell_boundary(&self) -> bool {
-        if self.cell_offsets.is_empty() {
-            return false;
-        }
-
-        // current_cell tracks which cell we're in. The next cell starts at
-        // cell_offsets[current_cell + 1]. If cursor position equals that offset,
-        // we're at a boundary.
-        let Some(&next_cell_start) = self.cell_offsets.get(self.current_cell + 1) else {
-            return false;
-        };
-
-        // Compute current offset: total source length minus remaining chars
-        let current_offset = self.total_source_length - self.text_len();
-        current_offset == next_cell_start
-    }
-
-    /// Advance past the current cell boundary. Returns `true` if there are more cells,
-    /// `false` if this was the last cell.
-    pub(crate) fn next_cell(&mut self) -> bool {
-        if self.current_cell + 1 < self.cell_offsets.len() {
-            self.current_cell += 1;
-            true
-        } else {
-            false
         }
     }
 
@@ -105,11 +42,8 @@ impl<'src> Cursor<'src> {
     }
 
     /// Peeks the next character from the input stream without consuming it.
-    /// Returns [`EOF_CHAR`] if the position is past the end of the file or at a cell boundary.
+    /// Returns [`EOF_CHAR`] if the position is past the end of the file.
     pub(super) fn first(&self) -> char {
-        if self.has_cells && self.is_at_cell_boundary() {
-            return EOF_CHAR;
-        }
         self.chars.clone().next().unwrap_or(EOF_CHAR)
     }
 
@@ -153,18 +87,14 @@ impl<'src> Cursor<'src> {
         self.source_length = self.text_len();
     }
 
-    /// Returns `true` if the cursor is at the end of file or at a cell boundary.
+    /// Returns `true` if the cursor is at the end of file.
     pub(super) fn is_eof(&self) -> bool {
-        self.chars.as_str().is_empty() || (self.has_cells && self.is_at_cell_boundary())
+        self.chars.as_str().is_empty()
     }
 
     /// Moves the cursor to the next character, returning the previous character.
-    /// Returns [`None`] if there is no next character or at a cell boundary.
+    /// Returns [`None`] if there is no next character.
     pub(super) fn bump(&mut self) -> Option<char> {
-        if self.has_cells && self.is_at_cell_boundary() {
-            return None;
-        }
-
         let prev = self.chars.next()?;
 
         #[cfg(debug_assertions)]

--- a/crates/ruff_python_parser/src/lexer/cursor.rs
+++ b/crates/ruff_python_parser/src/lexer/cursor.rs
@@ -16,18 +16,79 @@ pub(super) struct Cursor<'src> {
     /// token which is being lexed.
     source_length: TextSize,
 
+    /// Total length of the original source. Used to compute absolute cursor position
+    /// for cell boundary checks.
+    total_source_length: TextSize,
+
     /// Stores the previous character for debug assertions.
     #[cfg(debug_assertions)]
     prev_char: char,
+
+    /// Cell offsets for Jupyter notebook sources. Tracks the byte offsets where each cell
+    /// begins in the concatenated source. Empty slice for non-notebook sources.
+    cell_offsets: &'src [TextSize],
+
+    /// Index into `cell_offsets` indicating the current cell the cursor is in.
+    current_cell: usize,
 }
 
 impl<'src> Cursor<'src> {
     pub(crate) fn new(source: &'src str) -> Self {
         Self {
             source_length: source.text_len(),
+            total_source_length: source.text_len(),
             chars: source.chars(),
             #[cfg(debug_assertions)]
             prev_char: EOF_CHAR,
+            cell_offsets: &[],
+            current_cell: 0,
+        }
+    }
+
+    /// Set cell offsets for notebook cell boundary awareness.
+    pub(crate) fn set_cell_offsets(&mut self, cell_offsets: &'src [TextSize]) {
+        self.cell_offsets = cell_offsets;
+    }
+
+    /// Returns the current cell index.
+    pub(crate) fn current_cell(&self) -> usize {
+        self.current_cell
+    }
+
+    /// Set the current cell index (used during checkpoint/rewind).
+    pub(crate) fn set_current_cell(&mut self, cell: usize) {
+        self.current_cell = cell;
+    }
+
+    /// Returns `true` if the cursor is positioned at a notebook cell boundary.
+    ///
+    /// A cell boundary occurs when the cursor position equals the start offset
+    /// of the next cell (i.e., `cell_offsets[current_cell + 1]`).
+    pub(crate) fn is_at_cell_boundary(&self) -> bool {
+        if self.cell_offsets.is_empty() {
+            return false;
+        }
+
+        // current_cell tracks which cell we're in. The next cell starts at
+        // cell_offsets[current_cell + 1]. If cursor position equals that offset,
+        // we're at a boundary.
+        let Some(&next_cell_start) = self.cell_offsets.get(self.current_cell + 1) else {
+            return false;
+        };
+
+        // Compute current offset: total source length minus remaining chars
+        let current_offset = self.total_source_length - self.text_len();
+        current_offset == next_cell_start
+    }
+
+    /// Advance past the current cell boundary. Returns `true` if there are more cells,
+    /// `false` if this was the last cell.
+    pub(crate) fn next_cell(&mut self) -> bool {
+        if self.current_cell + 1 < self.cell_offsets.len() {
+            self.current_cell += 1;
+            true
+        } else {
+            false
         }
     }
 
@@ -38,8 +99,11 @@ impl<'src> Cursor<'src> {
     }
 
     /// Peeks the next character from the input stream without consuming it.
-    /// Returns [`EOF_CHAR`] if the position is past the end of the file.
+    /// Returns [`EOF_CHAR`] if the position is past the end of the file or at a cell boundary.
     pub(super) fn first(&self) -> char {
+        if self.is_at_cell_boundary() {
+            return EOF_CHAR;
+        }
         self.chars.clone().next().unwrap_or(EOF_CHAR)
     }
 
@@ -83,14 +147,18 @@ impl<'src> Cursor<'src> {
         self.source_length = self.text_len();
     }
 
-    /// Returns `true` if the cursor is at the end of file.
+    /// Returns `true` if the cursor is at the end of file or at a cell boundary.
     pub(super) fn is_eof(&self) -> bool {
-        self.chars.as_str().is_empty()
+        self.chars.as_str().is_empty() || self.is_at_cell_boundary()
     }
 
     /// Moves the cursor to the next character, returning the previous character.
-    /// Returns [`None`] if there is no next character.
+    /// Returns [`None`] if there is no next character or at a cell boundary.
     pub(super) fn bump(&mut self) -> Option<char> {
+        if self.is_at_cell_boundary() {
+            return None;
+        }
+
         let prev = self.chars.next()?;
 
         #[cfg(debug_assertions)]

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -76,7 +76,7 @@ use ruff_python_ast::token::Tokens;
 use ruff_python_ast::{
     Expr, Mod, ModExpression, ModModule, PySourceType, StringFlags, StringLiteral, Suite,
 };
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::{Ranged, TextRange, TextSize};
 
 mod error;
 pub mod lexer;
@@ -162,7 +162,7 @@ pub fn parse_expression_range(
     range: TextRange,
 ) -> Result<Parsed<ModExpression>, ParseError> {
     let source = &source[..range.end().to_usize()];
-    Parser::new_starts_at(source, range.start(), ParseOptions::from(Mode::Expression))
+    Parser::new_starts_at(source, range.start(), ParseOptions::from(Mode::Expression), &[])
         .parse()
         .try_into_expression()
         .unwrap()
@@ -192,6 +192,7 @@ pub fn parse_parenthesized_expression_range(
         source,
         range.start(),
         ParseOptions::from(Mode::ParenthesizedExpression),
+        &[],
     )
     .parse();
     parsed.try_into_expression().unwrap().into_result()
@@ -289,6 +290,24 @@ pub fn parse(source: &str, options: ParseOptions) -> Result<Parsed<Mod>, ParseEr
 /// and returns the [`Parsed`] as is.
 pub fn parse_unchecked(source: &str, options: ParseOptions) -> Parsed<Mod> {
     Parser::new(source, options).parse()
+}
+
+/// Parse the given Python source code using the specified [`ParseOptions`] with notebook
+/// cell boundary awareness.
+///
+/// The `cell_offsets` parameter contains the byte offsets where each notebook cell begins
+/// in the concatenated source. When the lexer crosses a cell boundary and the indent stack
+/// is not at the root level, it will emit `Dedent` tokens to flush the stack. This allows
+/// the parser to detect syntax errors that span cell boundaries (e.g., `if True:` in one
+/// cell with its body in another).
+///
+/// Pass an empty slice for non-notebook sources.
+pub fn parse_unchecked_with_cell_offsets(
+    source: &str,
+    options: ParseOptions,
+    cell_offsets: &[TextSize],
+) -> Parsed<Mod> {
+    Parser::new_starts_at(source, TextSize::new(0), options, cell_offsets).parse()
 }
 
 /// Parse the given Python source code using the specified [`PySourceType`].

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -161,11 +161,16 @@ pub fn parse_expression_range(
     range: TextRange,
 ) -> Result<Parsed<ModExpression>, ParseError> {
     let source = &source[..range.end().to_usize()];
-    Parser::new_starts_at(source, range.start(), ParseOptions::from(Mode::Expression))
-        .parse()
-        .try_into_expression()
-        .unwrap()
-        .into_result()
+    Parser::new_starts_at(
+        source,
+        range.start(),
+        ParseOptions::from(Mode::Expression),
+        &[],
+    )
+    .parse()
+    .try_into_expression()
+    .unwrap()
+    .into_result()
 }
 
 /// Parses a Python expression as if it is parenthesized.
@@ -191,6 +196,7 @@ pub fn parse_parenthesized_expression_range(
         source,
         range.start(),
         ParseOptions::from(Mode::ParenthesizedExpression),
+        &[],
     )
     .parse();
     parsed.try_into_expression().unwrap().into_result()

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -69,14 +69,13 @@ pub use crate::error::{
     UnsupportedSyntaxError, UnsupportedSyntaxErrorKind,
 };
 pub use crate::parser::ParseOptions;
-
-use crate::parser::Parser;
+pub use crate::parser::Parser;
 
 use ruff_python_ast::token::Tokens;
 use ruff_python_ast::{
     Expr, Mod, ModExpression, ModModule, PySourceType, StringFlags, StringLiteral, Suite,
 };
-use ruff_text_size::{Ranged, TextRange, TextSize};
+use ruff_text_size::{Ranged, TextRange};
 
 mod error;
 pub mod lexer;
@@ -162,7 +161,7 @@ pub fn parse_expression_range(
     range: TextRange,
 ) -> Result<Parsed<ModExpression>, ParseError> {
     let source = &source[..range.end().to_usize()];
-    Parser::new_starts_at(source, range.start(), ParseOptions::from(Mode::Expression), &[])
+    Parser::new_starts_at(source, range.start(), ParseOptions::from(Mode::Expression))
         .parse()
         .try_into_expression()
         .unwrap()
@@ -192,7 +191,6 @@ pub fn parse_parenthesized_expression_range(
         source,
         range.start(),
         ParseOptions::from(Mode::ParenthesizedExpression),
-        &[],
     )
     .parse();
     parsed.try_into_expression().unwrap().into_result()
@@ -290,24 +288,6 @@ pub fn parse(source: &str, options: ParseOptions) -> Result<Parsed<Mod>, ParseEr
 /// and returns the [`Parsed`] as is.
 pub fn parse_unchecked(source: &str, options: ParseOptions) -> Parsed<Mod> {
     Parser::new(source, options).parse()
-}
-
-/// Parse the given Python source code using the specified [`ParseOptions`] with notebook
-/// cell boundary awareness.
-///
-/// The `cell_offsets` parameter contains the byte offsets where each notebook cell begins
-/// in the concatenated source. When the lexer crosses a cell boundary and the indent stack
-/// is not at the root level, it will emit `Dedent` tokens to flush the stack. This allows
-/// the parser to detect syntax errors that span cell boundaries (e.g., `if True:` in one
-/// cell with its body in another).
-///
-/// Pass an empty slice for non-notebook sources.
-pub fn parse_unchecked_with_cell_offsets(
-    source: &str,
-    options: ParseOptions,
-    cell_offsets: &[TextSize],
-) -> Parsed<Mod> {
-    Parser::new_starts_at(source, TextSize::new(0), options, cell_offsets).parse()
 }
 
 /// Parse the given Python source code using the specified [`PySourceType`].

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -29,7 +29,7 @@ mod statement;
 mod tests;
 
 #[derive(Debug)]
-pub(crate) struct Parser<'src> {
+pub struct Parser<'src> {
     source: &'src str,
 
     /// Token source for the parser that skips over any non-trivia token.
@@ -60,8 +60,8 @@ pub(crate) struct Parser<'src> {
 
 impl<'src> Parser<'src> {
     /// Create a new parser for the given source code.
-    pub(crate) fn new(source: &'src str, options: ParseOptions) -> Self {
-        Parser::new_starts_at(source, TextSize::new(0), options, &[])
+    pub fn new(source: &'src str, options: ParseOptions) -> Self {
+        Parser::new_starts_at(source, TextSize::new(0), options)
     }
 
     /// Create a new parser for the given source code which starts parsing at the given offset.
@@ -69,9 +69,8 @@ impl<'src> Parser<'src> {
         source: &'src str,
         start_offset: TextSize,
         options: ParseOptions,
-        cell_offsets: &'src [TextSize],
     ) -> Self {
-        let tokens = TokenSource::from_source(source, options.mode, start_offset, cell_offsets);
+        let tokens = TokenSource::from_source(source, options.mode, start_offset);
 
         Parser {
             options,
@@ -86,8 +85,13 @@ impl<'src> Parser<'src> {
         }
     }
 
+    /// Set cell offsets for notebook cell boundary awareness.
+    pub fn set_cell_offsets(&mut self, cell_offsets: &'src [TextSize]) {
+        self.tokens.set_cell_offsets(cell_offsets);
+    }
+
     /// Consumes the [`Parser`] and returns the parsed [`Parsed`].
-    pub(crate) fn parse(mut self) -> Parsed<Mod> {
+    pub fn parse(mut self) -> Parsed<Mod> {
         let syntax = match self.options.mode {
             Mode::Expression | Mode::ParenthesizedExpression => {
                 Mod::Expression(self.parse_single_expression())

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -61,7 +61,7 @@ pub(crate) struct Parser<'src> {
 impl<'src> Parser<'src> {
     /// Create a new parser for the given source code.
     pub(crate) fn new(source: &'src str, options: ParseOptions) -> Self {
-        Parser::new_starts_at(source, TextSize::new(0), options)
+        Parser::new_starts_at(source, TextSize::new(0), options, &[])
     }
 
     /// Create a new parser for the given source code which starts parsing at the given offset.
@@ -69,8 +69,9 @@ impl<'src> Parser<'src> {
         source: &'src str,
         start_offset: TextSize,
         options: ParseOptions,
+        cell_offsets: &'src [TextSize],
     ) -> Self {
-        let tokens = TokenSource::from_source(source, options.mode, start_offset);
+        let tokens = TokenSource::from_source(source, options.mode, start_offset, cell_offsets);
 
         Parser {
             options,

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -61,7 +61,7 @@ pub struct Parser<'src> {
 impl<'src> Parser<'src> {
     /// Create a new parser for the given source code.
     pub fn new(source: &'src str, options: ParseOptions) -> Self {
-        Parser::new_starts_at(source, TextSize::new(0), options)
+        Parser::new_starts_at(source, TextSize::new(0), options, &[])
     }
 
     /// Create a new parser for the given source code which starts parsing at the given offset.
@@ -69,8 +69,9 @@ impl<'src> Parser<'src> {
         source: &'src str,
         start_offset: TextSize,
         options: ParseOptions,
+        cell_offsets: &'src [TextSize],
     ) -> Self {
-        let tokens = TokenSource::from_source(source, options.mode, start_offset);
+        let tokens = TokenSource::from_source(source, options.mode, start_offset, cell_offsets);
 
         Parser {
             options,

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -61,7 +61,16 @@ pub struct Parser<'src> {
 impl<'src> Parser<'src> {
     /// Create a new parser for the given source code.
     pub fn new(source: &'src str, options: ParseOptions) -> Self {
-        Parser::new_starts_at(source, TextSize::new(0), options, &[])
+        Parser::new_with_cell_offsets(source, options, &[])
+    }
+
+    /// Create a new parser with notebook cell offsets set before the first token is lexed.
+    pub fn new_with_cell_offsets(
+        source: &'src str,
+        options: ParseOptions,
+        cell_offsets: &'src [TextSize],
+    ) -> Self {
+        Parser::new_starts_at(source, TextSize::new(0), options, cell_offsets)
     }
 
     /// Create a new parser for the given source code which starts parsing at the given offset.

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -179,3 +179,162 @@ fn test_tstring_fstring_middle_fuzzer() {
 
     insta::assert_debug_snapshot!(error);
 }
+
+// --- Notebook cell boundary tests ---
+
+use ruff_text_size::TextSize;
+
+use crate::Parser;
+
+/// Helper: parse with cell offsets and return (syntax errors, semantic errors).
+fn parse_with_cells(source: &str, cell_offsets: &[TextSize]) -> crate::Parsed<crate::Mod> {
+    let options = ParseOptions::from(Mode::Module);
+    let parser = Parser::new_with_cell_offsets(source, options, cell_offsets);
+    parser.parse()
+}
+
+#[test]
+fn cell_boundary_if_across_cells() {
+    // Cell 1: `if True:` (no body)
+    // Cell 2: `    print("hello")`
+    // Jupyter executes cells independently, so Cell 1 is a syntax error.
+    let source = "if True:\n\n    print(\"hello\")\n";
+    // Cell boundary between the two lines
+    let cell_offsets = [TextSize::new(9)]; // after "if True:\n"
+    let parsed = parse_with_cells(source, &cell_offsets);
+    assert!(
+        !parsed.errors().is_empty(),
+        "Expected syntax error for `if True:` with no body in cell, got none. Errors: {:?}",
+        parsed.errors()
+    );
+}
+
+#[test]
+fn cell_boundary_for_across_cells() {
+    // Cell 1: `for x in range(10):` (no body)
+    // Cell 2: `    print(x)`
+    let source = "for x in range(10):\n\n    print(x)\n";
+    let cell_offsets = [TextSize::new(20)]; // after "for x in range(10):\n"
+    let parsed = parse_with_cells(source, &cell_offsets);
+    assert!(
+        !parsed.errors().is_empty(),
+        "Expected syntax error for `for` with no body in cell"
+    );
+}
+
+#[test]
+fn cell_boundary_def_across_cells() {
+    // Cell 1: `def foo():` (no body)
+    // Cell 2: `    return 1`
+    let source = "def foo():\n\n    return 1\n";
+    let cell_offsets = [TextSize::new(11)]; // after "def foo():\n"
+    let parsed = parse_with_cells(source, &cell_offsets);
+    assert!(
+        !parsed.errors().is_empty(),
+        "Expected syntax error for `def` with no body in cell"
+    );
+}
+
+#[test]
+fn cell_boundary_complete_blocks_no_error() {
+    // Cell 1: complete if block
+    // Cell 2: standalone expression
+    let source = "if True:\n    print(1)\n\nprint(2)\n";
+    let cell_offsets = [TextSize::new(21)]; // after "if True:\n    print(1)\n"
+    let parsed = parse_with_cells(source, &cell_offsets);
+    assert!(
+        parsed.errors().is_empty(),
+        "Expected no syntax error for complete blocks across cells, got: {:?}",
+        parsed.errors()
+    );
+}
+
+#[test]
+fn cell_boundary_deeply_nested_across_cells() {
+    // Cell 1: `if True:\n    if True:` (two levels open)
+    // Cell 2: `        print(1)\n    print(2)`
+    let source = "if True:\n    if True:\n\n        print(1)\n    print(2)\n";
+    let cell_offsets = [TextSize::new(24)]; // after "if True:\n    if True:\n"
+    let parsed = parse_with_cells(source, &cell_offsets);
+    assert!(
+        !parsed.errors().is_empty(),
+        "Expected syntax error for nested `if` spanning cells"
+    );
+}
+
+#[test]
+fn cell_boundary_while_across_cells() {
+    // Cell 1: `while True:` (no body)
+    // Cell 2: `    break`
+    let source = "while True:\n\n    break\n";
+    let cell_offsets = [TextSize::new(12)]; // after "while True:\n"
+    let parsed = parse_with_cells(source, &cell_offsets);
+    assert!(
+        !parsed.errors().is_empty(),
+        "Expected syntax error for `while` with no body in cell"
+    );
+}
+
+#[test]
+fn cell_boundary_class_across_cells() {
+    // Cell 1: `class Foo:` (no body)
+    // Cell 2: `    pass`
+    let source = "class Foo:\n\n    pass\n";
+    let cell_offsets = [TextSize::new(11)]; // after "class Foo:\n"
+    let parsed = parse_with_cells(source, &cell_offsets);
+    assert!(
+        !parsed.errors().is_empty(),
+        "Expected syntax error for `class` with no body in cell"
+    );
+}
+
+#[test]
+fn cell_boundary_with_across_cells() {
+    // Cell 1: `with open("f"):` (no body)
+    // Cell 2: `    pass`
+    let source = "with open(\"f\"):\n\n    pass\n";
+    let cell_offsets = [TextSize::new(16)]; // after "with open(\"f\"):\n"
+    let parsed = parse_with_cells(source, &cell_offsets);
+    assert!(
+        !parsed.errors().is_empty(),
+        "Expected syntax error for `with` with no body in cell"
+    );
+}
+
+#[test]
+fn cell_boundary_try_across_cells() {
+    // Cell 1: `try:` (no body)
+    // Cell 2: `    pass\nexcept:\n    pass`
+    let source = "try:\n\n    pass\nexcept:\n    pass\n";
+    let cell_offsets = [TextSize::new(5)]; // after "try:\n"
+    let parsed = parse_with_cells(source, &cell_offsets);
+    assert!(
+        !parsed.errors().is_empty(),
+        "Expected syntax error for `try` with no body in cell"
+    );
+}
+
+#[test]
+fn cell_boundary_multi_cell_complete() {
+    // Three cells, all complete
+    let source = "x = 1\n\ny = 2\n\nz = 3\n";
+    let cell_offsets = [TextSize::new(6), TextSize::new(12)]; // after "x = 1\n" and "y = 2\n"
+    let parsed = parse_with_cells(source, &cell_offsets);
+    assert!(
+        parsed.errors().is_empty(),
+        "Expected no syntax error for complete cells, got: {:?}",
+        parsed.errors()
+    );
+}
+
+#[test]
+fn cell_boundary_no_offsets_is_normal() {
+    // Without cell offsets, `if True:\n\n    print(1)` is valid (blank line is fine)
+    let source = "if True:\n\n    print(1)\n";
+    let parsed = parse_with_cells(source, &[]);
+    assert!(
+        parsed.errors().is_empty(),
+        "Expected no syntax error without cell offsets, got: {:?}",
+        parsed.errors()
+    );
+}

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -30,9 +30,19 @@ impl<'src> TokenSource<'src> {
     }
 
     /// Create a new token source from the given source code which starts at the given offset.
-    pub(crate) fn from_source(source: &'src str, mode: Mode, start_offset: TextSize) -> Self {
+    pub(crate) fn from_source(
+        source: &'src str,
+        mode: Mode,
+        start_offset: TextSize,
+        cell_offsets: &'src [TextSize],
+    ) -> Self {
         let lexer = Lexer::new(source, mode, start_offset);
         let mut source = TokenSource::new(lexer);
+
+        // Set cell offsets BEFORE the first bump so the lexer is cell-aware from the start.
+        if !cell_offsets.is_empty() {
+            source.set_cell_offsets(cell_offsets);
+        }
 
         // Initialize the token source so that the current token is set correctly.
         source.do_bump();

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -30,11 +30,7 @@ impl<'src> TokenSource<'src> {
     }
 
     /// Create a new token source from the given source code which starts at the given offset.
-    pub(crate) fn from_source(
-        source: &'src str,
-        mode: Mode,
-        start_offset: TextSize,
-    ) -> Self {
+    pub(crate) fn from_source(source: &'src str, mode: Mode, start_offset: TextSize) -> Self {
         let lexer = Lexer::new(source, mode, start_offset);
         let mut source = TokenSource::new(lexer);
 

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -34,14 +34,18 @@ impl<'src> TokenSource<'src> {
         source: &'src str,
         mode: Mode,
         start_offset: TextSize,
-        cell_offsets: &'src [TextSize],
     ) -> Self {
-        let lexer = Lexer::new(source, mode, start_offset, cell_offsets);
+        let lexer = Lexer::new(source, mode, start_offset);
         let mut source = TokenSource::new(lexer);
 
         // Initialize the token source so that the current token is set correctly.
         source.do_bump();
         source
+    }
+
+    /// Set cell offsets for notebook cell boundary awareness.
+    pub(crate) fn set_cell_offsets(&mut self, cell_offsets: &'src [TextSize]) {
+        self.lexer.set_cell_offsets(cell_offsets);
     }
 
     /// Returns the kind of the current token.

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -30,8 +30,13 @@ impl<'src> TokenSource<'src> {
     }
 
     /// Create a new token source from the given source code which starts at the given offset.
-    pub(crate) fn from_source(source: &'src str, mode: Mode, start_offset: TextSize) -> Self {
-        let lexer = Lexer::new(source, mode, start_offset);
+    pub(crate) fn from_source(
+        source: &'src str,
+        mode: Mode,
+        start_offset: TextSize,
+        cell_offsets: &'src [TextSize],
+    ) -> Self {
+        let lexer = Lexer::new(source, mode, start_offset, cell_offsets);
         let mut source = TokenSource::new(lexer);
 
         // Initialize the token source so that the current token is set correctly.

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -36,13 +36,11 @@ impl<'src> TokenSource<'src> {
         start_offset: TextSize,
         cell_offsets: &'src [TextSize],
     ) -> Self {
-        let lexer = Lexer::new(source, mode, start_offset);
-        let mut source = TokenSource::new(lexer);
-
-        // Set cell offsets BEFORE the first bump so the lexer is cell-aware from the start.
+        let mut lexer = Lexer::new(source, mode, start_offset);
         if !cell_offsets.is_empty() {
-            source.set_cell_offsets(cell_offsets);
+            lexer.set_cell_offsets(cell_offsets);
         }
+        let mut source = TokenSource::new(lexer);
 
         // Initialize the token source so that the current token is set correctly.
         source.do_bump();


### PR DESCRIPTION
## Summary

Make the Python lexer cell-boundary aware so compound statement syntax errors spanning Jupyter notebook cells are detected.

Part of #23782

## Problem

Ruff concatenates notebook cells into a single source and parses as one file. This masks errors like:

```python
# Cell 1
if True:

# Cell 2
    print("true")
```

This parses successfully because the concatenated source is valid, but Jupyter executes cells independently — if True: with no body in the same cell is a syntax error.

## Approach

Following the direction in [#23782](tg://search_hashtag?hashtag=23782), the lexer now resets its state at cell boundaries by forcing Dedent emission to close all open indent levels. This is the same behaviour the lexer uses at EOF.

When a compound statement like if True: spans cells, the forced Dedent closes its block. The parser then reports "expected indented block" for the orphaned compound statement.

## Changes

• lexer.rs — Added cell_offsets field and check_cell_boundary() method. When the lexer crosses into a new cell and the indent stack is non-empty, it schedules a Dedent emission on the next next_token() call.
• lib.rs — New parse_unchecked_with_cell_offsets() public API for passing cell offsets.
• parser/mod.rs — Accepts cell_offsets parameter (defaults to &[] for non-notebook sources).
• token_source.rs — Passes cell_offsets through to the lexer.
• linter.rs — Extracts cell offsets from notebook sources and passes to the parser.

