### PR TITLE
[ty] treat bivariance as covariant

### DIFF
--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -4271,11 +4271,11 @@ def function():
         );
 
         // TODO: Should this be constravariant instead?
-        assert_snapshot!(test.hover(), @"
-        P@Alias (bivariant)
+        assert_snapshot!(test.hover(), @r###"
+        P@Alias (covariant)
         ---------------------------------------------
         ```python
-        P@Alias (bivariant)
+        P@Alias (covariant)
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -4286,7 +4286,7 @@ def function():
           |                                         |
           |                                         source
           |
-        ");
+        "###);
     }
 
     #[test]

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -4271,7 +4271,7 @@ def function():
         );
 
         // TODO: Should this be constravariant instead?
-        assert_snapshot!(test.hover(), @r###"
+        assert_snapshot!(test.hover(), @"
         P@Alias (covariant)
         ---------------------------------------------
         ```python
@@ -4286,7 +4286,7 @@ def function():
           |                                         |
           |                                         source
           |
-        "###);
+        ");
     }
 
     #[test]

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -413,6 +413,7 @@ class GenericShape[T]:
     @classmethod
     def baz[U](cls, u: U) -> "GenericShape[U]":
         reveal_type(cls)  # revealed: type[Self@baz]
+        # error: [invalid-return-type]
         return cls()
 
 class GenericCircle[T](GenericShape[T]): ...
@@ -1091,7 +1092,7 @@ class ExplicitGeneric[T]:
 
 ExplicitGeneric[int]().special()
 
-# TODO: this should be an `invalid-argument-type` error
+# error: [invalid-argument-type] "Argument to bound method `special` is incorrect: Expected `ExplicitGeneric[int]`, found `ExplicitGeneric[str]`"
 ExplicitGeneric[str]().special()
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -1092,7 +1092,7 @@ class ExplicitGeneric[T]:
 
 ExplicitGeneric[int]().special()
 
-# error: [invalid-argument-type] "Argument to bound method `special` is incorrect: Expected `ExplicitGeneric[int]`, found `ExplicitGeneric[str]`"
+# error: [invalid-argument-type] "Argument to bound method `ExplicitGeneric.special` is incorrect: Expected `ExplicitGeneric[int]`, found `ExplicitGeneric[str]`"
 ExplicitGeneric[str]().special()
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -704,13 +704,14 @@ def _():
 ## Prefer the declared type of generic classes and callables
 
 When inferring a generic call, we only use the declared type as type context if it is in
-non-covariant position. The final annotated assignment binding still uses the declared type if the
-inferred and declared types are mutually assignable:
+non-covariant position. Unused type parameters are inferred as covariant. The final annotated
+assignment binding still uses the declared type if the inferred and declared types are mutually
+assignable:
 
 ```py
 from typing import Any
 
-class Bivariant[T]:
+class UnusedTypeParameter[T]:
     pass
 
 class Covariant[T]:
@@ -724,8 +725,8 @@ class Contravariant[T]:
 class Invariant[T]:
     x: T
 
-def bivariant[T](x: T) -> Bivariant[T]:
-    return Bivariant()
+def unused_type_parameter[T](x: T) -> UnusedTypeParameter[T]:
+    return UnusedTypeParameter()
 
 def covariant[T](x: T) -> Covariant[T]:
     return Covariant()
@@ -736,32 +737,32 @@ def contravariant[T](x: T) -> Contravariant[T]:
 def invariant[T](x: T) -> Invariant[T]:
     return Invariant()
 
-x1 = bivariant(1)
+x1 = unused_type_parameter(1)
 x2 = covariant(1)
 x3 = contravariant(1)
 x4 = invariant(1)
 
-reveal_type(x1)  # revealed: Bivariant[Literal[1]]
+reveal_type(x1)  # revealed: UnusedTypeParameter[Literal[1]]
 reveal_type(x2)  # revealed: Covariant[Literal[1]]
 reveal_type(x3)  # revealed: Contravariant[int]
 reveal_type(x4)  # revealed: Invariant[int]
 
-x5: Bivariant[int | None] = bivariant(1)
+x5: UnusedTypeParameter[int | None] = unused_type_parameter(1)
 x6: Covariant[int | None] = covariant(1)
 x7: Contravariant[int | None] = contravariant(1)
 x8: Invariant[int | None] = invariant(1)
 
-reveal_type(x5)  # revealed: Bivariant[Literal[1]]
+reveal_type(x5)  # revealed: UnusedTypeParameter[Literal[1]]
 reveal_type(x6)  # revealed: Covariant[Literal[1]]
 reveal_type(x7)  # revealed: Contravariant[int | None]
 reveal_type(x8)  # revealed: Invariant[int | None]
 
-x9: Bivariant[Any] = bivariant(1)
+x9: UnusedTypeParameter[Any] = unused_type_parameter(1)
 x10: Covariant[Any] = covariant(1)
 x11: Contravariant[Any] = contravariant(1)
 x12: Invariant[Any] = invariant(1)
 
-reveal_type(x9)  # revealed: Bivariant[Any]
+reveal_type(x9)  # revealed: UnusedTypeParameter[Any]
 reveal_type(x10)  # revealed: Covariant[Any]
 reveal_type(x11)  # revealed: Contravariant[Any]
 reveal_type(x12)  # revealed: Invariant[Any]

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -751,7 +751,7 @@ x6: Covariant[int | None] = covariant(1)
 x7: Contravariant[int | None] = contravariant(1)
 x8: Invariant[int | None] = invariant(1)
 
-reveal_type(x5)  # revealed: Bivariant[int | None]
+reveal_type(x5)  # revealed: Bivariant[Literal[1]]
 reveal_type(x6)  # revealed: Covariant[Literal[1]]
 reveal_type(x7)  # revealed: Contravariant[int | None]
 reveal_type(x8)  # revealed: Invariant[int | None]

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -230,12 +230,13 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Callable, Generic
+from typing import Callable, Generic, assert_type
 from typing_extensions import ParamSpec
 
 PList = ParamSpec("PList", default=[str])
 PEllipsis = ParamSpec("PEllipsis", default=...)
 PAnother = ParamSpec("PAnother", default=PList)
+DefaultP = ParamSpec("DefaultP", default=[str, int])
 
 class C1(Generic[PList]):
     x: Callable[PList, None]
@@ -246,9 +247,14 @@ class C2(Generic[PEllipsis]):
 class C3(Generic[PList, PAnother]):
     x: Callable[PAnother, None]
 
+class ClassParamSpec(Generic[DefaultP]):
+    x: Callable[DefaultP, None]
+
 reveal_type(C1().x)  # revealed: (str, /) -> None
 reveal_type(C2().x)  # revealed: (...) -> None
 reveal_type(C3().x)  # revealed: (str, /) -> None
+assert_type(ClassParamSpec(), ClassParamSpec[str, int])
+assert_type(ClassParamSpec[[bool, bool]](), ClassParamSpec[bool, bool])
 ```
 
 ### Forward references in stub files

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -230,13 +230,12 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Callable, Generic, assert_type
+from typing import Callable, Generic
 from typing_extensions import ParamSpec
 
 PList = ParamSpec("PList", default=[str])
 PEllipsis = ParamSpec("PEllipsis", default=...)
 PAnother = ParamSpec("PAnother", default=PList)
-DefaultP = ParamSpec("DefaultP", default=[str, int])
 
 class C1(Generic[PList]):
     x: Callable[PList, None]
@@ -247,14 +246,9 @@ class C2(Generic[PEllipsis]):
 class C3(Generic[PList, PAnother]):
     x: Callable[PAnother, None]
 
-class ClassParamSpec(Generic[DefaultP]):
-    x: Callable[DefaultP, None]
-
 reveal_type(C1().x)  # revealed: (str, /) -> None
 reveal_type(C2().x)  # revealed: (...) -> None
 reveal_type(C3().x)  # revealed: (str, /) -> None
-assert_type(ClassParamSpec(), ClassParamSpec[str, int])
-assert_type(ClassParamSpec[[bool, bool]](), ClassParamSpec[bool, bool])
 ```
 
 ### Forward references in stub files

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -313,17 +313,12 @@ If the type of a constructor parameter is a class typevar, we can use that to in
 parameter. The types inferred from a type context and from a constructor parameter must be
 consistent with each other.
 
-We have to add `x: T` to the classes to ensure they're not bivariant in `T` (__new__ and __init__
-signatures don't count towards variance).
-
 ### `__new__` only
 
 ```py
 from ty_extensions._internal import generic_context, into_regular_callable
 
 class C[T]:
-    x: T
-
     def __new__(cls, x: T) -> "C[T]":
         return object.__new__(cls)
 
@@ -332,9 +327,9 @@ reveal_type(generic_context(C))
 # revealed: ty_extensions._internal.GenericContext[T@C]
 reveal_type(generic_context(into_regular_callable(C)))
 
-reveal_type(C(1))  # revealed: C[int]
+reveal_type(C(1))  # revealed: C[Literal[1]]
 
-# error: [invalid-assignment] "Object of type `C[str]` is not assignable to `C[int]`"
+# error: [invalid-assignment] "Object of type `C[Literal["five"]]` is not assignable to `C[int]`"
 wrong_innards: C[int] = C("five")
 ```
 
@@ -344,8 +339,6 @@ wrong_innards: C[int] = C("five")
 from ty_extensions._internal import generic_context, into_regular_callable
 
 class C[T]:
-    x: T
-
     def __init__(self, x: T) -> None: ...
 
 # revealed: ty_extensions._internal.GenericContext[T@C]
@@ -353,9 +346,9 @@ reveal_type(generic_context(C))
 # revealed: ty_extensions._internal.GenericContext[T@C]
 reveal_type(generic_context(into_regular_callable(C)))
 
-reveal_type(C(1))  # revealed: C[int]
+reveal_type(C(1))  # revealed: C[Literal[1]]
 
-# error: [invalid-assignment] "Object of type `C[str]` is not assignable to `C[int]`"
+# error: [invalid-assignment] "Object of type `C[Literal["five"]]` is not assignable to `C[int]`"
 wrong_innards: C[int] = C("five")
 ```
 
@@ -553,10 +546,6 @@ from typing import overload
 from ty_extensions._internal import generic_context, into_regular_callable
 
 class C[T]:
-    # we need to use the type variable or else the class is bivariant in T, and
-    # specializations become meaningless
-    x: T
-
     @overload
     def __init__(self: C[str], x: str) -> None: ...
     @overload
@@ -593,10 +582,6 @@ C[None](b"bytes")  # error: [no-matching-overload]
 C[None](12)
 
 class D[T, U]:
-    # we need to use the type variable or else the class is bivariant in T, and
-    # specializations become meaningless
-    x: T
-
     @overload
     def __init__(self: "D[str, U]", u: U) -> None: ...
     @overload
@@ -610,7 +595,7 @@ reveal_type(generic_context(into_regular_callable(D)))
 
 reveal_type(D("string"))  # revealed: D[str, Literal["string"]]
 reveal_type(D(1))  # revealed: D[str, Literal[1]]
-reveal_type(D(1, "string"))  # revealed: D[int, Literal["string"]]
+reveal_type(D(1, "string"))  # revealed: D[Literal[1], Literal["string"]]
 ```
 
 ### Synthesized methods with dataclasses

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -729,11 +729,11 @@ reveal_type(add_letters(Array[B, D]()))  # revealed: Array[A, B, D, C]
 reveal_type(add_letter_a(Array[B, C]()))  # revealed: Array[A, B, C]
 
 reveal_type(del_letter_a(Array[A, B]()))  # revealed: Array[B]
-# TODO: error: [invalid-argument-type]
+# error: [invalid-argument-type] "Argument to function `del_letter_a` is incorrect: Expected `Array[A, C]`, found `Array[B, C]`"
 reveal_type(del_letter_a(Array[B, C]()))  # revealed: Array[C]
 
 reveal_type(del_letter_c(Array[A, B, C]()))  # revealed: Array[A, B]
-# TODO: error: [invalid-argument-type]
+# error: [invalid-argument-type] "Argument to function `del_letter_c` is incorrect: Expected `Array[A, C]`, found `Array[A, B]`"
 reveal_type(del_letter_c(Array[A, B]()))  # revealed: Array[A]
 
 reveal_type(generic(A(), Array[B, D]()))  # revealed: Array[A, B, D]
@@ -1026,8 +1026,7 @@ class Row[*Cells]:
 
 def f(pair: Row[int, str], triple: Row[int, str, bytes]) -> None:
     reveal_type(pair.get())  # revealed: Row[str, int]
-    # TODO: Should reveal `Row[str, bytes, int]`.
-    reveal_type(triple.get())  # revealed: Row[Unknown, Unknown]
+    reveal_type(triple.get())  # revealed: Row[str, bytes, int]
 ```
 
 ## Invalid Forms

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
@@ -7,8 +7,11 @@ python-version = "3.12"
 
 Type variables have a property called _variance_ that affects the subtyping and assignability
 relations. Much more detail can be found in the [spec]. To summarize, each typevar is either
-**covariant**, **contravariant**, **invariant**, or **bivariant**. (Note that bivariance is not
-currently mentioned in the typing spec, but is a fourth case that we must consider.)
+**covariant**, **contravariant**, or **invariant**. Our inference lattice also has an internal
+**bivariant** state; if a PEP 695 type parameter would otherwise infer to bivariance, we fall back
+to covariance instead. (Bivariance is technically correct when a typevar is unused, but it is
+confusing since it makes all specializations equivalent, it's not practically useful, and it's not
+in the spec, so we avoid it.)
 
 For all of the examples below, we will consider typevars `T` and `U`, two generic classes using
 those typevars `C[T]` and `D[U]`, and two types `A` and `B`.
@@ -284,15 +287,10 @@ static_assert(not is_equivalent_to(D[Any], C[Any]))
 static_assert(not is_equivalent_to(D[Any], C[Unknown]))
 ```
 
-## Bivariance
+## Bivariant Fallback
 
-With a bivariant typevar, _all_ specializations of the generic class are assignable to (and in fact,
-gradually equivalent to) each other, and all specializations are subtypes of (and equivalent to)
-each other.
-
-This is a bit of pathological case, which really only happens when the class doesn't use the typevar
-at all. (If it did, it would have to be covariant, contravariant, or invariant, depending on _how_
-the typevar was used.)
+If inference for a PEP 695 type parameter would otherwise conclude bivariance because the type
+parameter is unused, we fall back to covariance instead.
 
 ```py
 from ty_extensions import static_assert, Unknown
@@ -309,7 +307,7 @@ class D[U](C[U]):
     pass
 
 static_assert(is_assignable_to(C[B], C[A]))
-static_assert(is_assignable_to(C[A], C[B]))
+static_assert(not is_assignable_to(C[A], C[B]))
 static_assert(is_assignable_to(C[A], C[Any]))
 static_assert(is_assignable_to(C[B], C[Any]))
 static_assert(is_assignable_to(C[Any], C[A]))
@@ -317,37 +315,37 @@ static_assert(is_assignable_to(C[Any], C[B]))
 
 static_assert(is_assignable_to(D[B], C[A]))
 static_assert(is_subtype_of(C[A], C[A]))
-static_assert(is_assignable_to(D[A], C[B]))
+static_assert(not is_assignable_to(D[A], C[B]))
 static_assert(is_assignable_to(D[A], C[Any]))
 static_assert(is_assignable_to(D[B], C[Any]))
 static_assert(is_assignable_to(D[Any], C[A]))
 static_assert(is_assignable_to(D[Any], C[B]))
 
 static_assert(is_subtype_of(C[B], C[A]))
-static_assert(is_subtype_of(C[A], C[B]))
-static_assert(is_subtype_of(C[A], C[Any]))
-static_assert(is_subtype_of(C[B], C[Any]))
-static_assert(is_subtype_of(C[Any], C[A]))
-static_assert(is_subtype_of(C[Any], C[B]))
-static_assert(is_subtype_of(C[Any], C[Any]))
-static_assert(is_subtype_of(C[object], C[Any]))
-static_assert(is_subtype_of(C[Any], C[Never]))
+static_assert(not is_subtype_of(C[A], C[B]))
+static_assert(not is_subtype_of(C[A], C[Any]))
+static_assert(not is_subtype_of(C[B], C[Any]))
+static_assert(not is_subtype_of(C[Any], C[A]))
+static_assert(not is_subtype_of(C[Any], C[B]))
+static_assert(not is_subtype_of(C[Any], C[Any]))
+static_assert(not is_subtype_of(C[object], C[Any]))
+static_assert(not is_subtype_of(C[Any], C[Never]))
 
 static_assert(is_subtype_of(D[B], C[A]))
-static_assert(is_subtype_of(D[A], C[B]))
-static_assert(is_subtype_of(D[A], C[Any]))
-static_assert(is_subtype_of(D[B], C[Any]))
-static_assert(is_subtype_of(D[Any], C[A]))
-static_assert(is_subtype_of(D[Any], C[B]))
+static_assert(not is_subtype_of(D[A], C[B]))
+static_assert(not is_subtype_of(D[A], C[Any]))
+static_assert(not is_subtype_of(D[B], C[Any]))
+static_assert(not is_subtype_of(D[Any], C[A]))
+static_assert(not is_subtype_of(D[Any], C[B]))
 
 static_assert(is_equivalent_to(C[A], C[A]))
 static_assert(is_equivalent_to(C[B], C[B]))
-static_assert(is_equivalent_to(C[B], C[A]))
-static_assert(is_equivalent_to(C[A], C[B]))
-static_assert(is_equivalent_to(C[A], C[Any]))
-static_assert(is_equivalent_to(C[B], C[Any]))
-static_assert(is_equivalent_to(C[Any], C[A]))
-static_assert(is_equivalent_to(C[Any], C[B]))
+static_assert(not is_equivalent_to(C[B], C[A]))
+static_assert(not is_equivalent_to(C[A], C[B]))
+static_assert(not is_equivalent_to(C[A], C[Any]))
+static_assert(not is_equivalent_to(C[B], C[Any]))
+static_assert(not is_equivalent_to(C[Any], C[A]))
+static_assert(not is_equivalent_to(C[Any], C[B]))
 
 static_assert(not is_equivalent_to(D[A], C[A]))
 static_assert(not is_equivalent_to(D[B], C[B]))
@@ -767,10 +765,11 @@ class C[T]:
     def __new__(self, x: T): ...
 
 static_assert(is_subtype_of(C[B], C[A]))
-static_assert(is_subtype_of(C[A], C[B]))
+static_assert(not is_subtype_of(C[A], C[B]))
 ```
 
-This example is then bivariant because it doesn't use `T` outside of the two exempted methods.
+This example would otherwise be bivariant because it doesn't use `T` outside of the two exempted
+methods, so we fall back to covariance.
 
 This holds likewise for dataclasses with synthesized `__init__`:
 
@@ -1006,17 +1005,17 @@ static_assert(not is_subtype_of(InvariantLiteral1, InvariantInt))
 static_assert(not is_subtype_of(MyInvariant[Literal[1]], MyInvariant[int]))
 static_assert(not is_subtype_of(MyInvariant[int], MyInvariant[Literal[1]]))
 
-class Bivariant[T]:
+class WouldBeBivariant[T]:
     pass
 
-type BivariantLiteral1 = Bivariant[Literal[1]]
-type BivariantInt = Bivariant[int]
-type MyBivariant[T] = Bivariant[T]
+type WouldBeBivariantLiteral1 = WouldBeBivariant[Literal[1]]
+type WouldBeBivariantInt = WouldBeBivariant[int]
+type MyWouldBeBivariant[T] = WouldBeBivariant[T]
 
-static_assert(is_subtype_of(BivariantInt, BivariantLiteral1))
-static_assert(is_subtype_of(BivariantLiteral1, BivariantInt))
-static_assert(is_subtype_of(MyBivariant[Literal[1]], MyBivariant[int]))
-static_assert(is_subtype_of(MyBivariant[int], MyBivariant[Literal[1]]))
+static_assert(not is_subtype_of(WouldBeBivariantInt, WouldBeBivariantLiteral1))
+static_assert(is_subtype_of(WouldBeBivariantLiteral1, WouldBeBivariantInt))
+static_assert(is_subtype_of(MyWouldBeBivariant[Literal[1]], MyWouldBeBivariant[int]))
+static_assert(not is_subtype_of(MyWouldBeBivariant[int], MyWouldBeBivariant[Literal[1]]))
 ```
 
 ## Inheriting from generic classes with inferred variance

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
@@ -6,12 +6,11 @@ python-version = "3.12"
 ```
 
 Type variables have a property called _variance_ that affects the subtyping and assignability
-relations. Much more detail can be found in the [spec]. To summarize, each typevar is either
-**covariant**, **contravariant**, or **invariant**. Our inference lattice also has an internal
-**bivariant** state; if a PEP 695 type parameter would otherwise infer to bivariance, we fall back
-to covariance instead. (Bivariance is technically correct when a typevar is unused, but it is
-confusing since it makes all specializations equivalent, it's not practically useful, and it's not
-in the spec, so we avoid it.)
+relations. Much more detail can be found in the [spec]. PEP 695 defines inferred variance as
+**covariant**, **contravariant**, or **invariant**. We also represent **bivariance** internally, for
+cases where varying a type parameter does not change the type. For PEP 695 parameters, we report
+these cases as covariant, matching the spec's inference algorithm when assignment is valid in both
+directions.
 
 For all of the examples below, we will consider typevars `T` and `U`, two generic classes using
 those typevars `C[T]` and `D[U]`, and two types `A` and `B`.
@@ -377,11 +376,11 @@ of that instance affect its variance.
 from ty_extensions import static_assert
 from ty_extensions._internal import is_subtype_of
 
-class Bivariant[T]:
-    def takes_int_self(self, value: Bivariant[int]): ...
+class WouldBeBivariant[T]:
+    def takes_int_self(self, value: WouldBeBivariant[int]): ...
 
-static_assert(is_subtype_of(Bivariant[int], Bivariant[object]))
-static_assert(is_subtype_of(Bivariant[object], Bivariant[int]))
+static_assert(is_subtype_of(WouldBeBivariant[int], WouldBeBivariant[object]))
+static_assert(not is_subtype_of(WouldBeBivariant[object], WouldBeBivariant[int]))
 
 class Covariant[T]:
     def get(self) -> T:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type.md
@@ -212,7 +212,7 @@ def f(x: A[int] | B):
         reveal_type(x)  # revealed: A[int] | B
 
     if type(x) is A:
-        reveal_type(x)  # revealed: A[int]
+        reveal_type(x)  # revealed: A[int] | (B & A[object])
     else:
         reveal_type(x)  # revealed: A[int] | B
 
@@ -230,7 +230,7 @@ def f(x: A[int] | B):
     if type(x) is not A:
         reveal_type(x)  # revealed: A[int] | B
     else:
-        reveal_type(x)  # revealed: A[int]
+        reveal_type(x)  # revealed: A[int] | (B & A[object])
 
     if type(x) is not B:
         reveal_type(x)  # revealed: A[int] | B

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -5766,7 +5766,7 @@ def f(c: C[int]) -> None:
     # The key thing is that we don't stack overflow while checking this.
     # The cycle detection assumes compatibility when it detects potential
     # infinite recursion between protocol specializations.
-    takes_c(c)
+    takes_c(c)  # error: [invalid-argument-type]
 
 class Left[T](Protocol):
     @property

--- a/crates/ty_python_semantic/resources/mdtest/type_of/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/basic.md
@@ -319,8 +319,6 @@ from typing import final, Any
 from ty_extensions import static_assert
 from ty_extensions._internal import is_assignable_to, is_subtype_of, is_disjoint_from
 
-class Biv[T]: ...
-
 class Cov[T]:
     def pop(self) -> T:
         raise NotImplementedError
@@ -333,9 +331,6 @@ class Inv[T]:
     x: T
 
 @final
-class BivSub[T](Biv[T]): ...
-
-@final
 class CovSub[T](Cov[T]): ...
 
 @final
@@ -345,9 +340,6 @@ class ContraSub[T](Contra[T]): ...
 class InvSub[T](Inv[T]): ...
 
 def _[T, U]():
-    static_assert(is_subtype_of(type[BivSub[T]], type[BivSub[U]]))
-    static_assert(not is_disjoint_from(type[BivSub[U]], type[BivSub[T]]))
-
     # `T` and `U` could specialize to the same type.
     static_assert(not is_subtype_of(type[CovSub[T]], type[CovSub[U]]))
     static_assert(not is_disjoint_from(type[CovSub[U]], type[CovSub[T]]))
@@ -359,12 +351,6 @@ def _[T, U]():
     static_assert(not is_disjoint_from(type[InvSub[U]], type[InvSub[T]]))
 
 def _():
-    static_assert(is_subtype_of(type[BivSub[bool]], type[BivSub[int]]))
-    static_assert(is_subtype_of(type[BivSub[int]], type[BivSub[bool]]))
-    static_assert(not is_disjoint_from(type[BivSub[bool]], type[BivSub[int]]))
-    # `BivSub[int]` and `BivSub[str]` are mutual subtypes.
-    static_assert(not is_disjoint_from(type[BivSub[int]], type[BivSub[str]]))
-
     static_assert(is_subtype_of(type[CovSub[bool]], type[CovSub[int]]))
     static_assert(not is_subtype_of(type[CovSub[int]], type[CovSub[bool]]))
     static_assert(not is_disjoint_from(type[CovSub[bool]], type[CovSub[int]]))
@@ -383,12 +369,6 @@ def _():
     static_assert(is_disjoint_from(type[InvSub[bool]], type[InvSub[int]]))
 
 def _[T]():
-    static_assert(is_subtype_of(type[BivSub[T]], type[BivSub[Any]]))
-    static_assert(is_subtype_of(type[BivSub[Any]], type[BivSub[T]]))
-    static_assert(is_assignable_to(type[BivSub[T]], type[BivSub[Any]]))
-    static_assert(is_assignable_to(type[BivSub[Any]], type[BivSub[T]]))
-    static_assert(not is_disjoint_from(type[BivSub[T]], type[BivSub[Any]]))
-
     static_assert(not is_subtype_of(type[CovSub[T]], type[CovSub[Any]]))
     static_assert(not is_subtype_of(type[CovSub[Any]], type[CovSub[T]]))
     static_assert(is_assignable_to(type[CovSub[T]], type[CovSub[Any]]))
@@ -408,12 +388,6 @@ def _[T]():
     static_assert(not is_disjoint_from(type[InvSub[T]], type[InvSub[Any]]))
 
 def _[T, U]():
-    static_assert(is_subtype_of(type[BivSub[T]], type[Biv[T]]))
-    static_assert(not is_subtype_of(type[Biv[T]], type[BivSub[T]]))
-    static_assert(not is_disjoint_from(type[BivSub[T]], type[Biv[T]]))
-    static_assert(not is_disjoint_from(type[BivSub[U]], type[Biv[T]]))
-    static_assert(not is_disjoint_from(type[BivSub[U]], type[Biv[U]]))
-
     static_assert(is_subtype_of(type[CovSub[T]], type[Cov[T]]))
     static_assert(not is_subtype_of(type[Cov[T]], type[CovSub[T]]))
     static_assert(not is_disjoint_from(type[CovSub[T]], type[Cov[T]]))
@@ -433,11 +407,6 @@ def _[T, U]():
     static_assert(not is_disjoint_from(type[InvSub[U]], type[Inv[U]]))
 
 def _():
-    static_assert(is_subtype_of(type[BivSub[bool]], type[Biv[int]]))
-    static_assert(is_subtype_of(type[BivSub[int]], type[Biv[bool]]))
-    static_assert(not is_disjoint_from(type[BivSub[bool]], type[Biv[int]]))
-    static_assert(not is_disjoint_from(type[BivSub[int]], type[Biv[bool]]))
-
     static_assert(is_subtype_of(type[CovSub[bool]], type[Cov[int]]))
     static_assert(not is_subtype_of(type[CovSub[int]], type[Cov[bool]]))
     static_assert(not is_disjoint_from(type[CovSub[bool]], type[Cov[int]]))
@@ -454,12 +423,6 @@ def _():
     static_assert(is_disjoint_from(type[InvSub[int]], type[Inv[bool]]))
 
 def _[T]():
-    static_assert(is_subtype_of(type[BivSub[T]], type[Biv[Any]]))
-    static_assert(is_subtype_of(type[BivSub[Any]], type[Biv[T]]))
-    static_assert(is_assignable_to(type[BivSub[T]], type[Biv[Any]]))
-    static_assert(is_assignable_to(type[BivSub[Any]], type[Biv[T]]))
-    static_assert(not is_disjoint_from(type[BivSub[T]], type[Biv[Any]]))
-
     static_assert(not is_subtype_of(type[CovSub[T]], type[Cov[Any]]))
     static_assert(not is_subtype_of(type[CovSub[Any]], type[Cov[T]]))
     static_assert(is_assignable_to(type[CovSub[T]], type[Cov[Any]]))

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -601,9 +601,11 @@ expects_type_c_of_int_and_str(C)
 # Also OK, the specialized `C[int, str]` is assignable to `type[C[int, str]]`
 expects_type_c_of_int_and_str(C[int, str])
 
-# TODO: these should be errors
+# error: [invalid-argument-type]
 expects_type_c_of_int_and_str(C[str])
+# error: [invalid-argument-type]
 expects_type_c_of_int_and_str(C[int, str, bytes])
+# error: [invalid-argument-type]
 expects_type_c_of_int_and_str(C[str, int])
 ```
 
@@ -619,14 +621,17 @@ def expects_type_c_default_of_int_str(f: type[C[int, str]]): ...
 
 expects_type_c_default(C)
 expects_type_c_default(C[int, str])
-expects_type_c_default_of_int(C)
 expects_type_c_default_of_int(C[int])
 expects_type_c_default_of_int_str(C)
 expects_type_c_default_of_int_str(C[int, str])
 
-# TODO: these should be errors
+# error: [invalid-argument-type]
 expects_type_c_default(C[int])
+# error: [invalid-argument-type]
+expects_type_c_default_of_int(C)
+# error: [invalid-argument-type]
 expects_type_c_default_of_int(C[str])
+# error: [invalid-argument-type]
 expects_type_c_default_of_int_str(C[str, int])
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -931,14 +931,6 @@ static_assert(not is_subtype_of(Invariant[Any], Invariant[int]))
 static_assert(not is_subtype_of(Invariant[int], Invariant[Any]))
 static_assert(not is_subtype_of(Invariant[Any], Invariant[object]))
 static_assert(not is_subtype_of(Invariant[object], Invariant[Any]))
-
-class Bivariant[T]: ...
-
-static_assert(is_subtype_of(Bivariant[Any], Bivariant[Any]))
-static_assert(is_subtype_of(Bivariant[Any], Bivariant[int]))
-static_assert(is_subtype_of(Bivariant[int], Bivariant[Any]))
-static_assert(is_subtype_of(Bivariant[Any], Bivariant[object]))
-static_assert(is_subtype_of(Bivariant[object], Bivariant[Any]))
 ```
 
 The same for `Unknown`:

--- a/crates/ty_python_semantic/resources/mdtest/union_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/union_types.md
@@ -348,8 +348,6 @@ python-version = "3.12"
 ```py
 from typing import Any
 
-class Bivariant[T]: ...
-
 class Covariant[T]:
     def get(self) -> T:
         raise NotImplementedError
@@ -361,8 +359,6 @@ class Invariant[T]:
     mutable_attribute: T
 
 def _(
-    a: Bivariant[Any] | Bivariant[Any | str],
-    b: Bivariant[Any | str] | Bivariant[Any],
     c: Covariant[Any] | Covariant[Any | str],
     d: Covariant[Any | str] | Covariant[Any],
     e: Contravariant[Any | str] | Contravariant[Any],
@@ -370,8 +366,6 @@ def _(
     g: Invariant[Any] | Invariant[Any | str],
     h: Invariant[Any | str] | Invariant[Any],
 ):
-    reveal_type(a)  # revealed: Bivariant[Any]
-    reveal_type(b)  # revealed: Bivariant[Any | str]
     reveal_type(c)  # revealed: Covariant[Any | str]
     reveal_type(d)  # revealed: Covariant[Any | str]
     reveal_type(e)  # revealed: Contravariant[Any]

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -357,12 +357,19 @@ fn type_alias_variance() {
         };
         type_alias
     }
+    fn get_bound_typevar_instance<'db>(
+        db: &'db TestDb,
+        type_alias: PEP695TypeAliasType<'db>,
+    ) -> BoundTypeVarInstance<'db> {
+        let generic_context = type_alias.generic_context(db).unwrap();
+        generic_context.variables(db).next().unwrap()
+    }
+
     fn get_bound_typevar<'db>(
         db: &'db TestDb,
         type_alias: PEP695TypeAliasType<'db>,
     ) -> BoundTypeVarIdentity<'db> {
-        let generic_context = type_alias.generic_context(db).unwrap();
-        generic_context.variables(db).next().unwrap().identity(db)
+        get_bound_typevar_instance(db, type_alias).identity(db)
     }
 
     fn assert_effective_variance<'db>(
@@ -370,7 +377,7 @@ fn type_alias_variance() {
         type_alias: PEP695TypeAliasType<'db>,
         expected: TypeVarVariance,
     ) {
-        let typevar = get_bound_typevar(db, type_alias);
+        let typevar = get_bound_typevar_instance(db, type_alias);
         assert_eq!(typevar.variance(db), expected);
     }
 
@@ -406,6 +413,7 @@ type ContravariantAliasAlias[T] = ContravariantAlias[T]
 type InvariantAliasAlias[T] = InvariantAlias[T]
 type BivariantAliasAlias[T] = BivariantAlias[T]
 type ParamSpecContravariantAlias[**P] = Callable[P, None]
+type ParamSpecDefaultContravariantAlias[**P = [int, str]] = Callable[P, None]
 type ParamSpecConcatenateAlias[**P] = Callable[Concatenate[int, P], None]
 type ParamSpecBivariantAlias[**P] = int
 
@@ -477,6 +485,13 @@ type RecursiveAlias2[T] = None | list[T] | list[RecursiveAlias2[T]]
         TypeVarVariance::Contravariant
     );
 
+    let paramspec_default_contravariant = get_type_alias(&db, "ParamSpecDefaultContravariantAlias");
+    assert_eq!(
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(paramspec_default_contravariant))
+            .variance_of(&db, get_bound_typevar(&db, paramspec_default_contravariant)),
+        TypeVarVariance::Contravariant
+    );
+
     let paramspec_concatenate = get_type_alias(&db, "ParamSpecConcatenateAlias");
     assert_eq!(
         KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(paramspec_concatenate))
@@ -509,17 +524,33 @@ type RecursiveAlias2[T] = None | list[T] | list[RecursiveAlias2[T]]
     assert_effective_variance(&db, contravariant, TypeVarVariance::Contravariant);
     assert_effective_variance(&db, invariant, TypeVarVariance::Invariant);
     assert_effective_variance(&db, bivariant, TypeVarVariance::Covariant);
+    assert_effective_variance(&db, covariant_alias, TypeVarVariance::Covariant);
+    assert_effective_variance(&db, contravariant_alias, TypeVarVariance::Contravariant);
+    assert_effective_variance(&db, invariant_alias, TypeVarVariance::Invariant);
+    assert_effective_variance(&db, bivariant_alias, TypeVarVariance::Covariant);
     assert_effective_variance(&db, paramspec_contravariant, TypeVarVariance::Contravariant);
+    assert_effective_variance(
+        &db,
+        paramspec_default_contravariant,
+        TypeVarVariance::Contravariant,
+    );
     assert_effective_variance(&db, paramspec_concatenate, TypeVarVariance::Contravariant);
     assert_effective_variance(&db, paramspec_bivariant, TypeVarVariance::Covariant);
     assert_effective_variance(&db, recursive, TypeVarVariance::Covariant);
     assert_effective_variance(&db, recursive2, TypeVarVariance::Invariant);
 
-    assert_eq!(
-        get_bound_typevar(&db, bivariant)
-            .variance_with_polarity(&db, TypeVarVariance::Contravariant),
-        TypeVarVariance::Contravariant
-    );
+    let bivariant_typevar = get_bound_typevar_instance(&db, bivariant);
+    for polarity in [
+        TypeVarVariance::Covariant,
+        TypeVarVariance::Contravariant,
+        TypeVarVariance::Invariant,
+        TypeVarVariance::Bivariant,
+    ] {
+        assert_eq!(
+            bivariant_typevar.variance_with_polarity(&db, polarity),
+            polarity
+        );
+    }
 }
 
 #[test]

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -365,6 +365,15 @@ fn type_alias_variance() {
         generic_context.variables(db).next().unwrap().identity(db)
     }
 
+    fn assert_effective_variance<'db>(
+        db: &'db TestDb,
+        type_alias: PEP695TypeAliasType<'db>,
+        expected: TypeVarVariance,
+    ) {
+        let typevar = get_bound_typevar(db, type_alias);
+        assert_eq!(typevar.variance(db), expected);
+    }
+
     let mut db = setup_db();
     db.write_dedented(
         "/src/a.py",
@@ -494,6 +503,19 @@ type RecursiveAlias2[T] = None | list[T] | list[RecursiveAlias2[T]]
         KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(recursive2))
             .variance_of(&db, get_bound_typevar(&db, recursive2)),
         TypeVarVariance::Invariant
+    );
+
+    assert_effective_variance(&db, covariant, TypeVarVariance::Covariant);
+    assert_effective_variance(&db, contravariant, TypeVarVariance::Contravariant);
+    assert_effective_variance(&db, invariant, TypeVarVariance::Invariant);
+    assert_effective_variance(&db, bivariant, TypeVarVariance::Covariant);
+    assert_effective_variance(&db, recursive, TypeVarVariance::Covariant);
+    assert_effective_variance(&db, recursive2, TypeVarVariance::Invariant);
+
+    assert_eq!(
+        get_bound_typevar(&db, bivariant)
+            .variance_with_polarity(&db, TypeVarVariance::Contravariant),
+        TypeVarVariance::Contravariant
     );
 }
 

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -509,6 +509,9 @@ type RecursiveAlias2[T] = None | list[T] | list[RecursiveAlias2[T]]
     assert_effective_variance(&db, contravariant, TypeVarVariance::Contravariant);
     assert_effective_variance(&db, invariant, TypeVarVariance::Invariant);
     assert_effective_variance(&db, bivariant, TypeVarVariance::Covariant);
+    assert_effective_variance(&db, paramspec_contravariant, TypeVarVariance::Contravariant);
+    assert_effective_variance(&db, paramspec_concatenate, TypeVarVariance::Contravariant);
+    assert_effective_variance(&db, paramspec_bivariant, TypeVarVariance::Covariant);
     assert_effective_variance(&db, recursive, TypeVarVariance::Covariant);
     assert_effective_variance(&db, recursive2, TypeVarVariance::Invariant);
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1106,17 +1106,13 @@ impl<'db> BoundTypeVarInstance<'db> {
         match self.typevar(db).explicit_variance(db) {
             Some(explicit_variance) => explicit_variance.compose(polarity),
             None => match self.binding_context(db) {
-                BindingContext::Definition(definition) => {
-                    let inferred_variance =
-                        binding_type(db, definition).variance_of(db, self.identity(db));
-
-                    match inferred_variance {
+                BindingContext::Definition(definition) => polarity.compose_thunk(|| {
+                    match binding_type(db, definition).variance_of(db, self.identity(db)) {
                         // When both directions are valid, the typing spec selects covariance.
                         TypeVarVariance::Bivariant => TypeVarVariance::Covariant,
                         variance => variance,
                     }
-                    .compose(polarity)
-                }
+                }),
                 BindingContext::Synthetic => TypeVarVariance::Invariant,
             },
         }

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1102,12 +1102,21 @@ impl<'db> BoundTypeVarInstance<'db> {
         polarity: TypeVarVariance,
     ) -> TypeVarVariance {
         let _span = tracing::trace_span!("variance_with_polarity").entered();
+
         match self.typevar(db).explicit_variance(db) {
             Some(explicit_variance) => explicit_variance.compose(polarity),
             None => match self.binding_context(db) {
-                BindingContext::Definition(definition) => binding_type(db, definition)
-                    .with_polarity(polarity)
-                    .variance_of(db, self.identity(db)),
+                BindingContext::Definition(definition) => {
+                    let inferred_variance =
+                        binding_type(db, definition).variance_of(db, self.identity(db));
+
+                    match inferred_variance {
+                        // When both directions are valid, the typing spec selects covariance.
+                        TypeVarVariance::Bivariant => TypeVarVariance::Covariant,
+                        variance => variance,
+                    }
+                    .compose(polarity)
+                }
                 BindingContext::Synthetic => TypeVarVariance::Invariant,
             },
         }


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/1728.

Bivariance is confusing, not useful, and not in the spec. Fall back to covariant when we would otherwise infer bivariance.

This is primarily a revival of https://github.com/astral-sh/ruff/pull/23779, with a few preliminary fixes in prior PRs.
