### PR TITLE
[ty] Autocomplete arguments if in arguments node

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -1403,8 +1403,8 @@ fn add_argument_completions<'db>(
             ast::AnyNodeRef::Arguments(_) => {
                 in_arguments = true;
             }
-            ast::AnyNodeRef::ExprCall(call) => {
-                if in_arguments && call.arguments.range().contains_range(cursor.range) {
+            ast::AnyNodeRef::ExprCall(_) => {
+                if in_arguments {
                     add_function_arg_completions(db, model.file(), cursor, completions);
                 }
                 return;


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
-->

## Summary

Addresses [this comment](https://github.com/astral-sh/ty/issues/3087#issuecomment-4096258545).
Fixes https://github.com/astral-sh/ty/issues/3087.

I initially did the same ancestor walking check in both places but then I tried to come up with another way that does not iterate multiple times.
Since in `add_argument_completions` we are already iterating over node ancestors of the node the cursor is in, we can determine if cursor is in an arguments node.

So I did that instead of duplicating the `cursor.covering_node.ancestors() ...` code.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Added the test case that would panic in debug build without this fix.
<!-- How was it tested? -->
