### PR TITLE
[ty] avoid rewriting nested function literals in return-callable flow

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/regression/3135_self_referential_concatenate.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/3135_self_referential_concatenate.md
@@ -15,7 +15,6 @@ from typing import Concatenate
 
 from ty_extensions import TypeOf
 
-
 def foo[**P, T](
     x: Callable[Concatenate[TypeOf[foo], ...], T],
 ) -> Callable[Concatenate[TypeOf[foo], P], T]:

--- a/crates/ty_python_semantic/resources/mdtest/regression/3135_self_referential_concatenate.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/3135_self_referential_concatenate.md
@@ -1,0 +1,23 @@
+# Regression test for #3135
+
+Regression test for [this issue](https://github.com/astral-sh/ty/issues/3135).
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```python
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Concatenate
+
+from ty_extensions import TypeOf
+
+
+def foo[**P, T](
+    x: Callable[Concatenate[TypeOf[foo], ...], T],
+) -> Callable[Concatenate[TypeOf[foo], P], T]:
+    return x
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6390,6 +6390,18 @@ pub enum TypeMapping<'a, 'db> {
 }
 
 impl<'db> TypeMapping<'_, 'db> {
+    pub(crate) fn is_return_callable_mapping(&self) -> bool {
+        matches!(
+            self,
+            TypeMapping::RescopeReturnCallables(_)
+                | TypeMapping::ApplySpecialization(ApplySpecialization::ReturnCallables(_))
+                | TypeMapping::ApplySpecializationWithMaterialization {
+                    specialization: ApplySpecialization::ReturnCallables(_),
+                    ..
+                }
+        )
+    }
+
     /// Update the generic context of a [`Signature`] according to the current type mapping
     pub(crate) fn update_signature_generic_context(
         &self,

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -946,6 +946,13 @@ impl<'db> FunctionType<'db> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
+        if type_mapping.is_return_callable_mapping() {
+            // Return-callable mappings target the outer `CallableType` in a function's
+            // return annotation. Nested function literals are payload inside that
+            // callable, not separate rewrite targets.
+            return self;
+        }
+
         let updated_signature =
             self.signature(db)
                 .apply_type_mapping_impl(db, type_mapping, tcx, visitor);


### PR DESCRIPTION
Fixes astral-sh/ty#3135

**Summary:**

Fix a crash caused by rewriting a self-referential `TypeOf[foo]` inside a returned `Callable`.

The existing note says we only consider the outermost `Callable` in the return type https://github.com/astral-sh/ruff/blob/main/crates/ty_python_semantic/src/types/generics.rs#L687, which matches the intended fix here.

**Test Plan**

Added an mdtest regression.
The bug is at the intersection of `TypeOf` and `Callable`, so I put the test under regression rather than under a more specific mdtest file.