### PR TITLE
[ty] pass type context to sequence literals in binary operations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -133,6 +133,8 @@ reveal_type(d4_invalid_dict)  # revealed: TD
 d5_literal: dict[Hashable, Callable[..., object]] = {"x": lambda: 1}
 d5_dict: dict[Hashable, Callable[..., object]] = dict(x=lambda: 1)
 
+d6_dict: TD = {"x": 1} | {"x": 2}
+
 def return_literal() -> TD:
     return {"x": 1}
 

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -138,7 +138,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // so we can use bidirectional inference on the literal before calling the synthesized
         // `__or__`/`__ror__` method on the TypedDict side.
         if op == ast::Operator::BitOr && matches!(left, ast::Expr::Dict(_)) {
-            let right_ty = self.infer_expression(right, TypeContext::default());
+            let right_ty = self.infer_expression(right, operand_tcx(right));
             if let Type::TypedDict(typed_dict) = right_ty
                 && let Some(ty) = self.try_typed_dict_pep_584_dunder(
                     left,


### PR DESCRIPTION
Fixes https://github.com/astral-sh/ty/issues/3002.

This is a quick fix for this special case. A more general solution will be passing type context through generic method calls, with binary operations like these handled via their dunder methods.