### PR TITLE
Remove unused `non_root` variable

### DIFF
--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -239,7 +239,6 @@ impl<'a> Resolver<'a> {
         // For example, if `./foo/__init__.py` is a root, and then `./foo/bar` is empty, and
         // `./foo/bar/baz/__init__.py` was detected as a root, we should only consider
         // `./foo/__init__.py`.
-        let mut non_roots = FxHashSet::default();
         let mut router: Router<&Path> = Router::new();
         for root in package_roots
             .values()
@@ -258,7 +257,6 @@ impl<'a> Resolver<'a> {
                     matched.value.display()
                 );
                 package_roots.insert(root, Some(PackageRoot::nested(root)));
-                non_roots.insert(root);
             } else {
                 let _ = router.insert(format!("{path}/{{*filepath}}"), root);
             }


### PR DESCRIPTION
## Summary

While we did insert into `non_root`, we never read `non_root` or used the `insert`'s return value. 

This PR removes `non_root` because it's useless.

## Test Plan

`cargo test`
