### PR TITLE
ci: add affected-crate detection to skip unchanged tests

### DIFF
--- a/.affected.toml
+++ b/.affected.toml
@@ -1,0 +1,4 @@
+ignore = ["*.md", "docs/**", ".github/**", "LICENSE*", "*.txt", "*.yml", "*.yaml", "scripts/**", "python/**"]
+
+[test]
+cargo = "cargo nextest run -p {package} --profile ci"

--- a/.github/workflows/affected-test.yml
+++ b/.github/workflows/affected-test.yml
@@ -1,0 +1,89 @@
+# Experimental: Run tests only for crates affected by a PR.
+# This could replace the manual `determine_changes` step that uses hardcoded
+# git-diff path patterns — `affected` reads the Cargo dependency graph instead.
+#
+# Tool: https://github.com/Rani367/affected
+
+name: Affected Tests (experimental)
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  NEXTEST_PROFILE: ci
+
+jobs:
+  detect:
+    name: Detect affected crates
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.affected.outputs.matrix }}
+      has_affected: ${{ steps.affected.outputs.has_affected }}
+      count: ${{ steps.affected.outputs.count }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: Rani367/setup-affected@750ce2e1ff1be73b511666ea7ddc9a76b4dd80f2 # v1
+
+      - name: Detect affected crates
+        id: affected
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: affected ci --merge-base "origin/${BASE_REF:-main}"
+
+      - name: Summary
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          AFFECTED_COUNT: ${{ steps.affected.outputs.count }}
+        run: |
+          {
+            echo "### Affected Crates (${AFFECTED_COUNT})"
+            echo ""
+            affected list --merge-base "origin/${BASE_REF:-main}" --explain
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  test:
+    name: "test / ${{ matrix.package }}"
+    needs: detect
+    if: needs.detect.outputs.has_affected == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix: ${{ fromJson(needs.detect.outputs.matrix) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-on-failure: true
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@d858f8113943481093e02986a7586a4819a3bfd6 # v2
+        with:
+          tool: cargo-nextest
+
+      - name: "Test ${{ matrix.package }}"
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: cargo nextest run -p "$PACKAGE" --profile ci


### PR DESCRIPTION
## Problem

This repo has **47 crates** in its Cargo workspace. The current `ci.yaml` has a `determine_changes` job with manually maintained `git diff --quiet` path patterns for each component (parser, linter, formatter, ty, fuzzer). Those patterns don't understand the Cargo dependency graph — if a shared crate changes, you have to manually add it to every relevant pattern.

I analyzed the last 12 commits on `main`:

| Commit | Message | Affected | Total | Reduction |
|--------|---------|----------|-------|-----------|
| `1f430e6` | add deferred submodule move to .gitattributes | 0 | 47 | **100%** |
| `4b8dfd3` | [ty] Fix extra_items TypedDict tests | 11 | 47 | **77%** |
| `50ee3c2` | [flake8-simplify] Make fix for collapsible-if safe | 18 | 47 | **62%** |
| `de6d6be` | [ty] Validate TypedDict fields when subclassing | 18 | 47 | **62%** |

**Typical PRs skip 62-77% of crates.**

Example — a type checker change affects 11 of 47 crates:

```
11 affected package(s) (base: HEAD~2, 2 files changed):

  ● ty_python_semantic  (directly changed)
  ● ty                  (depends on: ty → ty_python_semantic)
  ● ty_project          (depends on: ty_project → ty_python_semantic)
  ● ty_ide              (depends on: ty_ide → ty_python_semantic)
  ...
  (36 crates NOT affected)
```

## What this PR adds

- **`.affected.toml`** — config file (ignores docs/markdown/CI/Python files)
- **`.github/workflows/affected-test.yml`** — experimental workflow that:
  1. Detects affected crates via `affected ci` (reads `cargo metadata`, diffs changed files, walks dependency graph)
  2. Creates a dynamic GitHub Actions matrix
  3. Runs `cargo nextest run -p <crate> --profile ci` per affected crate

This could eventually **replace the manual `determine_changes` path patterns** with automatic dependency-graph-based detection. No more maintaining hardcoded path lists.

**This runs alongside existing CI — it does NOT replace anything.**

## What `affected` is

[`affected`](https://github.com/Rani367/affected) — single 5MB Rust binary, zero config, MIT licensed. Auto-detects Cargo workspaces. Has a [GitHub Action](https://github.com/Rani367/setup-affected) and [PR comment bot](https://github.com/Rani367/affected-pr-comment).

Closes #24380