### PR TITLE
Don't measure the AST deallocation time in parser benchmarks

### DIFF
--- a/crates/ruff_benchmark/benches/parser.rs
+++ b/crates/ruff_benchmark/benches/parser.rs
@@ -6,8 +6,6 @@ use criterion::{
 use ruff_benchmark::{
     LARGE_DATASET, NUMPY_CTYPESLIB, NUMPY_GLOBALS, PYDANTIC_TYPES, TestCase, UNICODE_PYPINYIN,
 };
-use ruff_python_ast::Stmt;
-use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 use ruff_python_parser::parse_module;
 
 #[cfg(target_os = "windows")]
@@ -37,17 +35,6 @@ fn create_test_cases() -> Vec<TestCase> {
     ]
 }
 
-struct CountVisitor {
-    count: usize,
-}
-
-impl<'a> StatementVisitor<'a> for CountVisitor {
-    fn visit_stmt(&mut self, stmt: &'a Stmt) {
-        walk_stmt(self, stmt);
-        self.count += 1;
-    }
-}
-
 fn benchmark_parser(criterion: &mut Criterion<WallTime>) {
     let test_cases = create_test_cases();
     let mut group = criterion.benchmark_group("parser");
@@ -58,14 +45,8 @@ fn benchmark_parser(criterion: &mut Criterion<WallTime>) {
             BenchmarkId::from_parameter(case.name()),
             &case,
             |b, case| {
-                b.iter(|| {
-                    let parsed = parse_module(case.code())
-                        .expect("Input should be a valid Python code")
-                        .into_suite();
-
-                    let mut visitor = CountVisitor { count: 0 };
-                    visitor.visit_body(&parsed);
-                    visitor.count
+                b.iter_with_large_drop(|| {
+                    parse_module(case.code()).expect("Input should be a valid Python code")
                 });
             },
         );


### PR DESCRIPTION
## Summary

Looking at [CodSpeeds memory profiles](https://codspeed.io/astral-sh/ruff/branches/micha/codspeed-memory?utm_source=github&utm_medium=check&utm_content=button&uri=crates%2Fruff_benchmark%2Fbenches%2Fformatter.rs%3A%3Aformatter%3A%3Abenchmark_formatter%3A%3Aformatter%255Bunicode%2Fpypinyin.py%255D&runnerMode=Memory&q=mode%3Amemory&page=2) made me realize that
our parser benchmarks include the AST deallocation time. That's not really what we're interested in. 

This PR excludes the deallocation time from what's measured in the benchmarks.

## Test Plan

CI
