### PR TITLE
[ty] Remove `TypeInferenceBuilder::inferring_vararg_annotation`

### DIFF
--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -993,6 +993,10 @@ bitflags::bitflags! {
         /// are an error. It is unset in other contexts (e.g., `TypeVar` defaults, explicit class
         /// specialization) where unbound type variables are expected.
         const CHECK_UNBOUND_TYPEVARS = 1 << 1;
+
+        /// Whether the visitor is currently visiting a vararg annotation
+        /// (e.g., `*args: int` or `**kwargs: int` in a function definition).
+        const IN_VARARG_ANNOTATION = 1 << 2;
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -301,8 +301,6 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// is a stub file but we're still in a non-deferred region.
     deferred_state: DeferredExpressionState,
 
-    inferring_vararg_annotation: bool,
-
     /// For function definitions, the undecorated type of the function.
     undecorated_type: Option<Type<'db>>,
 
@@ -344,7 +342,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return_types_and_ranges: vec![],
             called_functions: FxIndexSet::default(),
             deferred_state: DeferredExpressionState::None,
-            inferring_vararg_annotation: false,
             expressions: FxHashMap::default(),
             expression_cache: None,
             qualifiers: FxHashMap::default(),
@@ -9082,7 +9079,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             typevar_binding_context: _,
             inference_flags: _,
             deferred_state: _,
-            inferring_vararg_annotation: _,
             called_functions: _,
             index: _,
             region: _,
@@ -9168,7 +9164,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             typevar_binding_context: _,
             inference_flags: _,
             deferred_state: _,
-            inferring_vararg_annotation: _,
             index: _,
             region: _,
             cycle_recovery: _,
@@ -9212,7 +9207,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             typevar_binding_context: _,
             inference_flags: _,
             deferred_state: _,
-            inferring_vararg_annotation: _,
             index: _,
             region: _,
             return_types_and_ranges: _,
@@ -9298,7 +9292,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             typevar_binding_context: _,
             inference_flags: _,
             deferred_state: _,
-            inferring_vararg_annotation: _,
             called_functions: _,
             index: _,
             region: _,
@@ -9336,7 +9329,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deferred_state,
             inference_flags,
             typevar_binding_context,
-            inferring_vararg_annotation,
             ref expression_cache,
             ref return_types_and_ranges,
             ref dataclass_field_specifiers,
@@ -9366,7 +9358,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         builder.deferred_state = deferred_state;
         builder.typevar_binding_context = typevar_binding_context;
         builder.inference_flags = inference_flags;
-        builder.inferring_vararg_annotation = inferring_vararg_annotation;
         builder.expression_cache.clone_from(expression_cache);
         builder
             .return_types_and_ranges
@@ -9400,7 +9391,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             typevar_binding_context: _,
             inference_flags: _,
             deferred_state: _,
-            inferring_vararg_annotation: _,
             called_functions: _,
             index: _,
             region: _,

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -21,7 +21,7 @@ use crate::{
         },
         generics::{enclosing_generic_contexts, typing_self},
         infer::{
-            TypeInferenceBuilder,
+            InferenceFlags, TypeInferenceBuilder,
             builder::{
                 DeclaredAndInferredType, DeferredExpressionState, TypeAndRange,
                 validate_paramspec_components,
@@ -550,9 +550,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.infer_parameter_with_default(param_with_default);
         }
         if let Some(vararg) = vararg {
-            self.inferring_vararg_annotation = true;
+            self.inference_flags |= InferenceFlags::IN_VARARG_ANNOTATION;
             self.infer_parameter(vararg);
-            self.inferring_vararg_annotation = false;
+            self.inference_flags
+                .remove(InferenceFlags::IN_VARARG_ANNOTATION);
         }
         if let Some(kwarg) = kwarg {
             self.infer_parameter(kwarg);

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1982,7 +1982,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 // However, we still need a Todo type for things like
                 // `def f(*args: Unpack[tuple[int, Unpack[tuple[str, ...]]]]): ...`,
                 // which we don't yet support.
-                if self.inferring_vararg_annotation
+                if self
+                    .inference_flags
+                    .contains(InferenceFlags::IN_VARARG_ANNOTATION)
                     || inner_ty.exact_tuple_instance_spec(self.db()).is_none()
                 {
                     todo_type!("`Unpack[]` special form")


### PR DESCRIPTION
## Summary

This field has existed on the `TypeInferenceBuilder` for a long time. Since we originally added it, we've added a more generalised way of keeping track of state in the builder via `InferenceFlags`. We can simplify the builder by getting rid of the field in favour of `InferenceFlags`.

## Test Plan

existing tests
