### PR TITLE
Use `yield` as a code indicator in `ERA001`

### DIFF
--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -9,7 +9,7 @@ use std::sync::LazyLock;
 
 static CODE_INDICATORS: LazyLock<AhoCorasick> = LazyLock::new(|| {
     AhoCorasick::new([
-        "(", ")", "[", "]", "{", "}", ":", "=", "%", "return", "break", "continue", "import",
+        "(", ")", "[", "]", "{", "}", ":", "=", "%", "return", "break", "continue", "import", "yield",
     ])
     .unwrap()
 });


### PR DESCRIPTION
## Summary

Python lines could contain just `yield val` and this is a valid code line, but is not currently identified as such.