### PR TITLE
[ty] Make `Divergent` a top-level type variant

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -2497,6 +2497,7 @@ fn completion_kind_from_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Comp
                 .iter_positive(db)
                 .find_map(|ty| imp(db, ty, visitor))?,
             Type::Dynamic(_)
+            | Type::Divergent(_)
             | Type::Never
             | Type::SpecialForm(_)
             | Type::KnownInstance(_)

--- a/crates/ty_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/cast.md
@@ -81,6 +81,22 @@ def f(x: Any, y: Unknown, z: Any | str | int):
     e = cast(str | int | Any, z)  # error: [redundant-cast]
 ```
 
+Recursive aliases that fall back to `Divergent` should not trigger `redundant-cast`.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import cast
+
+RecursiveAlias = list["RecursiveAlias | None"]
+
+def f(x: RecursiveAlias):
+    cast(RecursiveAlias, x)
+```
+
 ## Diagnostic snapshots
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/ide_support/all_members.md
+++ b/crates/ty_python_semantic/resources/mdtest/ide_support/all_members.md
@@ -108,6 +108,29 @@ static_assert(has_member(C(), "static_method"))
 static_assert(not has_member(C(), "non_existent"))
 ```
 
+Recursive attribute inference can fall back to `Divergent`, but should still preserve members that
+were available before the cycle was introduced:
+
+```py
+from ty_extensions import has_member, static_assert
+
+class Base:
+    def flip(self) -> "Base":
+        return Base()
+
+class Sub(Base):
+    pass
+
+class C:
+    def __init__(self, x: Sub):
+        self.x = [x]
+
+    def replace_with(self, other: "C"):
+        self.x = [self.x[0].flip()]
+
+static_assert(has_member(C(Sub()).x[0], "flip"))
+```
+
 ### Class objects
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1508,6 +1508,8 @@ _ = cast(Bar2, foo)  # error: [redundant-cast]
 ```py
 from typing import TypedDict, Final, Literal, Any
 
+RecursiveKey = list["RecursiveKey | None"]
+
 class Person(TypedDict):
     name: str
     age: int | None
@@ -1515,10 +1517,15 @@ class Person(TypedDict):
 class Animal(TypedDict):
     name: str
 
+class Movie(TypedDict):
+    name: str
+
 NAME_FINAL: Final = "name"
 AGE_FINAL: Final[Literal["age"]] = "age"
 
 def _(
+    recursive_key: RecursiveKey,
+    movie: Movie,
     person: Person,
     animal: Animal,
     being: Person | Animal,
@@ -1545,6 +1552,8 @@ def _(
 
     # No error here:
     reveal_type(person[unknown_key])  # revealed: Unknown
+
+    reveal_type(movie[recursive_key[0]])  # revealed: Unknown
 
     # error: [invalid-key] "Unknown key "anything" for TypedDict `Animal`"
     reveal_type(animal["anything"])  # revealed: Unknown

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -977,7 +977,7 @@ impl<'db> Type<'db> {
     }
 
     pub(crate) const fn is_dynamic(&self) -> bool {
-        matches!(self, Type::Dynamic(_))
+        matches!(self, Type::Dynamic(_) | Type::Divergent(_))
     }
 
     const fn is_non_divergent_dynamic(&self) -> bool {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -641,6 +641,8 @@ impl<'db> DataclassParams<'db> {
 pub enum Type<'db> {
     /// The dynamic type: a statically unknown set of values
     Dynamic(DynamicType<'db>),
+    /// A cycle marker used during recursive type inference.
+    Divergent(DivergentType),
     /// The empty set of values
     Never,
     /// A specific function object
@@ -777,11 +779,11 @@ impl<'db> Type<'db> {
     }
 
     pub(crate) fn divergent(id: salsa::Id) -> Self {
-        Self::Dynamic(DynamicType::Divergent(DivergentType { id }))
+        Self::Divergent(DivergentType { id })
     }
 
     pub(crate) const fn is_divergent(&self) -> bool {
-        matches!(self, Type::Dynamic(DynamicType::Divergent(_)))
+        matches!(self, Type::Divergent(_))
     }
 
     pub const fn is_unknown(&self) -> bool {
@@ -925,7 +927,6 @@ impl<'db> Type<'db> {
             DynamicType::Any
             | DynamicType::Unknown
             | DynamicType::UnknownGeneric(_)
-            | DynamicType::Divergent(_)
             | DynamicType::UnspecializedTypeVar => false,
             DynamicType::Todo(_)
             | DynamicType::TodoStarredExpression
@@ -1551,7 +1552,7 @@ impl<'db> Type<'db> {
         match self {
             Type::Never => Type::object(),
 
-            Type::Dynamic(_) => *self,
+            Type::Dynamic(_) | Type::Divergent(_) => *self,
 
             Type::NominalInstance(instance) if instance.is_object() => Type::Never,
 
@@ -1619,6 +1620,7 @@ impl<'db> Type<'db> {
             | Type::TypeAlias(_)
             | Type::SubclassOf(_)=> true,
             Type::Intersection(_)
+            | Type::Divergent(_)
             | Type::SpecialForm(_)
             | Type::BoundSuper(_)
             | Type::BoundMethod(_)
@@ -1814,6 +1816,7 @@ impl<'db> Type<'db> {
             Type::TypeGuard(type_guard) => {
                 recursive_type_normalize_type_guard_like(db, type_guard, div, nested)
             }
+            Type::Divergent(_) => Some(self),
             Type::Dynamic(dynamic) => Some(Type::Dynamic(dynamic.recursive_type_normalized())),
             Type::TypedDict(_) => {
                 // TODO: Normalize TypedDicts
@@ -1925,7 +1928,7 @@ impl<'db> Type<'db> {
     /// for more complicated types that are actually singletons.
     pub(crate) fn is_singleton(self, db: &'db dyn Db) -> bool {
         match self {
-            Type::Dynamic(_) | Type::Never => false,
+            Type::Dynamic(_) | Type::Divergent(_) | Type::Never => false,
 
             Type::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Int(..)
@@ -2114,6 +2117,7 @@ impl<'db> Type<'db> {
             Type::TypeAlias(alias) => alias.value_type(db).is_single_valued(db),
 
             Type::Dynamic(_)
+            | Type::Divergent(_)
             | Type::Never
             | Type::Union(..)
             | Type::Intersection(..)
@@ -2161,7 +2165,7 @@ impl<'db> Type<'db> {
                 }))
             }
 
-            Type::Dynamic(_) | Type::Never => Some(Place::bound(self).into()),
+            Type::Dynamic(_) | Type::Divergent(_) | Type::Never => Some(Place::bound(self).into()),
 
             Type::ClassLiteral(class) if class.is_typed_dict(db) => {
                 Some(class.typed_dict_member(db, None, name, policy))
@@ -2363,7 +2367,7 @@ impl<'db> Type<'db> {
             Type::Intersection(intersection) => intersection
                 .map_with_boundness_and_qualifiers(db, |elem| elem.instance_member(db, name)),
 
-            Type::Dynamic(_) | Type::Never => Place::bound(self).into(),
+            Type::Dynamic(_) | Type::Divergent(_) | Type::Never => Place::bound(self).into(),
 
             Type::NominalInstance(instance) => instance.class(db).instance_member(db, name),
             Type::NewTypeInstance(newtype) => {
@@ -2587,7 +2591,7 @@ impl<'db> Type<'db> {
             PlaceAndQualifiers {
                 place:
                     Place::Defined(DefinedPlace {
-                        ty: Type::Dynamic(_) | Type::Never,
+                        ty: Type::Dynamic(_) | Type::Divergent(_) | Type::Never,
                         ..
                     }),
                 qualifiers: _,
@@ -2906,7 +2910,7 @@ impl<'db> Type<'db> {
                     elem.member_lookup_with_policy(db, name_str.into(), policy)
                 }),
 
-            Type::Dynamic(..) | Type::Never => Place::bound(self).into(),
+            Type::Dynamic(..) | Type::Divergent(_) | Type::Never => Place::bound(self).into(),
 
             Type::FunctionLiteral(function) if name == "__get__" => Place::bound(
                 Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(function)),
@@ -3775,7 +3779,7 @@ impl<'db> Type<'db> {
 
             // Dynamic types are callable, and the return type is the same dynamic type. Similarly,
             // `Never` is always callable and returns `Never`.
-            Type::Dynamic(_) | Type::Never => {
+            Type::Dynamic(_) | Type::Divergent(_) | Type::Never => {
                 Binding::single(self, Signature::dynamic(self)).into()
             }
 
@@ -4870,7 +4874,7 @@ impl<'db> Type<'db> {
                     return_ty: return_builder.map(IntersectionBuilder::build),
                 })
             }
-            ty @ (Type::Dynamic(_) | Type::Never) => Some(GeneratorTypes {
+            ty @ (Type::Dynamic(_) | Type::Divergent(_) | Type::Never) => Some(GeneratorTypes {
                 yield_ty: Some(ty),
                 send_ty: Some(ty),
                 return_ty: Some(ty),
@@ -4892,7 +4896,7 @@ impl<'db> Type<'db> {
     #[must_use]
     pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<Type<'db>> {
         match self {
-            Type::Dynamic(_) | Type::Never => Some(self),
+            Type::Dynamic(_) | Type::Divergent(_) | Type::Never => Some(self),
             Type::ClassLiteral(class) => Some(Type::instance(db, class.default_specialization(db))),
             Type::GenericAlias(alias) => Some(Type::instance(db, ClassType::from(alias))),
             Type::SubclassOf(subclass_of_ty) => Some(subclass_of_ty.to_instance(db)),
@@ -5109,7 +5113,7 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::Dynamic(_) => Ok(*self),
+            Type::Dynamic(_) | Type::Divergent(_) => Ok(*self),
 
             Type::NominalInstance(instance) => match instance.known_class(db) {
                 Some(KnownClass::NoneType) => Ok(Type::none(db)),
@@ -5191,6 +5195,7 @@ impl<'db> Type<'db> {
             Type::GenericAlias(alias) => ClassType::from(alias).metaclass(db),
             Type::SubclassOf(subclass_of_ty) => subclass_of_ty.to_meta_type(db),
             Type::Dynamic(dynamic) => SubclassOfType::from(db, SubclassOfInner::Dynamic(dynamic)),
+            Type::Divergent(_) => self,
             // TODO intersections
             Type::Intersection(_) => {
                 SubclassOfType::try_from_type(db, todo_type!("Intersection meta-type"))
@@ -5525,19 +5530,15 @@ impl<'db> Type<'db> {
                 TypeMapping::ReplaceParameterDefaults |
                 TypeMapping::EagerExpansion |
                 TypeMapping::RescopeReturnCallables(_) => self,
-                TypeMapping::Materialize(materialization_kind) => match self {
-                    // `Divergent` is an internal cycle marker rather than a gradual type like
-                    // `Any` or `Unknown`. Materializing it away would destroy the marker we rely
-                    // on for recursive alias convergence.
-                    // TODO: We elsewhere treat `Divergent` as a dynamic type, so failing to
-                    // materialize it away here could lead to odd behavior.
-                    Type::Dynamic(DynamicType::Divergent(_)) => self,
-                    _ => match materialization_kind {
-                        MaterializationKind::Top => Type::object(),
-                        MaterializationKind::Bottom => Type::Never,
-                    },
+                TypeMapping::Materialize(materialization_kind) => match materialization_kind {
+                    MaterializationKind::Top => Type::object(),
+                    MaterializationKind::Bottom => Type::Never,
                 }
             }
+            // `Divergent` is an internal cycle marker rather than a gradual type like `Any` or
+            // `Unknown`. Materializing it away would destroy the marker we rely on for recursive
+            // alias convergence.
+            Type::Divergent(_) => self,
 
             Type::Never
             | Type::AlwaysTruthy
@@ -5613,6 +5614,7 @@ impl<'db> Type<'db> {
                     typevars.insert(bound_typevar);
                 }
             }
+            Type::Divergent(_) => {}
 
             Type::FunctionLiteral(function) => {
                 visitor.visit(self, || {
@@ -5970,9 +5972,9 @@ impl<'db> Type<'db> {
             Self::AlwaysFalsy => Type::SpecialForm(SpecialFormType::AlwaysFalsy).definition(db),
 
             // These types have no definition
-            Self::Dynamic(
-                DynamicType::Divergent(_)
-                | DynamicType::Todo(_)
+            Self::Divergent(_)
+            | Self::Dynamic(
+                DynamicType::Todo(_)
                 | DynamicType::TodoUnpack
                 | DynamicType::TodoStarredExpression
                 | DynamicType::TodoTypeVarTuple
@@ -6149,6 +6151,7 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
             Type::TypeGuard(type_guard_type) => type_guard_type.variance_of(db, typevar),
             Type::KnownInstance(known_instance) => known_instance.variance_of(db, typevar),
             Type::Dynamic(_)
+            | Type::Divergent(_)
             | Type::Never
             | Type::WrapperDescriptor(_)
             | Type::KnownBoundMethod(_)
@@ -6459,6 +6462,8 @@ pub enum DynamicType<'db> {
     TodoStarredExpression,
     /// A special Todo-variant for `TypeVarTuple` instances encountered in type expressions
     TodoTypeVarTuple,
+    /// A special Todo-variant for functional `TypedDict`s.
+    TodoFunctionalTypedDict,
     /// A type that is determined to be divergent during recursive type inference.
     Divergent(DivergentType),
 }
@@ -6485,6 +6490,7 @@ impl std::fmt::Display for DynamicType<'_> {
             DynamicType::TodoUnpack => f.write_str("@Todo(typing.Unpack)"),
             DynamicType::TodoStarredExpression => f.write_str("@Todo(StarredExpression)"),
             DynamicType::TodoTypeVarTuple => f.write_str("@Todo(TypeVarTuple)"),
+            DynamicType::TodoFunctionalTypedDict => f.write_str("@Todo(Functional TypedDicts)"),
             DynamicType::Divergent(_) => f.write_str("Divergent"),
         }
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6462,10 +6462,6 @@ pub enum DynamicType<'db> {
     TodoStarredExpression,
     /// A special Todo-variant for `TypeVarTuple` instances encountered in type expressions
     TodoTypeVarTuple,
-    /// A special Todo-variant for functional `TypedDict`s.
-    TodoFunctionalTypedDict,
-    /// A type that is determined to be divergent during recursive type inference.
-    Divergent(DivergentType),
 }
 
 impl DynamicType<'_> {
@@ -6490,8 +6486,6 @@ impl std::fmt::Display for DynamicType<'_> {
             DynamicType::TodoUnpack => f.write_str("@Todo(typing.Unpack)"),
             DynamicType::TodoStarredExpression => f.write_str("@Todo(StarredExpression)"),
             DynamicType::TodoTypeVarTuple => f.write_str("@Todo(TypeVarTuple)"),
-            DynamicType::TodoFunctionalTypedDict => f.write_str("@Todo(Functional TypedDicts)"),
-            DynamicType::Divergent(_) => f.write_str("Divergent"),
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -207,6 +207,7 @@ impl<'db> Type<'db> {
 
         let truthiness = match self {
             Type::Dynamic(_)
+            | Type::Divergent(_)
             | Type::Never
             | Type::Callable(_)
             | Type::TypeIs(_)

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -8,9 +8,9 @@ use crate::{
     Db, DisplaySettings,
     place::{Place, PlaceAndQualifiers},
     types::{
-        BoundTypeVarInstance, ClassBase, ClassType, DynamicType, IntersectionBuilder, KnownClass,
-        MemberLookupPolicy, NominalInstanceType, SpecialFormType, SubclassOfInner, SubclassOfType,
-        Type, TypeVarBoundOrConstraints, UnionBuilder,
+        BoundTypeVarInstance, ClassBase, ClassType, DivergentType, DynamicType,
+        IntersectionBuilder, KnownClass, MemberLookupPolicy, NominalInstanceType, SpecialFormType,
+        SubclassOfInner, SubclassOfType, Type, TypeVarBoundOrConstraints, UnionBuilder,
         constraints::ConstraintSet,
         context::InferContext,
         diagnostic::{INVALID_SUPER_ARGUMENT, UNAVAILABLE_IMPLICIT_SUPER_ARGUMENTS},
@@ -187,6 +187,7 @@ impl<'db> BoundSuperError<'db> {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, get_size2::GetSize, salsa::Update)]
 pub enum SuperOwnerKind<'db> {
     Dynamic(DynamicType<'db>),
+    Divergent(DivergentType),
     Class(ClassType<'db>),
     Instance(NominalInstanceType<'db>),
     /// An instance-like type variable owner (e.g., `self: Self` in an instance method).
@@ -208,6 +209,7 @@ impl<'db> SuperOwnerKind<'db> {
             SuperOwnerKind::Dynamic(dynamic) => {
                 Some(SuperOwnerKind::Dynamic(dynamic.recursive_type_normalized()))
             }
+            SuperOwnerKind::Divergent(_) => Some(self),
             SuperOwnerKind::Class(class) => Some(SuperOwnerKind::Class(
                 class.recursive_type_normalized_impl(db, div, nested)?,
             )),
@@ -226,6 +228,9 @@ impl<'db> SuperOwnerKind<'db> {
             SuperOwnerKind::Dynamic(dynamic) => {
                 Either::Left(ClassBase::Dynamic(dynamic).mro(db, None))
             }
+            SuperOwnerKind::Divergent(divergent) => {
+                Either::Left(ClassBase::Divergent(divergent).mro(db, None))
+            }
             SuperOwnerKind::Class(class) => Either::Right(class.iter_mro(db)),
             SuperOwnerKind::Instance(instance) => Either::Right(instance.class(db).iter_mro(db)),
             SuperOwnerKind::InstanceTypeVar(_, class) | SuperOwnerKind::ClassTypeVar(_, class) => {
@@ -236,7 +241,7 @@ impl<'db> SuperOwnerKind<'db> {
 
     fn into_class(self, db: &'db dyn Db) -> Option<ClassType<'db>> {
         match self {
-            SuperOwnerKind::Dynamic(_) => None,
+            SuperOwnerKind::Dynamic(_) | SuperOwnerKind::Divergent(_) => None,
             SuperOwnerKind::Class(class) => Some(class),
             SuperOwnerKind::Instance(instance) => Some(instance.class(db)),
             SuperOwnerKind::InstanceTypeVar(_, class) | SuperOwnerKind::ClassTypeVar(_, class) => {
@@ -258,6 +263,7 @@ impl<'db> SuperOwnerKind<'db> {
     pub(super) fn owner_type(self, db: &'db dyn Db) -> Type<'db> {
         match self {
             SuperOwnerKind::Dynamic(dynamic) => Type::Dynamic(dynamic),
+            SuperOwnerKind::Divergent(divergent) => Type::Divergent(divergent),
             SuperOwnerKind::Class(class) => class.into(),
             SuperOwnerKind::Instance(instance) => instance.into(),
             SuperOwnerKind::InstanceTypeVar(bound_typevar, _) => Type::TypeVar(bound_typevar),
@@ -356,6 +362,7 @@ impl<'db> BoundSuperType<'db> {
             Type::SpecialForm(SpecialFormType::Generic) => ClassBase::Generic,
             Type::SpecialForm(SpecialFormType::TypedDict) => ClassBase::TypedDict,
             Type::Dynamic(dynamic) => ClassBase::Dynamic(dynamic),
+            Type::Divergent(divergent) => ClassBase::Divergent(divergent),
             _ => {
                 return Err(BoundSuperError::InvalidPivotClassType {
                     pivot_class: pivot_class_type,
@@ -383,7 +390,7 @@ impl<'db> BoundSuperType<'db> {
                             // Validate constraint is a subclass of pivot class.
                             if let Some(pivot) = pivot_class_literal {
                                 if !class.iter_mro(db).any(|superclass| match superclass {
-                                    ClassBase::Dynamic(_) => true,
+                                    ClassBase::Dynamic(_) | ClassBase::Divergent(_) => true,
                                     ClassBase::Generic
                                     | ClassBase::Protocol
                                     | ClassBase::TypedDict => false,
@@ -418,6 +425,7 @@ impl<'db> BoundSuperType<'db> {
         let owner = match owner_type {
             Type::Never => SuperOwnerKind::Dynamic(DynamicType::Unknown),
             Type::Dynamic(dynamic) => SuperOwnerKind::Dynamic(dynamic),
+            Type::Divergent(divergent) => SuperOwnerKind::Divergent(divergent),
             Type::ClassLiteral(class) => SuperOwnerKind::Class(ClassType::NonGeneric(class)),
             Type::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
                 SubclassOfInner::Class(class) => SuperOwnerKind::Class(class),
@@ -599,7 +607,7 @@ impl<'db> BoundSuperType<'db> {
         {
             let pivot_class = pivot_class.class_literal(db);
             if !owner_class.iter_mro(db).any(|superclass| match superclass {
-                ClassBase::Dynamic(_) => true,
+                ClassBase::Dynamic(_) | ClassBase::Divergent(_) => true,
                 ClassBase::Generic | ClassBase::Protocol | ClassBase::TypedDict => false,
                 ClassBase::Class(superclass) => superclass.class_literal(db) == pivot_class,
             }) {
@@ -659,7 +667,7 @@ impl<'db> BoundSuperType<'db> {
         match owner {
             // If the owner is a dynamic type, we can't tell whether it's a class or an instance.
             // Also, invoking a descriptor on a dynamic attribute is meaningless, so we don't handle this.
-            SuperOwnerKind::Dynamic(_) => None,
+            SuperOwnerKind::Dynamic(_) | SuperOwnerKind::Divergent(_) => None,
             SuperOwnerKind::Class(_) => Some(
                 Type::try_call_dunder_get_on_attribute(db, attribute, None, owner.owner_type(db)).0,
             ),
@@ -696,6 +704,11 @@ impl<'db> BoundSuperType<'db> {
                 return Type::Dynamic(dynamic)
                     .find_name_in_mro_with_policy(db, name, policy)
                     .expect("Calling `find_name_in_mro` on dynamic type should return `Some`");
+            }
+            SuperOwnerKind::Divergent(_) => {
+                return Type::unknown()
+                    .find_name_in_mro_with_policy(db, name, policy)
+                    .expect("Calling `find_name_in_mro` on Unknown should return `Some`");
             }
             SuperOwnerKind::Class(class) => class,
             SuperOwnerKind::Instance(instance) => instance.class(db),
@@ -767,12 +780,10 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
             (ClassBase::Class(_), _) => self.never(),
 
             // A `Divergent` type is only equivalent to itself
-            (
-                ClassBase::Dynamic(DynamicType::Divergent(l)),
-                ClassBase::Dynamic(DynamicType::Divergent(r)),
-            ) => ConstraintSet::from_bool(self.constraints, l == r),
-            (ClassBase::Dynamic(DynamicType::Divergent(_)), _)
-            | (_, ClassBase::Dynamic(DynamicType::Divergent(_))) => self.never(),
+            (ClassBase::Divergent(l), ClassBase::Divergent(r)) => {
+                ConstraintSet::from_bool(self.constraints, l == r)
+            }
+            (ClassBase::Divergent(_), _) | (_, ClassBase::Divergent(_)) => self.never(),
             (ClassBase::Dynamic(_), ClassBase::Dynamic(_)) => self.always(),
             (ClassBase::Dynamic(_), _) => self.never(),
 
@@ -800,12 +811,10 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
             (SuperOwnerKind::Instance(_), _) => self.never(),
 
             // A `Divergent` type is only equivalent to itself
-            (
-                SuperOwnerKind::Dynamic(DynamicType::Divergent(l)),
-                SuperOwnerKind::Dynamic(DynamicType::Divergent(r)),
-            ) => ConstraintSet::from_bool(self.constraints, l == r),
-            (SuperOwnerKind::Dynamic(DynamicType::Divergent(_)), _)
-            | (_, SuperOwnerKind::Dynamic(DynamicType::Divergent(_))) => self.never(),
+            (SuperOwnerKind::Divergent(l), SuperOwnerKind::Divergent(r)) => {
+                ConstraintSet::from_bool(self.constraints, l == r)
+            }
+            (SuperOwnerKind::Divergent(_), _) | (_, SuperOwnerKind::Divergent(_)) => self.never(),
             (SuperOwnerKind::Dynamic(_), SuperOwnerKind::Dynamic(_)) => self.always(),
             (SuperOwnerKind::Dynamic(_), _) => self.never(),
 

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -55,6 +55,10 @@ impl<'db> Type<'db> {
                 db,
                 Signature::dynamic(self),
             ))),
+            Type::Divergent(_) => Some(CallableTypes::one(CallableType::function_like(
+                db,
+                Signature::dynamic(self),
+            ))),
 
             Type::FunctionLiteral(function_literal) => {
                 Some(CallableTypes::one(function_literal.into_callable_type(db)))

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1954,7 +1954,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         source.iter_mro(db).when_any(db, self.constraints, |base| {
             match base {
-                ClassBase::Dynamic(_) => match self.relation {
+                ClassBase::Dynamic(_) | ClassBase::Divergent(_) => match self.relation {
                     TypeRelation::Subtyping
                     | TypeRelation::Redundancy { .. }
                     | TypeRelation::SubtypingAssuming => {
@@ -2173,6 +2173,9 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                     // but adding such a method wouldn't make much sense -- it would always return `Any`!
                     dynamic_type.get_or_insert(Type::from(superclass));
                 }
+                ClassBase::Divergent(_) => {
+                    dynamic_type.get_or_insert(Type::from(superclass));
+                }
                 ClassBase::Class(class) => {
                     let known = class.known(db);
 
@@ -2238,7 +2241,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                 ClassBase::Generic | ClassBase::Protocol => {
                     // Skip over these very special class bases that aren't really classes.
                 }
-                ClassBase::Dynamic(_) => {
+                ClassBase::Dynamic(_) | ClassBase::Divergent(_) => {
                     // We already return the dynamic type for class member lookup, so we can
                     // just return unbound here (to avoid having to build a union of the
                     // dynamic type with itself).

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -3,9 +3,9 @@ use crate::types::generics::{ApplySpecialization, Specialization};
 use crate::types::mro::MroIterator;
 use crate::types::tuple::TupleType;
 use crate::types::{
-    ApplyTypeMappingVisitor, ClassLiteral, ClassType, DynamicType, KnownClass, KnownInstanceType,
-    MaterializationKind, SpecialFormType, StaticMroError, Type, TypeContext, TypeMapping,
-    todo_type,
+    ApplyTypeMappingVisitor, ClassLiteral, ClassType, DivergentType, DynamicType, KnownClass,
+    KnownInstanceType, MaterializationKind, SpecialFormType, StaticMroError, Type, TypeContext,
+    TypeMapping, todo_type,
 };
 use crate::{Db, DisplaySettings};
 
@@ -20,6 +20,7 @@ use crate::{Db, DisplaySettings};
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 pub enum ClassBase<'db> {
     Dynamic(DynamicType<'db>),
+    Divergent(DivergentType),
     Class(ClassType<'db>),
     /// Although `Protocol` is not a class in typeshed's stubs, it is at runtime,
     /// and can appear in the MRO of a class.
@@ -44,6 +45,7 @@ impl<'db> ClassBase<'db> {
     ) -> Option<Self> {
         match self {
             Self::Dynamic(dynamic) => Some(Self::Dynamic(dynamic.recursive_type_normalized())),
+            Self::Divergent(_) => Some(self),
             Self::Class(class) => Some(Self::Class(
                 class.recursive_type_normalized_impl(db, div, nested)?,
             )),
@@ -63,7 +65,7 @@ impl<'db> ClassBase<'db> {
                 | DynamicType::TodoStarredExpression
                 | DynamicType::TodoTypeVarTuple,
             ) => "@Todo",
-            ClassBase::Dynamic(DynamicType::Divergent(_)) => "Divergent",
+            ClassBase::Divergent(_) => "Divergent",
             ClassBase::Protocol => "Protocol",
             ClassBase::Generic => "Generic",
             ClassBase::TypedDict => "TypedDict",
@@ -89,6 +91,7 @@ impl<'db> ClassBase<'db> {
     ) -> Option<Self> {
         match ty {
             Type::Dynamic(dynamic) => Some(Self::Dynamic(dynamic)),
+            Type::Divergent(divergent) => Some(Self::Divergent(divergent)),
             Type::ClassLiteral(literal) => Some(Self::Class(literal.default_specialization(db))),
             Type::GenericAlias(generic) => Some(Self::Class(ClassType::Generic(generic))),
             Type::NominalInstance(instance)
@@ -275,7 +278,11 @@ impl<'db> ClassBase<'db> {
     pub(super) fn into_class(self) -> Option<ClassType<'db>> {
         match self {
             Self::Class(class) => Some(class),
-            Self::Dynamic(_) | Self::Generic | Self::Protocol | Self::TypedDict => None,
+            Self::Dynamic(_)
+            | Self::Divergent(_)
+            | Self::Generic
+            | Self::Protocol
+            | Self::TypedDict => None,
         }
     }
 
@@ -284,6 +291,7 @@ impl<'db> ClassBase<'db> {
         match self {
             Self::Class(class) => class.metaclass(db),
             Self::Dynamic(dynamic) => Type::Dynamic(dynamic),
+            Self::Divergent(divergent) => Type::Divergent(divergent),
             // TODO: all `Protocol` classes actually have `_ProtocolMeta` as their metaclass.
             Self::Protocol | Self::Generic | Self::TypedDict => KnownClass::Type.to_instance(db),
         }
@@ -300,7 +308,11 @@ impl<'db> ClassBase<'db> {
             Self::Class(class) => {
                 Self::Class(class.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
             }
-            Self::Dynamic(_) | Self::Generic | Self::Protocol | Self::TypedDict => self,
+            Self::Dynamic(_)
+            | Self::Divergent(_)
+            | Self::Generic
+            | Self::Protocol
+            | Self::TypedDict => self,
         }
     }
 
@@ -351,6 +363,7 @@ impl<'db> ClassBase<'db> {
                     .is_err_and(StaticMroError::is_cycle)
             }
             ClassBase::Dynamic(_)
+            | ClassBase::Divergent(_)
             | ClassBase::Generic
             | ClassBase::Protocol
             | ClassBase::TypedDict => false,
@@ -365,9 +378,10 @@ impl<'db> ClassBase<'db> {
     ) -> impl Iterator<Item = ClassBase<'db>> {
         match self {
             ClassBase::Protocol => ClassBaseMroIterator::length_3(db, self, ClassBase::Generic),
-            ClassBase::Dynamic(_) | ClassBase::Generic | ClassBase::TypedDict => {
-                ClassBaseMroIterator::length_2(db, self)
-            }
+            ClassBase::Dynamic(_)
+            | ClassBase::Divergent(_)
+            | ClassBase::Generic
+            | ClassBase::TypedDict => ClassBaseMroIterator::length_2(db, self),
             ClassBase::Class(class) => {
                 ClassBaseMroIterator::from_class(db, class, additional_specialization)
             }
@@ -393,6 +407,7 @@ impl<'db> ClassBase<'db> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 match self.base {
                     ClassBase::Dynamic(dynamic) => dynamic.fmt(f),
+                    ClassBase::Divergent(_) => f.write_str("Divergent"),
                     ClassBase::Class(class) => Type::from(class)
                         .display_with(self.db, self.settings.clone())
                         .fmt(f),
@@ -421,6 +436,7 @@ impl<'db> From<ClassBase<'db>> for Type<'db> {
     fn from(value: ClassBase<'db>) -> Self {
         match value {
             ClassBase::Dynamic(dynamic) => Type::Dynamic(dynamic),
+            ClassBase::Divergent(divergent) => Type::Divergent(divergent),
             ClassBase::Class(class) => class.into(),
             ClassBase::Protocol => Type::SpecialForm(SpecialFormType::Protocol),
             ClassBase::Generic => Type::SpecialForm(SpecialFormType::Generic),

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -865,6 +865,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                 }
                 write!(f.with_type(self.ty), "{dynamic}")
             }
+            Type::Divergent(_) => f.with_type(self.ty).write_str("Divergent"),
             Type::Never => f.with_type(self.ty).write_str("Never"),
             Type::NominalInstance(instance) => {
                 let class = instance.class(self.db);

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -2043,11 +2043,23 @@ impl KnownFunction {
                 let [Some(casted_type), Some(source_type)] = parameter_types else {
                     return;
                 };
-                let contains_unknown_or_todo =
-                    |ty| matches!(ty, Type::Dynamic(dynamic) if dynamic != DynamicType::Any);
+                let contains_unknown_or_todo_or_divergent = |ty: Type<'_>| {
+                    matches!(ty, Type::Divergent(_))
+                        || (ty.is_dynamic() && !matches!(ty, Type::Dynamic(DynamicType::Any)))
+                };
                 if source_type.is_equivalent_to(db, *casted_type)
-                    && !any_over_type(db, *source_type, true, contains_unknown_or_todo)
-                    && !any_over_type(db, *casted_type, true, contains_unknown_or_todo)
+                    && !any_over_type(
+                        db,
+                        *source_type,
+                        true,
+                        contains_unknown_or_todo_or_divergent,
+                    )
+                    && !any_over_type(
+                        db,
+                        *casted_type,
+                        true,
+                        contains_unknown_or_todo_or_divergent,
+                    )
                 {
                     if let Some(builder) = context.report_lint(&REDUNDANT_CAST, call_expression) {
                         let source_display = source_type.display(db).to_string();

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1571,6 +1571,7 @@ fn is_instance_truthiness<'db>(
         | Type::TypeGuard(..)
         | Type::Callable(..)
         | Type::Dynamic(..)
+        | Type::Divergent(_)
         | Type::Never
         | Type::TypedDict(_) => {
             // We could probably try to infer more precise types in some of these cases, but it's unclear

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -2043,23 +2043,12 @@ impl KnownFunction {
                 let [Some(casted_type), Some(source_type)] = parameter_types else {
                     return;
                 };
-                let contains_unknown_or_todo_or_divergent = |ty: Type<'_>| {
-                    matches!(ty, Type::Divergent(_))
-                        || (ty.is_dynamic() && !matches!(ty, Type::Dynamic(DynamicType::Any)))
+                let contains_unknown_or_todo = |ty: Type<'_>| {
+                    ty.is_dynamic() && !matches!(ty, Type::Dynamic(DynamicType::Any))
                 };
                 if source_type.is_equivalent_to(db, *casted_type)
-                    && !any_over_type(
-                        db,
-                        *source_type,
-                        true,
-                        contains_unknown_or_todo_or_divergent,
-                    )
-                    && !any_over_type(
-                        db,
-                        *casted_type,
-                        true,
-                        contains_unknown_or_todo_or_divergent,
-                    )
+                    && !any_over_type(db, *source_type, true, contains_unknown_or_todo)
+                    && !any_over_type(db, *casted_type, true, contains_unknown_or_todo)
                 {
                     if let Some(builder) = context.report_lint(&REDUNDANT_CAST, call_expression) {
                         let source_display = source_type.display(db).to_string();

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1363,7 +1363,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         // `@overload`ed functions without a body in unreachable code.
                         true
                     }
-                    Type::Dynamic(DynamicType::Divergent(_)) => true,
+                    Type::Divergent(_) => true,
                     _ => false,
                 }
             })
@@ -2169,7 +2169,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 false
             }
 
-            Type::Dynamic(..) | Type::Never => {
+            Type::Dynamic(..) | Type::Divergent(_) | Type::Never => {
                 infer_value_ty(self, TypeContext::default());
                 true
             }
@@ -2741,6 +2741,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 | Type::Intersection(..)
                 | Type::TypeAlias(..)
                 | Type::Dynamic(..)
+                | Type::Divergent(_)
                 | Type::Never
                 | Type::ModuleLiteral(..)
                 | Type::BoundSuper(..) => return None,
@@ -3832,7 +3833,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         disjoint_bases.insert(disjoint_base, idx, class_type.class_literal(db));
                     }
                 }
-                ClassBase::Dynamic(_) => {
+                ClassBase::Dynamic(_) | ClassBase::Divergent(_) => {
                     // Dynamic bases are allowed.
                 }
             }
@@ -4888,6 +4889,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 Type::Intersection(_) => None,
                 // All other types cannot have a callable kind propagated to them.
                 Type::Dynamic(_)
+                | Type::Divergent(_)
                 | Type::Never
                 | Type::FunctionLiteral(_)
                 | Type::BoundMethod(_)
@@ -8727,7 +8729,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         match (op, operand_type) {
-            (_, Type::Dynamic(_)) => operand_type,
+            (_, Type::Dynamic(_) | Type::Divergent(_)) => operand_type,
             (_, Type::Never) => Type::Never,
 
             (_, Type::TypeAlias(alias)) => {

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -342,8 +342,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
             // Non-todo Anys take precedence over Todos (as if we fix this `Todo` in the future,
             // the result would then become Any or Unknown, respectively).
-            (div @ Type::Dynamic(DynamicType::Divergent(_)), _, _)
-            | (_, div @ Type::Dynamic(DynamicType::Divergent(_)), _) => Some(div),
+            (div @ Type::Divergent(_), _, _) | (_, div @ Type::Divergent(_), _) => Some(div),
 
             (any @ Type::Dynamic(DynamicType::Any), _, _)
             | (_, any @ Type::Dynamic(DynamicType::Any), _) => Some(any),

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -1213,7 +1213,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // types like `LiteralString & Any` to pass, but it does not need to be perfect. We would just
                     // fail to provide the "can only be subscripted with a string literal key" hint in that case.
 
-                    if slice_ty.is_dynamic() {
+                    if slice_ty.is_dynamic() || slice_ty.is_divergent() {
                         return true;
                     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -1213,7 +1213,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // types like `LiteralString & Any` to pass, but it does not need to be perfect. We would just
                     // fail to provide the "can only be subscripted with a string literal key" hint in that case.
 
-                    if slice_ty.is_dynamic() || slice_ty.is_divergent() {
+                    if slice_ty.is_dynamic() {
                         return true;
                     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1347,7 +1347,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             Type::Dynamic(DynamicType::UnknownGeneric(_)) => {
                 self.infer_explicit_type_alias_specialization(subscript, value_ty, true)
             }
-            Type::Dynamic(_) => {
+            Type::Dynamic(_) | Type::Divergent(_) => {
                 // Infer slice as a value expression to avoid false-positive
                 // `invalid-type-form` diagnostics, when we have e.g.
                 // `MyCallable[[int, str], None]` but `MyCallable` is dynamic.

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -166,6 +166,7 @@ impl<'db> Type<'db> {
                 }
                 // N.B. This special case isn't strictly necessary, it's just an obvious optimization
                 Type::Dynamic(_) => Some(Cow::Owned(TupleSpec::homogeneous(ty))),
+                Type::Divergent(_) => Some(Cow::Owned(TupleSpec::homogeneous(ty))),
 
                 Type::FunctionLiteral(_)
                 | Type::GenericAlias(_)

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -170,12 +170,10 @@ impl<'db> AllMembers<'db> {
                     // `Type` guarantees that unions/intersections
                     // are kept in DNF (i.e., they are flattened).
                     ty.is_dynamic()
-                        || ty.is_divergent()
                         || match ty {
-                            Type::Intersection(intersection) => intersection
-                                .positive(db)
-                                .iter()
-                                .any(|ty| ty.is_dynamic() || ty.is_divergent()),
+                            Type::Intersection(intersection) => {
+                                intersection.positive(db).iter().any(Type::is_dynamic)
+                            }
                             _ => false,
                         }
                 }

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -170,10 +170,12 @@ impl<'db> AllMembers<'db> {
                     // `Type` guarantees that unions/intersections
                     // are kept in DNF (i.e., they are flattened).
                     ty.is_dynamic()
+                        || ty.is_divergent()
                         || match ty {
-                            Type::Intersection(intersection) => {
-                                intersection.positive(db).iter().any(Type::is_dynamic)
-                            }
+                            Type::Intersection(intersection) => intersection
+                                .positive(db)
+                                .iter()
+                                .any(|ty| ty.is_dynamic() || ty.is_divergent()),
                             _ => false,
                         }
                 }

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -284,7 +284,11 @@ impl<'db> AllMembers<'db> {
                 }
             },
 
-            Type::Dynamic(_) | Type::Never | Type::AlwaysTruthy | Type::AlwaysFalsy => {
+            Type::Dynamic(_)
+            | Type::Divergent(_)
+            | Type::Never
+            | Type::AlwaysTruthy
+            | Type::AlwaysFalsy => {
                 self.extend_with_type(db, Type::object());
             }
 

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -292,7 +292,9 @@ impl<'db> Mro<'db> {
                                     later_indices: later_indices.iter().copied().collect(),
                                 });
                             }
-                            ClassBase::Dynamic(_) => duplicate_dynamic_bases = true,
+                            ClassBase::Dynamic(_) | ClassBase::Divergent(_) => {
+                                duplicate_dynamic_bases = true;
+                            }
                         }
                     }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -190,7 +190,7 @@ impl ClassInfoConstraintFunction {
                     },
                 }
             }
-            Type::Dynamic(_) => Some(classinfo),
+            Type::Dynamic(_) | Type::Divergent(_) => Some(classinfo),
             Type::Intersection(intersection) => {
                 if intersection.negative(db).is_empty() {
                     let mut builder = IntersectionBuilder::new(db);
@@ -2031,6 +2031,7 @@ fn is_or_contains_typeddict<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
         Type::TypeAlias(alias) => is_or_contains_typeddict(db, alias.value_type(db)),
 
         Type::Dynamic(_)
+        | Type::Divergent(_)
         | Type::Never
         | Type::FunctionLiteral(_)
         | Type::BoundMethod(_)
@@ -2119,6 +2120,7 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
         // Only the four variants above can pass `is_or_contains_typeddict`, and this function is
         // always guarded by that check.
         Type::Dynamic(_)
+        | Type::Divergent(_)
         | Type::Never
         | Type::FunctionLiteral(_)
         | Type::BoundMethod(_)

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -268,6 +268,10 @@ fn check_class_declaration<'db>(
                     has_dynamic_superclass = true;
                     continue;
                 }
+                ClassBase::Divergent(_) => {
+                    has_dynamic_superclass = true;
+                    continue;
+                }
                 ClassBase::TypedDict => {
                     has_typeddict_in_mro = true;
                     continue;

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -11,8 +11,8 @@ use crate::types::enums::is_single_member_enum;
 use crate::types::function::FunctionDecorators;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::{
-    CallableType, ClassBase, ClassType, CycleDetector, DynamicType, KnownBoundMethodType,
-    KnownClass, KnownInstanceType, LiteralValueTypeKind, MemberLookupPolicy, PropertyInstanceType,
+    CallableType, ClassBase, ClassType, CycleDetector, KnownBoundMethodType, KnownClass,
+    KnownInstanceType, LiteralValueTypeKind, MemberLookupPolicy, PropertyInstanceType,
     ProtocolInstanceType, SubclassOfInner, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
 };
 use crate::{
@@ -268,6 +268,7 @@ impl<'db> Type<'db> {
             | Type::ClassLiteral(_)
              => true,
             Type::Dynamic(_)
+            | Type::Divergent(_)
             | Type::NominalInstance(_)
             | Type::ProtocolInstance(_)
             | Type::GenericAlias(_)
@@ -669,8 +670,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // In some specific situations, `Any`/`Unknown`/`@Todo` can be simplified out of unions and intersections,
             // but this is not true for divergent types (and moving this case any lower down appears to cause
             // "too many cycle iterations" panics).
-            (Type::Dynamic(DynamicType::Divergent(_)), _)
-            | (_, Type::Dynamic(DynamicType::Divergent(_))) => {
+            (Type::Divergent(_), _) | (_, Type::Divergent(_)) => {
                 ConstraintSet::from_bool(self.constraints, self.relation.is_assignability())
             }
 
@@ -728,27 +728,18 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // if `T` is also a dynamic type or a union that contains a dynamic type. Similarly,
             // `T <: Any` only holds true if `T` is a dynamic type or an intersection that
             // contains a dynamic type.
-            (Type::Dynamic(dynamic), _) => {
-                // If a `Divergent` type is involved, it must not be eliminated.
-                debug_assert!(
-                    !matches!(dynamic, DynamicType::Divergent(_)),
-                    "DynamicType::Divergent should have been handled in an earlier branch"
-                );
-                ConstraintSet::from_bool(
-                    self.constraints,
-                    match self.relation {
-                        TypeRelation::Subtyping | TypeRelation::SubtypingAssuming => false,
-                        TypeRelation::Assignability | TypeRelation::ConstraintSetAssignability => {
-                            true
-                        }
-                        TypeRelation::Redundancy { .. } => match target {
-                            Type::Dynamic(_) => true,
-                            Type::Union(union) => union.elements(db).iter().any(Type::is_dynamic),
-                            _ => false,
-                        },
+            (Type::Dynamic(_dynamic), _) => ConstraintSet::from_bool(
+                self.constraints,
+                match self.relation {
+                    TypeRelation::Subtyping | TypeRelation::SubtypingAssuming => false,
+                    TypeRelation::Assignability | TypeRelation::ConstraintSetAssignability => true,
+                    TypeRelation::Redundancy { .. } => match target {
+                        Type::Dynamic(_) => true,
+                        Type::Union(union) => union.elements(db).iter().any(Type::is_dynamic),
+                        _ => false,
                     },
-                )
-            }
+                },
+            ),
             (_, Type::Dynamic(_)) => ConstraintSet::from_bool(
                 self.constraints,
                 match self.relation {
@@ -1702,6 +1693,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             (Type::Never, _) | (_, Type::Never) => self.always(),
 
             (Type::Dynamic(_), _) | (_, Type::Dynamic(_)) => self.never(),
+            (Type::Divergent(_), _) | (_, Type::Divergent(_)) => self.never(),
 
             (Type::TypeAlias(alias), _) => {
                 let left_alias_ty = alias.value_type(db);

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -440,7 +440,7 @@ fn typed_dict_subscript<'db>(
     typed_dict: TypedDictType<'db>,
     slice_ty: Type<'db>,
 ) -> Result<Type<'db>, SubscriptError<'db>> {
-    if slice_ty.is_dynamic() {
+    if slice_ty.is_dynamic() || slice_ty.is_divergent() {
         return Ok(Type::unknown());
     }
 

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -440,7 +440,7 @@ fn typed_dict_subscript<'db>(
     typed_dict: TypedDictType<'db>,
     slice_ty: Type<'db>,
 ) -> Result<Type<'db>, SubscriptError<'db>> {
-    if slice_ty.is_dynamic() || slice_ty.is_divergent() {
+    if slice_ty.is_dynamic() {
         return Ok(Type::unknown());
     }
 

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -481,7 +481,7 @@ impl<'db> Type<'db> {
         let value_ty = self;
 
         let inferred = match (value_ty, slice_ty) {
-            (Type::Dynamic(_) | Type::Never, _) => Some(Ok(value_ty)),
+            (Type::Dynamic(_) | Type::Divergent(_) | Type::Never, _) => Some(Ok(value_ty)),
 
             (Type::TypeAlias(alias), _) => {
                 Some(alias.value_type(db).subscript(db, slice_ty, expr_context))

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -84,6 +84,8 @@ fn todo_types() {
 fn divergent_type() {
     let db = setup_db();
     let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    assert!(!div.is_dynamic());
+    assert!(!div.has_dynamic(&db));
 
     // The `Divergent` type must not be eliminated in union with other dynamic types,
     // as this would prevent detection of divergent type inference using `Divergent`.
@@ -152,6 +154,54 @@ fn divergent_type() {
         .recursive_type_normalized_impl(&db, div, false)
         .unwrap();
     assert_eq!(normalized.display(&db).to_string(), "list[Divergent]");
+
+    let recursive_tuple = Type::heterogeneous_tuple(
+        &db,
+        [
+            UnionType::from_elements(
+                &db,
+                [
+                    KnownClass::Int.to_instance(&db),
+                    Type::heterogeneous_tuple(
+                        &db,
+                        [
+                            UnionType::from_elements(&db, [KnownClass::Int.to_instance(&db), div]),
+                            KnownClass::Str.to_instance(&db),
+                        ],
+                    ),
+                ],
+            ),
+            KnownClass::Str.to_instance(&db),
+        ],
+    );
+    let normalized = recursive_tuple
+        .recursive_type_normalized_impl(&db, div, false)
+        .unwrap();
+    assert_eq!(normalized.display(&db).to_string(), "tuple[Divergent, str]");
+
+    let recursive_dict = KnownClass::Dict.to_specialized_instance(
+        &db,
+        &[
+            KnownClass::Str.to_instance(&db),
+            UnionType::from_elements(
+                &db,
+                [
+                    KnownClass::Int.to_instance(&db),
+                    KnownClass::Dict.to_specialized_instance(
+                        &db,
+                        &[
+                            KnownClass::Str.to_instance(&db),
+                            UnionType::from_elements(&db, [KnownClass::Int.to_instance(&db), div]),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    );
+    let normalized = recursive_dict
+        .recursive_type_normalized_impl(&db, div, false)
+        .unwrap();
+    assert_eq!(normalized.display(&db).to_string(), "dict[str, Divergent]");
 
     let union = UnionType::from_elements(&db, [div, KnownClass::Int.to_instance(&db)]);
     assert_eq!(union.display(&db).to_string(), "Divergent | int");

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -84,8 +84,8 @@ fn todo_types() {
 fn divergent_type() {
     let db = setup_db();
     let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    assert!(!div.is_dynamic());
-    assert!(!div.has_dynamic(&db));
+    assert!(div.is_dynamic());
+    assert!(div.has_dynamic(&db));
 
     // The `Divergent` type must not be eliminated in union with other dynamic types,
     // as this would prevent detection of divergent type inference using `Divergent`.

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -872,6 +872,7 @@ fn extract_typed_dict_keys<'db>(
         Type::TypeAlias(alias) => extract_typed_dict_keys(db, alias.value_type(db)),
         // All other types cannot contain a TypedDict
         Type::Dynamic(_)
+        | Type::Divergent(_)
         | Type::Never
         | Type::FunctionLiteral(_)
         | Type::BoundMethod(_)

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -545,9 +545,9 @@ impl<'db> TypeVarInstance<'db> {
                     DynamicType::Any
                     | DynamicType::Unknown
                     | DynamicType::UnknownGeneric(_)
-                    | DynamicType::UnspecializedTypeVar
-                    | DynamicType::Divergent(_) => Parameters::unknown(),
+                    | DynamicType::UnspecializedTypeVar => Parameters::unknown(),
                 },
+                Type::Divergent(_) => Parameters::unknown(),
                 Type::TypeVar(typevar) if typevar.is_paramspec(db) => {
                     return ty;
                 }

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -163,6 +163,7 @@ impl<'db> From<Type<'db>> for TypeKind<'db> {
             | Type::ModuleLiteral(_)
             | Type::ClassLiteral(_)
             | Type::SpecialForm(_)
+            | Type::Divergent(_)
             | Type::Dynamic(_) => TypeKind::Atomic,
 
             // Non-atomic types


### PR DESCRIPTION
## Summary

This PR follows https://github.com/astral-sh/ruff/pull/24245#discussion_r3002222558, making `Divergent` a top-level type rather than a `DynamicType` variant.
