### PR TITLE
publish installers to `/installers/ruff/latest` on the mirror

### DIFF
--- a/.github/workflows/publish-mirror.yml
+++ b/.github/workflows/publish-mirror.yml
@@ -43,3 +43,18 @@ jobs:
             --cache-control "public, max-age=31536000, immutable" \
             artifacts/ \
             "s3://${R2_BUCKET}/github/${PROJECT}/releases/download/${VERSION}/"
+      - name: "Upload latest installers to R2"
+        if: ${{ !fromJson(inputs.plan).announcement_is_prerelease }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.MIRROR_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MIRROR_R2_SECRET_ACCESS_KEY }}
+          AWS_ENDPOINT_URL: https://${{ secrets.MIRROR_R2_CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          AWS_DEFAULT_REGION: auto
+          R2_BUCKET: ${{ secrets.MIRROR_R2_BUCKET_NAME }}
+        run: |
+          for installer in ruff-installer.sh ruff-installer.ps1; do
+            aws s3 cp --output table --color on \
+              --cache-control "public, max-age=300" \
+              "artifacts/${installer}" \
+              "s3://${R2_BUCKET}/installers/ruff/latest/${installer}"
+          done


### PR DESCRIPTION
Like https://github.com/astral-sh/uv/pull/18725 but for Ruff.

This adds an extra step to mirror publishing that updates https://releases.astral.sh/installers/ruff/latest/ruff-installer.{sh,ps1} with the installers for the version we just released.

## Test Plan
Will run this as part of the next release, then verify these URLs return the right thing:

[releases.astral.sh/installers/ruff/latest/ruff-installer.sh](https://releases.astral.sh/installers/ruff/latest/ruff-installer.sh)
[releases.astral.sh/installers/ruff/latest/ruff-installer.ps1](https://releases.astral.sh/installers/ruff/latest/ruff-installer.ps1)