### PR TITLE
Extend PLR0124 to attributes, subscripts, and calls

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/comparison_with_itself.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/comparison_with_itself.py
@@ -55,3 +55,25 @@ id(foo) == id(bar)
 id(foo, bar) == id(foo, bar)
 
 id(foo, bar=1) == id(foo, bar=1)
+
+# Preview errors (attribute, subscript, call).
+self.x == self.x
+
+a.b.c == a.b.c
+
+a[0] == a[0]
+
+obj.method() == obj.method()
+
+a[0:2] == a[0:2]
+
+# Preview non-errors.
+self.x == self.y
+
+a.b.c == a.b.d
+
+a[0] == a[1]
+
+obj.method() == other.method()
+
+a.x == b.x

--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -14,6 +14,11 @@ pub(crate) const fn is_custom_exception_checking_enabled(settings: &LinterSettin
     settings.preview.is_enabled()
 }
 
+// https://github.com/astral-sh/ruff/issues/24155
+pub(crate) const fn is_comparison_with_itself_extended(settings: &LinterSettings) -> bool {
+    settings.preview.is_enabled()
+}
+
 // https://github.com/astral-sh/ruff/pull/15541
 pub(crate) const fn is_suspicious_function_reference_enabled(settings: &LinterSettings) -> bool {
     settings.preview.is_enabled()

--- a/crates/ruff_linter/src/rules/pylint/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/mod.rs
@@ -258,6 +258,10 @@ mod tests {
     }
 
     #[test_case(
+        Rule::ComparisonWithItself,
+        Path::new("comparison_with_itself.py")
+    )]
+    #[test_case(
         Rule::UselessExceptionStatement,
         Path::new("useless_exception_statement.py")
     )]

--- a/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
@@ -1,23 +1,32 @@
 use itertools::Itertools;
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
+use ruff_python_ast::comparable::ComparableExpr;
 use ruff_python_ast::{CmpOp, Expr};
 use ruff_text_size::Ranged;
 
 use crate::Violation;
 use crate::checkers::ast::Checker;
 use crate::fix::snippet::SourceCodeSnippet;
+use crate::preview::is_comparison_with_itself_extended;
 
 /// ## What it does
-/// Checks for operations that compare a name to itself.
+/// Checks for operations that compare an expression to itself.
 ///
 /// ## Why is this bad?
-/// Comparing a name to itself always results in the same value, and is likely
-/// a mistake.
+/// Comparing an expression to itself always results in the same value, and is
+/// likely a mistake.
 ///
 /// ## Example
 /// ```python
 /// foo == foo
+/// ```
+///
+/// In [preview], this rule also detects self-comparisons involving attribute
+/// accesses, subscripts, and function calls:
+/// ```python
+/// self.x == self.x
+/// a[0] == a[0]
 /// ```
 ///
 /// In some cases, self-comparisons are used to determine whether a float is
@@ -30,6 +39,8 @@ use crate::fix::snippet::SourceCodeSnippet;
 ///
 /// ## References
 /// - [Python documentation: Comparisons](https://docs.python.org/3/reference/expressions.html#comparisons)
+///
+/// [preview]: https://docs.astral.sh/ruff/preview/
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.273")]
 pub(crate) struct ComparisonWithItself {
@@ -59,72 +70,99 @@ pub(crate) fn comparison_with_itself(
         .tuple_windows()
         .zip(ops)
     {
-        match (left, right) {
-            // Ex) `foo == foo`
-            (Expr::Name(left_name), Expr::Name(right_name)) if left_name.id == right_name.id => {
-                let actual = format!(
-                    "{} {} {}",
-                    checker.locator().slice(left),
-                    op,
-                    checker.locator().slice(right)
-                );
-                checker.report_diagnostic(
-                    ComparisonWithItself {
-                        actual: SourceCodeSnippet::new(actual),
-                    },
-                    left_name.range(),
-                );
-            }
-            // Ex) `id(foo) == id(foo)`
-            (Expr::Call(left_call), Expr::Call(right_call)) => {
-                // Both calls must take a single argument, of the same name.
-                if !left_call.arguments.keywords.is_empty()
-                    || !right_call.arguments.keywords.is_empty()
-                {
-                    continue;
-                }
-                let [Expr::Name(left_arg)] = &*left_call.arguments.args else {
-                    continue;
-                };
-                let [Expr::Name(right_right)] = &*right_call.arguments.args else {
-                    continue;
-                };
-                if left_arg.id != right_right.id {
-                    continue;
-                }
+        // Ex) `foo == foo`
+        if let (Expr::Name(left_name), Expr::Name(right_name)) = (left, right)
+            && left_name.id == right_name.id
+        {
+            let actual = format!(
+                "{} {} {}",
+                checker.locator().slice(left),
+                op,
+                checker.locator().slice(right)
+            );
+            checker.report_diagnostic(
+                ComparisonWithItself {
+                    actual: SourceCodeSnippet::new(actual),
+                },
+                left_name.range(),
+            );
+            continue;
+        }
 
-                // Both calls must be to the same function.
-                let semantic = checker.semantic();
-                let Some(left_name) = semantic.resolve_builtin_symbol(&left_call.func) else {
-                    continue;
-                };
-                let Some(right_name) = semantic.resolve_builtin_symbol(&right_call.func) else {
-                    continue;
-                };
-                if left_name != right_name {
-                    continue;
-                }
+        // Ex) `id(foo) == id(foo)` (stable: only builtin pure functions)
+        if let (Expr::Call(left_call), Expr::Call(right_call)) = (left, right)
+            && is_builtin_self_comparison(checker, left_call, right_call)
+        {
+            let actual = format!(
+                "{} {} {}",
+                checker.locator().slice(left),
+                op,
+                checker.locator().slice(right)
+            );
+            checker.report_diagnostic(
+                ComparisonWithItself {
+                    actual: SourceCodeSnippet::new(actual),
+                },
+                left_call.range(),
+            );
+            continue;
+        }
 
-                // The call must be to pure function, like `id`.
-                if matches!(
-                    left_name,
-                    "id" | "len" | "type" | "int" | "bool" | "str" | "repr" | "bytes"
-                ) {
-                    let actual = format!(
-                        "{} {} {}",
-                        checker.locator().slice(left),
-                        op,
-                        checker.locator().slice(right)
-                    );
-                    checker.report_diagnostic(
-                        ComparisonWithItself {
-                            actual: SourceCodeSnippet::new(actual),
-                        },
-                        left_call.range(),
-                    );
-                }
-            }
-            _ => {}
+        // Ex) `self.x == self.x`, `a[0] == a[0]`, `obj.method() == obj.method()`
+        if is_comparison_with_itself_extended(checker.settings())
+            && !left.is_name_expr()
+            && !left.is_literal_expr()
+            && ComparableExpr::from(left) == ComparableExpr::from(right)
+        {
+            let actual = format!(
+                "{} {} {}",
+                checker.locator().slice(left),
+                op,
+                checker.locator().slice(right)
+            );
+            checker.report_diagnostic(
+                ComparisonWithItself {
+                    actual: SourceCodeSnippet::new(actual),
+                },
+                left.range(),
+            );
         }
     }
+}
+
+/// Returns `true` if the two calls are to the same builtin pure function with
+/// the same single argument (e.g., `id(foo) == id(foo)`).
+fn is_builtin_self_comparison(
+    checker: &Checker,
+    left_call: &ruff_python_ast::ExprCall,
+    right_call: &ruff_python_ast::ExprCall,
+) -> bool {
+    if !left_call.arguments.keywords.is_empty() || !right_call.arguments.keywords.is_empty() {
+        return false;
+    }
+    let [Expr::Name(left_arg)] = &*left_call.arguments.args else {
+        return false;
+    };
+    let [Expr::Name(right_arg)] = &*right_call.arguments.args else {
+        return false;
+    };
+    if left_arg.id != right_arg.id {
+        return false;
+    }
+
+    let semantic = checker.semantic();
+    let Some(left_name) = semantic.resolve_builtin_symbol(&left_call.func) else {
+        return false;
+    };
+    let Some(right_name) = semantic.resolve_builtin_symbol(&right_call.func) else {
+        return false;
+    };
+    if left_name != right_name {
+        return false;
+    }
+
+    matches!(
+        left_name,
+        "id" | "len" | "type" | "int" | "bool" | "str" | "repr" | "bytes"
+    )
 }

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__preview__PLR0124_comparison_with_itself.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__preview__PLR0124_comparison_with_itself.py.snap
@@ -1,0 +1,93 @@
+---
+source: crates/ruff_linter/src/rules/pylint/mod.rs
+---
+--- Linter settings ---
+-linter.preview = disabled
++linter.preview = enabled
+
+--- Summary ---
+Removed: 0
+Added: 7
+
+--- Added ---
+PLR0124 Name compared with itself, consider replacing `id(foo, bar) == id(foo, bar)`
+  --> comparison_with_itself.py:55:1
+   |
+53 | id(foo) == id(bar)
+54 |
+55 | id(foo, bar) == id(foo, bar)
+   | ^^^^^^^^^^^^
+56 |
+57 | id(foo, bar=1) == id(foo, bar=1)
+   |
+
+
+PLR0124 Name compared with itself, consider replacing `id(foo, bar=1) == id(foo, bar=1)`
+  --> comparison_with_itself.py:57:1
+   |
+55 | id(foo, bar) == id(foo, bar)
+56 |
+57 | id(foo, bar=1) == id(foo, bar=1)
+   | ^^^^^^^^^^^^^^
+58 |
+59 | # Preview errors (attribute, subscript, call).
+   |
+
+
+PLR0124 Name compared with itself, consider replacing `self.x == self.x`
+  --> comparison_with_itself.py:60:1
+   |
+59 | # Preview errors (attribute, subscript, call).
+60 | self.x == self.x
+   | ^^^^^^
+61 |
+62 | a.b.c == a.b.c
+   |
+
+
+PLR0124 Name compared with itself, consider replacing `a.b.c == a.b.c`
+  --> comparison_with_itself.py:62:1
+   |
+60 | self.x == self.x
+61 |
+62 | a.b.c == a.b.c
+   | ^^^^^
+63 |
+64 | a[0] == a[0]
+   |
+
+
+PLR0124 Name compared with itself, consider replacing `a[0] == a[0]`
+  --> comparison_with_itself.py:64:1
+   |
+62 | a.b.c == a.b.c
+63 |
+64 | a[0] == a[0]
+   | ^^^^
+65 |
+66 | obj.method() == obj.method()
+   |
+
+
+PLR0124 Name compared with itself, consider replacing `obj.method() == obj.method()`
+  --> comparison_with_itself.py:66:1
+   |
+64 | a[0] == a[0]
+65 |
+66 | obj.method() == obj.method()
+   | ^^^^^^^^^^^^
+67 |
+68 | a[0:2] == a[0:2]
+   |
+
+
+PLR0124 Name compared with itself, consider replacing `a[0:2] == a[0:2]`
+  --> comparison_with_itself.py:68:1
+   |
+66 | obj.method() == obj.method()
+67 |
+68 | a[0:2] == a[0:2]
+   | ^^^^^^
+69 |
+70 | # Preview non-errors.
+   |


### PR DESCRIPTION
Closes #24155

In preview mode, PLR0124 now detects self-comparisons beyond simple names. This catches copy-paste bugs like `self.x == self.x`, `a[0] == a[0]`, and `obj.method() == obj.method()`.

Stable behavior is unchanged — only `foo == foo` and builtin calls like `id(foo) == id(foo)` are flagged without preview.

New detections in preview:
- Attribute access: `self.x == self.x`, `a.b.c == a.b.c`
- Subscripts: `a[0] == a[0]`, `a[0:2] == a[0:2]`
- Arbitrary calls: `obj.method() == obj.method()`
- Multi-arg builtin calls: `id(foo, bar) == id(foo, bar)`

Uses `ComparableExpr` for structural AST equality. Literals are excluded (handled by other rules).