### PR TITLE
[ty] Preserve known local kwargs in overload resolution

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -1269,6 +1269,42 @@ f(**dict(a=1, b=2))
 f(**Foo(a=1, b=2))
 ```
 
+### Local kwargs variable
+
+```py
+from typing import Any, Optional, cast, overload
+
+MISSING = cast(Any, object())
+
+class Token: ...
+
+@overload
+def send(*, count: int, token: Token = MISSING) -> None: ...
+@overload
+def send(message: str, *, silent: bool = False, token: Token = MISSING) -> None: ...
+def send(*args: Any, **kwargs: Any) -> None: ...
+def _(message: str, silent: bool, token: Optional[Token]) -> None:
+    kwargs = {
+        "message": message,
+        "silent": silent,
+        "token": MISSING if token is None else token,
+    }
+    send(**kwargs)
+
+def f(*, message: str) -> None: ...
+def _(key: str, message: str) -> None:
+    kwargs: dict[str, object] = {}
+    kwargs[key] = {"message": message}
+    # error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `str`, found `object`"
+    f(**kwargs)
+
+def _(key: str, message: str) -> None:
+    kwargs: dict[str, object] = {}
+    kwargs[key]: object = {"message": message}
+    # error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `str`, found `object`"
+    f(**kwargs)
+```
+
 ### Multiple keywords argument
 
 ```py

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -195,6 +195,24 @@ pub(crate) struct Bindings<'db> {
     argument_forms: ArgumentForms,
 }
 
+/// Recover the underlying unpacked `dict` fallback from an intersection, if any.
+fn unpacked_dict_kwargs_fallback<'db>(
+    db: &'db dyn Db,
+    argument_type: Type<'db>,
+) -> Option<(Type<'db>, Type<'db>)> {
+    if let Type::Intersection(intersection) = argument_type {
+        intersection.positive(db).iter().find_map(|element| {
+            element
+                .as_nominal_instance()
+                .is_some_and(|instance| instance.has_known_class(db, KnownClass::Dict))
+                .then(|| element.unpack_keys_and_items(db))
+                .flatten()
+        })
+    } else {
+        argument_type.unpack_keys_and_items(db)
+    }
+}
+
 impl<'db> Bindings<'db> {
     /// Creates a new `Bindings` from an iterator of [`Bindings`]s for a union type.
     /// Each input `Bindings` becomes a union element, preserving any intersection structure.
@@ -3657,8 +3675,10 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         argument_index: usize,
         argument_type: Option<Type<'db>>,
     ) {
-        if let Some(Type::TypedDict(typed_dict)) = argument_type {
-            // Special case TypedDict because we know which keys are present.
+        if let Some(typed_dict) = argument_type
+            .and_then(Type::as_typed_dict)
+            .filter(|typed_dict| typed_dict.defining_class().is_some())
+        {
             for (name, field) in typed_dict.items(db) {
                 let _ = self.match_keyword(
                     argument_index,
@@ -3688,7 +3708,15 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                 let value_type = match argument_type {
                     Some(argument_type) => argument_type
                         .as_paramspec_typevar(db)
-                        .or_else(|| argument_type.getitem_dunder_call(db, parameter_name))
+                        .or_else(|| {
+                            argument_type
+                                .getitem_dunder_call(db, parameter_name)
+                                .filter(|value_type| !value_type.is_unknown())
+                        })
+                        .or_else(|| {
+                            unpacked_dict_kwargs_fallback(db, argument_type)
+                                .map(|(_, value_ty)| value_ty)
+                        })
                         .unwrap_or(Type::unknown()),
 
                     None => Type::unknown(),
@@ -4450,7 +4478,10 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         argument: Argument<'a>,
         argument_type: Type<'db>,
     ) {
-        if let Type::TypedDict(typed_dict) = argument_type {
+        if let Some(typed_dict) = argument_type
+            .as_typed_dict()
+            .filter(|typed_dict| typed_dict.defining_class().is_some())
+        {
             for (argument_type, parameter_index) in typed_dict
                 .items(self.db)
                 .values()
@@ -4470,11 +4501,13 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             return;
         }
 
-        let value_type_paramspec =
+        let (value_type_paramspec, value_type_fallback) =
             if let Some(paramspec) = argument_type.as_paramspec_typevar(self.db) {
-                Some(paramspec)
+                (Some(paramspec), None)
             } else {
-                let Some((key_type, _)) = argument_type.unpack_keys_and_items(self.db) else {
+                let Some((key_type, value_type)) =
+                    unpacked_dict_kwargs_fallback(self.db, argument_type)
+                else {
                     return;
                 };
 
@@ -4493,7 +4526,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     });
                 }
 
-                None
+                (None, Some(value_type))
             };
 
         for parameter_index in &self.argument_matches[argument_index].parameters {
@@ -4506,6 +4539,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
                 argument_type
                     .getitem_dunder_call(self.db, parameter_name)
+                    .filter(|value_type| !value_type.is_unknown())
+                    .or(value_type_fallback)
                     .unwrap_or(Type::unknown())
             };
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6827,8 +6827,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// Attempt to narrow a splatted dictionary argument based on the narrowed types of individual
     /// keys, if any.
     ///
-    /// Returns the intersection between the dictionary type and a synthesized typed dict of any narrowed
-    /// keys, or `None` otherwise.
+    /// Returns the intersection between the original dictionary type and a synthesized protocol
+    /// that refines `__getitem__` for the narrowed keys, or `None` otherwise.
     fn try_narrow_dict_kwargs(
         &self,
         argument_type: Type<'db>,
@@ -6847,37 +6847,106 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return None;
         }
 
-        let definition_key = |definition: Definition<'_>| {
-            let key = match definition.kind(db) {
-                DefinitionKind::DictKeyAssignment(assignment) => assignment.key(self.module()),
-                DefinitionKind::Assignment(assignment) => {
-                    &assignment.target(self.module()).as_subscript_expr()?.slice
-                }
-                DefinitionKind::AnnotatedAssignment(assignment) => {
-                    &assignment.target(self.module()).as_subscript_expr()?.slice
-                }
-                _ => return None,
-            };
+        // Collect the types of each distinct key from either whole-dict assignments like
+        // `kwargs = {"a": 1}` or subsequent key writes like `kwargs["a"] = 1`.
+        let mut elements: FxHashMap<Name, Type<'db>> = FxHashMap::default();
 
-            Some(key.as_string_literal_expr()?.value.to_str())
+        let mut add_element = |name: &str, ty| {
+            elements
+                .entry(Name::new(name))
+                .and_modify(|existing| {
+                    *existing = UnionType::from_two_elements(db, *existing, ty);
+                })
+                .or_insert(ty);
         };
-
-        // Collect the types of each distinct key.
-        let mut elements: Vec<(&str, Type<'db>)> = Vec::new();
 
         for bindings in use_def.multi_bindings_at_use(keyword.scoped_use_id(db, self.scope())) {
             let place = place_from_bindings(db, bindings.clone());
-            let Some(key) = place.first_definition.and_then(definition_key) else {
+            let Some(definition) = place.first_definition else {
                 continue;
             };
 
-            if let Place::Defined(DefinedPlace {
-                ty: field_ty,
-                definedness: Definedness::AlwaysDefined,
-                ..
-            }) = place.place
-            {
-                elements.push((key, field_ty));
+            match definition.kind(db) {
+                DefinitionKind::Assignment(assignment) => {
+                    let target = assignment.target(self.module());
+                    if let Some(subscript) = target.as_subscript_expr() {
+                        if let Some(key) = subscript.slice.as_string_literal_expr()
+                            && let Place::Defined(DefinedPlace {
+                                ty: field_ty,
+                                definedness: Definedness::AlwaysDefined,
+                                ..
+                            }) = place.place
+                        {
+                            add_element(key.value.to_str(), field_ty);
+                        }
+                        continue;
+                    }
+
+                    let Some(value) = definition.kind(db).value(self.module()) else {
+                        continue;
+                    };
+                    let Some(dict) = value.as_dict_expr() else {
+                        continue;
+                    };
+
+                    for item in &dict.items {
+                        let Some(key) = item
+                            .key
+                            .as_ref()
+                            .and_then(|key| key.as_string_literal_expr())
+                        else {
+                            continue;
+                        };
+                        add_element(key.value.to_str(), self.expression_type(&item.value));
+                    }
+                }
+                DefinitionKind::AnnotatedAssignment(assignment) => {
+                    let target = assignment.target(self.module());
+                    if let Some(subscript) = target.as_subscript_expr() {
+                        if let Some(key) = subscript.slice.as_string_literal_expr()
+                            && let Place::Defined(DefinedPlace {
+                                ty: field_ty,
+                                definedness: Definedness::AlwaysDefined,
+                                ..
+                            }) = place.place
+                        {
+                            add_element(key.value.to_str(), field_ty);
+                        }
+                        continue;
+                    }
+
+                    let Some(value) = definition.kind(db).value(self.module()) else {
+                        continue;
+                    };
+                    let Some(dict) = value.as_dict_expr() else {
+                        continue;
+                    };
+
+                    for item in &dict.items {
+                        let Some(key) = item
+                            .key
+                            .as_ref()
+                            .and_then(|key| key.as_string_literal_expr())
+                        else {
+                            continue;
+                        };
+                        add_element(key.value.to_str(), self.expression_type(&item.value));
+                    }
+                }
+                DefinitionKind::DictKeyAssignment(assignment) => {
+                    let Some(key) = assignment.key(self.module()).as_string_literal_expr() else {
+                        continue;
+                    };
+                    if let Place::Defined(DefinedPlace {
+                        ty: field_ty,
+                        definedness: Definedness::AlwaysDefined,
+                        ..
+                    }) = place.place
+                    {
+                        add_element(key.value.to_str(), field_ty);
+                    }
+                }
+                _ => {}
             }
         }
 
@@ -6893,7 +6962,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     [
                         Parameter::positional_only(Some(Name::new_static("self"))),
                         Parameter::positional_or_keyword(Name::new_static("key"))
-                            .with_annotated_type(Type::string_literal(db, name)),
+                            .with_annotated_type(Type::string_literal(db, name.as_str())),
                     ],
                 ),
                 ty,
@@ -6912,8 +6981,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             )],
         );
 
-        // Note that we return an intersection to preserve the original dictionary type,
-        // as it may contain keys that were not explicitly assigned to.
+        // Preserve the original dictionary type, which may still contain keys that were
+        // not explicitly assigned to, while refining `__getitem__` for known items.
         Some(IntersectionType::from_elements(
             db,
             [argument_type, getitem_protocol],


### PR DESCRIPTION
## Summary

Preserve known local `**kwargs` information during overload resolution.

ty can narrow local `kwargs` variables enough to refine keyed lookups, but `**kwargs` matching still treats an `Unknown` keyed result as final. That loses useful local key information too early and can report `no-matching-overload` for calls that should succeed.

This change still uses the local-key refinement, but only when it produces an informative result. If a keyed lookup comes back as `Unknown`, ty now falls back to the original unpacked `dict[str, T]` item type instead. It also stops treating nested dict literals written through `kwargs[key] = {...}` as though they were whole reassignments of `kwargs`, so their inner keys no longer leak into top-level keyword refinement.

## Test Plan

- local `kwargs = {...}` variables can satisfy the correct overload when their known keys line up with the selected overload
- nested dict literals written through `kwargs[key] = {...}` do not contaminate top-level kwargs refinement
- the annotated-subscript sibling case preserves the original `dict[str, object]` fallback
