### PR TITLE
docs: document argfile support for `ruff check` and `ruff format`

### DIFF
--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -14,6 +14,13 @@ ruff format path/to/code/     # Format all files in `path/to/code` (and any subd
 ruff format path/to/file.py   # Format a single file.
 ```
 
+`ruff format` also supports reading arguments from a file using `@`-prefixed argfiles. Each argument
+must be on its own line in the file:
+
+```shell
+ruff format @/path/to/file_list.txt
+```
+
 Similar to Black, running `ruff format /path/to/file.py` will format the given file or directory
 in-place, while `ruff format --check /path/to/file.py` will avoid writing any formatted files back,
 and instead exit with a non-zero status code upon detecting any unformatted files.

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -19,6 +19,16 @@ $ ruff check --watch          # Lint files in the current directory and re-lint 
 $ ruff check path/to/code/    # Lint files in `path/to/code`.
 ```
 
+`ruff check` also supports reading arguments from a file using `@`-prefixed argfiles. Each argument
+must be on its own line in the file:
+
+```console
+$ ruff check @/path/to/file_list.txt
+```
+
+This is useful when the list of files to lint is long, contains special characters, or is generated
+dynamically (e.g., by `git diff --name-only`).
+
 For the full list of supported options, run `ruff check --help`.
 
 ## Rule selection


### PR DESCRIPTION
Closes #21894.

## Summary

Both `ruff check` and `ruff format` support `@`-prefixed argfiles for passing paths to lint/format. This feature was confirmed by a maintainer in the issue but was never documented.

This PR adds a short paragraph and example to each command's section explaining:
- the `@/path/to/argfile` syntax
- the one-argument-per-line requirement
- a typical use case (large file lists, special characters, dynamically generated lists)

## Changes

- `docs/linter.md`: document argfile support in the `ruff check` section
- `docs/formatter.md`: document argfile support in the `ruff format` section

Made with [Cursor](https://cursor.com)