### PR TITLE
add recent move of the `deferred` submodule to `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -36,3 +36,5 @@ a9b2876bd33264c826aaf38e462632f1f7bceb55
 53ad26f1e10b749e1ef4680603aa9156dd528dc5
 # Split up types/class.rs
 34cee06dfa6c558c4ab1460200033ea44b368ae4
+# Move the `deferred` submodule inside `infer/builder`
+96d9e0964cb87498ef15510ea7f896ba336659f9


### PR DESCRIPTION
## Summary

https://github.com/astral-sh/ruff/pull/24368 was a pure refactor that touched a lot of lines of code

## Test Plan

<!-- How was it tested? -->
