### PR TITLE
Match .editorconfig and pre commit hook on trailing white space

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,9 @@ repos:
     hooks:
       - id: check-merge-conflict
         priority: 0
+      - id: trailing-whitespace
+        types: [rust]
+        priority: 0
       - id: end-of-file-fixer
         # Don't run this on all files: the absence of trailing newlines is often
         # intentional in parser/linter/formatter tests

--- a/crates/ruff/tests/cli/format.rs
+++ b/crates/ruff/tests/cli/format.rs
@@ -618,21 +618,21 @@ fn output_format_notebook() -> Result<()> {
     1 | import numpy
       - maths = (numpy.arange(100)**2).sum()
       - stats= numpy.asarray([1,2,3,4]).median()
-    2 + 
+    2 +
     3 + maths = (numpy.arange(100) ** 2).sum()
     4 + stats = numpy.asarray([1, 2, 3, 4]).median()
      ::: cell 3
     1 | # A cell with IPython escape command
     2 | def some_function(foo, bar):
     3 |     pass
-    4 + 
-    5 + 
+    4 +
+    5 +
     6 | %matplotlib inline
       ::: cell 4
     1  | foo = %pwd
        - def some_function(foo,bar,):
-    2  + 
-    3  + 
+    2  +
+    3  +
     4  + def some_function(
     5  +     foo,
     6  +     bar,
@@ -985,7 +985,7 @@ if True:
       Cause: Failed to parse [TMP]/ruff.toml
       Cause: TOML parse error at line 1, column 1
       |
-    1 | 
+    1 |
       | ^
     unknown field `tab-size`
     ");
@@ -2452,22 +2452,22 @@ fn markdown_formatting_preview_enabled() -> Result<()> {
     unformatted: File would be reformatted
       --> CRATE_ROOT/resources/test/fixtures/unformatted.md:1:1
     1  | This is a markdown document with two fenced code blocks:
-    2  | 
+    2  |
     3  | ```py
        - print( "hello" )
        - def foo(): pass
     4  + print("hello")
-    5  + 
-    6  + 
+    5  +
+    6  +
     7  + def foo():
     8  +     pass
     9  | ```
-    10 | 
+    10 |
     11 | ```pyi
        - print( "hello" )
        - def foo(): pass
     12 + print("hello")
-    13 + 
+    13 +
     14 + def foo():
     15 +     pass
     16 | ```
@@ -2554,7 +2554,7 @@ print( 'hello' )
     unformatted: File would be reformatted
      --> test.bar:1:1
     2 | Text string
-    3 | 
+    3 |
     4 | ```py
       - print( 'hello' )
     5 + print("hello")
@@ -2562,7 +2562,7 @@ print( 'hello' )
 
     unformatted: File would be reformatted
      --> test.foo:1:1
-      - 
+      -
       - print( 'hello' )
     1 + print("hello")
 

--- a/crates/ruff_formatter/src/printer/line_suffixes.rs
+++ b/crates/ruff_formatter/src/printer/line_suffixes.rs
@@ -36,6 +36,6 @@ pub(super) enum LineSuffixEntry<'a> {
     /// A line suffix to print
     Suffix(&'a FormatElement),
 
-    /// Potentially changed call arguments that should be used to format any following items.  
+    /// Potentially changed call arguments that should be used to format any following items.
     Args(PrintElementArgs),
 }

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -132,10 +132,10 @@ mod tests {
         info[code-action]: Ignore 'unresolved-reference' for this line
          --> main.py:1:5
           |
-        1 | b = a / 10  
+        1 | b = a / 10
           |     ^
           |
-          - b = a / 10  
+          - b = a / 10
         1 + b = a / 10  # ty:ignore[unresolved-reference]
         ");
     }
@@ -155,7 +155,7 @@ mod tests {
         2 | b = a / 0  # ty:ignore[division-by-zero]
           |     ^
           |
-        1 | 
+        1 |
           - b = a / 0  # ty:ignore[division-by-zero]
         2 + b = a / 0  # ty:ignore[division-by-zero, unresolved-reference]
         ");
@@ -176,7 +176,7 @@ mod tests {
         2 | b = a / 0  # type:ignore[ty:division-by-zero]
           |     ^
           |
-        1 | 
+        1 |
           - b = a / 0  # type:ignore[ty:division-by-zero]
         2 + b = a / 0  # type:ignore[ty:division-by-zero, ty:unresolved-reference]
         ");
@@ -197,7 +197,7 @@ mod tests {
         2 | b = a / 0  # type:ignore[mypy-code]
           |     ^
           |
-        1 | 
+        1 |
           - b = a / 0  # type:ignore[mypy-code]
         2 + b = a / 0  # type:ignore[mypy-code]  # ty:ignore[unresolved-reference]
         ");
@@ -222,9 +222,9 @@ mod tests {
         4 | b = a / 0
           |     ^
           |
-        1 | 
+        1 |
         2 | # ty:ignore[division-by-zero]
-        3 | 
+        3 |
           - b = a / 0
         4 + b = a / 0  # ty:ignore[unresolved-reference]
         ");
@@ -245,7 +245,7 @@ mod tests {
         2 | b = a / 0  # ty:ignore[division-by-zero,]
           |     ^
           |
-        1 | 
+        1 |
           - b = a / 0  # ty:ignore[division-by-zero,]
         2 + b = a / 0  # ty:ignore[division-by-zero, unresolved-reference]
         ");
@@ -266,7 +266,7 @@ mod tests {
         2 | b = a / 0  # ty:ignore[division-by-zero   ]
           |     ^
           |
-        1 | 
+        1 |
           - b = a / 0  # ty:ignore[division-by-zero   ]
         2 + b = a / 0  # ty:ignore[division-by-zero, unresolved-reference   ]
         ");
@@ -287,7 +287,7 @@ mod tests {
         2 | b = a / 0  # ty:ignore[division-by-zero] some explanation
           |     ^
           |
-        1 | 
+        1 |
           - b = a / 0  # ty:ignore[division-by-zero] some explanation
         2 + b = a / 0  # ty:ignore[division-by-zero] some explanation  # ty:ignore[unresolved-reference]
         ");
@@ -316,7 +316,7 @@ mod tests {
           | |_________^
         6 |   )
           |
-        1 | 
+        1 |
         2 | b = (
           -         a  # ty:ignore[division-by-zero]
         3 +         a  # ty:ignore[division-by-zero, unresolved-reference]
@@ -381,7 +381,7 @@ mod tests {
           | |_________^
         6 |   )
           |
-        1 | 
+        1 |
         2 | b = (
           -         a  # ty:ignore[division-by-zero]
         3 +         a  # ty:ignore[division-by-zero, unresolved-reference]
@@ -444,7 +444,7 @@ mod tests {
         5 |     }
         6 |     more text
           |
-        1 | 
+        1 |
         2 | b = f"""
         3 |     {
           -     a
@@ -474,7 +474,7 @@ mod tests {
         3 |     more text
         4 | """
           |
-        1 | 
+        1 |
         2 | b = a + """
         3 |     more text
           - """
@@ -499,7 +499,7 @@ mod tests {
           |     ^
         3 | + "test"
           |
-        1 | 
+        1 |
         2 | b = a \
           - + "test"
         3 + + "test"  # ty:ignore[unresolved-reference]
@@ -530,9 +530,9 @@ mod tests {
         6 |     ] # test
           |
         2 |     [  ccc # test
-        3 | 
+        3 |
         4 |         + ddd  \
-          - 
+          -
         5 +   # ty:ignore[unresolved-reference]
         6 |     ] # test
         ");
@@ -555,7 +555,7 @@ mod tests {
           |
         help: This is a preferred code action
         1 + from typing import reveal_type
-        2 | 
+        2 |
         3 | reveal_type(1)
 
         info[code-action]: Ignore 'undefined-reveal' for this line
@@ -564,7 +564,7 @@ mod tests {
         2 | reveal_type(1)
           | ^^^^^^^^^^^
           |
-        1 | 
+        1 |
           - reveal_type(1)
         2 + reveal_type(1)  # ty:ignore[undefined-reveal]
         ");
@@ -589,7 +589,7 @@ mod tests {
           |
         help: This is a preferred code action
         1 + from warnings import deprecated
-        2 | 
+        2 |
         3 | @deprecated("do not use")
         4 | def my_func(): ...
 
@@ -600,7 +600,7 @@ mod tests {
           |  ^^^^^^^^^^
         3 | def my_func(): ...
           |
-        1 | 
+        1 |
           - @deprecated("do not use")
         2 + @deprecated("do not use")  # ty:ignore[unresolved-reference]
         3 | def my_func(): ...
@@ -630,9 +630,9 @@ mod tests {
           |
         help: This is a preferred code action
         1 + from warnings import deprecated
-        2 | 
+        2 |
         3 | import warnings
-        4 | 
+        4 |
 
         info[code-action]: qualify warnings.deprecated
          --> main.py:4:2
@@ -644,9 +644,9 @@ mod tests {
         5 | def my_func(): ...
           |
         help: This is a preferred code action
-        1 | 
+        1 |
         2 | import warnings
-        3 | 
+        3 |
           - @deprecated("do not use")
         4 + @warnings.deprecated("do not use")
         5 | def my_func(): ...
@@ -660,9 +660,9 @@ mod tests {
           |  ^^^^^^^^^^
         5 | def my_func(): ...
           |
-        1 | 
+        1 |
         2 | import warnings
-        3 | 
+        3 |
           - @deprecated("do not use")
         4 + @deprecated("do not use")  # ty:ignore[unresolved-reference]
         5 | def my_func(): ...
@@ -687,7 +687,7 @@ mod tests {
           |
         help: This is a preferred code action
         1 + from importlib.abc import ExecutionLoader
-        2 | 
+        2 |
         3 | ExecutionLoader
 
         info[code-action]: Ignore 'unresolved-reference' for this line
@@ -696,7 +696,7 @@ mod tests {
         2 | ExecutionLoader
           | ^^^^^^^^^^^^^^^
           |
-        1 | 
+        1 |
           - ExecutionLoader
         2 + ExecutionLoader  # ty:ignore[unresolved-reference]
         ");
@@ -725,7 +725,7 @@ mod tests {
           |
         help: This is a preferred code action
         1 + from importlib.abc import ExecutionLoader
-        2 | 
+        2 |
         3 | import importlib
         4 | ExecutionLoader
 
@@ -736,7 +736,7 @@ mod tests {
         3 | ExecutionLoader
           | ^^^^^^^^^^^^^^^
           |
-        1 | 
+        1 |
         2 | import importlib
           - ExecutionLoader
         3 + ExecutionLoader  # ty:ignore[unresolved-reference]
@@ -763,7 +763,7 @@ mod tests {
           |
         help: This is a preferred code action
         1 + from importlib.abc import ExecutionLoader
-        2 | 
+        2 |
         3 | import importlib.abc
         4 | ExecutionLoader
 
@@ -775,7 +775,7 @@ mod tests {
           | ^^^^^^^^^^^^^^^
           |
         help: This is a preferred code action
-        1 | 
+        1 |
         2 | import importlib.abc
           - ExecutionLoader
         3 + importlib.abc.ExecutionLoader
@@ -787,7 +787,7 @@ mod tests {
         3 | ExecutionLoader
           | ^^^^^^^^^^^^^^^
           |
-        1 | 
+        1 |
         2 | import importlib.abc
           - ExecutionLoader
         3 + ExecutionLoader  # ty:ignore[unresolved-reference]

--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -867,24 +867,24 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @r"
-        Here \_this\_ and \_\_\_that\_\_ should be escaped  
-        Here *this* and **that** should be untouched  
-        Here `this` and ``that`` should be untouched  
-          
-        Here `_this_` and ``__that__`` should be untouched  
-        Here `_this_` ``__that__`` should be untouched  
-        `_this_too_should_be_untouched_`  
-          
-        Here `_this_```__that__`` should be untouched but this\_is\_escaped  
-        Here ``_this_```__that__` should be untouched but this\_is\_escaped  
-          
-        Here `_this_ and _that_ should be escaped (but isn't)  
-        Here \_this\_ and \_that\_` should be escaped  
-        `Here _this_ and _that_ should be escaped (but isn't)  
-        Here \_this\_ and \_that\_ should be escaped`  
-          
-        Here ```_is_``__a__`_balanced_``_mess_```  
-        Here ```_is_`````__a__``\_random\_````_mess__````  
+        Here \_this\_ and \_\_\_that\_\_ should be escaped
+        Here *this* and **that** should be untouched
+        Here `this` and ``that`` should be untouched
+
+        Here `_this_` and ``__that__`` should be untouched
+        Here `_this_` ``__that__`` should be untouched
+        `_this_too_should_be_untouched_`
+
+        Here `_this_```__that__`` should be untouched but this\_is\_escaped
+        Here ``_this_```__that__` should be untouched but this\_is\_escaped
+
+        Here `_this_ and _that_ should be escaped (but isn't)
+        Here \_this\_ and \_that\_` should be escaped
+        `Here _this_ and _that_ should be escaped (but isn't)
+        Here \_this\_ and \_that\_ should be escaped`
+
+        Here ```_is_``__a__`_balanced_``_mess_```
+        Here ```_is_`````__a__``\_random\_````_mess__````
         ```_is_`````__a__``\_random\_````_mess__````
         ");
     }
@@ -911,7 +911,7 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @r#"
-        Check out this great example code:    
+        Check out this great example code:
         ```````````python
             x_y = "hello"
 
@@ -949,7 +949,7 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @r#"
-        Check out this great example code    
+        Check out this great example code
         ```````````python
             x_y = "hello"
 
@@ -988,8 +988,8 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @r#"
-        Check out this great example code  
-        &nbsp;&nbsp;&nbsp;&nbsp;    
+        Check out this great example code
+        &nbsp;&nbsp;&nbsp;&nbsp;
         ```````````python
             x_y = "hello"
 
@@ -1025,7 +1025,7 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @r#"
-        Check out this great example code:  
+        Check out this great example code:
         ```````````python
             x_y = "hello"
 
@@ -1059,7 +1059,7 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @r#"
-        Check out this great example code:    
+        Check out this great example code:
         ```````````python
             x_y = "hello"
 
@@ -1096,18 +1096,18 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @r#"
-        The thing you need to understand is that computers are hard.  
-          
-        **Warning:**  
-        &nbsp;&nbsp;&nbsp;&nbsp;Now listen here buckaroo you might have seen me say computers are hard,  
-        &nbsp;&nbsp;&nbsp;&nbsp;and though "yeah I know computers are hard but NO you DON'T KNOW.  
-          
-        &nbsp;&nbsp;&nbsp;&nbsp;Listen:  
-          
-        &nbsp;&nbsp;&nbsp;&nbsp;- Computers  
-        &nbsp;&nbsp;&nbsp;&nbsp;- Are  
-        &nbsp;&nbsp;&nbsp;&nbsp;- Hard  
-          
+        The thing you need to understand is that computers are hard.
+
+        **Warning:**
+        &nbsp;&nbsp;&nbsp;&nbsp;Now listen here buckaroo you might have seen me say computers are hard,
+        &nbsp;&nbsp;&nbsp;&nbsp;and though "yeah I know computers are hard but NO you DON'T KNOW.
+
+        &nbsp;&nbsp;&nbsp;&nbsp;Listen:
+
+        &nbsp;&nbsp;&nbsp;&nbsp;- Computers
+        &nbsp;&nbsp;&nbsp;&nbsp;- Are
+        &nbsp;&nbsp;&nbsp;&nbsp;- Hard
+
         &nbsp;&nbsp;&nbsp;&nbsp;Ok!?!?!?
         "#);
     }
@@ -1135,18 +1135,18 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        Some much-updated docs  
-          
-        **Added in version 3.0:**  
-        &nbsp;&nbsp;&nbsp;Function added  
-          
-        **Changed in version 4.0:**  
-        &nbsp;&nbsp;&nbsp;The `spam` argument was added  
-        **Changed in version 4.1:**  
-        &nbsp;&nbsp;&nbsp;The `spam` argument is considered evil now.  
-          
-        &nbsp;&nbsp;&nbsp;You really shouldnt use it  
-          
+        Some much-updated docs
+
+        **Added in version 3.0:**
+        &nbsp;&nbsp;&nbsp;Function added
+
+        **Changed in version 4.0:**
+        &nbsp;&nbsp;&nbsp;The `spam` argument was added
+        **Changed in version 4.1:**
+        &nbsp;&nbsp;&nbsp;The `spam` argument is considered evil now.
+
+        &nbsp;&nbsp;&nbsp;You really shouldnt use it
+
         And that's the docs
         ");
     }
@@ -1163,7 +1163,7 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        **wow this is some changes Deprecated since version 1.2.3:**  
+        **wow this is some changes Deprecated since version 1.2.3:**
         &nbsp;&nbsp;&nbsp;&nbsp;x = 2
         ");
     }
@@ -1185,8 +1185,8 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        My cool func:  
-          
+        My cool func:
+
         ```python
         >>> thing.do_thing()
         wow it did the thing
@@ -1212,8 +1212,8 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        My cool func:  
-          
+        My cool func:
+
         `````python
         x_y = thing_do();
         ``` # this should't close the fence!
@@ -1238,8 +1238,8 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        My cool func:  
-          
+        My cool func:
+
         ~~~~~python
         x_y = thing_do();
         ~~~ # this should't close the fence!
@@ -1269,15 +1269,15 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        My cool func...  
-          
-        Returns:  
-        &nbsp;&nbsp;&nbsp;&nbsp;Some details  
+        My cool func...
+
+        Returns:
+        &nbsp;&nbsp;&nbsp;&nbsp;Some details
         `````python
             x_y = thing_do();
             ``` # this should't close the fence!
             a_b = other_thing();
-        `````  
+        `````
         &nbsp;&nbsp;&nbsp;&nbsp;And so on.
         ");
     }
@@ -1303,15 +1303,15 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        My cool func...  
-          
-        Returns:  
-        &nbsp;&nbsp;&nbsp;&nbsp;Some details  
+        My cool func...
+
+        Returns:
+        &nbsp;&nbsp;&nbsp;&nbsp;Some details
         ~~~~~~python
             x_y = thing_do();
             ~~~ # this should't close the fence!
             a_b = other_thing();
-        ~~~~~~  
+        ~~~~~~
         &nbsp;&nbsp;&nbsp;&nbsp;And so on.
         ");
     }
@@ -1329,8 +1329,8 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        My cool func:  
-          
+        My cool func:
+
         ````python
         x_y = thing_do();
         ````
@@ -1350,8 +1350,8 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        My cool func:  
-          
+        My cool func:
+
         ~~~~~python
         x_y = thing_do();
         ~~~~~
@@ -1373,8 +1373,8 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        My cool func:  
-          
+        My cool func:
+
         ``````we still think this is a codefence```
             x_y = thing_do();
         ```````````` and are sloppy as heck with indentation and closing shrugggg
@@ -1396,8 +1396,8 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        My cool func:  
-          
+        My cool func:
+
         ~~~~~~we still think this is a codefence~~~
             x_y = thing_do();
         ~~~~~~~~~~~~~ and are sloppy as heck with indentation and closing shrugggg
@@ -1419,9 +1419,9 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @r#"
-        Here's some code!  
-          
-          
+        Here's some code!
+
+
         ```````````python
             def main() {
                 print("hello world!")
@@ -1445,9 +1445,9 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @r#"
-        Here's some Rust code!  
-          
-          
+        Here's some Rust code!
+
+
         ```````````rust
             fn main() {
                 println!("hello world!");
@@ -1467,7 +1467,7 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        wow this is some code  
+        wow this is some code
         ```````````abc
             x = 2
         ```````````
@@ -1489,9 +1489,9 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @r#"
-        Here's some code!  
-          
-          
+        Here's some code!
+
+
         ```````````python
             fn main() {
                 println!("hello world!");
@@ -1515,9 +1515,9 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @r#"
-        Here's some Rust code!  
-          
-          
+        Here's some Rust code!
+
+
         ```````````rust
             fn main() {
                 print("hello world!")
@@ -1543,14 +1543,14 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description  
-          
+        This is a function description
+
         ```````````python
         >>> thing.do_thing()
         wow it did the thing
         >>> thing.do_other_thing()
         it sure did the thing
-        ```````````  
+        ```````````
         As you can see it did the thing!
         ");
     }
@@ -1572,14 +1572,14 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description  
-          
+        This is a function description
+
         ```````````python
             >>> thing.do_thing()
             wow it did the thing
             >>> thing.do_other_thing()
             it sure did the thing
-        ```````````  
+        ```````````
         As you can see it did the thing!
         ");
     }
@@ -1621,7 +1621,7 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description:    
+        This is a function description:
         ```````````python
             >>> thing.do_thing()
             wow it did the thing
@@ -1645,7 +1645,7 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        And so you can see that  
+        And so you can see that
         ```````````python
             >>> thing.do_thing()
             wow it did the thing
@@ -1695,15 +1695,15 @@ mod tests {
         ");
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description.  
-          
-        Args:  
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter description  
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): The second parameter description  
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.  
-        &nbsp;&nbsp;&nbsp;&nbsp;param3: A parameter without type annotation  
-          
-        Returns:  
+        This is a function description.
+
+        Args:
+        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter description
+        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): The second parameter description
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.
+        &nbsp;&nbsp;&nbsp;&nbsp;param3: A parameter without type annotation
+
+        Returns:
         &nbsp;&nbsp;&nbsp;&nbsp;str: The return value description
         ");
     }
@@ -1766,21 +1766,21 @@ mod tests {
         ");
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description.  
-          
-        Parameters  
-        ----------  
-        param1 : str  
-        &nbsp;&nbsp;&nbsp;&nbsp;The first parameter description  
-        param2 : int  
-        &nbsp;&nbsp;&nbsp;&nbsp;The second parameter description  
-        &nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.  
-        param3  
-        &nbsp;&nbsp;&nbsp;&nbsp;A parameter without type annotation  
-          
-        Returns  
-        -------  
-        str  
+        This is a function description.
+
+        Parameters
+        ----------
+        param1 : str
+        &nbsp;&nbsp;&nbsp;&nbsp;The first parameter description
+        param2 : int
+        &nbsp;&nbsp;&nbsp;&nbsp;The second parameter description
+        &nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.
+        param3
+        &nbsp;&nbsp;&nbsp;&nbsp;A parameter without type annotation
+
+        Returns
+        -------
+        str
         &nbsp;&nbsp;&nbsp;&nbsp;The return value description
         ");
     }
@@ -1823,13 +1823,13 @@ mod tests {
         ");
 
         assert_snapshot!(docstring.render_markdown(), @r"
-        Insert an entry into the list of warnings filters (at the front).  
-          
-        'param1' -- The first parameter description  
-        'param2' -- The second parameter description  
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.  
-        'param3' -- A parameter without type annotation  
-          
+        Insert an entry into the list of warnings filters (at the front).
+
+        'param1' -- The first parameter description
+        'param2' -- The second parameter description
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.
+        'param3' -- A parameter without type annotation
+
         ```````````python
         >>> print repr(foo.__doc__)
         '\n    This is the second line of the docstring.\n    '
@@ -1902,15 +1902,15 @@ mod tests {
         ");
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description.  
-          
-        Args:  
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): Google-style parameter  
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): Another Google-style parameter  
-          
-        Parameters  
-        ----------  
-        param3 : bool  
+        This is a function description.
+
+        Args:
+        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): Google-style parameter
+        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): Another Google-style parameter
+
+        Parameters
+        ----------
+        param3 : bool
         &nbsp;&nbsp;&nbsp;&nbsp;NumPy-style parameter
         ");
     }
@@ -1957,13 +1957,13 @@ mod tests {
         ");
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description.  
-          
-        :param str param1: The first parameter description  
-        :param int param2: The second parameter description  
-        &nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.  
-        :param param3: A parameter without type annotation  
-        :returns: The return value description  
+        This is a function description.
+
+        :param str param1: The first parameter description
+        :param int param2: The second parameter description
+        &nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.
+        :param param3: A parameter without type annotation
+        :returns: The return value description
         :rtype: str
         ");
     }
@@ -2022,17 +2022,17 @@ mod tests {
         ");
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description.  
-          
-        Args:  
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): Google-style parameter  
-          
-        :param int param2: reST-style parameter  
-        :param param3: Another reST-style parameter  
-          
-        Parameters  
-        ----------  
-        param4 : bool  
+        This is a function description.
+
+        Args:
+        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): Google-style parameter
+
+        :param int param2: reST-style parameter
+        :param param3: Another reST-style parameter
+
+        Parameters
+        ----------
+        param4 : bool
         &nbsp;&nbsp;&nbsp;&nbsp;NumPy-style parameter
         ");
     }
@@ -2095,21 +2095,21 @@ mod tests {
         ");
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description.  
-          
-        Parameters  
-        ----------  
-        param1 : str  
-        &nbsp;&nbsp;&nbsp;&nbsp;The first parameter description  
-        param2 : int  
-        &nbsp;&nbsp;&nbsp;&nbsp;The second parameter description  
-        &nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.  
-        param3  
-        &nbsp;&nbsp;&nbsp;&nbsp;A parameter without type annotation  
-          
-        Returns  
-        -------  
-        str  
+        This is a function description.
+
+        Parameters
+        ----------
+        param1 : str
+        &nbsp;&nbsp;&nbsp;&nbsp;The first parameter description
+        param2 : int
+        &nbsp;&nbsp;&nbsp;&nbsp;The second parameter description
+        &nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.
+        param3
+        &nbsp;&nbsp;&nbsp;&nbsp;A parameter without type annotation
+
+        Returns
+        -------
+        str
         &nbsp;&nbsp;&nbsp;&nbsp;The return value description
         ");
     }
@@ -2163,16 +2163,16 @@ mod tests {
         ");
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description.  
-          
-        Parameters  
-        ----------  
-        param1 : str  
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The first parameter description  
-        param2 : int  
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The second parameter description  
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.  
-        param3  
+        This is a function description.
+
+        Parameters
+        ----------
+        param1 : str
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The first parameter description
+        param2 : int
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The second parameter description
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.
+        param3
         &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A parameter without type annotation
         ");
     }
@@ -2223,10 +2223,10 @@ mod tests {
         ");
 
         assert_snapshot!(docstring_windows.render_markdown(), @"
-        This is a function description.  
-          
-        Args:  
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter  
+        This is a function description.
+
+        Args:
+        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter
         &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): The second parameter
         ");
 
@@ -2239,10 +2239,10 @@ mod tests {
         ");
 
         assert_snapshot!(docstring_mac.render_markdown(), @"
-        This is a function description.  
-          
-        Args:  
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter  
+        This is a function description.
+
+        Args:
+        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter
         &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): The second parameter
         ");
 
@@ -2255,10 +2255,10 @@ mod tests {
         ");
 
         assert_snapshot!(docstring_unix.render_markdown(), @"
-        This is a function description.  
-          
-        Args:  
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter  
+        This is a function description.
+
+        Args:
+        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter
         &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): The second parameter
         ");
     }
@@ -2292,13 +2292,13 @@ Done.
         // The blank line between foo() and bar() should be preserved inside the code block,
         // NOT cause the code block to end early with bar() rendered as regular text.
         assert_snapshot!(docstring.render_markdown(), @r#"
-        Example:  
-          
+        Example:
+
         ```````````python
         >>> print("hello")
         hello
-        ```````````  
-        Code example:    
+        ```````````
+        Code example:
         ```````````python
             def foo():
                 pass

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -269,8 +269,8 @@ mod tests {
         Literal[10]
         ```
         ---
-        This is the docs for this value  
-          
+        This is the docs for this value
+
         Wow these are good docs!
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -323,10 +323,10 @@ mod tests {
         ) -> Unknown
         ```
         ---
-        This is such a great func!!  
-          
-        Args:  
-        &nbsp;&nbsp;&nbsp;&nbsp;a: first for a reason  
+        This is such a great func!!
+
+        Args:
+        &nbsp;&nbsp;&nbsp;&nbsp;a: first for a reason
         &nbsp;&nbsp;&nbsp;&nbsp;b: coming for `a`'s title
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -378,10 +378,10 @@ mod tests {
         ) -> Unknown
         ```
         ---
-        This is such a great func!!  
-          
-        Args:  
-        &nbsp;&nbsp;&nbsp;&nbsp;a: first for a reason  
+        This is such a great func!!
+
+        Args:
+        &nbsp;&nbsp;&nbsp;&nbsp;a: first for a reason
         &nbsp;&nbsp;&nbsp;&nbsp;b: coming for `a`'s title
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -441,10 +441,10 @@ mod tests {
         <class 'MyClass'>
         ```
         ---
-        This is such a great class!!  
-          
-        &nbsp;&nbsp;&nbsp;&nbsp;Don't you know?  
-          
+        This is such a great class!!
+
+        &nbsp;&nbsp;&nbsp;&nbsp;Don't you know?
+
         Everyone loves my class!!
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -503,10 +503,10 @@ mod tests {
         <class 'MyClass'>
         ```
         ---
-        This is such a great class!!  
-          
-        &nbsp;&nbsp;&nbsp;&nbsp;Don't you know?  
-          
+        This is such a great class!!
+
+        &nbsp;&nbsp;&nbsp;&nbsp;Don't you know?
+
         Everyone loves my class!!
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -678,10 +678,10 @@ mod tests {
         <class 'MyClass'>
         ```
         ---
-        This is such a great class!!  
-          
-        &nbsp;&nbsp;&nbsp;&nbsp;Don't you know?  
-          
+        This is such a great class!!
+
+        &nbsp;&nbsp;&nbsp;&nbsp;Don't you know?
+
         Everyone loves my class!!
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -749,10 +749,10 @@ mod tests {
         ) -> Unknown
         ```
         ---
-        This is such a great func!!  
-          
-        Args:  
-        &nbsp;&nbsp;&nbsp;&nbsp;a: first for a reason  
+        This is such a great func!!
+
+        Args:
+        &nbsp;&nbsp;&nbsp;&nbsp;a: first for a reason
         &nbsp;&nbsp;&nbsp;&nbsp;b: coming for `a`'s title
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -2057,8 +2057,8 @@ def ab(a: int, *, c: int):
         <module 'lib'>
         ```
         ---
-        The cool lib/_py module!  
-          
+        The cool lib/_py module!
+
         Wow this module rocks.
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -2611,8 +2611,8 @@ def function():
         <module 'lib'>
         ```
         ---
-        The cool lib/_py module!  
-          
+        The cool lib/_py module!
+
         Wow this module rocks.
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -2732,8 +2732,8 @@ def function():
         Literal[1]
         ```
         ---
-        This is the docs for this value  
-          
+        This is the docs for this value
+
         Wow these are good docs!
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -2781,8 +2781,8 @@ def function():
         Literal[1]
         ```
         ---
-        This is the docs for this value  
-          
+        This is the docs for this value
+
         Wow these are good docs!
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -2830,8 +2830,8 @@ def function():
         Literal[2]
         ```
         ---
-        This is the docs for this value  
-          
+        This is the docs for this value
+
         Wow these are good docs!
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -2881,8 +2881,8 @@ def function():
         Unknown | Literal[1]
         ```
         ---
-        This is the docs for this value  
-          
+        This is the docs for this value
+
         Wow these are good docs!
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -2924,8 +2924,8 @@ def function():
         int
         ```
         ---
-        This is the docs for this value  
-          
+        This is the docs for this value
+
         Wow these are good docs!
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -2966,8 +2966,8 @@ def function():
         Literal[1]
         ```
         ---
-        This is the docs for this value  
-          
+        This is the docs for this value
+
         Wow these are good docs!
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -3011,8 +3011,8 @@ def function():
         int
         ```
         ---
-        This is the docs for this value  
-          
+        This is the docs for this value
+
         Wow these are good docs!
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -3053,8 +3053,8 @@ def function():
         int
         ```
         ---
-        This is the docs for this value  
-          
+        This is the docs for this value
+
         Wow these are good docs!
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -3100,8 +3100,8 @@ def function():
         int
         ```
         ---
-        This is the docs for this value  
-          
+        This is the docs for this value
+
         Wow these are good docs!
         ---------------------------------------------
         info[hover]: Hovered content is

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -1787,7 +1787,7 @@ b: list["int | str"] | None
 c: "list[int | str] | None"
 d: "list[int | str]" | "None"
 e: 'list["int | str"] | "None"'
-f: """'list["int | str"]' | 'None'""" 
+f: """'list["int | str"]' | 'None'"""
 "#,
         );
 
@@ -2148,7 +2148,7 @@ class Baz:
         prop: str = \"hello\"
 
 baz = Baz()
-s = baz.method 
+s = baz.method
 t = baz.CONSTANT
 r = baz.prop
 q = Baz.prop
@@ -2383,7 +2383,7 @@ class MyClass:
     def __init__(self): pass
 
     """unrelated string"""
-    
+
     x: str = "hello"
 "#,
         );
@@ -2414,7 +2414,7 @@ What a good module wooo
 def my_func(): pass
 
 """unrelated string"""
-    
+
 x: str = "hello"
 "#,
         );


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

While I was working on a change on `crates/ty_ide/src/hover.rs` I noticed trailing new lines are trimmed on saving the file. I'm using neovim.
I searched around and found out the reason is [.editorconfig](https://github.com/Glyphack/ruff/blob/b82f71c51fb5ecfb3eea4bd61fe779bbd8df45fa/.editorconfig#L7). Without this setting editor won't reformat the code anymore.

But since it's not bad to trim new lines we just need it to be consistent I added it to pre commit hooks. Not a lot of files have trailing whitespace.

Update: I didn't realize this initially but the whitespace is in the result snapshot not the source code so trimming it will make tests fail. I'm checking what can I do.


## Test Plan

<!-- How was it tested? -->
