### PR TITLE
annotate_snippets: render multiline titles with indentation

### DIFF
--- a/crates/ruff_annotate_snippets/src/renderer/display_list.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/display_list.rs
@@ -1115,7 +1115,7 @@ fn format_message<'m>(
 
     let mut sets = vec![];
     let body = if !snippets.is_empty() || primary {
-        vec![format_title(level, id, title, is_fixable)]
+        format_title(level, id, title, is_fixable)
     } else {
         format_footer(level, id, title)
     };
@@ -1161,17 +1161,32 @@ fn format_title<'a>(
     id: Option<Id<'a>>,
     label: &'a str,
     is_fixable: bool,
-) -> DisplayLine<'a> {
-    DisplayLine::Raw(DisplayRawLine::Annotation {
+) -> Vec<DisplayLine<'a>> {
+    let mut lines = label.lines();
+    let first = lines.next().unwrap_or("");
+    let mut result = vec![DisplayLine::Raw(DisplayRawLine::Annotation {
         annotation: Annotation {
             annotation_type: DisplayAnnotationType::from(level),
             id,
-            label: format_label(Some(label), Some(DisplayTextStyle::Emphasis)),
+            label: format_label(Some(first), Some(DisplayTextStyle::Emphasis)),
             is_fixable,
         },
         source_aligned: false,
         continuation: false,
-    })
+    })];
+    for line in lines {
+        result.push(DisplayLine::Raw(DisplayRawLine::Annotation {
+            annotation: Annotation {
+                annotation_type: DisplayAnnotationType::from(level),
+                id,
+                label: format_label(Some(line), Some(DisplayTextStyle::Emphasis)),
+                is_fixable: false,
+            },
+            source_aligned: false,
+            continuation: true,
+        }));
+    }
+    result
 }
 
 fn format_footer<'a>(

--- a/crates/ruff_annotate_snippets/tests/formatter.rs
+++ b/crates/ruff_annotate_snippets/tests/formatter.rs
@@ -235,6 +235,18 @@ error
 }
 
 #[test]
+fn test_multiline_title() {
+    let input = Level::Info.title("first line\nsecond line\nthird line");
+    let expected = str![[r#"
+info: first line
+      second line
+      third line
+"#]];
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input).to_string(), expected);
+}
+
+#[test]
 #[should_panic]
 fn test_i26() {
     let source = "short";


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
