### PR TITLE
[ty] Add a protocol relation visitor

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3314,6 +3314,46 @@ def f(c: C[int]) -> None:
     takes_c(c)
 ```
 
+### Recursive generic protocols with multiple growing self-type wrappers
+
+This regression test covers <https://github.com/astral-sh/ty/issues/3208>. Unlike issue #1736, the
+recursion alternates between different wrappers rather than repeating the same one, so we still need
+specialization-time recursion guards to stop growth like `Factory[Tagged[Wrapped[Tagged[...]]]]`.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol
+
+class Base[I, O]:
+    def run(self, input: I) -> O:
+        raise NotImplementedError
+
+class Impl[I, O](Base[I, O]):
+    def run(self, input: I) -> O:
+        raise NotImplementedError
+
+class Tagged[T]: ...
+class Wrapped[T]: ...
+
+class Factory[I, O](Protocol):
+    def create(self) -> Base[I, O]: ...
+    def tag(self) -> "Factory[Tagged[I], O]":
+        return TaggedFactory(self)
+
+    def wrap(self) -> "Factory[Wrapped[I], O]": ...
+
+class TaggedFactory[I, O](Factory[Tagged[I], O]):
+    def __init__(self, inner: Factory[I, O]):
+        pass
+
+    def create(self) -> Impl[Tagged[I], O]:
+        raise NotImplementedError
+```
+
 ### Recursive legacy generic protocol
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3314,6 +3314,30 @@ def f(c: C[int]) -> None:
     takes_c(c)
 ```
 
+### Recursive generic protocols preserve specialization differences
+
+Recursive protocol checks still need to distinguish incompatible specializations instead of
+collapsing everything to the same protocol origin:
+
+```py
+from typing import List, Protocol, TypeVar
+
+T_co = TypeVar("T_co")
+U_co = TypeVar("U_co")
+
+class Source(Protocol[T_co]):
+    def value(self) -> T_co: ...
+    def next(self) -> "Source[List[T_co]]": ...
+
+class Target(Protocol[U_co]):
+    def value(self) -> U_co: ...
+    def next(self) -> "Target[List[U_co]]": ...
+
+def takes_target(x: Target[int]) -> None: ...
+def f(x: Source[bool]) -> None:
+    takes_target(x)  # error: [invalid-argument-type]
+```
+
 ### Recursive generic protocols with multiple growing self-type wrappers
 
 This regression test covers <https://github.com/astral-sh/ty/issues/3208>. Unlike issue #1736, the

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5611,7 +5611,7 @@ impl<'db> Type<'db> {
                 }))
             }),
 
-            Type::ProtocolInstance(instance) => {
+            Type::ProtocolInstance(instance) => visitor.visit(self, type_mapping, || {
                 // TODO: Add tests for materialization once subtyping/assignability is implemented for
                 // protocols. It _might_ require changing the logic here because:
                 //
@@ -5619,8 +5619,10 @@ impl<'db> Type<'db> {
                 // > read-only property members, and method members, on protocols act covariantly;
                 // > write-only property members act contravariantly; and read/write attribute
                 // > members on protocols act invariantly
-                Type::ProtocolInstance(instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
-            }
+                Type::ProtocolInstance(
+                    instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                )
+            }),
 
             Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(function)) => {
                 Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(
@@ -5926,7 +5928,9 @@ impl<'db> Type<'db> {
             }
 
             Type::ProtocolInstance(instance) => {
-                instance.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                visitor.visit(self, || {
+                    instance.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                });
             }
 
             Type::NewTypeInstance(_) => {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -28,7 +28,8 @@ use crate::types::generics::{
 use crate::types::known_instance::DeprecatedInstance;
 use crate::types::member::Member;
 use crate::types::relation::{
-    HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
+    HasRelationToVisitor, IsDisjointVisitor, ProtocolRelationVisitor, TypeRelation,
+    TypeRelationChecker,
 };
 use crate::types::signatures::{CallableSignature, Parameter, Parameters, Signature};
 use crate::types::tuple::TupleSpec;
@@ -1125,12 +1126,14 @@ impl<'db> ClassType<'db> {
         let relation_visitor = HasRelationToVisitor::default(&constraints);
         let disjointness_visitor = IsDisjointVisitor::default(&constraints);
         let materialization_visitor = ApplyTypeMappingVisitor::default();
+        let protocol_relation_visitor = ProtocolRelationVisitor::default(&constraints);
         let checker = TypeRelationChecker::subtyping(
             &constraints,
             InferableTypeVars::None,
             &relation_visitor,
             &disjointness_visitor,
             &materialization_visitor,
+            &protocol_relation_visitor,
         );
         checker
             .check_class_pair(db, self, target)

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -18,7 +18,8 @@ use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, PathBounds, Solutions,
 };
 use crate::types::relation::{
-    DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
+    DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, ProtocolRelationVisitor,
+    TypeRelation, TypeRelationChecker,
 };
 use crate::types::signatures::{CallableSignature, Parameters};
 use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
@@ -1275,12 +1276,14 @@ impl<'db> Specialization<'db> {
         let relation_visitor = HasRelationToVisitor::default(constraints);
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let materialization_visitor = ApplyTypeMappingVisitor::default();
+        let protocol_relation_visitor = ProtocolRelationVisitor::default(constraints);
         let checker = DisjointnessChecker::new(
             constraints,
             inferable,
             &relation_visitor,
             &disjointness_visitor,
             &materialization_visitor,
+            &protocol_relation_visitor,
         );
         checker.check_specialization_pair(db, self, other)
     }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -23,7 +23,8 @@ use crate::types::protocol_class::{
     ProtocolClass, has_all_protocol_members_defined, walk_protocol_interface,
 };
 use crate::types::relation::{
-    DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelationChecker,
+    DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, ProtocolRelationVisitor,
+    TypeRelationChecker,
 };
 use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
 use crate::types::{
@@ -498,11 +499,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         }
 
         let structurally_satisfied = if let Type::ProtocolInstance(source_protocol) = ty {
-            self.check_protocol_interface_pair(
-                db,
-                source_protocol.interface(db),
-                protocol.interface(db),
-            )
+            self.with_protocol_recursion_guard(db, ty, protocol, || {
+                self.check_protocol_interface_pair(
+                    db,
+                    source_protocol.interface(db),
+                    protocol.interface(db),
+                )
+            })
         } else {
             protocol
                 .inner
@@ -720,12 +723,14 @@ impl<'db> ProtocolInstanceType<'db> {
             let relation_visitor = HasRelationToVisitor::default(&constraints);
             let disjointness_visitor = IsDisjointVisitor::default(&constraints);
             let materialization_visitor = ApplyTypeMappingVisitor::default();
+            let protocol_relation_visitor = ProtocolRelationVisitor::default(&constraints);
             let checker = TypeRelationChecker::subtyping(
                 &constraints,
                 InferableTypeVars::None,
                 &relation_visitor,
                 &disjointness_visitor,
                 &materialization_visitor,
+                &protocol_relation_visitor,
             );
             checker
                 .check_type_satisfies_protocol(db, Type::object(), protocol)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -11,7 +11,8 @@ use crate::types::enums::is_single_member_enum;
 use crate::types::function::FunctionDecorators;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::{
-    ApplyTypeMappingVisitor, CallableType, ClassBase, ClassType, CycleDetector, IntersectionType,
+    ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
+    IntersectionType,
     KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind, MemberLookupPolicy,
     PropertyInstanceType, ProtocolInstanceType, SubclassOfInner, TypeVarBoundOrConstraints,
     UnionType, UpcastPolicy,
@@ -322,17 +323,16 @@ impl<'db> Type<'db> {
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let relation_visitor = HasRelationToVisitor::default(constraints);
-        let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker {
             constraints,
             inferable,
             relation: TypeRelation::SubtypingAssuming,
             given: assuming,
-            relation_visitor: &relation_visitor,
-            disjointness_visitor: &disjointness_visitor,
+            relation_visitor: &HasRelationToVisitor::default(constraints),
+            disjointness_visitor: &IsDisjointVisitor::default(constraints),
             materialization_visitor: &materialization_visitor,
+            protocol_relation_visitor: &ProtocolRelationVisitor::default(constraints),
         };
         checker.check_type_pair(db, self, target)
     }
@@ -424,17 +424,16 @@ impl<'db> Type<'db> {
         inferable: InferableTypeVars<'db>,
         relation: TypeRelation,
     ) -> ConstraintSet<'db, 'c> {
-        let relation_visitor = HasRelationToVisitor::default(constraints);
-        let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker {
             constraints,
             inferable,
             relation,
             given: ConstraintSet::from_bool(constraints, false),
-            relation_visitor: &relation_visitor,
-            disjointness_visitor: &disjointness_visitor,
+            relation_visitor: &HasRelationToVisitor::default(constraints),
+            disjointness_visitor: &IsDisjointVisitor::default(constraints),
             materialization_visitor: &materialization_visitor,
+            protocol_relation_visitor: &ProtocolRelationVisitor::default(constraints),
         };
         checker.check_type_pair(db, self, target)
     }
@@ -493,14 +492,13 @@ impl<'db> Type<'db> {
         constraints: &'c ConstraintSetBuilder<'db>,
         materialization_visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let relation_visitor = HasRelationToVisitor::default(constraints);
-        let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let checker = EquivalenceChecker {
             constraints,
             given: ConstraintSet::from_bool(constraints, false),
-            relation_visitor: &relation_visitor,
-            disjointness_visitor: &disjointness_visitor,
+            relation_visitor: &HasRelationToVisitor::default(constraints),
+            disjointness_visitor: &IsDisjointVisitor::default(constraints),
             materialization_visitor,
+            protocol_relation_visitor: &ProtocolRelationVisitor::default(constraints),
         };
         checker.check_type_pair(db, self, other)
     }
@@ -533,16 +531,15 @@ impl<'db> Type<'db> {
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let relation_visitor = HasRelationToVisitor::default(constraints);
-        let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = DisjointnessChecker {
             constraints,
             inferable,
             given: ConstraintSet::from_bool(constraints, false),
-            disjointness_visitor: &disjointness_visitor,
-            relation_visitor: &relation_visitor,
+            disjointness_visitor: &IsDisjointVisitor::default(constraints),
+            relation_visitor: &HasRelationToVisitor::default(constraints),
             materialization_visitor: &materialization_visitor,
+            protocol_relation_visitor: &ProtocolRelationVisitor::default(constraints),
         };
         checker.check_type_pair(db, self, other)
     }
@@ -555,6 +552,27 @@ pub(crate) type HasRelationToVisitor<'db, 'c> =
 impl<'db, 'c> HasRelationToVisitor<'db, 'c> {
     pub(crate) fn default(constraints: &'c ConstraintSetBuilder<'db>) -> Self {
         HasRelationToVisitor::new(ConstraintSet::from_bool(constraints, true))
+    }
+}
+
+/// A recursion guard for structural protocol checks keyed by class origins rather than full
+/// specializations.
+///
+/// Recursive self-type protocols can keep producing fresh `(source, target)` pairs even though the
+/// underlying source and target class definitions are the same. In those cases we conservatively
+/// assume compatibility once we revisit the same class origins through a nested protocol check.
+pub(crate) type ProtocolRelationVisitor<'db, 'c> = CycleDetector<
+    ProtocolRelation,
+    (ClassLiteral<'db>, ClassLiteral<'db>, TypeRelation),
+    ConstraintSet<'db, 'c>,
+>;
+
+#[derive(Debug)]
+pub(crate) struct ProtocolRelation;
+
+impl<'db, 'c> ProtocolRelationVisitor<'db, 'c> {
+    pub(crate) fn default(constraints: &'c ConstraintSetBuilder<'db>) -> Self {
+        ProtocolRelationVisitor::new(ConstraintSet::from_bool(constraints, true))
     }
 }
 
@@ -586,6 +604,7 @@ pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
     relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
     disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
     pub(super) materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
+    protocol_relation_visitor: &'a ProtocolRelationVisitor<'db, 'c>,
 }
 
 impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
@@ -595,6 +614,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
         disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
         materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
+        protocol_relation_visitor: &'a ProtocolRelationVisitor<'db, 'c>,
     ) -> Self {
         Self {
             constraints,
@@ -604,6 +624,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             relation_visitor,
             disjointness_visitor,
             materialization_visitor,
+            protocol_relation_visitor,
         }
     }
 
@@ -612,6 +633,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
         disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
         materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
+        protocol_relation_visitor: &'a ProtocolRelationVisitor<'db, 'c>,
     ) -> Self {
         Self {
             constraints,
@@ -621,6 +643,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             relation_visitor,
             disjointness_visitor,
             materialization_visitor,
+            protocol_relation_visitor,
         }
     }
 
@@ -647,6 +670,34 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     ) -> ConstraintSet<'db, 'c> {
         self.relation_visitor
             .visit((source, target, self.relation), work)
+    }
+
+    pub(super) fn with_protocol_recursion_guard(
+        &self,
+        db: &'db dyn Db,
+        source: Type<'db>,
+        target: ProtocolInstanceType<'db>,
+        work: impl FnOnce() -> ConstraintSet<'db, 'c>,
+    ) -> ConstraintSet<'db, 'c> {
+        let Some(source_class) = (match source {
+            Type::NominalInstance(nominal) => Some(nominal.class_literal(db)),
+            Type::ProtocolInstance(protocol) => protocol
+                .to_nominal_instance()
+                .map(|nominal| nominal.class_literal(db)),
+            _ => None,
+        }) else {
+            return work();
+        };
+
+        let Some(target_class) = target
+            .to_nominal_instance()
+            .map(|nominal| nominal.class_literal(db))
+        else {
+            return work();
+        };
+
+        self.protocol_relation_visitor
+            .visit((source_class, target_class, self.relation), work)
     }
 
     /// Return a constraint set indicating the conditions under which `self.relation` holds between `source` and `target`.
@@ -1605,6 +1656,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
             materialization_visitor: self.materialization_visitor,
+            protocol_relation_visitor: self.protocol_relation_visitor,
         }
     }
 
@@ -1616,6 +1668,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
             materialization_visitor: self.materialization_visitor,
+            protocol_relation_visitor: self.protocol_relation_visitor,
         }
     }
 }
@@ -1633,6 +1686,7 @@ pub(super) struct EquivalenceChecker<'a, 'c, 'db> {
     relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
     disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
     materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
+    protocol_relation_visitor: &'a ProtocolRelationVisitor<'db, 'c>,
 }
 
 impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
@@ -1648,6 +1702,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
             materialization_visitor,
+            protocol_relation_visitor: self.protocol_relation_visitor,
         }
     }
 
@@ -1695,6 +1750,7 @@ pub(super) struct DisjointnessChecker<'a, 'c, 'db> {
     disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
     relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
     materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
+    protocol_relation_visitor: &'a ProtocolRelationVisitor<'db, 'c>,
 }
 
 impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
@@ -1704,6 +1760,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
         disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
         materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
+        protocol_relation_visitor: &'a ProtocolRelationVisitor<'db, 'c>,
     ) -> Self {
         Self {
             constraints,
@@ -1712,6 +1769,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             disjointness_visitor,
             relation_visitor,
             materialization_visitor,
+            protocol_relation_visitor,
         }
     }
 
@@ -1727,6 +1785,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
             materialization_visitor: self.materialization_visitor,
+            protocol_relation_visitor: self.protocol_relation_visitor,
         }
     }
 
@@ -1737,6 +1796,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
             materialization_visitor: self.materialization_visitor,
+            protocol_relation_visitor: self.protocol_relation_visitor,
         }
     }
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -555,20 +555,61 @@ impl<'db, 'c> HasRelationToVisitor<'db, 'c> {
     }
 }
 
-/// A recursion guard for structural protocol checks keyed by class origins rather than full
-/// specializations.
+/// A recursion guard for structural protocol checks keyed by protocol origins plus a shallow
+/// specialization shape.
 ///
-/// Recursive self-type protocols can keep producing fresh `(source, target)` pairs even though the
-/// underlying source and target class definitions are the same. In those cases we conservatively
-/// assume compatibility once we revisit the same class origins through a nested protocol check.
+/// Recursive protocol self-types can keep growing wrappers like `Factory[Tagged[Wrapped[...]]]`.
+/// Keying only on exact protocol instances misses those cycles, while keying only on class origins
+/// is too aggressive and conflates incompatible specializations like `Source[bool]` and
+/// `Source[list[bool]]`. A shallow shape keeps enough specialization information to distinguish
+/// those cases while still collapsing wrapper growth.
 pub(crate) type ProtocolRelationVisitor<'db, 'c> = CycleDetector<
     ProtocolRelation,
-    (ClassLiteral<'db>, ClassLiteral<'db>, TypeRelation),
+    (ProtocolRelationKey<'db>, TypeRelation),
     ConstraintSet<'db, 'c>,
 >;
 
 #[derive(Debug)]
 pub(crate) struct ProtocolRelation;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct ProtocolRelationKey<'db> {
+    source: ProtocolRelationProtocolShape<'db>,
+    target: ProtocolRelationProtocolShape<'db>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+enum ProtocolRelationProtocolShape<'db> {
+    Class {
+        class: ClassLiteral<'db>,
+        specialization: Box<[ProtocolRelationTypeShape<'db>]>,
+    },
+    Exact(ProtocolInstanceType<'db>),
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct ProtocolRelationTypeShape<'db> {
+    kind: ProtocolRelationTypeShapeKind,
+    class: Option<ClassLiteral<'db>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum ProtocolRelationTypeShapeKind {
+    Nominal,
+    ClassLiteral,
+    Dynamic,
+    Divergent,
+    TypeVar,
+    Union,
+    Intersection,
+    Callable,
+    SpecialForm,
+    SubclassOf,
+    TypedDict,
+    Property,
+    BoundSuper,
+    Other,
+}
 
 impl<'db, 'c> ProtocolRelationVisitor<'db, 'c> {
     pub(crate) fn default(constraints: &'c ConstraintSetBuilder<'db>) -> Self {
@@ -679,25 +720,115 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         target: ProtocolInstanceType<'db>,
         work: impl FnOnce() -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
-        let Some(source_class) = (match source {
-            Type::NominalInstance(nominal) => Some(nominal.class_literal(db)),
-            Type::ProtocolInstance(protocol) => protocol
-                .to_nominal_instance()
-                .map(|nominal| nominal.class_literal(db)),
+        let Some(source_protocol) = (match source {
+            Type::ProtocolInstance(protocol) => Some(protocol),
             _ => None,
         }) else {
             return work();
         };
 
-        let Some(target_class) = target
-            .to_nominal_instance()
-            .map(|nominal| nominal.class_literal(db))
-        else {
-            return work();
+        self.protocol_relation_visitor.visit(
+            (
+                ProtocolRelationKey {
+                    source: Self::protocol_relation_shape(db, source_protocol),
+                    target: Self::protocol_relation_shape(db, target),
+                },
+                self.relation,
+            ),
+            work,
+        )
+    }
+
+    fn protocol_relation_shape(
+        db: &'db dyn Db,
+        protocol: ProtocolInstanceType<'db>,
+    ) -> ProtocolRelationProtocolShape<'db> {
+        let protocol_type = Type::ProtocolInstance(protocol);
+
+        let Some(class) = protocol_type.nominal_class(db) else {
+            return ProtocolRelationProtocolShape::Exact(protocol);
         };
 
-        self.protocol_relation_visitor
-            .visit((source_class, target_class, self.relation), work)
+        let specialization = protocol_type
+            .class_specialization(db)
+            .map(|specialization| {
+                specialization
+                    .types(db)
+                    .iter()
+                    .map(|ty| Self::protocol_relation_type_shape(db, *ty))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        ProtocolRelationProtocolShape::Class {
+            class: class.class_literal(db),
+            specialization,
+        }
+    }
+
+    fn protocol_relation_type_shape(
+        db: &'db dyn Db,
+        ty: Type<'db>,
+    ) -> ProtocolRelationTypeShape<'db> {
+        if let Some(class) = ty
+            .literal_fallback_instance(db)
+            .and_then(|fallback| fallback.nominal_class(db))
+            .or_else(|| ty.nominal_class(db))
+        {
+            return ProtocolRelationTypeShape {
+                kind: ProtocolRelationTypeShapeKind::Nominal,
+                class: Some(class.class_literal(db)),
+            };
+        }
+
+        if let Some(class) = ty.as_class_literal() {
+            return ProtocolRelationTypeShape {
+                kind: ProtocolRelationTypeShapeKind::ClassLiteral,
+                class: Some(class),
+            };
+        }
+
+        if let Type::GenericAlias(alias) = ty {
+            return ProtocolRelationTypeShape {
+                kind: ProtocolRelationTypeShapeKind::ClassLiteral,
+                class: Some(ClassType::Generic(alias).class_literal(db)),
+            };
+        }
+
+        let kind = match ty {
+            Type::Dynamic(_) => ProtocolRelationTypeShapeKind::Dynamic,
+            Type::Divergent(_) => ProtocolRelationTypeShapeKind::Divergent,
+            Type::TypeVar(_) => ProtocolRelationTypeShapeKind::TypeVar,
+            Type::Union(_) => ProtocolRelationTypeShapeKind::Union,
+            Type::Intersection(_) => ProtocolRelationTypeShapeKind::Intersection,
+            Type::Callable(_)
+            | Type::FunctionLiteral(_)
+            | Type::BoundMethod(_)
+            | Type::KnownBoundMethod(_)
+            | Type::WrapperDescriptor(_)
+            | Type::DataclassDecorator(_)
+            | Type::DataclassTransformer(_)
+            | Type::TypeIs(_)
+            | Type::TypeGuard(_) => ProtocolRelationTypeShapeKind::Callable,
+            Type::SpecialForm(_) => ProtocolRelationTypeShapeKind::SpecialForm,
+            Type::SubclassOf(_) => ProtocolRelationTypeShapeKind::SubclassOf,
+            Type::TypedDict(_) => ProtocolRelationTypeShapeKind::TypedDict,
+            Type::PropertyInstance(_) => ProtocolRelationTypeShapeKind::Property,
+            Type::BoundSuper(_) => ProtocolRelationTypeShapeKind::BoundSuper,
+            Type::AlwaysTruthy | Type::AlwaysFalsy => ProtocolRelationTypeShapeKind::Other,
+            Type::Never
+            | Type::ModuleLiteral(_)
+            | Type::LiteralValue(_)
+            | Type::KnownInstance(_)
+            | Type::NominalInstance(_)
+            | Type::ProtocolInstance(_)
+            | Type::GenericAlias(_)
+            | Type::ClassLiteral(_)
+            | Type::TypeAlias(_)
+            | Type::NewTypeInstance(_) => ProtocolRelationTypeShapeKind::Other,
+        };
+
+        ProtocolRelationTypeShape { kind, class: None }
     }
 
     /// Return a constraint set indicating the conditions under which `self.relation` holds between `source` and `target`.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -25,7 +25,8 @@ use crate::types::constraints::{
 use crate::types::generics::{GenericContext, InferableTypeVars, walk_generic_context};
 use crate::types::infer::infer_deferred_types;
 use crate::types::relation::{
-    HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
+    HasRelationToVisitor, IsDisjointVisitor, ProtocolRelationVisitor, TypeRelation,
+    TypeRelationChecker,
 };
 use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType,
@@ -343,11 +344,13 @@ impl<'db> CallableSignature<'db> {
         let relation_visitor = HasRelationToVisitor::default(constraints);
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let materialization_visitor = ApplyTypeMappingVisitor::default();
+        let protocol_relation_visitor = ProtocolRelationVisitor::default(constraints);
         let checker = TypeRelationChecker::constraint_set_assignability(
             constraints,
             &relation_visitor,
             &disjointness_visitor,
             &materialization_visitor,
+            &protocol_relation_visitor,
         );
         checker.check_callable_signature_pair_inner(db, &self.overloads, &other.overloads)
     }
@@ -829,11 +832,13 @@ impl<'db> Signature<'db> {
         let relation_visitor = HasRelationToVisitor::default(constraints);
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let materialization_visitor = ApplyTypeMappingVisitor::default();
+        let protocol_relation_visitor = ProtocolRelationVisitor::default(constraints);
         let checker = TypeRelationChecker::constraint_set_assignability(
             constraints,
             &relation_visitor,
             &disjointness_visitor,
             &materialization_visitor,
+            &protocol_relation_visitor,
         );
         checker.check_signature_pair(db, self, other)
     }


### PR DESCRIPTION
## Summary

The problem was that recursive self-type protocols could keep producing fresh specializations like `Factory[Tagged[Wrapped[Tagged[...]]]]`... so the existing recursion guard never saw the same `(source, target)` pair twice.

This PR adds a protocol-specific recursion guard keyed by protocol class origins rather than full specializations, which recognizes those cycles and terminates.

Closes https://github.com/astral-sh/ty/issues/3208.
