### PR TITLE
[ty] Move snapshot for code action test with trailing whitespace to external file

### DIFF
--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -128,16 +128,8 @@ mod tests {
     fn add_ignore_trailing_whitespace() {
         let test = CodeActionTest::with_source(r#"b = <START>a<END> / 10  "#);
 
-        assert_snapshot!(test.code_actions(&UNRESOLVED_REFERENCE), @"
-        info[code-action]: Ignore 'unresolved-reference' for this line
-         --> main.py:1:5
-          |
-        1 | b = a / 10  
-          |     ^
-          |
-          - b = a / 10  
-        1 + b = a / 10  # ty:ignore[unresolved-reference]
-        ");
+        // Not an inline snapshot because of trailing whitespace.
+        assert_snapshot!(test.code_actions(&UNRESOLVED_REFERENCE));
     }
 
     #[test]

--- a/crates/ty_ide/src/snapshots/ty_ide__code_action__tests__add_ignore_trailing_whitespace.snap
+++ b/crates/ty_ide/src/snapshots/ty_ide__code_action__tests__add_ignore_trailing_whitespace.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ty_ide/src/code_action.rs
+expression: test.code_actions(&UNRESOLVED_REFERENCE)
+---
+info[code-action]: Ignore 'unresolved-reference' for this line
+ --> main.py:1:5
+  |
+1 | b = a / 10  
+  |     ^
+  |
+  - b = a / 10  
+1 + b = a / 10  # ty:ignore[unresolved-reference]


### PR DESCRIPTION
## Summary

Some editors (e.g. Zed) trim trailing whitespace, even if inside a string literal
and this test always started failing for me after making changes to the `code_action.rs`. 

This PR moves this one snappshot to an external snapshot to prevent this from happening.

## Test Plan

`cargo test`
