### PR TITLE
Detect superfluous else on try/except (RET505-508)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_return/RET505.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_return/RET505.py
@@ -252,3 +252,155 @@ def has_untracted_files():
     else:
 \
         return False
+
+
+###
+# Errors (try/except/else)
+###
+def try_except_else_return():
+    try:
+        foo()
+    except Exception:
+        return 1
+    else:
+        return 2
+
+
+def try_except_else_return_multiple_handlers():
+    try:
+        foo()
+    except ValueError:
+        return 1
+    except TypeError:
+        return 2
+    else:
+        return 3
+
+
+# Mixed exit types across handlers - reports based on first handler's type (RET505)
+def try_except_else_mixed_exits():
+    try:
+        foo()
+    except ValueError:
+        return 1
+    except TypeError:
+        raise RuntimeError
+    else:
+        return 3
+
+
+# Bare except clause
+def try_bare_except_else_return():
+    try:
+        foo()
+    except:
+        return 1
+    else:
+        return 2
+
+
+# Multi-statement else body
+def try_except_else_multi_stmt():
+    try:
+        foo()
+    except Exception:
+        return 1
+    else:
+        x = 1
+        y = 2
+        return x + y
+
+
+# Comment on the else line
+def try_except_else_comment_on_else():
+    try:
+        foo()
+    except Exception:
+        return 1
+    else:  # some comment
+        return 2
+
+
+# Nested try/except/else inside another try/except/else
+def try_except_else_nested():
+    try:
+        foo()
+    except Exception:
+        return 1
+    else:
+        try:
+            bar()
+        except Exception:
+            return 2
+        else:
+            return 3
+
+
+# try/except/else nested inside if/else body
+def try_except_else_inside_if():
+    if cond:
+        return 1
+    else:
+        try:
+            foo()
+        except Exception:
+            return 2
+        else:
+            return 3
+
+
+###
+# Non-errors (try/except/else)
+###
+
+# Has finally block - else is semantically significant
+def try_except_else_finally_return():
+    try:
+        foo()
+    except Exception:
+        return 1
+    else:
+        return 2
+    finally:
+        cleanup()
+
+
+# Not all handlers return
+def try_except_else_partial_return():
+    try:
+        foo()
+    except ValueError:
+        return 1
+    except TypeError:
+        pass
+    else:
+        return 3
+
+
+# No else block
+def try_except_no_else():
+    try:
+        foo()
+    except Exception:
+        return 1
+
+
+# Return is conditional within the handler - last stmt is not a return
+def try_except_else_conditional_return():
+    try:
+        foo()
+    except Exception:
+        if cond:
+            return 1
+    else:
+        return 2
+
+
+# Except handler's last statement is an expression, not an exit
+def try_except_else_handler_no_exit():
+    try:
+        foo()
+    except Exception:
+        log(error)
+    else:
+        return 1

--- a/crates/ruff_linter/resources/test/fixtures/flake8_return/RET506.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_return/RET506.py
@@ -110,3 +110,62 @@ def bar3(x, y, z):
     else:
         raise Exception(z)
     raise Exception(None)
+
+
+###
+# Errors (try/except/else)
+###
+def try_except_else_raise():
+    try:
+        foo()
+    except Exception:
+        raise ValueError
+    else:
+        raise TypeError
+
+
+def try_except_else_raise_multiple_handlers():
+    try:
+        foo()
+    except ValueError:
+        raise RuntimeError
+    except TypeError:
+        raise RuntimeError
+    else:
+        raise RuntimeError
+
+
+def try_except_star_else_raise():
+    try:
+        foo()
+    except* ValueError:
+        raise RuntimeError
+    except* TypeError:
+        raise RuntimeError
+    else:
+        raise RuntimeError
+
+
+###
+# Non-errors (try/except/else)
+###
+def try_except_else_finally_raise():
+    try:
+        foo()
+    except Exception:
+        raise ValueError
+    else:
+        raise TypeError
+    finally:
+        cleanup()
+
+
+def try_except_else_partial_raise():
+    try:
+        foo()
+    except ValueError:
+        raise RuntimeError
+    except TypeError:
+        pass
+    else:
+        raise RuntimeError

--- a/crates/ruff_linter/resources/test/fixtures/flake8_return/RET507.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_return/RET507.py
@@ -104,3 +104,55 @@ def bar3(x, y, z):
         else:
             return z
         return None
+
+
+###
+# Errors (try/except/else)
+###
+def try_except_else_continue():
+    for i in range(10):
+        try:
+            foo()
+        except Exception:
+            continue
+        else:
+            x = 1
+
+
+def try_except_else_continue_multiple_handlers():
+    for i in range(10):
+        try:
+            foo()
+        except ValueError:
+            continue
+        except TypeError:
+            continue
+        else:
+            x = 1
+
+
+###
+# Non-errors (try/except/else)
+###
+def try_except_else_finally_continue():
+    for i in range(10):
+        try:
+            foo()
+        except Exception:
+            continue
+        else:
+            x = 1
+        finally:
+            cleanup()
+
+
+def try_except_else_partial_continue():
+    for i in range(10):
+        try:
+            foo()
+        except ValueError:
+            continue
+        except TypeError:
+            pass
+        else:
+            x = 1

--- a/crates/ruff_linter/resources/test/fixtures/flake8_return/RET508.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_return/RET508.py
@@ -157,3 +157,55 @@ def elif2(x, y, w, z):
                 break
             else:
                 a = z
+
+
+###
+# Errors (try/except/else)
+###
+def try_except_else_break():
+    for i in range(10):
+        try:
+            foo()
+        except Exception:
+            break
+        else:
+            x = 1
+
+
+def try_except_else_break_multiple_handlers():
+    for i in range(10):
+        try:
+            foo()
+        except ValueError:
+            break
+        except TypeError:
+            break
+        else:
+            x = 1
+
+
+###
+# Non-errors (try/except/else)
+###
+def try_except_else_finally_break():
+    for i in range(10):
+        try:
+            foo()
+        except Exception:
+            break
+        else:
+            x = 1
+        finally:
+            cleanup()
+
+
+def try_except_else_partial_break():
+    for i in range(10):
+        try:
+            foo()
+        except ValueError:
+            break
+        except TypeError:
+            pass
+        else:
+            x = 1

--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -337,3 +337,8 @@ pub const fn is_warning_severity_enabled(preview: PreviewMode) -> bool {
 pub(crate) const fn is_trailing_pragma_in_line_length_enabled(preview: PreviewMode) -> bool {
     preview.is_enabled()
 }
+
+// <https://github.com/astral-sh/ruff/pull/24239>
+pub(crate) const fn is_superfluous_try_else_enabled(settings: &LinterSettings) -> bool {
+    settings.preview.is_enabled()
+}

--- a/crates/ruff_linter/src/rules/flake8_return/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/mod.rs
@@ -14,8 +14,10 @@ mod tests {
     use test_case::test_case;
 
     use crate::assert_diagnostics;
+    use crate::assert_diagnostics_diff;
     use crate::registry::Rule;
     use crate::settings::LinterSettings;
+    use crate::settings::types::PreviewMode;
     use crate::test::test_path;
 
     #[test_case(Rule::UnnecessaryReturnNone, Path::new("RET501.py"))]
@@ -33,6 +35,28 @@ mod tests {
             &LinterSettings::for_rule(rule_code),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Rule::SuperfluousElseReturn, Path::new("RET505.py"))]
+    #[test_case(Rule::SuperfluousElseRaise, Path::new("RET506.py"))]
+    #[test_case(Rule::SuperfluousElseContinue, Path::new("RET507.py"))]
+    #[test_case(Rule::SuperfluousElseBreak, Path::new("RET508.py"))]
+    fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!(
+            "preview__{}_{}",
+            rule_code.noqa_code(),
+            path.to_string_lossy()
+        );
+        assert_diagnostics_diff!(
+            snapshot,
+            Path::new("flake8_return").join(path).as_path(),
+            &LinterSettings::for_rule(rule_code),
+            &LinterSettings {
+                preview: PreviewMode::Enabled,
+                ..LinterSettings::for_rule(rule_code)
+            }
+        );
         Ok(())
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
@@ -4,6 +4,7 @@ use ruff_diagnostics::Applicability;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::helpers::{is_const_false, is_const_true};
 use ruff_python_ast::stmt_if::elif_else_range;
+use ruff_python_ast::stmt_try::try_else_range;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::whitespace::indentation;
@@ -22,6 +23,7 @@ use crate::rules::flake8_return::helpers::end_of_last_statement;
 use crate::{AlwaysFixableViolation, FixAvailability, Violation};
 use crate::{Edit, Fix};
 
+use crate::preview::is_superfluous_try_else_enabled;
 use crate::rules::flake8_return::branch::Branch;
 use crate::rules::flake8_return::helpers::result_exists;
 use crate::rules::flake8_return::visitor::{ReturnVisitor, Stack};
@@ -198,7 +200,7 @@ impl AlwaysFixableViolation for UnnecessaryAssign {
 
 /// ## What it does
 /// Checks for `else` statements with a `return` statement in the preceding
-/// `if` block.
+/// `if` block or in all `except` handlers of a `try` block.
 ///
 /// ## Why is this bad?
 /// The `else` statement is not needed as the `return` statement will always
@@ -243,7 +245,7 @@ impl Violation for SuperfluousElseReturn {
 
 /// ## What it does
 /// Checks for `else` statements with a `raise` statement in the preceding `if`
-/// block.
+/// block or in all `except` handlers of a `try` block.
 ///
 /// ## Why is this bad?
 /// The `else` statement is not needed as the `raise` statement will always
@@ -288,7 +290,7 @@ impl Violation for SuperfluousElseRaise {
 
 /// ## What it does
 /// Checks for `else` statements with a `continue` statement in the preceding
-/// `if` block.
+/// `if` block or in all `except` handlers of a `try` block.
 ///
 /// ## Why is this bad?
 /// The `else` statement is not needed, as the `continue` statement will always
@@ -335,7 +337,7 @@ impl Violation for SuperfluousElseContinue {
 
 /// ## What it does
 /// Checks for `else` statements with a `break` statement in the preceding `if`
-/// block.
+/// block or in all `except` handlers of a `try` block.
 ///
 /// ## Why is this bad?
 /// The `else` statement is not needed, as the `break` statement will always
@@ -680,8 +682,11 @@ fn superfluous_else_node(
     } else {
         Branch::Else
     };
-    let range = elif_else_range(elif_else, checker.locator().contents())
-        .unwrap_or_else(|| elif_else.range());
+
+    let Some(range) = elif_else_range(elif_else, checker.locator().contents()) else {
+        return false;
+    };
+
     for child in if_elif_body {
         let diagnostic = if child.is_return_stmt() {
             checker.report_diagnostic_if_enabled(SuperfluousElseReturn { branch }, range)
@@ -706,6 +711,68 @@ fn superfluous_else_node(
 fn superfluous_elif_else(checker: &Checker, stack: &Stack) {
     for (if_elif_body, elif_else) in &stack.elifs_elses {
         superfluous_else_node(checker, if_elif_body, elif_else);
+    }
+}
+
+/// RET505, RET506, RET507, RET508 for try/except/else
+fn superfluous_try_else(checker: &Checker, stack: &Stack) {
+    for stmt_try in &stack.try_elses {
+        // For `except*` handlers, only `raise` is a valid exit statement
+        // (`return`/`break`/`continue` are syntax errors in `except*` blocks),
+        // so this check naturally handles both `except` and `except*`
+        let all_handlers_exit = stmt_try.handlers.iter().all(|handler| {
+            let ast::ExceptHandler::ExceptHandler(handler) = handler;
+            handler.body.last().is_some_and(|last| {
+                last.is_return_stmt()
+                    || last.is_raise_stmt()
+                    || last.is_break_stmt()
+                    || last.is_continue_stmt()
+            })
+        });
+
+        if !all_handlers_exit || stmt_try.handlers.is_empty() {
+            continue;
+        }
+
+        // Use the first handler's exit type for the diagnostic, consistent
+        // with how `superfluous_else_node` works
+        let Some(ast::ExceptHandler::ExceptHandler(first_handler)) = stmt_try.handlers.first()
+        else {
+            continue;
+        };
+
+        let Some(last_stmt) = first_handler.body.last() else {
+            continue;
+        };
+
+        let Some(else_range) = try_else_range(stmt_try, checker.locator().contents()) else {
+            continue;
+        };
+
+        let branch = Branch::Else;
+
+        let diagnostic = if last_stmt.is_return_stmt() {
+            checker.report_diagnostic_if_enabled(SuperfluousElseReturn { branch }, else_range)
+        } else if last_stmt.is_raise_stmt() {
+            checker.report_diagnostic_if_enabled(SuperfluousElseRaise { branch }, else_range)
+        } else if last_stmt.is_continue_stmt() {
+            checker.report_diagnostic_if_enabled(SuperfluousElseContinue { branch }, else_range)
+        } else if last_stmt.is_break_stmt() {
+            checker.report_diagnostic_if_enabled(SuperfluousElseBreak { branch }, else_range)
+        } else {
+            continue;
+        };
+
+        if let Some(mut d) = diagnostic {
+            d.try_set_fix(|| {
+                let orelse_end = stmt_try
+                    .orelse
+                    .last()
+                    .map(Ranged::end)
+                    .unwrap_or(else_range.end());
+                remove_else_clause(checker, else_range.start(), &stmt_try.orelse, orelse_end)
+            });
+        }
     }
 }
 
@@ -767,6 +834,9 @@ pub(crate) fn function(checker: &Checker, function_def: &ast::StmtFunctionDef) {
         Rule::SuperfluousElseBreak,
     ]) {
         superfluous_elif_else(checker, &stack);
+        if is_superfluous_try_else_enabled(checker.settings()) {
+            superfluous_try_else(checker, &stack);
+        }
     }
 
     // Skip any functions without return statements.
@@ -792,12 +862,8 @@ pub(crate) fn function(checker: &Checker, function_def: &ast::StmtFunctionDef) {
     }
 }
 
-/// Generate a [`Fix`] to remove an `else` or `elif` clause.
+/// Generate a [`Fix`] to remove an `else` or `elif` clause from an `if` statement
 fn remove_else(checker: &Checker, elif_else: &ElifElseClause) -> Result<Fix> {
-    let locator = checker.locator();
-    let indexer = checker.indexer();
-    let stylist = checker.stylist();
-
     if elif_else.test.is_some() {
         // Ex) `elif` -> `if`
         Ok(Fix::safe_edit(Edit::deletion(
@@ -805,68 +871,82 @@ fn remove_else(checker: &Checker, elif_else: &ElifElseClause) -> Result<Fix> {
             elif_else.start() + TextSize::from(2),
         )))
     } else {
-        // the start of the line where the `else`` is
-        let else_line_start = locator.line_start(elif_else.start());
-
-        // making a tokenizer to find the Colon for the `else`, not always on the same line!
-        let mut else_line_tokenizer =
-            SimpleTokenizer::starts_at(elif_else.start(), locator.contents());
-
-        // find the Colon for the `else`
-        let Some(else_colon) =
-            else_line_tokenizer.find(|token| token.kind == SimpleTokenKind::Colon)
-        else {
-            return Err(anyhow::anyhow!("Cannot find `:` in `else` statement"));
-        };
-
-        // get the indentation of the `else`, since that is the indent level we want to end with
-        let Some(desired_indentation) = indentation(locator.contents(), elif_else) else {
-            return Err(anyhow::anyhow!("Compound statement cannot be inlined"));
-        };
-
-        // If the statement is on the same line as the `else`, just remove the `else: `.
-        // Ex) `else: return True` -> `return True`
-        if let Some(first) = elif_else.body.first() {
-            if indexer.preceded_by_multi_statement_line(first, locator.contents()) {
-                return Ok(Fix::safe_edit(Edit::deletion(
-                    elif_else.start(),
-                    first.start(),
-                )));
-            }
-        }
-
-        // we're deleting the `else`, and it's Colon, and the rest of the line(s) they're on,
-        // so here we get the last position of the line the Colon is on
-        let else_colon_end = locator.full_line_end(else_colon.end());
-
-        // if there is a comment on the same line as the Colon, let's keep it
-        // and give it the proper indentation once we unindent it
-        let else_comment_after_colon = else_line_tokenizer
-            .find(|token| token.kind.is_comment())
-            .and_then(|token| {
-                if token.kind == SimpleTokenKind::Comment && token.start() < else_colon_end {
-                    return Some(format!(
-                        "{desired_indentation}{}{}",
-                        locator.slice(token),
-                        stylist.line_ending().as_str(),
-                    ));
-                }
-                None
-            })
-            .unwrap_or(String::new());
-
-        let indented = adjust_indentation(
-            TextRange::new(else_colon_end, elif_else.end()),
-            desired_indentation,
-            locator,
-            indexer,
-            stylist,
-        )?;
-
-        Ok(Fix::safe_edit(Edit::replacement(
-            format!("{else_comment_after_colon}{indented}"),
-            else_line_start,
-            elif_else.end(),
-        )))
+        remove_else_clause(checker, elif_else.start(), &elif_else.body, elif_else.end())
     }
+}
+
+/// Generate a [`Fix`] to remove an `else:` clause, dedenting its body
+///
+/// Shared by `remove_else` (for if/elif/else) and `superfluous_try_else`
+/// (for try/except/else)
+fn remove_else_clause(
+    checker: &Checker,
+    else_start: TextSize,
+    body: &[Stmt],
+    body_end: TextSize,
+) -> Result<Fix> {
+    let locator = checker.locator();
+    let indexer = checker.indexer();
+    let stylist = checker.stylist();
+
+    // the start of the line where the `else` is
+    let else_line_start = locator.line_start(else_start);
+
+    // making a tokenizer to find the Colon for the `else`, not always on the same line!
+    let mut else_line_tokenizer = SimpleTokenizer::starts_at(else_start, locator.contents());
+
+    // find the Colon for the `else`
+    let Some(else_colon) = else_line_tokenizer.find(|token| token.kind == SimpleTokenKind::Colon)
+    else {
+        return Err(anyhow::anyhow!("Cannot find `:` in `else` statement"));
+    };
+
+    // get the indentation of the `else`, since that is the indent level we want to end with
+    let Some(desired_indentation) =
+        indentation(locator.contents(), &TextRange::new(else_start, body_end))
+    else {
+        return Err(anyhow::anyhow!("Compound statement cannot be inlined"));
+    };
+
+    // If the statement is on the same line as the `else`, just remove the `else: `
+    // Ex) `else: return True` -> `return True`
+    if let Some(first) = body.first() {
+        if indexer.preceded_by_multi_statement_line(first, locator.contents()) {
+            return Ok(Fix::safe_edit(Edit::deletion(else_start, first.start())));
+        }
+    }
+
+    // we're deleting the `else`, and it's Colon, and the rest of the line(s) they're on,
+    // so here we get the last position of the line the Colon is on
+    let else_colon_end = locator.full_line_end(else_colon.end());
+
+    // if there is a comment on the same line as the Colon, let's keep it
+    // and give it the proper indentation once we unindent it
+    let else_comment_after_colon = else_line_tokenizer
+        .find(|token| token.kind.is_comment())
+        .and_then(|token| {
+            if token.kind == SimpleTokenKind::Comment && token.start() < else_colon_end {
+                return Some(format!(
+                    "{desired_indentation}{}{}",
+                    locator.slice(token),
+                    stylist.line_ending().as_str(),
+                ));
+            }
+            None
+        })
+        .unwrap_or_default();
+
+    let indented = adjust_indentation(
+        TextRange::new(else_colon_end, body_end),
+        desired_indentation,
+        locator,
+        indexer,
+        stylist,
+    )?;
+
+    Ok(Fix::safe_edit(Edit::replacement(
+        format!("{else_comment_after_colon}{indented}"),
+        else_line_start,
+        body_end,
+    )))
 }

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET505_RET505.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET505_RET505.py.snap
@@ -475,3 +475,33 @@ RET505 Unnecessary `else` after `return` statement
 254 |         return False
     |
 help: Remove unnecessary `else`
+
+RET505 [*] Unnecessary `else` after `return` statement
+   --> RET505.py:343:5
+    |
+341 |     if cond:
+342 |         return 1
+343 |     else:
+    |     ^^^^
+344 |         try:
+345 |             foo()
+    |
+help: Remove unnecessary `else`
+340 | def try_except_else_inside_if():
+341 |     if cond:
+342 |         return 1
+343 +     try:
+344 +         foo()
+345 +     except Exception:
+346 +         return 2
+347 |     else:
+    -         try:
+    -             foo()
+    -         except Exception:
+    -             return 2
+    -         else:
+    -             return 3
+348 +         return 3
+349 | 
+350 | 
+351 | ###

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET508_RET508.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET508_RET508.py.snap
@@ -169,3 +169,6 @@ help: Remove unnecessary `else`
     -             else:
     -                 a = z
 158 +             a = z
+159 | 
+160 | 
+161 | ###

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__preview__RET505_RET505.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__preview__RET505_RET505.py.snap
@@ -1,0 +1,215 @@
+---
+source: crates/ruff_linter/src/rules/flake8_return/mod.rs
+---
+--- Linter settings ---
+-linter.preview = disabled
++linter.preview = enabled
+
+--- Summary ---
+Removed: 0
+Added: 9
+
+--- Added ---
+RET505 [*] Unnecessary `else` after `return` statement
+   --> RET505.py:265:5
+    |
+263 |     except Exception:
+264 |         return 1
+265 |     else:
+    |     ^^^^
+266 |         return 2
+    |
+help: Remove unnecessary `else`
+262 |         foo()
+263 |     except Exception:
+264 |         return 1
+    -     else:
+    -         return 2
+265 +     return 2
+266 | 
+267 | 
+268 | def try_except_else_return_multiple_handlers():
+
+
+RET505 [*] Unnecessary `else` after `return` statement
+   --> RET505.py:276:5
+    |
+274 |     except TypeError:
+275 |         return 2
+276 |     else:
+    |     ^^^^
+277 |         return 3
+    |
+help: Remove unnecessary `else`
+273 |         return 1
+274 |     except TypeError:
+275 |         return 2
+    -     else:
+    -         return 3
+276 +     return 3
+277 | 
+278 | 
+279 | # Mixed exit types across handlers - reports based on first handler's type (RET505)
+
+
+RET505 [*] Unnecessary `else` after `return` statement
+   --> RET505.py:288:5
+    |
+286 |     except TypeError:
+287 |         raise RuntimeError
+288 |     else:
+    |     ^^^^
+289 |         return 3
+    |
+help: Remove unnecessary `else`
+285 |         return 1
+286 |     except TypeError:
+287 |         raise RuntimeError
+    -     else:
+    -         return 3
+288 +     return 3
+289 | 
+290 | 
+291 | # Bare except clause
+
+
+RET505 [*] Unnecessary `else` after `return` statement
+   --> RET505.py:298:5
+    |
+296 |     except:
+297 |         return 1
+298 |     else:
+    |     ^^^^
+299 |         return 2
+    |
+help: Remove unnecessary `else`
+295 |         foo()
+296 |     except:
+297 |         return 1
+    -     else:
+    -         return 2
+298 +     return 2
+299 | 
+300 | 
+301 | # Multi-statement else body
+
+
+RET505 [*] Unnecessary `else` after `return` statement
+   --> RET505.py:308:5
+    |
+306 |     except Exception:
+307 |         return 1
+308 |     else:
+    |     ^^^^
+309 |         x = 1
+310 |         y = 2
+    |
+help: Remove unnecessary `else`
+305 |         foo()
+306 |     except Exception:
+307 |         return 1
+    -     else:
+    -         x = 1
+    -         y = 2
+    -         return x + y
+308 +     x = 1
+309 +     y = 2
+310 +     return x + y
+311 | 
+312 | 
+313 | # Comment on the else line
+
+
+RET505 [*] Unnecessary `else` after `return` statement
+   --> RET505.py:320:5
+    |
+318 |     except Exception:
+319 |         return 1
+320 |     else:  # some comment
+    |     ^^^^
+321 |         return 2
+    |
+help: Remove unnecessary `else`
+317 |         foo()
+318 |     except Exception:
+319 |         return 1
+    -     else:  # some comment
+    -         return 2
+320 +     # some comment
+321 +     return 2
+322 | 
+323 | 
+324 | # Nested try/except/else inside another try/except/else
+
+
+RET505 [*] Unnecessary `else` after `return` statement
+   --> RET505.py:330:5
+    |
+328 |     except Exception:
+329 |         return 1
+330 |     else:
+    |     ^^^^
+331 |         try:
+332 |             bar()
+    |
+help: Remove unnecessary `else`
+327 |         foo()
+328 |     except Exception:
+329 |         return 1
+330 +     try:
+331 +         bar()
+332 +     except Exception:
+333 +         return 2
+334 |     else:
+    -         try:
+    -             bar()
+    -         except Exception:
+    -             return 2
+    -         else:
+    -             return 3
+335 +         return 3
+336 | 
+337 | 
+338 | # try/except/else nested inside if/else body
+
+
+RET505 [*] Unnecessary `else` after `return` statement
+   --> RET505.py:335:9
+    |
+333 |         except Exception:
+334 |             return 2
+335 |         else:
+    |         ^^^^
+336 |             return 3
+    |
+help: Remove unnecessary `else`
+332 |             bar()
+333 |         except Exception:
+334 |             return 2
+    -         else:
+    -             return 3
+335 +         return 3
+336 | 
+337 | 
+338 | # try/except/else nested inside if/else body
+
+
+RET505 [*] Unnecessary `else` after `return` statement
+   --> RET505.py:348:9
+    |
+346 |         except Exception:
+347 |             return 2
+348 |         else:
+    |         ^^^^
+349 |             return 3
+    |
+help: Remove unnecessary `else`
+345 |             foo()
+346 |         except Exception:
+347 |             return 2
+    -         else:
+    -             return 3
+348 +         return 3
+349 | 
+350 | 
+351 | ###

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__preview__RET506_RET506.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__preview__RET506_RET506.py.snap
@@ -1,0 +1,73 @@
+---
+source: crates/ruff_linter/src/rules/flake8_return/mod.rs
+---
+--- Linter settings ---
+-linter.preview = disabled
++linter.preview = enabled
+
+--- Summary ---
+Removed: 0
+Added: 3
+
+--- Added ---
+RET506 [*] Unnecessary `else` after `raise` statement
+   --> RET506.py:123:5
+    |
+121 |     except Exception:
+122 |         raise ValueError
+123 |     else:
+    |     ^^^^
+124 |         raise TypeError
+    |
+help: Remove unnecessary `else`
+120 |         foo()
+121 |     except Exception:
+122 |         raise ValueError
+    -     else:
+    -         raise TypeError
+123 +     raise TypeError
+124 | 
+125 | 
+126 | def try_except_else_raise_multiple_handlers():
+
+
+RET506 [*] Unnecessary `else` after `raise` statement
+   --> RET506.py:134:5
+    |
+132 |     except TypeError:
+133 |         raise RuntimeError
+134 |     else:
+    |     ^^^^
+135 |         raise RuntimeError
+    |
+help: Remove unnecessary `else`
+131 |         raise RuntimeError
+132 |     except TypeError:
+133 |         raise RuntimeError
+    -     else:
+    -         raise RuntimeError
+134 +     raise RuntimeError
+135 | 
+136 | 
+137 | def try_except_star_else_raise():
+
+
+RET506 [*] Unnecessary `else` after `raise` statement
+   --> RET506.py:145:5
+    |
+143 |     except* TypeError:
+144 |         raise RuntimeError
+145 |     else:
+    |     ^^^^
+146 |         raise RuntimeError
+    |
+help: Remove unnecessary `else`
+142 |         raise RuntimeError
+143 |     except* TypeError:
+144 |         raise RuntimeError
+    -     else:
+    -         raise RuntimeError
+145 +     raise RuntimeError
+146 | 
+147 | 
+148 | ###

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__preview__RET507_RET507.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__preview__RET507_RET507.py.snap
@@ -1,0 +1,52 @@
+---
+source: crates/ruff_linter/src/rules/flake8_return/mod.rs
+---
+--- Linter settings ---
+-linter.preview = disabled
++linter.preview = enabled
+
+--- Summary ---
+Removed: 0
+Added: 2
+
+--- Added ---
+RET507 [*] Unnecessary `else` after `continue` statement
+   --> RET507.py:118:9
+    |
+116 |         except Exception:
+117 |             continue
+118 |         else:
+    |         ^^^^
+119 |             x = 1
+    |
+help: Remove unnecessary `else`
+115 |             foo()
+116 |         except Exception:
+117 |             continue
+    -         else:
+    -             x = 1
+118 +         x = 1
+119 | 
+120 | 
+121 | def try_except_else_continue_multiple_handlers():
+
+
+RET507 [*] Unnecessary `else` after `continue` statement
+   --> RET507.py:130:9
+    |
+128 |         except TypeError:
+129 |             continue
+130 |         else:
+    |         ^^^^
+131 |             x = 1
+    |
+help: Remove unnecessary `else`
+127 |             continue
+128 |         except TypeError:
+129 |             continue
+    -         else:
+    -             x = 1
+130 +         x = 1
+131 | 
+132 | 
+133 | ###

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__preview__RET508_RET508.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__preview__RET508_RET508.py.snap
@@ -1,0 +1,52 @@
+---
+source: crates/ruff_linter/src/rules/flake8_return/mod.rs
+---
+--- Linter settings ---
+-linter.preview = disabled
++linter.preview = enabled
+
+--- Summary ---
+Removed: 0
+Added: 2
+
+--- Added ---
+RET508 [*] Unnecessary `else` after `break` statement
+   --> RET508.py:171:9
+    |
+169 |         except Exception:
+170 |             break
+171 |         else:
+    |         ^^^^
+172 |             x = 1
+    |
+help: Remove unnecessary `else`
+168 |             foo()
+169 |         except Exception:
+170 |             break
+    -         else:
+    -             x = 1
+171 +         x = 1
+172 | 
+173 | 
+174 | def try_except_else_break_multiple_handlers():
+
+
+RET508 [*] Unnecessary `else` after `break` statement
+   --> RET508.py:183:9
+    |
+181 |         except TypeError:
+182 |             break
+183 |         else:
+    |         ^^^^
+184 |             x = 1
+    |
+help: Remove unnecessary `else`
+180 |             break
+181 |         except TypeError:
+182 |             break
+    -         else:
+    -             x = 1
+183 +         x = 1
+184 | 
+185 | 
+186 | ###

--- a/crates/ruff_linter/src/rules/flake8_return/visitor.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/visitor.rs
@@ -28,6 +28,8 @@ pub(super) struct Stack<'data> {
     /// of `foo()` to an `int`. Removing the `x = foo()` statement would
     /// change the return type of the function.
     pub(super) annotations: FxHashSet<&'data str>,
+    /// The `try/except/else` statements (without `finally`) in the current function
+    pub(super) try_elses: Vec<&'data ast::StmtTry>,
     /// Whether the current function is a generator.
     pub(super) is_generator: bool,
     /// The `assignment`-to-`return` statement pairs in the current function.
@@ -166,6 +168,14 @@ impl<'a> Visitor<'a> for ReturnVisitor<'_, 'a> {
             }) => {
                 if let Some(first) = elif_else_clauses.first() {
                     self.stack.elifs_elses.push((body, first));
+                }
+            }
+            Stmt::Try(stmt_try) => {
+                // Collect try/except/else statements where `else` is non-empty
+                // and `finally` is empty (presence of `finally` changes execution
+                // order, making the `else` semantically significant)
+                if !stmt_try.orelse.is_empty() && stmt_try.finalbody.is_empty() {
+                    self.stack.try_elses.push(stmt_try);
                 }
             }
             _ => {}

--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -28,6 +28,7 @@ pub mod relocate;
 pub mod script;
 pub mod statement_visitor;
 pub mod stmt_if;
+pub mod stmt_try;
 pub mod str;
 pub mod str_prefix;
 pub mod token;

--- a/crates/ruff_python_ast/src/stmt_try.rs
+++ b/crates/ruff_python_ast/src/stmt_try.rs
@@ -1,0 +1,15 @@
+use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer};
+use ruff_text_size::{Ranged, TextRange};
+
+use crate::StmtTry;
+
+/// Return the `Range` of the `Else` token in a `Try` statement.
+pub fn try_else_range(stmt_try: &StmtTry, contents: &str) -> Option<TextRange> {
+    let search_start = stmt_try.handlers.last().map(Ranged::end)?;
+
+    let token = SimpleTokenizer::starts_at(search_start, contents)
+        .skip_trivia()
+        .next()?;
+
+    matches!(token.kind, SimpleTokenKind::Else).then_some(token.range())
+}


### PR DESCRIPTION
Closes #8018
Closes #9625

## Summary

Extends RET505/506/507/508 to detect superfluous `else` blocks on `try/except/else` statements where all `except` handlers unconditionally exit (return/raise/break/continue). Gated behind preview.

 ```python
  # flagged
  def foo():
      try:
          something()
      except Exception:
          return 1
      else:
          return 2

  # fixed
  def foo():
      try:
          something()
      except Exception:
          return 1
      return 2
```

Cases with `finally` are excluded since removing else changes execution order.

Also did a little refactoring to re-use some existing functions.

## Test Plan

- Added test fixtures for all four rules (RET505-508)
- Separate stable and preview snapshots