### PR TITLE
[ty] Preserve recursively-defined flag during normalization

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2804,6 +2804,25 @@ class Counter:
 reveal_type(Counter().count)  # revealed: Unknown | int
 ```
 
+Inherited recursive implicit attributes should also converge when the concrete seed is only
+available through the MRO.
+
+```py
+class Count:
+    def __init__(self):
+        self.i = 0
+
+class PositiveCount(Count):
+    def increment(self):
+        self.i = self.i + 1
+
+    def decrement(self):
+        if self.i != 0:
+            self.i = self.i - 1
+
+reveal_type(PositiveCount().i)  # revealed: Unknown | int
+```
+
 We also handle infinitely nested generics:
 
 ```py

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -898,7 +898,7 @@ pub(crate) fn place_by_id<'db>(
         PlaceAndQualifiers {
             place:
                 Place::Defined(DefinedPlace {
-                    ty: Type::Dynamic(DynamicType::Unknown),
+                    ty: Type::Dynamic(DynamicType::Unknown(_)),
                     origin,
                     definedness,
                     ..

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -30,11 +30,11 @@ pub(crate) use self::infer::{
 };
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
-use self::set_theoretic::KnownUnion;
 pub(crate) use self::set_theoretic::builder::{IntersectionBuilder, UnionBuilder};
 pub use self::set_theoretic::{
     IntersectionType, NegativeIntersectionElements, NegativeIntersectionElementsIterator, UnionType,
 };
+use self::set_theoretic::{KnownUnion, RecursivelyDefined};
 pub use self::signatures::ParameterKind;
 pub(crate) use self::signatures::Signature;
 pub(crate) use self::subclass_of::{SubclassOfInner, SubclassOfType};
@@ -777,7 +777,7 @@ impl<'db> Type<'db> {
     }
 
     pub const fn unknown() -> Self {
-        Self::Dynamic(DynamicType::Unknown)
+        Self::Dynamic(DynamicType::unknown())
     }
 
     pub(crate) fn divergent(id: salsa::Id) -> Self {
@@ -829,8 +829,42 @@ impl<'db> Type<'db> {
     pub const fn is_unknown(&self) -> bool {
         matches!(
             self,
-            Type::Dynamic(DynamicType::Unknown | DynamicType::UnknownGeneric(_))
+            Type::Dynamic(DynamicType::Unknown(_) | DynamicType::UnknownGeneric(..))
         )
+    }
+
+    pub(crate) fn recursively_defined(self, db: &'db dyn Db) -> RecursivelyDefined {
+        match self {
+            Type::Union(union) => union.recursively_defined(db),
+            Type::LiteralValue(literal) => literal.recursively_defined(),
+            Type::Dynamic(dynamic) => dynamic.recursively_defined(),
+            _ => RecursivelyDefined::No,
+        }
+    }
+
+    pub(crate) fn with_recursively_defined(
+        self,
+        db: &'db dyn Db,
+        recursively_defined: RecursivelyDefined,
+    ) -> Self {
+        match self {
+            Type::Union(union) => Type::Union(UnionType::new(
+                db,
+                union.elements(db).to_vec().into_boxed_slice(),
+                recursively_defined,
+            )),
+            Type::LiteralValue(literal) => {
+                Type::LiteralValue(literal.with_recursively_defined(recursively_defined))
+            }
+            Type::Dynamic(dynamic) => {
+                Type::Dynamic(dynamic.with_recursively_defined(recursively_defined))
+            }
+            _ => self,
+        }
+    }
+
+    fn without_recursive_provenance(self, db: &'db dyn Db) -> Self {
+        self.with_recursively_defined(db, RecursivelyDefined::No)
     }
 
     pub(crate) const fn is_never(&self) -> bool {
@@ -972,8 +1006,8 @@ impl<'db> Type<'db> {
     pub(crate) fn is_todo(&self) -> bool {
         self.as_dynamic().is_some_and(|dynamic| match dynamic {
             DynamicType::Any
-            | DynamicType::Unknown
-            | DynamicType::UnknownGeneric(_)
+            | DynamicType::Unknown(_)
+            | DynamicType::UnknownGeneric(..)
             | DynamicType::UnspecializedTypeVar => false,
             DynamicType::Todo(_)
             | DynamicType::TodoStarredExpression
@@ -1013,9 +1047,7 @@ impl<'db> Type<'db> {
             Type::TypedDict(typed_dict) => typed_dict
                 .defining_class()
                 .is_some_and(ClassType::is_generic),
-            Type::Dynamic(dynamic) => {
-                matches!(dynamic, DynamicType::UnknownGeneric(_))
-            }
+            Type::Dynamic(dynamic) => matches!(dynamic, DynamicType::UnknownGeneric(..)),
             // Due to inheritance rules, enums cannot be generic.
             Type::LiteralValue(literal) if literal.is_enum() => false,
             // Once generic NewType is officially specified, handle it.
@@ -1749,8 +1781,8 @@ impl<'db> Type<'db> {
 
             Type::Dynamic(dynamic) => match dynamic {
                 DynamicType::Any => true,
-                DynamicType::Unknown
-                | DynamicType::UnknownGeneric(_)
+                DynamicType::Unknown(_)
+                | DynamicType::UnknownGeneric(..)
                 | DynamicType::UnspecializedTypeVar
                 | DynamicType::TodoUnpack
                 | DynamicType::TodoTypeVarTuple
@@ -5970,7 +6002,7 @@ impl<'db> Type<'db> {
                 }
             },
 
-            Type::Dynamic(DynamicType::UnknownGeneric(generic_context)) => {
+            Type::Dynamic(DynamicType::UnknownGeneric(generic_context, _)) => {
                 for variable in generic_context.variables(db) {
                     if let Some(variable) = matching_typevar(&variable) {
                         typevars.insert(variable);
@@ -6174,7 +6206,7 @@ impl<'db> Type<'db> {
             Self::SpecialForm(special_form) => special_form.definition(db),
             Self::Never => Type::SpecialForm(SpecialFormType::Never).definition(db),
             Self::Dynamic(DynamicType::Any) => Type::SpecialForm(SpecialFormType::Any).definition(db),
-            Self::Dynamic(DynamicType::Unknown | DynamicType::UnknownGeneric(_)) => Type::SpecialForm(SpecialFormType::Unknown).definition(db),
+            Self::Dynamic(DynamicType::Unknown(_) | DynamicType::UnknownGeneric(..)) => Type::SpecialForm(SpecialFormType::Unknown).definition(db),
             Self::AlwaysTruthy => Type::SpecialForm(SpecialFormType::AlwaysTruthy).definition(db),
             Self::AlwaysFalsy => Type::SpecialForm(SpecialFormType::AlwaysFalsy).definition(db),
 
@@ -6661,19 +6693,27 @@ impl DivergentType {
     }
 }
 
+bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default, salsa::Update)]
+    pub struct DynamicFlags: u8 {
+        const RECURSIVELY_DEFINED = 1 << 0;
+    }
+}
+
+impl get_size2::GetSize for DynamicFlags {}
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
 pub enum DynamicType<'db> {
     /// An explicitly annotated `typing.Any`
     Any,
     /// An unannotated value, or a dynamic type resulting from an error
-    Unknown,
+    Unknown(DynamicFlags),
     /// Similar to `Unknown`, this represents a dynamic type that has been explicitly specialized
     /// with legacy typevars, e.g. `UnknownClass[T]`, where `T` is a legacy typevar. We keep track
     /// of the type variables in the generic context in case this type is later specialized again.
     ///
     /// TODO: Once we implement <https://github.com/astral-sh/ty/issues/1711>, this variant might
     /// not be needed anymore.
-    UnknownGeneric(GenericContext<'db>),
+    UnknownGeneric(GenericContext<'db>, DynamicFlags),
     /// An unspecialized type variable during generic call inference.
     ///
     /// TODO: This variant should be removed once type variables are unified across nested generic
@@ -6698,9 +6738,52 @@ pub enum DynamicType<'db> {
     TodoTypeVarTuple,
 }
 
-impl DynamicType<'_> {
+impl<'db> DynamicType<'db> {
+    pub(crate) const fn unknown() -> Self {
+        Self::Unknown(DynamicFlags::empty())
+    }
+
+    pub(crate) fn unknown_generic(generic_context: GenericContext<'db>) -> Self {
+        Self::UnknownGeneric(generic_context, DynamicFlags::empty())
+    }
+
     fn recursive_type_normalized(self) -> Self {
         self
+    }
+
+    fn flags(self) -> DynamicFlags {
+        match self {
+            Self::Unknown(flags) | Self::UnknownGeneric(_, flags) => flags,
+            _ => DynamicFlags::empty(),
+        }
+    }
+
+    fn map_flags(self, f: impl FnOnce(DynamicFlags) -> DynamicFlags) -> Self {
+        match self {
+            Self::Unknown(flags) => Self::Unknown(f(flags)),
+            Self::UnknownGeneric(generic_context, flags) => {
+                Self::UnknownGeneric(generic_context, f(flags))
+            }
+            _ => self,
+        }
+    }
+
+    fn recursively_defined(self) -> RecursivelyDefined {
+        if self.flags().intersects(DynamicFlags::RECURSIVELY_DEFINED) {
+            RecursivelyDefined::Yes
+        } else {
+            RecursivelyDefined::No
+        }
+    }
+
+    fn with_recursively_defined(self, recursively_defined: RecursivelyDefined) -> Self {
+        self.map_flags(|mut flags| {
+            flags.set(
+                DynamicFlags::RECURSIVELY_DEFINED,
+                recursively_defined.is_yes(),
+            );
+            flags
+        })
     }
 
     pub(crate) fn is_todo(&self) -> bool {
@@ -6712,7 +6795,7 @@ impl std::fmt::Display for DynamicType<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             DynamicType::Any => f.write_str("Any"),
-            DynamicType::Unknown | DynamicType::UnknownGeneric(_) => f.write_str("Unknown"),
+            DynamicType::Unknown(_) | DynamicType::UnknownGeneric(..) => f.write_str("Unknown"),
             DynamicType::UnspecializedTypeVar => f.write_str("UnspecializedTypeVar"),
             // `DynamicType::Todo`'s display should be explicit that is not a valid display of
             // any other type

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -423,7 +423,7 @@ impl<'db> BoundSuperType<'db> {
             };
 
         let owner = match owner_type {
-            Type::Never => SuperOwnerKind::Dynamic(DynamicType::Unknown),
+            Type::Never => SuperOwnerKind::Dynamic(DynamicType::unknown()),
             Type::Dynamic(dynamic) => SuperOwnerKind::Dynamic(dynamic),
             Type::Divergent(divergent) => SuperOwnerKind::Divergent(divergent),
             Type::ClassLiteral(class) => SuperOwnerKind::Class(ClassType::NonGeneric(class)),
@@ -636,7 +636,7 @@ impl<'db> BoundSuperType<'db> {
         mro_iter: impl Iterator<Item = ClassBase<'db>>,
     ) -> impl Iterator<Item = ClassBase<'db>> {
         let Some(pivot_class) = self.pivot_class(db).into_class() else {
-            return Either::Left(ClassBase::Dynamic(DynamicType::Unknown).mro(db, None));
+            return Either::Left(ClassBase::Dynamic(DynamicType::unknown()).mro(db, None));
         };
 
         let mut pivot_found = false;

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -34,7 +34,7 @@ pub enum ClassBase<'db> {
 
 impl<'db> ClassBase<'db> {
     pub(crate) const fn unknown() -> Self {
-        Self::Dynamic(DynamicType::Unknown)
+        Self::Dynamic(DynamicType::unknown())
     }
 
     pub(super) fn recursive_type_normalized_impl(
@@ -57,7 +57,9 @@ impl<'db> ClassBase<'db> {
         match self {
             ClassBase::Class(class) => class.name(db),
             ClassBase::Dynamic(DynamicType::Any) => "Any",
-            ClassBase::Dynamic(DynamicType::Unknown | DynamicType::UnknownGeneric(_)) => "Unknown",
+            ClassBase::Dynamic(DynamicType::Unknown(_) | DynamicType::UnknownGeneric(..)) => {
+                "Unknown"
+            }
             ClassBase::Dynamic(DynamicType::UnspecializedTypeVar) => "UnspecializedTypeVar",
             ClassBase::Dynamic(
                 DynamicType::Todo(_)

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -5,11 +5,13 @@ use smallvec::SmallVec;
 
 use crate::{
     Db, FxIndexMap,
-    place::{DefinedPlace, Place, place_from_bindings, place_from_declarations},
+    place::{
+        DefinedPlace, Place, PlaceAndQualifiers, place_from_bindings, place_from_declarations,
+    },
     semantic_index::{definition::DefinitionKind, place_table, scope::ScopeId, use_def_map},
     types::{
         ClassBase, ClassLiteral, DynamicType, EnumLiteralType, KnownClass, LiteralValueTypeKind,
-        MemberLookupPolicy, StaticClassLiteral, Type, function::FunctionType,
+        MemberLookupPolicy, StaticClassLiteral, Type, TypeQualifiers, function::FunctionType,
         set_theoretic::builder::UnionBuilder,
     },
 };
@@ -346,9 +348,8 @@ pub(crate) fn enum_metadata<'db>(
             }
 
             let declarations = use_def_map.end_of_scope_symbol_declarations(symbol_id);
-
-            if !explicit_member_wrapper
-                && declarations.clone().any_reachable(db, |declaration| {
+            let allows_annotated_assignment_member =
+                !declarations.clone().any_reachable(db, |declaration| {
                     declaration.is_defined_and(|declaration| {
                         !matches!(
                             declaration.kind(db),
@@ -358,9 +359,42 @@ pub(crate) fn enum_metadata<'db>(
                                     .is_some()
                         )
                     })
-                })
-            {
-                return None;
+                });
+            let declared =
+                place_from_declarations(db, declarations).ignore_conflicting_declarations();
+
+            if !explicit_member_wrapper {
+                match declared {
+                    PlaceAndQualifiers {
+                        place:
+                            Place::Defined(DefinedPlace {
+                                ty: Type::Dynamic(DynamicType::Unknown(_)),
+                                ..
+                            }),
+                        qualifiers,
+                    } if qualifiers.contains(TypeQualifiers::FINAL) => {}
+                    PlaceAndQualifiers {
+                        place: Place::Undefined,
+                        ..
+                    } => {
+                        // Undeclared attributes are considered members.
+                    }
+                    PlaceAndQualifiers {
+                        place:
+                            Place::Defined(DefinedPlace {
+                                ty: Type::NominalInstance(instance),
+                                ..
+                            }),
+                        ..
+                    } if instance.has_known_class(db, KnownClass::Member) => {
+                        // If the attribute is specifically declared with `enum.member`, it is considered a member.
+                    }
+                    _ if allows_annotated_assignment_member => {}
+                    _ => {
+                        // Declared attributes are considered non-members.
+                        return None;
+                    }
+                }
             }
 
             Some((name.clone(), value_ty))

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3236,7 +3236,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             // `Unknown` is likely to be the result of an unresolved import or a typo, which will
             // already get a diagnostic, so don't pile on an extra diagnostic here.
-            Type::Dynamic(DynamicType::Unknown) => return,
+            Type::Dynamic(DynamicType::Unknown(_)) => return,
             _ => {}
         }
         if let Some(builder) = self
@@ -3782,7 +3782,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     && !matches!(name_expr.id.as_str(), "_ignore_" | "_value_" | "_name_")
                     // Not bare Final (bare Final is allowed on enum members)
                     && !(declared.qualifiers.contains(TypeQualifiers::FINAL)
-                        && matches!(declared.inner_type(), Type::Dynamic(DynamicType::Unknown)))
+                        && declared.inner_type().is_unknown())
                     // Value type would be an enum member at runtime (exclude callables,
                     // which are never members)
                     && !inferred_ty.is_subtype_of(
@@ -6400,7 +6400,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // return type as type context.
         let return_tcx = if let Some(signature) = callable_tcx {
             match signature.return_ty {
-                Type::Dynamic(DynamicType::Unknown) => TypeContext::new(None),
+                Type::Dynamic(DynamicType::Unknown(_)) => TypeContext::new(None),
                 _ => TypeContext::new(Some(signature.return_ty)),
             }
         } else {

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -372,11 +372,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             (any @ Type::Dynamic(DynamicType::Any), _, _)
             | (_, any @ Type::Dynamic(DynamicType::Any), _) => Some(any),
 
-            (unknown @ Type::Dynamic(DynamicType::Unknown), _, _)
-            | (_, unknown @ Type::Dynamic(DynamicType::Unknown), _) => Some(unknown),
+            (unknown @ Type::Dynamic(DynamicType::Unknown(_)), _, _)
+            | (_, unknown @ Type::Dynamic(DynamicType::Unknown(_)), _) => Some(unknown),
 
-            (unknown @ Type::Dynamic(DynamicType::UnknownGeneric(_)), _, _)
-            | (_, unknown @ Type::Dynamic(DynamicType::UnknownGeneric(_)), _) => Some(unknown),
+            (unknown @ Type::Dynamic(DynamicType::UnknownGeneric(..)), _, _)
+            | (_, unknown @ Type::Dynamic(DynamicType::UnknownGeneric(..)), _) => Some(unknown),
 
             (typevar @ Type::Dynamic(DynamicType::UnspecializedTypeVar), _, _)
             | (_, typevar @ Type::Dynamic(DynamicType::UnspecializedTypeVar), _) => Some(typevar),

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -170,7 +170,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     &mut variables,
                 );
                 let generic_context = GenericContext::from_typevar_instances(db, variables);
-                return Type::Dynamic(DynamicType::UnknownGeneric(generic_context));
+                return Type::Dynamic(DynamicType::unknown_generic(generic_context));
             }
             Type::KnownInstance(KnownInstanceType::TypeAliasType(type_alias)) => {
                 if let Some(generic_context) = type_alias.generic_context(db) {
@@ -331,7 +331,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ) => {
                 return self.infer_explicit_type_alias_specialization(subscript, value_ty, false);
             }
-            Type::Dynamic(DynamicType::Unknown) => {
+            Type::Dynamic(DynamicType::Unknown(_)) => {
                 let slice_ty = self.infer_expression(slice, TypeContext::default());
                 let mut variables = FxOrderSet::default();
                 slice_ty.bind_and_find_all_legacy_typevars(
@@ -340,7 +340,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     &mut variables,
                 );
                 let generic_context = GenericContext::from_typevar_instances(db, variables);
-                return Type::Dynamic(DynamicType::UnknownGeneric(generic_context));
+                return Type::Dynamic(DynamicType::unknown_generic(generic_context));
             }
             _ => {}
         }
@@ -969,7 +969,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     &mut variables,
                 );
                 let generic_context = GenericContext::from_typevar_instances(db, variables);
-                Ok(Type::Dynamic(DynamicType::UnknownGeneric(generic_context)))
+                Ok(Type::Dynamic(DynamicType::unknown_generic(generic_context)))
             }
             _ => value_ty.subscript(db, slice_ty, expr_context),
         };

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1477,7 +1477,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     );
                     let generic_context =
                         GenericContext::from_typevar_instances(self.db(), variables);
-                    Type::Dynamic(DynamicType::UnknownGeneric(generic_context))
+                    Type::Dynamic(DynamicType::unknown_generic(generic_context))
                 }
                 KnownInstanceType::LiteralStringAlias(_) => {
                     self.infer_expression(slice, TypeContext::default());
@@ -1550,7 +1550,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     Type::unknown()
                 }
             },
-            Type::Dynamic(DynamicType::UnknownGeneric(_)) => {
+            Type::Dynamic(DynamicType::UnknownGeneric(..)) => {
                 self.infer_explicit_type_alias_specialization(subscript, value_ty, true)
             }
             Type::Dynamic(_) | Type::Divergent(_) => {

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -416,6 +416,8 @@ impl<'db> UnionBuilder<'db> {
     }
 
     pub(crate) fn add_in_place_impl(&mut self, ty: Type<'db>, seen_aliases: &mut Vec<Type<'db>>) {
+        self.recursively_defined = self.recursively_defined.or(ty.recursively_defined(self.db));
+        let ty = ty.without_recursive_provenance(self.db);
         let cycle_recovery = self.cycle_recovery;
         let should_widen = |literals, recursively_defined: RecursivelyDefined| {
             if recursively_defined.is_yes() && cycle_recovery {
@@ -435,9 +437,6 @@ impl<'db> UnionBuilder<'db> {
                 for element in new_elements {
                     self.add_in_place_impl(*element, seen_aliases);
                 }
-                self.recursively_defined = self
-                    .recursively_defined
-                    .or(union.recursively_defined(self.db));
                 if self.cycle_recovery && self.recursively_defined.is_yes() {
                     let literals = self.elements.iter().fold(0, |acc, elem| match elem {
                         UnionElement::IntLiterals(literals) => acc + literals.len(),
@@ -463,8 +462,6 @@ impl<'db> UnionBuilder<'db> {
                 }
             }
             Type::LiteralValue(literal) => {
-                self.recursively_defined =
-                    self.recursively_defined.or(literal.recursively_defined());
                 match literal.kind() {
                     // If adding a string literal, look for an existing `UnionElement::StringLiterals` to
                     // add it to, or an existing element that is a super-type of string literals, which
@@ -863,7 +860,7 @@ impl<'db> UnionBuilder<'db> {
         }
         match types.len() {
             0 => None,
-            1 => Some(types[0]),
+            1 => Some(types[0].with_recursively_defined(self.db, self.recursively_defined)),
             _ => Some(Type::Union(UnionType::new(
                 self.db,
                 types.into_boxed_slice(),

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2607,9 +2607,9 @@ impl<'db> Parameters<'db> {
         Self {
             value: vec![
                 Parameter::variadic(Name::new_static("args"))
-                    .with_annotated_type(Type::Dynamic(DynamicType::Unknown)),
+                    .with_annotated_type(Type::Dynamic(DynamicType::unknown())),
                 Parameter::keyword_variadic(Name::new_static("kwargs"))
-                    .with_annotated_type(Type::Dynamic(DynamicType::Unknown)),
+                    .with_annotated_type(Type::Dynamic(DynamicType::unknown())),
             ],
             kind: ParametersKind::Gradual,
         }

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -68,7 +68,7 @@ impl<'db> SubclassOfType<'db> {
             Type::GenericAlias(generic) => SubclassOfInner::Class(ClassType::Generic(generic)),
             Type::SpecialForm(SpecialFormType::Any) => SubclassOfInner::Dynamic(DynamicType::Any),
             Type::SpecialForm(SpecialFormType::Unknown) => {
-                SubclassOfInner::Dynamic(DynamicType::Unknown)
+                SubclassOfInner::Dynamic(DynamicType::unknown())
             }
             _ => return None,
         };
@@ -369,7 +369,7 @@ pub(crate) enum SubclassOfInner<'db> {
 
 impl<'db> SubclassOfInner<'db> {
     pub(crate) const fn unknown() -> Self {
-        Self::Dynamic(DynamicType::Unknown)
+        Self::Dynamic(DynamicType::unknown())
     }
 
     pub(crate) const fn is_dynamic(self) -> bool {
@@ -423,7 +423,9 @@ impl<'db> SubclassOfInner<'db> {
             },
             Type::TypeVar(bound_typevar) => SubclassOfInner::TypeVar(bound_typevar),
             Type::Dynamic(DynamicType::Any) => SubclassOfInner::Dynamic(DynamicType::Any),
-            Type::Dynamic(DynamicType::Unknown) => SubclassOfInner::Dynamic(DynamicType::Unknown),
+            Type::Dynamic(DynamicType::Unknown(_)) => {
+                SubclassOfInner::Dynamic(DynamicType::unknown())
+            }
             _ => return None,
         })
     }

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -543,8 +543,8 @@ impl<'db> TypeVarInstance<'db> {
                     | DynamicType::TodoStarredExpression
                     | DynamicType::TodoTypeVarTuple => Parameters::todo(),
                     DynamicType::Any
-                    | DynamicType::Unknown
-                    | DynamicType::UnknownGeneric(_)
+                    | DynamicType::Unknown(_)
+                    | DynamicType::UnknownGeneric(..)
                     | DynamicType::UnspecializedTypeVar => Parameters::unknown(),
                 },
                 Type::Divergent(_) => Parameters::unknown(),


### PR DESCRIPTION
## Summary

This PR allows the `Unknown` variant to retain a recursively-normalized flag so that it's not dropped during normalization.

Consider this motivating example:

```python
class Count:
    def __init__(self):
        self.i = 0

class PositiveCount(Count):
    def increment(self):
        self.i = self.i + 1

    def decrement(self):
        if self.i != 0:
            self.i = self.i - 1
```

`PositiveCount.i` is initially inferred as `Unknown` in the subclass (the subclass doesn't see `self.i = 0` upfront, because `implicit_attribute_inner` operates on a single class). Instead, it sees the `self.i = self.i + 1` and `self.i = self.i - 1` statements, which adds `Divergent` to the type. Recursive normalization drops the `Divergent` arms and marks the result recursive... but that flag doesn't have anywhere to go. Then, when evaluating `self.i + 1`, it walks the MRO and adds the `Literal[0]` from `self.i = 0`, so we have `Unknown | Literal[0]`, but we've already "lost" the recursively-normalized flag.

I also considered https://github.com/astral-sh/ruff/pull/24272 which is more targeted, but this felt more structurally correct and less targeted.

Closes https://github.com/astral-sh/ty/issues/3149.
