### PR TITLE
`analyze graph`: fix incorrect cross-package module resolution in `ruff analyze graph` (#24182)

### DIFF
--- a/crates/ruff/src/commands/analyze_graph.rs
+++ b/crates/ruff/src/commands/analyze_graph.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use indexmap::IndexSet;
 use log::{debug, warn};
 use path_absolutize::CWD;
-use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf};
+use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf, deduplicate_nested_paths};
 use ruff_graph::{Direction, ImportMap, ModuleDb, ModuleImports};
 use ruff_linter::package::PackageRoot;
 use ruff_linter::source_kind::SourceKind;
@@ -86,14 +86,16 @@ pub(crate) fn analyze_graph(
             .filter_map(|path| SystemPathBuf::from_path_buf(path.clone()).ok()),
     );
 
-    // Add detected package roots.
-    src_roots.extend(
-        package_roots
-            .values()
-            .filter_map(|package| package.as_deref())
-            .filter_map(|path| path.parent())
-            .filter_map(|path| SystemPathBuf::from_path_buf(path.to_path_buf()).ok()),
-    );
+    // Add discovered package root parents as src roots. Deduplicate to only
+    // outermost directories to avoid adding every top-level package directory
+    // as a separate search root.
+    let root_parents: Vec<SystemPathBuf> = package_roots
+        .values()
+        .filter_map(|package| package.as_deref())
+        .filter_map(|path| path.parent())
+        .filter_map(|path| SystemPathBuf::from_path_buf(path.to_path_buf()).ok())
+        .collect();
+    src_roots.extend(deduplicate_nested_paths(root_parents));
 
     let system = OsSystem::default();
     let db = ModuleDb::from_src_roots(

--- a/crates/ruff/tests/analyze_graph.rs
+++ b/crates/ruff/tests/analyze_graph.rs
@@ -1203,3 +1203,155 @@ fn notebook_with_magic() -> Result<()> {
 
     Ok(())
 }
+
+/// In a large monorepo, there might be multiple packages with the same name in different
+/// directories. Imports should NOT resolve to these unrelated packages just because they
+/// share a name.
+#[test]
+fn no_cross_package_resolution() -> Result<()> {
+    let tempdir = TempDir::new()?;
+    let root = ChildPath::new(tempdir.path());
+
+    // Create a main application that imports "foo"
+    root.child("ruff").child("__init__.py").write_str("")?;
+    root.child("ruff")
+        .child("main.py")
+        .write_str(indoc::indoc! {r#"
+        import foo  # This is meant to be a third-party library, not resolved locally
+    "#})?;
+
+    // Create an unrelated "foo" module in a completely different part of the repo
+    root.child("other")
+        .child("tools")
+        .child("foo")
+        .child("__init__.py")
+        .write_str("# Unrelated internal tool")?;
+
+    // The import should NOT resolve to the unrelated other/tools/foo module
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec(),
+    }, {
+        assert_cmd_snapshot!(command().current_dir(&root), @r#"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        {
+          "other/tools/foo/__init__.py": [],
+          "ruff/__init__.py": [],
+          "ruff/main.py": []
+        }
+
+        ----- stderr -----
+        "#);
+    });
+
+    Ok(())
+}
+
+/// Test that imports in one package don't resolve to modules in sibling packages
+/// unless explicitly configured.
+#[test]
+fn no_sibling_package_resolution() -> Result<()> {
+    let tempdir = TempDir::new()?;
+    let root = ChildPath::new(tempdir.path());
+
+    // Create two sibling packages that are independent
+    root.child("packages")
+        .child("alpha")
+        .child("__init__.py")
+        .write_str("")?;
+    root.child("packages")
+        .child("alpha")
+        .child("main.py")
+        .write_str(indoc::indoc! {r#"
+        import bar  # Intended to be a third-party library
+    "#})?;
+
+    root.child("packages")
+        .child("beta")
+        .child("__init__.py")
+        .write_str("")?;
+    root.child("packages")
+        .child("beta")
+        .child("bar")
+        .child("__init__.py")
+        .write_str("# Beta-specific module")?;
+
+    // alpha's `import bar` should NOT resolve to beta's bar module
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec(),
+    }, {
+        assert_cmd_snapshot!(command().arg("packages/alpha").current_dir(&root), @r#"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        {
+          "packages/alpha/__init__.py": [],
+          "packages/alpha/main.py": []
+        }
+
+        ----- stderr -----
+        "#);
+    });
+
+    Ok(())
+}
+
+/// Test that when src is configured, imports resolve correctly
+/// but still don't leak across to unrelated packages.
+#[test]
+fn configured_src_no_cross_resolution() -> Result<()> {
+    let tempdir = TempDir::new()?;
+    let root = ChildPath::new(tempdir.path());
+
+    // Configure src to include only the lib directory
+    root.child("ruff.toml").write_str(indoc::indoc! {r#"
+        src = ["lib"]
+    "#})?;
+
+    // Create the main library
+    root.child("lib")
+        .child("ruff")
+        .child("__init__.py")
+        .write_str("")?;
+    root.child("lib")
+        .child("ruff")
+        .child("a.py")
+        .write_str(indoc::indoc! {r#"
+        from ruff import b
+        import baz  # Third-party, should not resolve
+    "#})?;
+    root.child("lib")
+        .child("ruff")
+        .child("b.py")
+        .write_str("")?;
+
+    // Create an unrelated "baz" module outside the configured src
+    root.child("other")
+        .child("baz")
+        .child("__init__.py")
+        .write_str("# Unrelated module")?;
+
+    // `from ruff import b` should resolve (same package)
+    // `import baz` should NOT resolve (not in configured src)
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec(),
+    }, {
+        assert_cmd_snapshot!(command().arg("lib").current_dir(&root), @r#"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        {
+          "lib/ruff/__init__.py": [],
+          "lib/ruff/a.py": [
+            "lib/ruff/b.py"
+          ],
+          "lib/ruff/b.py": []
+        }
+
+        ----- stderr -----
+        "#);
+    });
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

The previous implementation added all detected package roots to the module search paths (`src_roots`). In a monorepo with many packages, this caused `import foo` in one package to incorrectly resolve to an unrelated `foo` package elsewhere in the repository.

## Solution

Two key changes:

  1. **src_roots collection:** Instead of adding all package roots, collect `src` paths from discovered configs using `resolver.settings()`. This uses ruff's hierarchical config discovery - each file's settings come from its closest pyproject.toml, and only explicitly configured `src` paths are used for resolution.

  2. **module_path computation:** Fix the path calculation in lib.rs to use `package.parent()` as the src_root when computing the module path. This ensures relative imports resolve correctly (the package directory must be included in the module path, not used as the strip prefix).

## Performance

The reduced search space dramatically improves performance on a large
  monorepo:

  - Before: ~27 seconds
  - After:  ~3.3 seconds (~8x faster)

## Notes

  - One test unexpectedly relied on finding code from other roots. i looked at the example from `uv` and modified the test to more representatively look like a `uv` workspace
  - The other tests added are ones which would fail today on `main` to represent the issue

See #24182
