### PR TITLE
[ty] Support basic narrowing with aliased conditional expressions

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -735,6 +735,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     }
 
     /// Try to register a narrowing alias for a simple name assignment.
+    ///
+    /// Any pre-existing alias entry for the `target` name has already been removed by
+    /// [`Self::invalidate_narrowing_aliases_for`] in the binding pathway that ran before
+    /// this call, so we only need to decide whether to insert a new entry.
     fn try_register_narrowing_alias(&mut self, target: &ast::Expr, value: Option<&'ast ast::Expr>) {
         let Some(target_name_expr) = target.as_name_expr() else {
             return;
@@ -743,7 +747,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let target_name = &target_name_expr.id;
 
         if !Self::can_register_narrowing_alias(value) {
-            self.narrowing_aliases.remove(target_name);
             return;
         }
 
@@ -751,7 +754,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let narrowed_places =
             PossiblyNarrowedPlacesBuilder::new(self.db, place_table).expression(value);
 
-        // Don't register if the target itself is one of the narrowed places.
+        // Don't register if the target itself is one of the narrowed places (e.g. `x = x is None`),
+        // since the alias would be invalidated immediately by this same assignment.
         let target_is_narrowed = place_table
             .symbol_id(target_name)
             .is_some_and(|symbol| narrowed_places.contains(&symbol.into()));
@@ -765,8 +769,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     narrowed_places,
                 },
             );
-        } else {
-            self.narrowing_aliases.remove(target_name);
         }
     }
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -58,8 +58,8 @@ use crate::use_def::{
 };
 use crate::{Db, Statement, StatementNodeKey};
 use crate::{
-    EvaluationMode, ExpressionsScopeMap, LoopHeader, LoopToken, PossiblyNarrowedPlaces,
-    SemanticIndex, VisibleAncestorsIter, get_loop_header,
+    EvaluationMode, ExpressionsScopeMap, LoopHeader, LoopToken, NarrowingAliasPredicate,
+    PossiblyNarrowedPlaces, SemanticIndex, VisibleAncestorsIter, get_loop_header,
 };
 
 use super::place::PlaceExprRef;
@@ -85,10 +85,24 @@ impl Loop {
     }
 }
 
-struct ScopeInfo {
+/// A narrowing alias: a variable whose RHS is a narrowing expression
+/// (e.g., `is_none = x is None`).
+#[derive(Clone, Debug)]
+struct NarrowingAlias<'ast> {
+    /// The RHS expression (e.g., `x is None`).
+    expression: &'ast ast::Expr,
+    /// The scope whose place table should be used to resolve the aliased expression.
+    expression_scope: FileScopeId,
+    /// Places that, if reassigned, should invalidate this alias.
+    narrowed_places: PossiblyNarrowedPlaces,
+}
+
+struct ScopeInfo<'ast> {
     file_scope_id: FileScopeId,
     /// Current loop state; None if we are not currently visiting a loop
     current_loop: Option<Loop>,
+    /// Saved narrowing aliases from the enclosing scope, restored on `pop_scope`.
+    narrowing_aliases: FxHashMap<Name, NarrowingAlias<'ast>>,
 }
 
 pub(super) struct SemanticIndexBuilder<'db, 'ast> {
@@ -97,7 +111,7 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     file: File,
     source_type: PySourceType,
     module: &'ast ParsedModuleRef,
-    scope_stack: Vec<ScopeInfo>,
+    scope_stack: Vec<ScopeInfo<'ast>>,
     /// The assignments we're currently visiting, with
     /// the most recent visit at the end of the Vec.
     current_assignments: Vec<CurrentAssignment<'ast, 'db>>,
@@ -145,6 +159,13 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, ScopedEnclosingSnapshotId>,
     /// Errors collected by the `semantic_checker`.
     semantic_syntax_errors: RefCell<Vec<SemanticSyntaxError>>,
+
+    /// Maps alias variable names to their narrowing expressions (same-scope only).
+    /// TODO: cross-scope alias narrowing support
+    narrowing_aliases: FxHashMap<Name, NarrowingAlias<'ast>>,
+
+    /// Alias metadata for predicate leaf names in the current file.
+    alias_predicates: FxHashMap<ExpressionNodeKey, NarrowingAliasPredicate<'db>>,
 }
 
 impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
@@ -188,19 +209,21 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             semantic_checker: SemanticSyntaxChecker::default(),
             in_try: false,
             semantic_syntax_errors: RefCell::default(),
+            narrowing_aliases: FxHashMap::default(),
+            alias_predicates: FxHashMap::default(),
         };
 
         builder.push_scope_with_parent(NodeWithScopeRef::Module, None);
         builder
     }
 
-    fn current_scope_info(&self) -> &ScopeInfo {
+    fn current_scope_info(&self) -> &ScopeInfo<'ast> {
         self.scope_stack
             .last()
             .expect("SemanticIndexBuilder should have created a root scope")
     }
 
-    fn current_scope_info_mut(&mut self) -> &mut ScopeInfo {
+    fn current_scope_info_mut(&mut self) -> &mut ScopeInfo<'ast> {
         self.scope_stack
             .last_mut()
             .expect("SemanticIndexBuilder should have created a root scope")
@@ -349,9 +372,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
         debug_assert_eq!(ast_id_scope, file_scope_id);
 
+        // Save narrowing aliases. They will be restored with `pop_scope` after returning from inspecting the inner scope.
+        // TODO: Cross-scope alias narrowing is not supported yet.
+        let saved_aliases = std::mem::take(&mut self.narrowing_aliases);
         self.scope_stack.push(ScopeInfo {
             file_scope_id,
             current_loop: None,
+            narrowing_aliases: saved_aliases,
         });
     }
 
@@ -655,11 +682,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
         let ScopeInfo {
             file_scope_id: popped_scope_id,
+            narrowing_aliases,
             ..
         } = self
             .scope_stack
             .pop()
             .expect("Root scope should be present");
+        self.narrowing_aliases = narrowing_aliases;
 
         let children_end = self.scopes.next_index();
 
@@ -703,6 +732,153 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     fn current_ast_ids(&mut self) -> &mut AstIdsBuilder {
         let scope_id = self.current_scope();
         &mut self.ast_ids[scope_id]
+    }
+
+    /// Try to register a narrowing alias for a simple name assignment.
+    fn try_register_narrowing_alias(&mut self, target: &ast::Expr, value: Option<&'ast ast::Expr>) {
+        let Some(target_name_expr) = target.as_name_expr() else {
+            return;
+        };
+        let Some(value) = value else { return };
+        let target_name = &target_name_expr.id;
+
+        if !Self::can_register_narrowing_alias(value) {
+            self.narrowing_aliases.remove(target_name);
+            return;
+        }
+
+        let place_table = self.current_place_table();
+        let narrowed_places =
+            PossiblyNarrowedPlacesBuilder::new(self.db, place_table).expression(value);
+
+        // Don't register if the target itself is one of the narrowed places.
+        let target_is_narrowed = place_table
+            .symbol_id(target_name)
+            .is_some_and(|symbol| narrowed_places.contains(&symbol.into()));
+
+        if !narrowed_places.is_empty() && !target_is_narrowed {
+            self.narrowing_aliases.insert(
+                target_name.clone(),
+                NarrowingAlias {
+                    expression: value,
+                    expression_scope: self.current_scope(),
+                    narrowed_places,
+                },
+            );
+        } else {
+            self.narrowing_aliases.remove(target_name);
+        }
+    }
+
+    /// Invalidate any narrowing aliases affected by a new definition of `place`.
+    fn invalidate_narrowing_aliases_for(&mut self, place: ScopedPlaceId) {
+        // Remove aliases whose narrowed places include this place.
+        self.narrowing_aliases
+            .retain(|_, alias| !alias.narrowed_places.contains(&place));
+        // Remove alias for the place itself (alias variable reassigned).
+        if let Some(symbol_id) = place.as_symbol() {
+            let name = self.current_place_table().symbol(symbol_id).name().clone();
+            self.narrowing_aliases.remove(&name);
+        }
+    }
+
+    fn can_register_narrowing_alias(value: &ast::Expr) -> bool {
+        match value {
+            // Bare names are too common to treat as alias candidates on every assignment,
+            // and doing so would noticeably degrade performance. Excluding them only means
+            // we don't infer truthiness narrowing for arbitrary chained aliases.
+            ast::Expr::Name(_) => false,
+            ast::Expr::Compare(_) | ast::Expr::Call(_) => true,
+            ast::Expr::UnaryOp(unary) if unary.op == ast::UnaryOp::Not => {
+                Self::can_register_narrowing_alias(&unary.operand)
+            }
+            ast::Expr::BoolOp(bool_op) => bool_op
+                .values
+                .iter()
+                .any(Self::can_register_narrowing_alias),
+            ast::Expr::If(expr_if) => {
+                Self::can_register_narrowing_alias(&expr_if.test)
+                    || Self::can_register_narrowing_alias(&expr_if.body)
+                    || Self::can_register_narrowing_alias(&expr_if.orelse)
+            }
+            _ => false,
+        }
+    }
+
+    /// Walk a predicate expression tree, calling `f` on each leaf position
+    /// where an alias Name could appear.
+    fn walk_narrowing_alias_predicate<'expr>(
+        expr: &'expr ast::Expr,
+        f: &mut impl FnMut(&'expr ast::Expr),
+    ) {
+        match expr {
+            ast::Expr::Name(_) => f(expr),
+            ast::Expr::UnaryOp(unary) if unary.op == ast::UnaryOp::Not => {
+                Self::walk_narrowing_alias_predicate(&unary.operand, f);
+            }
+            ast::Expr::BoolOp(bool_op) => {
+                for value in &bool_op.values {
+                    Self::walk_narrowing_alias_predicate(value, f);
+                }
+            }
+            ast::Expr::Call(call) => {
+                for arg in &call.arguments.args {
+                    Self::walk_narrowing_alias_predicate(arg, f);
+                }
+                for keyword in &call.arguments.keywords {
+                    Self::walk_narrowing_alias_predicate(&keyword.value, f);
+                }
+            }
+            ast::Expr::If(expr_if) => {
+                Self::walk_narrowing_alias_predicate(&expr_if.test, f);
+                Self::walk_narrowing_alias_predicate(&expr_if.body, f);
+                Self::walk_narrowing_alias_predicate(&expr_if.orelse, f);
+            }
+            _ => {}
+        }
+    }
+
+    /// Register alias predicates for alias Names found in a predicate expression.
+    fn register_narrowing_alias_predicates(&mut self, expr: &'ast ast::Expr) {
+        Self::walk_narrowing_alias_predicate(expr, &mut |leaf| {
+            let Some(name) = leaf.as_name_expr() else {
+                return;
+            };
+            let Some(alias) = self.narrowing_aliases.get(&name.id).cloned() else {
+                return;
+            };
+            let aliased_expression = Expression::new(
+                self.db,
+                self.file,
+                alias.expression_scope,
+                AstNodeRef::new(self.module, alias.expression),
+                None,
+                ExpressionKind::Normal,
+            );
+            self.alias_predicates.insert(
+                ExpressionNodeKey::from(leaf),
+                NarrowingAliasPredicate {
+                    expression: aliased_expression,
+                },
+            );
+        });
+    }
+
+    /// Add narrowed places from aliased expressions to the possibly-narrowed set.
+    fn add_alias_narrowed_places(&self, expr: &ast::Expr, places: &mut PossiblyNarrowedPlaces) {
+        Self::walk_narrowing_alias_predicate(expr, &mut |leaf| {
+            let key = ExpressionNodeKey::from(leaf);
+            if let Some(alias_predicate) = self.alias_predicates.get(&key) {
+                let aliased_node = alias_predicate
+                    .expression
+                    .node_ref(self.db)
+                    .node(self.module);
+                let aliased_places =
+                    PossiblyNarrowedPlacesBuilder::new(self.db, self.current_place_table())
+                        .expression(aliased_node);
+                places.extend(aliased_places);
+            }
+        });
     }
 
     fn flow_snapshot(&self) -> FlowSnapshot {
@@ -941,6 +1117,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         // ```
         if category.is_binding() && !is_loop_header {
             self.mark_place_bound(place);
+            self.invalidate_narrowing_aliases_for(place);
         }
         if category.is_declaration() {
             self.mark_place_declared(place);
@@ -1139,14 +1316,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
     fn record_expression_narrowing_constraint(
         &mut self,
-        predicate_node: &ast::Expr,
+        predicate_node: &'ast ast::Expr,
     ) -> (PredicateOrLiteral<'db>, ScopedPredicateId) {
         let predicate = self.build_predicate(predicate_node);
         let predicate_id = self.record_narrowing_constraint(predicate);
         (predicate, predicate_id)
     }
 
-    fn build_predicate(&mut self, predicate_node: &ast::Expr) -> PredicateOrLiteral<'db> {
+    fn build_predicate(&mut self, predicate_node: &'ast ast::Expr) -> PredicateOrLiteral<'db> {
         // Some commonly used test expressions are eagerly evaluated as `true`
         // or `false` here for performance reasons. This list does not need to
         // be exhaustive. More complex expressions will still evaluate to the
@@ -1169,6 +1346,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 _ => None,
             }
         }
+
+        self.register_narrowing_alias_predicates(predicate_node);
 
         let expression = self.add_standalone_expression(predicate_node);
 
@@ -1236,8 +1415,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 match pred.node {
                     PredicateNode::Expression(expression) => {
                         let expression_node = expression.node_ref(self.db).node(self.module);
-                        PossiblyNarrowedPlacesBuilder::new(self.db, place_table)
-                            .expression(expression_node)
+                        let mut places = PossiblyNarrowedPlacesBuilder::new(self.db, place_table)
+                            .expression(expression_node);
+                        self.add_alias_narrowed_places(expression_node, &mut places);
+                        places
                     }
                     PredicateNode::Pattern(pattern) => {
                         let module = self.module;
@@ -1951,6 +2132,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             enclosing_snapshots: self.enclosing_snapshots,
             semantic_syntax_errors: self.semantic_syntax_errors.into_inner(),
             generator_functions: self.generator_functions,
+            narrowing_alias_predicates: self.alias_predicates,
         }
     }
 
@@ -2373,6 +2555,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     self.push_assignment(CurrentAssignment::Assign { node, unpack: None });
                     self.visit_expr(target);
                     self.pop_assignment();
+
+                    self.try_register_narrowing_alias(target, Some(&node.value));
                 } else {
                     let value = self.add_standalone_assigned_expression(&node.value, node);
 
@@ -2426,6 +2610,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     self.push_assignment(node.into());
                     self.visit_expr(&node.target);
                     self.pop_assignment();
+
+                    self.try_register_narrowing_alias(&node.target, node.value.as_deref());
                 } else {
                     self.visit_expr(&node.target);
                 }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -772,9 +772,17 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
     /// Invalidate any narrowing aliases affected by a new definition of `place`.
     fn invalidate_narrowing_aliases_for(&mut self, place: ScopedPlaceId) {
-        // Remove aliases whose narrowed places include this place.
-        self.narrowing_aliases
-            .retain(|_, alias| !alias.narrowed_places.contains(&place));
+        // Also invalidate aliases that narrow any member of `place`.
+        let associated_members = self
+            .current_place_table()
+            .associated_place_ids(place)
+            .to_vec();
+        self.narrowing_aliases.retain(|_, alias| {
+            !alias.narrowed_places.contains(&place)
+                && !associated_members
+                    .iter()
+                    .any(|m| alias.narrowed_places.contains(&(*m).into()))
+        });
         // Remove alias for the place itself (alias variable reassigned).
         if let Some(symbol_id) = place.as_symbol() {
             let name = self.current_place_table().symbol(symbol_id).name().clone();
@@ -3279,6 +3287,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         }
 
                         let place_id = self.add_place(target);
+                        self.invalidate_narrowing_aliases_for(place_id);
                         self.delete_binding(place_id);
                     }
                 }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -774,22 +774,24 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
     /// Invalidate any narrowing aliases affected by a new definition of `place`.
     fn invalidate_narrowing_aliases_for(&mut self, place: ScopedPlaceId) {
-        // Also invalidate aliases that narrow any member of `place`.
-        let associated_members = self
-            .current_place_table()
-            .associated_place_ids(place)
-            .to_vec();
-        self.narrowing_aliases.retain(|_, alias| {
+        let place_table = &self.place_tables[self.current_scope()];
+        let associated_members = place_table.associated_place_ids(place);
+        let reassigned_alias_name = place
+            .as_symbol()
+            .map(|symbol_id| place_table.symbol(symbol_id).name());
+
+        self.narrowing_aliases.retain(|name, alias| {
+            // Drop aliases that narrow the reassigned place or any of its members.
+            //  e.g. `is_none = x is None and ...; x = 1`
             !alias.narrowed_places.contains(&place)
+                //  e.g. `is_none = a.x is None; a = A()`
                 && !associated_members
                     .iter()
                     .any(|m| alias.narrowed_places.contains(&(*m).into()))
+                // Drop the alias whose own variable is the reassigned place.
+                // e.g. `is_none = x is None; is_none = False`
+                && reassigned_alias_name != Some(name)
         });
-        // Remove alias for the place itself (alias variable reassigned).
-        if let Some(symbol_id) = place.as_symbol() {
-            let name = self.current_place_table().symbol(symbol_id).name().clone();
-            self.narrowing_aliases.remove(&name);
-        }
     }
 
     fn can_register_narrowing_alias(value: &ast::Expr) -> bool {

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -307,6 +307,17 @@ pub struct SemanticIndex<'db> {
 
     /// Set of all generator functions in this file.
     generator_functions: FxHashSet<FileScopeId>,
+
+    /// Narrowing alias metadata for predicate leaf names.
+    /// When a predicate references an alias variable (e.g., `is_none` from `is_none = x is None`),
+    /// the alias Name node is mapped to its aliased expression for constraint-generation time.
+    narrowing_alias_predicates: FxHashMap<ExpressionNodeKey, NarrowingAliasPredicate<'db>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+pub struct NarrowingAliasPredicate<'db> {
+    /// Aliased expression, e.g., `x is None` in `is_none = x is None`.
+    pub expression: Expression<'db>,
 }
 
 impl<'db> SemanticIndex<'db> {
@@ -317,6 +328,14 @@ impl<'db> SemanticIndex<'db> {
     #[track_caller]
     pub fn place_table(&self, scope_id: FileScopeId) -> &PlaceTable {
         &self.place_tables[scope_id]
+    }
+
+    /// Returns alias metadata for an alias Name node in a predicate, if one exists.
+    pub fn narrowing_alias_predicate(
+        &self,
+        key: impl Into<ExpressionNodeKey>,
+    ) -> Option<&NarrowingAliasPredicate<'db>> {
+        self.narrowing_alias_predicates.get(&key.into())
     }
 
     /// Returns the use-def map for a specific scope.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -208,8 +208,8 @@ def _(l: list[int | None], lb: list[bool]):
 
 ## Narrowing is invalidated when target is reassigned
 
-If the narrowed variable is reassigned between the alias and its use as a condition, the alias must
-not be followed.
+If the target is reassigned between the definition of the alias and its use as a condition,
+narrowing does not take place:
 
 ```py
 def _(x: int | None, cond: bool):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -324,7 +324,7 @@ def _(a: A):
 
 ## Cross-scope invalidation
 
-### Narrowed variable reassigned
+### Target reassignments
 
 If the target is reassigned inside an eager scope, narrowing does not take place within that scope.
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -271,12 +271,12 @@ def _(x: int | None):
     if is_none:
         reveal_type(x)  # revealed: None
 
-    class Inner:
+    class EagerScope:
         if is_none:
             # TODO: should be `None`
             reveal_type(x)  # revealed: int | None
 
-        def inner():
+        def lazy_scope():
             if is_none:
                 # TODO: should be `None`
                 reveal_type(x)  # revealed: int | None

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -1,0 +1,713 @@
+# Narrowing with aliased conditions
+
+Narrowing is supported when a narrowing expression is stored in an intermediate variable (an
+"aliased conditional expression") and that variable is later used as a condition.
+
+## `is None` alias
+
+```py
+def _(x: int | None):
+    is_none = x is None
+    if is_none:
+        reveal_type(x)  # revealed: None
+    else:
+        reveal_type(x)  # revealed: int
+
+def _(x: int | None):
+    is_none: bool = x is None
+    if is_none:
+        reveal_type(x)  # revealed: None
+    else:
+        reveal_type(x)  # revealed: int
+```
+
+## `is not None` alias
+
+```py
+def _(x: int | None):
+    is_not_none = x is not None
+    if is_not_none:
+        reveal_type(x)  # revealed: int
+    else:
+        reveal_type(x)  # revealed: None
+```
+
+## `isinstance` alias
+
+```py
+def _(x: int | None):
+    is_int = isinstance(x, int)
+    if is_int:
+        reveal_type(x)  # revealed: int
+    else:
+        reveal_type(x)  # revealed: None
+```
+
+## Equality comparisons
+
+```py
+from typing import Literal
+
+def _(x: Literal[1, 2]):
+    is_one = x == 1
+    if is_one:
+        reveal_type(x)  # revealed: Literal[1]
+    else:
+        reveal_type(x)  # revealed: Literal[2]
+```
+
+## `TypeGuard`/`TypeIs` alias
+
+```py
+from typing_extensions import TypeGuard, TypeIs
+
+def is_int(x: object) -> TypeGuard[int]:
+    return isinstance(x, int)
+
+def _(x: int | None):
+    is_i = is_int(x)
+    if is_i:
+        reveal_type(x)  # revealed: int
+    else:
+        reveal_type(x)  # revealed: int | None
+
+def is_int2(x: object) -> TypeIs[int]:
+    return isinstance(x, int)
+
+def _(x: int | None):
+    is_i = is_int2(x)
+    if is_i:
+        reveal_type(x)  # revealed: int
+    else:
+        reveal_type(x)  # revealed: None
+```
+
+## `if` expression alias
+
+```py
+def _(x: int | None):
+    is_none = x is None if True else False
+    if is_none:
+        reveal_type(x)  # revealed: None
+    else:
+        reveal_type(x)  # revealed: int
+```
+
+## `bool()` alias
+
+```py
+def _(x: int | None):
+    is_none = bool(x is None)
+    if is_none:
+        reveal_type(x)  # revealed: None
+    else:
+        reveal_type(x)  # revealed: int
+```
+
+## Negated alias with `not`
+
+```py
+def _(x: int | None):
+    is_none = x is None
+    if not is_none:
+        reveal_type(x)  # revealed: int
+    else:
+        reveal_type(x)  # revealed: None
+```
+
+## Boolean-operated alias
+
+```py
+def _(x: str | int | None):
+    is_none = x is None
+    is_int = isinstance(x, int)
+    if is_none:
+        reveal_type(x)  # revealed: None
+    if is_int:
+        reveal_type(x)  # revealed: int
+    if is_none or is_int:
+        reveal_type(is_none)  # revealed: bool
+        reveal_type(x)  # revealed: None | int
+    if is_none and is_int:
+        reveal_type(is_none)  # revealed: Literal[True]
+        reveal_type(x)  # revealed: Never
+    if not (is_none or is_int):
+        reveal_type(is_none)  # revealed: Literal[False]
+        reveal_type(x)  # revealed: str
+```
+
+## Aliases in complex predicates
+
+```py
+def _(x: int | None):
+    is_none = x is None
+    if bool(is_none):
+        reveal_type(x)  # revealed: None
+    if is_none if True else False:
+        reveal_type(x)  # revealed: None
+    if is_none == True:
+        # TODO: it would be nice to support this case, but even direct narrowing doesn't work here
+        reveal_type(x)  # revealed: int | None
+    if (is_none,)[0]:
+        # TODO: same as above
+        reveal_type(x)  # revealed: int | None
+    if y := is_none:
+        # TODO: same as above
+        reveal_type(x)  # revealed: int | None
+    if (lambda: is_none)():
+        # TODO: same as above
+        reveal_type(x)  # revealed: int | None
+```
+
+## Attribute access alias
+
+```py
+class A:
+    x: int | None
+    b: bool
+
+    def negate_b(self):
+        self.b = not self.b
+
+def _(a: A):
+    is_none = a.x is None
+    if is_none:
+        reveal_type(a.x)  # revealed: None
+    else:
+        reveal_type(a.x)  # revealed: int
+
+def _(a: A):
+    is_none = a.x is None
+    a.x = 1
+    if is_none:
+        reveal_type(a.x)  # revealed: Literal[1]
+
+def _(a: A):
+    # Attribute targets are not treated as aliases.
+    # It is difficult to track them accurately.
+    a.b = a.x is None
+    a.negate_b()
+    if a.b:
+        reveal_type(a.x)  # revealed: int | None
+    else:
+        reveal_type(a.x)  # revealed: int | None
+```
+
+## Subscript access alias
+
+```py
+def _(l: list[int | None]):
+    is_none = l[0] is None
+    if is_none:
+        reveal_type(l[0])  # revealed: None
+    else:
+        reveal_type(l[0])  # revealed: int
+
+def _(l: list[int | None], lb: list[bool]):
+    # Same as attributes: subscript targets are not treated as aliases.
+    lb[0] = l[0] is None
+    if lb[0]:
+        reveal_type(l[0])  # revealed: int | None
+    else:
+        reveal_type(l[0])  # revealed: int | None
+```
+
+## Narrowed variable reassigned invalidates alias
+
+If the narrowed variable is reassigned between the alias and its use as a condition, the alias must
+not be followed.
+
+```py
+def _(x: int | None, cond: bool):
+    is_none = x is None
+    if cond:
+        x = 1
+    if is_none:
+        reveal_type(x)  # revealed: int | None
+
+    is_none = x is None
+    if is_none:
+        reveal_type(x)  # revealed: None
+```
+
+## Alias variable reassigned invalidates alias
+
+If the alias variable itself is reassigned, it no longer represents the original check.
+
+```py
+def _(x: int | None):
+    is_none = x is None
+    is_none = True
+    if is_none:
+        reveal_type(x)  # revealed: int | None
+
+    is_none = x is None
+    if is_none:
+        reveal_type(x)  # revealed: None
+```
+
+## Nested scope can preserve alias
+
+> TODO: This feature is not supported yet.
+
+Aliases remain valid inside nested scopes. For eager scopes (class bodies, comprehensions) they are
+evaluated inline. For lazy scopes (inner functions), the narrowing evaluator uses lazy snapshots to
+track whether the narrowed variable was reassigned, so alias-based narrowing works the same as
+direct narrowing across scope boundaries.
+
+```py
+def _(x: int | None):
+    is_none = x is None
+
+    if is_none:
+        reveal_type(x)  # revealed: None
+
+    class Inner:
+        if is_none:
+            # TODO: should be `None`
+            reveal_type(x)  # revealed: int | None
+
+        def inner():
+            if is_none:
+                # TODO: should be `None`
+                reveal_type(x)  # revealed: int | None
+
+    def inner2():
+        if is_none:
+            # TODO: should be `None`
+            reveal_type(x)  # revealed: int | None
+
+        class Inner2:
+            if is_none:
+                # TODO: should be `None`
+                reveal_type(x)  # revealed: int | None
+
+class A:
+    x: int | None
+
+def _(a: A):
+    a = A()
+    a.x = None
+    is_none = a.x is None
+
+    if is_none:
+        reveal_type(a.x)  # revealed: None
+
+    class Inner:
+        if is_none:
+            reveal_type(a.x)  # revealed: None
+
+        def inner():
+            if is_none:
+                # TODO: should be `None`
+                reveal_type(a.x)  # revealed: int | None
+
+    def inner2():
+        if is_none:
+            # TODO: should be `None`
+            reveal_type(a.x)  # revealed: int | None
+
+        class Inner2:
+            if is_none:
+                # TODO: should be `None`
+                reveal_type(a.x)  # revealed: int | None
+```
+
+## Cross-scope invalidation
+
+### Narrowed variable reassigned
+
+If the narrowed variable is reassigned inside an eager scope, the alias is invalidated within that
+scope.
+
+```py
+def _(x: int | None):
+    is_none = x is None
+
+    class Inner:
+        x = 42
+        x = 43
+        if is_none:
+            reveal_type(x)  # revealed: Literal[43]
+
+        def f():
+            reveal_type(x)  # revealed: int | None
+            if is_none:
+                # TODO: should be `None`
+                reveal_type(x)  # revealed: int | None
+
+        class Inner2:
+            if is_none:
+                # `x` here refers to the function scope variable, not the class-scope `x`.
+                # Python's name resolution skips class scopes for nested scopes, so the alias
+                # remains valid.
+                # TODO: should be `None`
+                reveal_type(x)  # revealed: int | None
+
+    if is_none:
+        reveal_type(x)  # revealed: None
+```
+
+The same applies to a lazy scope:
+
+```py
+def _(x: int | None):
+    is_none = x is None
+
+    def inner():
+        nonlocal x
+        x = 42
+        if is_none:
+            reveal_type(x)  # revealed: Literal[42]
+
+    # TODO: should be `int | None`
+    # We don't yet track that `inner()` can modify `x` via `nonlocal`.
+    # (https://github.com/astral-sh/ty/issues/2731)
+    if is_none:
+        reveal_type(x)  # revealed: None
+
+def _(x: int | None):
+    is_none = x is None
+
+    def inner():
+        if is_none:
+            reveal_type(x)  # revealed: int | None
+
+        def inner2():
+            if is_none:
+                reveal_type(x)  # revealed: int | None
+
+    x = 42
+
+    inner()
+```
+
+### Alias variable reassigned
+
+If the alias variable itself is reassigned inside an eager scope, the alias is invalidated within
+that scope.
+
+```py
+def _(x: int | None):
+    is_none = x is None
+
+    class Inner:
+        is_none = True
+        if is_none:
+            reveal_type(x)  # revealed: int | None
+
+        class Inner2:
+            # `is_none` here refers to the function scope variable, not the class-scope
+            # `is_none = True`. Python's name resolution skips class scopes for nested
+            # scopes, so the alias remains valid.
+            if is_none:
+                # TODO: should be `None`
+                reveal_type(x)  # revealed: int | None
+
+    if is_none:
+        reveal_type(x)  # revealed: None
+```
+
+The same applies to a lazy scope:
+
+```py
+def _(x: int | None):
+    is_none = x is None
+
+    def inner():
+        nonlocal is_none
+        is_none = True
+        if is_none:
+            reveal_type(x)  # revealed: int | None
+
+    inner()
+
+    # TODO: should be `int | None`
+    # We don't yet track that `inner()` can modify `is_none` via `nonlocal`.
+    # (https://github.com/astral-sh/ty/issues/2731)
+    if is_none:
+        reveal_type(x)  # revealed: None
+
+def _(x: int | None):
+    is_none = x is None
+
+    def inner():
+        if is_none:
+            reveal_type(x)  # revealed: int | None
+
+        def inner2():
+            if is_none:
+                reveal_type(x)  # revealed: int | None
+
+    is_none = True
+
+    inner()
+```
+
+## Chained alias
+
+> TODO: This feature is not supported yet.
+
+### Basic
+
+```py
+def _(x: int | None):
+    is_none = x is None
+    is_none_alias = is_none
+    if is_none_alias:
+        # TODO: should be `None`
+        reveal_type(x)  # revealed: int | None
+
+    class Inner:
+        if is_none_alias:
+            # TODO: should be `None`
+            reveal_type(x)  # revealed: int | None
+
+    def inner():
+        if is_none_alias:
+            # TODO: should be `None`
+            reveal_type(x)  # revealed: int | None
+
+def _(x: int | None):
+    is_none = x is None
+    is_none_alias = is_none
+
+    x = 42
+
+    if is_none_alias:
+        reveal_type(x)  # revealed: Literal[42]
+    if is_none:
+        reveal_type(x)  # revealed: Literal[42]
+
+    class Inner:
+        if is_none_alias:
+            reveal_type(x)  # revealed: Literal[42]
+        if is_none:
+            reveal_type(x)  # revealed: Literal[42]
+
+    def inner():
+        x = 42
+        if is_none_alias:
+            reveal_type(x)  # revealed: Literal[42]
+        if is_none:
+            reveal_type(x)  # revealed: Literal[42]
+
+def _(x: int | None):
+    is_none = x is None
+    is_none_alias = is_none
+
+    class Inner:
+        is_none_alias = True
+        if is_none_alias:
+            reveal_type(x)  # revealed: int | None
+        if is_none:
+            # TODO: should be `None`
+            reveal_type(x)  # revealed: int | None
+
+        class Inner2:
+            if is_none_alias:
+                # TODO: should be `None`
+                reveal_type(x)  # revealed: int | None
+            if is_none:
+                # TODO: should be `None`
+                reveal_type(x)  # revealed: int | None
+
+    class Inner2:
+        is_none = True
+        if is_none_alias:
+            # TODO: should be `None`
+            reveal_type(x)  # revealed: int | None
+        if is_none:
+            reveal_type(x)  # revealed: int | None
+
+        class Inner3:
+            if is_none_alias:
+                # TODO: should be `None`
+                reveal_type(x)  # revealed: int | None
+            if is_none:
+                # TODO: should be `None`
+                reveal_type(x)  # revealed: int | None
+
+    def inner():
+        is_none_alias = True
+        if is_none_alias:
+            reveal_type(x)  # revealed: int | None
+        if is_none:
+            # TODO: should be `None`
+            reveal_type(x)  # revealed: int | None
+
+        def inner2():
+            if is_none_alias:
+                reveal_type(x)  # revealed: int | None
+            if is_none:
+                # TODO: should be `None`
+                reveal_type(x)  # revealed: int | None
+
+    def inner2():
+        is_none = True
+        if is_none_alias:
+            # TODO: should be `None`
+            reveal_type(x)  # revealed: int | None
+        if is_none:
+            reveal_type(x)  # revealed: int | None
+
+        def inner3():
+            if is_none_alias:
+                # TODO: should be `None`
+                reveal_type(x)  # revealed: int | None
+            if is_none:
+                reveal_type(x)  # revealed: int | None
+```
+
+### Cross-scope chained alias
+
+```py
+def _(x: int | None):
+    is_none = x is None
+
+    class Inner:
+        is_none_alias = is_none
+        if is_none_alias:
+            # TODO: should be `None`
+            reveal_type(x)  # revealed: int | None
+
+    def inner():
+        is_none_alias = is_none
+        if is_none_alias:
+            # TODO: should be `None`
+            reveal_type(x)  # revealed: int | None
+
+is_none = True
+
+def _(x: int | None):
+    is_none = x is None
+
+    class Inner:
+        # This resolves to the global `is_none`!
+        is_none_alias = is_none
+        is_none = False
+        reveal_type(is_none_alias)  # revealed: Literal[True]
+        if is_none_alias:
+            reveal_type(x)  # revealed: int | None
+
+    def inner():
+        # error: [unresolved-reference] "Name `is_none` used when not defined"
+        is_none_alias = is_none
+        is_none = True
+        if is_none_alias:
+            reveal_type(x)  # revealed: int | None
+
+def _(x: int | None):
+    is_none = x is None
+
+    class Inner:
+        is_none_alias = is_none
+        x = 42
+        if is_none_alias:
+            reveal_type(x)  # revealed: Literal[42]
+
+    def inner():
+        is_none_alias = is_none
+        x = 42
+        if is_none_alias:
+            reveal_type(x)  # revealed: Literal[42]
+```
+
+### Negated chained alias
+
+```py
+def _(x: int | None):
+    is_none = x is None
+    is_not_none = not is_none
+    if is_not_none:
+        # TODO: should be `int`
+        reveal_type(x)  # revealed: int | None
+
+    class Inner:
+        if is_not_none:
+            # TODO: should be `int`
+            reveal_type(x)  # revealed: int | None
+
+    def inner():
+        if is_not_none:
+            # TODO: should be `int`
+            reveal_type(x)  # revealed: int | None
+
+def _(x: int | None):
+    is_none = x is None
+    is_not_none = not is_none
+    if is_not_none:
+        # TODO: should be `int`
+        reveal_type(x)  # revealed: int | None
+
+    class Inner:
+        x = 42
+        if is_not_none:
+            reveal_type(x)  # revealed: Literal[42]
+
+    def inner():
+        x = 42
+        if is_not_none:
+            reveal_type(x)  # revealed: Literal[42]
+
+def _(x: int | None):
+    is_none = x is None
+    is_not_none = not is_none
+
+    is_none = True
+    if is_not_none:
+        # TODO: should be `int`
+        reveal_type(x)  # revealed: int | None
+
+    class Inner:
+        is_none = True
+        if is_not_none:
+            # TODO: should be `int`
+            reveal_type(x)  # revealed: int | None
+
+    def inner():
+        is_none = True
+        if is_not_none:
+            # TODO: should be `int`
+            reveal_type(x)  # revealed: int | None
+```
+
+### Boolean-operated chained alias
+
+```py
+def _(x: int | None):
+    is_none = x is None
+    is_int = isinstance(x, int)
+    is_none_and_int = is_none and is_int
+    if is_none_and_int:
+        # TODO: should be `Never`
+        reveal_type(x)  # revealed: int | None
+
+    class Inner:
+        if is_none_and_int:
+            # TODO: should be `Never`
+            reveal_type(x)  # revealed: int | None
+
+    def inner():
+        if is_none_and_int:
+            # TODO: should be `Never`
+            reveal_type(x)  # revealed: int | None
+
+def _(x: str | int | None):
+    is_none = x is None
+    is_int = isinstance(x, int)
+    is_int_or_none = is_int or is_none
+    if is_int_or_none:
+        # TODO: should be `int | None`
+        reveal_type(x)  # revealed: str | int | None
+
+    class Inner:
+        if is_int_or_none:
+            # TODO: should be `int | None`
+            reveal_type(x)  # revealed: str | int | None
+
+    def inner():
+        if is_int_or_none:
+            # TODO: should be `int | None`
+            reveal_type(x)  # revealed: str | int | None
+```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -259,10 +259,12 @@ def _(x: int | None):
 
 > TODO: This feature is not supported yet.
 
-Aliases remain valid inside nested scopes. For eager scopes (class bodies, comprehensions) they are
-evaluated inline. For lazy scopes (inner functions), the narrowing evaluator uses lazy snapshots to
-track whether the narrowed variable was reassigned, so alias-based narrowing works the same as
-direct narrowing across scope boundaries.
+Aliases defined in the outer scope behave the same way across nested scope boundaries as if the
+target had been directly narrowed (see also: [`conditionals/nested.md`](./conditionals/nested.md)).
+
+In other words, in eager scope (class body, list comprehension, etc.), the alias is adopted as it
+was when it entered the scope. In lazy scope (function body, etc.), the alias remains valid unless
+either the target or the alias is reassigned.
 
 ```py
 def _(x: int | None):
@@ -296,7 +298,6 @@ class A:
 
 def _(a: A):
     a = A()
-    a.x = None
     is_none = a.x is None
 
     if is_none:
@@ -304,7 +305,8 @@ def _(a: A):
 
     class Inner:
         if is_none:
-            reveal_type(a.x)  # revealed: None
+            # TODO: should be `None`
+            reveal_type(a.x)  # revealed: int | None
 
         def inner():
             if is_none:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -326,8 +326,7 @@ def _(a: A):
 
 ### Narrowed variable reassigned
 
-If the narrowed variable is reassigned inside an eager scope, the alias is invalidated within that
-scope.
+If the target is reassigned inside an eager scope, narrowing does not take place within that scope.
 
 ```py
 def _(x: int | None):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -452,7 +452,7 @@ def _(x: int | None):
     inner()
 ```
 
-## Chained alias
+## Chained aliases
 
 > TODO: This feature is not supported yet.
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -177,12 +177,6 @@ def _(a: A):
         reveal_type(a.x)  # revealed: int
 
 def _(a: A):
-    is_none = a.x is None
-    a.x = 1
-    if is_none:
-        reveal_type(a.x)  # revealed: Literal[1]
-
-def _(a: A):
     # Attribute targets are not treated as aliases.
     # It is difficult to track them accurately.
     a.b = a.x is None
@@ -228,6 +222,21 @@ def _(x: int | None, cond: bool):
     is_none = x is None
     if is_none:
         reveal_type(x)  # revealed: None
+
+class A:
+    x: int | None
+
+def _(a: A):
+    is_none = a.x is None
+    a.x = 1
+    if is_none:
+        reveal_type(a.x)  # revealed: Literal[1]
+
+def _(a: A):
+    is_none = a.x is None
+    a = A()
+    if is_none:
+        reveal_type(a.x)  # revealed: int | None
 ```
 
 ## Alias variable reassigned invalidates alias

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -237,6 +237,14 @@ def _(a: A):
     a = A()
     if is_none:
         reveal_type(a.x)  # revealed: int | None
+
+def _(x: int | None):
+    # In-place reassignment
+    x = x is None
+    if x:
+        reveal_type(x)  # revealed: Literal[True]
+    else:
+        reveal_type(x)  # revealed: Literal[False]
 ```
 
 ## Alias variable reassigned invalidates alias

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -206,7 +206,7 @@ def _(l: list[int | None], lb: list[bool]):
         reveal_type(l[0])  # revealed: int | None
 ```
 
-## Narrowed variable reassigned invalidates alias
+## Narrowing is invalidated when target is reassigned
 
 If the narrowed variable is reassigned between the alias and its use as a condition, the alias must
 not be followed.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -721,3 +721,41 @@ def _(x: str | int | None):
             # TODO: should be `int | None`
             reveal_type(x)  # revealed: str | int | None
 ```
+
+## Simple name aliases do not have a narrowing effect
+
+This is a technical limitation: simple name aliases are so common in real-world Python code that
+assuming all of them are subject to alias narrowing would lead to performance degradation. TODO: It
+would be nice if we could resolve this limitation, but it probably won't be a serious issue in
+practice.
+
+```py
+def _(x: int, y: bool):
+    if x:
+        reveal_type(x)  # revealed: int & ~AlwaysFalsy
+    if y:
+        reveal_type(y)  # revealed: Literal[True]
+    if x and y:
+        reveal_type(x)  # revealed: int & ~AlwaysFalsy
+        reveal_type(y)  # revealed: Literal[True]
+
+    x_alias = x
+    y_alias = y
+    if x_alias:
+        reveal_type(x)  # revealed: int
+    if y_alias:
+        reveal_type(y)  # revealed: bool
+    if x_alias and y_alias:
+        reveal_type(x)  # revealed: int
+        reveal_type(y)  # revealed: bool
+
+    x_alias2 = bool(x)
+    y_alias2 = bool(y)
+    if x_alias2:
+        reveal_type(x)  # revealed: int & ~AlwaysFalsy
+    if y_alias2:
+        reveal_type(y)  # revealed: Literal[True]
+    if x_alias2 and y_alias2:
+        reveal_type(x)  # revealed: int & ~AlwaysFalsy
+        reveal_type(y)  # revealed: Literal[True]
+```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -343,17 +343,14 @@ def _(a: Foo | Bar):
     reveal_type(c)  # revealed: TypeIs[Bar @ a]
 
     if b:
-        # TODO should be `Foo`
-        reveal_type(a)  # revealed: Foo | Bar
+        reveal_type(a)  # revealed: Foo
     else:
         reveal_type(a)  # revealed: Foo | Bar
 
     if c:
-        # TODO should be `Bar`
-        reveal_type(a)  # revealed: Foo | Bar
+        reveal_type(a)  # revealed: Bar
     else:
-        # TODO should be `Foo & ~Bar`
-        reveal_type(a)  # revealed: Foo | Bar
+        reveal_type(a)  # revealed: Foo & ~Bar
 ```
 
 Further writes to the narrowed place invalidate the narrowing:

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -636,6 +636,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 if let Some(alias_predicate) = index.narrowing_alias_predicate(expression_node) {
                     let aliased_constraints =
                         self.evaluate_expression_predicate(alias_predicate.expression, is_positive);
+                    // For example, suppose we have an alias `is_none = x is None`.
+                    // When this alias is used for narrowing, that is, within a block like `if is_none: ...`,
+                    // both the constraint `is_none: Literal[True]` and the constraint `x: None` should be imposed.
+                    // The former is `constraints` and the latter is `aliased_constraints`.
                     Self::merge_optional_constraints_and(constraints, aliased_constraints)
                 } else {
                     constraints

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -20,7 +20,7 @@ use ty_python_core::predicate::{
     PredicateNode,
 };
 use ty_python_core::scope::ScopeId;
-use ty_python_core::{NarrowingEvaluator, place_table};
+use ty_python_core::{NarrowingEvaluator, place_table, semantic_index};
 
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_python_ast::name::Name;
@@ -629,7 +629,19 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
         match expression_node {
-            ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::Subscript(_) => {
+            ast::Expr::Name(_) => {
+                let file = expression.file(self.db);
+                let index = semantic_index(self.db, file);
+                let constraints = self.evaluate_simple_expr(expression_node, is_positive);
+                if let Some(alias_predicate) = index.narrowing_alias_predicate(expression_node) {
+                    let aliased_constraints =
+                        self.evaluate_expression_predicate(alias_predicate.expression, is_positive);
+                    Self::merge_optional_constraints_and(constraints, aliased_constraints)
+                } else {
+                    constraints
+                }
+            }
+            ast::Expr::Attribute(_) | ast::Expr::Subscript(_) => {
                 self.evaluate_simple_expr(expression_node, is_positive)
             }
             ast::Expr::Compare(expr_compare) => {


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ty/issues/719 (almost)

From #23937

A complete implementation is already available in #23937. However, due to the complexity of the mechanism, I decided to extract only the basic support. As explicitly stated in mdtest, this PR does not yet implement support for cross-scope alias narrowing and chained aliases.

## Test Plan

new mdtest: narrow/aliased_conditions.md
