### PR TITLE
fix(pyflakes): restore builtins after del shadowing

### DIFF
--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -1363,6 +1363,30 @@ mod tests {
     }
 
     #[test]
+    fn del_builtin_shadowing_restores_builtin() {
+        flakes("print = 0; del print; print(1)", &[]);
+    }
+
+    #[test]
+    fn del_configured_builtin_shadowing_restores_builtin() {
+        let diagnostics = test_snippet(
+            r#"
+def _(message):
+    return message
+messages = [_("x"), _("y"), _("z")]
+del _
+for message in messages:
+    print(_(message))
+"#,
+            &LinterSettings {
+                builtins: vec!["_".to_string()],
+                ..LinterSettings::for_rule(Rule::UndefinedName)
+            },
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn del_global() {
         // Del a global binding from a function.
         flakes(

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -535,6 +535,28 @@ impl<'a> SemanticModel<'a> {
                             }
                         }
 
+                        let deletion_range = self.bindings[binding_id].range;
+                        if deletion_range.start() < name.range.start() {
+                            if let Some(builtin_id) = self.scopes[scope_id]
+                                .shadowed_bindings(binding_id)
+                                .skip(1)
+                                .find(|shadowed_id| {
+                                    matches!(self.bindings[*shadowed_id].kind, BindingKind::Builtin)
+                                })
+                            {
+                                let reference_id = self.resolved_references.push(
+                                    self.scope_id,
+                                    self.node_id,
+                                    ExprContext::Load,
+                                    self.flags,
+                                    name.range,
+                                );
+                                self.bindings[builtin_id].references.push(reference_id);
+                                self.resolved_names.insert(name.into(), builtin_id);
+                                return ReadResult::Resolved(builtin_id);
+                            }
+                        }
+
                         self.unresolved_references.push(
                             name.range,
                             self.exceptions(),


### PR DESCRIPTION
## Summary
- restore builtin resolution after del removes a local name that shadowed a builtin
- cover both the plain builtin case and a configured builtin like _

## Testing
- cargo test -p ruff_linter del_builtin_shadowing_restores_builtin
- cargo test -p ruff_linter del_configured_builtin_shadowing_restores_builtin
- cargo test -p ruff_linter 'rules::pyflakes::tests::del'

Closes #14772.