### PR TITLE
[refurb] Skip writelines fix when walrus collides with genexp target (FURB122)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB122.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB122.py
@@ -97,6 +97,21 @@ def _():
             f.write(f"{char}")
 
 
+# Assignment expression vs comprehension iteration - https://github.com/astral-sh/ruff/issues/21107
+
+
+def _():
+    with open("file", "w") as f:
+        for line in lines:
+            f.write(line := line.upper())
+
+
+def _():
+    with open("file", "w") as f:
+        for first, *rest in lines:
+            f.write(rest := "".join(rest))
+
+
 # OK
 
 def _():

--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB122_21107.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB122_21107.py
@@ -1,0 +1,17 @@
+# Attribute and subscript loop targets with walrus (version-dependent; #21107).
+from types import SimpleNamespace
+
+
+def _():
+    ns = SimpleNamespace(prev=[], last=None)
+    with open("file", "r", encoding="utf-8") as src, open("file", "w", encoding="utf-8") as dst:
+        for ns.last in src:
+            dst.write((ns := SimpleNamespace(prev=[*ns.prev, ns.last], last=None)).prev[-1])
+
+
+def _():
+    cache = {}
+    index = 0
+    with open("file", "r", encoding="utf-8") as src, open("file", "w", encoding="utf-8") as dst:
+        for cache[index] in src:
+            dst.write(str(index := 0))

--- a/crates/ruff_linter/src/rules/refurb/mod.rs
+++ b/crates/ruff_linter/src/rules/refurb/mod.rs
@@ -79,6 +79,19 @@ mod tests {
     }
 
     #[test]
+    fn for_loop_writes_attribute_iter_target_python_version_diff() -> Result<()> {
+        assert_diagnostics_diff!(
+            "for_loop_writes_attribute_iter_target_python_version_diff",
+            Path::new("refurb/FURB122_21107.py"),
+            &settings::LinterSettings::for_rule(Rule::ForLoopWrites)
+                .with_target_version(PythonVersion::PY311),
+            &settings::LinterSettings::for_rule(Rule::ForLoopWrites)
+                .with_target_version(PythonVersion::PY312),
+        );
+        Ok(())
+    }
+
+    #[test]
     fn write_whole_file_python_39() -> Result<()> {
         let diagnostics = test_path(
             Path::new("refurb/FURB103_0.py"),

--- a/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs
@@ -1,14 +1,17 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::{Expr, ExprList, ExprName, ExprTuple, Stmt, StmtFor};
+use ruff_python_ast::name::Name;
+use ruff_python_ast::visitor::{Visitor, walk_expr};
+use ruff_python_ast::{
+    Expr, ExprList, ExprName, ExprNamed, ExprTuple, PythonVersion, Stmt, StmtFor,
+};
 use ruff_python_semantic::analyze::typing;
 use ruff_python_semantic::{Binding, ScopeId, SemanticModel, TypingOnlyBindingsStatus};
 use ruff_text_size::{Ranged, TextRange, TextSize};
+use rustc_hash::FxHashSet;
 
 use crate::checkers::ast::Checker;
-use crate::rules::refurb::helpers::IterLocation;
-use crate::{AlwaysFixableViolation, Applicability, Edit, Fix};
-
-use crate::rules::refurb::helpers::parenthesize_loop_iter_if_necessary;
+use crate::rules::refurb::helpers::{IterLocation, parenthesize_loop_iter_if_necessary};
+use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 
 /// ## What it does
 /// Checks for the use of `IOBase.write` in a for loop.
@@ -44,6 +47,13 @@ use crate::rules::refurb::helpers::parenthesize_loop_iter_if_necessary;
 /// ## Fix safety
 /// This fix is marked as unsafe if it would cause comments to be deleted.
 ///
+/// ## Known problems
+/// When the `write` argument contains an assignment expression (`:=`) whose target collides
+/// with the `for` loop target under generator-expression scoping, the fix is omitted. Prior
+/// to Python 3.12, that also applies when the `:=` target matches a name referenced in an
+/// attribute or subscript loop target (for example `for ns.last in ...` and `ns := ...`, or
+/// `for cache[i] in ...` and `i := ...`).
+///
 /// ## References
 /// - [Python documentation: `io.IOBase.writelines`](https://docs.python.org/3/library/io.html#io.IOBase.writelines)
 #[derive(ViolationMetadata)]
@@ -52,14 +62,16 @@ pub(crate) struct ForLoopWrites {
     name: String,
 }
 
-impl AlwaysFixableViolation for ForLoopWrites {
+impl Violation for ForLoopWrites {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("Use of `{}.write` in a for loop", self.name)
     }
 
-    fn fix_title(&self) -> String {
-        format!("Replace with `{}.writelines`", self.name)
+    fn fix_title(&self) -> Option<String> {
+        Some(format!("Replace with `{}.writelines`", self.name))
     }
 }
 
@@ -104,34 +116,6 @@ pub(crate) fn for_loop_writes_stmt(checker: &Checker, for_stmt: &StmtFor) {
     let scope_id = checker.semantic().scope_id;
 
     for_loop_writes(checker, for_stmt, scope_id, &[]);
-}
-
-/// Find the names in a `for` loop target
-/// that are assigned to during iteration.
-///
-/// ```python
-/// for ((), [(a,), [[b]]], c.d, e[f], *[*g]) in h:
-///     #      ^      ^                   ^
-///     ...
-/// ```
-fn binding_names(for_target: &Expr) -> Vec<&ExprName> {
-    fn collect_names<'a>(expr: &'a Expr, names: &mut Vec<&'a ExprName>) {
-        match expr {
-            Expr::Name(name) => names.push(name),
-
-            Expr::Starred(starred) => collect_names(&starred.value, names),
-
-            Expr::List(ExprList { elts, .. }) | Expr::Tuple(ExprTuple { elts, .. }) => elts
-                .iter()
-                .for_each(|element| collect_names(element, names)),
-
-            _ => {}
-        }
-    }
-
-    let mut names = vec![];
-    collect_names(for_target, &mut names);
-    names
 }
 
 /// FURB122
@@ -195,6 +179,19 @@ fn for_loop_writes(
             )
         }
         (for_target, write_arg) => {
+            if walrus_conflicts_with_comprehension_target(
+                write_arg,
+                &for_stmt.target,
+                checker.target_version(),
+            ) {
+                checker.report_diagnostic(
+                    ForLoopWrites {
+                        name: io_object_name.id.to_string(),
+                    },
+                    for_stmt.range,
+                );
+                return;
+            }
             format!(
                 "{}.writelines({} for {} in {})",
                 locator.slice(io_object_name),
@@ -223,6 +220,128 @@ fn for_loop_writes(
             for_stmt.range,
         )
         .set_fix(fix);
+}
+
+// --- helpers ---
+
+/// Find the names in a `for` loop target
+/// that are assigned to during iteration.
+///
+/// ```python
+/// for ((), [(a,), [[b]]], c.d, e[f], *[*g]) in h:
+///     #      ^      ^                   ^
+///     ...
+/// ```
+fn binding_names(for_target: &Expr) -> Vec<&ExprName> {
+    fn collect_names<'a>(expr: &'a Expr, names: &mut Vec<&'a ExprName>) {
+        match expr {
+            Expr::Name(name) => names.push(name),
+
+            Expr::Starred(starred) => collect_names(&starred.value, names),
+
+            Expr::List(ExprList { elts, .. }) | Expr::Tuple(ExprTuple { elts, .. }) => elts
+                .iter()
+                .for_each(|element| collect_names(element, names)),
+
+            _ => {}
+        }
+    }
+
+    let mut names = vec![];
+    collect_names(for_target, &mut names);
+    names
+}
+
+/// Names whose rebinding via `:=` in a generator element is invalid for this `for` target.
+///
+/// Always includes the directly-bound names (`for a, b in ...` → `{a, b}`).
+/// Before Python 3.12, also includes names *referenced* in attribute and subscript
+/// sub-targets (`for ns.last in ...` → `ns`, `for cache[i] in ...` → `cache`, `i`).
+fn comprehension_walrus_forbidden_names(
+    for_target: &Expr,
+    python_version: PythonVersion,
+) -> FxHashSet<Name> {
+    let mut out: FxHashSet<Name> = binding_names(for_target)
+        .into_iter()
+        .map(|name| name.id.clone())
+        .collect();
+    if python_version < PythonVersion::PY312 {
+        collect_target_loaded_names(for_target, &mut out);
+    }
+    out
+}
+
+/// Collect all names in `Load` context within attribute and subscript sub-targets.
+///
+/// `for ns.last in ...` → `ns`;  `for cache[i] in ...` → `cache`, `i`.
+/// Before Python 3.12, rebinding any of these via `:=` inside a comprehension
+/// element is either a `SyntaxError` or changes semantics.
+fn collect_target_loaded_names(expr: &Expr, out: &mut FxHashSet<Name>) {
+    match expr {
+        Expr::Attribute(attr) => {
+            collect_all_names(&attr.value, out);
+        }
+        Expr::Subscript(subscript) => {
+            collect_all_names(&subscript.value, out);
+            collect_all_names(&subscript.slice, out);
+        }
+        Expr::Starred(starred) => collect_target_loaded_names(&starred.value, out),
+        Expr::List(ExprList { elts, .. }) | Expr::Tuple(ExprTuple { elts, .. }) => {
+            for elt in elts {
+                collect_target_loaded_names(elt, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Collect every `Name` node reachable from `expr`.
+fn collect_all_names(expr: &Expr, out: &mut FxHashSet<Name>) {
+    struct NameCollector<'a>(&'a mut FxHashSet<Name>);
+
+    impl Visitor<'_> for NameCollector<'_> {
+        fn visit_expr(&mut self, expr: &Expr) {
+            if let Expr::Name(name) = expr {
+                self.0.insert(name.id.clone());
+            }
+            walk_expr(self, expr);
+        }
+    }
+
+    NameCollector(out).visit_expr(expr);
+}
+
+fn walrus_conflicts_with_comprehension_target(
+    write_arg: &Expr,
+    for_target: &Expr,
+    python_version: PythonVersion,
+) -> bool {
+    let forbidden = comprehension_walrus_forbidden_names(for_target, python_version);
+    if forbidden.is_empty() {
+        return false;
+    }
+    let mut walrus_targets = FxHashSet::default();
+    collect_walrus_assignment_targets(write_arg, &mut walrus_targets);
+    walrus_targets.iter().any(|name| forbidden.contains(name))
+}
+
+fn collect_walrus_assignment_targets(expr: &Expr, out: &mut FxHashSet<Name>) {
+    struct Collector<'a>(&'a mut FxHashSet<Name>);
+
+    impl Visitor<'_> for Collector<'_> {
+        fn visit_expr(&mut self, expr: &Expr) {
+            if let Expr::Named(ExprNamed { target, value, .. }) = expr {
+                if let Expr::Name(name) = target.as_ref() {
+                    self.0.insert(name.id.clone());
+                }
+                self.visit_expr(value);
+            } else {
+                walk_expr(self, expr);
+            }
+        }
+    }
+
+    Collector(out).visit_expr(expr);
 }
 
 fn loop_variables_are_used_outside_loop(

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB122_FURB122.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB122_FURB122.py.snap
@@ -293,122 +293,144 @@ help: Replace with `f.writelines`
 96 +         ))
 97 | 
 98 | 
-99 | # OK
+99 | # Assignment expression vs comprehension iteration - https://github.com/astral-sh/ruff/issues/21107
 note: This is an unsafe fix and may change runtime behavior
 
-FURB122 [*] Use of `f.write` in a for loop
-   --> FURB122.py:183:9
+FURB122 Use of `f.write` in a for loop
+   --> FURB122.py:105:9
     |
-181 |   def _():
-182 |       with Path("file.txt").open("w", encoding="utf-8") as f:
-183 | /         for l in lambda: 0:
-184 | |             f.write(f"[{l}]")
+103 |   def _():
+104 |       with open("file", "w") as f:
+105 | /         for line in lines:
+106 | |             f.write(line := line.upper())
+    | |_________________________________________^
+    |
+help: Replace with `f.writelines`
+
+FURB122 Use of `f.write` in a for loop
+   --> FURB122.py:111:9
+    |
+109 |   def _():
+110 |       with open("file", "w") as f:
+111 | /         for first, *rest in lines:
+112 | |             f.write(rest := "".join(rest))
+    | |__________________________________________^
+    |
+help: Replace with `f.writelines`
+
+FURB122 [*] Use of `f.write` in a for loop
+   --> FURB122.py:198:9
+    |
+196 |   def _():
+197 |       with Path("file.txt").open("w", encoding="utf-8") as f:
+198 | /         for l in lambda: 0:
+199 | |             f.write(f"[{l}]")
     | |_____________________________^
     |
 help: Replace with `f.writelines`
-180 | 
-181 | def _():
-182 |     with Path("file.txt").open("w", encoding="utf-8") as f:
+195 | 
+196 | def _():
+197 |     with Path("file.txt").open("w", encoding="utf-8") as f:
     -         for l in lambda: 0:
     -             f.write(f"[{l}]")
-183 +         f.writelines(f"[{l}]" for l in (lambda: 0))
-184 | 
-185 | 
-186 | def _():
+198 +         f.writelines(f"[{l}]" for l in (lambda: 0))
+199 | 
+200 | 
+201 | def _():
 
 FURB122 [*] Use of `f.write` in a for loop
-   --> FURB122.py:189:9
+   --> FURB122.py:204:9
     |
-187 |   def _():
-188 |       with Path("file.txt").open("w", encoding="utf-8") as f:
-189 | /         for l in (1,) if True else (2,):
-190 | |             f.write(f"[{l}]")
+202 |   def _():
+203 |       with Path("file.txt").open("w", encoding="utf-8") as f:
+204 | /         for l in (1,) if True else (2,):
+205 | |             f.write(f"[{l}]")
     | |_____________________________^
     |
 help: Replace with `f.writelines`
-186 | 
-187 | def _():
-188 |     with Path("file.txt").open("w", encoding="utf-8") as f:
+201 | 
+202 | def _():
+203 |     with Path("file.txt").open("w", encoding="utf-8") as f:
     -         for l in (1,) if True else (2,):
     -             f.write(f"[{l}]")
-189 +         f.writelines(f"[{l}]" for l in ((1,) if True else (2,)))
-190 | 
-191 | 
-192 | # don't need to add parentheses when making a function argument
+204 +         f.writelines(f"[{l}]" for l in ((1,) if True else (2,)))
+205 | 
+206 | 
+207 | # don't need to add parentheses when making a function argument
 
 FURB122 [*] Use of `f.write` in a for loop
-   --> FURB122.py:196:9
+   --> FURB122.py:211:9
     |
-194 |   def _():
-195 |       with open("file", "w") as f:
-196 | /         for line in lambda: 0:
-197 | |             f.write(line)
+209 |   def _():
+210 |       with open("file", "w") as f:
+211 | /         for line in lambda: 0:
+212 | |             f.write(line)
     | |_________________________^
     |
 help: Replace with `f.writelines`
-193 | # don't need to add parentheses when making a function argument
-194 | def _():
-195 |     with open("file", "w") as f:
+208 | # don't need to add parentheses when making a function argument
+209 | def _():
+210 |     with open("file", "w") as f:
     -         for line in lambda: 0:
     -             f.write(line)
-196 +         f.writelines(lambda: 0)
-197 | 
-198 | 
-199 | def _():
+211 +         f.writelines(lambda: 0)
+212 | 
+213 | 
+214 | def _():
 
 FURB122 [*] Use of `f.write` in a for loop
-   --> FURB122.py:202:9
+   --> FURB122.py:217:9
     |
-200 |   def _():
-201 |       with open("file", "w") as f:
-202 | /         for line in (1,) if True else (2,):
-203 | |             f.write(line)
+215 |   def _():
+216 |       with open("file", "w") as f:
+217 | /         for line in (1,) if True else (2,):
+218 | |             f.write(line)
     | |_________________________^
     |
 help: Replace with `f.writelines`
-199 | 
-200 | def _():
-201 |     with open("file", "w") as f:
+214 | 
+215 | def _():
+216 |     with open("file", "w") as f:
     -         for line in (1,) if True else (2,):
     -             f.write(line)
-202 +         f.writelines((1,) if True else (2,))
-203 | 
-204 | 
-205 | # don't add extra parentheses if they're already parenthesized
+217 +         f.writelines((1,) if True else (2,))
+218 | 
+219 | 
+220 | # don't add extra parentheses if they're already parenthesized
 
 FURB122 [*] Use of `f.write` in a for loop
-   --> FURB122.py:209:9
+   --> FURB122.py:224:9
     |
-207 |   def _():
-208 |       with open("file", "w") as f:
-209 | /         for line in (lambda: 0):
-210 | |             f.write(f"{line}")
+222 |   def _():
+223 |       with open("file", "w") as f:
+224 | /         for line in (lambda: 0):
+225 | |             f.write(f"{line}")
     | |______________________________^
     |
 help: Replace with `f.writelines`
-206 | # don't add extra parentheses if they're already parenthesized
-207 | def _():
-208 |     with open("file", "w") as f:
+221 | # don't add extra parentheses if they're already parenthesized
+222 | def _():
+223 |     with open("file", "w") as f:
     -         for line in (lambda: 0):
     -             f.write(f"{line}")
-209 +         f.writelines(f"{line}" for line in (lambda: 0))
-210 | 
-211 | 
-212 | def _():
+224 +         f.writelines(f"{line}" for line in (lambda: 0))
+225 | 
+226 | 
+227 | def _():
 
 FURB122 [*] Use of `f.write` in a for loop
-   --> FURB122.py:215:9
+   --> FURB122.py:230:9
     |
-213 |   def _():
-214 |       with open("file", "w") as f:
-215 | /         for line in ((1,) if True else (2,)):
-216 | |             f.write(f"{line}")
+228 |   def _():
+229 |       with open("file", "w") as f:
+230 | /         for line in ((1,) if True else (2,)):
+231 | |             f.write(f"{line}")
     | |______________________________^
     |
 help: Replace with `f.writelines`
-212 | 
-213 | def _():
-214 |     with open("file", "w") as f:
+227 | 
+228 | def _():
+229 |     with open("file", "w") as f:
     -         for line in ((1,) if True else (2,)):
     -             f.write(f"{line}")
-215 +         f.writelines(f"{line}" for line in ((1,) if True else (2,)))
+230 +         f.writelines(f"{line}" for line in ((1,) if True else (2,)))

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__for_loop_writes_attribute_iter_target_python_version_diff.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__for_loop_writes_attribute_iter_target_python_version_diff.snap
@@ -1,0 +1,75 @@
+---
+source: crates/ruff_linter/src/rules/refurb/mod.rs
+---
+--- Linter settings ---
+-linter.unresolved_target_version = 3.11
++linter.unresolved_target_version = 3.12
+
+--- Summary ---
+Removed: 2
+Added: 2
+
+--- Removed ---
+FURB122 Use of `dst.write` in a for loop
+ --> FURB122_21107.py:8:9
+  |
+6 |       ns = SimpleNamespace(prev=[], last=None)
+7 |       with open("file", "r", encoding="utf-8") as src, open("file", "w", encoding="utf-8") as dst:
+8 | /         for ns.last in src:
+9 | |             dst.write((ns := SimpleNamespace(prev=[*ns.prev, ns.last], last=None)).prev[-1])
+  | |____________________________________________________________________________________________^
+  |
+help: Replace with `dst.writelines`
+
+
+FURB122 Use of `dst.write` in a for loop
+  --> FURB122_21107.py:16:9
+   |
+14 |       index = 0
+15 |       with open("file", "r", encoding="utf-8") as src, open("file", "w", encoding="utf-8") as dst:
+16 | /         for cache[index] in src:
+17 | |             dst.write(str(index := 0))
+   | |______________________________________^
+   |
+help: Replace with `dst.writelines`
+
+
+
+--- Added ---
+FURB122 [*] Use of `dst.write` in a for loop
+ --> FURB122_21107.py:8:9
+  |
+6 |       ns = SimpleNamespace(prev=[], last=None)
+7 |       with open("file", "r", encoding="utf-8") as src, open("file", "w", encoding="utf-8") as dst:
+8 | /         for ns.last in src:
+9 | |             dst.write((ns := SimpleNamespace(prev=[*ns.prev, ns.last], last=None)).prev[-1])
+  | |____________________________________________________________________________________________^
+  |
+help: Replace with `dst.writelines`
+5  | def _():
+6  |     ns = SimpleNamespace(prev=[], last=None)
+7  |     with open("file", "r", encoding="utf-8") as src, open("file", "w", encoding="utf-8") as dst:
+   -         for ns.last in src:
+   -             dst.write((ns := SimpleNamespace(prev=[*ns.prev, ns.last], last=None)).prev[-1])
+8  +         dst.writelines((ns := SimpleNamespace(prev=[*ns.prev, ns.last], last=None)).prev[-1] for ns.last in src)
+9  | 
+10 | 
+11 | def _():
+
+
+FURB122 [*] Use of `dst.write` in a for loop
+  --> FURB122_21107.py:16:9
+   |
+14 |       index = 0
+15 |       with open("file", "r", encoding="utf-8") as src, open("file", "w", encoding="utf-8") as dst:
+16 | /         for cache[index] in src:
+17 | |             dst.write(str(index := 0))
+   | |______________________________________^
+   |
+help: Replace with `dst.writelines`
+13 |     cache = {}
+14 |     index = 0
+15 |     with open("file", "r", encoding="utf-8") as src, open("file", "w", encoding="utf-8") as dst:
+   -         for cache[index] in src:
+   -             dst.write(str(index := 0))
+16 +         dst.writelines(str(index := 0) for cache[index] in src)


### PR DESCRIPTION
Closes #21107

Skips the `FURB122` fix when the `writelines` rewrite would produce invalid Python due to a `:=` target colliding with the generator's iteration variable.

Three cases from the issue:

- `for line in src: dst.write(line := line.upper())` — walrus rebinds a simple loop variable
- `for first, *rest in src: dst.write(rest := ...)` — walrus rebinds a starred-unpacking variable
- `for ns.last in src: dst.write((ns := ...).prev[-1])` — walrus rebinds the root of an attribute target (invalid before 3.12, valid on 3.12+)

The diagnostic is still emitted in all cases; the fix is just omitted when it would be invalid. `ForLoopWrites` switches from `AlwaysFixableViolation` to `Violation` with `FixAvailability::Sometimes`.

## Test Plan

- New fixtures in `FURB122.py` for the simple-name and starred-unpacking cases.
- `FURB122_21107.py` with `assert_diagnostics_diff` for `PY311` vs `PY312` on the attribute target case.
- `cargo test -p ruff_linter refurb::tests`