### PR TITLE
[ty] Add missing test case for inline functional TypedDict with an invalid type passed to the `name` parameter

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2596,6 +2596,9 @@ Bad10 = TypedDict("Bad10", {name: 42})
 
 # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
 class Bad11(TypedDict("Bad11", {name: 42})): ...
+
+# error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
+class Bad12(TypedDict(123, {"field": int})): ...
 ```
 
 ## Functional `TypedDict` with unknown fields


### PR DESCRIPTION
~~I'm pretty sure this branch is unreachable following https://github.com/astral-sh/ruff/pull/24331~~

Currently no tests fail if you delete this branch: https://github.com/astral-sh/ruff/blob/a42d89b74346baf0422d1a06d6c16890951e6f19/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs#L182-L192

This PR adds the missing test coverage