### PR TITLE
`PERF401`: Support tuple unpacking in for-loop targets

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/perflint/PERF401.py
+++ b/crates/ruff_linter/resources/test/fixtures/perflint/PERF401.py
@@ -326,3 +326,66 @@ def f():
     ) in original:
         if i > 0:
             filtered.append(i)
+
+
+# Tuple unpacking support (https://github.com/astral-sh/ruff/issues/21648)
+# The following cases are preview-gated.
+
+def f():
+    result = []
+    for x, y in [(1, 2), (3, 4)]:
+        result.append(x + y)  # PERF401 (preview)
+
+
+def f():
+    result = []
+    for x, y in [(1, 2), (3, 4)]:
+        if x > 0:
+            result.append(y)  # PERF401 (preview)
+
+
+def f():
+    result = []
+    for [x, y] in [[1, 2], [3, 4]]:
+        result.append(x + y)  # PERF401 (preview)
+
+
+def f():
+    result = [1, 2]
+    for x, y in [(1, 2), (3, 4)]:
+        result.append(x + y)  # PERF401 (preview, extend)
+
+
+async def f():
+    result = []
+    async for x, y in aiter:
+        result.append(x + y)  # PERF401 (preview, async)
+
+
+# Single-element tuple: PERF402 can't handle this, so PERF401 should flag it
+def f():
+    result = []
+    for x, in [(1,), (2,)]:
+        result.append(x)  # PERF401 (preview)
+
+
+# Should NOT be flagged: nested unpacking
+def f():
+    result = []
+    for (x, y), z in [((1, 2), 3)]:
+        result.append(x + y + z)  # OK
+
+
+# Should NOT be flagged: starred expression
+def f():
+    result = []
+    for x, *y in [(1, 2, 3)]:
+        result.append(x)  # OK
+
+
+# Should NOT be flagged: target used after the loop
+def f():
+    result = []
+    for x, y in [(1, 2), (3, 4)]:
+        result.append(x + y)  # OK
+    print(x)

--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -320,6 +320,11 @@ pub(crate) const fn is_up006_future_annotations_fix_enabled(settings: &LinterSet
     settings.preview.is_enabled()
 }
 
+// https://github.com/astral-sh/ruff/issues/21648
+pub(crate) const fn is_perf401_tuple_unpacking_enabled(settings: &LinterSettings) -> bool {
+    settings.preview.is_enabled()
+}
+
 // https://github.com/astral-sh/ruff/pull/23845
 pub const fn is_warning_severity_enabled(preview: PreviewMode) -> bool {
     preview.is_enabled()

--- a/crates/ruff_linter/src/rules/perflint/rules/manual_list_comprehension.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_list_comprehension.rs
@@ -2,7 +2,8 @@ use ruff_python_ast::{self as ast, Arguments, Expr};
 
 use crate::{Edit, Fix, FixAvailability, Violation};
 use crate::{
-    checkers::ast::Checker, preview::is_fix_manual_list_comprehension_enabled,
+    checkers::ast::Checker,
+    preview::{is_fix_manual_list_comprehension_enabled, is_perf401_tuple_unpacking_enabled},
     rules::perflint::helpers::statement_deletion_range,
 };
 use anyhow::{Result, anyhow};
@@ -95,12 +96,23 @@ impl Violation for ManualListComprehension {
 
 /// PERF401
 pub(crate) fn manual_list_comprehension(checker: &Checker, for_stmt: &ast::StmtFor) {
-    let Expr::Name(ast::ExprName {
-        id: for_stmt_target_id,
-        ..
-    }) = &*for_stmt.target
-    else {
-        return;
+    // Extract target variable names from the for-loop target.
+    // Tuple/list unpacking (e.g., `for x, y in items`) is preview-gated
+    // since it expands the rule's scope.
+    let target_names: Vec<&ast::ExprName> = match &*for_stmt.target {
+        Expr::Name(name) => vec![name],
+        Expr::Tuple(ast::ExprTuple { elts, .. }) | Expr::List(ast::ExprList { elts, .. }) => {
+            if !is_perf401_tuple_unpacking_enabled(checker.settings()) {
+                return;
+            }
+            let names: Vec<_> = elts.iter().filter_map(Expr::as_name_expr).collect();
+            // Only handle flat unpacking; bail on nested tuples or starred expressions
+            if names.len() != elts.len() {
+                return;
+            }
+            names
+        }
+        _ => return,
     };
 
     let (stmt, if_test) = match &*for_stmt.body {
@@ -175,16 +187,17 @@ pub(crate) fn manual_list_comprehension(checker: &Checker, for_stmt: &ast::StmtF
     };
 
     // Ignore direct list copies (e.g., `for x in y: filtered.append(x)`), unless it's async, which
-    // `manual-list-copy` doesn't cover.
-    if !for_stmt.is_async {
-        if if_test.is_none() {
-            if arg
-                .as_name_expr()
-                .is_some_and(|arg| arg.id == *for_stmt_target_id)
-            {
-                return;
-            }
-        }
+    // `manual-list-copy` doesn't cover. We check that the target is a plain name (not a
+    // single-element tuple like `for x, in ...`) because PERF402 only handles `Expr::Name` targets.
+    if !for_stmt.is_async
+        && if_test.is_none()
+        && for_stmt.target.is_name_expr()
+        && let [target] = target_names.as_slice()
+        && arg
+            .as_name_expr()
+            .is_some_and(|arg| arg.id == *target.id)
+    {
+        return;
     }
 
     // Avoid, e.g., `for x in y: filtered.append(filtered[-1] * 2)`.
@@ -230,7 +243,7 @@ pub(crate) fn manual_list_comprehension(checker: &Checker, for_stmt: &ast::StmtF
         return;
     }
 
-    // Avoid if the for-loop target is used outside the for loop, e.g.,
+    // Avoid if any for-loop target variable is used outside the for loop, e.g.,
     //
     // ```python
     // for x in y:
@@ -244,25 +257,29 @@ pub(crate) fn manual_list_comprehension(checker: &Checker, for_stmt: &ast::StmtF
     // filtered = [x for x in y]
     // print(x)
     // ```
-    let target_binding = checker
-        .semantic()
-        .bindings
-        .iter()
-        .find(|binding| for_stmt.target.range() == binding.range)
-        .unwrap();
-    // If the target variable is global (e.g., `global INDEX`) or nonlocal (e.g., `nonlocal INDEX`),
-    // then it is intended to be used elsewhere outside the for loop.
-    if target_binding.is_global() || target_binding.is_nonlocal() {
-        return;
-    }
-    // If any references to the loop target variable are after the loop,
-    // then converting it into a comprehension would cause a NameError
-    if target_binding
-        .references()
-        .map(|reference| checker.semantic().reference(reference))
-        .any(|other_reference| for_stmt.end() < other_reference.start())
-    {
-        return;
+    for target_name in &target_names {
+        let Some(target_binding) = checker
+            .semantic()
+            .bindings
+            .iter()
+            .find(|binding| target_name.range() == binding.range)
+        else {
+            return;
+        };
+        // If the target variable is global or nonlocal, it is intended
+        // to be used elsewhere outside the for loop.
+        if target_binding.is_global() || target_binding.is_nonlocal() {
+            return;
+        }
+        // If any references to the loop target variable are after the loop,
+        // then converting it into a comprehension would cause a NameError
+        if target_binding
+            .references()
+            .map(|reference| checker.semantic().reference(reference))
+            .any(|other_reference| for_stmt.end() < other_reference.start())
+        {
+            return;
+        }
     }
 
     let list_binding_stmt = list_binding.statement(checker.semantic());

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__preview__PERF401_PERF401.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__preview__PERF401_PERF401.py.snap
@@ -677,4 +677,133 @@ help: Replace for loop with list comprehension
     -             filtered.append(i)
 323 +     # comment
 324 +     filtered = [i for i in original if i > 0]
+325 | 
+326 | 
+327 | # Tuple unpacking support (https://github.com/astral-sh/ruff/issues/21648)
+note: This is an unsafe fix and may change runtime behavior
+
+PERF401 [*] Use a list comprehension to create a transformed list
+   --> PERF401.py:337:9
+    |
+335 |     result = []
+336 |     for x, y in [(1, 2), (3, 4)]:
+337 |         result.append(x + y)  # PERF401 (preview)
+    |         ^^^^^^^^^^^^^^^^^^^^
+    |
+help: Replace for loop with list comprehension
+332 | # The following cases are preview-gated.
+333 | 
+334 | def f():
+    -     result = []
+    -     for x, y in [(1, 2), (3, 4)]:
+    -         result.append(x + y)  # PERF401 (preview)
+335 +     result = [x + y for x, y in [(1, 2), (3, 4)]]  # PERF401 (preview)
+336 | 
+337 | 
+338 | def f():
+note: This is an unsafe fix and may change runtime behavior
+
+PERF401 [*] Use a list comprehension to create a transformed list
+   --> PERF401.py:344:13
+    |
+342 |     for x, y in [(1, 2), (3, 4)]:
+343 |         if x > 0:
+344 |             result.append(y)  # PERF401 (preview)
+    |             ^^^^^^^^^^^^^^^^
+    |
+help: Replace for loop with list comprehension
+338 | 
+339 | 
+340 | def f():
+    -     result = []
+    -     for x, y in [(1, 2), (3, 4)]:
+    -         if x > 0:
+    -             result.append(y)  # PERF401 (preview)
+341 +     result = [y for x, y in [(1, 2), (3, 4)] if x > 0]  # PERF401 (preview)
+342 | 
+343 | 
+344 | def f():
+note: This is an unsafe fix and may change runtime behavior
+
+PERF401 [*] Use a list comprehension to create a transformed list
+   --> PERF401.py:350:9
+    |
+348 |     result = []
+349 |     for [x, y] in [[1, 2], [3, 4]]:
+350 |         result.append(x + y)  # PERF401 (preview)
+    |         ^^^^^^^^^^^^^^^^^^^^
+    |
+help: Replace for loop with list comprehension
+345 | 
+346 | 
+347 | def f():
+    -     result = []
+    -     for [x, y] in [[1, 2], [3, 4]]:
+    -         result.append(x + y)  # PERF401 (preview)
+348 +     result = [x + y for [x, y] in [[1, 2], [3, 4]]]  # PERF401 (preview)
+349 | 
+350 | 
+351 | def f():
+note: This is an unsafe fix and may change runtime behavior
+
+PERF401 [*] Use `list.extend` to create a transformed list
+   --> PERF401.py:356:9
+    |
+354 |     result = [1, 2]
+355 |     for x, y in [(1, 2), (3, 4)]:
+356 |         result.append(x + y)  # PERF401 (preview, extend)
+    |         ^^^^^^^^^^^^^^^^^^^^
+    |
+help: Replace for loop with list.extend
+352 | 
+353 | def f():
+354 |     result = [1, 2]
+    -     for x, y in [(1, 2), (3, 4)]:
+    -         result.append(x + y)  # PERF401 (preview, extend)
+355 +     result.extend(x + y for x, y in [(1, 2), (3, 4)])  # PERF401 (preview, extend)
+356 | 
+357 | 
+358 | async def f():
+note: This is an unsafe fix and may change runtime behavior
+
+PERF401 [*] Use an async list comprehension to create a transformed list
+   --> PERF401.py:362:9
+    |
+360 |     result = []
+361 |     async for x, y in aiter:
+362 |         result.append(x + y)  # PERF401 (preview, async)
+    |         ^^^^^^^^^^^^^^^^^^^^
+    |
+help: Replace for loop with list comprehension
+357 | 
+358 | 
+359 | async def f():
+    -     result = []
+    -     async for x, y in aiter:
+    -         result.append(x + y)  # PERF401 (preview, async)
+360 +     result = [x + y async for x, y in aiter]  # PERF401 (preview, async)
+361 | 
+362 | 
+363 | # Single-element tuple: PERF402 can't handle this, so PERF401 should flag it
+note: This is an unsafe fix and may change runtime behavior
+
+PERF401 [*] Use a list comprehension to create a transformed list
+   --> PERF401.py:369:9
+    |
+367 |     result = []
+368 |     for x, in [(1,), (2,)]:
+369 |         result.append(x)  # PERF401 (preview)
+    |         ^^^^^^^^^^^^^^^^
+    |
+help: Replace for loop with list comprehension
+364 | 
+365 | # Single-element tuple: PERF402 can't handle this, so PERF401 should flag it
+366 | def f():
+    -     result = []
+    -     for x, in [(1,), (2,)]:
+    -         result.append(x)  # PERF401 (preview)
+367 +     result = [x for x, in [(1,), (2,)]]  # PERF401 (preview)
+368 | 
+369 | 
+370 | # Should NOT be flagged: nested unpacking
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Fixes #21648. Continues #22450.

- PERF401 missed `for` loops with tuple/list unpacking (e.g., `for x, y in items`). This adds detection for those patterns behind the preview gate.

- Nested unpacking and starred expressions are intentionally skipped. The PERF402 overlap guard is preserved for simple name targets.

- Test cases cover tuple unpacking, list unpacking, conditionals, extend, async, single-element tuples, and cases that should not be flagged.