### PR TITLE
set `trim_trailing_whitespace` to false for inline snapshots

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,11 @@ indent_size = 2
 [*.{rs,py,pyi,toml}]
 indent_size = 4
 
+# The following file has trailing white space in inline snapshot results.
+# Trimming them would cause tests to fail
+[crates/ty_ide/src/{hover,code_action,docstring}.rs]
+trim_trailing_whitespace = false
+
 [*.snap]
 trim_trailing_whitespace = false
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Some files have trailing whitespaces in the source code. I thought this [was accidental](https://github.com/astral-sh/ruff/pull/24266) but then realized it's on purpose because markdown is sensitive to whitespace.

Another solution I found to stop neovim from formatting these files on save is to set `trim_trailing_whitespace` to false for them. Without this change whenever you save that file any editor that supports [EditorConfig](https://editorconfig.org/) it's gonna remove whitespaces and tests would fail.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
