### PR TITLE
fix: let TD003 behave the same for urls and issue codes

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
@@ -2,6 +2,9 @@
 # TODO: this comment has a link
 # https://github.com/astral-sh/ruff/issues/3870
 
+# TODO: this comment has a link with some text afterwards
+# https://github.com/astral-sh/ruff/issues/3870 is the url of the ticket in our internal jira
+
 # TODO: this comment has an issue
 # TDO-3870
 

--- a/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
@@ -5,11 +5,21 @@
 # TODO: this comment has an issue
 # TDO-3870
 
+# TODO: this comment has an issue without any code prefix
+# this was already existing, but not tested
+# 3870
+
 # TODO: the link has an issue code of the minimum length
 # T-001
 
 # TODO: the issue code can be arbitrarily long
 # ABCDEFGHIJKLMNOPQRSTUVWXYZ-001
+
+# TODO: the issue code can be followed by text
+# TD003 is the id of the ticket in our internal jira
+
+# TODO: this works even if we have just a number
+# 1234 is the id of the ticket in our internal jira
 
 # TDO003 - errors
 # TODO: this comment has no

--- a/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
@@ -6,8 +6,12 @@
 # TDO-3870
 
 # TODO: this comment has an issue without any code prefix
-# this was already existing, but not tested
+# this was already in place, but not tested?
 # 3870
+
+# TODO: this comment has an issue without any code prefix
+# and some other text after it
+# 3870 is the id of the ticket in our internal jira
 
 # TODO: the link has an issue code of the minimum length
 # T-001
@@ -17,9 +21,6 @@
 
 # TODO: the issue code can be followed by text
 # TD003 is the id of the ticket in our internal jira
-
-# TODO: this works even if we have just a number
-# 1234 is the id of the ticket in our internal jira
 
 # TDO003 - errors
 # TODO: this comment has no

--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -241,8 +241,8 @@ impl Violation for MissingSpaceAfterTodoColon {
 static ISSUE_LINK_OWN_LINE_REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     RegexSet::new([
         r"^#\s*(http|https)://.*", // issue link
-        r"^#\s*\d+$",              // issue code - like "003"
-        r"^#\s*[A-Z]+\-?\d+$",     // issue code - like "TD003"
+        r"^#\s*\d+.*",              // issue code - like "003"
+        r"^#\s*[A-Z]+\-?\d+.*",     // issue code - like "TD003"
     ])
     .unwrap()
 });

--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -241,8 +241,8 @@ impl Violation for MissingSpaceAfterTodoColon {
 static ISSUE_LINK_OWN_LINE_REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     RegexSet::new([
         r"^#\s*(http|https)://.*", // issue link
-        r"^#\s*\d+.*",              // issue code - like "003"
-        r"^#\s*[A-Z]+\-?\d+.*",     // issue code - like "TD003"
+        r"^#\s*\d+.*",             // issue code - like "003"
+        r"^#\s*[A-Z]+\-?\d+.*",    // issue code - like "TD003"
     ])
     .unwrap()
 });

--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -102,6 +102,12 @@ impl Violation for MissingTodoAuthor {
 ///
 /// # TODO(charlie): this comment has an issue code (matches the regex `[A-Z]+\-?\d+`)
 /// # SIXCHR-003
+/// 
+/// # TODO(charlie): this comment has a 3-digit issue code (matches the regex `\d+`)
+/// # 003 will resolve this todo comment
+/// 
+/// # TODO(charlie): this comment has an issue code (matches the regex `[A-Z]+\-?\d+`)
+/// # SIXCHR-003 will resolve this todo comment
 /// ```
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.269")]

--- a/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__missing-todo-link_TD003.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__missing-todo-link_TD003.py.snap
@@ -2,63 +2,63 @@
 source: crates/ruff_linter/src/rules/flake8_todos/mod.rs
 ---
 TD003 Missing issue link for this TODO
-  --> TD003.py:15:3
+  --> TD003.py:29:3
    |
-14 | # TDO003 - errors
-15 | # TODO: this comment has no
+28 | # TDO003 - errors
+29 | # TODO: this comment has no
    |   ^^^^
-16 | # link after it
+30 | # link after it
    |
 
 TD003 Missing issue link for this TODO
-  --> TD003.py:18:3
+  --> TD003.py:32:3
    |
-16 | # link after it
-17 |
-18 | # TODO: here's a TODO with no link after it
+30 | # link after it
+31 |
+32 | # TODO: here's a TODO with no link after it
    |   ^^^^
-19 | def foo(x):
-20 |     return x
+33 | def foo(x):
+34 |     return x
    |
 
 TD003 Missing issue link for this TODO
-  --> TD003.py:31:3
+  --> TD003.py:45:3
    |
-29 | # TDO-3870
-30 |
-31 | # TODO: here's a TODO without an issue link
+43 | # TDO-3870
+44 |
+45 | # TODO: here's a TODO without an issue link
    |   ^^^^
-32 | # TODO: followed by a new TODO with an issue link
-33 | # TDO-3870
+46 | # TODO: followed by a new TODO with an issue link
+47 | # TDO-3870
    |
 
 TD003 Missing issue link for this TODO
-  --> TD003.py:35:9
+  --> TD003.py:49:9
    |
-33 | # TDO-3870
-34 |
-35 | # foo # TODO: no link!
+47 | # TDO-3870
+48 |
+49 | # foo # TODO: no link!
    |         ^^^^
-36 |
-37 | # TODO: https://github.com/astral-sh/ruff/pull/9627 A todo with a link on the same line
+50 |
+51 | # TODO: https://github.com/astral-sh/ruff/pull/9627 A todo with a link on the same line
    |
 
 TD003 Missing issue link for this TODO
-  --> TD003.py:41:3
+  --> TD003.py:55:3
    |
-39 | # TODO: #9627 A todo with a number on the same line
-40 |
-41 | # TODO: A todo with a random number, 5431
+53 | # TODO: #9627 A todo with a number on the same line
+54 |
+55 | # TODO: A todo with a random number, 5431
    |   ^^^^
-42 |
-43 | # TODO: here's a TODO on the last line with no link
+56 |
+57 | # TODO: here's a TODO on the last line with no link
    |
 
 TD003 Missing issue link for this TODO
-  --> TD003.py:43:3
+  --> TD003.py:57:3
    |
-41 | # TODO: A todo with a random number, 5431
-42 |
-43 | # TODO: here's a TODO on the last line with no link
+55 | # TODO: A todo with a random number, 5431
+56 |
+57 | # TODO: here's a TODO on the last line with no link
    |   ^^^^
    |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

The goal of this change is to allow the TD003 rule to behave consistently between different regexps, i.e., to capture extra text after the capture of the url / issue code is done.

Follow up of #24156 but with testing and from my personal profile.

## Test Plan

Added "accepted" test cases to prove the new regex groups and tested locally with `cargo test`