### PR TITLE
[ty] Fix protocol attribute lookup for declared members

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -109,7 +109,7 @@ static ALTAIR: Benchmark = Benchmark::new(
         max_dep_date: "2025-06-17",
         python_version: PythonVersion::PY312,
     },
-    898,
+    900,
 );
 
 static COLOUR_SCIENCE: Benchmark = Benchmark::new(

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -698,8 +698,7 @@ class Linkable(Protocol):
         return self.next_node
 
 def _(l: Linkable) -> None:
-    # TODO: Should be `Linkable`
-    reveal_type(l.next_node)  # revealed: @Todo(type[T] for protocols)
+    reveal_type(l.next_node)  # revealed: Linkable
 
 class CopyableImpl:
     def copy(self) -> Self:

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -1579,6 +1579,29 @@ as something that must be supported by type checkers:
 > To distinguish between protocol class variables and protocol instance variables, the special
 > `ClassVar` annotation should be used.
 
+## Declared instance attribute members
+
+Declared protocol instance attributes should be available both on protocol-typed values and through
+`self` inside protocol methods, with `Self` rebinding appropriately.
+
+```py
+from typing import Protocol
+from typing_extensions import Self
+
+class Linked(Protocol):
+    value: int
+    next: Self
+
+    def advance(self) -> Self:
+        reveal_type(self.value)  # revealed: int
+        reveal_type(self.next)  # revealed: Self@advance
+        return self.next
+
+def f(x: Linked) -> None:
+    reveal_type(x.value)  # revealed: int
+    reveal_type(x.next)  # revealed: Linked
+```
+
 ## Subtyping of protocols with property members
 
 A read-only property on a protocol can be satisfied by a mutable attribute, a read-only property, a

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -731,7 +731,7 @@ class Foo(Protocol):
     value: Final[int] = 42
 
     def foo(self, value: int):
-        # TODO: should emit an invalid-assignment error
+        # error: [invalid-assignment] "Cannot assign to final attribute `value` on type `Self@foo`: `Final` attributes can only be assigned in the class body or `__init__`"
         self.value = value
 
 def bar(x: Foo, value: int):

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2348,8 +2348,35 @@ impl<'db> Type<'db> {
                         .find_name_in_mro_with_policy(db, name.as_str(), policy)
                         .expect(
                             "`Type::find_name_in_mro()` should return `Some()` when called on a meta-type",
-                        )
+                    )
                 }
+            }
+
+            Type::TypeVar(bound_typevar)
+                if matches!(
+                    bound_typevar.typevar(db).bound_or_constraints(db),
+                    Some(TypeVarBoundOrConstraints::UpperBound(bound))
+                        if bound.as_protocol_instance().is_some()
+                ) =>
+            {
+                let TypeVarBoundOrConstraints::UpperBound(bound) = bound_typevar
+                    .typevar(db)
+                    .bound_or_constraints(db)
+                    .expect("matched above")
+                else {
+                    unreachable!("matched above");
+                };
+
+                let protocol = bound
+                    .as_protocol_instance()
+                    .expect("matched above to a protocol upper bound");
+
+                protocol
+                    .to_meta_type(db)
+                    .find_name_in_mro_with_policy(db, name.as_str(), policy)
+                    .expect(
+                        "`Type::find_name_in_mro()` should return `Some()` when called on a protocol meta-type",
+                    )
             }
 
             _ => self
@@ -6243,6 +6270,9 @@ fn self_typevar_owner_class_literal<'db>(
         .upper_bound(db)
         .and_then(|ty| match ty {
             Type::NominalInstance(instance) => Some(instance.class_literal(db)),
+            Type::ProtocolInstance(protocol) => protocol
+                .to_nominal_instance()
+                .map(|instance| instance.class_literal(db)),
             _ => None,
         })
 }
@@ -6288,6 +6318,9 @@ impl<'db> SelfBinding<'db> {
     ) -> Self {
         let class_literal = match self_type {
             Type::NominalInstance(instance) => Some(instance.class_literal(db)),
+            Type::ProtocolInstance(protocol) => protocol
+                .to_nominal_instance()
+                .map(|instance| instance.class_literal(db)),
             Type::TypeVar(typevar) if typevar.typevar(db).is_self(db) => {
                 self_typevar_owner_class_literal(db, typevar)
             }


### PR DESCRIPTION
## Summary

I sort of have to assume this is wrong given my prior experience with protocols, but this PR unblocks the following example surfaced in #23880, i.e., `Final` validation of:

```python
from typing import Final, Protocol

class Foo(Protocol):
    value: Final[int] = 42

    def foo(self, value: int):
        self.value = value
```

On main, `self.value` resolves to `@Todo(type[T] for protocols)`, whereas on this PR, we...

- Special-case a `TypeVar` whose upper bound is a protocol, and look the attribute up on the protocol meta-type directly instead of falling into `type[T]` for protocols...
- Teach `Self` binding that protocol instances have an owning class too, so the result can stay correctly bound as `Self@foo`...
