### PR TITLE
[ty] Fix instance-attribute lookup in methods of protocol classes

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -109,7 +109,7 @@ static ALTAIR: Benchmark = Benchmark::new(
         max_dep_date: "2025-06-17",
         python_version: PythonVersion::PY312,
     },
-    898,
+    950,
 );
 
 static COLOUR_SCIENCE: Benchmark = Benchmark::new(

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -698,8 +698,7 @@ class Linkable(Protocol):
         return self.next_node
 
 def _(l: Linkable) -> None:
-    # TODO: Should be `Linkable`
-    reveal_type(l.next_node)  # revealed: @Todo(type[T] for protocols)
+    reveal_type(l.next_node)  # revealed: Linkable
 
 class CopyableImpl:
     def copy(self) -> Self:

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -1579,6 +1579,29 @@ as something that must be supported by type checkers:
 > To distinguish between protocol class variables and protocol instance variables, the special
 > `ClassVar` annotation should be used.
 
+## Declared instance attribute members
+
+Declared protocol instance attributes should be available both on protocol-typed values and through
+`self` inside protocol methods, with `Self` rebinding appropriately.
+
+```py
+from typing import Protocol
+from typing_extensions import Self
+
+class Linked(Protocol):
+    value: int
+    next: Self
+
+    def advance(self) -> Self:
+        reveal_type(self.value)  # revealed: int
+        reveal_type(self.next)  # revealed: Self@advance
+        return self.next
+
+def f(x: Linked) -> None:
+    reveal_type(x.value)  # revealed: int
+    reveal_type(x.next)  # revealed: Linked
+```
+
 ## Subtyping of protocols with property members
 
 A read-only property on a protocol can be satisfied by a mutable attribute, a read-only property, a

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -731,7 +731,7 @@ class Foo(Protocol):
     value: Final[int] = 42
 
     def foo(self, value: int):
-        # TODO: should emit an invalid-assignment error
+        # error: [invalid-assignment] "Cannot assign to final attribute `value` on type `Self@foo`: `Final` attributes can only be assigned in the class body or `__init__`"
         self.value = value
 
 def bar(x: Foo, value: int):

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6241,10 +6241,8 @@ fn self_typevar_owner_class_literal<'db>(
     bound_typevar
         .typevar(db)
         .upper_bound(db)
-        .and_then(|ty| match ty {
-            Type::NominalInstance(instance) => Some(instance.class_literal(db)),
-            _ => None,
-        })
+        .and_then(|ty| ty.nominal_class(db))
+        .map(|class| class.class_literal(db))
 }
 
 #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
@@ -6287,11 +6285,12 @@ impl<'db> SelfBinding<'db> {
         binding_context: Option<BindingContext<'db>>,
     ) -> Self {
         let class_literal = match self_type {
-            Type::NominalInstance(instance) => Some(instance.class_literal(db)),
             Type::TypeVar(typevar) if typevar.typevar(db).is_self(db) => {
                 self_typevar_owner_class_literal(db, typevar)
             }
-            _ => None,
+            _ => self_type
+                .nominal_class(db)
+                .map(|class| class.class_literal(db)),
         };
 
         Self {

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -908,6 +908,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let infer_type_argument = |builder: &mut Self, slice: &ast::Expr| {
             let slice_ty = builder.infer_type_expression(slice);
+            if matches!(slice_ty, Type::ProtocolInstance(_)) {
+                return SubclassOfType::from(
+                    builder.db(),
+                    todo_type!("type[T] for protocols").expect_dynamic(),
+                );
+            }
             SubclassOfType::try_from_instance(builder.db(), slice_ty).unwrap_or_else(|| {
                 match slice_ty {
                     Type::Callable(_) => invalid_type_argument(builder, slice),

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -80,17 +80,18 @@ impl<'db> SubclassOfType<'db> {
     pub(crate) fn try_from_instance(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
         // Handle unions by distributing `type[]` over each element:
         // `type[A | B]` -> `type[A] | type[B]`
-        if let Type::Union(union) = ty {
-            return UnionType::try_from_elements(
+        match ty {
+            Type::Union(union) => UnionType::try_from_elements(
                 db,
                 union
                     .elements(db)
                     .iter()
                     .map(|element| Self::try_from_instance(db, *element)),
-            );
+            ),
+            Type::ProtocolInstance(protocol) => Some(protocol.to_meta_type(db)),
+            _ => SubclassOfInner::try_from_instance(db, ty)
+                .map(|subclass_of| Self::from(db, subclass_of)),
         }
-
-        SubclassOfInner::try_from_instance(db, ty).map(|subclass_of| Self::from(db, subclass_of))
     }
 
     /// Return a [`Type`] instance representing the type `type[Unknown]`.
@@ -423,9 +424,6 @@ impl<'db> SubclassOfInner<'db> {
             Type::TypeVar(bound_typevar) => SubclassOfInner::TypeVar(bound_typevar),
             Type::Dynamic(DynamicType::Any) => SubclassOfInner::Dynamic(DynamicType::Any),
             Type::Dynamic(DynamicType::Unknown) => SubclassOfInner::Dynamic(DynamicType::Unknown),
-            Type::ProtocolInstance(_) => {
-                SubclassOfInner::Dynamic(todo_type!("type[T] for protocols").expect_dynamic())
-            }
             _ => return None,
         })
     }


### PR DESCRIPTION
## Summary

Our existing `@Todo` type for the meta-type of protocols was being applied too broadly. The intent was only ever to use a `@Todo` type for `type[P]` when a user had actually written such an annotation in an annotation expression. This PR makes the situations where we infer this `@Todo` type much narrower, reflecting the original intent and allowing us to fix a bunch of TODOs in our test suite.

## Test Plan

mdtests updated
