### PR TITLE
[ruff] Make UP026 target-version aware for  statements

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP026_py37.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP026_py37.py
@@ -1,0 +1,23 @@
+# Skipped: AsyncMock was added to unittest.mock in 3.8
+from mock import AsyncMock
+
+# Skipped: ThreadingMock was added to unittest.mock in 3.13
+from mock import ThreadingMock
+
+# Skipped: any unavailable name suppresses the entire import
+from mock import Mock, AsyncMock
+
+# Error: all names available since 3.3
+from mock import Mock
+
+# Error: seal was added in 3.7, which matches the target
+from mock import seal
+
+# Error: all names available since 3.3
+from mock import patch, MagicMock
+
+# Error: star imports can't be checked
+from mock import *
+
+# Error: bare `import mock` always works (the module exists since 3.3)
+import mock

--- a/crates/ruff_linter/src/rules/pyupgrade/mod.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/mod.rs
@@ -282,6 +282,19 @@ mod tests {
     }
 
     #[test]
+    fn deprecated_mock_import_py37() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("pyupgrade/UP026_py37.py"),
+            &settings::LinterSettings {
+                unresolved_target_version: PythonVersion::PY37.into(),
+                ..settings::LinterSettings::for_rule(Rule::DeprecatedMockImport)
+            },
+        )?;
+        assert_diagnostics!("UP026_py37", diagnostics);
+        Ok(())
+    }
+
+    #[test]
     fn async_timeout_error_alias_not_applied_py310() -> Result<()> {
         let diagnostics = test_path(
             Path::new("pyupgrade/UP041.py"),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -8,7 +8,7 @@ use log::debug;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::name::UnqualifiedName;
 use ruff_python_ast::whitespace::indentation;
-use ruff_python_ast::{self as ast, Stmt};
+use ruff_python_ast::{self as ast, PythonVersion, Stmt};
 use ruff_python_codegen::Stylist;
 use ruff_python_semantic::Modules;
 use ruff_text_size::Ranged;
@@ -50,6 +50,15 @@ pub(crate) enum MockReference {
 /// This rule will not trigger if the `mock` import is required by the `isort` configuration.
 ///
 /// - `lint.isort.required-imports`
+/// - `target-version`
+///
+/// ## Note
+///
+/// The standalone `mock` package on `PyPI` is a rolling backport of `unittest.mock`
+/// that may include APIs not yet present in the standard library for a given Python
+/// version (e.g., `AsyncMock` was added in Python 3.8, `ThreadingMock` in 3.13).
+/// This rule will not flag `from mock import ...` statements that reference such
+/// APIs when the target Python version predates their introduction.
 ///
 /// ## References
 /// - [Python documentation: `unittest.mock`](https://docs.python.org/3/library/unittest.mock.html)
@@ -257,6 +266,18 @@ fn format_import_from(
     }
 }
 
+/// Returns the minimum Python version that includes the given member in
+/// `unittest.mock`, for members added after the module's introduction in 3.3.
+/// Returns `None` for members that have always been available.
+fn mock_member_min_version(name: &str) -> Option<PythonVersion> {
+    match name {
+        "seal" => Some(PythonVersion::PY37),
+        "AsyncMock" => Some(PythonVersion::PY38),
+        "ThreadingMock" => Some(PythonVersion::PY313),
+        _ => None,
+    }
+}
+
 /// UP026
 pub(crate) fn deprecated_mock_attribute(checker: &Checker, attribute: &ast::ExprAttribute) {
     if !checker.semantic().seen_module(Modules::MOCK) {
@@ -344,6 +365,16 @@ pub(crate) fn deprecated_mock_import(checker: &Checker, stmt: &Stmt) {
             }
 
             if module == "mock" {
+                // The PyPI `mock` package is a rolling backport that may include APIs
+                // not yet available in `unittest.mock` for the target Python version.
+                // Skip the diagnostic if any imported name requires a newer version.
+                if names.iter().any(|alias| {
+                    mock_member_min_version(alias.name.as_str())
+                        .is_some_and(|min_version| checker.target_version() < min_version)
+                }) {
+                    return;
+                }
+
                 if names.iter().any(|alias| {
                     alias.name.as_str() == "mock"
                         && is_import_required_by_isort(

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP026_py37.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP026_py37.snap
@@ -1,0 +1,92 @@
+---
+source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
+---
+UP026 [*] `mock` is deprecated, use `unittest.mock`
+  --> UP026_py37.py:11:1
+   |
+10 | # Error: all names available since 3.3
+11 | from mock import Mock
+   | ^^^^^^^^^^^^^^^^^^^^^
+12 |
+13 | # Error: seal was added in 3.7, which matches the target
+   |
+help: Import from `unittest.mock` instead
+8  | from mock import Mock, AsyncMock
+9  | 
+10 | # Error: all names available since 3.3
+   - from mock import Mock
+11 + from unittest.mock import Mock
+12 | 
+13 | # Error: seal was added in 3.7, which matches the target
+14 | from mock import seal
+
+UP026 [*] `mock` is deprecated, use `unittest.mock`
+  --> UP026_py37.py:14:1
+   |
+13 | # Error: seal was added in 3.7, which matches the target
+14 | from mock import seal
+   | ^^^^^^^^^^^^^^^^^^^^^
+15 |
+16 | # Error: all names available since 3.3
+   |
+help: Import from `unittest.mock` instead
+11 | from mock import Mock
+12 | 
+13 | # Error: seal was added in 3.7, which matches the target
+   - from mock import seal
+14 + from unittest.mock import seal
+15 | 
+16 | # Error: all names available since 3.3
+17 | from mock import patch, MagicMock
+
+UP026 [*] `mock` is deprecated, use `unittest.mock`
+  --> UP026_py37.py:17:1
+   |
+16 | # Error: all names available since 3.3
+17 | from mock import patch, MagicMock
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+18 |
+19 | # Error: star imports can't be checked
+   |
+help: Import from `unittest.mock` instead
+14 | from mock import seal
+15 | 
+16 | # Error: all names available since 3.3
+   - from mock import patch, MagicMock
+17 + from unittest.mock import patch, MagicMock
+18 | 
+19 | # Error: star imports can't be checked
+20 | from mock import *
+
+UP026 [*] `mock` is deprecated, use `unittest.mock`
+  --> UP026_py37.py:20:1
+   |
+19 | # Error: star imports can't be checked
+20 | from mock import *
+   | ^^^^^^^^^^^^^^^^^^
+21 |
+22 | # Error: bare `import mock` always works (the module exists since 3.3)
+   |
+help: Import from `unittest.mock` instead
+17 | from mock import patch, MagicMock
+18 | 
+19 | # Error: star imports can't be checked
+   - from mock import *
+20 + from unittest.mock import *
+21 | 
+22 | # Error: bare `import mock` always works (the module exists since 3.3)
+23 | import mock
+
+UP026 [*] `mock` is deprecated, use `unittest.mock`
+  --> UP026_py37.py:23:8
+   |
+22 | # Error: bare `import mock` always works (the module exists since 3.3)
+23 | import mock
+   |        ^^^^
+   |
+help: Import from `unittest.mock` instead
+20 | from mock import *
+21 | 
+22 | # Error: bare `import mock` always works (the module exists since 3.3)
+   - import mock
+23 + from unittest import mock


### PR DESCRIPTION
The `mock` package on PyPI backports newer APIs to older Python. UP026 was rewriting `from mock import AsyncMock` to `from unittest.mock import AsyncMock` even on Python 3.7, where `AsyncMock` doesn't exist yet. That breaks at runtime.

Now the rule checks if each imported name exists in `unittest.mock` for the configured target version. If any name isn't available, the diagnostic is skipped. Version-gated names: `seal` (3.7), `AsyncMock` (3.8), `ThreadingMock` (3.13). Plain `import mock` and star imports are not affected.

## Test Plan

New fixture `UP026_py37.py` with `target-version = py37` covering skipped cases (`AsyncMock`, `ThreadingMock`, mixed imports) and flagged cases (`Mock`, `seal`, `patch`, star import, bare `import mock`).

`cargo test -p ruff_linter pyupgrade::tests`


Close: #22343