### PR TITLE
[ty] Add bidirectional type context for TypedDict `pop()` defaults

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1827,9 +1827,6 @@ def union_get(u: HasX | OptX) -> None:
 `pop()` also uses the field type as bidirectional context for the default argument:
 
 ```py
-from typing import TypedDict
-from typing_extensions import NotRequired
-
 class Config(TypedDict, total=False):
     data: dict[str, int]
 

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -376,12 +376,6 @@ where
             ];
             let pop_sig = Signature::new(Parameters::new(db, pop_parameters), field.declared_ty);
 
-            let t_default = BoundTypeVarInstance::synthetic(
-                db,
-                Name::new_static("T"),
-                TypeVarVariance::Covariant,
-            );
-
             // Non-generic overload that accepts the field type as the default,
             // providing bidirectional inference context for the default argument.
             let pop_with_typed_default_sig = Signature::new(
@@ -397,6 +391,12 @@ where
                     ],
                 ),
                 field.declared_ty,
+            );
+
+            let t_default = BoundTypeVarInstance::synthetic(
+                db,
+                Name::new_static("T"),
+                TypeVarVariance::Covariant,
             );
 
             let pop_with_default_parameters = [


### PR DESCRIPTION
## Summary

Like #24225, but for `pop()`.
