### PR TITLE
docs(SIM102): add fix safety section

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
@@ -42,6 +42,25 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 ///     ...
 /// ```
 ///
+/// ## Fix safety
+///
+/// This fix is marked as unsafe because it may discard comments between the
+/// outer and inner `if` statements.
+///
+/// For example, this code:
+/// ```python
+/// if foo:
+///     # This comment will be removed
+///     if bar:
+///         ...
+/// ```
+///
+/// ...would be converted to:
+/// ```python
+/// if foo and bar:
+///     ...
+/// ```
+///
 /// ## Options
 ///
 /// The rule will consult these two settings when deciding if a fix can be provided:


### PR DESCRIPTION
## Summary

Adds a `## Fix safety` section to the documentation for rule `SIM102` (`CollapsibleIf`).

Part of #15584.

## Details

- **Rule:** SIM102 — Use a single `if` statement instead of nested `if` statements
- **Safety level:** Unsafe (`Fix::unsafe_edit`)
- **Reason:** The fix may discard comments placed between the outer and inner `if` statements. This is reflected in the existing source comment (line 124–125 of `collapsible_if.rs`): *"The fixer preserves comments in the nested body, but removes comments between the outer and inner if statements."*

## Checklist
- [x] Grammar and spelling verified
- [x] Code example provided showing the comment-loss scenario
- [x] Tests pass locally (`cargo test -p ruff_linter`)