### PR TITLE
[ty] Add go-to definition for dataclass/TypedDict/NamedTuple fields from keyword arguments

### DIFF
--- a/crates/ty_ide/src/goto_declaration.rs
+++ b/crates/ty_ide/src/goto_declaration.rs
@@ -2374,6 +2374,188 @@ class MyClass:
     }
 
     #[test]
+    fn goto_declaration_keyword_argument_typeddict() {
+        let test = cursor_test(
+            r#"
+        from typing import TypedDict
+
+        class TD(TypedDict):
+            f: int
+            g: str
+
+        TD(f<CURSOR>=1)
+        "#,
+        );
+
+        assert_snapshot!(test.goto_declaration(), @"
+      info[goto-declaration]: Go to declaration
+       --> main.py:8:4
+        |
+      6 |     g: str
+      7 |
+      8 | TD(f=1)
+        |    ^ Clicking here
+        |
+      info: Found 1 declaration
+       --> main.py:5:5
+        |
+      4 | class TD(TypedDict):
+      5 |     f: int
+        |     -
+      6 |     g: str
+        |
+      ");
+    }
+
+    #[test]
+    fn goto_declaration_keyword_argument_namedtuple() {
+        let test = cursor_test(
+            r#"
+        from typing import NamedTuple
+
+        class NT(NamedTuple):
+            f: int
+            g: str
+
+        NT(f<CURSOR>=1)
+        "#,
+        );
+
+        assert_snapshot!(test.goto_declaration(), @"
+      info[goto-declaration]: Go to declaration
+       --> main.py:8:4
+        |
+      6 |     g: str
+      7 |
+      8 | NT(f=1)
+        |    ^ Clicking here
+        |
+      info: Found 1 declaration
+       --> main.py:5:5
+        |
+      4 | class NT(NamedTuple):
+      5 |     f: int
+        |     -
+      6 |     g: str
+        |
+      ");
+    }
+
+    #[test]
+    fn goto_declaration_keyword_argument_dataclass() {
+        let test = cursor_test(
+            r#"
+        from dataclasses import dataclass
+
+        @dataclass
+        class DC:
+            f: int
+            g: str
+
+        DC(f<CURSOR>=1)
+        "#,
+        );
+
+        assert_snapshot!(test.goto_declaration(), @"
+      info[goto-declaration]: Go to declaration
+       --> main.py:9:4
+        |
+      7 |     g: str
+      8 |
+      9 | DC(f=1)
+        |    ^ Clicking here
+        |
+      info: Found 1 declaration
+       --> main.py:6:5
+        |
+      4 | @dataclass
+      5 | class DC:
+      6 |     f: int
+        |     -
+      7 |     g: str
+        |
+      ");
+    }
+
+    #[test]
+    fn goto_declaration_keyword_argument_dataclass_custom_init() {
+        let test = cursor_test(
+            r#"
+        from dataclasses import dataclass
+
+        @dataclass
+        class DC:
+            f: int
+            g: str
+
+            def __init__(self, f: int) -> None: ...
+
+        DC(f<CURSOR>=1)
+        "#,
+        );
+
+        assert_snapshot!(test.goto_declaration(), @"
+      info[goto-declaration]: Go to declaration
+        --> main.py:11:4
+         |
+       9 |     def __init__(self, f: int) -> None: ...
+      10 |
+      11 | DC(f=1)
+         |    ^ Clicking here
+         |
+      info: Found 1 declaration
+        --> main.py:9:24
+         |
+       7 |     g: str
+       8 |
+       9 |     def __init__(self, f: int) -> None: ...
+         |                        -
+      10 |
+      11 | DC(f=1)
+         |
+      ");
+    }
+
+    #[test]
+    fn goto_declaration_keyword_argument_dataclass_transform_alias() {
+        let test = cursor_test(
+            r#"
+        from typing import dataclass_transform
+
+        def Field(alias: str = ...): ...
+
+        @dataclass_transform(field_specifiers=(Field,))
+        class MyDataclass: ...
+
+        class DC(MyDataclass):
+            f: int = Field(alias='g')
+
+        DC(g<CURSOR>=1)
+        "#,
+        );
+
+        assert_snapshot!(test.goto_declaration(), @"
+      info[goto-declaration]: Go to declaration
+        --> main.py:12:4
+         |
+      10 |     f: int = Field(alias='g')
+      11 |
+      12 | DC(g=1)
+         |    ^ Clicking here
+         |
+      info: Found 1 declaration
+        --> main.py:10:5
+         |
+       9 | class DC(MyDataclass):
+      10 |     f: int = Field(alias='g')
+         |     -
+      11 |
+      12 | DC(g=1)
+         |
+      ");
+    }
+
+    #[test]
     fn goto_declaration_overload_type_disambiguated1() {
         let test = CursorTest::builder()
             .source(

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -5,7 +5,9 @@ use crate::place::builtins_module_scope;
 use crate::semantic_index::definition::{Definition, DefinitionKind};
 use crate::semantic_index::{attribute_scopes, global_scope, semantic_index, use_def_map};
 use crate::types::call::{CallArguments, CallError, MatchedArgument};
-use crate::types::class::{DynamicClassAnchor, DynamicEnumAnchor, DynamicNamedTupleAnchor};
+use crate::types::class::{
+    CodeGeneratorKind, DynamicClassAnchor, DynamicEnumAnchor, DynamicNamedTupleAnchor, FieldKind,
+};
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::signatures::{ParameterForm, ParametersKind, Signature};
 use crate::types::{
@@ -534,6 +536,32 @@ pub fn definitions_for_keyword_argument<'db>(
                         }
                     }
                 }
+            }
+        }
+    }
+
+    // Go to field definitions if the type is a dataclass-like type, a named tuple or a typed dict. Only do so if no definition was found,
+    // as having existing definition(s) would mean a custom constructor is defined and as such takes priority:
+    if resolved_definitions.is_empty()
+        && let Some(class_literal) = func_type.as_class_literal()
+        && let Some(static_class_literal) = class_literal.as_static()
+        && let Some(field_policy) = CodeGeneratorKind::from_class(db, class_literal, None)
+    {
+        for (field_name, field) in static_class_literal.fields(db, None, field_policy) {
+            let Some(definition) = field.first_declaration else {
+                continue;
+            };
+
+            let alias = match &field.kind {
+                FieldKind::Dataclass { alias, .. } => alias.as_ref(),
+                _ => None,
+            };
+
+            if keyword_name == alias.map_or(field_name.as_str(), |a| a.as_ref()) {
+                let module = parsed_module(db, definition.file(db)).load(db);
+                resolved_definitions.push(ResolvedDefinition::FileWithRange(
+                    definition.focus_range(db, &module),
+                ));
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -170,7 +170,7 @@ const NUM_FIELD_SPECIFIERS_INLINE: usize = 1;
 ///
 /// A builder is used by creating it with [`new()`](TypeInferenceBuilder::new), and then calling
 /// [`finish_expression()`](TypeInferenceBuilder::finish_expression), [`finish_definition()`](TypeInferenceBuilder::finish_definition), or [`finish_scope()`](TypeInferenceBuilder::finish_scope) on it, which returns
-/// type inference result..
+/// type inference result.
 ///
 /// There are a few different kinds of methods in the type inference builder, and the naming
 /// distinctions are a bit subtle.


### PR DESCRIPTION
Fixes https://github.com/astral-sh/ty/issues/3207.

Also fixes a small unrelated typo.

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
