### PR TITLE
[ty] Adapt `many_enum_members` benchmark

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -579,11 +579,11 @@ fn benchmark_many_enum_members(criterion: &mut Criterion) {
     }
     writeln!(&mut code).ok();
 
-    write!(&mut code, "print((").ok();
+    code.push_str("print((");
     for i in 0..NUM_ENUM_MEMBERS {
         write!(&mut code, "E.m{i}, ").ok();
     }
-    write!(&mut code, "))").ok();
+    code.push_str("))");
 
     criterion.bench_function("ty_micro[many_enum_members]", |b| {
         b.iter_batched_ref(


### PR DESCRIPTION
## Summary

This changes the `many_enum_members` benchmark from this structure:

```py
class E(Enum):
    m1 = 1
    m2 = 2
    ...

print(E.m1)
print(E.m2)
...
```

to this structure:

```py
class E(Enum):
    m1 = 1
    m2 = 2
    ...

print((E.m1, E.m2, …))
```

The idea here is to make this benchmark less susceptible to changes in our reachability constraints (that we record for `print` calls). The idea of the `print` statements was only to have "uses" of these enum members. It was never the idea to be an example of 512 function calls in sequence.

I'm certainly not trying to hide the fact that this benchmark revealed a huge regression in https://github.com/astral-sh/ruff/pull/23245. But it did so for the wrong reasons. We would have already had that regression on `main` if those `print` calls would have been inside another function scope. And so it seems fair to change the benchmark before we proceed with #23245 (which shows no regressions elsewhere, and even leads to performance improvements in real world projects).

Adding Alex here as a reviewer since we discussed this in person.