### PR TITLE
[`eradicate`] ignore `ty: ignore` comments in `ERA001`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/eradicate/ERA001.py
+++ b/crates/ruff_linter/resources/test/fixtures/eradicate/ERA001.py
@@ -91,7 +91,10 @@ print(1)
 # Foobar
 
 
-# Regression tests for https://github.com/astral-sh/ruff/issues/19713
+# Regression tests for https://github.com/astral-sh/ruff/issues/19713,
+# https://github.com/astral-sh/ruff/issues/24186
+
+# ty: ignore
 
 # mypy: ignore-errors
 # pyright: ignore-errors

--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -25,6 +25,7 @@ static ALLOWLIST_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         |   ruff\s*:\s*(disable|enable)
         |   mypy:
         |   type:\s*ignore
+        |   ty:\s*ignore
         |   SPDX-License-Identifier:
         |   fmt:\s*(on|off|skip)
         |   region|endregion
@@ -322,6 +323,15 @@ mod tests {
         assert!(!comment_contains_code("# type:ignore", &[]));
         assert!(!comment_contains_code("# type: ignore[import]", &[]));
         assert!(!comment_contains_code("# type:ignore[import]", &[]));
+        assert!(!comment_contains_code("# ty: ignore", &[]));
+        assert!(!comment_contains_code("# ty:ignore", &[]));
+        assert!(!comment_contains_code("# ty: ignore[import]", &[]));
+        assert!(!comment_contains_code("# ty:ignore[import]", &[]));
+        assert!(!comment_contains_code(
+            "# ty: ignore[missing-argument, invalid-argument-type]",
+            &[]
+        ));
+        assert!(!comment_contains_code("# ty: ignore[]", &[]));
         assert!(!comment_contains_code(
             "# TODO: Do that",
             &["TODO".to_string()]


### PR DESCRIPTION
## Summary

Don't flag `# ty: ignore` comments as commented-out code.

Closes #24186

## Test Plan

New unit tests and fixture case.