### PR TITLE
Sort formatter diagnostics in snapshots

### DIFF
--- a/crates/ruff_python_formatter/tests/fixtures.rs
+++ b/crates/ruff_python_formatter/tests/fixtures.rs
@@ -477,9 +477,16 @@ fn ensure_unchanged_ast(
     formatted_unsupported_syntax_errors
         .retain(|fingerprint, _| !unformatted_unsupported_syntax_errors.contains_key(fingerprint));
 
+    // Sort the errors by location to ensure the snapshot output is stable.
+    let mut formatted_unsupported_syntax_errors = formatted_unsupported_syntax_errors
+        .into_values()
+        .collect::<Vec<_>>();
+    formatted_unsupported_syntax_errors
+        .sort_by_key(|error| (error.range().start(), error.range().end()));
+
     let file = SourceFileBuilder::new(input_path.file_name().unwrap(), formatted_code).finish();
     let diagnostics = formatted_unsupported_syntax_errors
-        .values()
+        .iter()
         .map(|error| {
             let mut diag = Diagnostic::new(DiagnosticId::InvalidSyntax, Severity::Error, error);
             let span = Span::from(file.clone()).with_range(error.range());

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__nested_string_quote_style.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__nested_string_quote_style.py.snap
@@ -392,18 +392,6 @@ t"{('implicit concatenation', ["'single'", '"double"'])}"
 
 ### Unsupported Syntax Errors
 error[invalid-syntax]: Cannot reuse outer quote character in f-strings on Python 3.11 (syntax was added in Python 3.12)
-  --> nested_string_quote_style.py:30:24
-   |
-28 | f'"double" quotes and {'nested string with "double" quotes'}'  # syntax error pre-3.12
-29 | t'"double" quotes and {'nested string with "double" quotes'}'
-30 | f"'single' quotes and {"nested string with 'single' quotes"}'"  # syntax error pre-3.12
-   |                        ^
-31 | t"'single' quotes and {"nested string with 'single' quotes"}'"
-32 | f'"double" quotes and {"nested string with 'single' quotes"}'  # syntax error pre-3.12
-   |
-warning: Only accept new syntax errors if they are also present in the input. The formatter should not introduce syntax errors.
-
-error[invalid-syntax]: Cannot reuse outer quote character in f-strings on Python 3.11 (syntax was added in Python 3.12)
   --> nested_string_quote_style.py:28:24
    |
 26 | f"'single' quotes and {'nested string'}"
@@ -412,6 +400,18 @@ error[invalid-syntax]: Cannot reuse outer quote character in f-strings on Python
    |                        ^
 29 | t'"double" quotes and {'nested string with "double" quotes'}'
 30 | f"'single' quotes and {"nested string with 'single' quotes"}'"  # syntax error pre-3.12
+   |
+warning: Only accept new syntax errors if they are also present in the input. The formatter should not introduce syntax errors.
+
+error[invalid-syntax]: Cannot reuse outer quote character in f-strings on Python 3.11 (syntax was added in Python 3.12)
+  --> nested_string_quote_style.py:30:24
+   |
+28 | f'"double" quotes and {'nested string with "double" quotes'}'  # syntax error pre-3.12
+29 | t'"double" quotes and {'nested string with "double" quotes'}'
+30 | f"'single' quotes and {"nested string with 'single' quotes"}'"  # syntax error pre-3.12
+   |                        ^
+31 | t"'single' quotes and {"nested string with 'single' quotes"}'"
+32 | f'"double" quotes and {"nested string with 'single' quotes"}'  # syntax error pre-3.12
    |
 warning: Only accept new syntax errors if they are also present in the input. The formatter should not introduce syntax errors.
 
@@ -519,18 +519,6 @@ t"{('implicit concatenation', ["'single'", '"double"'])}"
 
 ### Unsupported Syntax Errors
 error[invalid-syntax]: Cannot reuse outer quote character in f-strings on Python 3.11 (syntax was added in Python 3.12)
-  --> nested_string_quote_style.py:30:24
-   |
-28 | f'"double" quotes and {'nested string with "double" quotes'}'  # syntax error pre-3.12
-29 | t'"double" quotes and {'nested string with "double" quotes'}'
-30 | f"'single' quotes and {"nested string with 'single' quotes"}'"  # syntax error pre-3.12
-   |                        ^
-31 | t"'single' quotes and {"nested string with 'single' quotes"}'"
-32 | f'"double" quotes and {"nested string with 'single' quotes"}'  # syntax error pre-3.12
-   |
-warning: Only accept new syntax errors if they are also present in the input. The formatter should not introduce syntax errors.
-
-error[invalid-syntax]: Cannot reuse outer quote character in f-strings on Python 3.11 (syntax was added in Python 3.12)
   --> nested_string_quote_style.py:28:24
    |
 26 | f"'single' quotes and {'nested string'}"
@@ -539,5 +527,17 @@ error[invalid-syntax]: Cannot reuse outer quote character in f-strings on Python
    |                        ^
 29 | t'"double" quotes and {'nested string with "double" quotes'}'
 30 | f"'single' quotes and {"nested string with 'single' quotes"}'"  # syntax error pre-3.12
+   |
+warning: Only accept new syntax errors if they are also present in the input. The formatter should not introduce syntax errors.
+
+error[invalid-syntax]: Cannot reuse outer quote character in f-strings on Python 3.11 (syntax was added in Python 3.12)
+  --> nested_string_quote_style.py:30:24
+   |
+28 | f'"double" quotes and {'nested string with "double" quotes'}'  # syntax error pre-3.12
+29 | t'"double" quotes and {'nested string with "double" quotes'}'
+30 | f"'single' quotes and {"nested string with 'single' quotes"}'"  # syntax error pre-3.12
+   |                        ^
+31 | t"'single' quotes and {"nested string with 'single' quotes"}'"
+32 | f'"double" quotes and {"nested string with 'single' quotes"}'  # syntax error pre-3.12
    |
 warning: Only accept new syntax errors if they are also present in the input. The formatter should not introduce syntax errors.


### PR DESCRIPTION
## Summary

Right now these tests are dependent on input order, so changes in the underlying hash can lead to churn in the fixtures. See, e.g.: https://github.com/astral-sh/ruff/pull/24355#discussion_r3026451902.
