### PR TITLE
Adds isort lexicographical config option

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/isort/lexicographical.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/lexicographical.py
@@ -1,0 +1,6 @@
+import a_2
+import a_1
+import a_10
+import B_a
+import b_A
+from foo import a_2, a_1, a_10, B_a, b_A

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -648,6 +648,24 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Path::new("lexicographical.py"))]
+    fn lexicographical(path: &Path) -> Result<()> {
+        let snapshot = format!("lexicographical_{}", path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("isort").join(path).as_path(),
+            &LinterSettings {
+                isort: super::settings::Settings {
+                    lexicographical: true,
+                    ..super::settings::Settings::default()
+                },
+                src: vec![test_resource_path("fixtures/isort")],
+                ..LinterSettings::for_rule(Rule::UnsortedImports)
+            },
+        )?;
+        assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
+
     #[test_case(Path::new("propagate_inline_comments.py"))]
     fn propagate_inline_comments(path: &Path) -> Result<()> {
         let snapshot = format!("propagate_inline_comments_{}", path.to_string_lossy());

--- a/crates/ruff_linter/src/rules/isort/settings.rs
+++ b/crates/ruff_linter/src/rules/isort/settings.rs
@@ -70,6 +70,7 @@ pub struct Settings {
     pub from_first: bool,
     pub length_sort: bool,
     pub length_sort_straight: bool,
+    pub lexicographical: bool,
 }
 
 impl Settings {
@@ -125,6 +126,7 @@ impl Default for Settings {
             from_first: false,
             length_sort: false,
             length_sort_straight: false,
+            lexicographical: false,
         }
     }
 }
@@ -161,7 +163,8 @@ impl Display for Settings {
                 self.no_sections,
                 self.from_first,
                 self.length_sort,
-                self.length_sort_straight
+                self.length_sort_straight,
+                self.lexicographical
             ]
         }
         Ok(())

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__lexicographical_lexicographical.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__lexicographical_lexicographical.py.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+---
+I001 [*] Import block is un-sorted or un-formatted
+ --> lexicographical.py:1:1
+  |
+1 | / import a_2
+2 | | import a_1
+3 | | import a_10
+4 | | import B_a
+5 | | import b_A
+6 | | from foo import a_2, a_1, a_10, B_a, b_A
+  | |________________________________________^
+  |
+help: Organize imports
+  - import a_2
+1 | import a_1
+2 | import a_10
+3 + import a_2
+4 | import B_a
+5 | import b_A
+  - from foo import a_2, a_1, a_10, B_a, b_A
+6 + from foo import B_a, a_1, a_10, a_2, b_A

--- a/crates/ruff_linter/src/rules/isort/sorting.rs
+++ b/crates/ruff_linter/src/rules/isort/sorting.rs
@@ -39,29 +39,33 @@ fn member_type(name: &str, settings: &Settings) -> MemberType {
 }
 
 #[derive(Eq, PartialEq, Debug)]
-pub(crate) struct NatOrdStr<'a>(Cow<'a, str>);
+pub(crate) struct CmpStr<'a> {
+    s: Cow<'a, str>,
+    lexicographical: bool,
+}
 
-impl Ord for NatOrdStr<'_> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        natord::compare(&self.0, &other.0)
+impl<'a> CmpStr<'a> {
+    fn new(s: impl Into<Cow<'a, str>>, lexicographical: bool) -> Self {
+        Self {
+            s: s.into(),
+            lexicographical,
+        }
     }
 }
 
-impl PartialOrd for NatOrdStr<'_> {
+impl Ord for CmpStr<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.lexicographical {
+            self.s.cmp(&other.s)
+        } else {
+            natord::compare(&self.s, &other.s)
+        }
+    }
+}
+
+impl PartialOrd for CmpStr<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
-    }
-}
-
-impl<'a> From<&'a str> for NatOrdStr<'a> {
-    fn from(s: &'a str) -> Self {
-        NatOrdStr(Cow::Borrowed(s))
-    }
-}
-
-impl From<String> for NatOrdStr<'_> {
-    fn from(s: String) -> Self {
-        NatOrdStr(Cow::Owned(s))
     }
 }
 
@@ -87,10 +91,10 @@ pub(crate) struct ModuleKey<'a> {
     force_to_top: bool,
     maybe_length: Option<usize>,
     distance: Distance,
-    maybe_lowercase_name: Option<NatOrdStr<'a>>,
-    module_name: Option<NatOrdStr<'a>>,
+    maybe_lowercase_name: Option<CmpStr<'a>>,
+    module_name: Option<CmpStr<'a>>,
     first_alias: Option<MemberKey<'a>>,
-    asname: Option<NatOrdStr<'a>>,
+    asname: Option<CmpStr<'a>>,
 }
 
 impl<'a> ModuleKey<'a> {
@@ -121,12 +125,15 @@ impl<'a> ModuleKey<'a> {
         };
 
         let maybe_lowercase_name = name.and_then(|name| {
-            (!settings.case_sensitive).then_some(NatOrdStr(maybe_lowercase(name)))
+            (!settings.case_sensitive).then_some(CmpStr::new(
+                maybe_lowercase(name),
+                settings.lexicographical,
+            ))
         });
 
-        let module_name = name.map(NatOrdStr::from);
+        let module_name = name.map(|n| CmpStr::new(n, settings.lexicographical));
 
-        let asname = asname.map(NatOrdStr::from);
+        let asname = asname.map(|n| CmpStr::new(n, settings.lexicographical));
 
         let first_alias =
             first_alias.map(|(name, asname)| MemberKey::from_member(name, asname, settings));
@@ -150,9 +157,9 @@ pub(crate) struct MemberKey<'a> {
     not_star_import: bool,
     member_type: Option<MemberType>,
     maybe_length: Option<usize>,
-    maybe_lowercase_name: Option<NatOrdStr<'a>>,
-    module_name: NatOrdStr<'a>,
-    asname: Option<NatOrdStr<'a>>,
+    maybe_lowercase_name: Option<CmpStr<'a>>,
+    module_name: CmpStr<'a>,
+    asname: Option<CmpStr<'a>>,
 }
 
 impl<'a> MemberKey<'a> {
@@ -164,10 +171,10 @@ impl<'a> MemberKey<'a> {
         let maybe_length = settings
             .length_sort
             .then(|| name.chars().map(|c| c.width().unwrap_or(0)).sum());
-        let maybe_lowercase_name =
-            (!settings.case_sensitive).then_some(NatOrdStr(maybe_lowercase(name)));
-        let module_name = NatOrdStr::from(name);
-        let asname = asname.map(NatOrdStr::from);
+        let maybe_lowercase_name = (!settings.case_sensitive)
+            .then_some(CmpStr::new(maybe_lowercase(name), settings.lexicographical));
+        let module_name = CmpStr::new(name, settings.lexicographical);
+        let asname = asname.map(|n| CmpStr::new(n, settings.lexicographical));
 
         Self {
             not_star_import,

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2836,6 +2836,16 @@ pub struct IsortOptions {
     )]
     pub length_sort_straight: Option<bool>,
 
+    /// Tells isort to sort imports lexicographically (alphabetical but with uppercase letters before lowercase).
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
+        example = r#"
+            lexicographical = true
+        "#
+    )]
+    pub lexicographical: Option<bool>,
+
     // Tables are required to go last.
     /// A list of mappings from section names to modules.
     ///
@@ -3080,6 +3090,7 @@ impl IsortOptions {
             from_first,
             length_sort: self.length_sort.unwrap_or(false),
             length_sort_straight: self.length_sort_straight.unwrap_or(false),
+            lexicographical: self.lexicographical.unwrap_or(false),
         })
     }
 }

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1909,6 +1909,13 @@
             "null"
           ]
         },
+        "lexicographical": {
+          "description": "Tells isort to sort imports lexicographically (alphabetical but with uppercase letters before lowercase).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "lines-after-imports": {
           "description": "The number of blank lines to place after imports.\nUse `-1` for automatic determination.\n\nRuff uses at most one blank line after imports in typing stub files (files with `.pyi` extension) in accordance to\nthe typing style recommendations ([source](https://typing.python.org/en/latest/guides/writing_stubs.html#blank-lines)).\n\nWhen using the formatter, only the values `-1`, `1`, and `2` are compatible because\nit enforces at least one empty and at most two empty lines after imports.",
           "type": [


### PR DESCRIPTION
Adds lexicographical for isort options like:

```toml
[tool.ruff.lint.isort]
lexicographical = true
```