### PR TITLE
[ty] Infer generic class specializations for class and static methods

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -322,6 +322,33 @@ C.f2(1)
 C().f2(1)
 ```
 
+The same classmethod-like shortcut should preserve generic owner specialization when the decorated
+attribute is materialized as a `Callable` rather than a plain function literal:
+
+```py
+from typing import Callable, Generic, TypeVar
+from typing_extensions import ParamSpec
+
+T = TypeVar("T")
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def callable_identity(func: Callable[P, R]) -> Callable[P, R]:
+    return func
+
+class Box(Generic[T]):
+    @callable_identity
+    @classmethod
+    def make(cls, x: T) -> Box[T]:
+        return cls()
+
+class Child(Box[T]): ...
+
+reveal_type(Box.make(1))  # revealed: Box[int]
+reveal_type(Box[int].make(1))  # revealed: Box[int]
+reveal_type(Child.make(1))  # revealed: Box[int]
+```
+
 ## Types are not bound-method descriptors
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -514,6 +514,146 @@ with Child().create() as child:
     reveal_type(child)  # revealed: Child
 ```
 
+### Generic classmethod factories preserve the class specialization
+
+```py
+from inspect import getattr_static
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+class Box(Generic[T]):
+    def __init__(self, x: T) -> None:
+        self.x = x
+
+    @classmethod
+    def make(cls, x: T) -> "Box[T]":
+        return cls(x)
+
+    @classmethod
+    def pair(cls, x: T, extra: U) -> tuple["Box[T]", U]:
+        return cls(x), extra
+
+reveal_type(getattr_static(Box, "make"))  # revealed: def make[T](cls, x: T) -> Box[T]
+reveal_type(Box.make(1))  # revealed: Box[int]
+reveal_type(Box.pair(1, "a"))  # revealed: tuple[Box[int], Literal["a"]]
+reveal_type(Box[int].make(1))  # revealed: Box[int]
+```
+
+### Generic classmethod factories still contextually type dict literals
+
+```py
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Domain(Generic[T]): ...
+
+class Poly(Generic[T]):
+    @classmethod
+    def from_dict(cls, rep: dict[tuple[int, ...], T], lev: int, dom: Domain[T]) -> "Poly[T]":
+        raise NotImplementedError
+
+def from_dict_fn(rep: dict[tuple[int, ...], T], lev: int, dom: Domain[T]) -> Poly[T]:
+    raise NotImplementedError
+
+class MPZ: ...
+
+ZZ = Domain[MPZ]()
+
+reveal_type(from_dict_fn({(1, 1): MPZ(), (0, 0): MPZ()}, 1, ZZ))  # revealed: Poly[MPZ]
+reveal_type(Poly.from_dict({(1, 1): MPZ(), (0, 0): MPZ()}, 1, ZZ))  # revealed: Poly[MPZ]
+```
+
+### Generic classmethod factories can satisfy callable parameters tied to the receiver type
+
+```py
+from typing import Callable, Generic, TypeVar, overload
+from typing_extensions import TypeVarTuple, Unpack
+
+T = TypeVar("T")
+Ts = TypeVarTuple("Ts")
+
+@overload
+def get_callable_args(x: T, fn: None = ...) -> tuple[object, ...]: ...
+@overload
+def get_callable_args(x: T, fn: Callable[[Unpack[Ts]], T]) -> tuple[Unpack[Ts]] | None: ...
+def get_callable_args(x: T, fn: Callable[[Unpack[Ts]], T] | None = None) -> tuple[Unpack[Ts]] | None:
+    return None
+
+class Vec(Generic[T]):
+    @classmethod
+    def empty(cls) -> "Vec[T]":
+        return cls()
+
+    @classmethod
+    def make(cls, x: T) -> "Vec[T]":
+        return cls()
+
+    def value(self) -> None:
+        reveal_type(get_callable_args(self, Vec.empty))  # revealed: tuple[@Todo(TypeVarTuple), ...] | None
+        reveal_type(get_callable_args(self, Vec.make))  # revealed: tuple[@Todo(TypeVarTuple), ...] | None
+```
+
+### Callable-owned type variables are still abstracted away
+
+```py
+from typing import Callable, TypeVar, cast
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+def get_result(fn: Callable[[], T]) -> T:
+    return fn()
+
+def generic() -> U:
+    return cast(U, 0)
+
+reveal_type(get_result(generic))  # revealed: Unknown
+```
+
+### Generic classmethods only inherit the class context when the signature needs it
+
+```py
+from typing import Generic, TypeVar
+from ty_extensions import generic_context
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+class Box(Generic[T]):
+    @classmethod
+    def cls_echo(cls, x: U) -> U:
+        return x
+
+# revealed: ty_extensions.GenericContext[Self@cls_echo, U@cls_echo]
+reveal_type(generic_context(Box.cls_echo))
+reveal_type(Box.cls_echo(1))  # revealed: Literal[1]
+```
+
+### Inherited generic classmethod factories preserve the lookup class specialization
+
+```py
+from inspect import getattr_static
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+class Base(Generic[T]):
+    @classmethod
+    def make(cls, x: T) -> "Base[T]":
+        raise NotImplementedError
+
+class Child(Base[U]):
+    def __init__(self, x: U) -> None:
+        self.x = x
+
+reveal_type(getattr_static(Child, "make"))  # revealed: def make[U](cls, x: U) -> Base[U]
+reveal_type(Child.make(1))  # revealed: Base[int]
+```
+
 ### `__init_subclass__`
 
 #### Basics
@@ -937,6 +1077,75 @@ reveal_type(D.ctx(5))  # revealed: _GeneratorContextManager[int, None, None]
 
 # Accessing via instance should also work (no self-binding)
 reveal_type(D().ctx(5))  # revealed: _GeneratorContextManager[int, None, None]
+```
+
+### Generic staticmethod factories preserve the class specialization
+
+```py
+from inspect import getattr_static
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+class Box(Generic[T]):
+    def __init__(self, x: T) -> None:
+        self.x = x
+
+    @staticmethod
+    def make(x: T) -> "Box[T]":
+        return Box(x)
+
+    @staticmethod
+    def pair(x: T, extra: U) -> tuple["Box[T]", U]:
+        return Box(x), extra
+
+reveal_type(getattr_static(Box, "make"))  # revealed: def make[T](x: T) -> Box[T]
+reveal_type(Box.make(1))  # revealed: Box[int]
+reveal_type(Box.pair(1, "a"))  # revealed: tuple[Box[int], Literal["a"]]
+```
+
+### Generic staticmethods only inherit the class context when the signature needs it
+
+```py
+from typing import Generic, TypeVar
+from ty_extensions import generic_context
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+class Box(Generic[T]):
+    @staticmethod
+    def static_echo(x: U) -> U:
+        return x
+
+# revealed: ty_extensions.GenericContext[U@static_echo]
+reveal_type(generic_context(Box.static_echo))
+reveal_type(Box.static_echo(1))  # revealed: Literal[1]
+```
+
+### Inherited generic staticmethod factories preserve the lookup class specialization
+
+```py
+from inspect import getattr_static
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+class Base(Generic[T]):
+    @staticmethod
+    def make_static(x: T) -> "Base[T]":
+        return Base(x)
+
+    def __init__(self, x: T) -> None:
+        self.x = x
+
+class Child(Base[U]):
+    pass
+
+reveal_type(getattr_static(Child, "make_static"))  # revealed: def make_static[U](x: U) -> Base[U]
+reveal_type(Child.make_static(1))  # revealed: Base[int]
 ```
 
 ### `__new__`

--- a/crates/ty_python_semantic/resources/mdtest/external/numpy.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/numpy.md
@@ -15,8 +15,7 @@ dependencies = ["numpy==2.3.0"]
 import numpy as np
 
 xs = np.array([1, 2, 3])
-# TODO: should be `ndarray[tuple[Any, ...], dtype[Any]]`
-reveal_type(xs)  # revealed: ndarray[tuple[Any, ...], dtype[Unknown]]
+reveal_type(xs)  # revealed: ndarray[tuple[Any, ...], dtype[Any]]
 
 xs = np.array([1.0, 2.0, 3.0], dtype=np.float64)
 # TODO: should be `ndarray[tuple[Any, ...], dtype[float64]]`

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2755,8 +2755,18 @@ impl<'db> Type<'db> {
                     Some((self, AttributeKind::NormalOrNonDataDescriptor))
                 } else {
                     let self_type = instance.unwrap_or_else(|| {
-                        // For classmethod-like callables, bind to the owner class.
-                        owner.to_instance(db).unwrap_or(owner)
+                        if callable.is_classmethod_like(db) {
+                            match owner {
+                                Type::ClassLiteral(class)
+                                    if class.generic_context(db).is_some() =>
+                                {
+                                    Type::from(class.identity_specialization(db))
+                                }
+                                _ => owner.to_instance(db).unwrap_or(owner),
+                            }
+                        } else {
+                            owner.to_instance(db).unwrap_or(owner)
+                        }
                     });
 
                     Some((

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -36,7 +36,9 @@ use crate::{
         diagnostic::INVALID_DATACLASS_OVERRIDE,
         enums::{enum_metadata, is_enum_class_by_inheritance, try_unwrap_nonmember_value},
         function::{
-            DataclassTransformerParams, KnownFunction, is_implicit_classmethod,
+            DataclassTransformerParams, KnownFunction,
+            callable_signatures_mention_inherited_typevars,
+            function_signature_mentions_inherited_typevars, is_implicit_classmethod,
             is_implicit_staticmethod,
         },
         generics::Specialization,
@@ -963,6 +965,40 @@ impl<'db> StaticClassLiteral<'db> {
         Ok((candidate.metaclass.into(), transform_info))
     }
 
+    /// Return whether `name` should be looked up on the identity specialization first.
+    ///
+    /// A generic classmethod or staticmethod that still mentions class typevars needs those
+    /// typevars in its callable signature so later call inference can solve them.
+    fn needs_identity_specialization_for_own_class_member(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+    ) -> bool {
+        let Some(generic_context) = self.generic_context(db) else {
+            return false;
+        };
+
+        match class_member(db, self.body_scope(db), name)
+            .inner
+            .place
+            .raw_type()
+        {
+            Some(Type::FunctionLiteral(function)) => {
+                (function.is_classmethod(db) || function.is_staticmethod(db))
+                    && function_signature_mentions_inherited_typevars(db, function, generic_context)
+            }
+            Some(Type::Callable(callable)) => {
+                (callable.is_classmethod_like(db) || callable.is_staticmethod_like(db))
+                    && callable_signatures_mention_inherited_typevars(
+                        db,
+                        callable.signatures(db),
+                        generic_context,
+                    )
+            }
+            _ => false,
+        }
+    }
+
     /// Returns the class member of this class named `name`.
     ///
     /// The member resolves to a member on the class itself or any of its proper superclasses.
@@ -991,7 +1027,16 @@ impl<'db> StaticClassLiteral<'db> {
             }
         }
 
-        let mut member = self.class_member_inner(db, None, name, policy);
+        let specialization = self
+            .needs_identity_specialization_for_own_class_member(db, name)
+            .then(|| {
+                self.identity_specialization(db)
+                    .class_literal_and_specialization(db)
+                    .1
+                    .expect("identity specialization exists for generic classes")
+            });
+
+        let mut member = self.class_member_inner(db, specialization, name, policy);
 
         // We generally treat dunder attributes with `Callable` types as function-like callables.
         // See `callables_as_descriptors.md` for more details.
@@ -1092,27 +1137,61 @@ impl<'db> StaticClassLiteral<'db> {
 
         let body_scope = self.body_scope(db);
         let member = class_member(db, body_scope, name).map_type(|ty| {
-            // The `__new__` and `__init__` members of a non-specialized generic class are handled
-            // specially: they inherit the generic context of their class. That lets us treat them
-            // as generic functions when constructing the class, and infer the specialization of
-            // the class from the arguments that are passed in.
-            //
-            // We might decide to handle other class methods the same way, having them inherit the
-            // class's generic context, and performing type inference on calls to them to determine
-            // the specialization of the class. If we do that, we would update this to also apply
-            // to any method with a `@classmethod` decorator. (`__init__` would remain a special
-            // case, since it's an _instance_ method where we don't yet know the generic class's
-            // specialization.)
-            match (inherited_generic_context, ty, specialization, name) {
-                (
-                    Some(generic_context),
-                    Type::FunctionLiteral(function),
-                    Some(_),
-                    "__new__" | "__init__",
-                ) => Type::FunctionLiteral(
-                    function.with_inherited_generic_context(db, generic_context),
-                ),
-                _ => ty,
+            let Some(generic_context) = inherited_generic_context else {
+                return ty;
+            };
+
+            let specialized_ty = ty.apply_optional_specialization(db, specialization);
+
+            match (ty, specialized_ty) {
+                (Type::FunctionLiteral(function), _) if matches!(name, "__new__" | "__init__") => {
+                    Type::FunctionLiteral(
+                        function.with_inherited_generic_context(db, generic_context),
+                    )
+                }
+                // Preserve inherited class typevars only for class/static methods whose active
+                // specialization still depends on them. Other generic methods keep their own
+                // signature-local generic context.
+                (Type::FunctionLiteral(function), Type::FunctionLiteral(specialized_function))
+                    if (function.is_classmethod(db) || function.is_staticmethod(db))
+                        && function_signature_mentions_inherited_typevars(
+                            db,
+                            specialized_function,
+                            generic_context,
+                        ) =>
+                {
+                    Type::FunctionLiteral(
+                        function.with_inherited_generic_context(db, generic_context),
+                    )
+                }
+                (Type::Callable(callable), _) if matches!(name, "__new__" | "__init__") => {
+                    Type::Callable(CallableType::new(
+                        db,
+                        callable
+                            .signatures(db)
+                            .with_inherited_generic_context(db, generic_context),
+                        callable.kind(db),
+                        callable.provenance(db),
+                    ))
+                }
+                (Type::Callable(callable), Type::Callable(specialized_callable))
+                    if (callable.is_classmethod_like(db) || callable.is_staticmethod_like(db))
+                        && callable_signatures_mention_inherited_typevars(
+                            db,
+                            specialized_callable.signatures(db),
+                            generic_context,
+                        ) =>
+                {
+                    Type::Callable(CallableType::new(
+                        db,
+                        callable
+                            .signatures(db)
+                            .with_inherited_generic_context(db, generic_context),
+                        callable.kind(db),
+                        callable.provenance(db),
+                    ))
+                }
+                (ty, _) => ty,
             }
         });
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -84,7 +84,10 @@ use crate::types::known_instance::DeprecatedInstance;
 use crate::types::list_members::all_members;
 use crate::types::narrow::ClassInfoConstraintFunction;
 use crate::types::relation::TypeRelationChecker;
-use crate::types::signatures::{CallableSignature, ReturnCallableTypeVarScope, Signature};
+use crate::types::signatures::{
+    CallableSignature, Parameter, ReturnCallableTypeVarScope, Signature,
+};
+use crate::types::typevar::BoundTypeVarIdentity;
 use crate::types::variance::{TypeVarVariance, VarianceInferable};
 use crate::types::visitor::any_over_type;
 use crate::types::{
@@ -982,6 +985,88 @@ pub(super) fn walk_function_type<'db, V: super::visitor::TypeVisitor<'db> + ?Siz
     if let Some(signature) = function.updated_last_definition_signature(db) {
         walk_signature(db, signature, visitor);
     }
+}
+
+pub(crate) fn callable_signatures_mention_inherited_typevars<'db>(
+    db: &'db dyn Db,
+    signatures: &CallableSignature<'db>,
+    inherited_generic_context: GenericContext<'db>,
+) -> bool {
+    fn type_mentions_inherited_typevars<'db>(
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        inherited_typevars: &FxOrderSet<BoundTypeVarIdentity<'db>>,
+    ) -> bool {
+        any_over_type(
+            db,
+            ty,
+            true,
+            |nested| matches!(nested, Type::TypeVar(typevar) if inherited_typevars.contains(&typevar.identity(db))),
+        )
+    }
+
+    fn signature_mentions_inherited_typevars<'db>(
+        db: &'db dyn Db,
+        signature: &Signature<'db>,
+        inherited_typevars: &FxOrderSet<BoundTypeVarIdentity<'db>>,
+    ) -> bool {
+        // Method-local typevars can still depend on inherited class typevars through their
+        // explicit bounds or constraints, even when those inherited typevars do not appear
+        // directly in parameter or return annotations.
+        let annotations_mention_inherited_typevars = signature
+            .parameters()
+            .iter()
+            .filter(|parameter| parameter.should_annotation_be_displayed())
+            .map(Parameter::annotated_type)
+            .chain(std::iter::once(signature.return_ty))
+            .any(|ty| type_mentions_inherited_typevars(db, ty, inherited_typevars));
+
+        let typevar_bounds_or_constraints_mention_inherited_typevars =
+            signature.generic_context.is_some_and(|generic_context| {
+                generic_context
+                    .variables(db)
+                    .filter(|typevar| !typevar.typevar(db).is_self(db))
+                    .filter_map(|typevar| typevar.typevar(db).bound_or_constraints(db))
+                    .any(|bound_or_constraints| match bound_or_constraints {
+                        TypeVarBoundOrConstraints::UpperBound(bound) => {
+                            type_mentions_inherited_typevars(db, bound, inherited_typevars)
+                        }
+                        TypeVarBoundOrConstraints::Constraints(constraints) => {
+                            constraints.elements(db).iter().copied().any(|constraint| {
+                                type_mentions_inherited_typevars(db, constraint, inherited_typevars)
+                            })
+                        }
+                    })
+            });
+
+        annotations_mention_inherited_typevars
+            || typevar_bounds_or_constraints_mention_inherited_typevars
+    }
+
+    let inherited_typevars = inherited_generic_context
+        .variables(db)
+        .map(|typevar| typevar.identity(db))
+        .collect::<FxOrderSet<_>>();
+
+    signatures
+        .iter()
+        .any(|signature| signature_mentions_inherited_typevars(db, signature, &inherited_typevars))
+}
+
+pub(crate) fn function_signature_mentions_inherited_typevars<'db>(
+    db: &'db dyn Db,
+    function: FunctionType<'db>,
+    inherited_generic_context: GenericContext<'db>,
+) -> bool {
+    callable_signatures_mention_inherited_typevars(
+        db,
+        function.signature(db),
+        inherited_generic_context,
+    ) || callable_signatures_mention_inherited_typevars(
+        db,
+        &CallableSignature::single(function.last_definition_signature(db).clone()),
+        inherited_generic_context,
+    )
 }
 
 #[salsa::tracked]

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -7,7 +7,7 @@ use itertools::{Either, Itertools};
 use ruff_python_ast as ast;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::types::callable::walk_callable_type;
+use crate::types::callable::{CallableTypeKind, walk_callable_type};
 use crate::types::class::ClassType;
 use crate::types::class_base::ClassBase;
 use crate::types::constraints::{
@@ -1808,6 +1808,21 @@ pub(crate) struct SpecializationBuilder<'db, 'c> {
 pub(crate) type TypeVarAssignment<'db> = (BoundTypeVarIdentity<'db>, TypeVarVariance, Type<'db>);
 
 impl<'db, 'c> SpecializationBuilder<'db, 'c> {
+    fn should_preserve_inherited_source_typevars(
+        &self,
+        actual_callable: CallableType<'db>,
+    ) -> bool {
+        // Function-like and descriptor-like callables can borrow inherited typevars from an
+        // enclosing generic owner. Constructors and other regular callables should keep
+        // existentially quantifying their signature-local typevars during callable inference.
+        matches!(
+            actual_callable.kind(self.db),
+            CallableTypeKind::FunctionLike
+                | CallableTypeKind::StaticMethodLike
+                | CallableTypeKind::ClassMethodLike
+        )
+    }
+
     pub(crate) fn new(
         db: &'db dyn Db,
         constraints: &'c ConstraintSetBuilder<'db>,
@@ -1957,9 +1972,23 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
         for actual_callable in actual_callables.as_slice() {
             if formal_is_single_paramspec {
-                let when = actual_callable
-                    .signatures(self.db)
-                    .when_constraint_set_assignable_to(self.db, formal_signature, self.constraints);
+                let when = if self.should_preserve_inherited_source_typevars(*actual_callable) {
+                    actual_callable
+                        .signatures(self.db)
+                        .when_constraint_set_assignable_to_preserving_source_inherited(
+                            self.db,
+                            formal_signature,
+                            self.constraints,
+                        )
+                } else {
+                    actual_callable
+                        .signatures(self.db)
+                        .when_constraint_set_assignable_to(
+                            self.db,
+                            formal_signature,
+                            self.constraints,
+                        )
+                };
                 self.add_type_mappings_from_constraint_set(formal, when, &mut *f)?;
             } else {
                 // An overloaded actual callable is compatible with the formal signature if at
@@ -1967,11 +1996,20 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 // overloads, and only report an error if none of them are satisfiable.
                 let mut any_satisfiable = false;
                 for actual_signature in &actual_callable.signatures(self.db).overloads {
-                    let when = actual_signature.when_constraint_set_assignable_to_signatures(
-                        self.db,
-                        formal_signature,
-                        self.constraints,
-                    );
+                    let when = if self.should_preserve_inherited_source_typevars(*actual_callable) {
+                        actual_signature
+                            .when_constraint_set_assignable_to_signatures_preserving_source_inherited(
+                                self.db,
+                                formal_signature,
+                                self.constraints,
+                            )
+                    } else {
+                        actual_signature.when_constraint_set_assignable_to_signatures(
+                            self.db,
+                            formal_signature,
+                            self.constraints,
+                        )
+                    };
                     if self
                         .add_type_mappings_from_constraint_set(formal, when, &mut *f)
                         .is_ok()

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6419,60 +6419,91 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             {
                 let db = self.db();
 
-                let path_bounds =
-                    identity_instance.assignable_solutions_with_inferable(db, tcx, inferable);
-                let solutions = path_bounds.solve_with(|typevar, variance, lower, upper| {
-                    let identity = typevar.identity(db);
-                    elt_tcx_variance
-                        .entry(identity)
-                        .and_modify(|current| *current = current.join(variance))
-                        .or_insert(variance);
-                    PathBounds::default_solve(db, &constraints, typevar, lower, upper)
-                });
-
-                match solutions {
-                    // If the type context is not compatible with the collection type (e.g., a
-                    // `list` literal where a `tuple` is expected), the assignability check
-                    // produces an unsatisfiable result. In that case, we simply proceed without
-                    // type context constraints rather than aborting the entire collection literal
-                    // inference.
-                    Solutions::Unsatisfiable | Solutions::Unconstrained => {}
-                    Solutions::Constrained(solutions) => {
-                        for solution in &solutions {
-                            for binding in solution {
-                                // The SequentMap's transitivity reasoning can inject
-                                // cross-typevar references into the solution bounds.
-                                // For example, `_KT ≤ str ∧ str ≤ _VT` derives `_KT ≤ _VT`,
-                                // which adds `_KT` to `_VT`'s lower bound. Filter out any
-                                // inferable typevars from the solution, since they represent
-                                // cross-typevar relationships that are resolved independently.
-                                let inferred_ty = binding.solution.filter_union(db, |ty| {
-                                    !ty.as_typevar()
-                                        .is_some_and(|tv| tv.is_inferable(db, inferable))
-                                });
-
-                                // Avoid inferring a preferred type based on partially specialized
-                                // type context from an outer generic call. If the type context is
-                                // a union, we try to keep any concrete elements.
-                                let inferred_ty = inferred_ty
-                                    .filter_union(db, |ty| !ty.has_unspecialized_type_var(db));
-                                if inferred_ty.has_unspecialized_type_var(db) {
-                                    continue;
-                                }
-
-                                let identity = binding.bound_typevar.identity(db);
-                                elt_tcx_constraints
-                                    .entry(identity)
-                                    .and_modify(|existing| existing.add(db, inferred_ty))
-                                    .or_insert_with(|| UnionAccumulator::new(inferred_ty));
+                if tcx.has_unspecialized_type_var(db) {
+                    // Partially-specialized parameter types from multi-inference can still carry
+                    // useful concrete context on some collection elements. For example,
+                    // `dict[tuple[int, ...], UnspecializedTypeVar]` should still contextually type
+                    // the key expression against `tuple[int, ...]`.
+                    //
+                    // Keep that direct per-element context only when the annotation is a
+                    // specialization of this same concrete collection class. This avoids the
+                    // broader assignability walk through protocol and superclass structure that
+                    // motivated the contamination guard added in `b8fad8312fd`.
+                    if let Some(specialization) = tcx.known_specialization(db, collection_class) {
+                        for (elt_ty, specialized_ty) in elt_tys
+                            .clone()
+                            .zip(specialization.types(db).iter().copied())
+                        {
+                            let inferred_tcx = specialized_ty
+                                .filter_union(db, |ty| !ty.has_unspecialized_type_var(db));
+                            if inferred_tcx.has_unspecialized_type_var(db) {
+                                continue;
                             }
-                        }
 
-                        // Remove variance entries for typevars whose solutions were filtered out
-                        // (e.g., due to unspecialized typevars). Variance should only be tracked
-                        // for typevars with actual type context constraints.
+                            let identity = elt_ty.identity(db);
+                            elt_tcx_constraints
+                                .entry(identity)
+                                .and_modify(|existing| existing.add(db, inferred_tcx))
+                                .or_insert_with(|| UnionAccumulator::new(inferred_tcx));
+                            elt_tcx_variance.insert(identity, elt_ty.variance(db));
+                        }
+                    }
+                } else {
+                    let path_bounds =
+                        identity_instance.assignable_solutions_with_inferable(db, tcx, inferable);
+                    let solutions = path_bounds.solve_with(|typevar, variance, lower, upper| {
+                        let identity = typevar.identity(db);
                         elt_tcx_variance
-                            .retain(|identity, _| elt_tcx_constraints.contains_key(identity));
+                            .entry(identity)
+                            .and_modify(|current| *current = current.join(variance))
+                            .or_insert(variance);
+                        PathBounds::default_solve(db, &constraints, typevar, lower, upper)
+                    });
+
+                    match solutions {
+                        // If the type context is not compatible with the collection type (e.g., a
+                        // `list` literal where a `tuple` is expected), the assignability check
+                        // produces an unsatisfiable result. In that case, we simply proceed without
+                        // type context constraints rather than aborting the entire collection literal
+                        // inference.
+                        Solutions::Unsatisfiable | Solutions::Unconstrained => {}
+                        Solutions::Constrained(solutions) => {
+                            for solution in &solutions {
+                                for binding in solution {
+                                    // The SequentMap's transitivity reasoning can inject
+                                    // cross-typevar references into the solution bounds.
+                                    // For example, `_KT ≤ str ∧ str ≤ _VT` derives `_KT ≤ _VT`,
+                                    // which adds `_KT` to `_VT`'s lower bound. Filter out any
+                                    // inferable typevars from the solution, since they represent
+                                    // cross-typevar relationships that are resolved independently.
+                                    let inferred_ty = binding.solution.filter_union(db, |ty| {
+                                        !ty.as_typevar()
+                                            .is_some_and(|tv| tv.is_inferable(db, inferable))
+                                    });
+
+                                    // Avoid inferring a preferred type based on partially specialized
+                                    // type context from an outer generic call. If the type context is
+                                    // a union, we try to keep any concrete elements.
+                                    let inferred_ty = inferred_ty
+                                        .filter_union(db, |ty| !ty.has_unspecialized_type_var(db));
+                                    if inferred_ty.has_unspecialized_type_var(db) {
+                                        continue;
+                                    }
+
+                                    let identity = binding.bound_typevar.identity(db);
+                                    elt_tcx_constraints
+                                        .entry(identity)
+                                        .and_modify(|existing| existing.add(db, inferred_ty))
+                                        .or_insert_with(|| UnionAccumulator::new(inferred_ty));
+                                }
+                            }
+
+                            // Remove variance entries for typevars whose solutions were filtered out
+                            // (e.g., due to unspecialized typevars). Variance should only be tracked
+                            // for typevars with actual type context constraints.
+                            elt_tcx_variance
+                                .retain(|identity, _| elt_tcx_constraints.contains_key(identity));
+                        }
                     }
                 }
             }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -339,6 +339,7 @@ impl<'db> Type<'db> {
             inferable,
             relation: TypeRelation::SubtypingAssuming,
             context_tree: ErrorContextTree::disabled(),
+            preserve_source_inherited_signature_typevars: false,
             given: assuming,
             relation_visitor: &relation_visitor,
             disjointness_visitor: &disjointness_visitor,
@@ -375,6 +376,7 @@ impl<'db> Type<'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             context_tree: ErrorContextTree::enabled(),
+            preserve_source_inherited_signature_typevars: false,
             given: ConstraintSet::from_bool(&builder, false),
             relation_visitor: &HasRelationToVisitor::default(&builder),
             disjointness_visitor: &IsDisjointVisitor::default(&builder),
@@ -504,6 +506,7 @@ impl<'db> Type<'db> {
             inferable,
             relation,
             context_tree: ErrorContextTree::disabled(),
+            preserve_source_inherited_signature_typevars: false,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor: &relation_visitor,
             disjointness_visitor: &disjointness_visitor,
@@ -654,6 +657,7 @@ pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
     pub(super) inferable: InferableTypeVars<'db>,
     pub(super) relation: TypeRelation,
     context_tree: ErrorContextTree<'db>,
+    pub(super) preserve_source_inherited_signature_typevars: bool,
     given: ConstraintSet<'db, 'c>,
 
     // N.B. these fields are private to reduce the risk of
@@ -682,6 +686,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable,
             relation: TypeRelation::Subtyping,
             context_tree: ErrorContextTree::disabled(),
+            preserve_source_inherited_signature_typevars: false,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
             disjointness_visitor,
@@ -702,6 +707,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::ConstraintSetAssignability,
             context_tree: ErrorContextTree::disabled(),
+            preserve_source_inherited_signature_typevars: false,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
             disjointness_visitor,
@@ -722,6 +728,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::ConstraintSetAssignability,
             context_tree: ErrorContextTree::enabled(),
+            preserve_source_inherited_signature_typevars: false,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
             disjointness_visitor,
@@ -742,6 +749,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             context_tree: ErrorContextTree::enabled(),
+            preserve_source_inherited_signature_typevars: false,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
             disjointness_visitor,
@@ -759,6 +767,13 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
     pub(super) fn into_error_context(self) -> ErrorContextTree<'db> {
         self.context_tree
+    }
+
+    pub(super) fn with_preserved_source_inherited_signature_typevars(&self) -> Self {
+        Self {
+            preserve_source_inherited_signature_typevars: true,
+            ..self.clone()
+        }
     }
 
     pub(super) fn always(&self) -> ConstraintSet<'db, 'c> {
@@ -2083,6 +2098,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
             context_tree: ErrorContextTree::disabled(),
             given: self.given,
             inferable: InferableTypeVars::None,
+            preserve_source_inherited_signature_typevars: false,
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
             signature_relation_visitor: self.signature_relation_visitor,
@@ -2166,6 +2182,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             constraints: self.constraints,
             inferable: self.inferable,
             context_tree: ErrorContextTree::disabled(),
+            preserve_source_inherited_signature_typevars: false,
             given: self.given,
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -455,6 +455,25 @@ impl<'db> CallableSignature<'db> {
         other: &Self,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        self.when_constraint_set_assignable_to_inner(db, other, constraints, false)
+    }
+
+    pub(crate) fn when_constraint_set_assignable_to_preserving_source_inherited<'c>(
+        &self,
+        db: &'db dyn Db,
+        other: &Self,
+        constraints: &'c ConstraintSetBuilder<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        self.when_constraint_set_assignable_to_inner(db, other, constraints, true)
+    }
+
+    fn when_constraint_set_assignable_to_inner<'c>(
+        &self,
+        db: &'db dyn Db,
+        other: &Self,
+        constraints: &'c ConstraintSetBuilder<'db>,
+        preserve_source_inherited: bool,
+    ) -> ConstraintSet<'db, 'c> {
         let relation_visitor = HasRelationToVisitor::default(constraints);
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
@@ -466,6 +485,11 @@ impl<'db> CallableSignature<'db> {
             &signature_relation_visitor,
             &materialization_visitor,
         );
+        let checker = if preserve_source_inherited {
+            checker.with_preserved_source_inherited_signature_typevars()
+        } else {
+            checker
+        };
         checker.check_callable_signature_pair_inner(db, &self.overloads, &other.overloads)
     }
 }
@@ -1123,6 +1147,26 @@ impl<'db> Signature<'db> {
         }
     }
 
+    fn owned_inferable_typevars(&self, db: &'db dyn Db) -> FxHashSet<BoundTypeVarIdentity<'db>> {
+        let Some(generic_context) = self.generic_context else {
+            return FxHashSet::default();
+        };
+
+        generic_context
+            .variables(db)
+            .filter(
+                |typevar| match (self.definition, typevar.binding_context(db)) {
+                    (Some(definition), BindingContext::Definition(binding_context)) => {
+                        binding_context == definition
+                    }
+                    (None, BindingContext::Synthetic) => true,
+                    _ => false,
+                },
+            )
+            .map(|typevar| typevar.identity(db))
+            .collect()
+    }
+
     pub(crate) fn is_non_generic(&self) -> bool {
         self.generic_context.is_none()
     }
@@ -1207,6 +1251,25 @@ impl<'db> Signature<'db> {
         other: &CallableSignature<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        self.when_constraint_set_assignable_to_signatures_inner(db, other, constraints, false)
+    }
+
+    pub(crate) fn when_constraint_set_assignable_to_signatures_preserving_source_inherited<'c>(
+        &self,
+        db: &'db dyn Db,
+        other: &CallableSignature<'db>,
+        constraints: &'c ConstraintSetBuilder<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        self.when_constraint_set_assignable_to_signatures_inner(db, other, constraints, true)
+    }
+
+    fn when_constraint_set_assignable_to_signatures_inner<'c>(
+        &self,
+        db: &'db dyn Db,
+        other: &CallableSignature<'db>,
+        constraints: &'c ConstraintSetBuilder<'db>,
+        preserve_source_inherited: bool,
+    ) -> ConstraintSet<'db, 'c> {
         // If this signature is a paramspec, bind it to the entire overloaded other callable.
         if let Some(self_bound_typevar) = self.parameters.as_paramspec()
             && other.is_single_paramspec().is_none()
@@ -1248,15 +1311,21 @@ impl<'db> Signature<'db> {
             .overloads
             .iter()
             .when_all(db, constraints, |other_signature| {
-                self.when_constraint_set_assignable_to(db, other_signature, constraints)
+                self.when_constraint_set_assignable_to_inner(
+                    db,
+                    other_signature,
+                    constraints,
+                    preserve_source_inherited,
+                )
             })
     }
 
-    fn when_constraint_set_assignable_to<'c>(
+    fn when_constraint_set_assignable_to_inner<'c>(
         &self,
         db: &'db dyn Db,
         other: &Self,
         constraints: &'c ConstraintSetBuilder<'db>,
+        preserve_source_inherited: bool,
     ) -> ConstraintSet<'db, 'c> {
         let relation_visitor = HasRelationToVisitor::default(constraints);
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
@@ -1269,6 +1338,11 @@ impl<'db> Signature<'db> {
             &signature_relation_visitor,
             &materialization_visitor,
         );
+        let checker = if preserve_source_inherited {
+            checker.with_preserved_source_inherited_signature_typevars()
+        } else {
+            checker
+        };
         checker.check_signature_pair(db, self, other)
     }
 
@@ -1649,10 +1723,20 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // we produce, we reduce it back down to the inferable set that the caller asked about.
         // If we introduced new inferable typevars, those will be existentially quantified away
         // before returning.
+        let source_reduced: FxHashSet<_> = if self.preserve_source_inherited_signature_typevars {
+            // Function-like source signatures can borrow inherited typevars from an enclosing
+            // generic owner. Reducing those away here would lose the callable-to-receiver link
+            // before specialization inference can solve it.
+            source.owned_inferable_typevars(db)
+        } else {
+            source_inferable.iter(db).collect()
+        };
+        let target_reduced: FxHashSet<_> = target_inferable.iter(db).collect();
+
         when.reduce_inferable(
             db,
             self.constraints,
-            source_inferable.iter(db).chain(target_inferable.iter(db)),
+            source_reduced.iter().chain(target_reduced.iter()).copied(),
         )
     }
 


### PR DESCRIPTION
## Summary

Relates to:
- https://github.com/astral-sh/ty/issues/541
- https://github.com/astral-sh/ty/issues/2554

Infer generic class specializations for factory-like class and static methods, and preserve the generic context those calls need during downstream inference.

On `main`, bare generic class lookup default-specializes these members too early, so calls like `Box.make(1)`, `Box.make_static(1)`, and `Child.make(1)` lose the class specialization before call inference runs. Once that is repaired, two more seams show up:

- partially-specialized collection contexts can still contain useful same-class element context that should not be dropped wholesale
- callable inference can existentially quantify inherited source signature typevars too early, which loses the link between a function-like callable and the generic owner it borrows typevars from

This PR:

- preserves identity specialization for constructor-like class and static methods whose signatures mention inherited class type parameters
- binds classmethod-like descriptor access on bare generic classes against the identity-specialized owner
- keeps `type[Self]` constructor calls gradual only when the upper bound has no meaningful non-`object` constructor surface, while still preserving strict `__new__` checking when `__new__` is defined
- keeps direct same-class collection element context when a partially-specialized type context still contains concrete information, which fixes dict-literal contextual typing for generic classmethod factories
- preserves inherited source signature typevars during callable specialization only for function-like actual callables, while still abstracting callable-owned typevars away

## Test Plan

- generic classmethod factories infer `Box[int]` and preserve helper type variables
- generic staticmethod factories infer `Box[int]` and preserve helper type variables
- inherited classmethod and staticmethod factories use the lookup class specialization
- unrelated classmethod and staticmethod generics do not inherit the outer class context
- `cls(...)` inside a generic classmethod stays constructor-like through `type[Self]`
- `type[Self]` remains strict when the bound provides an informative `__new__` but no custom `__init__`
- generic classmethod factories still contextually type dict literals from same-class collection element context
- generic classmethod factories can satisfy callable parameters tied to the receiver type
- generic callable inference still abstracts callable-owned typevars away
- decorated classmethod-like `Callable`s still preserve generic owner specialization
