### PR TITLE
[ty] Add materialization to `Divergent` type

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2741,7 +2741,7 @@ class ManyCycles2:
         self.x3 = [1]
 
     def f1(self: "ManyCycles2"):
-        reveal_type(self.x3)  # revealed: Unknown | list[int] | list[Divergent]
+        reveal_type(self.x3)  # revealed: Unknown | list[int] | list[Divergent] | list[Unknown]
 
         self.x1 = [self.x2] + [self.x3]
         self.x2 = [self.x1] + [self.x3]

--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -1684,3 +1684,20 @@ def _(
     reveal_type(nested_dict_int)  # revealed: dict[str, Divergent]
     reveal_type(nested_list_str)  # revealed: list[Divergent]
 ```
+
+### Materialization of self-referential generic implicit type aliases
+
+```py
+from typing import TypeVar, Union
+from ty_extensions import Bottom, Top, is_subtype_of, static_assert
+
+T = TypeVar("T")
+K = TypeVar("K")
+V = TypeVar("V")
+
+NestedList = list["NestedList[T] | None"]
+NestedDict = dict[K, Union[V, "NestedDict[K, V]"]]
+
+static_assert(is_subtype_of(Bottom[NestedList[str]], Top[NestedList[str]]))
+static_assert(is_subtype_of(Bottom[NestedDict[str, int]], Top[NestedDict[str, int]]))
+```

--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -347,6 +347,20 @@ my_isinstance(1, 1)
 my_isinstance(1, (int, (str, 1)))
 ```
 
+## Materialization of self-referential generic PEP 613 type aliases
+
+```py
+from typing import TypeAlias, TypeVar, Union
+from ty_extensions import Bottom, Top, is_subtype_of, static_assert
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+NestedDict: TypeAlias = dict[K, Union[V, "NestedDict[K, V]"]]
+
+static_assert(is_subtype_of(Bottom[NestedDict[str, int]], Top[NestedDict[str, int]]))
+```
+
 ## Conditionally imported on Python < 3.10
 
 ```toml

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -257,7 +257,7 @@ pub(crate) struct VisitSpecialization;
 /// Similarly, there is `Bottom[list[Any]]`.
 /// This type is harder to make sense of in a set-theoretic framework, but
 /// it is a subtype of all materializations of `list[Any]`.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
 pub enum MaterializationKind {
     Top,
     Bottom,
@@ -779,11 +779,35 @@ impl<'db> Type<'db> {
     }
 
     pub(crate) fn divergent(id: salsa::Id) -> Self {
-        Self::Divergent(DivergentType { id })
+        Self::Divergent(DivergentType::new(id))
     }
 
     pub(crate) const fn is_divergent(&self) -> bool {
         matches!(self, Type::Divergent(_))
+    }
+
+    /// Returns `true` if both `self` and `other` are `Divergent` types originating from the
+    /// same cycle (i.e., sharing the same query ID), regardless of materialization state.
+    fn same_divergent_marker(self, other: Type<'db>) -> bool {
+        match (self, other) {
+            (Type::Divergent(left), Type::Divergent(right)) => left.same_marker(right),
+            _ => false,
+        }
+    }
+
+    /// If `self` is a materialized `Divergent` type, returns the concrete type it should
+    /// behave as: `object` for top-materialized, `Never` for bottom-materialized.
+    /// Returns `None` if `self` is not `Divergent` or has not been materialized.
+    fn materialized_divergent_fallback(self) -> Option<Type<'db>> {
+        let Type::Divergent(divergent) = self else {
+            return None;
+        };
+
+        match divergent.materialization_kind() {
+            Some(MaterializationKind::Top) => Some(Type::object()),
+            Some(MaterializationKind::Bottom) => Some(Type::Never),
+            None => None,
+        }
     }
 
     pub const fn is_unknown(&self) -> bool {
@@ -794,7 +818,14 @@ impl<'db> Type<'db> {
     }
 
     pub(crate) const fn is_never(&self) -> bool {
-        matches!(self, Type::Never)
+        matches!(
+            self,
+            Type::Never
+                | Type::Divergent(DivergentType {
+                    materialization: Some(MaterializationKind::Bottom),
+                    ..
+                })
+        )
     }
 
     /// Returns `true` if this type contains a `Self` type variable.
@@ -1552,7 +1583,14 @@ impl<'db> Type<'db> {
         match self {
             Type::Never => Type::object(),
 
-            Type::Dynamic(_) | Type::Divergent(_) => *self,
+            Type::Dynamic(_) => *self,
+
+            Type::Divergent(divergent) => match divergent.materialization_kind() {
+                Some(materialization_kind) => {
+                    Type::Divergent(divergent.materialized(materialization_kind.flip()))
+                }
+                None => *self,
+            },
 
             Type::NominalInstance(instance) if instance.is_object() => Type::Never,
 
@@ -1768,7 +1806,7 @@ impl<'db> Type<'db> {
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
-        if nested && self == div {
+        if nested && self.same_divergent_marker(div) {
             return None;
         }
         match self {
@@ -5536,9 +5574,14 @@ impl<'db> Type<'db> {
                 }
             }
             // `Divergent` is an internal cycle marker rather than a gradual type like `Any` or
-            // `Unknown`. Materializing it away would destroy the marker we rely on for recursive
-            // alias convergence.
-            Type::Divergent(_) => self,
+            // `Unknown`. Preserve the marker across materialization, while recording whether this
+            // occurrence should behave like the top (`object`) or bottom (`Never`) bound.
+            Type::Divergent(divergent) => match type_mapping {
+                TypeMapping::Materialize(materialization_kind) => {
+                    Type::Divergent(divergent.materialized(*materialization_kind))
+                }
+                _ => self,
+            },
 
             Type::Never
             | Type::AlwaysTruthy
@@ -6422,10 +6465,37 @@ impl<'db> TypeMapping<'_, 'db> {
 pub struct DivergentType {
     /// The query ID that caused the cycle.
     id: salsa::Id,
+    /// If this divergent marker has been materialized, preserve whether it should behave like the
+    /// top (`object`) or bottom (`Never`) bound while still remaining recognizable as divergent.
+    materialization: Option<MaterializationKind>,
 }
 
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for DivergentType {}
+
+impl DivergentType {
+    const fn new(id: salsa::Id) -> Self {
+        Self {
+            id,
+            materialization: None,
+        }
+    }
+
+    fn same_marker(self, other: Self) -> bool {
+        self.id == other.id
+    }
+
+    const fn materialized(self, kind: MaterializationKind) -> Self {
+        Self {
+            id: self.id,
+            materialization: Some(kind),
+        }
+    }
+
+    const fn materialization_kind(self) -> Option<MaterializationKind> {
+        self.materialization
+    }
+}
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
 pub enum DynamicType<'db> {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -810,6 +810,20 @@ impl<'db> Type<'db> {
         }
     }
 
+    /// Negating a divergent marker preserves the marker and flips its materialization, if any.
+    fn negated_divergent(self) -> Option<Type<'db>> {
+        let Type::Divergent(divergent) = self else {
+            return None;
+        };
+
+        Some(match divergent.materialization_kind() {
+            Some(materialization_kind) => {
+                Type::Divergent(divergent.materialized(materialization_kind.flip()))
+            }
+            None => Type::Divergent(divergent),
+        })
+    }
+
     pub const fn is_unknown(&self) -> bool {
         matches!(
             self,
@@ -1008,7 +1022,14 @@ impl<'db> Type<'db> {
     }
 
     pub(crate) const fn is_dynamic(&self) -> bool {
-        matches!(self, Type::Dynamic(_) | Type::Divergent(_))
+        matches!(
+            self,
+            Type::Dynamic(_)
+                | Type::Divergent(DivergentType {
+                    materialization: None,
+                    ..
+                })
+        )
     }
 
     const fn is_non_divergent_dynamic(&self) -> bool {
@@ -1585,12 +1606,9 @@ impl<'db> Type<'db> {
 
             Type::Dynamic(_) => *self,
 
-            Type::Divergent(divergent) => match divergent.materialization_kind() {
-                Some(materialization_kind) => {
-                    Type::Divergent(divergent.materialized(materialization_kind.flip()))
-                }
-                None => *self,
-            },
+            Type::Divergent(_) => (*self)
+                .negated_divergent()
+                .expect("matched `Type::Divergent` above"),
 
             Type::NominalInstance(instance) if instance.is_object() => Type::Never,
 
@@ -2186,6 +2204,10 @@ impl<'db> Type<'db> {
         name: &str,
         policy: MemberLookupPolicy,
     ) -> Option<PlaceAndQualifiers<'db>> {
+        if let Some(fallback) = (*self).materialized_divergent_fallback() {
+            return fallback.find_name_in_mro_with_policy(db, name, policy);
+        }
+
         match self {
             Type::Union(union) => Some(union.map_with_boundness_and_qualifiers(db, |elem| {
                 elem.find_name_in_mro_with_policy(db, name, policy)
@@ -2524,6 +2546,10 @@ impl<'db> Type<'db> {
             instance.unwrap_or_else(|| Type::none(db)).display(db),
             owner.display(db)
         );
+        if let Some(fallback) = self.materialized_divergent_fallback() {
+            return fallback.try_call_dunder_get(db, instance, owner);
+        }
+
         match self {
             Type::Callable(callable) if callable.is_staticmethod_like(db) => {
                 // For "staticmethod-like" callables, model the behavior of `staticmethod.__get__`.
@@ -2617,6 +2643,32 @@ impl<'db> Type<'db> {
         instance: Option<Type<'db>>,
         owner: Type<'db>,
     ) -> (PlaceAndQualifiers<'db>, AttributeKind) {
+        if let PlaceAndQualifiers {
+            place:
+                Place::Defined(DefinedPlace {
+                    ty,
+                    origin,
+                    definedness,
+                    widening,
+                }),
+            qualifiers,
+        } = attribute
+            && let Some(fallback) = ty.materialized_divergent_fallback()
+        {
+            return Self::try_call_dunder_get_on_attribute(
+                db,
+                Place::Defined(DefinedPlace {
+                    ty: fallback,
+                    origin,
+                    definedness,
+                    widening,
+                })
+                .with_qualifiers(qualifiers),
+                instance,
+                owner,
+            );
+        }
+
         match attribute {
             // This branch is not strictly needed, but it short-circuits the lookup of various dunder
             // methods and calls that would otherwise be made.
@@ -2932,6 +2984,10 @@ impl<'db> Type<'db> {
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
         tracing::trace!("member_lookup_with_policy: {}.{}", self.display(db), name);
+        if let Some(fallback) = self.materialized_divergent_fallback() {
+            return fallback.member_lookup_with_policy(db, name, policy);
+        }
+
         if name == "__class__" {
             return Place::bound(self.dunder_class(db)).into();
         }
@@ -3504,6 +3560,10 @@ impl<'db> Type<'db> {
     /// elements. It's usually best to only worry about "callability" relative to a particular
     /// argument list, via [`try_call`][Self::try_call] and [`CallErrorKind::NotCallable`].
     fn bindings(self, db: &'db dyn Db) -> Bindings<'db> {
+        if let Some(fallback) = self.materialized_divergent_fallback() {
+            return fallback.bindings(db);
+        }
+
         match self {
             Type::Callable(callable) => {
                 CallableBinding::from_overloads(self, callable.signatures(db).iter().cloned())

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -48,6 +48,10 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         policy: UpcastPolicy,
     ) -> Option<CallableTypes<'db>> {
+        if let Some(fallback) = self.materialized_divergent_fallback() {
+            return fallback.try_upcast_to_callable_with_policy(db, policy);
+        }
+
         match self {
             Type::Callable(callable) => Some(CallableTypes::one(callable)),
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -8,7 +8,10 @@ use ruff_python_ast::name::Name;
 use ty_module_resolver::{ModuleName, file_to_module};
 
 use super::protocol_class::ProtocolInterface;
-use super::{BoundTypeVarInstance, ClassType, KnownClass, SubclassOfType, Type, TypeVarVariance};
+use super::{
+    BoundTypeVarInstance, ClassType, DivergentType, KnownClass, MaterializationKind,
+    SubclassOfType, Type, TypeVarVariance,
+};
 use crate::place::PlaceAndQualifiers;
 use crate::semantic_index::definition::Definition;
 use crate::types::constraints::{
@@ -39,6 +42,10 @@ impl<'db> Type<'db> {
         matches!(
             self,
             Type::NominalInstance(NominalInstanceType(NominalInstanceInner::Object))
+                | Type::Divergent(DivergentType {
+                    materialization: Some(MaterializationKind::Top),
+                    ..
+                })
         )
     }
 

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -5,8 +5,9 @@ use crate::types::enums::is_single_member_enum;
 use crate::types::known_instance::KnownInstanceType;
 use crate::types::tuple::TupleType;
 use crate::types::{
-    BoundMethodType, EnumLiteralType, IntersectionBuilder, IntersectionType, KnownClass, Parameter,
-    Parameters, Signature, SpecialFormType, SubclassOfType, Type, UnionType,
+    ApplyTypeMappingVisitor, BoundMethodType, EnumLiteralType, IntersectionBuilder,
+    IntersectionType, KnownClass, MaterializationKind, Parameter, Parameters, Signature,
+    SpecialFormType, SubclassOfType, Type, UnionType,
 };
 use quickcheck::{Arbitrary, Gen};
 use ruff_db::files::system_path_to_file;
@@ -22,6 +23,9 @@ use ty_module_resolver::KnownModule;
 pub(crate) enum Ty {
     Never,
     Unknown,
+    Divergent,
+    TopDivergent,
+    BottomDivergent,
     None,
     Any,
     IntLiteral(i64),
@@ -147,6 +151,9 @@ impl Ty {
         match self {
             Ty::Never => Type::Never,
             Ty::Unknown => Type::unknown(),
+            Ty::Divergent => divergent(db, 1, None),
+            Ty::TopDivergent => divergent(db, 2, Some(MaterializationKind::Top)),
+            Ty::BottomDivergent => divergent(db, 3, Some(MaterializationKind::Bottom)),
             Ty::None => Type::none(db),
             Ty::Any => Type::any(),
             Ty::IntLiteral(n) => Type::int_literal(n),
@@ -258,6 +265,19 @@ impl Ty {
     }
 }
 
+fn divergent(db: &TestDb, id_bits: u64, materialization: Option<MaterializationKind>) -> Type<'_> {
+    let divergent = Type::divergent(salsa::plumbing::Id::from_bits(id_bits));
+
+    match materialization {
+        Some(materialization_kind) => divergent.materialize(
+            db,
+            materialization_kind,
+            &ApplyTypeMappingVisitor::default(),
+        ),
+        None => divergent,
+    }
+}
+
 fn newtype_instance<'db>(db: &'db dyn Db, name: &str) -> Type<'db> {
     let file = system_path_to_file(db, super::setup::PROPERTY_TEST_MODULE_PATH)
         .expect("Property-test module must exist");
@@ -288,10 +308,13 @@ fn arbitrary_core_type(g: &mut Gen, fully_static: bool) -> Ty {
     let bool_lit = Ty::BooleanLiteral(bool::arbitrary(g));
 
     // Update this if new non-fully-static types are added below.
-    let fully_static_index = 5;
+    let fully_static_index = 8;
     let types = &[
         Ty::Any,
         Ty::Unknown,
+        Ty::Divergent,
+        Ty::TopDivergent,
+        Ty::BottomDivergent,
         Ty::SubclassOfAny,
         Ty::UnittestMockLiteral,
         Ty::UnittestMockInstance,

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -604,6 +604,14 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         source: Type<'db>,
         target: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        if let Some(source) = source.materialized_divergent_fallback() {
+            return self.check_type_pair(db, source, target);
+        }
+
+        if let Some(target) = target.materialized_divergent_fallback() {
+            return self.check_type_pair(db, source, target);
+        }
+
         // Subtyping implies assignability, so if subtyping is reflexive and the two types are
         // equal, it is both a subtype and assignable. Assignability is always reflexive.
         //
@@ -1689,6 +1697,14 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         left: Type<'db>,
         right: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        if let Some(left) = left.materialized_divergent_fallback() {
+            return self.check_type_pair(db, left, right);
+        }
+
+        if let Some(right) = right.materialized_divergent_fallback() {
+            return self.check_type_pair(db, left, right);
+        }
+
         match (left, right) {
             (Type::Never, _) | (_, Type::Never) => self.always(),
 

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -312,7 +312,7 @@ impl<'db> UnionType<'db> {
             if nested {
                 // list[T | Divergent] => list[Divergent]
                 let ty = ty.recursive_type_normalized_impl(db, div, nested)?;
-                if ty == div {
+                if ty.same_divergent_marker(div) {
                     return Some(ty);
                 }
                 builder = builder.add(ty);
@@ -320,7 +320,7 @@ impl<'db> UnionType<'db> {
             } else {
                 // `Divergent` in a union type does not mean true divergence, so we skip it if not nested.
                 // e.g. T | Divergent == T | (T | (T | (T | ...))) == T
-                if ty == &div {
+                if (*ty).same_divergent_marker(div) {
                     builder = builder.recursively_defined(RecursivelyDefined::Yes);
                     continue;
                 }

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1344,10 +1344,20 @@ impl<'db> InnerIntersectionBuilder<'db> {
 
     /// Adds a negative type to this intersection.
     fn add_negative(&mut self, db: &'db dyn Db, new_negative: Type<'db>) {
-        // `Divergent & ~T` -> `Divergent`. Note that `~Divergent` becomes `Divergent` via the
-        // `Type::Dynamic` branch below, so we don't need a special case for that.
+        // `Never & ~T` -> `Never`.
+        if self.positive.contains(&Type::Never) {
+            return;
+        }
+
+        // `Divergent & ~T` -> `Divergent`.
         if self.positive.iter().any(Type::is_divergent) {
             debug_assert_eq!(self.positive.len(), 1, "`Divergent` should be alone");
+            return;
+        }
+
+        if let Some(negated_divergent) = new_negative.negated_divergent() {
+            *self = Self::default();
+            self.positive.insert(negated_divergent);
             return;
         }
 

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -440,6 +440,10 @@ fn typed_dict_subscript<'db>(
     typed_dict: TypedDictType<'db>,
     slice_ty: Type<'db>,
 ) -> Result<Type<'db>, SubscriptError<'db>> {
+    if let Some(fallback) = slice_ty.materialized_divergent_fallback() {
+        return typed_dict_subscript(db, typed_dict, fallback);
+    }
+
     if slice_ty.is_dynamic() {
         return Ok(Type::unknown());
     }
@@ -478,6 +482,14 @@ impl<'db> Type<'db> {
         slice_ty: Type<'db>,
         expr_context: ast::ExprContext,
     ) -> Result<Type<'db>, SubscriptError<'db>> {
+        if let Some(fallback) = self.materialized_divergent_fallback() {
+            return fallback.subscript(db, slice_ty, expr_context);
+        }
+
+        if let Some(fallback) = slice_ty.materialized_divergent_fallback() {
+            return self.subscript(db, fallback, expr_context);
+        }
+
         let value_ty = self;
 
         let inferred = match (value_ty, slice_ty) {

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -3,6 +3,7 @@ use crate::db::tests::{TestDbBuilder, setup_db};
 use crate::place::{typing_extensions_symbol, typing_symbol};
 use crate::types::type_alias::PEP695TypeAliasType;
 use ruff_db::system::DbWithWritableSystem as _;
+use ruff_python_ast as ast;
 use ruff_python_ast::PythonVersion;
 use test_case::test_case;
 
@@ -92,12 +93,27 @@ fn divergent_type() {
 
     assert!(top_div.is_divergent());
     assert!(bottom_div.is_divergent());
+    assert!(!top_div.is_dynamic());
+    assert!(!bottom_div.is_dynamic());
+    assert!(!top_div.has_dynamic(&db));
+    assert!(!bottom_div.has_dynamic(&db));
     assert!(top_div.is_object());
     assert!(!top_div.is_never());
     assert!(!bottom_div.is_object());
     assert!(bottom_div.is_never());
     assert_eq!(top_div.negate(&db), bottom_div);
     assert_eq!(bottom_div.negate(&db), top_div);
+    assert_eq!(IntersectionBuilder::new(&db).add_negative(div).build(), div);
+    assert_eq!(
+        IntersectionBuilder::new(&db).add_negative(top_div).build(),
+        bottom_div
+    );
+    assert_eq!(
+        IntersectionBuilder::new(&db)
+            .add_negative(bottom_div)
+            .build(),
+        top_div
+    );
     assert!(
         KnownClass::Int
             .to_instance(&db)
@@ -109,6 +125,20 @@ fn divergent_type() {
         !KnownClass::Int
             .to_instance(&db)
             .is_assignable_to(&db, bottom_div)
+    );
+    assert_eq!(
+        top_div.member(&db, "__str__").place.expect_type(),
+        Type::object().member(&db, "__str__").place.expect_type()
+    );
+    assert_eq!(
+        top_div.member(&db, "__class__").place.expect_type(),
+        Type::object().dunder_class(&db)
+    );
+    assert!(top_div.try_upcast_to_callable(&db).is_none());
+    assert!(
+        top_div
+            .subscript(&db, Type::int_literal(0), ast::ExprContext::Load)
+            .is_err()
     );
     assert_eq!(top_div.recursive_type_normalized_impl(&db, div, true), None);
     assert_eq!(

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -86,6 +86,35 @@ fn divergent_type() {
     let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
     assert!(div.is_dynamic());
     assert!(div.has_dynamic(&db));
+    let visitor = ApplyTypeMappingVisitor::default();
+    let top_div = div.materialize(&db, MaterializationKind::Top, &visitor);
+    let bottom_div = div.materialize(&db, MaterializationKind::Bottom, &visitor);
+
+    assert!(top_div.is_divergent());
+    assert!(bottom_div.is_divergent());
+    assert!(top_div.is_object());
+    assert!(!top_div.is_never());
+    assert!(!bottom_div.is_object());
+    assert!(bottom_div.is_never());
+    assert_eq!(top_div.negate(&db), bottom_div);
+    assert_eq!(bottom_div.negate(&db), top_div);
+    assert!(
+        KnownClass::Int
+            .to_instance(&db)
+            .is_assignable_to(&db, top_div)
+    );
+    assert!(!top_div.is_assignable_to(&db, KnownClass::Int.to_instance(&db)));
+    assert!(bottom_div.is_assignable_to(&db, KnownClass::Int.to_instance(&db)));
+    assert!(
+        !KnownClass::Int
+            .to_instance(&db)
+            .is_assignable_to(&db, bottom_div)
+    );
+    assert_eq!(top_div.recursive_type_normalized_impl(&db, div, true), None);
+    assert_eq!(
+        bottom_div.recursive_type_normalized_impl(&db, div, true),
+        None
+    );
 
     // The `Divergent` type must not be eliminated in union with other dynamic types,
     // as this would prevent detection of divergent type inference using `Divergent`.


### PR DESCRIPTION
## Summary

This PR follows https://github.com/astral-sh/ruff/pull/24245#discussion_r3002222558 such that we preserve the top or bottom materialization on `Divergent` materializing recursive types.
