### PR TITLE
feat: added isort options for completeness

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/isort/group_by_package.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/group_by_package.py
@@ -1,0 +1,6 @@
+from a import b
+import a.c
+from a.d import e
+import a
+from b import a
+import a.e

--- a/crates/ruff_linter/resources/test/fixtures/isort/lexicographical.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/lexicographical.py
@@ -1,0 +1,7 @@
+import a2
+import a12
+import a1
+import a13
+import a20
+import a100
+import a3

--- a/crates/ruff_linter/resources/test/fixtures/isort/line_length.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/line_length.py
@@ -1,0 +1,1 @@
+from my_module import a_very_long_name_that_should_not_wrap_if_line_length_is_high_enough

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -78,6 +78,7 @@ pub(crate) fn format_imports(
     settings: &Settings,
     tokens: &Tokens,
 ) -> String {
+    let line_length = settings.line_length.unwrap_or(line_length);
     let trailer = &block.trailer;
     let block = annotate_imports(
         &block.imports,
@@ -288,6 +289,7 @@ mod tests {
     use ruff_python_semantic::{MemberNameImport, ModuleNameImport, NameImport};
 
     use crate::assert_diagnostics;
+    use crate::line_width::LineLength;
     use crate::registry::Rule;
     use crate::rules::isort::categorize::{ImportSection, KnownModules};
     use crate::settings::LinterSettings;
@@ -599,6 +601,62 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Path::new("group_by_package.py"))]
+    fn group_by_package(path: &Path) -> Result<()> {
+        let snapshot = format!("group_by_package_{}", path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("isort").join(path).as_path(),
+            &LinterSettings {
+                isort: super::settings::Settings {
+                    group_by_package: true,
+                    force_sort_within_sections: true,
+                    ..super::settings::Settings::default()
+                },
+                src: vec![test_resource_path("fixtures/isort")],
+                ..LinterSettings::for_rule(Rule::UnsortedImports)
+            },
+        )?;
+        assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Path::new("lexicographical.py"))]
+    fn lexicographical(path: &Path) -> Result<()> {
+        let snapshot = format!("lexicographical_{}", path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("isort").join(path).as_path(),
+            &LinterSettings {
+                isort: super::settings::Settings {
+                    lexicographical: true,
+                    ..super::settings::Settings::default()
+                },
+                src: vec![test_resource_path("fixtures/isort")],
+                ..LinterSettings::for_rule(Rule::UnsortedImports)
+            },
+        )?;
+        assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Path::new("line_length.py"))]
+    fn line_length(path: &Path) -> Result<()> {
+        let snapshot = format!("line_length_{}", path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("isort").join(path).as_path(),
+            &LinterSettings {
+                isort: super::settings::Settings {
+                    line_length: Some(LineLength::try_from(120).unwrap()),
+                    ..super::settings::Settings::default()
+                },
+                line_length: LineLength::try_from(10).unwrap(), // Global constraint defaults to very narrow (causing wrap)
+                src: vec![test_resource_path("fixtures/isort")],
+                ..LinterSettings::for_rule(Rule::UnsortedImports)
+            },
+        )?;
+        assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
+
     #[test_case(Path::new("force_single_line.py"))]
     fn force_single_line(path: &Path) -> Result<()> {
         let snapshot = format!("force_single_line_{}", path.to_string_lossy());
@@ -620,6 +678,8 @@ mod tests {
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())
     }
+
+
 
     #[test_case(Path::new("propagate_inline_comments.py"))]
     fn propagate_inline_comments(path: &Path) -> Result<()> {

--- a/crates/ruff_linter/src/rules/isort/order.rs
+++ b/crates/ruff_linter/src/rules/isort/order.rs
@@ -82,7 +82,7 @@ pub(crate) fn order_imports<'a>(
                     .map(Import),
             )
             .collect()
-    } else if settings.force_sort_within_sections {
+    } else if settings.force_sort_within_sections || settings.lexicographical {
         straight_imports
             .map(Import)
             .chain(from_imports.map(ImportFrom))

--- a/crates/ruff_linter/src/rules/isort/settings.rs
+++ b/crates/ruff_linter/src/rules/isort/settings.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 
 use crate::display_settings;
+use crate::line_width::LineLength;
 use crate::rules::isort::ImportType;
 use crate::rules::isort::categorize::KnownModules;
 use ruff_macros::CacheKey;
@@ -47,6 +48,8 @@ pub struct Settings {
     pub combine_as_imports: bool,
     pub force_single_line: bool,
     pub force_sort_within_sections: bool,
+    pub lexicographical: bool,
+    pub group_by_package: bool,
     pub case_sensitive: bool,
     pub force_wrap_aliases: bool,
     pub force_to_top: FxHashSet<String>,
@@ -69,6 +72,7 @@ pub struct Settings {
     pub from_first: bool,
     pub length_sort: bool,
     pub length_sort_straight: bool,
+    pub line_length: Option<LineLength>,
 }
 
 impl Settings {
@@ -101,6 +105,8 @@ impl Default for Settings {
             combine_as_imports: false,
             force_single_line: false,
             force_sort_within_sections: false,
+            lexicographical: false,
+            group_by_package: false,
             detect_same_package: true,
             case_sensitive: false,
             force_wrap_aliases: false,
@@ -123,6 +129,7 @@ impl Default for Settings {
             from_first: false,
             length_sort: false,
             length_sort_straight: false,
+            line_length: None,
         }
     }
 }
@@ -137,6 +144,8 @@ impl Display for Settings {
                 self.combine_as_imports,
                 self.force_single_line,
                 self.force_sort_within_sections,
+                self.lexicographical,
+                self.group_by_package,
                 self.detect_same_package,
                 self.case_sensitive,
                 self.force_wrap_aliases,
@@ -158,7 +167,8 @@ impl Display for Settings {
                 self.no_sections,
                 self.from_first,
                 self.length_sort,
-                self.length_sort_straight
+                self.length_sort_straight,
+                self.line_length | optional
             ]
         }
         Ok(())

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__group_by_package_group_by_package.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__group_by_package_group_by_package.py.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+---
+I001 [*] Import block is un-sorted or un-formatted
+ --> group_by_package.py:1:1
+  |
+1 | / from a import b
+2 | | import a.c
+3 | | from a.d import e
+4 | | import a
+5 | | from b import a
+6 | | import a.e
+  | |__________^
+  |
+help: Organize imports
+1 + import a
+2 | from a import b
+3 | import a.c
+4 | from a.d import e
+  - import a
+5 + import a.e
+6 | from b import a
+  - import a.e

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__lexicographical_lexicographical.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__lexicographical_lexicographical.py.snap
@@ -1,0 +1,27 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+assertion_line: 618
+---
+I001 [*] Import block is un-sorted or un-formatted
+ --> lexicographical.py:1:1
+  |
+1 | / import a2
+2 | | import a12
+3 | | import a1
+4 | | import a13
+5 | | import a20
+6 | | import a100
+7 | | import a3
+  | |_________^
+  |
+help: Organize imports
+  - import a2
+1 + import a1
+2 + import a100
+3 | import a12
+  - import a1
+4 | import a13
+5 + import a2
+6 | import a20
+  - import a100
+7 | import a3

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__line_length_line_length.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__line_length_line_length.py.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+assertion_line: 637
+---
+

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2341,11 +2341,34 @@ pub struct IsortOptions {
     #[option(
         default = r#"false"#,
         value_type = "bool",
-        example = r#"
-            force-sort-within-sections = true
-        "#
+        example = r#"force-sort-within-sections = true"#
     )]
     pub force_sort_within_sections: Option<bool>,
+
+    /// Whether to sort imports lexicographically, which ignores case unless
+    /// [`case-sensitive`](#lint_isort_case-sensitive) is enabled.
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
+        example = r#"lexicographical = true"#
+    )]
+    pub lexicographical: Option<bool>,
+
+    /// Whether to group imports by package when sorting.
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
+        example = r#"group-by-package = true"#
+    )]
+    pub group_by_package: Option<bool>,
+
+    /// The line length to use for `isort` specifically.
+    #[option(
+        default = r#"null"#,
+        value_type = "int",
+        example = r#"line-length = 1000"#
+    )]
+    pub line_length: Option<LineLength>,
 
     /// Sort imports taking into account case sensitivity.
     ///
@@ -2862,6 +2885,8 @@ impl IsortOptions {
             combine_as_imports: self.combine_as_imports.unwrap_or(false),
             force_single_line: self.force_single_line.unwrap_or(false),
             force_sort_within_sections,
+            lexicographical: self.lexicographical.unwrap_or(false),
+            group_by_package: self.group_by_package.unwrap_or(false),
             case_sensitive: self.case_sensitive.unwrap_or(false),
             force_wrap_aliases: self.force_wrap_aliases.unwrap_or(false),
             detect_same_package: self.detect_same_package.unwrap_or(true),
@@ -2892,6 +2917,7 @@ impl IsortOptions {
             from_first,
             length_sort: self.length_sort.unwrap_or(false),
             length_sort_straight: self.length_sort_straight.unwrap_or(false),
+            line_length: self.line_length,
         })
     }
 }


### PR DESCRIPTION
WIP to add completeness for isort options like:

```toml
[tool.ruff.lint.isort]
lexicographical = true
line-length = 1000
group-by-package = true
force-single-line = true
force-sort-within-sections = true
single-line-exclusions = [
  "collections.abc",
  "six.moves",
  "typing",
  "typing-extensions"
]
order-by-type = false
```