### PR TITLE
[`fastapi`] Resolve `Annotated` dependency aliases in `FAST003`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
+++ b/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
@@ -396,3 +396,17 @@ async def read_thing_type_alias_dep(query: ThingDepTypeAlias): ...
 # Error: alias dependency does not define `thing_id`.
 @app.get("/alias-missing/{thing_id}")
 async def read_thing_alias_missing_dep(query: ThingDepMissingAlias): ...
+
+# Alias shadowing: the last binding at module scope should be used.
+ShadowedAlias = Annotated[dict, Depends(takes_other_alias)]
+ShadowedAlias = Annotated[dict, Depends(takes_thing_id_alias)]
+
+# No error: the second (active) binding includes `thing_id`.
+@app.get("/alias-shadow/{thing_id}")
+async def read_thing_alias_shadow(query: ShadowedAlias): ...
+
+# Alias that is not `Annotated` — should be ignored, not crash.
+PlainAlias = dict
+
+@app.get("/alias-plain/{thing_id}")
+async def read_thing_alias_plain(query: PlainAlias): ...

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -6,7 +6,7 @@ use regex::{CaptureMatches, Regex};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast as ast;
 use ruff_python_ast::{Arguments, Expr, ExprCall, ExprSubscript, Parameter, ParameterWithDefault};
-use ruff_python_semantic::{BindingKind, Modules, ScopeKind, SemanticModel};
+use ruff_python_semantic::{BindingKind, Modules, ScopeId, ScopeKind, SemanticModel};
 use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_text_size::{Ranged, TextSize};
 
@@ -270,13 +270,14 @@ impl<'a> Dependency<'a> {
             return Some(dependency);
         }
 
-        Self::from_annotation(parameter.annotation()?, semantic, 0)
+        Self::from_annotation(parameter.annotation()?, semantic, 0, None)
     }
 
     fn from_annotation(
         annotation: &'a Expr,
         semantic: &SemanticModel<'a>,
         alias_depth: usize,
+        scope_hint: Option<ScopeId>,
     ) -> Option<Self> {
         if alias_depth > Self::MAX_ALIAS_DEPTH {
             return Some(Self::Unknown);
@@ -289,8 +290,14 @@ impl<'a> Dependency<'a> {
         }
 
         let alias_name = annotation.as_name_expr()?;
-        let alias_annotation = Self::resolve_local_alias_annotation(alias_name, semantic)?;
-        Self::from_annotation(alias_annotation, semantic, alias_depth + 1)
+        let (alias_annotation, alias_scope) =
+            Self::resolve_local_alias_annotation(alias_name, semantic, scope_hint)?;
+        Self::from_annotation(
+            alias_annotation,
+            semantic,
+            alias_depth + 1,
+            Some(alias_scope),
+        )
     }
 
     fn from_annotated_slice(slice: &'a Expr, semantic: &SemanticModel<'a>) -> Option<Self> {
@@ -323,9 +330,14 @@ impl<'a> Dependency<'a> {
     fn resolve_local_alias_annotation(
         name: &'a ast::ExprName,
         semantic: &SemanticModel<'a>,
-    ) -> Option<&'a Expr> {
-        let binding_id = semantic.lookup_symbol(name.id.as_str())?;
+        scope_hint: Option<ScopeId>,
+    ) -> Option<(&'a Expr, ScopeId)> {
+        let binding_id = match scope_hint {
+            Some(scope_id) => semantic.lookup_symbol_in_scope(name.id.as_str(), scope_id, false)?,
+            None => semantic.lookup_symbol(name.id.as_str())?,
+        };
         let binding = semantic.binding(binding_id);
+        let binding_scope = binding.scope;
         let source = binding.source?;
         let statement = semantic.statement(source);
 
@@ -336,7 +348,7 @@ impl<'a> Dependency<'a> {
                         .as_name_expr()
                         .is_some_and(|target| target.id == name.id)
                 {
-                    Some(value.as_ref())
+                    Some((value.as_ref(), binding_scope))
                 } else {
                     None
                 }
@@ -346,7 +358,7 @@ impl<'a> Dependency<'a> {
                     .as_name_expr()
                     .is_some_and(|target| target.id == name.id)
                 {
-                    value.as_deref()
+                    Some((value.as_deref()?, binding_scope))
                 } else {
                     None
                 }
@@ -360,7 +372,7 @@ impl<'a> Dependency<'a> {
                     .as_name_expr()
                     .is_some_and(|alias_name| alias_name.id == name.id)
                 {
-                    Some(value.as_ref())
+                    Some((value.as_ref(), binding_scope))
                 } else {
                     None
                 }

--- a/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
+++ b/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
@@ -552,4 +552,24 @@ help: Add `thing_id` to function signature
 397 | @app.get("/alias-missing/{thing_id}")
     - async def read_thing_alias_missing_dep(query: ThingDepMissingAlias): ...
 398 + async def read_thing_alias_missing_dep(query: ThingDepMissingAlias, thing_id): ...
+399 | 
+400 | # Alias shadowing: the last binding at module scope should be used.
+401 | ShadowedAlias = Annotated[dict, Depends(takes_other_alias)]
+note: This is an unsafe fix and may change runtime behavior
+
+FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing_alias_plain` signature
+   --> FAST003.py:411:24
+    |
+409 | PlainAlias = dict
+410 |
+411 | @app.get("/alias-plain/{thing_id}")
+    |                        ^^^^^^^^^^
+412 | async def read_thing_alias_plain(query: PlainAlias): ...
+    |
+help: Add `thing_id` to function signature
+409 | PlainAlias = dict
+410 | 
+411 | @app.get("/alias-plain/{thing_id}")
+    - async def read_thing_alias_plain(query: PlainAlias): ...
+412 + async def read_thing_alias_plain(query: PlainAlias, thing_id): ...
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

`FAST003` only extracted dependency metadata when the parameter annotation was directly `Annotated[...]`. That missed alias-based annotations like `thing: ThingDep` where `ThingDep = Annotated[..., Depends(...)]`, which caused a false positive.

This change resolves local alias annotations for `Assign`, `AnnAssign`, and `TypeAlias` forms (including alias chains), then reuses the existing dependency parsing path.

## Test Plan

- Added FAST003 fixture cases for:
  - direct alias (`ThingDep = Annotated[...]`)
  - alias chain (`ThingDepAliasChain = ThingDepAlias`)
  - PEP 695 alias (`type ThingDepTypeAlias = Annotated[...]`)
  - negative alias case where dependency does not include the route parameter
- Updated FAST003 snapshots (regular + deferred annotations)
- Ran:
  - `cargo test -p ruff_linter fastapi::tests::rules -- --nocapture`
  - `cargo test -p ruff_linter fastapi::tests::deferred_annotations_diff -- --nocapture`
  - `cargo clippy -p ruff_linter --all-targets --all-features -- -D warnings`
  - `cargo fmt --all`
  
  Closes #21075