### PR TITLE
[ty] Fix nested global and nonlocal lookups through forwarding scopes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/scopes/global.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/global.md
@@ -86,27 +86,12 @@ def f():
 
 ## Nested function after conditional rebinding
 
-A nested function should still resolve a name in the module scope if the enclosing function marks it
-`global`, even if that function also has a conditional assignment to the name:
+A nested function should resolve a `global` name through the enclosing scope, even if that scope
+conditionally rebinds it. Here, the early return means `inner` only sees the original module
+binding:
 
 ```py
-PULL_SUMS: list[float] = []
-
-def bandit(foo: int) -> None:
-    global PULL_SUMS
-
-    if foo == 0:
-        PULL_SUMS = []
-        return
-
-    def bar(arm: int) -> None:
-        PULL_SUMS[arm]
-```
-
-A simpler scalar case should also keep falling back to the module global:
-
-```py
-x: int = 1
+x = 1
 
 def outer(flag: bool) -> None:
     global x
@@ -116,7 +101,26 @@ def outer(flag: bool) -> None:
         return
 
     def inner() -> None:
-        y: int = x
+        reveal_type(x)  # revealed: Literal[1]
+```
+
+Without the early return, the nested function should see both possible bindings. This is a known
+limitation: we currently infer only the rebound value instead of the union of both:
+
+```py
+x = 1
+
+def outer(flag: bool) -> None:
+    global x
+
+    if flag:
+        x = 2
+
+    def inner() -> None:
+        # TODO: should be `Literal[1, 2]`
+        reveal_type(x)  # revealed: Literal[2]
+
+    inner()
 ```
 
 ## `nonlocal` and `global`

--- a/crates/ty_python_semantic/resources/mdtest/scopes/global.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/global.md
@@ -84,6 +84,41 @@ def f():
         y: int = x  # allowed, because x cannot be None in this branch
 ```
 
+## Nested function after conditional rebinding
+
+A nested function should still resolve a name in the module scope if the enclosing function marks it
+`global`, even if that function also has a conditional assignment to the name:
+
+```py
+PULL_SUMS: list[float] = []
+
+def bandit(foo: int) -> None:
+    global PULL_SUMS
+
+    if foo == 0:
+        PULL_SUMS = []
+        return
+
+    def bar(arm: int) -> None:
+        PULL_SUMS[arm]
+```
+
+A simpler scalar case should also keep falling back to the module global:
+
+```py
+x: int = 1
+
+def outer(flag: bool) -> None:
+    global x
+
+    if flag:
+        x = 2
+        return
+
+    def inner() -> None:
+        y: int = x
+```
+
 ## `nonlocal` and `global`
 
 A binding cannot be both `nonlocal` and `global`. This should emit a semantic syntax error. CPython

--- a/crates/ty_python_semantic/resources/mdtest/scopes/global.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/global.md
@@ -298,6 +298,20 @@ def f():
     global int  # error: [unresolved-global] "Invalid global declaration of `int`: `int` has no declarations or bindings in the global scope"
 ```
 
+## Nested class after global rebinding
+
+Even if a `global` declaration is unresolved at module scope, nested eager scopes in the same
+function should still see a rebinding that already happened:
+
+```py
+def factory():
+    global x  # error: [unresolved-global] "Invalid global declaration of `x`: `x` has no declarations or bindings in the global scope"
+    x = 1
+
+    class C:
+        reveal_type(x)  # revealed: Literal[1]
+```
+
 ## References to variables before they are defined within a class scope are considered global
 
 If we try to access a variable in a class before it has been defined, the lookup will fall back to

--- a/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
@@ -104,6 +104,27 @@ def outer(flag: bool) -> None:
             y: int = x
 ```
 
+## Generator expression after nonlocal rebinding
+
+A nested eager scope such as a generator expression should see the rebound type of a `nonlocal`
+symbol:
+
+```py
+from typing import Optional
+
+class C:
+    value: int
+
+def check(x: Optional[C]) -> C:
+    return C()
+
+def outer(x: Optional[C]) -> None:
+    def inner() -> None:
+        nonlocal x
+        x = check(x)
+        all(reveal_type(x.value) == 1 for _ in [0])  # revealed: int
+```
+
 ## The types of `nonlocal` binding get unioned
 
 Without a type declaration, we union the bindings in enclosing scopes to infer a type. But name

--- a/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
@@ -84,6 +84,26 @@ def f():
         x = "hello"  # error: [invalid-assignment] "Object of type `Literal["hello"]` is not assignable to `int`"
 ```
 
+## Nested function after conditional nonlocal rebinding
+
+An inner function should still resolve a name through an enclosing `nonlocal` declaration, even if
+that enclosing scope also conditionally rebinds the name:
+
+```py
+def outer(flag: bool) -> None:
+    x: int = 1
+
+    def middle() -> None:
+        nonlocal x
+
+        if flag:
+            x = 2
+            return
+
+        def inner() -> None:
+            y: int = x
+```
+
 ## The types of `nonlocal` binding get unioned
 
 Without a type declaration, we union the bindings in enclosing scopes to infer a type. But name

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -430,8 +430,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
             // We don't record lazy snapshots of attributes or subscripts, because these are difficult to track as they modify.
             for nested_symbol in self.place_tables[popped_scope_id].symbols() {
-                // For the same reason, symbols declared as nonlocal or global are not recorded.
-                // Also, if the enclosing scope allows its members to be modified from elsewhere, the snapshot will not be recorded.
+                // For the same reason, we don't snapshot bindings owned by `global`/`nonlocal`
+                // forwarding declarations here; `snapshot_enclosing_state` stores only a
+                // constraint for those symbols. Also, if the enclosing scope allows its members to
+                // be modified from elsewhere, the snapshot will not be recorded.
                 // (In the case of class scopes, class variables can be modified from elsewhere, but this has no effect in nested scopes,
                 // as class variables are not visible to them)
                 if self.scopes[enclosing_scope_id].kind().is_module() {

--- a/crates/ty_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/ty_python_semantic/src/semantic_index/use_def.rs
@@ -1470,15 +1470,20 @@ impl<'db> UseDefMapBuilder<'db> {
         let is_forwarding_symbol = enclosing_place_expr
             .as_symbol()
             .is_some_and(|symbol| symbol.is_global() || symbol.is_nonlocal());
+        let stores_visible_bindings = !is_forwarding_symbol
+            || (enclosing_place_expr.is_bound()
+                && bindings.iter().any(|binding| !binding.binding.is_unbound()));
         // Names bound in class scopes are never visible to nested scopes (but
         // attributes/subscripts are visible), so we never need to save eager scope bindings in a
         // class scope. There is one exception to this rule: annotation scopes can see names
-        // defined in an immediately-enclosing class scope. Likewise, `global` and `nonlocal`
-        // symbols in the enclosing scope are forwarding declarations, so nested scopes should
-        // continue walking outward instead of treating any bindings here as owned by this scope.
+        // defined in an immediately-enclosing class scope. Likewise, unbound `global` and
+        // `nonlocal` symbols in the enclosing scope are forwarding declarations, so nested scopes
+        // should continue walking outward instead of treating any bindings here as owned by this
+        // scope. However, if the enclosing scope actually rebound the forwarded name, that visible
+        // state needs to be snapshotted so nested scopes can see the rebound type.
         if (is_class_symbol && !is_parent_of_annotation_scope)
             || !enclosing_place_expr.is_bound()
-            || is_forwarding_symbol
+            || !stores_visible_bindings
         {
             self.enclosing_snapshots.push(EnclosingSnapshot::Constraint(
                 bindings.unbound_narrowing_constraint(),

--- a/crates/ty_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/ty_python_semantic/src/semantic_index/use_def.rs
@@ -1467,11 +1467,19 @@ impl<'db> UseDefMapBuilder<'db> {
         };
 
         let is_class_symbol = enclosing_scope.is_class() && enclosing_place.is_symbol();
+        let is_forwarding_symbol = enclosing_place_expr
+            .as_symbol()
+            .is_some_and(|symbol| symbol.is_global() || symbol.is_nonlocal());
         // Names bound in class scopes are never visible to nested scopes (but
         // attributes/subscripts are visible), so we never need to save eager scope bindings in a
         // class scope. There is one exception to this rule: annotation scopes can see names
-        // defined in an immediately-enclosing class scope.
-        if (is_class_symbol && !is_parent_of_annotation_scope) || !enclosing_place_expr.is_bound() {
+        // defined in an immediately-enclosing class scope. Likewise, `global` and `nonlocal`
+        // symbols in the enclosing scope are forwarding declarations, so nested scopes should
+        // continue walking outward instead of treating any bindings here as owned by this scope.
+        if (is_class_symbol && !is_parent_of_annotation_scope)
+            || !enclosing_place_expr.is_bound()
+            || is_forwarding_symbol
+        {
             self.enclosing_snapshots.push(EnclosingSnapshot::Constraint(
                 bindings.unbound_narrowing_constraint(),
             ))

--- a/crates/ty_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/ty_python_semantic/src/semantic_index/use_def.rs
@@ -1470,9 +1470,8 @@ impl<'db> UseDefMapBuilder<'db> {
         let is_forwarding_symbol = enclosing_place_expr
             .as_symbol()
             .is_some_and(|symbol| symbol.is_global() || symbol.is_nonlocal());
-        let stores_visible_bindings = !is_forwarding_symbol
-            || (enclosing_place_expr.is_bound()
-                && bindings.iter().any(|binding| !binding.binding.is_unbound()));
+        let stores_visible_bindings = enclosing_place_expr.is_bound()
+            && bindings.iter().any(|binding| !binding.binding.is_unbound());
         // Names bound in class scopes are never visible to nested scopes (but
         // attributes/subscripts are visible), so we never need to save eager scope bindings in a
         // class scope. There is one exception to this rule: annotation scopes can see names
@@ -1483,7 +1482,7 @@ impl<'db> UseDefMapBuilder<'db> {
         // state needs to be snapshotted so nested scopes can see the rebound type.
         if (is_class_symbol && !is_parent_of_annotation_scope)
             || !enclosing_place_expr.is_bound()
-            || !stores_visible_bindings
+            || (is_forwarding_symbol && !stores_visible_bindings)
         {
             self.enclosing_snapshots.push(EnclosingSnapshot::Constraint(
                 bindings.unbound_narrowing_constraint(),


### PR DESCRIPTION
## Summary

Given the motivating example:

```python
PULL_SUMS: "list[float]" = []

def bandit(foo: int) -> None:
    global PULL_SUMS

    if foo == 0:
        # commenting this out fixes it
        PULL_SUMS = []
        return

    def bar(arm):
        return PULL_SUMS[arm]
```

Before this change, in `bar`, we'd first look at the `bandit` scope, but because `bandit` had `PULL_SUMS = []`, we stopped walking outward to the module scope, and never saw the top-level `PULL_SUMS: "list[float]" = []`.

Now, if the binding in the scope is just an unbound placeholder for a `nonlocal` or `global`, we  keep walking outwards.

Closes https://github.com/astral-sh/ty/issues/3157.