### PR TITLE
[ty] Preserve inherited typevars in decorated helper returns

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -289,6 +289,34 @@ reveal_type(MyClass().method)  # revealed: (...) -> int
 reveal_type(MyClass().method.__name__)  # revealed: str
 ```
 
+## Generic helper returns through lossy `Callable` decorators
+
+Lossy `Callable[..., R]` decorators should preserve owner-borrowed typevars while still reducing
+away method-owned ones.
+
+```py
+from typing import Callable
+
+def callable_identity[R](func: Callable[..., R]) -> Callable[..., R]:
+    return func
+
+class Box[T]:
+    def __init__(self, x: T):
+        self.x = x
+
+    @callable_identity
+    def clone(self) -> Box[T]:
+        return self
+
+class C:
+    @callable_identity
+    def generic_method[T](self, value: T) -> T:
+        return value
+
+reveal_type(Box(1).clone())  # revealed: Box[int]
+reveal_type(C().generic_method(1))  # revealed: Unknown
+```
+
 ## classmethods passed through Callable-returning decorators
 
 The behavior described above is also applied to classmethods. If a method is decorated with

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -7,7 +7,7 @@ use itertools::{Either, Itertools};
 use ruff_python_ast as ast;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::types::callable::walk_callable_type;
+use crate::types::callable::{CallableTypeKind, walk_callable_type};
 use crate::types::class::ClassType;
 use crate::types::class_base::ClassBase;
 use crate::types::constraints::{
@@ -1808,6 +1808,19 @@ pub(crate) struct SpecializationBuilder<'db, 'c> {
 pub(crate) type TypeVarAssignment<'db> = (BoundTypeVarIdentity<'db>, TypeVarVariance, Type<'db>);
 
 impl<'db, 'c> SpecializationBuilder<'db, 'c> {
+    fn should_preserve_inherited_source_typevars(
+        &self,
+        actual_callable: CallableType<'db>,
+    ) -> bool {
+        // Only function-like callables can borrow inherited typevars from an enclosing generic
+        // owner. Other callables should keep existentially quantifying their signature-local
+        // typevars during callable inference.
+        matches!(
+            actual_callable.kind(self.db),
+            CallableTypeKind::FunctionLike
+        )
+    }
+
     pub(crate) fn new(
         db: &'db dyn Db,
         constraints: &'c ConstraintSetBuilder<'db>,
@@ -1957,9 +1970,23 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
         for actual_callable in actual_callables.as_slice() {
             if formal_is_single_paramspec {
-                let when = actual_callable
-                    .signatures(self.db)
-                    .when_constraint_set_assignable_to(self.db, formal_signature, self.constraints);
+                let when = if self.should_preserve_inherited_source_typevars(*actual_callable) {
+                    actual_callable
+                        .signatures(self.db)
+                        .when_constraint_set_assignable_to_preserving_source_inherited(
+                            self.db,
+                            formal_signature,
+                            self.constraints,
+                        )
+                } else {
+                    actual_callable
+                        .signatures(self.db)
+                        .when_constraint_set_assignable_to(
+                            self.db,
+                            formal_signature,
+                            self.constraints,
+                        )
+                };
                 self.add_type_mappings_from_constraint_set(formal, when, &mut *f)?;
             } else {
                 // An overloaded actual callable is compatible with the formal signature if at
@@ -1967,11 +1994,20 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 // overloads, and only report an error if none of them are satisfiable.
                 let mut any_satisfiable = false;
                 for actual_signature in &actual_callable.signatures(self.db).overloads {
-                    let when = actual_signature.when_constraint_set_assignable_to_signatures(
-                        self.db,
-                        formal_signature,
-                        self.constraints,
-                    );
+                    let when = if self.should_preserve_inherited_source_typevars(*actual_callable) {
+                        actual_signature
+                            .when_constraint_set_assignable_to_signatures_preserving_source_inherited(
+                                self.db,
+                                formal_signature,
+                                self.constraints,
+                            )
+                    } else {
+                        actual_signature.when_constraint_set_assignable_to_signatures(
+                            self.db,
+                            formal_signature,
+                            self.constraints,
+                        )
+                    };
                     if self
                         .add_type_mappings_from_constraint_set(formal, when, &mut *f)
                         .is_ok()

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -339,6 +339,7 @@ impl<'db> Type<'db> {
             inferable,
             relation: TypeRelation::SubtypingAssuming,
             context_tree: ErrorContextTree::disabled(),
+            preserve_source_inherited_signature_typevars: false,
             given: assuming,
             relation_visitor: &relation_visitor,
             disjointness_visitor: &disjointness_visitor,
@@ -375,6 +376,7 @@ impl<'db> Type<'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             context_tree: ErrorContextTree::enabled(),
+            preserve_source_inherited_signature_typevars: false,
             given: ConstraintSet::from_bool(&builder, false),
             relation_visitor: &HasRelationToVisitor::default(&builder),
             disjointness_visitor: &IsDisjointVisitor::default(&builder),
@@ -504,6 +506,7 @@ impl<'db> Type<'db> {
             inferable,
             relation,
             context_tree: ErrorContextTree::disabled(),
+            preserve_source_inherited_signature_typevars: false,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor: &relation_visitor,
             disjointness_visitor: &disjointness_visitor,
@@ -654,6 +657,7 @@ pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
     pub(super) inferable: InferableTypeVars<'db>,
     pub(super) relation: TypeRelation,
     context_tree: ErrorContextTree<'db>,
+    pub(super) preserve_source_inherited_signature_typevars: bool,
     given: ConstraintSet<'db, 'c>,
 
     // N.B. these fields are private to reduce the risk of
@@ -682,6 +686,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable,
             relation: TypeRelation::Subtyping,
             context_tree: ErrorContextTree::disabled(),
+            preserve_source_inherited_signature_typevars: false,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
             disjointness_visitor,
@@ -702,6 +707,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::ConstraintSetAssignability,
             context_tree: ErrorContextTree::disabled(),
+            preserve_source_inherited_signature_typevars: false,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
             disjointness_visitor,
@@ -722,6 +728,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::ConstraintSetAssignability,
             context_tree: ErrorContextTree::enabled(),
+            preserve_source_inherited_signature_typevars: false,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
             disjointness_visitor,
@@ -742,6 +749,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             context_tree: ErrorContextTree::enabled(),
+            preserve_source_inherited_signature_typevars: false,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
             disjointness_visitor,
@@ -759,6 +767,13 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
     pub(super) fn into_error_context(self) -> ErrorContextTree<'db> {
         self.context_tree
+    }
+
+    pub(super) fn with_preserved_source_inherited_signature_typevars(&self) -> Self {
+        Self {
+            preserve_source_inherited_signature_typevars: true,
+            ..self.clone()
+        }
     }
 
     pub(super) fn always(&self) -> ConstraintSet<'db, 'c> {
@@ -2083,6 +2098,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
             context_tree: ErrorContextTree::disabled(),
             given: self.given,
             inferable: InferableTypeVars::None,
+            preserve_source_inherited_signature_typevars: false,
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
             signature_relation_visitor: self.signature_relation_visitor,
@@ -2166,6 +2182,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             constraints: self.constraints,
             inferable: self.inferable,
             context_tree: ErrorContextTree::disabled(),
+            preserve_source_inherited_signature_typevars: false,
             given: self.given,
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -455,6 +455,25 @@ impl<'db> CallableSignature<'db> {
         other: &Self,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        self.when_constraint_set_assignable_to_inner(db, other, constraints, false)
+    }
+
+    pub(crate) fn when_constraint_set_assignable_to_preserving_source_inherited<'c>(
+        &self,
+        db: &'db dyn Db,
+        other: &Self,
+        constraints: &'c ConstraintSetBuilder<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        self.when_constraint_set_assignable_to_inner(db, other, constraints, true)
+    }
+
+    fn when_constraint_set_assignable_to_inner<'c>(
+        &self,
+        db: &'db dyn Db,
+        other: &Self,
+        constraints: &'c ConstraintSetBuilder<'db>,
+        preserve_source_inherited: bool,
+    ) -> ConstraintSet<'db, 'c> {
         let relation_visitor = HasRelationToVisitor::default(constraints);
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
@@ -466,6 +485,11 @@ impl<'db> CallableSignature<'db> {
             &signature_relation_visitor,
             &materialization_visitor,
         );
+        let checker = if preserve_source_inherited {
+            checker.with_preserved_source_inherited_signature_typevars()
+        } else {
+            checker
+        };
         checker.check_callable_signature_pair_inner(db, &self.overloads, &other.overloads)
     }
 }
@@ -1201,11 +1225,53 @@ impl<'db> Signature<'db> {
         }
     }
 
+    fn owned_inferable_typevars(&self, db: &'db dyn Db) -> FxHashSet<BoundTypeVarIdentity<'db>> {
+        let Some(generic_context) = self.generic_context else {
+            return FxHashSet::default();
+        };
+
+        // Keep only the type variables introduced by this signature's own binding context. Any
+        // remaining inferable type variables were borrowed from an enclosing generic owner and
+        // must stay visible to the caller.
+        generic_context
+            .variables(db)
+            .filter(
+                |typevar| match (self.definition, typevar.binding_context(db)) {
+                    (Some(definition), BindingContext::Definition(binding_context)) => {
+                        binding_context == definition
+                    }
+                    (None, BindingContext::Synthetic) => true,
+                    _ => false,
+                },
+            )
+            .map(|typevar| typevar.identity(db))
+            .collect()
+    }
+
     pub(crate) fn when_constraint_set_assignable_to_signatures<'c>(
         &self,
         db: &'db dyn Db,
         other: &CallableSignature<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        self.when_constraint_set_assignable_to_signatures_inner(db, other, constraints, false)
+    }
+
+    pub(crate) fn when_constraint_set_assignable_to_signatures_preserving_source_inherited<'c>(
+        &self,
+        db: &'db dyn Db,
+        other: &CallableSignature<'db>,
+        constraints: &'c ConstraintSetBuilder<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        self.when_constraint_set_assignable_to_signatures_inner(db, other, constraints, true)
+    }
+
+    fn when_constraint_set_assignable_to_signatures_inner<'c>(
+        &self,
+        db: &'db dyn Db,
+        other: &CallableSignature<'db>,
+        constraints: &'c ConstraintSetBuilder<'db>,
+        preserve_source_inherited: bool,
     ) -> ConstraintSet<'db, 'c> {
         // If this signature is a paramspec, bind it to the entire overloaded other callable.
         if let Some(self_bound_typevar) = self.parameters.as_paramspec()
@@ -1244,20 +1310,6 @@ impl<'db> Signature<'db> {
             return param_spec_matches.and(db, constraints, || return_types_match);
         }
 
-        other
-            .overloads
-            .iter()
-            .when_all(db, constraints, |other_signature| {
-                self.when_constraint_set_assignable_to(db, other_signature, constraints)
-            })
-    }
-
-    fn when_constraint_set_assignable_to<'c>(
-        &self,
-        db: &'db dyn Db,
-        other: &Self,
-        constraints: &'c ConstraintSetBuilder<'db>,
-    ) -> ConstraintSet<'db, 'c> {
         let relation_visitor = HasRelationToVisitor::default(constraints);
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
@@ -1269,7 +1321,18 @@ impl<'db> Signature<'db> {
             &signature_relation_visitor,
             &materialization_visitor,
         );
-        checker.check_signature_pair(db, self, other)
+        let checker = if preserve_source_inherited {
+            checker.with_preserved_source_inherited_signature_typevars()
+        } else {
+            checker
+        };
+
+        other
+            .overloads
+            .iter()
+            .when_all(db, constraints, |other_signature| {
+                checker.check_signature_pair(db, self, other_signature)
+            })
     }
 
     /// Create a new signature with the given definition.
@@ -1649,10 +1712,20 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // we produce, we reduce it back down to the inferable set that the caller asked about.
         // If we introduced new inferable typevars, those will be existentially quantified away
         // before returning.
+        let source_reduced: FxHashSet<_> = if self.preserve_source_inherited_signature_typevars {
+            // Function-like source signatures can borrow inherited typevars from an enclosing
+            // generic owner. Reducing those away here loses the callable-to-owner link before
+            // specialization inference can solve it.
+            source.owned_inferable_typevars(db)
+        } else {
+            source_inferable.iter(db).collect()
+        };
+        let target_reduced: FxHashSet<_> = target_inferable.iter(db).collect();
+
         when.reduce_inferable(
             db,
             self.constraints,
-            source_inferable.iter(db).chain(target_inferable.iter(db)),
+            source_reduced.iter().chain(target_reduced.iter()).copied(),
         )
     }
 


### PR DESCRIPTION
## Summary

When a function-like method returning `Box[T]` passes through a lossy `Callable[..., R]` decorator, callable specialization currently reduces away all inferable source signature typevars. That is correct for typevars owned by the method itself, but too aggressive for typevars borrowed from an enclosing generic owner, so cases like `Box(1).clone()` collapse to `Unknown`.

This PR preserves inherited source signature typevars for function-like decorated callables while still reducing away typevars owned by the decorated method itself. That keeps helper returns specialized without changing the behavior of method-local generics.

## Test Plan

Added mdtests for a decorated `Box[T].clone()` helper return and for a decorated method-local generic that should still reveal `Unknown`