### PR TITLE
[ty] Fix excess subscript argument inference for non-generic types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -678,10 +678,7 @@ def _(doubly_specialized: DoublySpecialized):
 # error: [not-subscriptable] "Cannot subscript non-generic type `<class 'list[int]'>`"
 List = list[int][int]
 
-# TODO: one error would be enough here
-#
 # error: [not-subscriptable] "Cannot subscript non-generic type `<class 'list[int]'>`"
-# error: [invalid-type-form] "Int literals are not allowed in this context in a type expression"
 WorseList = list[int][0]
 
 def _(doubly_specialized: List, doubly_specialized_2: WorseList):

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -632,7 +632,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                 }
                 EitherOrBoth::Right(expr) => {
-                    inferred_type_arguments.push(self.infer_type_expression(expr));
+                    // If there are no typevars at all, this is not a generic type,
+                    // so we should not infer excess arguments as type expressions.
+                    // For example, `list[int][0]` — the `0` is not a type expression.
+                    if typevars_len == 0 {
+                        inferred_type_arguments
+                            .push(self.infer_expression(expr, TypeContext::default()));
+                    } else {
+                        inferred_type_arguments.push(self.infer_type_expression(expr));
+                    }
                     first_excess_type_argument_index.get_or_insert(index);
                 }
             }


### PR DESCRIPTION
## Summary

When a non-generic type (like `list[int]`) is subscripted with excess arguments (e.g., `list[int][0]`), the excess arguments should be inferred as regular expressions, not type expressions. This prevents spurious "Int literals are not allowed in this context" errors.

The fix checks if the base type has any type variables. If `typevars_len == 0`, we know it's not a generic type, so excess subscript arguments are inferred using `infer_expression()` with a default context instead of `infer_type_expression()`. This allows us to properly handle non-type values in excess subscripts while still reporting the primary error that the type is not subscriptable.

This change also eliminates a duplicate error message in the test case `list[int][0]`, reducing the error count from two to one.

## Test Plan

mdtests updated