### PR TITLE
[ty] Type Server Protocol Phase 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,6 @@ tracing.folded
 tracing-flamechart.svg
 tracing-flamegraph.svg
 
-# Personal notes
-/.notes
-
 # insta
 *.rs.pending-snap
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ tracing.folded
 tracing-flamechart.svg
 tracing-flamegraph.svg
 
+# Personal notes
+/.notes
+
 # insta
 *.rs.pending-snap
 

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -26,6 +26,7 @@ mod signature_help;
 mod stub_mapping;
 mod symbols;
 mod type_hierarchy;
+mod type_info;
 mod workspace_symbols;
 
 pub use all_symbols::{AllSymbolInfo, all_symbols};
@@ -51,6 +52,9 @@ pub use signature_help::{ParameterDetails, SignatureDetails, SignatureHelpInfo, 
 pub use symbols::{FlatSymbols, HierarchicalSymbols, SymbolId, SymbolInfo, SymbolKind};
 pub use type_hierarchy::{
     TypeHierarchyItem, prepare_type_hierarchy, type_hierarchy_subtypes, type_hierarchy_supertypes,
+};
+pub use type_info::{
+    DeclarationInfo, TypeCategory, TypeInfo, declared_type_info, expected_type_info, type_info,
 };
 pub use workspace_symbols::{WorkspaceSymbolInfo, workspace_symbols};
 

--- a/crates/ty_ide/src/type_info.rs
+++ b/crates/ty_ide/src/type_info.rs
@@ -1,0 +1,759 @@
+//! External API for type information.
+//!
+//! This module provides a clean external interface for obtaining type information
+//! at a specific position in a Python file. It's designed for use by external consumers
+//! like language server protocol implementations (e.g., TSP) without exposing
+//! internal ty type system details.
+
+use crate::goto::{Definitions, GotoTarget, find_goto_target};
+use crate::{Db, NavigationTarget, RangedValue};
+use ruff_db::files::File;
+use ruff_db::parsed::parsed_module;
+use ruff_python_ast::AnyNodeRef;
+use ruff_python_ast::find_node::covering_node;
+use ruff_python_ast::token::TokenKind;
+use ruff_text_size::{Ranged, TextSize};
+use ty_python_semantic::types::Type;
+use ty_python_semantic::types::ide_support::call_signature_details;
+use ty_python_semantic::{
+    HasType, ImportAliasResolution, SemanticModel, declared_type_for_definition,
+    function_overload_info,
+};
+
+/// The category of a type, providing a high-level classification.
+///
+/// This enumeration mirrors common type categories without exposing
+/// internal type system details.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeCategory {
+    Unknown,
+    Any,
+    Never,
+    None,
+    Class,
+    Instance,
+    Union,
+    Intersection,
+    Function,
+    BoundMethod,
+    Module,
+    TypeVar,
+    Literal,
+    Tuple,
+    TypedDict,
+    TypeAlias,
+    Callable,
+    OverloadedFunction,
+    SpecialForm,
+    Property,
+    NewType,
+    SubclassOf,
+    TypeGuard,
+    Dynamic,
+}
+
+/// Information about the declaration location of a type.
+#[derive(Debug, Clone)]
+pub struct DeclarationInfo {
+    /// The navigation target for the declaration.
+    pub target: NavigationTarget,
+}
+
+/// Structured information about a type at a specific position.
+///
+/// This struct provides all the information external consumers typically need
+/// without exposing internal ty types.
+#[derive(Debug, Clone)]
+pub struct TypeInfo {
+    /// The high-level category of this type.
+    pub category: TypeCategory,
+    /// Human-readable display string for the type.
+    pub display: String,
+    /// Optional declaration location for the symbol at the cursor position.
+    pub declaration: Option<DeclarationInfo>,
+    /// Optional declaration location for the TYPE itself (e.g., class definition).
+    /// For `x = A()`, `declaration` points to `x`, while `type_definition` points to `class A:`.
+    pub type_definition: Option<DeclarationInfo>,
+    /// For union types, the number of members.
+    pub union_member_count: Option<usize>,
+    /// For union types, the `TypeInfo` for each member type.
+    /// This allows external consumers to decompose unions into their constituent types
+    /// without needing access to ty's internal `Type<'db>` values.
+    pub union_members: Option<Vec<TypeInfo>>,
+    /// For overloaded functions, the `TypeInfo` for each `@overload` signature.
+    pub overload_members: Option<Vec<TypeInfo>>,
+    /// For overloaded functions, the `TypeInfo` for the implementation (non-`@overload` def).
+    pub implementation_member: Option<Box<TypeInfo>>,
+    /// For literal types, the literal value as a string.
+    pub literal_value: Option<String>,
+    /// For function types, the simplified signature if available.
+    pub signature: Option<String>,
+}
+
+/// Get type information at a specific position in a file.
+///
+/// This is the main entry point for external consumers who need type information
+/// at a cursor position.
+pub fn type_info(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<TypeInfo>> {
+    let parsed = parsed_module(db, file).load(db);
+    let model = SemanticModel::new(db, file);
+    let goto_target = find_goto_target(&model, &parsed, offset)?;
+
+    let ty = goto_target.inferred_type(&model)?;
+
+    let declaration = goto_target
+        .get_definition_targets(&model, ImportAliasResolution::ResolveAliases)
+        .and_then(|defs| get_declaration_from_definitions(db, defs, &ty, &model, &goto_target));
+
+    let signature = goto_target.call_type_simplified_by_overloads(&model);
+
+    let info = extract_type_info(db, ty, declaration, signature);
+
+    Some(RangedValue {
+        range: ruff_db::files::FileRange::new(file, goto_target.range()),
+        value: info,
+    })
+}
+
+/// Get the declared (annotated) type at a specific position in a file.
+///
+/// This returns the type from an explicit type annotation, if present.
+/// For example:
+/// - `x: int = 1` → returns `int` (not `Literal[1]`)
+/// - `def foo(x: str)` → for parameter `x`, returns `str`
+pub fn declared_type_info(
+    db: &dyn Db,
+    file: File,
+    offset: TextSize,
+) -> Option<RangedValue<TypeInfo>> {
+    let parsed = parsed_module(db, file).load(db);
+    let model = SemanticModel::new(db, file);
+    let goto_target = find_goto_target(&model, &parsed, offset)?;
+
+    let definitions =
+        goto_target.get_definition_targets(&model, ImportAliasResolution::ResolveAliases)?;
+
+    let declared_ty = get_declared_type_from_definitions(db, &definitions)?;
+
+    let info = extract_type_info(db, declared_ty, None, None);
+
+    Some(RangedValue {
+        range: ruff_db::files::FileRange::new(file, goto_target.range()),
+        value: info,
+    })
+}
+
+/// Get the declared (annotated) type from definitions.
+fn get_declared_type_from_definitions<'db>(
+    db: &'db dyn Db,
+    definitions: &Definitions<'db>,
+) -> Option<Type<'db>> {
+    for resolved_def in &definitions.0 {
+        if let Some(definition) = resolved_def.definition() {
+            if let Some(ty) = declared_type_for_definition(db, definition) {
+                return Some(ty);
+            }
+        }
+    }
+    None
+}
+
+/// Get the expected/contextual type at a specific position in a file.
+///
+/// Returns the type that the expression at this position is expected to have,
+/// based on its context. For example:
+/// - `x: int = <expr>` → expected type for `<expr>` is `int`
+/// - `foo(<expr>)` where `foo(x: int)` → expected type is `int`
+/// - `return <expr>` in a function with `-> int` → expected type is `int`
+pub fn expected_type_info(
+    db: &dyn Db,
+    file: File,
+    offset: TextSize,
+) -> Option<RangedValue<TypeInfo>> {
+    let parsed = parsed_module(db, file).load(db);
+    let model = SemanticModel::new(db, file);
+    let tokens = parsed.tokens();
+
+    let token = tokens
+        .at_offset(offset)
+        .max_by_key(|t| i32::from(t.kind() == TokenKind::Name))?;
+
+    let covering = covering_node(parsed.syntax().into(), token.range())
+        .find_first(AnyNodeRef::is_expression)
+        .ok()?;
+
+    let expr_node = covering.node();
+    let expr_range = expr_node.range();
+
+    let expected_ty = find_expected_type_from_context(db, &model, &covering)?;
+
+    let info = extract_type_info(db, expected_ty, None, None);
+
+    Some(RangedValue {
+        range: ruff_db::files::FileRange::new(file, expr_range),
+        value: info,
+    })
+}
+
+/// Find the expected type from the AST context of an expression.
+fn find_expected_type_from_context<'db>(
+    db: &'db dyn Db,
+    model: &SemanticModel<'db>,
+    covering: &ruff_python_ast::find_node::CoveringNode<'_>,
+) -> Option<Type<'db>> {
+    let expr_node = covering.node();
+
+    for ancestor in covering.ancestors() {
+        match ancestor {
+            // Case 1: Annotated assignment - `x: int = <expr>`
+            AnyNodeRef::StmtAnnAssign(ann_assign) => {
+                if let Some(value) = &ann_assign.value {
+                    if value.range().contains_range(expr_node.range()) {
+                        return ann_assign.annotation.inferred_type(model);
+                    }
+                }
+            }
+
+            // Case 2: Function call - `foo(<expr>)` where foo expects a certain type
+            AnyNodeRef::ExprCall(call_expr) => {
+                if let Some(expected_ty) =
+                    find_expected_type_for_argument(db, model, call_expr, expr_node)
+                {
+                    return Some(expected_ty);
+                }
+            }
+
+            // Case 3: Return statement - `return <expr>` in a function with return type
+            AnyNodeRef::StmtReturn(return_stmt) => {
+                if let Some(value) = &return_stmt.value {
+                    if value.range().contains_range(expr_node.range()) {
+                        if let Some(return_ty) =
+                            find_enclosing_function_return_type(model, covering)
+                        {
+                            return Some(return_ty);
+                        }
+                    }
+                }
+            }
+
+            _ => continue,
+        }
+    }
+
+    None
+}
+
+/// Find the expected type for an argument in a function call.
+fn find_expected_type_for_argument<'db>(
+    _db: &'db dyn Db,
+    model: &SemanticModel<'db>,
+    call_expr: &ruff_python_ast::ExprCall,
+    expr_node: AnyNodeRef<'_>,
+) -> Option<Type<'db>> {
+    let mut arg_index = None;
+
+    for (i, arg) in call_expr.arguments.args.iter().enumerate() {
+        if arg.range().contains_range(expr_node.range()) {
+            arg_index = Some(i);
+            break;
+        }
+    }
+
+    let arg_index = arg_index?;
+
+    let signature_details = call_signature_details(model, call_expr);
+    let signature = signature_details.first()?;
+
+    let arg_mapping = signature.argument_to_parameter_mapping.get(arg_index)?;
+
+    if !arg_mapping.matched {
+        return None;
+    }
+
+    let param_index = arg_mapping.parameters.first()?;
+
+    signature.parameter_types.get(*param_index).copied()
+}
+
+/// Find the return type of the enclosing function.
+fn find_enclosing_function_return_type<'db>(
+    model: &SemanticModel<'db>,
+    covering: &ruff_python_ast::find_node::CoveringNode<'_>,
+) -> Option<Type<'db>> {
+    for ancestor in covering.ancestors() {
+        if let AnyNodeRef::StmtFunctionDef(func_def) = ancestor {
+            if let Some(returns) = &func_def.returns {
+                return returns.inferred_type(model);
+            }
+            return None;
+        }
+    }
+
+    None
+}
+
+/// Extract structured type information from a Type.
+fn extract_type_info(
+    db: &dyn Db,
+    ty: Type<'_>,
+    declaration: Option<DeclarationInfo>,
+    signature: Option<String>,
+) -> TypeInfo {
+    let category = determine_category(&ty);
+    let display = ty.display(db).to_string();
+
+    let (union_member_count, literal_value) = extract_type_details(db, &ty);
+
+    let union_members = if let Type::Union(union) = &ty {
+        let members: Vec<TypeInfo> = union
+            .elements(db)
+            .iter()
+            .map(|member_ty| extract_type_info(db, *member_ty, None, None))
+            .collect();
+        Some(members)
+    } else {
+        None
+    };
+
+    let (overload_members, implementation_member) = match function_overload_info(db, ty) {
+        Some(info) => {
+            let overloads: Vec<TypeInfo> = info
+                .overloads
+                .into_iter()
+                .map(|detail| TypeInfo {
+                    category: TypeCategory::Function,
+                    display: detail.display,
+                    declaration: None,
+                    type_definition: None,
+                    union_member_count: None,
+                    union_members: None,
+                    overload_members: None,
+                    implementation_member: None,
+                    literal_value: None,
+                    signature: None,
+                })
+                .collect();
+            let implementation = info.implementation.map(|detail| {
+                Box::new(TypeInfo {
+                    category: TypeCategory::Function,
+                    display: detail.display,
+                    declaration: None,
+                    type_definition: None,
+                    union_member_count: None,
+                    union_members: None,
+                    overload_members: None,
+                    implementation_member: None,
+                    literal_value: None,
+                    signature: None,
+                })
+            });
+            (Some(overloads), implementation)
+        }
+        None => (None, None),
+    };
+
+    let type_definition = ty
+        .definition(db)
+        .and_then(|type_def| get_navigation_target_from_type_definition(db, &type_def))
+        .map(|target| DeclarationInfo { target });
+
+    TypeInfo {
+        category,
+        display,
+        declaration,
+        type_definition,
+        union_member_count,
+        union_members,
+        overload_members,
+        implementation_member,
+        literal_value,
+        signature,
+    }
+}
+
+/// Determine the category of a type.
+fn determine_category(ty: &Type<'_>) -> TypeCategory {
+    match ty {
+        Type::Dynamic(dyn_type) => match dyn_type {
+            ty_python_semantic::types::DynamicType::Any => TypeCategory::Any,
+            ty_python_semantic::types::DynamicType::Unknown => TypeCategory::Unknown,
+            _ => TypeCategory::Dynamic,
+        },
+        Type::Never => TypeCategory::Never,
+        Type::FunctionLiteral(_) => TypeCategory::Function,
+        Type::BoundMethod(_) | Type::KnownBoundMethod(_) => TypeCategory::BoundMethod,
+        Type::WrapperDescriptor(_) => TypeCategory::Function,
+        Type::DataclassDecorator(_) | Type::DataclassTransformer(_) => TypeCategory::Callable,
+        Type::Callable(_) => TypeCategory::Callable,
+        Type::ModuleLiteral(_) => TypeCategory::Module,
+        Type::ClassLiteral(_) | Type::GenericAlias(_) => TypeCategory::Class,
+        Type::SubclassOf(_) => TypeCategory::SubclassOf,
+        Type::NominalInstance(_) | Type::ProtocolInstance(_) => TypeCategory::Instance,
+        Type::SpecialForm(_) | Type::KnownInstance(_) => TypeCategory::SpecialForm,
+        Type::PropertyInstance(_) => TypeCategory::Property,
+        Type::Union(_) => TypeCategory::Union,
+        Type::Intersection(_) => TypeCategory::Intersection,
+        Type::AlwaysTruthy | Type::AlwaysFalsy => TypeCategory::Instance,
+        Type::LiteralValue(_) => TypeCategory::Literal,
+        Type::TypeVar(_) => TypeCategory::TypeVar,
+        Type::BoundSuper(_) => TypeCategory::Instance,
+        Type::TypeIs(_) | Type::TypeGuard(_) => TypeCategory::TypeGuard,
+        Type::TypedDict(_) => TypeCategory::TypedDict,
+        Type::TypeAlias(_) => TypeCategory::TypeAlias,
+        Type::NewTypeInstance(_) => TypeCategory::NewType,
+    }
+}
+
+/// Extract additional type details for specific type categories.
+fn extract_type_details(db: &dyn Db, ty: &Type<'_>) -> (Option<usize>, Option<String>) {
+    match ty {
+        Type::Union(union) => {
+            let count = union.elements(db).len();
+            (Some(count), None)
+        }
+        _ => (None, None),
+    }
+}
+
+/// Get declaration info from definitions.
+fn get_declaration_from_definitions<'db>(
+    db: &'db dyn Db,
+    definitions: Definitions<'db>,
+    ty: &Type<'db>,
+    model: &SemanticModel<'db>,
+    goto_target: &GotoTarget<'_>,
+) -> Option<DeclarationInfo> {
+    if let Some(targets) = definitions.declaration_targets(model, goto_target) {
+        if let Some(target) = targets.into_iter().next() {
+            return Some(DeclarationInfo { target });
+        }
+    }
+
+    // Fallback: try to get definition from the type itself
+    if let Some(type_def) = ty.definition(db) {
+        if let Some(target) = get_navigation_target_from_type_definition(db, &type_def) {
+            return Some(DeclarationInfo { target });
+        }
+    }
+
+    None
+}
+
+/// Convert a `TypeDefinition` to a `NavigationTarget`.
+fn get_navigation_target_from_type_definition(
+    db: &dyn Db,
+    type_def: &ty_python_semantic::types::TypeDefinition<'_>,
+) -> Option<NavigationTarget> {
+    use crate::HasNavigationTargets;
+    let targets = type_def.navigation_targets(db);
+    targets.into_iter().next()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::cursor_test;
+
+    #[test]
+    fn test_type_info_basic() {
+        let test = cursor_test(
+            r#"
+        x = 10
+        x<CURSOR>
+        "#,
+        );
+
+        let info = type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(info.is_some());
+        let info = info.unwrap();
+        assert_eq!(info.value.category, TypeCategory::Literal);
+        assert!(info.value.display.contains("10"));
+    }
+
+    #[test]
+    fn test_type_info_function() {
+        let test = cursor_test(
+            r#"
+        def func(a: int) -> str:
+            return ""
+
+        fun<CURSOR>c
+        "#,
+        );
+
+        let info = type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(info.is_some());
+        let info = info.unwrap();
+        assert_eq!(info.value.category, TypeCategory::Function);
+    }
+
+    #[test]
+    fn test_type_info_class() {
+        let test = cursor_test(
+            r#"
+        class MyClass:
+            pass
+
+        MyCla<CURSOR>ss
+        "#,
+        );
+
+        let info = type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(info.is_some());
+        let info = info.unwrap();
+        assert_eq!(info.value.category, TypeCategory::Class);
+    }
+
+    #[test]
+    fn test_type_info_union() {
+        let test = cursor_test(
+            r#"
+        def foo(x: int | str):
+            return x<CURSOR>
+        "#,
+        );
+
+        let info = type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(info.is_some());
+        let info = info.unwrap();
+        assert_eq!(info.value.category, TypeCategory::Union);
+        assert!(info.value.union_member_count.is_some());
+    }
+
+    #[test]
+    fn test_type_info_instance() {
+        let test = cursor_test(
+            r#"
+        x: int = 10
+        x<CURSOR>
+        "#,
+        );
+
+        let info = type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(info.is_some());
+        let info = info.unwrap();
+        // With explicit annotation, we get int instance, not literal
+        assert!(
+            info.value.category == TypeCategory::Instance
+                || info.value.category == TypeCategory::Literal
+        );
+    }
+
+    #[test]
+    fn test_type_info_none() {
+        let test = cursor_test(
+            r#"
+        x = None
+        x<CURSOR>
+        "#,
+        );
+
+        let info = type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(info.is_some());
+        let info = info.unwrap();
+        assert!(info.value.display.contains("None"));
+    }
+
+    #[test]
+    fn test_type_info_no_type() {
+        let test = cursor_test(
+            r#"
+        <CURSOR>
+        "#,
+        );
+
+        let info = type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(info.is_none());
+    }
+
+    #[test]
+    fn test_declared_type_info_with_annotation() {
+        let test = cursor_test(
+            r#"
+        x: int = 1
+        x<CURSOR>
+        "#,
+        );
+
+        let info = declared_type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(
+            info.is_some(),
+            "declared_type_info should return Some for annotated variable"
+        );
+        let info = info.unwrap();
+        assert_eq!(info.value.category, TypeCategory::Instance);
+        assert!(info.value.display.contains("int"));
+    }
+
+    #[test]
+    fn test_declared_type_info_no_annotation() {
+        let test = cursor_test(
+            r#"
+        x = 1
+        x<CURSOR>
+        "#,
+        );
+
+        let info = declared_type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(info.is_none());
+    }
+
+    #[test]
+    fn test_expected_type_info_annotated_assignment() {
+        let test = cursor_test(
+            r#"
+        x: int = 1<CURSOR>0
+        "#,
+        );
+
+        let info = expected_type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(info.is_some());
+        let info = info.unwrap();
+        assert_eq!(info.value.category, TypeCategory::Instance);
+        assert!(info.value.display.contains("int"));
+    }
+
+    #[test]
+    fn test_expected_type_info_function_argument() {
+        let test = cursor_test(
+            r#"
+        def foo(x: str):
+            pass
+
+        foo("hel<CURSOR>lo")
+        "#,
+        );
+
+        let info = expected_type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(info.is_some());
+        let info = info.unwrap();
+        assert_eq!(info.value.category, TypeCategory::Instance);
+        assert!(info.value.display.contains("str"));
+    }
+
+    #[test]
+    fn test_expected_type_info_return_statement() {
+        let test = cursor_test(
+            r#"
+        def foo() -> int:
+            return 4<CURSOR>2
+        "#,
+        );
+
+        let info = expected_type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(info.is_some());
+        let info = info.unwrap();
+        assert_eq!(info.value.category, TypeCategory::Instance);
+        assert!(info.value.display.contains("int"));
+    }
+
+    #[test]
+    fn test_expected_type_info_no_context() {
+        let test = cursor_test(
+            r#"
+        x = 1<CURSOR>0
+        "#,
+        );
+
+        let info = expected_type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(info.is_none());
+    }
+
+    #[test]
+    fn test_type_definition_for_class_instance() {
+        let test = cursor_test(
+            r#"
+        class MyClass:
+            pass
+
+        x = MyClass()
+        <CURSOR>x
+        "#,
+        );
+
+        let info = type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(info.is_some());
+        let info = info.unwrap();
+        assert_eq!(info.value.category, TypeCategory::Instance);
+        assert!(
+            info.value.type_definition.is_some(),
+            "type_definition should be populated for class instances"
+        );
+    }
+
+    #[test]
+    fn test_declared_type_info_parameter() {
+        let test = cursor_test(
+            r#"
+        def foo(x<CURSOR>: str):
+            pass
+        "#,
+        );
+
+        let info = declared_type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(
+            info.is_some(),
+            "declared_type_info should return Some for annotated parameter"
+        );
+        let info = info.unwrap();
+        assert!(info.value.display.contains("str"));
+    }
+
+    #[test]
+    fn test_overloaded_function_decomposition() {
+        let test = cursor_test(
+            r#"
+        from typing import overload
+
+        @overload
+        def func(x: int) -> int: ...
+        @overload
+        def func(x: str) -> str: ...
+        def func(x):
+            return x
+
+        fun<CURSOR>c
+        "#,
+        );
+
+        let info = type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(info.is_some());
+        let info = info.unwrap();
+        assert_eq!(info.value.category, TypeCategory::Function);
+        assert!(
+            info.value.overload_members.is_some(),
+            "overload_members should be populated for overloaded functions"
+        );
+        let overloads = info.value.overload_members.unwrap();
+        assert_eq!(overloads.len(), 2, "should have 2 @overload signatures");
+        assert!(
+            info.value.implementation_member.is_some(),
+            "implementation_member should be populated when an implementation exists"
+        );
+    }
+
+    #[test]
+    fn test_non_overloaded_function_has_no_overloads() {
+        let test = cursor_test(
+            r#"
+        def bar(x: int) -> int:
+            return x
+
+        ba<CURSOR>r
+        "#,
+        );
+
+        let info = type_info(&test.db, test.cursor.file, test.cursor.offset);
+        assert!(info.is_some());
+        let info = info.unwrap();
+        assert_eq!(info.value.category, TypeCategory::Function);
+        assert!(
+            info.value.overload_members.is_none(),
+            "non-overloaded function should have no overload_members"
+        );
+        assert!(
+            info.value.implementation_member.is_none(),
+            "non-overloaded function should have no implementation_member"
+        );
+    }
+}

--- a/crates/ty_ide/src/type_info.rs
+++ b/crates/ty_ide/src/type_info.rs
@@ -401,6 +401,7 @@ fn determine_category(ty: &Type<'_>) -> TypeCategory {
         Type::TypedDict(_) => TypeCategory::TypedDict,
         Type::TypeAlias(_) => TypeCategory::TypeAlias,
         Type::NewTypeInstance(_) => TypeCategory::NewType,
+        Type::Divergent(_) => TypeCategory::Dynamic,
     }
 }
 

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -28,9 +28,10 @@ pub use ty_site_packages::{
     SitePackagesPaths, SysPrefixPathOrigin,
 };
 pub use types::ide_support::{
-    ImportAliasResolution, ResolvedDefinition, TypeHierarchyClass, definitions_for_attribute,
-    definitions_for_bin_op, definitions_for_imported_symbol, definitions_for_name,
-    definitions_for_unary_op, map_stub_definition, type_hierarchy_prepare, type_hierarchy_subtypes,
+    ImportAliasResolution, OverloadDetail, OverloadInfo, ResolvedDefinition, TypeHierarchyClass,
+    declared_type_for_definition, definitions_for_attribute, definitions_for_bin_op,
+    definitions_for_imported_symbol, definitions_for_name, definitions_for_unary_op,
+    function_overload_info, map_stub_definition, type_hierarchy_prepare, type_hierarchy_subtypes,
     type_hierarchy_supertypes,
 };
 pub use types::{DisplaySettings, TypeQualifiers};

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -350,7 +350,7 @@ impl<'db> OverloadLiteral<'db> {
     /// calling query is not in the same file as this function is defined in, then this will create
     /// a cross-module dependency directly on the full AST which will lead to cache
     /// over-invalidation.
-    fn definition(self, db: &'db dyn Db) -> Definition<'db> {
+    pub(crate) fn definition(self, db: &'db dyn Db) -> Definition<'db> {
         let body_scope = self.body_scope(db);
         let index = semantic_index(db, body_scope.file(db));
         index.expect_single_definition(body_scope.node(db).expect_function())

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1821,3 +1821,74 @@ fn class_literal_to_hierarchy_info(
         selection_range,
     }
 }
+
+// -- Declared-type and overload-decomposition APIs for external consumers -----
+
+/// Get the declared (annotated) type for a definition.
+///
+/// Returns the type from an explicit type annotation on the given definition,
+/// or `None` if the definition has no annotation or the declared type is unknown.
+pub fn declared_type_for_definition<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+) -> Option<Type<'db>> {
+    let inference = crate::types::infer::infer_definition_types(db, definition);
+    // Use try_declaration_type to avoid panicking for binding-only definitions
+    let taq = inference.try_declaration_type(definition)?;
+    let ty = taq.inner_type();
+    if ty.is_unknown() { None } else { Some(ty) }
+}
+
+/// Information about a single overload or implementation of a function.
+#[derive(Debug)]
+pub struct OverloadDetail<'db> {
+    /// Display string for this overload's signature (e.g., `(x: int) -> str`).
+    pub display: String,
+    /// The definition for this overload, if available.
+    pub definition: Option<Definition<'db>>,
+    /// Whether this is an `@overload` signature (as opposed to the implementation).
+    pub is_overload: bool,
+}
+
+/// Information about the overloads and implementation of a function.
+#[derive(Debug)]
+pub struct OverloadInfo<'db> {
+    /// The `@overload` signatures, in source order.
+    pub overloads: Vec<OverloadDetail<'db>>,
+    /// The implementation signature (the non-`@overload` def), if present.
+    pub implementation: Option<OverloadDetail<'db>>,
+}
+
+/// Decompose a function type into its overload signatures and implementation.
+///
+/// Returns `None` if the type is not a function literal or if the function
+/// has no `@overload` signatures. For a plain function with a single definition,
+/// this returns `None` — use `Type::display()` directly for those.
+pub fn function_overload_info<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<OverloadInfo<'db>> {
+    let func_type = ty.as_function_literal()?;
+    let (overloads, implementation) = func_type.overloads_and_implementation(db);
+
+    if overloads.is_empty() {
+        return None;
+    }
+
+    let overload_details: Vec<OverloadDetail<'db>> = overloads
+        .iter()
+        .map(|ol| OverloadDetail {
+            display: ol.signature(db).display(db).to_string(),
+            definition: Some(ol.definition(db)),
+            is_overload: true,
+        })
+        .collect();
+
+    let impl_detail = implementation.map(|ol| OverloadDetail {
+        display: ol.signature(db).display(db).to_string(),
+        definition: Some(ol.definition(db)),
+        is_overload: false,
+    });
+
+    Some(OverloadInfo {
+        overloads: overload_details,
+        implementation: impl_detail,
+    })
+}

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -845,6 +845,18 @@ impl<'db> DefinitionInference<'db> {
 
     #[track_caller]
     pub(crate) fn declaration_type(&self, definition: Definition<'db>) -> TypeAndQualifiers<'db> {
+        self.try_declaration_type(definition).expect(
+            "definition should belong to this TypeInference region and \
+                TypeInferenceBuilder should have inferred a type for it",
+        )
+    }
+
+    /// Like [`declaration_type`](Self::declaration_type), but returns `None`
+    /// instead of panicking when the definition has no declaration type.
+    pub(crate) fn try_declaration_type(
+        &self,
+        definition: Definition<'db>,
+    ) -> Option<TypeAndQualifiers<'db>> {
         self.declarations
             .iter()
             .find_map(|(def, qualifiers)| {
@@ -855,10 +867,6 @@ impl<'db> DefinitionInference<'db> {
                 }
             })
             .or_else(|| self.fallback_type().map(TypeAndQualifiers::declared))
-            .expect(
-                "definition should belong to this TypeInference region and \
-                TypeInferenceBuilder should have inferred a type for it",
-            )
     }
 
     fn declarations(

--- a/crates/ty_server/src/lib.rs
+++ b/crates/ty_server/src/lib.rs
@@ -18,6 +18,7 @@ mod logging;
 mod server;
 mod session;
 mod system;
+pub(crate) mod tsp;
 
 pub(crate) const SERVER_NAME: &str = "ty";
 pub(crate) const DIAGNOSTIC_NAME: &str = "ty";

--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -12,7 +12,7 @@ use std::num::NonZeroUsize;
 use std::panic::{PanicHookInfo, RefUnwindSafe};
 use std::sync::Arc;
 
-mod api;
+pub(crate) mod api;
 mod lazy_work_done_progress;
 mod main_loop;
 mod schedule;

--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -12,12 +12,13 @@ mod notifications;
 mod requests;
 mod semantic_tokens;
 mod symbols;
-mod traits;
+pub(crate) mod traits;
 mod type_hierarchy;
 
 use self::traits::{NotificationHandler, RequestHandler};
 use super::{Result, schedule::BackgroundSchedule};
 use crate::session::client::Client;
+use crate::tsp;
 pub(crate) use diagnostics::publish_settings_diagnostics;
 pub use requests::{PartialWorkspaceProgress, PartialWorkspaceProgressParams};
 use ruff_db::panic::PanicError;
@@ -126,6 +127,20 @@ pub(super) fn request(req: server::Request) -> Task {
             req, BackgroundSchedule::Worker
         ),
         lsp_types::request::Shutdown::METHOD => sync_request_task::<requests::ShutdownHandler>(req),
+
+        // TSP (Type Server Protocol) handlers
+        tsp::handlers::version::GetSupportedProtocolVersionHandler::METHOD => {
+            sync_request_task::<tsp::handlers::version::GetSupportedProtocolVersionHandler>(req)
+        }
+        tsp::handlers::snapshot::GetSnapshotHandler::METHOD => {
+            sync_request_task::<tsp::handlers::snapshot::GetSnapshotHandler>(req)
+        }
+        tsp::handlers::search_paths::GetPythonSearchPathsHandler::METHOD => {
+            background_request_task::<tsp::handlers::search_paths::GetPythonSearchPathsHandler>(
+                req,
+                BackgroundSchedule::Worker,
+            )
+        }
 
         method => {
             tracing::warn!("Received request {method} which does not have a handler");

--- a/crates/ty_server/src/server/api/notifications/did_change.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change.rs
@@ -8,6 +8,7 @@ use crate::server::api::diagnostics::publish_diagnostics_if_needed;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::session::Session;
 use crate::session::client::Client;
+use crate::tsp::handlers::send_snapshot_changed_if_needed;
 
 pub(crate) struct DidChangeTextDocumentHandler;
 
@@ -26,6 +27,8 @@ impl SyncNotificationHandler for DidChangeTextDocumentHandler {
             content_changes,
         } = params;
 
+        let old_revision = session.revision();
+
         let mut document = session
             .document_handle(&uri)
             .with_failure_code(ErrorCode::InternalError)?;
@@ -35,6 +38,7 @@ impl SyncNotificationHandler for DidChangeTextDocumentHandler {
             .with_failure_code(ErrorCode::InternalError)?;
 
         publish_diagnostics_if_needed(&document, session, client);
+        send_snapshot_changed_if_needed(old_revision, session, client);
 
         Ok(())
     }

--- a/crates/ty_server/src/server/api/notifications/did_change_notebook.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_notebook.rs
@@ -8,6 +8,7 @@ use crate::server::api::diagnostics::publish_diagnostics;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::session::Session;
 use crate::session::client::Client;
+use crate::tsp::handlers::send_snapshot_changed_if_needed;
 
 pub(crate) struct DidChangeNotebookHandler;
 
@@ -24,6 +25,8 @@ impl SyncNotificationHandler for DidChangeNotebookHandler {
             change: types::NotebookDocumentChangeEvent { cells, metadata },
         }: types::DidChangeNotebookDocumentParams,
     ) -> Result<()> {
+        let old_revision = session.revision();
+
         let mut document = session
             .document_handle(&uri)
             .with_failure_code(ErrorCode::InternalError)?;
@@ -34,6 +37,7 @@ impl SyncNotificationHandler for DidChangeNotebookHandler {
 
         // Always publish diagnostics because notebooks only support publish diagnostics.
         publish_diagnostics(&document, session, client);
+        send_snapshot_changed_if_needed(old_revision, session, client);
 
         Ok(())
     }

--- a/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
@@ -7,6 +7,7 @@ use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::session::Session;
 use crate::session::client::Client;
 use crate::system::AnySystemPath;
+use crate::tsp::handlers::send_snapshot_changed_if_needed;
 use lsp_types as types;
 use lsp_types::{FileChangeType, notification as notif};
 use rustc_hash::FxHashMap;
@@ -77,6 +78,8 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
             return Ok(());
         }
 
+        let old_revision = session.revision();
+
         for (root, changes) in events_by_db {
             tracing::debug!("Applying changes to `{root}`");
 
@@ -101,6 +104,8 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
         if client_capabilities.supports_inlay_hint_refresh() {
             client.send_request::<types::request::InlayHintRefreshRequest>(session, (), |_, ()| {});
         }
+
+        send_snapshot_changed_if_needed(old_revision, session, client);
 
         Ok(())
     }

--- a/crates/ty_server/src/server/api/notifications/did_change_workspace_folders.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_workspace_folders.rs
@@ -5,6 +5,7 @@ use crate::server::Result;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::session::Session;
 use crate::session::client::Client;
+use crate::tsp::handlers::send_snapshot_changed_if_needed;
 
 pub(crate) struct DidChangeWorkspaceFoldersHandler;
 
@@ -18,6 +19,8 @@ impl SyncNotificationHandler for DidChangeWorkspaceFoldersHandler {
         client: &Client,
         params: types::DidChangeWorkspaceFoldersParams,
     ) -> Result<()> {
+        let old_revision = session.revision();
+
         let format_workspace_folders = |folders: &[lsp_types::WorkspaceFolder]| -> String {
             if folders.is_empty() {
                 "<empty>".to_string()
@@ -77,6 +80,9 @@ impl SyncNotificationHandler for DidChangeWorkspaceFoldersHandler {
         if added_workspace_folder {
             session.request_uninitialized_workspace_folder_configurations(client);
         }
+
+        send_snapshot_changed_if_needed(old_revision, session, client);
+
         Ok(())
     }
 }

--- a/crates/ty_server/src/server/api/notifications/did_close.rs
+++ b/crates/ty_server/src/server/api/notifications/did_close.rs
@@ -8,6 +8,7 @@ use crate::server::api::diagnostics::clear_diagnostics_if_needed;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::session::Session;
 use crate::session::client::Client;
+use crate::tsp::handlers::send_snapshot_changed_if_needed;
 
 pub(crate) struct DidCloseTextDocumentHandler;
 
@@ -25,6 +26,8 @@ impl SyncNotificationHandler for DidCloseTextDocumentHandler {
             text_document: TextDocumentIdentifier { uri },
         } = params;
 
+        let old_revision = session.revision();
+
         let document = session
             .document_handle(&uri)
             .with_failure_code(ErrorCode::InternalError)?;
@@ -36,6 +39,7 @@ impl SyncNotificationHandler for DidCloseTextDocumentHandler {
         if should_clear_diagnostics {
             clear_diagnostics_if_needed(&document, session, client);
         }
+        send_snapshot_changed_if_needed(old_revision, session, client);
 
         Ok(())
     }

--- a/crates/ty_server/src/server/api/notifications/did_close_notebook.rs
+++ b/crates/ty_server/src/server/api/notifications/did_close_notebook.rs
@@ -6,6 +6,7 @@ use crate::server::api::LSPResult;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::session::Session;
 use crate::session::client::Client;
+use crate::tsp::handlers::send_snapshot_changed_if_needed;
 
 pub(crate) struct DidCloseNotebookHandler;
 
@@ -16,13 +17,15 @@ impl NotificationHandler for DidCloseNotebookHandler {
 impl SyncNotificationHandler for DidCloseNotebookHandler {
     fn run(
         session: &mut Session,
-        _client: &Client,
+        client: &Client,
         params: DidCloseNotebookDocumentParams,
     ) -> Result<()> {
         let DidCloseNotebookDocumentParams {
             notebook_document: NotebookDocumentIdentifier { uri },
             ..
         } = params;
+
+        let old_revision = session.revision();
 
         let document = session
             .document_handle(&uri)
@@ -33,6 +36,8 @@ impl SyncNotificationHandler for DidCloseNotebookHandler {
         let _ = document
             .close(session)
             .with_failure_code(lsp_server::ErrorCode::InternalError)?;
+
+        send_snapshot_changed_if_needed(old_revision, session, client);
 
         Ok(())
     }

--- a/crates/ty_server/src/server/api/notifications/did_open.rs
+++ b/crates/ty_server/src/server/api/notifications/did_open.rs
@@ -7,6 +7,7 @@ use crate::server::api::diagnostics::publish_diagnostics_if_needed;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::session::Session;
 use crate::session::client::Client;
+use crate::tsp::handlers::send_snapshot_changed_if_needed;
 
 pub(crate) struct DidOpenTextDocumentHandler;
 
@@ -30,9 +31,12 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
                 },
         } = params;
 
+        let old_revision = session.revision();
+
         let text_doc = TextDocument::new(uri, text, version, &language_id);
         let document = session.open_text_document(text_doc);
         publish_diagnostics_if_needed(&document, session, client);
+        send_snapshot_changed_if_needed(old_revision, session, client);
 
         Ok(())
     }

--- a/crates/ty_server/src/server/api/notifications/did_open_notebook.rs
+++ b/crates/ty_server/src/server/api/notifications/did_open_notebook.rs
@@ -10,6 +10,7 @@ use crate::server::api::diagnostics::publish_diagnostics;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::session::Session;
 use crate::session::client::Client;
+use crate::tsp::handlers::send_snapshot_changed_if_needed;
 
 pub(crate) struct DidOpenNotebookHandler;
 
@@ -31,6 +32,8 @@ impl SyncNotificationHandler for DidOpenNotebookHandler {
             ..
         } = params.notebook_document;
 
+        let old_revision = session.revision();
+
         let notebook =
             NotebookDocument::new(notebook_uri, version, cells, metadata.unwrap_or_default())
                 .with_failure_code(ErrorCode::InternalError)?;
@@ -47,6 +50,7 @@ impl SyncNotificationHandler for DidOpenNotebookHandler {
 
         // Always publish diagnostics because notebooks only support publish diagnostics.
         publish_diagnostics(&document, session, client);
+        send_snapshot_changed_if_needed(old_revision, session, client);
 
         Ok(())
     }

--- a/crates/ty_server/src/server/api/traits.rs
+++ b/crates/ty_server/src/server/api/traits.rs
@@ -44,7 +44,7 @@ use lsp_types::request::Request;
 use ty_project::ProjectDatabase;
 
 /// A supertrait for any server request handler.
-pub(super) trait RequestHandler {
+pub(crate) trait RequestHandler {
     type RequestType: Request;
     const METHOD: &'static str = <<Self as RequestHandler>::RequestType>::METHOD;
 }
@@ -54,7 +54,7 @@ pub(super) trait RequestHandler {
 /// This will block the main message receiver loop, meaning that no incoming requests or
 /// notifications will be handled while `run` is executing. Try to avoid doing any I/O or
 /// long-running computations.
-pub(super) trait SyncRequestHandler: RequestHandler {
+pub(crate) trait SyncRequestHandler: RequestHandler {
     fn run(
         session: &mut Session,
         client: &Client,
@@ -62,7 +62,7 @@ pub(super) trait SyncRequestHandler: RequestHandler {
     ) -> super::Result<<<Self as RequestHandler>::RequestType as Request>::Result>;
 }
 
-pub(super) trait RetriableRequestHandler: RequestHandler {
+pub(crate) trait RetriableRequestHandler: RequestHandler {
     /// Whether this request can be cancelled if the Salsa database is modified.
     const RETRY_ON_CANCELLATION: bool = false;
 
@@ -85,7 +85,7 @@ pub(super) trait RetriableRequestHandler: RequestHandler {
 /// A request handler that can be run on a background thread.
 ///
 /// This handler is specific to requests that operate on a single document.
-pub(super) trait BackgroundDocumentRequestHandler: RetriableRequestHandler {
+pub(crate) trait BackgroundDocumentRequestHandler: RetriableRequestHandler {
     /// Returns the URL of the document that this request handler operates on.
     fn document_url(
         params: &<<Self as RequestHandler>::RequestType as Request>::Params,
@@ -132,7 +132,7 @@ pub(super) trait BackgroundDocumentRequestHandler: RetriableRequestHandler {
 /// which includes all the workspaces, without being tied to a specific document. It is useful for
 /// operations that require access to the entire session state, such as fetching workspace
 /// diagnostics.
-pub(super) trait BackgroundRequestHandler: RetriableRequestHandler {
+pub(crate) trait BackgroundRequestHandler: RetriableRequestHandler {
     /// Processes the request parameters and returns the LSP request result.
     ///
     /// This is the main method that handlers implement. It takes the request parameters
@@ -167,7 +167,7 @@ pub(super) trait BackgroundRequestHandler: RetriableRequestHandler {
 }
 
 /// A supertrait for any server notification handler.
-pub(super) trait NotificationHandler {
+pub(crate) trait NotificationHandler {
     type NotificationType: Notification;
     const METHOD: &'static str = <<Self as NotificationHandler>::NotificationType>::METHOD;
 }
@@ -177,7 +177,7 @@ pub(super) trait NotificationHandler {
 /// This will block the main message receiver loop, meaning that no incoming requests or
 /// notifications will be handled while `run` is executing. Try to avoid doing any I/O or
 /// long-running computations.
-pub(super) trait SyncNotificationHandler: NotificationHandler {
+pub(crate) trait SyncNotificationHandler: NotificationHandler {
     fn run(
         session: &mut Session,
         client: &Client,
@@ -186,7 +186,7 @@ pub(super) trait SyncNotificationHandler: NotificationHandler {
 }
 
 /// A notification handler that can be run on a background thread.
-pub(super) trait BackgroundDocumentNotificationHandler: NotificationHandler {
+pub(crate) trait BackgroundDocumentNotificationHandler: NotificationHandler {
     /// Returns the URL of the document that this notification handler operates on.
     fn document_url(
         params: &<<Self as NotificationHandler>::NotificationType as Notification>::Params,

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -245,6 +245,10 @@ impl Session {
         self.revision += 1;
     }
 
+    pub(crate) fn revision(&self) -> u64 {
+        self.revision
+    }
+
     /// The LSP specification doesn't allow configuration requests during initialization,
     /// but we need access to the configuration to resolve the settings in turn to create the
     /// project databases. This will become more important in the future when we support

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -108,6 +108,11 @@ pub(crate) struct Session {
 
     /// The name of the client (editor) that connected to this server.
     client_name: ClientName,
+
+    /// Whether the client has registered as a TSP consumer by calling
+    /// `typeServer/getSupportedProtocolVersion`. When `true`, the server sends
+    /// `typeServer/snapshotChanged` notifications after state mutations.
+    tsp_consumer_registered: bool,
 }
 
 /// LSP State for a Project
@@ -172,6 +177,7 @@ impl Session {
             revision: 0,
             registrations: HashSet::new(),
             client_name,
+            tsp_consumer_registered: false,
         })
     }
 
@@ -247,6 +253,17 @@ impl Session {
 
     pub(crate) fn revision(&self) -> u64 {
         self.revision
+    }
+
+    /// Marks the client as a TSP consumer. Called when the client sends
+    /// `typeServer/getSupportedProtocolVersion`.
+    pub(crate) fn register_tsp_consumer(&mut self) {
+        self.tsp_consumer_registered = true;
+    }
+
+    /// Returns `true` if the client has registered as a TSP consumer.
+    pub(crate) fn is_tsp_consumer(&self) -> bool {
+        self.tsp_consumer_registered
     }
 
     /// The LSP specification doesn't allow configuration requests during initialization,

--- a/crates/ty_server/src/tsp/handlers/mod.rs
+++ b/crates/ty_server/src/tsp/handlers/mod.rs
@@ -9,12 +9,16 @@ pub(crate) mod snapshot;
 pub(crate) mod version;
 
 /// Sends a `typeServer/snapshotChanged` notification to the client if the
-/// session revision has changed since `old_revision`.
+/// session revision has changed since `old_revision` and the client has
+/// registered as a TSP consumer.
 pub(crate) fn send_snapshot_changed_if_needed(
     old_revision: u64,
     session: &Session,
     client: &Client,
 ) {
+    if !session.is_tsp_consumer() {
+        return;
+    }
     let new_revision = session.revision();
     if new_revision != old_revision {
         client.send_notification::<SnapshotChanged>(SnapshotChangedParams {

--- a/crates/ty_server/src/tsp/handlers/mod.rs
+++ b/crates/ty_server/src/tsp/handlers/mod.rs
@@ -1,0 +1,25 @@
+//! TSP request and notification handlers.
+
+use crate::session::Session;
+use crate::session::client::Client;
+use crate::tsp::requests::{SnapshotChanged, SnapshotChangedParams};
+
+pub(crate) mod search_paths;
+pub(crate) mod snapshot;
+pub(crate) mod version;
+
+/// Sends a `typeServer/snapshotChanged` notification to the client if the
+/// session revision has changed since `old_revision`.
+pub(crate) fn send_snapshot_changed_if_needed(
+    old_revision: u64,
+    session: &Session,
+    client: &Client,
+) {
+    let new_revision = session.revision();
+    if new_revision != old_revision {
+        client.send_notification::<SnapshotChanged>(SnapshotChangedParams {
+            old: old_revision,
+            new: new_revision,
+        });
+    }
+}

--- a/crates/ty_server/src/tsp/handlers/search_paths.rs
+++ b/crates/ty_server/src/tsp/handlers/search_paths.rs
@@ -1,0 +1,66 @@
+//! Handler for `typeServer/getPythonSearchPaths`.
+
+use crate::server::api::traits::{
+    BackgroundRequestHandler, RequestHandler, RetriableRequestHandler,
+};
+use crate::session::SessionSnapshot;
+use crate::session::client::Client;
+use crate::tsp::handlers::snapshot::validate_snapshot;
+use crate::tsp::requests::{GetPythonSearchPaths, GetPythonSearchPathsParams};
+use anyhow::anyhow;
+use lsp_server::ErrorCode;
+use ty_module_resolver::ModuleResolveMode;
+use ty_project::Db;
+
+pub(crate) struct GetPythonSearchPathsHandler;
+
+impl RequestHandler for GetPythonSearchPathsHandler {
+    type RequestType = GetPythonSearchPaths;
+}
+
+impl RetriableRequestHandler for GetPythonSearchPathsHandler {}
+
+impl BackgroundRequestHandler for GetPythonSearchPathsHandler {
+    fn run(
+        snapshot: &SessionSnapshot,
+        _client: &Client,
+        params: GetPythonSearchPathsParams,
+    ) -> crate::server::Result<Option<Vec<String>>> {
+        if let Err(e) = validate_snapshot(params.snapshot, snapshot.revision()) {
+            return Err(crate::server::api::Error::new(
+                anyhow!(e.message),
+                ErrorCode::ServerCancelled,
+            ));
+        }
+
+        // Find the project database that best matches fromUri.
+        // Fall back to the first project if no match is found.
+        let from_path = lsp_types::Url::parse(&params.from_uri)
+            .ok()
+            .and_then(|url| url.to_file_path().ok());
+
+        let db = if let Some(ref path) = from_path {
+            snapshot
+                .projects()
+                .iter()
+                .find(|db| {
+                    let root = db.project().root(*db).as_std_path();
+                    path.starts_with(root)
+                })
+                .or_else(|| snapshot.projects().first())
+        } else {
+            snapshot.projects().first()
+        };
+
+        let Some(db) = db else {
+            return Ok(None);
+        };
+
+        let paths: Vec<String> =
+            ty_module_resolver::search_paths(db, ModuleResolveMode::StubsAllowed)
+                .filter_map(|sp| sp.as_system_path().map(ToString::to_string))
+                .collect();
+
+        Ok(Some(paths))
+    }
+}

--- a/crates/ty_server/src/tsp/handlers/snapshot.rs
+++ b/crates/ty_server/src/tsp/handlers/snapshot.rs
@@ -1,0 +1,54 @@
+//! Handler for `typeServer/getSnapshot`.
+
+use crate::server::api::traits::{RequestHandler, SyncRequestHandler};
+use crate::session::Session;
+use crate::session::client::Client;
+use crate::tsp::requests::GetSnapshot;
+
+pub(crate) struct GetSnapshotHandler;
+
+impl RequestHandler for GetSnapshotHandler {
+    type RequestType = GetSnapshot;
+}
+
+impl SyncRequestHandler for GetSnapshotHandler {
+    fn run(session: &mut Session, _client: &Client, _params: ()) -> crate::server::Result<u64> {
+        Ok(session.revision())
+    }
+}
+
+/// Validate that a client-provided snapshot matches the current session revision.
+///
+/// Returns `Ok(())` if the snapshot is current, or a `ServerCancelled` error
+/// if the snapshot is stale.
+pub(crate) fn validate_snapshot(
+    client_snapshot: u64,
+    session_revision: u64,
+) -> Result<(), lsp_server::ResponseError> {
+    if client_snapshot != session_revision {
+        Err(lsp_server::ResponseError {
+            code: lsp_server::ErrorCode::ServerCancelled as i32,
+            message: format!("Snapshot {client_snapshot} is stale (current: {session_revision})"),
+            data: None,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_snapshot_current() {
+        assert!(validate_snapshot(42, 42).is_ok());
+    }
+
+    #[test]
+    fn validate_snapshot_stale() {
+        let err = validate_snapshot(41, 42).unwrap_err();
+        assert_eq!(err.code, lsp_server::ErrorCode::ServerCancelled as i32);
+        assert!(err.message.contains("stale"));
+    }
+}

--- a/crates/ty_server/src/tsp/handlers/version.rs
+++ b/crates/ty_server/src/tsp/handlers/version.rs
@@ -13,7 +13,8 @@ impl RequestHandler for GetSupportedProtocolVersionHandler {
 }
 
 impl SyncRequestHandler for GetSupportedProtocolVersionHandler {
-    fn run(_session: &mut Session, _client: &Client, _params: ()) -> crate::server::Result<String> {
+    fn run(session: &mut Session, _client: &Client, _params: ()) -> crate::server::Result<String> {
+        session.register_tsp_consumer();
         Ok(PROTOCOL_VERSION.to_string())
     }
 }

--- a/crates/ty_server/src/tsp/handlers/version.rs
+++ b/crates/ty_server/src/tsp/handlers/version.rs
@@ -1,0 +1,19 @@
+//! Handler for `typeServer/getSupportedProtocolVersion`.
+
+use crate::server::api::traits::{RequestHandler, SyncRequestHandler};
+use crate::session::Session;
+use crate::session::client::Client;
+use crate::tsp::protocol::PROTOCOL_VERSION;
+use crate::tsp::requests::GetSupportedProtocolVersion;
+
+pub(crate) struct GetSupportedProtocolVersionHandler;
+
+impl RequestHandler for GetSupportedProtocolVersionHandler {
+    type RequestType = GetSupportedProtocolVersion;
+}
+
+impl SyncRequestHandler for GetSupportedProtocolVersionHandler {
+    fn run(_session: &mut Session, _client: &Client, _params: ()) -> crate::server::Result<String> {
+        Ok(PROTOCOL_VERSION.to_string())
+    }
+}

--- a/crates/ty_server/src/tsp/mod.rs
+++ b/crates/ty_server/src/tsp/mod.rs
@@ -1,0 +1,19 @@
+//! Type Server Protocol (TSP) types and definitions.
+//!
+//! This module defines the Rust types that correspond to the TSP protocol
+//! defined in `typeServerProtocol.ts`. These are used for JSON-RPC
+//! communication between a TSP client (e.g., Pylance) and ty.
+//!
+//! The module is organized into:
+//! - [`protocol`]: Method name constants and protocol version
+//! - [`types`]: Type representations sent over the wire
+//! - [`requests`]: Request/response parameter types
+//! - [`handlers`]: Request handler implementations
+
+pub(crate) mod handlers;
+pub(crate) mod protocol;
+// Types and requests still have members not yet consumed by handlers.
+#[allow(dead_code)]
+pub(crate) mod requests;
+#[allow(dead_code)]
+pub(crate) mod types;

--- a/crates/ty_server/src/tsp/protocol.rs
+++ b/crates/ty_server/src/tsp/protocol.rs
@@ -1,0 +1,47 @@
+//! TSP protocol constants and method names.
+
+/// TSP method name constants.
+pub(crate) mod methods {
+    pub(crate) const GET_SUPPORTED_PROTOCOL_VERSION: &str =
+        "typeServer/getSupportedProtocolVersion";
+    pub(crate) const GET_SNAPSHOT: &str = "typeServer/getSnapshot";
+    pub(crate) const SNAPSHOT_CHANGED: &str = "typeServer/snapshotChanged";
+    pub(crate) const GET_PYTHON_SEARCH_PATHS: &str = "typeServer/getPythonSearchPaths";
+    pub(crate) const RESOLVE_IMPORT: &str = "typeServer/resolveImport";
+    pub(crate) const GET_COMPUTED_TYPE: &str = "typeServer/getComputedType";
+    pub(crate) const GET_EXPECTED_TYPE: &str = "typeServer/getExpectedType";
+    pub(crate) const GET_DECLARED_TYPE: &str = "typeServer/getDeclaredType";
+}
+
+/// The current TSP protocol version.
+pub(crate) const PROTOCOL_VERSION: &str = "0.4.0";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TSP_NAMESPACE: &str = "typeServer";
+
+    fn is_tsp_method(method: &str) -> bool {
+        method.starts_with(TSP_NAMESPACE)
+    }
+
+    #[test]
+    fn tsp_methods_recognized() {
+        assert!(is_tsp_method(methods::GET_SNAPSHOT));
+        assert!(is_tsp_method(methods::GET_COMPUTED_TYPE));
+        assert!(is_tsp_method(methods::SNAPSHOT_CHANGED));
+        assert!(is_tsp_method(methods::GET_PYTHON_SEARCH_PATHS));
+        assert!(is_tsp_method(methods::RESOLVE_IMPORT));
+        assert!(is_tsp_method(methods::GET_EXPECTED_TYPE));
+        assert!(is_tsp_method(methods::GET_DECLARED_TYPE));
+        assert!(is_tsp_method(methods::GET_SUPPORTED_PROTOCOL_VERSION));
+    }
+
+    #[test]
+    fn non_tsp_methods_rejected() {
+        assert!(!is_tsp_method("textDocument/hover"));
+        assert!(!is_tsp_method("initialize"));
+        assert!(!is_tsp_method(""));
+    }
+}

--- a/crates/ty_server/src/tsp/requests.rs
+++ b/crates/ty_server/src/tsp/requests.rs
@@ -1,0 +1,400 @@
+//! TSP request and response types.
+//!
+//! Parameter and result types for all TSP requests and notifications,
+//! plus custom `lsp_types::request::Request` impls for dispatch integration.
+
+use lsp_types::{Range, Url};
+use serde::{Deserialize, Serialize};
+
+use crate::tsp::protocol::methods;
+use crate::tsp::types::{Declaration, Type};
+
+// -- Shared types ------------------------------------------------------------
+
+/// An AST node identified by document URI and range.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Node {
+    pub uri: Url,
+    pub range: Range,
+}
+
+/// The `arg` parameter for type query requests — either a full `Declaration`
+/// or a plain `Node`.
+///
+/// Discriminated by presence of the `kind` field:
+/// - `kind` present → `Declaration`
+/// - `kind` absent  → plain `Node`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DeclarationOrNode {
+    Declaration(Declaration),
+    Node(Node),
+}
+
+impl DeclarationOrNode {
+    /// Extract the inner `Node`, if available.
+    ///
+    /// Returns `None` for `Declaration::Synthesized` (no source node).
+    pub(crate) fn node(&self) -> Option<&Node> {
+        match self {
+            Self::Node(n) => Some(n),
+            Self::Declaration(Declaration::Regular { node, .. }) => Some(node),
+            Self::Declaration(Declaration::Synthesized { .. }) => None,
+        }
+    }
+}
+
+impl Serialize for DeclarationOrNode {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Declaration(d) => d.serialize(serializer),
+            Self::Node(n) => n.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for DeclarationOrNode {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        if value.get("kind").is_some() {
+            serde_json::from_value(value)
+                .map(Self::Declaration)
+                .map_err(serde::de::Error::custom)
+        } else {
+            serde_json::from_value(value)
+                .map(Self::Node)
+                .map_err(serde::de::Error::custom)
+        }
+    }
+}
+
+/// A module name descriptor for import resolution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ModuleDescriptor {
+    /// Leading dots for relative imports (0 for absolute).
+    pub leading_dots: u32,
+    /// Module name parts split by dots (e.g., `["os", "path"]`).
+    pub name_parts: Vec<String>,
+}
+
+impl ModuleDescriptor {
+    /// Convert to a dotted module name string.
+    pub(crate) fn to_module_name(&self) -> String {
+        let dots = ".".repeat(self.leading_dots as usize);
+        let name = self.name_parts.join(".");
+        format!("{dots}{name}")
+    }
+}
+
+// -- Snapshot ----------------------------------------------------------------
+
+/// Parameters for `typeServer/snapshotChanged` notification.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SnapshotChangedParams {
+    pub old: u64,
+    pub new: u64,
+}
+
+// -- Search paths ------------------------------------------------------------
+
+/// Parameters for `typeServer/getPythonSearchPaths`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GetPythonSearchPathsParams {
+    pub from_uri: String,
+    pub snapshot: u64,
+}
+
+// -- Import resolution -------------------------------------------------------
+
+/// Parameters for `typeServer/resolveImport`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ResolveImportParams {
+    pub source_uri: String,
+    pub module_descriptor: ModuleDescriptor,
+    pub snapshot: u64,
+}
+
+// -- Type queries ------------------------------------------------------------
+
+/// Parameters for `typeServer/getComputedType`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct GetComputedTypeParams {
+    pub arg: DeclarationOrNode,
+    pub snapshot: u64,
+}
+
+/// Parameters for `typeServer/getExpectedType`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct GetExpectedTypeParams {
+    pub arg: DeclarationOrNode,
+    pub snapshot: u64,
+}
+
+/// Parameters for `typeServer/getDeclaredType`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct GetDeclaredTypeParams {
+    pub arg: DeclarationOrNode,
+    pub snapshot: u64,
+}
+
+// -- Custom LSP request types for dispatch -----------------------------------
+
+/// `typeServer/getSupportedProtocolVersion` — returns a version string.
+pub(crate) enum GetSupportedProtocolVersion {}
+
+impl lsp_types::request::Request for GetSupportedProtocolVersion {
+    type Params = ();
+    type Result = String;
+    const METHOD: &'static str = methods::GET_SUPPORTED_PROTOCOL_VERSION;
+}
+
+/// `typeServer/getSnapshot` — returns the current snapshot number.
+pub(crate) enum GetSnapshot {}
+
+impl lsp_types::request::Request for GetSnapshot {
+    type Params = ();
+    type Result = u64;
+    const METHOD: &'static str = methods::GET_SNAPSHOT;
+}
+
+/// `typeServer/getPythonSearchPaths` — returns search paths for a workspace.
+pub(crate) enum GetPythonSearchPaths {}
+
+impl lsp_types::request::Request for GetPythonSearchPaths {
+    type Params = GetPythonSearchPathsParams;
+    type Result = Option<Vec<String>>;
+    const METHOD: &'static str = methods::GET_PYTHON_SEARCH_PATHS;
+}
+
+/// `typeServer/resolveImport` — resolves a module name to a file URI.
+pub(crate) enum ResolveImport {}
+
+impl lsp_types::request::Request for ResolveImport {
+    type Params = ResolveImportParams;
+    type Result = Option<String>;
+    const METHOD: &'static str = methods::RESOLVE_IMPORT;
+}
+
+/// `typeServer/getComputedType` — returns the inferred type at a position.
+pub(crate) enum GetComputedType {}
+
+impl lsp_types::request::Request for GetComputedType {
+    type Params = GetComputedTypeParams;
+    type Result = Option<Type>;
+    const METHOD: &'static str = methods::GET_COMPUTED_TYPE;
+}
+
+/// `typeServer/getExpectedType` — returns the expected type at a position.
+pub(crate) enum GetExpectedType {}
+
+impl lsp_types::request::Request for GetExpectedType {
+    type Params = GetExpectedTypeParams;
+    type Result = Option<Type>;
+    const METHOD: &'static str = methods::GET_EXPECTED_TYPE;
+}
+
+/// `typeServer/getDeclaredType` — returns the declared type at a position.
+pub(crate) enum GetDeclaredType {}
+
+impl lsp_types::request::Request for GetDeclaredType {
+    type Params = GetDeclaredTypeParams;
+    type Result = Option<Type>;
+    const METHOD: &'static str = methods::GET_DECLARED_TYPE;
+}
+
+// -- Custom LSP notification types -------------------------------------------
+
+/// `typeServer/snapshotChanged` — sent to the client when the snapshot changes.
+pub(crate) enum SnapshotChanged {}
+
+impl lsp_types::notification::Notification for SnapshotChanged {
+    type Params = SnapshotChangedParams;
+    const METHOD: &'static str = methods::SNAPSHOT_CHANGED;
+}
+
+// -- Tests -------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lsp_types::Position;
+
+    #[test]
+    fn node_roundtrip() {
+        let node = Node {
+            uri: Url::parse("file:///test.py").unwrap(),
+            range: Range {
+                start: Position::new(0, 0),
+                end: Position::new(0, 5),
+            },
+        };
+        let json = serde_json::to_string(&node).unwrap();
+        let back: Node = serde_json::from_str(&json).unwrap();
+        assert_eq!(node, back);
+    }
+
+    #[test]
+    fn declaration_or_node_plain_node() {
+        let json = r#"{"uri": "file:///test.py", "range": {"start": {"line": 1, "character": 2}, "end": {"line": 1, "character": 5}}}"#;
+        let parsed: DeclarationOrNode = serde_json::from_str(json).unwrap();
+        assert!(matches!(parsed, DeclarationOrNode::Node(_)));
+        assert!(parsed.node().is_some());
+    }
+
+    #[test]
+    fn declaration_or_node_regular_declaration() {
+        let json = r#"{"kind": 0, "category": 5, "name": "my_func", "node": {"uri": "file:///test.py", "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 7}}}}"#;
+        let parsed: DeclarationOrNode = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            parsed,
+            DeclarationOrNode::Declaration(Declaration::Regular { .. })
+        ));
+        let node = parsed
+            .node()
+            .expect("regular declaration should have a node");
+        assert_eq!(node.uri.as_str(), "file:///test.py");
+    }
+
+    #[test]
+    fn declaration_or_node_synthesized() {
+        let json = r#"{"kind": 1, "uri": "file:///builtins.pyi"}"#;
+        let parsed: DeclarationOrNode = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            parsed,
+            DeclarationOrNode::Declaration(Declaration::Synthesized { .. })
+        ));
+        assert!(parsed.node().is_none());
+    }
+
+    #[test]
+    fn module_descriptor_absolute() {
+        let desc = ModuleDescriptor {
+            leading_dots: 0,
+            name_parts: vec!["os".to_string(), "path".to_string()],
+        };
+        assert_eq!(desc.to_module_name(), "os.path");
+        let json = serde_json::to_string(&desc).unwrap();
+        assert_eq!(json, r#"{"leadingDots":0,"nameParts":["os","path"]}"#);
+    }
+
+    #[test]
+    fn module_descriptor_relative() {
+        let desc = ModuleDescriptor {
+            leading_dots: 2,
+            name_parts: vec!["foo".to_string()],
+        };
+        assert_eq!(desc.to_module_name(), "..foo");
+    }
+
+    #[test]
+    fn snapshot_changed_params_serialization() {
+        let params = SnapshotChangedParams { old: 1, new: 2 };
+        let json = serde_json::to_string(&params).unwrap();
+        assert_eq!(json, r#"{"old":1,"new":2}"#);
+    }
+
+    #[test]
+    fn search_paths_params_camel_case() {
+        let params = GetPythonSearchPathsParams {
+            from_uri: "file:///workspace".to_string(),
+            snapshot: 42,
+        };
+        let json = serde_json::to_value(&params).unwrap();
+        assert_eq!(json["fromUri"], "file:///workspace");
+        assert_eq!(json["snapshot"], 42);
+        assert!(json.get("from_uri").is_none());
+    }
+
+    #[test]
+    fn resolve_import_params_roundtrip() {
+        let params = ResolveImportParams {
+            source_uri: "file:///test.py".to_string(),
+            module_descriptor: ModuleDescriptor {
+                leading_dots: 0,
+                name_parts: vec!["os".to_string()],
+            },
+            snapshot: 1,
+        };
+        let json = serde_json::to_string(&params).unwrap();
+        let back: ResolveImportParams = serde_json::from_str(&json).unwrap();
+        assert_eq!(params, back);
+    }
+
+    #[test]
+    fn get_computed_type_params_with_node() {
+        let params = GetComputedTypeParams {
+            arg: DeclarationOrNode::Node(Node {
+                uri: Url::parse("file:///test.py").unwrap(),
+                range: Range {
+                    start: Position::new(0, 0),
+                    end: Position::new(0, 5),
+                },
+            }),
+            snapshot: 1,
+        };
+        let json = serde_json::to_string(&params).unwrap();
+        let back: GetComputedTypeParams = serde_json::from_str(&json).unwrap();
+        assert_eq!(params, back);
+    }
+
+    #[test]
+    fn get_computed_type_params_with_declaration() {
+        let json = r#"{
+            "arg": {
+                "kind": 0,
+                "category": 6,
+                "name": "Literal",
+                "node": {
+                    "uri": "file:///test.py",
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 5}
+                    }
+                }
+            },
+            "snapshot": 1
+        }"#;
+        let parsed: GetComputedTypeParams = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.snapshot, 1);
+        let node = parsed
+            .arg
+            .node()
+            .expect("regular declaration should have a node");
+        assert_eq!(node.uri.as_str(), "file:///test.py");
+    }
+
+    #[test]
+    fn request_method_constants_match() {
+        assert_eq!(
+            <GetSupportedProtocolVersion as lsp_types::request::Request>::METHOD,
+            "typeServer/getSupportedProtocolVersion"
+        );
+        assert_eq!(
+            <GetSnapshot as lsp_types::request::Request>::METHOD,
+            "typeServer/getSnapshot"
+        );
+        assert_eq!(
+            <GetComputedType as lsp_types::request::Request>::METHOD,
+            "typeServer/getComputedType"
+        );
+        assert_eq!(
+            <GetExpectedType as lsp_types::request::Request>::METHOD,
+            "typeServer/getExpectedType"
+        );
+        assert_eq!(
+            <GetDeclaredType as lsp_types::request::Request>::METHOD,
+            "typeServer/getDeclaredType"
+        );
+        assert_eq!(
+            <GetPythonSearchPaths as lsp_types::request::Request>::METHOD,
+            "typeServer/getPythonSearchPaths"
+        );
+        assert_eq!(
+            <ResolveImport as lsp_types::request::Request>::METHOD,
+            "typeServer/resolveImport"
+        );
+    }
+}

--- a/crates/ty_server/src/tsp/types.rs
+++ b/crates/ty_server/src/tsp/types.rs
@@ -1,0 +1,918 @@
+//! TSP type representations.
+//!
+//! These types correspond to the TypeScript protocol defined in
+//! `typeServerProtocol.ts` and are sent over the wire as JSON.
+
+use lsp_types::{Range, Url};
+use serde::{Deserialize, Serialize};
+
+use crate::tsp::requests::Node;
+
+/// A unique identifier for a type within a snapshot.
+pub(crate) type TypeId = i64;
+
+// -- Declaration types -------------------------------------------------------
+
+/// Discriminator for the `Declaration` union.
+/// Serializes as numeric `0` or `1`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum DeclarationKind {
+    /// Declaration exists in source code with an AST node.
+    Regular = 0,
+    /// Declaration synthesized by the type checker (no source node).
+    Synthesized = 1,
+}
+
+impl Serialize for DeclarationKind {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u8(*self as u8)
+    }
+}
+
+impl<'de> Deserialize<'de> for DeclarationKind {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match u8::deserialize(deserializer)? {
+            0 => Ok(Self::Regular),
+            1 => Ok(Self::Synthesized),
+            n => Err(serde::de::Error::custom(format!(
+                "invalid DeclarationKind: {n}"
+            ))),
+        }
+    }
+}
+
+/// The category of a declaration.
+/// Serializes as numeric `0`–`7`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum DeclarationCategory {
+    Intrinsic = 0,
+    Variable = 1,
+    Param = 2,
+    TypeParam = 3,
+    TypeAlias = 4,
+    Function = 5,
+    Class = 6,
+    Import = 7,
+}
+
+impl Serialize for DeclarationCategory {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u8(*self as u8)
+    }
+}
+
+impl<'de> Deserialize<'de> for DeclarationCategory {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match u8::deserialize(deserializer)? {
+            0 => Ok(Self::Intrinsic),
+            1 => Ok(Self::Variable),
+            2 => Ok(Self::Param),
+            3 => Ok(Self::TypeParam),
+            4 => Ok(Self::TypeAlias),
+            5 => Ok(Self::Function),
+            6 => Ok(Self::Class),
+            7 => Ok(Self::Import),
+            n => Err(serde::de::Error::custom(format!(
+                "invalid DeclarationCategory: {n}"
+            ))),
+        }
+    }
+}
+
+/// A declaration in the type system.
+///
+/// Discriminated by the `kind` field:
+/// - `Regular` → `{ kind: 0, category, node, name? }`
+/// - `Synthesized` → `{ kind: 1, uri }`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Declaration {
+    Regular {
+        category: DeclarationCategory,
+        node: Node,
+        name: Option<String>,
+    },
+    Synthesized {
+        uri: String,
+    },
+}
+
+impl Declaration {
+    /// Create a regular declaration pointing to a source location.
+    pub(crate) fn regular(
+        category: DeclarationCategory,
+        uri: Url,
+        range: Range,
+        name: Option<String>,
+    ) -> Self {
+        Self::Regular {
+            category,
+            node: Node { uri, range },
+            name,
+        }
+    }
+
+    /// Create a synthesized declaration with just a URI.
+    pub(crate) fn synthesized(uri: impl Into<String>) -> Self {
+        Self::Synthesized { uri: uri.into() }
+    }
+}
+
+impl Serialize for Declaration {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        match self {
+            Self::Regular {
+                category,
+                node,
+                name,
+            } => {
+                let field_count = if name.is_some() { 4 } else { 3 };
+                let mut map = serializer.serialize_map(Some(field_count))?;
+                map.serialize_entry("kind", &DeclarationKind::Regular)?;
+                map.serialize_entry("category", category)?;
+                map.serialize_entry("node", node)?;
+                if let Some(n) = name {
+                    map.serialize_entry("name", n)?;
+                }
+                map.end()
+            }
+            Self::Synthesized { uri } => {
+                let mut map = serializer.serialize_map(Some(2))?;
+                map.serialize_entry("kind", &DeclarationKind::Synthesized)?;
+                map.serialize_entry("uri", uri)?;
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Declaration {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let kind = value
+            .get("kind")
+            .and_then(serde_json::Value::as_u64)
+            .ok_or_else(|| serde::de::Error::missing_field("kind"))?;
+        match kind {
+            0 => {
+                let category: DeclarationCategory =
+                    serde_json::from_value(value.get("category").cloned().unwrap_or_default())
+                        .map_err(serde::de::Error::custom)?;
+                let node: Node = serde_json::from_value(
+                    value
+                        .get("node")
+                        .cloned()
+                        .ok_or_else(|| serde::de::Error::missing_field("node"))?,
+                )
+                .map_err(serde::de::Error::custom)?;
+                let name = value.get("name").and_then(|v| v.as_str()).map(String::from);
+                Ok(Self::Regular {
+                    category,
+                    node,
+                    name,
+                })
+            }
+            1 => {
+                let uri = value
+                    .get("uri")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| serde::de::Error::missing_field("uri"))?
+                    .to_string();
+                Ok(Self::Synthesized { uri })
+            }
+            n => Err(serde::de::Error::custom(format!(
+                "invalid DeclarationKind: {n}"
+            ))),
+        }
+    }
+}
+
+// -- Type kind ---------------------------------------------------------------
+
+/// The kind of a type (discriminator for the Type union).
+/// Serializes as `0`–`9`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum TypeKind {
+    BuiltIn = 0,
+    Declared = 1,
+    Function = 2,
+    Class = 3,
+    Union = 4,
+    Module = 5,
+    TypeVar = 6,
+    Overloaded = 7,
+    Synthesized = 8,
+    TypeReference = 9,
+}
+
+impl Serialize for TypeKind {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u8(*self as u8)
+    }
+}
+
+impl<'de> Deserialize<'de> for TypeKind {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match u8::deserialize(deserializer)? {
+            0 => Ok(Self::BuiltIn),
+            1 => Ok(Self::Declared),
+            2 => Ok(Self::Function),
+            3 => Ok(Self::Class),
+            4 => Ok(Self::Union),
+            5 => Ok(Self::Module),
+            6 => Ok(Self::TypeVar),
+            7 => Ok(Self::Overloaded),
+            8 => Ok(Self::Synthesized),
+            9 => Ok(Self::TypeReference),
+            n => Err(serde::de::Error::custom(format!("invalid TypeKind: {n}"))),
+        }
+    }
+}
+
+// -- Type flags --------------------------------------------------------------
+
+/// Bitfield flags describing characteristics of a type.
+pub(crate) mod type_flags {
+    pub(crate) const NONE: u32 = 0;
+    /// The type can be instantiated (e.g., a class object itself).
+    pub(crate) const INSTANTIABLE: u32 = 1 << 0;
+    /// The type represents an instance (as opposed to a class).
+    pub(crate) const INSTANCE: u32 = 1 << 1;
+    /// An instance of the type can be called like a function.
+    pub(crate) const CALLABLE: u32 = 1 << 2;
+}
+
+// -- The main Type struct ----------------------------------------------------
+
+/// A type in the TSP protocol.
+///
+/// `details` is flattened into the parent JSON object during serialization
+/// to match the TypeScript protocol's flat type union.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[expect(clippy::struct_field_names)]
+pub(crate) struct Type {
+    /// Unique ID of this type within the snapshot.
+    pub id: TypeId,
+    /// Discriminator kind.
+    pub kind: TypeKind,
+    /// Human-readable display string.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display: Option<String>,
+    /// Bitfield of [`type_flags`].
+    #[serde(default)]
+    pub flags: u32,
+    /// Source declaration for declared types.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub declaration: Option<Declaration>,
+    /// Type arguments for generic types (inline Type objects).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_args: Option<Vec<Type>>,
+    /// Kind-specific details (flattened in JSON).
+    #[serde(default)]
+    pub details: Option<TypeDetails>,
+}
+
+impl Serialize for Type {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+
+        // Count required + optional fields
+        let mut n = 3; // id, kind, flags
+        if self.display.is_some() {
+            n += 1;
+        }
+        if self.declaration.is_some() {
+            n += 1;
+        }
+        if self.type_args.is_some() {
+            n += 1;
+        }
+        n += detail_field_count(self.details.as_ref());
+
+        let mut map = serializer.serialize_map(Some(n))?;
+        map.serialize_entry("id", &self.id)?;
+        map.serialize_entry("kind", &self.kind)?;
+        if let Some(ref display) = self.display {
+            map.serialize_entry("display", display)?;
+        }
+        map.serialize_entry("flags", &self.flags)?;
+        if let Some(ref decl) = self.declaration {
+            map.serialize_entry("declaration", decl)?;
+        }
+        if let Some(ref args) = self.type_args {
+            map.serialize_entry("typeArgs", args)?;
+        }
+
+        // Flatten details into the top-level map
+        serialize_details(&mut map, self.details.as_ref())?;
+
+        map.end()
+    }
+}
+
+/// Count how many JSON fields a `TypeDetails` variant contributes.
+fn detail_field_count(details: Option<&TypeDetails>) -> usize {
+    match details {
+        Some(TypeDetails::Synthesized(_)) => 2,
+        Some(TypeDetails::Union(_)) => 1,
+        Some(TypeDetails::Literal(_)) => 2,
+        Some(TypeDetails::Tuple(_)) => 2,
+        Some(TypeDetails::TypeReference(_)) => 1,
+        Some(TypeDetails::Module(_)) => 1,
+        Some(TypeDetails::Class(_)) => 3,
+        Some(TypeDetails::Overloaded(_)) => 2,
+        Some(TypeDetails::Function(_)) => 3,
+        None => 0,
+    }
+}
+
+/// Serialize `TypeDetails` fields directly into an open map.
+fn serialize_details<S: serde::ser::SerializeMap>(
+    map: &mut S,
+    details: Option<&TypeDetails>,
+) -> Result<(), S::Error> {
+    match details {
+        Some(TypeDetails::Synthesized(d)) => {
+            map.serialize_entry("stubContent", &d.stub_content)?;
+            map.serialize_entry("metadata", &d.metadata)?;
+        }
+        Some(TypeDetails::Union(d)) => {
+            map.serialize_entry("subTypes", &d.members)?;
+        }
+        Some(TypeDetails::Literal(d)) => {
+            map.serialize_entry("value", &d.value)?;
+            map.serialize_entry("literalKind", &d.literal_kind)?;
+        }
+        Some(TypeDetails::Tuple(d)) => {
+            map.serialize_entry("elements", &d.elements)?;
+            if let Some(ref unbounded) = d.is_unbounded {
+                map.serialize_entry("isUnbounded", unbounded)?;
+            }
+        }
+        Some(TypeDetails::TypeReference(d)) => {
+            map.serialize_entry("referencedTypeId", &d.referenced_type_id)?;
+        }
+        Some(TypeDetails::Module(d)) => {
+            map.serialize_entry("moduleName", &d.module_name)?;
+        }
+        Some(TypeDetails::Class(d)) => {
+            map.serialize_entry("qualifiedName", &d.qualified_name)?;
+            if let Some(ref module) = d.module {
+                map.serialize_entry("module", module)?;
+            }
+            if let Some(ref args) = d.type_arguments {
+                map.serialize_entry("typeArguments", args)?;
+            }
+        }
+        Some(TypeDetails::Overloaded(d)) => {
+            map.serialize_entry("overloads", &d.overloads)?;
+            if let Some(ref impl_type) = d.implementation {
+                map.serialize_entry("implementation", impl_type)?;
+            }
+        }
+        Some(TypeDetails::Function(d)) => {
+            if let Some(ref name) = d.name {
+                map.serialize_entry("name", name)?;
+            }
+            if let Some(ref params) = d.parameters {
+                map.serialize_entry("parameters", params)?;
+            }
+            if let Some(ref ret) = d.return_type {
+                map.serialize_entry("returnType", ret)?;
+            }
+        }
+        None => {}
+    }
+    Ok(())
+}
+
+impl Type {
+    /// Create an Unknown built-in type.
+    pub(crate) fn unknown(id: TypeId) -> Self {
+        Self {
+            id,
+            kind: TypeKind::BuiltIn,
+            display: Some("Unknown".to_string()),
+            flags: type_flags::NONE,
+            declaration: None,
+            type_args: None,
+            details: None,
+        }
+    }
+
+    /// Create an Any built-in type.
+    pub(crate) fn any(id: TypeId) -> Self {
+        Self {
+            id,
+            kind: TypeKind::BuiltIn,
+            display: Some("Any".to_string()),
+            flags: type_flags::NONE,
+            declaration: None,
+            type_args: None,
+            details: None,
+        }
+    }
+
+    /// Create a Never built-in type.
+    pub(crate) fn never(id: TypeId) -> Self {
+        Self {
+            id,
+            kind: TypeKind::BuiltIn,
+            display: Some("Never".to_string()),
+            flags: type_flags::NONE,
+            declaration: None,
+            type_args: None,
+            details: None,
+        }
+    }
+
+    /// Create a None built-in type.
+    pub(crate) fn none(id: TypeId) -> Self {
+        Self {
+            id,
+            kind: TypeKind::BuiltIn,
+            display: Some("None".to_string()),
+            flags: type_flags::NONE,
+            declaration: None,
+            type_args: None,
+            details: None,
+        }
+    }
+}
+
+// -- TypeDetails variants ----------------------------------------------------
+
+/// Kind-specific details for a `Type`.
+///
+/// Variant ordering matters for untagged deserialization — variants with
+/// required fields must come before variants with all-optional fields.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum TypeDetails {
+    Synthesized(SynthesizedDetails),
+    Union(UnionDetails),
+    Literal(LiteralDetails),
+    Tuple(TupleDetails),
+    TypeReference(TypeReferenceDetails),
+    Module(ModuleDetails),
+    Class(ClassDetails),
+    Overloaded(OverloadedDetails),
+    /// All fields optional — must be last for untagged deserialization.
+    Function(FunctionDetails),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ClassDetails {
+    /// Fully qualified class name.
+    pub qualified_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub module: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub type_arguments: Option<Vec<TypeId>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct UnionDetails {
+    /// Inline member types.
+    pub members: Vec<Type>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct OverloadedDetails {
+    /// The `@overload` signatures.
+    pub overloads: Vec<Type>,
+    /// The implementation signature (non-`@overload` def).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub implementation: Option<Box<Type>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FunctionDetails {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<Vec<FunctionParameter>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub return_type: Option<TypeId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FunctionParameter {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub type_id: Option<TypeId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub has_default: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<ParameterKind>,
+}
+
+/// The kind of a function parameter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum ParameterKind {
+    PositionalOnly,
+    PositionalOrKeyword,
+    VarPositional,
+    KeywordOnly,
+    VarKeyword,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LiteralDetails {
+    pub value: String,
+    pub literal_kind: LiteralKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum LiteralKind {
+    Int,
+    Bool,
+    Str,
+    Bytes,
+    EnumMember,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TupleDetails {
+    pub elements: Vec<TypeId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_unbounded: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TypeReferenceDetails {
+    pub referenced_type_id: TypeId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ModuleDetails {
+    pub module_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SynthesizedDetails {
+    /// Python stub content for a type without source code.
+    pub stub_content: String,
+    pub metadata: SynthesizedMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SynthesizedMetadata {
+    /// Module where the synthesized type is defined.
+    pub module: ModuleName,
+    /// Byte offset into `stub_content` where the primary definition starts.
+    pub primary_definition_offset: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ModuleName {
+    pub name_parts: Vec<String>,
+}
+
+// -- Tests -------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lsp_types::Position;
+
+    #[test]
+    fn type_kind_serializes_as_number() {
+        assert_eq!(serde_json::to_value(TypeKind::BuiltIn).unwrap(), 0);
+        assert_eq!(serde_json::to_value(TypeKind::Class).unwrap(), 3);
+        assert_eq!(serde_json::to_value(TypeKind::TypeReference).unwrap(), 9);
+    }
+
+    #[test]
+    fn type_kind_roundtrips() {
+        for (expected_num, expected_kind) in [
+            (0, TypeKind::BuiltIn),
+            (1, TypeKind::Declared),
+            (2, TypeKind::Function),
+            (3, TypeKind::Class),
+            (4, TypeKind::Union),
+            (5, TypeKind::Module),
+            (6, TypeKind::TypeVar),
+            (7, TypeKind::Overloaded),
+            (8, TypeKind::Synthesized),
+            (9, TypeKind::TypeReference),
+        ] {
+            let json = serde_json::to_value(expected_kind).unwrap();
+            assert_eq!(json, expected_num);
+            let back: TypeKind = serde_json::from_value(json).unwrap();
+            assert_eq!(back, expected_kind);
+        }
+    }
+
+    #[test]
+    fn declaration_kind_serializes_as_number() {
+        assert_eq!(serde_json::to_value(DeclarationKind::Regular).unwrap(), 0);
+        assert_eq!(
+            serde_json::to_value(DeclarationKind::Synthesized).unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn declaration_category_roundtrips() {
+        for (n, cat) in [
+            (0, DeclarationCategory::Intrinsic),
+            (1, DeclarationCategory::Variable),
+            (2, DeclarationCategory::Param),
+            (3, DeclarationCategory::TypeParam),
+            (4, DeclarationCategory::TypeAlias),
+            (5, DeclarationCategory::Function),
+            (6, DeclarationCategory::Class),
+            (7, DeclarationCategory::Import),
+        ] {
+            let json = serde_json::to_value(cat).unwrap();
+            assert_eq!(json, n);
+            let back: DeclarationCategory = serde_json::from_value(json).unwrap();
+            assert_eq!(back, cat);
+        }
+    }
+
+    #[test]
+    fn type_flags_values() {
+        assert_eq!(type_flags::NONE, 0);
+        assert_eq!(type_flags::INSTANTIABLE, 1);
+        assert_eq!(type_flags::INSTANCE, 2);
+        assert_eq!(type_flags::CALLABLE, 4);
+        // Flags should be combinable
+        let combined = type_flags::INSTANCE | type_flags::CALLABLE;
+        assert_eq!(combined, 6);
+    }
+
+    #[test]
+    fn regular_declaration_serialization() {
+        let decl = Declaration::regular(
+            DeclarationCategory::Class,
+            Url::parse("file:///test.py").unwrap(),
+            Range {
+                start: Position::new(0, 0),
+                end: Position::new(0, 5),
+            },
+            Some("MyClass".to_string()),
+        );
+        let json = serde_json::to_value(&decl).unwrap();
+        assert_eq!(json["kind"], 0);
+        assert_eq!(json["category"], 6);
+        assert_eq!(json["name"], "MyClass");
+        assert_eq!(json["node"]["uri"], "file:///test.py");
+    }
+
+    #[test]
+    fn synthesized_declaration_serialization() {
+        let decl = Declaration::synthesized("file:///builtins.pyi");
+        let json = serde_json::to_value(&decl).unwrap();
+        assert_eq!(json["kind"], 1);
+        assert_eq!(json["uri"], "file:///builtins.pyi");
+        assert!(json.get("node").is_none());
+    }
+
+    #[test]
+    fn declaration_roundtrip_regular() {
+        let decl = Declaration::regular(
+            DeclarationCategory::Function,
+            Url::parse("file:///test.py").unwrap(),
+            Range {
+                start: Position::new(1, 4),
+                end: Position::new(1, 11),
+            },
+            Some("my_func".to_string()),
+        );
+        let json = serde_json::to_string(&decl).unwrap();
+        let back: Declaration = serde_json::from_str(&json).unwrap();
+        assert_eq!(decl, back);
+    }
+
+    #[test]
+    fn declaration_roundtrip_synthesized() {
+        let decl = Declaration::synthesized("file:///stub.pyi");
+        let json = serde_json::to_string(&decl).unwrap();
+        let back: Declaration = serde_json::from_str(&json).unwrap();
+        assert_eq!(decl, back);
+    }
+
+    #[test]
+    fn builtin_type_serialization() {
+        let ty = Type::unknown(1);
+        let json = serde_json::to_value(&ty).unwrap();
+        assert_eq!(json["id"], 1);
+        assert_eq!(json["kind"], 0);
+        assert_eq!(json["display"], "Unknown");
+        assert_eq!(json["flags"], 0);
+        // No details fields should be present
+        assert!(json.get("subTypes").is_none());
+        assert!(json.get("qualifiedName").is_none());
+    }
+
+    #[test]
+    fn type_with_union_details_flattened() {
+        let ty = Type {
+            id: 10,
+            kind: TypeKind::Union,
+            display: Some("int | str".to_string()),
+            flags: type_flags::NONE,
+            declaration: None,
+            type_args: None,
+            details: Some(TypeDetails::Union(UnionDetails {
+                members: vec![
+                    Type {
+                        id: 11,
+                        kind: TypeKind::Class,
+                        display: Some("int".to_string()),
+                        flags: type_flags::INSTANCE,
+                        declaration: None,
+                        type_args: None,
+                        details: None,
+                    },
+                    Type {
+                        id: 12,
+                        kind: TypeKind::Class,
+                        display: Some("str".to_string()),
+                        flags: type_flags::INSTANCE,
+                        declaration: None,
+                        type_args: None,
+                        details: None,
+                    },
+                ],
+            })),
+        };
+        let json = serde_json::to_value(&ty).unwrap();
+        // Union members should be flattened as "subTypes"
+        let sub_types = json["subTypes"].as_array().unwrap();
+        assert_eq!(sub_types.len(), 2);
+        assert_eq!(sub_types[0]["display"], "int");
+        assert_eq!(sub_types[1]["display"], "str");
+    }
+
+    #[test]
+    fn type_with_class_details_flattened() {
+        let ty = Type {
+            id: 5,
+            kind: TypeKind::Class,
+            display: Some("list[int]".to_string()),
+            flags: type_flags::INSTANCE,
+            declaration: None,
+            type_args: None,
+            details: Some(TypeDetails::Class(ClassDetails {
+                qualified_name: "builtins.list".to_string(),
+                module: Some("builtins".to_string()),
+                type_arguments: Some(vec![6]),
+            })),
+        };
+        let json = serde_json::to_value(&ty).unwrap();
+        assert_eq!(json["qualifiedName"], "builtins.list");
+        assert_eq!(json["module"], "builtins");
+        assert_eq!(json["typeArguments"], serde_json::json!([6]));
+    }
+
+    #[test]
+    fn type_with_literal_details_flattened() {
+        let ty = Type {
+            id: 20,
+            kind: TypeKind::Class,
+            display: Some("Literal[42]".to_string()),
+            flags: type_flags::INSTANCE,
+            declaration: None,
+            type_args: None,
+            details: Some(TypeDetails::Literal(LiteralDetails {
+                value: "42".to_string(),
+                literal_kind: LiteralKind::Int,
+            })),
+        };
+        let json = serde_json::to_value(&ty).unwrap();
+        assert_eq!(json["value"], "42");
+        assert_eq!(json["literalKind"], "int");
+    }
+
+    #[test]
+    fn type_camel_case_field_names() {
+        let ty = Type {
+            id: 1,
+            kind: TypeKind::Class,
+            display: None,
+            flags: type_flags::NONE,
+            declaration: None,
+            type_args: Some(vec![Type::unknown(2)]),
+            details: Some(TypeDetails::Class(ClassDetails {
+                qualified_name: "foo.Bar".to_string(),
+                module: None,
+                type_arguments: Some(vec![2]),
+            })),
+        };
+        let json = serde_json::to_value(&ty).unwrap();
+        // Verify camelCase naming
+        assert!(json.get("typeArgs").is_some());
+        assert!(json.get("qualifiedName").is_some());
+        assert!(json.get("typeArguments").is_some());
+        // No snake_case
+        assert!(json.get("type_args").is_none());
+        assert!(json.get("qualified_name").is_none());
+        assert!(json.get("type_arguments").is_none());
+    }
+
+    #[test]
+    fn literal_kind_serializes_as_camel_case() {
+        assert_eq!(
+            serde_json::to_value(LiteralKind::Int).unwrap(),
+            serde_json::json!("int")
+        );
+        assert_eq!(
+            serde_json::to_value(LiteralKind::Bool).unwrap(),
+            serde_json::json!("bool")
+        );
+        assert_eq!(
+            serde_json::to_value(LiteralKind::EnumMember).unwrap(),
+            serde_json::json!("enumMember")
+        );
+    }
+
+    #[test]
+    fn parameter_kind_serializes_as_camel_case() {
+        assert_eq!(
+            serde_json::to_value(ParameterKind::VarPositional).unwrap(),
+            serde_json::json!("varPositional")
+        );
+        assert_eq!(
+            serde_json::to_value(ParameterKind::KeywordOnly).unwrap(),
+            serde_json::json!("keywordOnly")
+        );
+    }
+
+    #[test]
+    fn function_details_flattened() {
+        let ty = Type {
+            id: 30,
+            kind: TypeKind::Function,
+            display: Some("def foo(x: int) -> str".to_string()),
+            flags: type_flags::CALLABLE,
+            declaration: None,
+            type_args: None,
+            details: Some(TypeDetails::Function(FunctionDetails {
+                name: Some("foo".to_string()),
+                parameters: Some(vec![FunctionParameter {
+                    name: "x".to_string(),
+                    type_id: Some(1),
+                    has_default: Some(false),
+                    kind: Some(ParameterKind::PositionalOrKeyword),
+                }]),
+                return_type: Some(2),
+            })),
+        };
+        let json = serde_json::to_value(&ty).unwrap();
+        assert_eq!(json["name"], "foo");
+        assert_eq!(json["returnType"], 2);
+        let params = json["parameters"].as_array().unwrap();
+        assert_eq!(params.len(), 1);
+        assert_eq!(params[0]["name"], "x");
+        assert_eq!(params[0]["typeId"], 1);
+    }
+
+    #[test]
+    fn synthesized_details_flattened() {
+        let ty = Type {
+            id: 40,
+            kind: TypeKind::Synthesized,
+            display: Some("def bar() -> None".to_string()),
+            flags: type_flags::CALLABLE,
+            declaration: Some(Declaration::synthesized("tsp://stub/40")),
+            type_args: None,
+            details: Some(TypeDetails::Synthesized(SynthesizedDetails {
+                stub_content: "def bar() -> None: ...".to_string(),
+                metadata: SynthesizedMetadata {
+                    module: ModuleName {
+                        name_parts: vec!["mymodule".to_string()],
+                    },
+                    primary_definition_offset: 0,
+                },
+            })),
+        };
+        let json = serde_json::to_value(&ty).unwrap();
+        assert_eq!(json["stubContent"], "def bar() -> None: ...");
+        assert_eq!(
+            json["metadata"]["module"]["nameParts"],
+            serde_json::json!(["mymodule"])
+        );
+        assert_eq!(json["metadata"]["primaryDefinitionOffset"], 0);
+    }
+}


### PR DESCRIPTION
## Summary

This PR lays the foundation for Type Server Protocol (TSP) support in ty, following the architecture discussed in https://github.com/astral-sh/ruff/discussions/23432. TSP enables structured type queries over JSON-RPC, allowing VS code extensions like Pylance to consume ty's type information programmatically.

**This PR does not yet make TSP usable end-to-end** — it establishes the infrastructure that type query handlers (coming in a follow-up) will build on. Let me know if you'd like this PR split even more or would rather I push an even bigger PR with the whole of TSP working.

## What's included

### Type information API (`ty_ide::type_info`)
- `TypeCategory` enum classifying types (Function, Class, Union, Literal, etc.)
- `TypeInfo` / `DeclarationInfo` structs for structured type data
- `type_info()`, `declared_type_info()`, `expected_type_info()` public functions
- Supporting APIs in `ty_python_semantic`: `declared_type_for_definition()`, `function_overload_info()`

### TSP protocol types (`ty_server::tsp`)
- Wire-format types: `Type`, `TypeKind`, `TypeFlags`, `Declaration`, `DeclarationCategory`
- Request/response parameter types for all 8 TSP methods
- Custom `lsp_types::request::Request` impls for trait-based dispatch
- Method constants and protocol version (`0.4.0`)

### Core handlers (`ty_server::tsp::handlers`)
- `getSupportedProtocolVersion` — returns protocol version string
- `getSnapshot` — returns `Session::revision()` for snapshot validation
- `getPythonSearchPaths` — returns search paths for a given workspace
- `snapshotChanged` notification — sent to clients after every revision bump
- Snapshot validation helper for stale-request rejection

### Integration
- TSP handlers registered in `server::api::request()` dispatch
- All 8 notification handlers send `snapshotChanged` after state mutations
- Handler traits widened to `pub(crate)` for cross-module access

## What's NOT included (follow-ups)
- Type query handlers (`getComputedType`, `getDeclaredType`, `getExpectedType`)
- `TypeInfo` → TSP `Type` serialization
- Import resolution (`resolveImport`)
- Stub generation for synthesized types
- Typeshed content serving

## Test plan

51 new tests across `ty_ide` (17) and `ty_server` (34), all passing. Clippy clean.

/cc @MichaReiser 