### PR TITLE
[ty] Infer lambda parameter types with `Callable` type context

### DIFF
--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -43,7 +43,7 @@ use ruff_python_ast::{
 };
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use std::ops::Deref;
-use ty_python_core::definition::{Definition, DefinitionKind};
+use ty_python_core::definition::{Definition, DefinitionKind, ParameterDefinitionNodeKind};
 use ty_python_semantic::{
     HasType, SemanticModel,
     types::ide_support::{
@@ -314,7 +314,7 @@ impl<'db> SemanticTokenVisitor<'db> {
             }
             DefinitionKind::Class(_) => Some((SemanticTokenType::Class, modifiers)),
             DefinitionKind::TypeVar(_) => Some((SemanticTokenType::TypeParameter, modifiers)),
-            DefinitionKind::Parameter(parameter) => {
+            DefinitionKind::Parameter(ParameterDefinitionNodeKind::Parameter(parameter)) => {
                 let parsed = parsed_module(db, definition.file(db));
                 let ty = parameter.node(&parsed.load(db)).inferred_type(&model);
 
@@ -342,12 +342,7 @@ impl<'db> SemanticTokenVisitor<'db> {
 
                 Some((SemanticTokenType::Parameter, modifiers))
             }
-            DefinitionKind::VariadicPositionalParameter(_) => {
-                Some((SemanticTokenType::Parameter, modifiers))
-            }
-            DefinitionKind::VariadicKeywordParameter(_) => {
-                Some((SemanticTokenType::Parameter, modifiers))
-            }
+            DefinitionKind::Parameter(_) => Some((SemanticTokenType::Parameter, modifiers)),
             DefinitionKind::TypeAlias(_) => Some((SemanticTokenType::TypeParameter, modifiers)),
             DefinitionKind::Import(_)
             | DefinitionKind::ImportFrom(_)

--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -150,6 +150,12 @@ pub(crate) mod node_key {
         }
     }
 
+    impl From<&ast::ExprLambda> for ExpressionNodeKey {
+        fn from(value: &ast::ExprLambda) -> Self {
+            Self(NodeKey::from_node(value))
+        }
+    }
+
     impl From<&ast::Identifier> for ExpressionNodeKey {
         fn from(value: &ast::Identifier) -> Self {
             Self(NodeKey::from_node(value))

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3334,9 +3334,10 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 }
             }
             ast::Expr::Lambda(lambda) => {
-                if let Some(current_statement) = self.current_statement_mut() {
-                    current_statement.lambda_exprs.push(lambda);
-                }
+                self.current_statement_mut()
+                    .expect("every lambda expression is part of a statement")
+                    .lambda_exprs
+                    .push(lambda);
 
                 if let Some(parameters) = &lambda.parameters {
                     // The default value of the parameters needs to be evaluated in the

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -20,7 +20,6 @@ use ruff_python_parser::semantic_errors::{
 use ruff_text_size::{Ranged, TextRange};
 use ty_module_resolver::{ModuleName, resolve_module};
 
-use crate::Db;
 use crate::HasTrackedScope;
 use crate::ast_ids::AstIdsBuilder;
 use crate::ast_ids::node_key::ExpressionNodeKey;
@@ -30,8 +29,9 @@ use crate::definition::{
     ComprehensionDefinitionNodeRef, Definition, DefinitionCategory, DefinitionNodeKey,
     DefinitionNodeRef, Definitions, DictKeyAssignmentNodeRef, ExceptHandlerDefinitionNodeRef,
     ForStmtDefinitionNodeRef, ImportDefinitionNodeRef, ImportFromDefinitionNodeRef,
-    ImportFromSubmoduleDefinitionNodeRef, LoopHeaderDefinitionNodeRef, LoopStmtRef,
-    MatchPatternDefinitionNodeRef, StarImportDefinitionNodeRef, WithItemDefinitionNodeRef,
+    ImportFromSubmoduleDefinitionNodeRef, LambdaParameterDefinitionNodeRef,
+    LoopHeaderDefinitionNodeRef, LoopStmtRef, MatchPatternDefinitionNodeRef,
+    ParameterDefinitionNodeRef, StarImportDefinitionNodeRef, WithItemDefinitionNodeRef,
 };
 use crate::expression::{Expression, ExpressionKind};
 use crate::member::MemberExprBuilder;
@@ -49,12 +49,14 @@ use crate::scope::{
     FileScopeId, NodeWithScopeKey, NodeWithScopeKind, NodeWithScopeRef, Scope, ScopeId, ScopeKind,
     ScopeLaziness,
 };
+use crate::statement::StatementInner;
 use crate::symbol::{ScopedSymbolId, Symbol};
 use crate::unpack::{Unpack, UnpackKind, UnpackPosition, UnpackValue};
 use crate::use_def::{
     EnclosingSnapshotKey, FlowSnapshot, PreviousDefinitions, ScopedDefinitionId,
     ScopedEnclosingSnapshotId, UseDefMapBuilder,
 };
+use crate::{Db, Statement, StatementNodeKey};
 use crate::{
     EvaluationMode, ExpressionsScopeMap, LoopHeader, LoopToken, PossiblyNarrowedPlaces,
     SemanticIndex, VisibleAncestorsIter, get_loop_header,
@@ -97,8 +99,11 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     module: &'ast ParsedModuleRef,
     scope_stack: Vec<ScopeInfo>,
     /// The assignments we're currently visiting, with
-    /// the most recent visit at the end of the Vec
+    /// the most recent visit at the end of the Vec.
     current_assignments: Vec<CurrentAssignment<'ast, 'db>>,
+    /// The statements we're currently visiting, with
+    /// the most recent visit at the end of the Vec.
+    current_statements: Vec<CurrentStatement<'ast>>,
     /// The match case we're currently visiting.
     current_match_case: Option<CurrentMatchCase<'ast>>,
     /// The name of the first function parameter of the innermost function that we're currently visiting.
@@ -128,6 +133,8 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     scopes_by_expression: ExpressionsScopeMapBuilder,
     definitions_by_node: FxHashMap<DefinitionNodeKey, Definitions<'db>>,
     expressions_by_node: FxHashMap<ExpressionNodeKey, Expression<'db>>,
+    statements_by_node: FxHashMap<StatementNodeKey, Statement<'db>>,
+    enclosing_lambda_statements: FxHashMap<ExpressionNodeKey, Statement<'db>>,
     imported_modules: FxHashSet<ModuleName>,
     seen_submodule_imports: FxHashSet<String>,
     /// Hashset of all [`FileScopeId`]s that correspond to [generator functions].
@@ -148,7 +155,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             source_type: file.source_type(db),
             module: module_ref,
             scope_stack: Vec::new(),
-            current_assignments: vec![],
+            current_assignments: Vec::new(),
+            current_statements: Vec::new(),
             current_match_case: None,
             current_first_parameter_name: None,
             try_node_context_stack_manager: TryNodeContextStackManager::default(),
@@ -166,6 +174,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             scopes_by_node: FxHashMap::default(),
             definitions_by_node: FxHashMap::default(),
             expressions_by_node: FxHashMap::default(),
+            statements_by_node: FxHashMap::default(),
+            enclosing_lambda_statements: FxHashMap::default(),
 
             seen_submodule_imports: FxHashSet::default(),
             imported_modules: FxHashSet::default(),
@@ -198,6 +208,20 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
     fn current_scope(&self) -> FileScopeId {
         self.current_scope_info().file_scope_id
+    }
+
+    pub(crate) fn expect_single_definition(
+        &self,
+        definition_key: impl Into<DefinitionNodeKey> + std::fmt::Debug + Copy,
+    ) -> Definition<'db> {
+        let definitions = &self.definitions_by_node[&definition_key.into()];
+        debug_assert_eq!(
+            definitions.len(),
+            1,
+            "Expected exactly one definition to be associated with AST node {definition_key:?} but found {}",
+            definitions.len()
+        );
+        definitions[0]
     }
 
     /// Returns an iterator over ancestors of `scope` that are visible for name resolution,
@@ -1312,6 +1336,18 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.current_assignments.last_mut()
     }
 
+    fn push_statement(&mut self, statement: CurrentStatement<'ast>) {
+        self.current_statements.push(statement);
+    }
+
+    fn pop_statement(&mut self) -> CurrentStatement<'ast> {
+        self.current_statements.pop().unwrap()
+    }
+
+    fn current_statement_mut(&mut self) -> Option<&mut CurrentStatement<'ast>> {
+        self.current_statements.last_mut()
+    }
+
     fn predicate_kind(&mut self, pattern: &ast::Pattern) -> PatternPredicateKind<'db> {
         match pattern {
             ast::Pattern::MatchValue(pattern) => {
@@ -1483,6 +1519,56 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         expression
     }
 
+    fn add_standalone_statement(&mut self, statement_node: &ast::Stmt) -> Statement<'db> {
+        // Avoid allocating a salsa ingredient if the statement represents an existing
+        // definition or standalone expression.
+        let statement = match statement_node {
+            ast::Stmt::FunctionDef(function) => Some(Statement::Definition(
+                self.expect_single_definition(function),
+            )),
+            ast::Stmt::ClassDef(class) => {
+                Some(Statement::Definition(self.expect_single_definition(class)))
+            }
+            ast::Stmt::Expr(expr) => self
+                .expressions_by_node
+                .get(&(&expr.value).into())
+                .copied()
+                .map(Statement::Expression),
+            ast::Stmt::Assign(assign) => {
+                if let [ast::Expr::Name(name)] = &assign.targets[..] {
+                    Some(Statement::Definition(self.expect_single_definition(name)))
+                } else {
+                    None
+                }
+            }
+            ast::Stmt::AnnAssign(assign) if assign.target.is_name_expr() => {
+                Some(Statement::Definition(self.expect_single_definition(assign)))
+            }
+            ast::Stmt::AugAssign(assign) if assign.target.is_name_expr() => {
+                Some(Statement::Definition(self.expect_single_definition(assign)))
+            }
+            ast::Stmt::TypeAlias(alias) => {
+                Some(Statement::Definition(self.expect_single_definition(alias)))
+            }
+            _ => None,
+        };
+
+        let statement = if let Some(statement) = statement {
+            statement
+        } else {
+            Statement::Other(StatementInner::new(
+                self.db,
+                self.file,
+                self.current_scope(),
+                AstNodeRef::new(self.module, statement_node),
+            ))
+        };
+
+        self.statements_by_node
+            .insert(statement_node.into(), statement);
+        statement
+    }
+
     fn with_type_params(
         &mut self,
         with_scope: NodeWithScopeRef,
@@ -1627,7 +1713,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 .mark_parameter();
             self.add_definition(
                 symbol.into(),
-                DefinitionNodeRef::VariadicPositionalParameter(vararg),
+                ParameterDefinitionNodeRef::VariadicPositionalParameter(vararg),
             );
         }
         if let Some(kwarg) = parameters.kwarg.as_ref() {
@@ -1637,7 +1723,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 .mark_parameter();
             self.add_definition(
                 symbol.into(),
-                DefinitionNodeRef::VariadicKeywordParameter(kwarg),
+                ParameterDefinitionNodeRef::VariadicKeywordParameter(kwarg),
             );
         }
     }
@@ -1645,7 +1731,90 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     fn declare_parameter(&mut self, parameter: &'ast ast::ParameterWithDefault) {
         let symbol = self.add_symbol(parameter.name().id().clone());
 
-        let definition = self.add_definition(symbol.into(), parameter);
+        let definition = self.add_definition(
+            symbol.into(),
+            ParameterDefinitionNodeRef::Parameter(parameter),
+        );
+
+        self.current_place_table_mut()
+            .symbol_mut(symbol)
+            .mark_parameter();
+
+        // Insert a mapping from the inner Parameter node to the same definition. This
+        // ensures that calling `HasType::inferred_type` on the inner parameter returns
+        // a valid type (and doesn't panic)
+        let existing_definition = self.definitions_by_node.insert(
+            (&parameter.parameter).into(),
+            Definitions::single(definition),
+        );
+        debug_assert_eq!(existing_definition, None);
+    }
+
+    fn declare_lambda_parameters(
+        &mut self,
+        parameters: &'ast ast::Parameters,
+        lambda: &'ast ast::ExprLambda,
+    ) {
+        let mut index = 0;
+        for parameter in &parameters.posonlyargs {
+            self.declare_lambda_parameter(index, parameter, lambda);
+            index += 1;
+        }
+        for parameter in &parameters.args {
+            self.declare_lambda_parameter(index, parameter, lambda);
+            index += 1;
+        }
+        if let Some(vararg) = parameters.vararg.as_ref() {
+            let symbol = self.add_symbol(vararg.name.id().clone());
+            self.current_place_table_mut()
+                .symbol_mut(symbol)
+                .mark_parameter();
+            self.add_definition(
+                symbol.into(),
+                LambdaParameterDefinitionNodeRef {
+                    index,
+                    lambda,
+                    parameter: ParameterDefinitionNodeRef::VariadicPositionalParameter(vararg),
+                },
+            );
+            index += 1;
+        }
+        for parameter in &parameters.kwonlyargs {
+            self.declare_lambda_parameter(index, parameter, lambda);
+            index += 1;
+        }
+        if let Some(kwarg) = parameters.kwarg.as_ref() {
+            let symbol = self.add_symbol(kwarg.name.id().clone());
+            self.current_place_table_mut()
+                .symbol_mut(symbol)
+                .mark_parameter();
+            self.add_definition(
+                symbol.into(),
+                LambdaParameterDefinitionNodeRef {
+                    index,
+                    lambda,
+                    parameter: ParameterDefinitionNodeRef::VariadicKeywordParameter(kwarg),
+                },
+            );
+        }
+    }
+
+    fn declare_lambda_parameter(
+        &mut self,
+        index: usize,
+        parameter: &'ast ast::ParameterWithDefault,
+        lambda: &'ast ast::ExprLambda,
+    ) {
+        let symbol = self.add_symbol(parameter.name().id().clone());
+
+        let definition = self.add_definition(
+            symbol.into(),
+            LambdaParameterDefinitionNodeRef {
+                index,
+                lambda,
+                parameter: ParameterDefinitionNodeRef::Parameter(parameter),
+            },
+        );
 
         self.current_place_table_mut()
             .symbol_mut(symbol)
@@ -1757,6 +1926,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         use_def_maps.shrink_to_fit();
         ast_ids.shrink_to_fit();
         self.definitions_by_node.shrink_to_fit();
+        self.statements_by_node.shrink_to_fit();
+        self.enclosing_lambda_statements.shrink_to_fit();
 
         self.scope_ids_by_scope.shrink_to_fit();
         self.scopes_by_node.shrink_to_fit();
@@ -1768,11 +1939,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             scopes: self.scopes,
             definitions_by_node: self.definitions_by_node,
             expressions_by_node: self.expressions_by_node,
+            statements_by_node: self.statements_by_node,
             scope_ids_by_scope: self.scope_ids_by_scope,
             ast_ids,
             scopes_by_expression: self.scopes_by_expression.build(),
             scopes_by_node: self.scopes_by_node,
             use_def_maps,
+            enclosing_lambda_statements: self.enclosing_lambda_statements,
             imported_modules: Arc::new(self.imported_modules),
             has_future_annotations: self.has_future_annotations,
             enclosing_snapshots: self.enclosing_snapshots,
@@ -1791,10 +1964,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.source_text
             .get_or_init(|| source_text(self.db, self.file))
     }
-}
 
-impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
-    fn visit_stmt(&mut self, stmt: &'ast ast::Stmt) {
+    fn visit_stmt_impl(&mut self, stmt: &'ast ast::Stmt) {
         self.with_semantic_checker(|semantic, context| semantic.visit_stmt(stmt, context));
 
         let in_type_checking_block = self.in_type_checking_block;
@@ -3009,6 +3180,29 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
             }
         }
     }
+}
+
+impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
+    fn visit_stmt(&mut self, stmt: &'ast ast::Stmt) {
+        self.push_statement(CurrentStatement {
+            lambda_exprs: Vec::new(),
+        });
+
+        self.visit_stmt_impl(stmt);
+
+        let current_statement = self.pop_statement();
+        if !current_statement.lambda_exprs.is_empty() {
+            // The body of a lambda expression needs access to the `Callable` type
+            // context the lambda is being inferred with, and so any statement
+            // containing a lambda must be inferable as a standalone statement
+            // to avoid large scope-level cycles.
+            let standalone_stmt = self.add_standalone_statement(stmt);
+            for lambda in current_statement.lambda_exprs {
+                self.enclosing_lambda_statements
+                    .insert(lambda.into(), standalone_stmt);
+            }
+        }
+    }
 
     fn visit_keyword(&mut self, keyword: &'ast ast::Keyword) {
         walk_keyword(self, keyword);
@@ -3140,6 +3334,10 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 }
             }
             ast::Expr::Lambda(lambda) => {
+                if let Some(current_statement) = self.current_statement_mut() {
+                    current_statement.lambda_exprs.push(lambda);
+                }
+
                 if let Some(parameters) = &lambda.parameters {
                     // The default value of the parameters needs to be evaluated in the
                     // enclosing scope.
@@ -3155,7 +3353,7 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
 
                 // Add symbols and definitions for the parameters to the lambda scope.
                 if let Some(parameters) = lambda.parameters.as_ref() {
-                    self.declare_parameters(parameters);
+                    self.declare_lambda_parameters(parameters, lambda);
                 }
 
                 self.visit_expr(lambda.body.as_ref());
@@ -3579,6 +3777,11 @@ impl<'ast> From<&'ast ast::ExprNamed> for CurrentAssignment<'ast, '_> {
     fn from(value: &'ast ast::ExprNamed) -> Self {
         Self::Named(value)
     }
+}
+
+struct CurrentStatement<'ast> {
+    /// The lambda expressions part of this statement.
+    lambda_exprs: Vec<&'ast ast::ExprLambda>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -263,9 +263,8 @@ pub(crate) enum DefinitionNodeRef<'ast, 'db> {
     AugmentedAssignment(&'ast ast::StmtAugAssign),
     DictKeyAssignment(DictKeyAssignmentNodeRef<'ast, 'db>),
     Comprehension(ComprehensionDefinitionNodeRef<'ast, 'db>),
-    VariadicPositionalParameter(&'ast ast::Parameter),
-    VariadicKeywordParameter(&'ast ast::Parameter),
-    Parameter(&'ast ast::ParameterWithDefault),
+    Parameter(ParameterDefinitionNodeRef<'ast>),
+    LambdaParameter(LambdaParameterDefinitionNodeRef<'ast>),
     WithItem(WithItemDefinitionNodeRef<'ast, 'db>),
     MatchPattern(MatchPatternDefinitionNodeRef<'ast>),
     ExceptHandler(ExceptHandlerDefinitionNodeRef<'ast>),
@@ -383,9 +382,15 @@ impl<'ast, 'db> From<ComprehensionDefinitionNodeRef<'ast, 'db>> for DefinitionNo
     }
 }
 
-impl<'ast> From<&'ast ast::ParameterWithDefault> for DefinitionNodeRef<'ast, '_> {
-    fn from(node: &'ast ast::ParameterWithDefault) -> Self {
+impl<'ast> From<ParameterDefinitionNodeRef<'ast>> for DefinitionNodeRef<'ast, '_> {
+    fn from(node: ParameterDefinitionNodeRef<'ast>) -> Self {
         Self::Parameter(node)
+    }
+}
+
+impl<'ast> From<LambdaParameterDefinitionNodeRef<'ast>> for DefinitionNodeRef<'ast, '_> {
+    fn from(node: LambdaParameterDefinitionNodeRef<'ast>) -> Self {
+        Self::LambdaParameter(node)
     }
 }
 
@@ -492,6 +497,48 @@ pub(crate) struct ComprehensionDefinitionNodeRef<'ast, 'db> {
     pub(crate) target: &'ast ast::Expr,
     pub(crate) first: bool,
     pub(crate) is_async: bool,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum ParameterDefinitionNodeRef<'ast> {
+    VariadicPositionalParameter(&'ast ast::Parameter),
+    VariadicKeywordParameter(&'ast ast::Parameter),
+    Parameter(&'ast ast::ParameterWithDefault),
+}
+
+impl ParameterDefinitionNodeRef<'_> {
+    pub(super) fn into_owned(self, parsed: &ParsedModuleRef) -> ParameterDefinitionNodeKind {
+        match self {
+            Self::VariadicPositionalParameter(parameter) => {
+                ParameterDefinitionNodeKind::VariadicPositionalParameter(AstNodeRef::new(
+                    parsed, parameter,
+                ))
+            }
+            Self::VariadicKeywordParameter(parameter) => {
+                ParameterDefinitionNodeKind::VariadicKeywordParameter(AstNodeRef::new(
+                    parsed, parameter,
+                ))
+            }
+            Self::Parameter(parameter) => {
+                ParameterDefinitionNodeKind::Parameter(AstNodeRef::new(parsed, parameter))
+            }
+        }
+    }
+
+    pub(super) fn key(self) -> DefinitionNodeKey {
+        match self {
+            Self::VariadicPositionalParameter(node) => node.into(),
+            Self::VariadicKeywordParameter(node) => node.into(),
+            Self::Parameter(node) => node.into(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct LambdaParameterDefinitionNodeRef<'ast> {
+    pub(crate) index: usize,
+    pub(crate) parameter: ParameterDefinitionNodeRef<'ast>,
+    pub(crate) lambda: &'ast ast::ExprLambda,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -615,15 +662,18 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
                 first,
                 is_async,
             }),
-            DefinitionNodeRef::VariadicPositionalParameter(parameter) => {
-                DefinitionKind::VariadicPositionalParameter(AstNodeRef::new(parsed, parameter))
-            }
-            DefinitionNodeRef::VariadicKeywordParameter(parameter) => {
-                DefinitionKind::VariadicKeywordParameter(AstNodeRef::new(parsed, parameter))
-            }
             DefinitionNodeRef::Parameter(parameter) => {
-                DefinitionKind::Parameter(AstNodeRef::new(parsed, parameter))
+                DefinitionKind::Parameter(parameter.into_owned(parsed))
             }
+            DefinitionNodeRef::LambdaParameter(LambdaParameterDefinitionNodeRef {
+                index,
+                parameter,
+                lambda,
+            }) => DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
+                index,
+                parameter: parameter.into_owned(parsed),
+                lambda: AstNodeRef::new(parsed, lambda),
+            }),
             DefinitionNodeRef::WithItem(WithItemDefinitionNodeRef {
                 unpack,
                 context_expr,
@@ -723,9 +773,10 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
             Self::Comprehension(ComprehensionDefinitionNodeRef { target, .. }) => {
                 DefinitionNodeKey(NodeKey::from_node(target))
             }
-            Self::VariadicPositionalParameter(node) => node.into(),
-            Self::VariadicKeywordParameter(node) => node.into(),
-            Self::Parameter(node) => node.into(),
+            Self::LambdaParameter(LambdaParameterDefinitionNodeRef { parameter, .. }) => {
+                parameter.key()
+            }
+            Self::Parameter(parameter) => parameter.key(),
             Self::WithItem(WithItemDefinitionNodeRef {
                 context_expr: _,
                 unpack: _,
@@ -805,9 +856,8 @@ pub enum DefinitionKind<'db> {
     DictKeyAssignment(DictKeyAssignmentKind<'db>),
     For(ForStmtDefinitionKind<'db>),
     Comprehension(ComprehensionDefinitionKind<'db>),
-    VariadicPositionalParameter(AstNodeRef<ast::Parameter>),
-    VariadicKeywordParameter(AstNodeRef<ast::Parameter>),
-    Parameter(AstNodeRef<ast::ParameterWithDefault>),
+    Parameter(ParameterDefinitionNodeKind),
+    LambdaParameter(LambdaParameterDefinitionNodeKind),
     WithItem(WithItemDefinitionKind<'db>),
     MatchPattern(MatchPatternDefinitionKind),
     ExceptHandler(ExceptHandlerDefinitionKind),
@@ -860,12 +910,7 @@ impl DefinitionKind<'_> {
     }
 
     pub const fn is_parameter_def(&self) -> bool {
-        matches!(
-            self,
-            DefinitionKind::VariadicPositionalParameter(_)
-                | DefinitionKind::VariadicKeywordParameter(_)
-                | DefinitionKind::Parameter(_)
-        )
+        matches!(self, DefinitionKind::Parameter(_))
     }
 
     pub const fn is_loop_header(&self) -> bool {
@@ -902,13 +947,11 @@ impl DefinitionKind<'_> {
             }
             DefinitionKind::For(for_stmt) => for_stmt.target.node(module).range(),
             DefinitionKind::Comprehension(comp) => comp.target(module).range(),
-            DefinitionKind::VariadicPositionalParameter(parameter) => {
-                parameter.node(module).name.range()
-            }
-            DefinitionKind::VariadicKeywordParameter(parameter) => {
-                parameter.node(module).name.range()
-            }
-            DefinitionKind::Parameter(parameter) => parameter.node(module).parameter.name.range(),
+            DefinitionKind::Parameter(parameter) => parameter.target_range(module),
+            DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
+                parameter,
+                ..
+            }) => parameter.target_range(module),
             DefinitionKind::WithItem(with_item) => with_item.target.node(module).range(),
             DefinitionKind::MatchPattern(match_pattern) => {
                 match_pattern.identifier.node(module).range()
@@ -959,11 +1002,11 @@ impl DefinitionKind<'_> {
             }
             DefinitionKind::For(for_stmt) => for_stmt.target.node(module).range(),
             DefinitionKind::Comprehension(comp) => comp.target(module).range(),
-            DefinitionKind::VariadicPositionalParameter(parameter) => {
-                parameter.node(module).range()
-            }
-            DefinitionKind::VariadicKeywordParameter(parameter) => parameter.node(module).range(),
-            DefinitionKind::Parameter(parameter) => parameter.node(module).parameter.range(),
+            DefinitionKind::Parameter(parameter) => parameter.full_range(module),
+            DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
+                parameter,
+                ..
+            }) => parameter.full_range(module),
             DefinitionKind::WithItem(with_item) => with_item.target.node(module).range(),
             DefinitionKind::MatchPattern(match_pattern) => {
                 match_pattern.identifier.node(module).range()
@@ -988,28 +1031,11 @@ impl DefinitionKind<'_> {
             | DefinitionKind::TypeVar(_)
             | DefinitionKind::ParamSpec(_)
             | DefinitionKind::TypeVarTuple(_) => DefinitionCategory::DeclarationAndBinding,
-            // a parameter always binds a value, but is only a declaration if annotated
-            DefinitionKind::VariadicPositionalParameter(parameter)
-            | DefinitionKind::VariadicKeywordParameter(parameter) => {
-                if parameter.node(module).annotation.is_some() {
-                    DefinitionCategory::DeclarationAndBinding
-                } else {
-                    DefinitionCategory::Binding
-                }
-            }
-            // presence of a default is irrelevant, same logic as for a no-default parameter
-            DefinitionKind::Parameter(parameter_with_default) => {
-                if parameter_with_default
-                    .node(module)
-                    .parameter
-                    .annotation
-                    .is_some()
-                {
-                    DefinitionCategory::DeclarationAndBinding
-                } else {
-                    DefinitionCategory::Binding
-                }
-            }
+            DefinitionKind::Parameter(parameter) => parameter.category(module),
+            DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
+                parameter,
+                ..
+            }) => parameter.category(module),
             // Annotated assignment is always a declaration. It is also a binding if there is a RHS
             // or if we are in a stub file. Unfortunately, it is common for stubs to omit even an `...` value placeholder.
             DefinitionKind::AnnotatedAssignment(ann_assign) => {
@@ -1144,6 +1170,65 @@ impl<'db> ComprehensionDefinitionKind<'db> {
     pub fn is_async(&self) -> bool {
         self.is_async
     }
+}
+
+#[derive(Clone, Debug, get_size2::GetSize)]
+pub enum ParameterDefinitionNodeKind {
+    VariadicPositionalParameter(AstNodeRef<ast::Parameter>),
+    VariadicKeywordParameter(AstNodeRef<ast::Parameter>),
+    Parameter(AstNodeRef<ast::ParameterWithDefault>),
+}
+
+impl ParameterDefinitionNodeKind {
+    pub(crate) fn target_range(&self, module: &ParsedModuleRef) -> TextRange {
+        match self {
+            Self::VariadicPositionalParameter(parameter) => parameter.node(module).name.range(),
+            Self::VariadicKeywordParameter(parameter) => parameter.node(module).name.range(),
+            Self::Parameter(parameter) => parameter.node(module).parameter.name.range(),
+        }
+    }
+
+    pub(crate) fn full_range(&self, module: &ParsedModuleRef) -> TextRange {
+        match self {
+            Self::VariadicPositionalParameter(parameter) => parameter.node(module).range(),
+            Self::VariadicKeywordParameter(parameter) => parameter.node(module).range(),
+            Self::Parameter(parameter) => parameter.node(module).parameter.range(),
+        }
+    }
+
+    pub(crate) fn category(&self, module: &ParsedModuleRef) -> DefinitionCategory {
+        match self {
+            // a parameter always binds a value, but is only a declaration if annotated
+            Self::VariadicPositionalParameter(parameter)
+            | Self::VariadicKeywordParameter(parameter) => {
+                if parameter.node(module).annotation.is_some() {
+                    DefinitionCategory::DeclarationAndBinding
+                } else {
+                    DefinitionCategory::Binding
+                }
+            }
+            // presence of a default is irrelevant, same logic as for a no-default parameter
+            Self::Parameter(parameter_with_default) => {
+                if parameter_with_default
+                    .node(module)
+                    .parameter
+                    .annotation
+                    .is_some()
+                {
+                    DefinitionCategory::DeclarationAndBinding
+                } else {
+                    DefinitionCategory::Binding
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, get_size2::GetSize)]
+pub struct LambdaParameterDefinitionNodeKind {
+    pub index: usize,
+    pub lambda: AstNodeRef<ast::ExprLambda>,
+    pub parameter: ParameterDefinitionNodeKind,
 }
 
 #[derive(Clone, Debug, get_size2::GetSize)]

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -15,7 +15,7 @@ use smallvec::SmallVec;
 use ty_module_resolver::ModuleName;
 
 use crate::place::ScopedPlaceId;
-
+pub use crate::statement::{Statement, StatementNodeKey};
 use ast_ids::AstIds;
 pub use ast_ids::ExpressionNodeKey;
 use builder::SemanticIndexBuilder;
@@ -49,6 +49,7 @@ pub mod rank;
 mod re_exports;
 pub mod reachability_constraints;
 pub mod scope;
+pub mod statement;
 pub mod symbol;
 pub mod unpack;
 mod use_def;
@@ -271,8 +272,14 @@ pub struct SemanticIndex<'db> {
     /// Map from a standalone expression to its [`Expression`] ingredient.
     expressions_by_node: FxHashMap<ExpressionNodeKey, Expression<'db>>,
 
+    /// Map from a standalone statement to its [`Statement`] ingredient.
+    statements_by_node: FxHashMap<StatementNodeKey, Statement<'db>>,
+
     /// Map from nodes that create a scope to the scope they create.
     scopes_by_node: FxHashMap<NodeWithScopeKey, FileScopeId>,
+
+    /// Map from a lambda expression to its containing statement.
+    enclosing_lambda_statements: FxHashMap<ExpressionNodeKey, Statement<'db>>,
 
     /// Map from the file-local [`FileScopeId`] to the salsa-ingredient [`ScopeId`].
     scope_ids_by_scope: IndexVec<FileScopeId, ScopeId<'db>>,
@@ -423,6 +430,10 @@ impl<'db> SemanticIndex<'db> {
             .map(|node_ref| self.expect_single_definition(node_ref))
     }
 
+    pub fn enclosing_lambda_statement(&self, lambda: ExpressionNodeKey) -> Option<Statement<'db>> {
+        self.enclosing_lambda_statements.get(&lambda).copied()
+    }
+
     pub fn is_in_type_checking_block(&self, scope_id: FileScopeId, range: TextRange) -> bool {
         self.ancestor_scopes(scope_id).any(|(scope_id, _)| {
             self.use_def_map(scope_id)
@@ -519,6 +530,13 @@ impl<'db> SemanticIndex<'db> {
     pub fn is_standalone_expression(&self, expression_key: impl Into<ExpressionNodeKey>) -> bool {
         self.expressions_by_node
             .contains_key(&expression_key.into())
+    }
+
+    pub fn try_statement(
+        &self,
+        statement_key: impl Into<StatementNodeKey>,
+    ) -> Option<Statement<'db>> {
+        self.statements_by_node.get(&statement_key.into()).copied()
     }
 
     /// Returns the id of the scope that `node` creates.
@@ -922,7 +940,9 @@ mod tests {
     use crate::{
         ast_ids::{HasScopedUseId, ScopedUseId},
         db::tests::{TestDb, TestDbBuilder},
-        definition::DefinitionKind,
+        definition::{
+            DefinitionKind, LambdaParameterDefinitionNodeKind, ParameterDefinitionNodeKind,
+        },
     };
 
     impl UseDefMap<'_> {
@@ -1209,14 +1229,14 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
             .unwrap();
         assert!(matches!(
             args_binding.kind(&db),
-            DefinitionKind::VariadicPositionalParameter(_)
+            DefinitionKind::Parameter(ParameterDefinitionNodeKind::VariadicPositionalParameter(_))
         ));
         let kwargs_binding = use_def
             .first_public_binding(function_table.symbol_id("kwargs").expect("symbol exists"))
             .unwrap();
         assert!(matches!(
             kwargs_binding.kind(&db),
-            DefinitionKind::VariadicKeywordParameter(_)
+            DefinitionKind::Parameter(ParameterDefinitionNodeKind::VariadicKeywordParameter(_))
         ));
     }
 
@@ -1239,7 +1259,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
         let lambda_table = index.place_table(lambda_scope_id);
         assert_eq!(
             names(lambda_table),
-            vec!["a", "b", "c", "d", "args", "kwargs"],
+            vec!["a", "b", "c", "args", "d", "kwargs"],
         );
 
         let use_def = index.use_def_map(lambda_scope_id);
@@ -1247,21 +1267,36 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
             let binding = use_def
                 .first_public_binding(lambda_table.symbol_id(name).expect("symbol exists"))
                 .unwrap();
-            assert!(matches!(binding.kind(&db), DefinitionKind::Parameter(_)));
+            assert!(matches!(
+                binding.kind(&db),
+                DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
+                    index: _,
+                    lambda: _,
+                    parameter: ParameterDefinitionNodeKind::Parameter(_)
+                })
+            ));
         }
         let args_binding = use_def
             .first_public_binding(lambda_table.symbol_id("args").expect("symbol exists"))
             .unwrap();
         assert!(matches!(
             args_binding.kind(&db),
-            DefinitionKind::VariadicPositionalParameter(_)
+            DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
+                index: 3,
+                lambda: _,
+                parameter: ParameterDefinitionNodeKind::VariadicPositionalParameter(_)
+            })
         ));
         let kwargs_binding = use_def
             .first_public_binding(lambda_table.symbol_id("kwargs").expect("symbol exists"))
             .unwrap();
         assert!(matches!(
             kwargs_binding.kind(&db),
-            DefinitionKind::VariadicKeywordParameter(_)
+            DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
+                index: 5,
+                lambda: _,
+                parameter: ParameterDefinitionNodeKind::VariadicKeywordParameter(_)
+            })
         ));
     }
 

--- a/crates/ty_python_core/src/statement.rs
+++ b/crates/ty_python_core/src/statement.rs
@@ -1,0 +1,68 @@
+use crate::ast_node_ref::AstNodeRef;
+use crate::db::Db;
+use crate::definition::Definition;
+use crate::expression::Expression;
+use crate::node_key::NodeKey;
+use crate::scope::{FileScopeId, ScopeId};
+use ruff_db::files::File;
+use ruff_python_ast as ast;
+use salsa;
+
+/// An independently type-inferable statement.
+///
+/// Many statements can be treated directly as definitions or expressions,
+/// and so do not require a separate Salsa allocation.
+#[derive(
+    Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Supertype, salsa::Update, get_size2::GetSize,
+)]
+pub enum Statement<'db> {
+    Expression(Expression<'db>),
+    Definition(Definition<'db>),
+    Other(StatementInner<'db>),
+}
+
+/// An independently type-inferable statement.
+///
+/// ## Module-local type
+/// This type should not be used as part of any cross-module API because
+/// it holds a reference to the AST node. Range-offset changes
+/// then propagate through all usages, and deserialization requires
+/// reparsing the entire module.
+///
+/// E.g. don't use this type in:
+///
+/// * a return type of a cross-module query
+/// * a field of a type that is a return type of a cross-module query
+/// * an argument of a cross-module query
+#[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
+pub struct StatementInner<'db> {
+    /// The file in which the statement occurs.
+    pub file: File,
+
+    /// The scope in which the statement occurs.
+    pub file_scope: FileScopeId,
+
+    /// The statement node.
+    #[no_eq]
+    #[tracked]
+    #[returns(ref)]
+    pub node_ref: AstNodeRef<ast::Stmt>,
+}
+
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for StatementInner<'_> {}
+
+impl<'db> StatementInner<'db> {
+    pub fn scope(self, db: &'db dyn Db) -> ScopeId<'db> {
+        self.file_scope(db).to_scope_id(db, self.file(db))
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, salsa::Update, get_size2::GetSize)]
+pub struct StatementNodeKey(NodeKey);
+
+impl From<&ast::Stmt> for StatementNodeKey {
+    fn from(node: &ast::Stmt) -> Self {
+        Self(NodeKey::from_node(node))
+    }
+}

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -474,6 +474,9 @@ from typing import Callable, TypedDict
 class Bar(TypedDict):
     bar: int
 
+def id[T](x: T) -> T:
+    return x
+
 f1 = lambda x: {"bar": 1}
 reveal_type(f1)  # revealed: (x) -> dict[str, int]
 
@@ -485,26 +488,49 @@ reveal_type(f2)  # revealed: (x: int) -> Bar
 f3: Callable[[int], Bar] = lambda x: {}
 reveal_type(f3)  # revealed: (int, /) -> Bar
 
-# TODO: This should reveal `str`.
-f4: Callable[[str], str] = lambda x: reveal_type(x)  # revealed: Unknown
-reveal_type(f4)  # revealed: (x: str) -> Unknown
+f4: Callable[[str], str] = lambda x: reveal_type(x)  # revealed: str
+reveal_type(f4)  # revealed: (x: str) -> str
+
+f5: Callable[[str], str] = id(lambda x: reveal_type(x))  # revealed: str
+reveal_type(f5)  # revealed: (x: str) -> str
 
 # TODO: This should not error once we support `Unpack`.
 # error: [invalid-assignment]
-f5: Callable[[*tuple[int, ...]], None] = lambda x, y, z: None
-reveal_type(f5)  # revealed: (tuple[int, ...], /) -> None
+f6: Callable[[*tuple[int, ...]], None] = lambda x, y, z: None
+reveal_type(f6)  # revealed: (tuple[int, ...], /) -> None
 
-f6: Callable[[int, str], None] = lambda *args: None
-reveal_type(f6)  # revealed: (*args) -> None
+f7: Callable[[int, str], None] = lambda *args: None
+reveal_type(f7)  # revealed: (*args) -> None
 
 # N.B. `Callable` annotations only support positional parameters.
 # error: [invalid-assignment]
-f7: Callable[[int], None] = lambda *, x=1: None
-reveal_type(f7)  # revealed: (int, /) -> None
+f8: Callable[[int], None] = lambda *, x=1: None
+reveal_type(f8)  # revealed: (int, /) -> None
 
 # TODO: This should reveal `(*args: int, *, x=1) -> None` once we support `Unpack`.
-f8: Callable[[*tuple[int, ...], int], None] = lambda *args, x=1: None
-reveal_type(f8)  # revealed: (*args, *, x=1) -> None
+f9: Callable[[*tuple[int, ...], int], None] = lambda *args, x=1: None
+reveal_type(f9)  # revealed: (*args, *, x=1) -> None
+
+f10: Callable[[str, int, str], tuple[str, int, str]] = lambda x, y, z: reveal_type((x, y, z))  # revealed: tuple[str, int, str]
+reveal_type(f10)  # revealed: (x: str, y: int, z: str) -> tuple[str, int, str]
+
+# TODO: This should reveal `tuple[int, ...]` once we support `Unpack`.
+f11: Callable[[*tuple[int, ...]], tuple[int, ...]] = lambda *args: reveal_type(args)  # revealed: tuple[Unknown, ...]
+reveal_type(f11)  # revealed: (*args) -> tuple[Unknown, ...]
+
+# TODO: Better generic call inference.
+def _(x: list[int]):
+    f12 = list(map(lambda y: y + 1, x))
+    reveal_type(f12)  # revealed: list[Unknown]
+
+def _() -> Callable[[int], int]:
+    return id(lambda x: reveal_type(x))  # revealed: int
+
+def _():
+    def takes_callable(_: Callable[[int], int]): ...
+
+    takes_callable(lambda x: reveal_type(x))  # revealed: int
+    takes_callable(id(id(lambda x: reveal_type(x))))  # revealed: int
 
 def _(x: bool):
     signatures = {
@@ -520,10 +546,10 @@ def _(x: bool):
 We do not currently account for type annotations present later in the scope:
 
 ```py
-f9 = lambda: [1]
+f12 = lambda: [1]
 # TODO: This should not error.
-_: list[int | str] = f9()  # error: [invalid-assignment]
-reveal_type(f9)  # revealed: () -> list[int]
+_: list[int | str] = f12()  # error: [invalid-assignment]
+reveal_type(f12)  # revealed: () -> list[int]
 ```
 
 ## Dunder Calls

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/unused_awaitable.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/unused_awaitable.md
@@ -8,8 +8,12 @@ Calling an `async def` function produces a coroutine that must be awaited.
 async def fetch() -> int:
     return 42
 
+async def fetch_complex(x) -> int:
+    return 42
+
 async def main():
     fetch()  # error: [unused-awaitable]
+    fetch_complex(lambda: None)  # error: [unused-awaitable]
 ```
 
 ## Awaited coroutine is fine

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1873,9 +1873,8 @@ mod resolve_definition {
             | DefinitionKind::DictKeyAssignment(_)
             | DefinitionKind::For(_)
             | DefinitionKind::Comprehension(_)
-            | DefinitionKind::VariadicPositionalParameter(_)
-            | DefinitionKind::VariadicKeywordParameter(_)
             | DefinitionKind::Parameter(_)
+            | DefinitionKind::LambdaParameter { .. }
             | DefinitionKind::WithItem(_)
             | DefinitionKind::MatchPattern(_)
             | DefinitionKind::ExceptHandler(_)

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -20,9 +20,8 @@ fn should_consider_definition(kind: &DefinitionKind<'_>) -> bool {
         | DefinitionKind::AnnotatedAssignment(_)
         | DefinitionKind::For(_)
         | DefinitionKind::Comprehension(_)
-        | DefinitionKind::VariadicPositionalParameter(_)
-        | DefinitionKind::VariadicKeywordParameter(_)
         | DefinitionKind::Parameter(_)
+        | DefinitionKind::LambdaParameter { .. }
         | DefinitionKind::WithItem(_)
         | DefinitionKind::MatchPattern(_)
         | DefinitionKind::ExceptHandler(_) => true,

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1,10 +1,16 @@
-//! We have Salsa queries for inferring types at three different granularities: scope-level,
-//! definition-level, and expression-level, plus lightweight queries for focused subregions like
-//! function decorators.
+//! We have Salsa queries for inferring types at four different granularities: scope-level,
+//! statement-level, definition-level, and expression-level, plus lightweight queries for
+//! focused subregions like function decorators.
 //!
 //! Scope-level inference is for when we are actually checking a file, and need to check types for
 //! everything in that file's scopes, or give a linter access to types of arbitrary expressions
 //! (via the [`HasType`](crate::semantic_model::HasType) trait).
+//!
+//! Statement-level inference is needed in only a few cases. Some expressions need access to
+//! type context from a parent expression, e.g., the type of lambda parameter depends on the
+//! annotated type of the lambda. Statements are the minimal unit of code that can be inferred
+//! without external type context, and so statement-level inference allows us to resolve type
+//! context without relying on scope-level inference cycles.
 //!
 //! Definition-level inference allows us to look up the types of places in other scopes (e.g. for
 //! imports) with the minimum inference necessary, so that if we're looking up one place from a
@@ -19,10 +25,10 @@
 //! cached by Salsa. We also need the expression-level query for inferring types in type guard
 //! expressions (e.g. the test clause of an `if` statement.)
 //!
-//! Inferring types at any of the three region granularities returns a [`ExpressionInference`],
-//! [`DefinitionInference`], or [`ScopeInference`], which hold the types for every expression
-//! within the inferred region. Some inference types also expose the type of every definition
-//! within the inferred region.
+//! Inferring types at any of the four region granularities returns a [`ExpressionInference`],
+//! [`DefinitionInference`], [`StatementInference`], or [`ScopeInference`], which hold the types for
+//! every expression within the inferred region. Some inference types also expose the type of every
+//! definition within the inferred region.
 //!
 //! Some type expressions can require deferred evaluation. This includes all type expressions in
 //! stub files, or annotation expressions in modules with `from __future__ import annotations`, or
@@ -42,6 +48,7 @@ use ruff_text_size::Ranged;
 use rustc_hash::{FxHashMap, FxHashSet};
 use salsa;
 use salsa::plumbing::AsId;
+use ty_python_core::statement::StatementInner;
 
 use crate::Db;
 use crate::types::diagnostic::TypeCheckDiagnostics;
@@ -58,7 +65,7 @@ use ty_python_core::definition::Definition;
 use ty_python_core::expression::Expression;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::unpack::Unpack;
-use ty_python_core::{ExpressionNodeKey, SemanticIndex, semantic_index};
+use ty_python_core::{ExpressionNodeKey, SemanticIndex, Statement, semantic_index};
 
 mod builder;
 mod comparisons;
@@ -387,6 +394,64 @@ fn infer_expression_type_impl<'db>(db: &'db dyn Db, input: InferExpression<'db>)
     inference.expression_type(expression.node_ref(db))
 }
 
+/// Infer all types for a [`Statement`].
+///
+/// This is useful when you want to infer a sub-expression with its natural type context, as
+/// statements are the minimal unit of code that can be inferred without external type context.
+pub(super) fn infer_statement_types<'db>(
+    db: &'db dyn Db,
+    statement: Statement<'db>,
+) -> StatementInference<'db> {
+    match statement {
+        Statement::Expression(expression) => StatementInference::Expression(
+            infer_expression_types(db, expression, TypeContext::default()),
+        ),
+        Statement::Definition(definition) => {
+            StatementInference::Definition(infer_definition_types(db, definition))
+        }
+        Statement::Other(statement) => {
+            StatementInference::Other(infer_statement_types_impl(db, statement))
+        }
+    }
+}
+
+#[salsa::tracked(
+    returns(ref),
+    cycle_initial=statement_cycle_initial,
+    cycle_fn=|db, cycle, previous: &StatementInferenceInner<'db>, inference: StatementInferenceInner<'db>, _| {
+        inference.cycle_normalized(db, previous, cycle)
+    },
+    heap_size=ruff_memory_usage::heap_size
+)]
+fn infer_statement_types_impl<'db>(
+    db: &'db dyn Db,
+    statement: StatementInner<'db>,
+) -> StatementInferenceInner<'db> {
+    let file = statement.file(db);
+    let module = parsed_module(db, file).load(db);
+    let _span = tracing::trace_span!(
+        "infer_statement_types",
+        statement = ?statement.as_id(),
+        range = ?statement.node_ref(db).node(&module).range(),
+        ?file
+    )
+    .entered();
+
+    let index = semantic_index(db, file);
+
+    TypeInferenceBuilder::new(db, InferenceRegion::Statement(statement), index, &module)
+        .finish_statement()
+}
+
+fn statement_cycle_initial<'db>(
+    db: &'db dyn Db,
+    id: salsa::Id,
+    statement: StatementInner<'db>,
+) -> StatementInferenceInner<'db> {
+    let cycle_recovery = Type::divergent(id);
+    StatementInferenceInner::cycle_initial(statement.scope(db), cycle_recovery)
+}
+
 /// An `Expression` with an optional `TypeContext`.
 ///
 /// This is a Salsa supertype used as the input to `infer_expression_types` to avoid
@@ -585,6 +650,8 @@ pub(crate) fn nearest_enclosing_function<'db>(
 /// A region within which we can infer types.
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum InferenceRegion<'db> {
+    // infer types for a [`Statement`].
+    Statement(StatementInner<'db>),
     /// infer types for a standalone [`Expression`]
     Expression(Expression<'db>, TypeContext<'db>),
     /// infer types for a [`Definition`]
@@ -600,6 +667,7 @@ pub(crate) enum InferenceRegion<'db> {
 impl<'db> InferenceRegion<'db> {
     fn scope(self, db: &'db dyn Db) -> ScopeId<'db> {
         match self {
+            InferenceRegion::Statement(statement) => statement.scope(db),
             InferenceRegion::Expression(expression, _) => expression.scope(db),
             InferenceRegion::Definition(definition)
             | InferenceRegion::FunctionDecorators(definition)
@@ -968,6 +1036,155 @@ impl<'db> ExpressionInference<'db> {
     }
 
     fn fallback_type(&self) -> Option<Type<'db>> {
+        self.extra.as_ref().and_then(|extra| extra.cycle_recovery)
+    }
+}
+
+/// The inferred types for a statement region.
+///
+/// Many statements can be treated directly as definitions or expressions,
+/// and so simply wrapped the inference result of those regions.
+#[derive(Debug, Eq, PartialEq, get_size2::GetSize)]
+pub(crate) enum StatementInference<'db> {
+    Expression(&'db ExpressionInference<'db>),
+    Definition(&'db DefinitionInference<'db>),
+    Other(&'db StatementInferenceInner<'db>),
+}
+
+impl<'db> StatementInference<'db> {
+    pub(crate) fn expression_type(&self, expression: impl Into<ExpressionNodeKey>) -> Type<'db> {
+        match self {
+            StatementInference::Expression(inference) => inference.expression_type(expression),
+            StatementInference::Definition(inference) => inference.expression_type(expression),
+            StatementInference::Other(inference) => inference.expression_type(expression),
+        }
+    }
+}
+
+/// The inferred types for a statement region.
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) struct StatementInferenceInner<'db> {
+    /// The types of every expression in this region.
+    expressions: FxHashMap<ExpressionNodeKey, Type<'db>>,
+
+    /// The scope this region is part of.
+    #[cfg(debug_assertions)]
+    scope: ScopeId<'db>,
+
+    /// The types of every binding in this region.
+    bindings: Box<[(Definition<'db>, Type<'db>)]>,
+
+    /// The types and type qualifiers of every declaration in this region.
+    declarations: Box<[(Definition<'db>, TypeAndQualifiers<'db>)]>,
+
+    /// The extra data that is only present for few inference regions.
+    extra: Option<Box<StatementInferenceInnerExtra<'db>>>,
+}
+
+#[derive(Debug, Eq, PartialEq, get_size2::GetSize, salsa::Update, Default)]
+struct StatementInferenceInnerExtra<'db> {
+    /// String annotations found in this region
+    string_annotations: FxHashSet<ExpressionNodeKey>,
+
+    /// Functions called while inferring this statement.
+    called_functions: Box<[FunctionType<'db>]>,
+
+    /// The fallback type for missing expressions/bindings/declarations or recursive type inference.
+    cycle_recovery: Option<Type<'db>>,
+
+    /// The definitions that have some deferred parts.
+    deferred: Box<[Definition<'db>]>,
+
+    /// The diagnostics for this region.
+    diagnostics: TypeCheckDiagnostics,
+
+    /// Type qualifiers (`Required`, `NotRequired`, etc.) for annotation expressions.
+    /// Only populated for expressions that have non-empty qualifiers.
+    qualifiers: FxHashMap<ExpressionNodeKey, TypeQualifiers>,
+}
+
+impl<'db> StatementInferenceInner<'db> {
+    fn cycle_initial(scope: ScopeId<'db>, cycle_recovery: Type<'db>) -> Self {
+        let _ = scope;
+
+        Self {
+            expressions: FxHashMap::default(),
+            bindings: Box::default(),
+            declarations: Box::default(),
+            #[cfg(debug_assertions)]
+            scope,
+            extra: Some(Box::new(StatementInferenceInnerExtra {
+                cycle_recovery: Some(cycle_recovery),
+                ..StatementInferenceInnerExtra::default()
+            })),
+        }
+    }
+
+    fn cycle_normalized(
+        mut self,
+        db: &'db dyn Db,
+        previous_inference: &StatementInferenceInner<'db>,
+        cycle: &salsa::Cycle,
+    ) -> StatementInferenceInner<'db> {
+        for (expr, ty) in &mut self.expressions {
+            let previous_ty = previous_inference.expression_type(*expr);
+            *ty = ty.cycle_normalized(db, previous_ty, cycle);
+        }
+        for (binding, binding_ty) in &mut self.bindings {
+            if let Some((_, previous_binding)) = previous_inference
+                .bindings
+                .iter()
+                .find(|(previous_binding, _)| previous_binding == binding)
+            {
+                *binding_ty = binding_ty.cycle_normalized(db, *previous_binding, cycle);
+            } else {
+                *binding_ty = binding_ty.recursive_type_normalized(db, cycle);
+            }
+        }
+        for (declaration, declaration_ty) in &mut self.declarations {
+            if let Some((_, previous_declaration)) = previous_inference
+                .declarations
+                .iter()
+                .find(|(previous_declaration, _)| previous_declaration == declaration)
+            {
+                *declaration_ty = declaration_ty.map_type(|decl_ty| {
+                    decl_ty.cycle_normalized(db, previous_declaration.inner_type(), cycle)
+                });
+            } else {
+                *declaration_ty =
+                    declaration_ty.map_type(|decl_ty| decl_ty.recursive_type_normalized(db, cycle));
+            }
+        }
+
+        self
+    }
+
+    pub(crate) fn expression_type(&self, expression: impl Into<ExpressionNodeKey>) -> Type<'db> {
+        self.try_expression_type(expression)
+            .unwrap_or_else(Type::unknown)
+    }
+
+    pub(crate) fn try_expression_type(
+        &self,
+        expression: impl Into<ExpressionNodeKey>,
+    ) -> Option<Type<'db>> {
+        self.expressions
+            .get(&expression.into())
+            .copied()
+            .or_else(|| self.fallback_type())
+    }
+
+    fn bindings(&self) -> impl ExactSizeIterator<Item = (Definition<'db>, Type<'db>)> {
+        self.bindings.iter().copied()
+    }
+
+    fn declarations(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (Definition<'db>, TypeAndQualifiers<'db>)> {
+        self.declarations.iter().copied()
+    }
+
+    pub(crate) fn fallback_type(&self) -> Option<Type<'db>> {
         self.extra.as_ref().and_then(|extra| extra.cycle_recovery)
     }
 }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -48,7 +48,6 @@ use ruff_text_size::Ranged;
 use rustc_hash::{FxHashMap, FxHashSet};
 use salsa;
 use salsa::plumbing::AsId;
-use ty_python_core::statement::StatementInner;
 
 use crate::Db;
 use crate::types::diagnostic::TypeCheckDiagnostics;
@@ -64,6 +63,7 @@ pub(super) use comparisons::UnsupportedComparisonError;
 use ty_python_core::definition::Definition;
 use ty_python_core::expression::Expression;
 use ty_python_core::scope::ScopeId;
+use ty_python_core::statement::StatementInner;
 use ty_python_core::unpack::Unpack;
 use ty_python_core::{ExpressionNodeKey, SemanticIndex, Statement, semantic_index};
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -20,6 +20,7 @@ use smallvec::SmallVec;
 use strum::IntoEnumIterator;
 use ty_module_resolver::{KnownModule, ModuleName, resolve_module};
 use ty_python_core::ast_ids::HasScopedUseId;
+use ty_python_core::statement::StatementInner;
 
 use super::{
     DefinitionInference, DefinitionInferenceExtra, ExpressionInference, ExpressionInferenceExtra,
@@ -73,7 +74,10 @@ use crate::types::generics::{InferableTypeVars, SpecializationBuilder, bind_type
 use crate::types::infer::builder::named_tuple::NamedTupleKind;
 use crate::types::infer::builder::paramspec_validation::validate_paramspec_components;
 use crate::types::infer::builder::typed_dict::TypedDictConstructorForm;
-use crate::types::infer::{nearest_enclosing_class, nearest_enclosing_function};
+use crate::types::infer::{
+    StatementInference, StatementInferenceInner, StatementInferenceInnerExtra,
+    infer_statement_types, nearest_enclosing_class, nearest_enclosing_function,
+};
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::newtype::NewType;
 use crate::types::set_theoretic::RecursivelyDefined;
@@ -93,12 +97,12 @@ use crate::types::{
     UnionType, binding_type, infer_complete_scope_types, infer_scope_types, todo_type,
 };
 use crate::{AnalysisSettings, Db, FxIndexSet, Program};
-use ty_python_core::ExpressionNodeKey;
 use ty_python_core::ast_ids::ScopedUseId;
 use ty_python_core::definition::{
     AnnotatedAssignmentDefinitionKind, AssignmentDefinitionKind, ComprehensionDefinitionKind,
     Definition, DefinitionKind, DefinitionNodeKey, DefinitionState, ExceptHandlerDefinitionKind,
-    ForStmtDefinitionKind, LoopHeaderDefinitionKind, TargetKind, WithItemDefinitionKind,
+    ForStmtDefinitionKind, LambdaParameterDefinitionNodeKind, LoopHeaderDefinitionKind,
+    ParameterDefinitionNodeKind, TargetKind, WithItemDefinitionKind,
 };
 use ty_python_core::expression::{Expression, ExpressionKind};
 use ty_python_core::narrowing_constraints::ConstraintKey;
@@ -110,6 +114,7 @@ use ty_python_core::{
     ApplicableConstraints, EnclosingSnapshotResult, EvaluationMode, SemanticIndex, Truthiness,
     place_table, unpack::UnpackPosition,
 };
+use ty_python_core::{ExpressionNodeKey, Statement};
 
 mod annotation_expression;
 mod binary_expressions;
@@ -387,6 +392,35 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
+    fn extend_statement(&mut self, inference: &StatementInference<'db>) {
+        let inference = match inference {
+            StatementInference::Other(inference) => inference,
+            StatementInference::Expression(inference) => return self.extend_expression(inference),
+            StatementInference::Definition(inference) => return self.extend_definition(inference),
+        };
+
+        #[cfg(debug_assertions)]
+        assert_eq!(self.scope, inference.scope);
+
+        self.expressions.extend(inference.expressions.iter());
+        self.declarations.extend(inference.declarations());
+
+        if !matches!(self.region, InferenceRegion::Scope(..)) {
+            self.bindings.extend(inference.bindings());
+        }
+
+        if let Some(extra) = &inference.extra {
+            self.called_functions
+                .extend(extra.called_functions.iter().copied());
+            self.extend_cycle_recovery(extra.cycle_recovery);
+            self.context.extend(&extra.diagnostics);
+            self.deferred.extend(extra.deferred.iter().copied());
+            self.string_annotations
+                .extend(extra.string_annotations.iter().copied());
+            self.qualifiers.extend(extra.qualifiers.iter());
+        }
+    }
+
     fn extend_expression(&mut self, inference: &ExpressionInference<'db>) {
         #[cfg(debug_assertions)]
         assert_eq!(self.scope, inference.scope);
@@ -602,6 +636,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// Infers types in the given [`InferenceRegion`].
     fn infer_region(&mut self) {
         match self.region {
+            InferenceRegion::Statement(statement) => self.infer_region_statement(statement),
             InferenceRegion::Scope(scope, tcx) => self.infer_region_scope(scope, tcx),
             InferenceRegion::Definition(definition) => self.infer_region_definition(definition),
             InferenceRegion::FunctionDecorators(definition) => {
@@ -746,6 +781,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
+    fn infer_region_statement(&mut self, statement: StatementInner<'db>) {
+        self.infer_statement(statement.node_ref(self.db()).node(self.module()));
+    }
+
     fn infer_region_definition(&mut self, definition: Definition<'db>) {
         match definition.kind(self.db()) {
             DefinitionKind::Function(function) => {
@@ -812,21 +851,60 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             DefinitionKind::Comprehension(comprehension) => {
                 self.infer_comprehension_definition(comprehension, definition);
             }
-            DefinitionKind::VariadicPositionalParameter(parameter) => {
+            DefinitionKind::Parameter(
+                ParameterDefinitionNodeKind::VariadicPositionalParameter(parameter),
+            ) => {
                 self.infer_variadic_positional_parameter_definition(
                     parameter.node(self.module()),
                     definition,
                 );
             }
-            DefinitionKind::VariadicKeywordParameter(parameter) => {
+            DefinitionKind::Parameter(ParameterDefinitionNodeKind::VariadicKeywordParameter(
+                parameter,
+            )) => {
                 self.infer_variadic_keyword_parameter_definition(
                     parameter.node(self.module()),
                     definition,
                 );
             }
-            DefinitionKind::Parameter(parameter_with_default) => {
+            DefinitionKind::Parameter(ParameterDefinitionNodeKind::Parameter(
+                parameter_with_default,
+            )) => {
                 self.infer_parameter_definition(
                     parameter_with_default.node(self.module()),
+                    definition,
+                );
+            }
+            DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
+                index,
+                lambda,
+                parameter: ParameterDefinitionNodeKind::VariadicPositionalParameter(parameter),
+            }) => {
+                self.infer_variadic_positional_lambda_parameter_definition(
+                    *index,
+                    parameter.node(self.module()),
+                    lambda.node(self.module()),
+                    definition,
+                );
+            }
+            DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
+                parameter: ParameterDefinitionNodeKind::VariadicKeywordParameter(parameter),
+                ..
+            }) => {
+                self.infer_variadic_keyword_lambda_parameter_definition(
+                    parameter.node(self.module()),
+                    definition,
+                );
+            }
+            DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
+                index,
+                lambda,
+                parameter: ParameterDefinitionNodeKind::Parameter(parameter_with_default),
+            }) => {
+                self.infer_lambda_parameter_definition(
+                    *index,
+                    parameter_with_default.node(self.module()),
+                    lambda.node(self.module()),
                     definition,
                 );
             }
@@ -1391,7 +1469,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn infer_body(&mut self, suite: &[ast::Stmt]) {
         for statement in suite {
-            self.infer_statement(statement);
+            self.infer_maybe_standalone_statement(statement);
+
+            if let ast::Stmt::Expr(ast::StmtExpr {
+                range: _,
+                node_index: _,
+                value,
+            }) = statement
+            {
+                let ty = self.expression_type(value);
+                if ty.is_awaitable(self.db()) && !self.is_known_function_call(value) {
+                    if let Some(builder) =
+                        self.context.report_lint(&UNUSED_AWAITABLE, value.as_ref())
+                    {
+                        builder.into_diagnostic(format_args!(
+                            "Object of type `{}` is not awaited",
+                            ty.display(self.db()),
+                        ));
+                    }
+                }
+            }
         }
     }
 
@@ -1406,18 +1503,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }) => {
                 // If this is a call expression, we would have added an `IsNonTerminalCall`
                 // constraint, meaning this will be a standalone expression.
-                let ty = self.infer_maybe_standalone_expression(value, TypeContext::default());
-
-                if ty.is_awaitable(self.db()) && !self.is_known_function_call(value) {
-                    if let Some(builder) =
-                        self.context.report_lint(&UNUSED_AWAITABLE, value.as_ref())
-                    {
-                        builder.into_diagnostic(format_args!(
-                            "Object of type `{}` is not awaited",
-                            ty.display(self.db()),
-                        ));
-                    }
-                }
+                self.infer_maybe_standalone_expression(value, TypeContext::default());
             }
             ast::Stmt::If(if_statement) => self.infer_if_statement(if_statement),
             ast::Stmt::Try(try_statement) => self.infer_try_statement(try_statement),
@@ -5172,6 +5258,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
+    fn infer_maybe_standalone_statement(&mut self, statement: &ast::Stmt) {
+        if let Some(standalone_statement) = self.index.try_statement(statement) {
+            self.infer_standalone_statement_impl(standalone_statement);
+        } else {
+            self.infer_statement(statement);
+        }
+    }
+
+    fn infer_standalone_statement_impl(&mut self, standalone_statement: Statement<'db>) {
+        let types = infer_statement_types(self.db(), standalone_statement);
+        self.extend_statement(&types);
+    }
+
     fn infer_optional_expression(
         &mut self,
         expression: Option<&ast::Expr>,
@@ -8874,6 +8973,86 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
+    pub(super) fn finish_statement(mut self) -> StatementInferenceInner<'db> {
+        self.infer_region();
+
+        let Self {
+            context,
+            mut expressions,
+            mut qualifiers,
+            string_annotations,
+            scope,
+            bindings,
+            declarations,
+            deferred,
+            cycle_recovery,
+            called_functions,
+
+            // Ignored; only relevant to definition regions
+            undecorated_type: _,
+
+            // builder only state
+            expression_cache: _,
+            dataclass_field_specifiers: _,
+            typevar_binding_context: _,
+            deferred_state: _,
+            index: _,
+            region: _,
+            return_types_and_ranges: _,
+        } = self;
+
+        let _ = scope;
+        let diagnostics = context.finish();
+
+        let extra = (!diagnostics.is_empty()
+            || !string_annotations.is_empty()
+            || cycle_recovery.is_some()
+            || !deferred.is_empty()
+            || !called_functions.is_empty()
+            || !qualifiers.is_empty())
+        .then(|| {
+            qualifiers.shrink_to_fit();
+            Box::new(StatementInferenceInnerExtra {
+                string_annotations,
+                called_functions: called_functions
+                    .into_iter()
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice(),
+                cycle_recovery,
+                deferred: deferred.into_boxed_slice(),
+                diagnostics,
+                qualifiers,
+            })
+        });
+
+        if bindings.len() > 20 {
+            tracing::debug!(
+                "Inferred statement region `{:?}` contains {} bindings. Lookups by linear scan might be slow.",
+                self.region,
+                bindings.len(),
+            );
+        }
+
+        if declarations.len() > 20 {
+            tracing::debug!(
+                "Inferred statement region `{:?}` contains {} declarations. Lookups by linear scan might be slow.",
+                self.region,
+                declarations.len(),
+            );
+        }
+
+        expressions.shrink_to_fit();
+
+        StatementInferenceInner {
+            expressions,
+            #[cfg(debug_assertions)]
+            scope,
+            bindings: bindings.into_boxed_slice(),
+            declarations: declarations.into_boxed_slice(),
+            extra,
+        }
+    }
+
     pub(super) fn finish_function_decorator_inference(mut self) -> FunctionDecoratorInference<'db> {
         self.infer_region();
 
@@ -9020,7 +9199,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             scope,
             cycle_recovery,
 
-            // Ignored, because scope types are never extended into other scopes.
+            // Ignored, never leaked into other scopes
             deferred: _,
             bindings: _,
             declarations: _,

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -22,7 +22,7 @@ use crate::{
                 DeclaredAndInferredType, DeferredExpressionState, TypeAndRange,
                 validate_paramspec_components,
             },
-            function_known_decorators, nearest_enclosing_function,
+            function_known_decorators, infer_statement_types, nearest_enclosing_function,
         },
         infer_definition_types, infer_scope_types, todo_type,
     },
@@ -906,6 +906,97 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             self.add_binding(parameter.into(), definition)
                 .insert(self, inferred_ty);
+        }
+    }
+
+    /// Set initial declared type (if annotated) and inferred type for a lambda-parameter symbol,
+    /// in the lambda body scope.
+    pub(super) fn infer_lambda_parameter_definition(
+        &mut self,
+        index: usize,
+        parameter_with_default: &'ast ast::ParameterWithDefault,
+        lambda: &'ast ast::ExprLambda,
+        definition: Definition<'db>,
+    ) {
+        let ast::ParameterWithDefault {
+            parameter,
+            default,
+            range: _,
+            node_index: _,
+        } = parameter_with_default;
+
+        let default_expr = default.as_ref();
+        let ty = if let Some(parameter_type) = self.annotated_lambda_parameter_type(index, lambda) {
+            parameter_type
+        } else if let Some(default_expr) = default_expr {
+            let default_ty = self.file_expression_type(default_expr);
+            UnionType::from_two_elements(self.db(), Type::unknown(), default_ty)
+        } else {
+            Type::unknown()
+        };
+
+        self.add_binding(parameter.into(), definition)
+            .insert(self, ty);
+    }
+
+    /// Set initial declared/inferred types for a `*args` variadic positional parameter
+    /// in a lambda expression.
+    pub(super) fn infer_variadic_positional_lambda_parameter_definition(
+        &mut self,
+        index: usize,
+        parameter: &'ast ast::Parameter,
+        lambda: &'ast ast::ExprLambda,
+        definition: Definition<'db>,
+    ) {
+        // Note that this currently always returns `None` because we do not support `Unpack`
+        // annotations for callable types.
+        let ty = if let Some(parameter_type) = self.annotated_lambda_parameter_type(index, lambda) {
+            parameter_type
+        } else {
+            Type::homogeneous_tuple(self.db(), Type::unknown())
+        };
+        self.add_binding(parameter.into(), definition)
+            .insert(self, ty);
+    }
+
+    /// Set initial declared/inferred types for a `**kwargs` keyword-variadic parameter
+    /// in a lambda expression.
+    pub(super) fn infer_variadic_keyword_lambda_parameter_definition(
+        &mut self,
+        parameter: &'ast ast::Parameter,
+        definition: Definition<'db>,
+    ) {
+        let inferred_ty = KnownClass::Dict.to_specialized_instance(
+            self.db(),
+            &[KnownClass::Str.to_instance(self.db()), Type::unknown()],
+        );
+
+        self.add_binding(parameter.into(), definition)
+            .insert(self, inferred_ty);
+    }
+
+    /// Returns the annotated type of the lambda parameter at the given index in the provided
+    /// lambda expression, based on a `Callable` type annotation, if present.
+    fn annotated_lambda_parameter_type(
+        &mut self,
+        index: usize,
+        lambda: &'ast ast::ExprLambda,
+    ) -> Option<Type<'db>> {
+        let enclosing_stmt = infer_statement_types(
+            self.db(),
+            self.index.enclosing_lambda_statement(lambda.into())?,
+        );
+        let callable = enclosing_stmt.expression_type(lambda).as_callable()?;
+        let [signature] = callable.signatures(self.db()).overloads.as_slice() else {
+            // TODO: If there are multiple applicable overloads, we could attempt multi-inference.
+            return None;
+        };
+
+        let parameter_type = signature.parameters().as_slice()[index].annotated_type();
+        if parameter_type.is_unknown() || parameter_type.has_unspecialized_type_var(self.db()) {
+            None
+        } else {
+            Some(parameter_type)
         }
     }
 }


### PR DESCRIPTION
Improves https://github.com/astral-sh/ruff/pull/22633 to infer the use of lambda parameters in a lambda body with type context, e.g.,
```py
x: Callable[[str], str] = lambda x: reveal_type(x)  # revealed: str
reveal_type(x)  # revealed: (x: str) -> str
```

Unlike other definitions, lambda parameter types cannot be determined purely syntactically in semantic indexing. Instead, they depend on the inferred type of the lambda to access its parameter types. Unfortunately, this makes lambda inference cyclic, as the body of the lambda depends on the outer lambda type, and there is no obvious way of splitting out inference of the lambda parameter types from its return type.

To avoid initiating cycles on the entire scope containing the lambda, this PR introduces a new inference query — statement-level inference. Statements are a minimal unit of code that encapsulate any internal type context. This makes them very useful to infer a given sub-expression "naturally" without having to provide any external type context. There are other places where we currently rely on scope-level inference for this purpose (e.g., see `infer_complete_scope_types`, the current implementation of https://github.com/astral-sh/ruff/pull/23761, and the discussion in https://github.com/astral-sh/ty/issues/3124). Note that statement-level inference is not perfectly fine-grained, e.g., the test expression of an `if` statement does not require external type context and is independent from its body, so statement-level inference may lead to unnecessarily large cycles, but having the unit of code being generalized to an AST structure allows us to avoid the need for such special cases, but this can always change in the future.

Additionally, many statements are simply wrappers around definitions or standalone expressions, so we can avoid extra salsa allocations in the common case.