### PR TITLE
[ty] Various cleanups to functional `TypedDict` parsing logic

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Function_syntax_with…_(4b18755412dfaff1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Function_syntax_with…_(4b18755412dfaff1).snap
@@ -1,0 +1,586 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: typed_dict.md - `TypedDict` - Function syntax with invalid arguments
+mdtest path: crates/ty_python_semantic/resources/mdtest/typed_dict.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | from typing_extensions import TypedDict
+ 2 | 
+ 3 | # error: [too-many-positional-arguments] "Too many positional arguments to function `TypedDict`: expected 2, got 3"
+ 4 | TypedDict("Foo", {}, {})
+ 5 | # error: [missing-argument] "No arguments provided for required parameters `typename` and `fields` of function `TypedDict`"
+ 6 | TypedDict()
+ 7 | # error: [missing-argument] "No argument provided for required parameter `fields` of function `TypedDict`"
+ 8 | TypedDict("Foo")
+ 9 | 
+10 | # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "Bad1", got variable of type `Literal[123]`"
+11 | Bad1 = TypedDict(123, {"name": str})
+12 | 
+13 | # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "BadTypedDict3", got "WrongName""
+14 | BadTypedDict3 = TypedDict("WrongName", {"name": str})
+15 | 
+16 | def f(x: str) -> None:
+17 |     # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "Y", got variable of type `str`"
+18 |     Y = TypedDict(x, {})
+19 | 
+20 | def g(x: str) -> None:
+21 |     TypedDict(x, {})  # fine
+22 | 
+23 | name = "GoodTypedDict"
+24 | GoodTypedDict = TypedDict(name, {"name": str})
+25 | 
+26 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
+27 | Bad2 = TypedDict("Bad2", "not a dict")
+28 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
+29 | TypedDict("Bad2", "not a dict")
+30 | 
+31 | def get_fields() -> dict[str, object]:
+32 |     return {"name": str}
+33 | 
+34 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
+35 | Bad2b = TypedDict("Bad2b", get_fields())
+36 | 
+37 | # error: [invalid-argument-type] "Invalid argument to parameter `total` of `TypedDict()`"
+38 | Bad3 = TypedDict("Bad3", {"name": str}, total="not a bool")
+39 | 
+40 | # error: [invalid-argument-type] "Invalid argument to parameter `closed` of `TypedDict()`"
+41 | Bad4 = TypedDict("Bad4", {"name": str}, closed=123)
+42 | 
+43 | tup = ("foo", "bar")
+44 | kw = {"name": str}
+45 | 
+46 | # error: [invalid-argument-type] "Variadic positional arguments are not supported in `TypedDict()` calls"
+47 | Bad5 = TypedDict(*tup)
+48 | 
+49 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
+50 | Bad6 = TypedDict("Bad6", {"name": str}, **kw)
+51 | 
+52 | # error: [invalid-argument-type] "Variadic positional and keyword arguments are not supported in `TypedDict()` calls"
+53 | Bad7 = TypedDict(*tup, "foo", "bar", **kw)
+54 | 
+55 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
+56 | # error: [unknown-argument] "Argument `random_other_arg` does not match any known parameter of function `TypedDict`"
+57 | Bad7b = TypedDict("Bad7b", **kw, random_other_arg=56)
+58 | 
+59 | kwargs = {"x": int}
+60 | 
+61 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+62 | Bad8 = TypedDict("Bad8", {**kwargs})
+63 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+64 | TypedDict("Bad8", {**kwargs})
+65 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+66 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+67 | Bad81 = TypedDict("Bad81", {**kwargs, **kwargs})
+68 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+69 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+70 | TypedDict("Bad81", {**kwargs, **kwargs})
+71 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+72 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+73 | Bad82 = TypedDict("Bad82", {**kwargs, "foo": []})
+74 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+75 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+76 | TypedDict("Bad82", {**kwargs, "foo": []})
+77 | 
+78 | def get_name() -> str:
+79 |     return "x"
+80 | 
+81 | name = get_name()
+82 | 
+83 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+84 | Bad9 = TypedDict("Bad9", {name: int})
+85 | 
+86 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+87 | # error: [invalid-type-form]
+88 | Bad10 = TypedDict("Bad10", {name: 42})
+89 | 
+90 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+91 | # error: [invalid-type-form] "Int literals are not allowed in this context in a type expression"
+92 | class Bad11(TypedDict("Bad11", {name: 42})): ...
+93 | 
+94 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
+95 | class Bad12(TypedDict(123, {"field": int})): ...
+```
+
+# Diagnostics
+
+```
+error[too-many-positional-arguments]: Too many positional arguments to function `TypedDict`: expected 2, got 3
+ --> src/mdtest_snippet.py:4:22
+  |
+3 | # error: [too-many-positional-arguments] "Too many positional arguments to function `TypedDict`: expected 2, got 3"
+4 | TypedDict("Foo", {}, {})
+  |                      ^^
+5 | # error: [missing-argument] "No arguments provided for required parameters `typename` and `fields` of function `TypedDict`"
+6 | TypedDict()
+  |
+info: rule `too-many-positional-arguments` is enabled by default
+
+```
+
+```
+error[missing-argument]: No arguments provided for required parameters `typename` and `fields` of function `TypedDict`
+ --> src/mdtest_snippet.py:6:1
+  |
+4 | TypedDict("Foo", {}, {})
+5 | # error: [missing-argument] "No arguments provided for required parameters `typename` and `fields` of function `TypedDict`"
+6 | TypedDict()
+  | ^^^^^^^^^^^
+7 | # error: [missing-argument] "No argument provided for required parameter `fields` of function `TypedDict`"
+8 | TypedDict("Foo")
+  |
+info: rule `missing-argument` is enabled by default
+
+```
+
+```
+error[missing-argument]: No argument provided for required parameter `fields` of function `TypedDict`
+  --> src/mdtest_snippet.py:8:1
+   |
+ 6 | TypedDict()
+ 7 | # error: [missing-argument] "No argument provided for required parameter `fields` of function `TypedDict`"
+ 8 | TypedDict("Foo")
+   | ^^^^^^^^^^^^^^^^
+ 9 |
+10 | # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "Bad1", got variable of type `Lit…
+   |
+info: rule `missing-argument` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: TypedDict name must match the variable it is assigned to
+  --> src/mdtest_snippet.py:11:18
+   |
+10 | # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "Bad1", got variable of type `Lit…
+11 | Bad1 = TypedDict(123, {"name": str})
+   |                  ^^^ Expected "Bad1", got variable of type `Literal[123]`
+12 |
+13 | # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "BadTypedDict3", got "WrongName""
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: TypedDict name must match the variable it is assigned to
+  --> src/mdtest_snippet.py:14:27
+   |
+13 | # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "BadTypedDict3", got "WrongName""
+14 | BadTypedDict3 = TypedDict("WrongName", {"name": str})
+   |                           ^^^^^^^^^^^ Expected "BadTypedDict3", got "WrongName"
+15 |
+16 | def f(x: str) -> None:
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: TypedDict name must match the variable it is assigned to
+  --> src/mdtest_snippet.py:18:19
+   |
+16 | def f(x: str) -> None:
+17 |     # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "Y", got variable of type `st…
+18 |     Y = TypedDict(x, {})
+   |                   ^ Expected "Y", got variable of type `str`
+19 |
+20 | def g(x: str) -> None:
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Expected a dict literal for parameter `fields` of `TypedDict()`
+  --> src/mdtest_snippet.py:27:26
+   |
+26 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
+27 | Bad2 = TypedDict("Bad2", "not a dict")
+   |                          ^^^^^^^^^^^^
+28 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
+29 | TypedDict("Bad2", "not a dict")
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Expected a dict literal for parameter `fields` of `TypedDict()`
+  --> src/mdtest_snippet.py:29:19
+   |
+27 | Bad2 = TypedDict("Bad2", "not a dict")
+28 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
+29 | TypedDict("Bad2", "not a dict")
+   |                   ^^^^^^^^^^^^
+30 |
+31 | def get_fields() -> dict[str, object]:
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Expected a dict literal for parameter `fields` of `TypedDict()`
+  --> src/mdtest_snippet.py:35:28
+   |
+34 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
+35 | Bad2b = TypedDict("Bad2b", get_fields())
+   |                            ^^^^^^^^^^^^
+36 |
+37 | # error: [invalid-argument-type] "Invalid argument to parameter `total` of `TypedDict()`"
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Invalid argument to parameter `total` of `TypedDict()`
+  --> src/mdtest_snippet.py:38:47
+   |
+37 | # error: [invalid-argument-type] "Invalid argument to parameter `total` of `TypedDict()`"
+38 | Bad3 = TypedDict("Bad3", {"name": str}, total="not a bool")
+   |                                               ^^^^^^^^^^^^ Expected either `True` or `False`, got object of type `Literal["not a bool"]`
+39 |
+40 | # error: [invalid-argument-type] "Invalid argument to parameter `closed` of `TypedDict()`"
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Invalid argument to parameter `closed` of `TypedDict()`
+  --> src/mdtest_snippet.py:41:48
+   |
+40 | # error: [invalid-argument-type] "Invalid argument to parameter `closed` of `TypedDict()`"
+41 | Bad4 = TypedDict("Bad4", {"name": str}, closed=123)
+   |                                                ^^^ Expected either `True` or `False`, got object of type `Literal[123]`
+42 |
+43 | tup = ("foo", "bar")
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Variadic positional arguments are not supported in `TypedDict()` calls
+  --> src/mdtest_snippet.py:47:18
+   |
+46 | # error: [invalid-argument-type] "Variadic positional arguments are not supported in `TypedDict()` calls"
+47 | Bad5 = TypedDict(*tup)
+   |                  ^^^^
+48 |
+49 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Variadic keyword arguments are not supported in `TypedDict()` calls
+  --> src/mdtest_snippet.py:50:41
+   |
+49 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
+50 | Bad6 = TypedDict("Bad6", {"name": str}, **kw)
+   |                                         ^^^^
+51 |
+52 | # error: [invalid-argument-type] "Variadic positional and keyword arguments are not supported in `TypedDict()` calls"
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Variadic positional and keyword arguments are not supported in `TypedDict()` calls
+  --> src/mdtest_snippet.py:53:18
+   |
+52 | # error: [invalid-argument-type] "Variadic positional and keyword arguments are not supported in `TypedDict()` calls"
+53 | Bad7 = TypedDict(*tup, "foo", "bar", **kw)
+   |                  ^^^^                ----
+54 |
+55 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Variadic keyword arguments are not supported in `TypedDict()` calls
+  --> src/mdtest_snippet.py:57:28
+   |
+55 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
+56 | # error: [unknown-argument] "Argument `random_other_arg` does not match any known parameter of function `TypedDict`"
+57 | Bad7b = TypedDict("Bad7b", **kw, random_other_arg=56)
+   |                            ^^^^
+58 |
+59 | kwargs = {"x": int}
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[unknown-argument]: Argument `random_other_arg` does not match any known parameter of function `TypedDict`
+  --> src/mdtest_snippet.py:57:34
+   |
+55 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
+56 | # error: [unknown-argument] "Argument `random_other_arg` does not match any known parameter of function `TypedDict`"
+57 | Bad7b = TypedDict("Bad7b", **kw, random_other_arg=56)
+   |                                  ^^^^^^^^^^^^^^^^^^^
+58 |
+59 | kwargs = {"x": int}
+   |
+info: rule `unknown-argument` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
+  --> src/mdtest_snippet.py:62:29
+   |
+61 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+62 | Bad8 = TypedDict("Bad8", {**kwargs})
+   |                             ^^^^^^
+63 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+64 | TypedDict("Bad8", {**kwargs})
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
+  --> src/mdtest_snippet.py:64:22
+   |
+62 | Bad8 = TypedDict("Bad8", {**kwargs})
+63 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+64 | TypedDict("Bad8", {**kwargs})
+   |                      ^^^^^^
+65 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+66 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
+  --> src/mdtest_snippet.py:67:31
+   |
+65 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+66 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+67 | Bad81 = TypedDict("Bad81", {**kwargs, **kwargs})
+   |                               ^^^^^^
+68 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+69 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
+  --> src/mdtest_snippet.py:67:41
+   |
+65 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+66 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+67 | Bad81 = TypedDict("Bad81", {**kwargs, **kwargs})
+   |                                         ^^^^^^
+68 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+69 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
+  --> src/mdtest_snippet.py:70:23
+   |
+68 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+69 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+70 | TypedDict("Bad81", {**kwargs, **kwargs})
+   |                       ^^^^^^
+71 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+72 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
+  --> src/mdtest_snippet.py:70:33
+   |
+68 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+69 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+70 | TypedDict("Bad81", {**kwargs, **kwargs})
+   |                                 ^^^^^^
+71 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+72 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
+  --> src/mdtest_snippet.py:73:31
+   |
+71 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+72 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+73 | Bad82 = TypedDict("Bad82", {**kwargs, "foo": []})
+   |                               ^^^^^^
+74 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+75 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-type-form]: List literals are not allowed in this context in a type expression
+  --> src/mdtest_snippet.py:73:46
+   |
+71 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+72 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+73 | Bad82 = TypedDict("Bad82", {**kwargs, "foo": []})
+   |                                              ^^
+74 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+75 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+   |
+info: See the following page for a reference on valid type expressions:
+info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
+info: rule `invalid-type-form` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
+  --> src/mdtest_snippet.py:76:23
+   |
+74 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+75 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+76 | TypedDict("Bad82", {**kwargs, "foo": []})
+   |                       ^^^^^^
+77 |
+78 | def get_name() -> str:
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-type-form]: List literals are not allowed in this context in a type expression
+  --> src/mdtest_snippet.py:76:38
+   |
+74 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+75 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+76 | TypedDict("Bad82", {**kwargs, "foo": []})
+   |                                      ^^
+77 |
+78 | def get_name() -> str:
+   |
+info: See the following page for a reference on valid type expressions:
+info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
+info: rule `invalid-type-form` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Expected a string-literal key in the `fields` dict of `TypedDict()`
+  --> src/mdtest_snippet.py:84:27
+   |
+83 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+84 | Bad9 = TypedDict("Bad9", {name: int})
+   |                           ^^^^ Found `str`
+85 |
+86 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Expected a string-literal key in the `fields` dict of `TypedDict()`
+  --> src/mdtest_snippet.py:88:29
+   |
+86 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+87 | # error: [invalid-type-form]
+88 | Bad10 = TypedDict("Bad10", {name: 42})
+   |                             ^^^^ Found `str`
+89 |
+90 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-type-form]: Int literals are not allowed in this context in a type expression
+  --> src/mdtest_snippet.py:88:35
+   |
+86 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+87 | # error: [invalid-type-form]
+88 | Bad10 = TypedDict("Bad10", {name: 42})
+   |                                   ^^
+89 |
+90 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+   |
+info: See the following page for a reference on valid type expressions:
+info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
+info: rule `invalid-type-form` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Expected a string-literal key in the `fields` dict of `TypedDict()`
+  --> src/mdtest_snippet.py:92:33
+   |
+90 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+91 | # error: [invalid-type-form] "Int literals are not allowed in this context in a type expression"
+92 | class Bad11(TypedDict("Bad11", {name: 42})): ...
+   |                                 ^^^^ Found `str`
+93 |
+94 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```
+
+```
+error[invalid-type-form]: Int literals are not allowed in this context in a type expression
+  --> src/mdtest_snippet.py:92:39
+   |
+90 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+91 | # error: [invalid-type-form] "Int literals are not allowed in this context in a type expression"
+92 | class Bad11(TypedDict("Bad11", {name: 42})): ...
+   |                                       ^^
+93 |
+94 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
+   |
+info: See the following page for a reference on valid type expressions:
+info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
+info: rule `invalid-type-form` is enabled by default
+
+```
+
+```
+error[invalid-argument-type]: Invalid argument to parameter `typename` of `TypedDict()`
+  --> src/mdtest_snippet.py:95:23
+   |
+94 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
+95 | class Bad12(TypedDict(123, {"field": int})): ...
+   |                       ^^^ Expected `str`, found `Literal[123]`
+   |
+info: rule `invalid-argument-type` is enabled by default
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2255,7 +2255,7 @@ from typing_extensions import TypedDict
 
 # error: [missing-argument] "No argument provided for required parameter `fields` of function `TypedDict`"
 Empty = TypedDict("Empty")
-reveal_type(Empty)  # revealed: <class 'Empty'>
+reveal_type(Empty)  # revealed: type[Mapping[str, object]] & Unknown
 ```
 
 Constructor validation also works with dict literals:
@@ -2526,8 +2526,17 @@ Movie2 = TypedDict("Movie2", name=str, year=int)
 
 ## Function syntax with invalid arguments
 
+<!-- snapshot-diagnostics -->
+
 ```py
 from typing_extensions import TypedDict
+
+# error: [too-many-positional-arguments] "Too many positional arguments to function `TypedDict`: expected 2, got 3"
+TypedDict("Foo", {}, {})
+# error: [missing-argument] "No arguments provided for required parameters `typename` and `fields` of function `TypedDict`"
+TypedDict()
+# error: [missing-argument] "No argument provided for required parameter `fields` of function `TypedDict`"
+TypedDict("Foo")
 
 # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "Bad1", got variable of type `Literal[123]`"
 Bad1 = TypedDict(123, {"name": str})
@@ -2547,6 +2556,8 @@ GoodTypedDict = TypedDict(name, {"name": str})
 
 # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
 Bad2 = TypedDict("Bad2", "not a dict")
+# error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
+TypedDict("Bad2", "not a dict")
 
 def get_fields() -> dict[str, object]:
     return {"name": str}
@@ -2570,7 +2581,7 @@ Bad5 = TypedDict(*tup)
 Bad6 = TypedDict("Bad6", {"name": str}, **kw)
 
 # error: [invalid-argument-type] "Variadic positional and keyword arguments are not supported in `TypedDict()` calls"
-Bad7 = TypedDict(*tup, **kw)
+Bad7 = TypedDict(*tup, "foo", "bar", **kw)
 
 # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
 # error: [unknown-argument] "Argument `random_other_arg` does not match any known parameter of function `TypedDict`"
@@ -2578,9 +2589,22 @@ Bad7b = TypedDict("Bad7b", **kw, random_other_arg=56)
 
 kwargs = {"x": int}
 
-# error: [invalid-argument-type] "Expected a dict literal with string-literal keys for parameter `fields` of `TypedDict()`"
-# error: [invalid-type-form]
+# error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
 Bad8 = TypedDict("Bad8", {**kwargs})
+# error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+TypedDict("Bad8", {**kwargs})
+# error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+# error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+Bad81 = TypedDict("Bad81", {**kwargs, **kwargs})
+# error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+# error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+TypedDict("Bad81", {**kwargs, **kwargs})
+# error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+# error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+Bad82 = TypedDict("Bad82", {**kwargs, "foo": []})
+# error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+# error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+TypedDict("Bad82", {**kwargs, "foo": []})
 
 def get_name() -> str:
     return "x"
@@ -2595,6 +2619,7 @@ Bad9 = TypedDict("Bad9", {name: int})
 Bad10 = TypedDict("Bad10", {name: 42})
 
 # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+# error: [invalid-type-form] "Int literals are not allowed in this context in a type expression"
 class Bad11(TypedDict("Bad11", {name: 42})): ...
 
 # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -1,5 +1,6 @@
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, NodeIndex};
+use smallvec::SmallVec;
 
 use super::TypeInferenceBuilder;
 use crate::semantic_index::definition::Definition;
@@ -29,8 +30,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             node_index: _,
         } = &call_expr.arguments;
 
-        let has_starred = args.iter().any(ast::Expr::is_starred_expr);
-        let has_double_starred = keywords.iter().any(|kw| kw.arg.is_none());
+        let starred_arguments: SmallVec<[&ast::Expr; 1]> =
+            args.iter().filter(|arg| arg.is_starred_expr()).collect();
+        let double_starred_arguments: SmallVec<[&ast::Keyword; 1]> =
+            keywords.iter().filter(|kw| kw.arg.is_none()).collect();
 
         // The fallback type reflects the fact that if the call were successful,
         // it would return a class that is a subclass of `Mapping[str, object]`
@@ -42,59 +45,48 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         };
 
         // Emit diagnostic for unsupported variadic arguments.
-        if (has_starred || has_double_starred)
-            && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, call_expr)
-        {
-            let arg_type = if has_starred && has_double_starred {
-                "Variadic positional and keyword arguments are"
-            } else if has_starred {
-                "Variadic positional arguments are"
-            } else {
-                "Variadic keyword arguments are"
-            };
-            builder.into_diagnostic(format_args!(
-                "{arg_type} not supported in `TypedDict()` calls"
-            ));
-        }
-
-        let Some(name_arg) = args.first() else {
-            for arg in args {
-                self.infer_expression(arg, TypeContext::default());
+        match (&*starred_arguments, &*double_starred_arguments) {
+            ([], []) => {}
+            (starred, []) => {
+                if let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, starred[0])
+                {
+                    let mut diagnostic = builder.into_diagnostic(
+                        "Variadic positional arguments are not supported in `TypedDict()` calls",
+                    );
+                    for arg in &starred[1..] {
+                        diagnostic.annotate(self.context.secondary(arg));
+                    }
+                }
             }
-            for kw in keywords {
-                self.infer_expression(&kw.value, TypeContext::default());
+            ([], double_starred) => {
+                if let Some(builder) = self
+                    .context
+                    .report_lint(&INVALID_ARGUMENT_TYPE, double_starred[0])
+                {
+                    let mut diagnostic = builder.into_diagnostic(
+                        "Variadic keyword arguments are not supported in `TypedDict()` calls",
+                    );
+                    for arg in &double_starred[1..] {
+                        diagnostic.annotate(self.context.secondary(arg));
+                    }
+                }
             }
-
-            if !has_starred
-                && !has_double_starred
-                && let Some(builder) = self.context.report_lint(&MISSING_ARGUMENT, call_expr)
-            {
-                builder.into_diagnostic(
-                    "No argument provided for required parameter `typename` of function `TypedDict`",
-                );
+            _ => {
+                if let Some(builder) = self
+                    .context
+                    .report_lint(&INVALID_ARGUMENT_TYPE, starred_arguments[0])
+                {
+                    let mut diagnostic = builder.into_diagnostic(
+                        "Variadic positional and keyword arguments are not supported in `TypedDict()` calls",
+                    );
+                    for arg in &starred_arguments[1..] {
+                        diagnostic.annotate(self.context.secondary(arg));
+                    }
+                    for arg in &double_starred_arguments {
+                        diagnostic.annotate(self.context.secondary(arg));
+                    }
+                }
             }
-
-            return fallback();
-        };
-
-        let name_type = self.infer_expression(name_arg, TypeContext::default());
-        let fields_arg = args.get(1);
-
-        for arg in args.iter().skip(2) {
-            self.infer_expression(arg, TypeContext::default());
-        }
-
-        if args.len() > 2
-            && !has_starred
-            && !has_double_starred
-            && let Some(builder) = self
-                .context
-                .report_lint(&TOO_MANY_POSITIONAL_ARGUMENTS, &args[2])
-        {
-            builder.into_diagnostic(format_args!(
-                "Too many positional arguments to function `TypedDict`: expected 2, got {}",
-                args.len()
-            ));
         }
 
         let mut total = true;
@@ -104,7 +96,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 continue;
             };
 
-            match arg.id.as_str() {
+            match &**arg {
                 arg_name @ ("total" | "closed") => {
                     let kw_type = self.infer_expression(&kw.value, TypeContext::default());
                     if kw_type
@@ -146,16 +138,48 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
         }
 
-        if has_double_starred || has_starred {
+        if !starred_arguments.is_empty() || !double_starred_arguments.is_empty() {
+            for arg in args {
+                self.infer_expression(arg, TypeContext::default());
+            }
             return fallback();
         }
 
-        if fields_arg.is_none()
-            && let Some(builder) = self.context.report_lint(&MISSING_ARGUMENT, call_expr)
+        if args.len() > 2
+            && let Some(builder) = self
+                .context
+                .report_lint(&TOO_MANY_POSITIONAL_ARGUMENTS, &args[2])
         {
-            builder.into_diagnostic(
-                "No argument provided for required parameter `fields` of function `TypedDict`",
-            );
+            builder.into_diagnostic(format_args!(
+                "Too many positional arguments to function `TypedDict`: expected 2, got {}",
+                args.len()
+            ));
+        }
+
+        let Some(name_arg) = args.first() else {
+            if let Some(builder) = self.context.report_lint(&MISSING_ARGUMENT, call_expr) {
+                builder.into_diagnostic(
+                    "No arguments provided for required parameters `typename` \
+                    and `fields` of function `TypedDict`",
+                );
+            }
+
+            return fallback();
+        };
+
+        let name_type = self.infer_expression(name_arg, TypeContext::default());
+
+        let Some(fields_arg) = args.get(1) else {
+            if let Some(builder) = self.context.report_lint(&MISSING_ARGUMENT, call_expr) {
+                builder.into_diagnostic(
+                    "No argument provided for required parameter `fields` of function `TypedDict`",
+                );
+            }
+            return fallback();
+        };
+
+        for arg in args.iter().skip(2) {
+            self.infer_expression(arg, TypeContext::default());
         }
 
         let name = name_type
@@ -179,7 +203,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     name_type.display(db)
                 ));
             }
-        } else if !name_type.is_assignable_to(db, KnownClass::Str.to_instance(db))
+        } else if name.is_none()
+            && !name_type.is_assignable_to(db, KnownClass::Str.to_instance(db))
             && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, name_arg)
         {
             let mut diagnostic = builder.into_diagnostic(format_args!(
@@ -193,12 +218,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let name = name.unwrap_or_else(|| Name::new_static("<unknown>"));
 
+        self.validate_fields_arg(fields_arg);
+
         if let Some(definition) = definition {
             self.deferred.insert(definition);
-        }
-
-        if let Some(fields_arg) = fields_arg {
-            self.validate_fields_arg(fields_arg);
         }
 
         let scope = self.scope();
@@ -213,12 +236,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let call_u32 = call_node_index
                     .as_u32()
                     .expect("call node should not be NodeIndex::NONE");
-
-                let schema = if let Some(fields_arg) = fields_arg {
-                    self.infer_dangling_typeddict_spec(fields_arg, total)
-                } else {
-                    TypedDictSchema::default()
-                };
+                let schema = self.infer_dangling_typeddict_spec(fields_arg, total);
 
                 DynamicTypedDictAnchor::ScopeOffset {
                     scope,
@@ -255,13 +273,23 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             return schema;
         };
 
-        for item in &dict_expr.items {
+        for (i, item) in dict_expr.iter().enumerate() {
             let Some(key) = &item.key else {
+                for ast::DictItem { key, value } in &dict_expr.items[i + 1..] {
+                    if key.is_some() {
+                        self.infer_annotation_expression(value, self.deferred_state);
+                    }
+                }
                 return TypedDictSchema::default();
             };
 
-            let key_ty = self.expression_type(key);
-            let Some(key_literal) = key_ty.as_string_literal() else {
+            let key_type = self.expression_type(key);
+            let Some(key_literal) = key_type.as_string_literal() else {
+                for ast::DictItem { key, value } in &dict_expr.items[i..] {
+                    if key.is_some() {
+                        self.infer_annotation_expression(value, self.deferred_state);
+                    }
+                }
                 return TypedDictSchema::default();
             };
 
@@ -290,21 +318,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     /// definition is complete. This enables support for recursive `TypedDict`s where field types
     /// may reference the `TypedDict` being defined.
     pub(super) fn infer_functional_typeddict_deferred(&mut self, arguments: &ast::Arguments) {
-        if let Some(fields_arg) = arguments.args.get(1) {
-            self.infer_typeddict_field_types(fields_arg);
+        if let Some(ast::Expr::Dict(dict_expr)) = arguments.args.get(1) {
+            for ast::DictItem { key, value } in dict_expr {
+                if key.is_some() {
+                    self.infer_annotation_expression(value, self.deferred_state);
+                }
+            }
         }
 
         if let Some(extra_items_kwarg) = arguments.find_keyword("extra_items") {
             self.infer_annotation_expression(&extra_items_kwarg.value, self.deferred_state);
-        }
-    }
-
-    /// Infer field types from a `TypedDict` fields dict argument.
-    fn infer_typeddict_field_types(&mut self, fields_arg: &ast::Expr) {
-        if let ast::Expr::Dict(dict_expr) = fields_arg {
-            for item in &dict_expr.items {
-                self.infer_annotation_expression(&item.value, self.deferred_state);
-            }
         }
     }
 
@@ -316,42 +339,27 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let db = self.db();
 
         if let ast::Expr::Dict(dict_expr) = fields_arg {
-            for (i, item) in dict_expr.items.iter().enumerate() {
-                let ast::DictItem { key, value: _ } = item;
-
-                let Some(key) = key else {
-                    if let Some(builder) =
-                        self.context.report_lint(&INVALID_ARGUMENT_TYPE, fields_arg)
+            for ast::DictItem { key, value } in dict_expr {
+                if let Some(key) = key {
+                    let key_type = self.infer_expression(key, TypeContext::default());
+                    if !key_type.is_string_literal()
+                        && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, key)
                     {
-                        builder.into_diagnostic(
-                            "Expected a dict literal with string-literal keys \
-                                for parameter `fields` of `TypedDict()`",
-                        );
-                    }
-                    for item in &dict_expr.items[i + 1..] {
-                        if let Some(key) = &item.key {
-                            self.infer_expression(key, TypeContext::default());
-                        }
-                    }
-                    return;
-                };
-
-                let key_ty = self.infer_expression(key, TypeContext::default());
-                if key_ty.as_string_literal().is_none() {
-                    if let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, key) {
                         let mut diagnostic = builder.into_diagnostic(
                             "Expected a string-literal key \
                                 in the `fields` dict of `TypedDict()`",
                         );
                         diagnostic
-                            .set_primary_message(format_args!("Found `{}`", key_ty.display(db)));
+                            .set_primary_message(format_args!("Found `{}`", key_type.display(db)));
                     }
-                    for item in &dict_expr.items[i + 1..] {
-                        if let Some(key) = &item.key {
-                            self.infer_expression(key, TypeContext::default());
-                        }
+                } else {
+                    self.infer_expression(value, TypeContext::default());
+                    if let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, value) {
+                        builder.into_diagnostic(
+                            "Keyword splats are not allowed in the `fields` \
+                            parameter to `TypedDict()`",
+                        );
                     }
-                    return;
                 }
             }
         } else {


### PR DESCRIPTION
## Summary

- Add missing test coverage for several invalid functional `TypedDict` constructions that weren't previously tested
- Ensure we always iterate exhaustively through all `key:value` pairs in the `fields` argument, so that errors in later `key:value` pairs are still flagged even if there were errors in earlier `key:value` pairs
- Improve the diagnostic ranges for several errors (e.g., the diagnostic range for the error telling you off for having a starred argument covered the whole call expression, when covering just a single argument would be better), and add snapshots to the tests.