### PR TITLE
[ty] Synthesize instance types for Django model fields

### DIFF
--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -333,6 +333,8 @@ pub enum KnownModule {
     #[strum(serialize = "unittest.mock")]
     UnittestMock,
     Uuid,
+    Datetime,
+    Decimal,
     Warnings,
     Numbers,
     #[strum(serialize = "struct", serialize = "_struct")]
@@ -364,6 +366,8 @@ impl KnownModule {
             Self::Warnings => "warnings",
             Self::UnittestMock => "unittest.mock",
             Self::Uuid => "uuid",
+            Self::Datetime => "datetime",
+            Self::Decimal => "decimal",
             Self::Templatelib => "string.templatelib",
             Self::Numbers => "numbers",
             Self::Struct => "struct",

--- a/crates/ty_python_semantic/resources/mdtest/django/basic_fields.md
+++ b/crates/ty_python_semantic/resources/mdtest/django/basic_fields.md
@@ -1,0 +1,564 @@
+# Django Model Basic Field Types
+
+```toml
+[environment]
+python-version = "3.11"
+python = "/.venv"
+```
+
+## Field access returns Python type (not descriptor)
+
+Accessing a field on a model instance returns the Python value type, not the descriptor object.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField, IntegerField, FloatField, BooleanField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+
+class IntegerField(Field[int, int]):
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+
+class FloatField(Field[float, float]):
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+
+class BooleanField(Field[bool, bool]):
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+```
+
+```py
+from django.db.models import Model, CharField, IntegerField, FloatField, BooleanField
+
+class Article(Model):
+    title = CharField(max_length=100)
+    view_count = IntegerField()
+    rating = FloatField()
+    published = BooleanField()
+
+a = Article()
+reveal_type(a.title)  # revealed: str
+reveal_type(a.view_count)  # revealed: int
+reveal_type(a.rating)  # revealed: float
+reveal_type(a.published)  # revealed: bool
+
+# TODO(ty#1018): class-level access currently returns the synthesized instance
+# type rather than the field descriptor, because attribute resolution does not
+# yet distinguish class-level from instance-level access.
+reveal_type(Article.title)  # revealed: str
+```
+
+## Attribute-style field references (`models.CharField`) are recognized
+
+Django code commonly uses `import django.db.models as models` and then declares fields as
+`models.CharField(...)` rather than importing field classes individually. The module-qualified form
+resolves the same as the bare import form.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField, IntegerField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+class CharField:
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+
+class IntegerField:
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+```
+
+```py
+import django.db.models as models
+
+class Post(models.Model):
+    title = models.CharField(max_length=100)
+    count = models.IntegerField()
+
+p = Post()
+reveal_type(p.title)  # revealed: str
+reveal_type(p.count)  # revealed: int
+```
+
+## Stdlib type fields resolve to their corresponding Python types
+
+`DateField`, `DateTimeField`, `TimeField`, `DecimalField`, and `UUIDField` resolve to their
+corresponding stdlib types. When `null=True` is passed, the type is unioned with `None`.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import DateField, DateTimeField, TimeField, DecimalField, UUIDField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+class DateField:
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+
+class DateTimeField:
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+
+class TimeField:
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+
+class DecimalField:
+    def __init__(
+        self, *, max_digits: int = 10, decimal_places: int = 2, null: bool = False, blank: bool = False, default=None
+    ): ...
+
+class UUIDField:
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+```
+
+```py
+from django.db.models import Model, DateField, DateTimeField, TimeField, DecimalField, UUIDField
+
+class Event(Model):
+    start_date = DateField()
+    start_datetime = DateTimeField()
+    start_time = TimeField()
+    amount = DecimalField(max_digits=10, decimal_places=2)
+    session_id = UUIDField()
+
+    nullable_date = DateField(null=True)
+    nullable_datetime = DateTimeField(null=True)
+    nullable_time = TimeField(null=True)
+    nullable_amount = DecimalField(max_digits=10, decimal_places=2, null=True)
+    nullable_token = UUIDField(null=True)
+
+e = Event()
+reveal_type(e.start_date)  # revealed: date
+reveal_type(e.start_datetime)  # revealed: datetime
+reveal_type(e.start_time)  # revealed: time
+reveal_type(e.amount)  # revealed: Decimal
+reveal_type(e.session_id)  # revealed: UUID
+
+reveal_type(e.nullable_date)  # revealed: date | None
+reveal_type(e.nullable_datetime)  # revealed: datetime | None
+reveal_type(e.nullable_time)  # revealed: time | None
+reveal_type(e.nullable_amount)  # revealed: Decimal | None
+reveal_type(e.nullable_token)  # revealed: UUID | None
+```
+
+## BinaryField, FileField, ImageField, and JSONField
+
+`BinaryField` resolves to `bytes`. `FileField` and `ImageField` return `FieldFile`/`ImageFieldFile`
+at runtime, which ty does not yet model, so they resolve to `Unknown`. `JSONField` stores arbitrary
+JSON data and also resolves to `Unknown`.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import BinaryField, FileField, ImageField, JSONField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+class BinaryField:
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+
+class FileField:
+    def __init__(self, *, upload_to: str = "", null: bool = False, blank: bool = False, default=None): ...
+
+class ImageField:
+    def __init__(self, *, upload_to: str = "", null: bool = False, blank: bool = False, default=None): ...
+
+class JSONField:
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+```
+
+```py
+from django.db.models import Model, BinaryField, FileField, ImageField, JSONField
+
+class Media(Model):
+    data = BinaryField()
+    optional_data = BinaryField(null=True)
+    upload = FileField()
+    photo = ImageField()
+    config = JSONField()
+
+m = Media()
+reveal_type(m.data)  # revealed: bytes
+reveal_type(m.optional_data)  # revealed: bytes | None
+reveal_type(m.upload)  # revealed: Unknown
+reveal_type(m.photo)  # revealed: Unknown
+reveal_type(m.config)  # revealed: Unknown
+```
+
+## Unrecognized field classes fall back to normal inference
+
+A field class not recognized as a Django field falls through to normal descriptor inference.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import UnknownCustomField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class UnknownCustomField(Field):
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+```
+
+```py
+from django.db.models import Model, UnknownCustomField
+
+class Fallback(Model):
+    data = UnknownCustomField()
+    nullable_data = UnknownCustomField(null=True)
+
+f = Fallback()
+reveal_type(f.data)  # revealed: Unknown
+reveal_type(f.nullable_data)  # revealed: Unknown
+```
+
+## CharField variant fields resolve to str
+
+Django ships several `CharField` subclasses with built-in validation. ty maps all of them to `str`.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import (
+    SlugField,
+    EmailField,
+    URLField,
+    TextField,
+    GenericIPAddressField,
+    IPAddressField,
+    FilePathField,
+)
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+class SlugField:
+    def __init__(self, *, max_length: int = 50, null: bool = False): ...
+
+class EmailField:
+    def __init__(self, *, max_length: int = 254, null: bool = False): ...
+
+class URLField:
+    def __init__(self, *, max_length: int = 200, null: bool = False): ...
+
+class TextField:
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+
+class GenericIPAddressField:
+    def __init__(self, *, protocol: str = "both", null: bool = False): ...
+
+class IPAddressField:
+    def __init__(self, *, null: bool = False): ...
+
+class FilePathField:
+    def __init__(self, *, path: str = "", null: bool = False): ...
+```
+
+```py
+from django.db.models import (
+    Model,
+    SlugField,
+    EmailField,
+    URLField,
+    TextField,
+    GenericIPAddressField,
+    IPAddressField,
+    FilePathField,
+)
+
+class Page(Model):
+    slug = SlugField()
+    contact_email = EmailField()
+    source_url = URLField()
+    body = TextField()
+    ip_address = GenericIPAddressField()
+    legacy_ip = IPAddressField()
+    config_path = FilePathField()
+
+p = Page()
+reveal_type(p.slug)  # revealed: str
+reveal_type(p.contact_email)  # revealed: str
+reveal_type(p.source_url)  # revealed: str
+reveal_type(p.body)  # revealed: str
+reveal_type(p.ip_address)  # revealed: str
+reveal_type(p.legacy_ip)  # revealed: str
+reveal_type(p.config_path)  # revealed: str
+```
+
+## Integer field variants resolve to int
+
+Django's integer field subclasses all resolve to `int` regardless of their range constraints.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import (
+    SmallIntegerField,
+    BigIntegerField,
+    PositiveIntegerField,
+    PositiveSmallIntegerField,
+    PositiveBigIntegerField,
+)
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+class SmallIntegerField:
+    def __init__(self, *, null: bool = False): ...
+
+class BigIntegerField:
+    def __init__(self, *, null: bool = False): ...
+
+class PositiveIntegerField:
+    def __init__(self, *, null: bool = False): ...
+
+class PositiveSmallIntegerField:
+    def __init__(self, *, null: bool = False): ...
+
+class PositiveBigIntegerField:
+    def __init__(self, *, null: bool = False): ...
+```
+
+```py
+from django.db.models import (
+    Model,
+    SmallIntegerField,
+    BigIntegerField,
+    PositiveIntegerField,
+    PositiveSmallIntegerField,
+    PositiveBigIntegerField,
+)
+
+class Counters(Model):
+    small = SmallIntegerField()
+    big = BigIntegerField()
+    positive = PositiveIntegerField()
+    positive_small = PositiveSmallIntegerField()
+    positive_big = PositiveBigIntegerField()
+
+c = Counters()
+reveal_type(c.small)  # revealed: int
+reveal_type(c.big)  # revealed: int
+reveal_type(c.positive)  # revealed: int
+reveal_type(c.positive_small)  # revealed: int
+reveal_type(c.positive_big)  # revealed: int
+```
+
+## Annotated field declarations trigger invalid-assignment but synthesis still works
+
+Writing `title: str = CharField(max_length=100)` causes an `invalid-assignment` diagnostic because
+`CharField(...)` returns a descriptor object, not a `str`, so the assigned value is incompatible
+with the declared annotation. The field is still recognized and produces the correct instance type
+for attribute access.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField, IntegerField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+class CharField:
+    def __init__(self, *, max_length: int = 255, null: bool = False): ...
+
+class IntegerField:
+    def __init__(self, *, null: bool = False): ...
+```
+
+```py
+from django.db.models import Model, CharField, IntegerField
+
+class AnnotatedModel(Model):
+    title: str = CharField(max_length=100)  # error: [invalid-assignment]
+    count: int = IntegerField()  # error: [invalid-assignment]
+
+m = AnnotatedModel()
+reveal_type(m.title)  # revealed: str
+reveal_type(m.count)  # revealed: int
+```

--- a/crates/ty_python_semantic/resources/mdtest/django/custom_fields.md
+++ b/crates/ty_python_semantic/resources/mdtest/django/custom_fields.md
@@ -1,0 +1,262 @@
+# Django Custom Field Subclasses
+
+```toml
+[environment]
+python-version = "3.11"
+python = "/.venv"
+```
+
+## Custom CharField subclass resolves to str
+
+A user-defined field that inherits from `CharField` resolves to `str` on instance access.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+```
+
+```py
+from django.db.models import Model, CharField
+
+class TrimmedCharField(CharField):
+    pass
+
+class Article(Model):
+    slug = TrimmedCharField(max_length=50)
+
+a = Article()
+reveal_type(a.slug)  # revealed: str
+```
+
+## Custom IntegerField subclass resolves to int
+
+A user-defined field inheriting from `IntegerField` resolves to `int` on instance access.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import IntegerField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class IntegerField(Field[int, int]):
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+```
+
+```py
+from django.db.models import Model, IntegerField
+
+class BoundedIntegerField(IntegerField):
+    pass
+
+class Score(Model):
+    value = BoundedIntegerField()
+
+s = Score()
+reveal_type(s.value)  # revealed: int
+```
+
+## Multi-level custom field chain resolves to base type
+
+A field subclassed two levels deep still inherits the generic parameters from the root field class.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+```
+
+```py
+from django.db.models import Model, CharField
+
+class BaseSlugField(CharField):
+    pass
+
+class AutoSlugField(BaseSlugField):
+    pass
+
+class Post(Model):
+    slug = AutoSlugField(max_length=100)
+
+p = Post()
+reveal_type(p.slug)  # revealed: str
+```
+
+## Custom field imported from another module falls through to normal inference
+
+When a custom field is referenced via a module attribute (`field_lib.TitleField(...)`) rather than
+imported directly, it falls through to normal descriptor inference.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+```
+
+`field_lib.py`:
+
+```py
+from django.db.models.fields import CharField
+
+class TitleField(CharField):
+    pass
+```
+
+```py
+import field_lib
+from django.db.models import Model
+
+class Article(Model):
+    title = field_lib.TitleField(max_length=100)
+
+a = Article()
+reveal_type(a.title)  # revealed: Unknown | str
+```

--- a/crates/ty_python_semantic/resources/mdtest/django/edge_cases.md
+++ b/crates/ty_python_semantic/resources/mdtest/django/edge_cases.md
@@ -1,0 +1,277 @@
+# Django Model Edge Cases
+
+```toml
+[environment]
+python-version = "3.11"
+python = "/.venv"
+```
+
+## Model with no fields has pk and id synthesized
+
+A model with no field declarations still has `pk` and `id` as `int` from the implicit auto primary
+key.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+```py
+from django.db.models import Model
+
+class Empty(Model):
+    pass
+
+e = Empty()
+reveal_type(e.pk)  # revealed: int
+reveal_type(e.id)  # revealed: int
+```
+
+## Circular ForeignKey between two models in the same file
+
+When model `A` references `B` via FK and `B` references `A` via FK in the same file, both forward
+references resolve correctly.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields.related import ForeignKey
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/related.py`:
+
+```py
+from typing import Generic, TypeVar, overload, Union
+
+_To = TypeVar("_To")
+
+class ForeignKey(Generic[_To]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "ForeignKey[_To]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _To: ...
+    def __get__(self, instance, owner): ...
+    def __init__(self, to: Union[type, str], *, on_delete, null: bool = False, related_name: str = "", db_column: str = ""): ...
+```
+
+```py
+from django.db.models import Model, ForeignKey
+
+class NodeA(Model):
+    partner = ForeignKey("NodeB", on_delete=None)
+
+class NodeB(Model):
+    partner = ForeignKey("NodeA", on_delete=None)
+
+a = NodeA()
+b = NodeB()
+reveal_type(a.partner)  # revealed: NodeB
+reveal_type(b.partner)  # revealed: NodeA
+```
+
+## Fields from a chain of abstract models are visible on the concrete subclass
+
+Fields defined on a chain of abstract models all appear on the final concrete model.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField, IntegerField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+
+class IntegerField(Field[int, int]):
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+```
+
+```py
+from django.db.models import Model, CharField, IntegerField
+
+class AbstractBase(Model):
+    base_field = CharField(max_length=50)
+
+    class Meta:
+        abstract = True
+
+class AbstractMiddle(AbstractBase):
+    middle_field = IntegerField()
+
+    class Meta:
+        abstract = True
+
+class Concrete(AbstractMiddle):
+    own_field = CharField(max_length=100)
+
+c = Concrete()
+reveal_type(c.base_field)  # revealed: str
+reveal_type(c.middle_field)  # revealed: int
+reveal_type(c.own_field)  # revealed: str
+```
+
+## Class named Model that is not a Django model
+
+A class named `Model` that does not inherit from `django.db.models.Model` does not receive any
+Django-specific attribute synthesis.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+```py
+class Model:
+    name: str = "placeholder"
+
+m = Model()
+reveal_type(m.name)  # revealed: str
+```
+
+## Accessing a nonexistent attribute on a Django model is an error
+
+Accessing an attribute that is not a declared field or a synthesized virtual attribute (`pk`, `id`)
+is an `unresolved-attribute` error.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+```
+
+```py
+from django.db.models import Model, CharField
+
+class Article(Model):
+    title = CharField(max_length=100)
+
+a = Article()
+a.title  # fine
+a.nonexistent_field  # error: [unresolved-attribute]
+```

--- a/crates/ty_python_semantic/resources/mdtest/django/foreign_key.md
+++ b/crates/ty_python_semantic/resources/mdtest/django/foreign_key.md
@@ -1,0 +1,337 @@
+# Django ForeignKey Field Types
+
+```toml
+[environment]
+python-version = "3.11"
+python = "/.venv"
+```
+
+## ForeignKey on instance returns related model instance
+
+Accessing a ForeignKey field on a model instance should return an instance of the related model, not
+a `ForeignKey` descriptor.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField
+from django.db.models.fields.related import ForeignKey
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/related.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_To = TypeVar("_To")
+
+class ForeignKey(Generic[_To]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "ForeignKey[_To]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _To: ...
+    def __get__(self, instance, owner): ...
+    def __init__(self, to: type, *, on_delete, null: bool = False, related_name: str = "", db_column: str = ""): ...
+```
+
+```py
+from django.db.models import Model, CharField, ForeignKey
+
+class Author(Model):
+    name = CharField(max_length=100)
+
+class Book(Model):
+    author = ForeignKey(Author, on_delete=None)
+
+b = Book()
+reveal_type(b.author)  # revealed: Author
+reveal_type(b.author.name)  # revealed: str
+```
+
+## Nullable ForeignKey resolves to related model | None
+
+When `null=True` is passed to `ForeignKey`, the instance access type becomes `RelatedModel | None`.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField
+from django.db.models.fields.related import ForeignKey
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/related.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_To = TypeVar("_To")
+
+class ForeignKey(Generic[_To]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "ForeignKey[_To]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _To: ...
+    def __get__(self, instance, owner): ...
+    def __init__(self, to: type, *, on_delete, null: bool = False, related_name: str = "", db_column: str = ""): ...
+```
+
+```py
+from django.db.models import Model, CharField, ForeignKey
+
+class Tag(Model):
+    label = CharField(max_length=50)
+
+class Article(Model):
+    primary_tag = ForeignKey(Tag, null=True, on_delete=None)
+
+a = Article()
+reveal_type(a.primary_tag)  # revealed: Tag | None
+```
+
+## ForeignKey with explicit to= keyword
+
+When `to=` is passed as a keyword argument rather than positionally, ty resolves the related model
+the same way.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField
+from django.db.models.fields.related import ForeignKey
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+class CharField:
+    def __init__(self, *, max_length: int = 255, null: bool = False): ...
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/related.py`:
+
+```py
+class ForeignKey:
+    def __init__(self, to: type, *, on_delete, null: bool = False): ...
+```
+
+```py
+from django.db.models import Model, CharField, ForeignKey
+
+class Publisher(Model):
+    name = CharField(max_length=100)
+
+class Book(Model):
+    publisher = ForeignKey(to=Publisher, on_delete=None)
+
+b = Book()
+reveal_type(b.publisher)  # revealed: Publisher
+```
+
+## OneToOneField resolves to related model instance
+
+`OneToOneField` is resolved identically to `ForeignKey`.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField
+from django.db.models.fields.related import OneToOneField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+class CharField:
+    def __init__(self, *, max_length: int = 255, null: bool = False): ...
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/related.py`:
+
+```py
+class OneToOneField:
+    def __init__(self, to: type, *, on_delete, null: bool = False): ...
+```
+
+```py
+from django.db.models import Model, CharField, OneToOneField
+
+class UserProfile(Model):
+    display_name = CharField(max_length=100)
+
+class Account(Model):
+    profile = OneToOneField(UserProfile, on_delete=None)
+    nullable_profile = OneToOneField(UserProfile, null=True, on_delete=None)
+
+a = Account()
+reveal_type(a.profile)  # revealed: UserProfile
+reveal_type(a.nullable_profile)  # revealed: UserProfile | None
+```
+
+## ForeignObject resolves like ForeignKey
+
+`ForeignObject` is Django's low-level base for relational fields. ty resolves it the same as
+`ForeignKey`.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField
+from django.db.models.fields.related import ForeignObject
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+class CharField:
+    def __init__(self, *, max_length: int = 255, null: bool = False): ...
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/related.py`:
+
+```py
+class ForeignObject:
+    def __init__(self, to: type, *, on_delete, null: bool = False): ...
+```
+
+```py
+from django.db.models import Model, CharField, ForeignObject
+
+class Target(Model):
+    name = CharField(max_length=100)
+
+class Source(Model):
+    target = ForeignObject(Target, on_delete=None)
+
+s = Source()
+reveal_type(s.target)  # revealed: Target
+```

--- a/crates/ty_python_semantic/resources/mdtest/django/inheritance.md
+++ b/crates/ty_python_semantic/resources/mdtest/django/inheritance.md
@@ -1,0 +1,273 @@
+# Django Model Inheritance
+
+```toml
+[environment]
+python-version = "3.11"
+python = "/.venv"
+```
+
+## Fields declared on a parent model are visible on the child
+
+When a concrete model inherits from another model, all fields declared on the parent are accessible
+on instances of the child class, with the same types as on the parent.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+```
+
+```py
+from django.db.models import Model, CharField
+
+class TimestampedModel(Model):
+    created_at = CharField(max_length=50)
+
+class Post(TimestampedModel):
+    title = CharField(max_length=200)
+
+p = Post()
+reveal_type(p.title)  # revealed: str
+reveal_type(p.created_at)  # revealed: str
+```
+
+## Child model can override a parent field
+
+A child model can redeclare a field that exists on a parent. The child's declaration takes
+precedence.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField, IntegerField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+
+class IntegerField(Field[int, int]):
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+```
+
+```py
+from django.db.models import Model, CharField, IntegerField
+
+class Base(Model):
+    value = CharField(max_length=50)
+
+class Child(Base):
+    value = IntegerField()
+
+c = Child()
+reveal_type(c.value)  # revealed: int
+```
+
+## Multi-level inheritance propagates fields correctly
+
+Fields are visible through multiple levels of model inheritance.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField, IntegerField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+
+class IntegerField(Field[int, int]):
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+```
+
+```py
+from django.db.models import Model, CharField, IntegerField
+
+class GrandParent(Model):
+    gp_field = CharField(max_length=10)
+
+class Parent(GrandParent):
+    p_field = IntegerField()
+
+class Child(Parent):
+    c_field = CharField(max_length=20)
+
+c = Child()
+reveal_type(c.c_field)  # revealed: str
+reveal_type(c.p_field)  # revealed: int
+reveal_type(c.gp_field)  # revealed: str
+```
+
+## Diamond inheritance uses MRO to resolve conflicting field names
+
+When two parent models declare a field with the same name, Python's C3 linearization (MRO)
+determines which definition wins. The first class in the MRO that defines the field takes
+precedence, so the order of bases in the subclass declaration matters.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField, IntegerField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+
+class IntegerField(Field[int, int]):
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+```
+
+```py
+from django.db.models import Model, CharField, IntegerField
+
+class MixinA(Model):
+    value = CharField(max_length=50)
+
+class MixinB(Model):
+    value = IntegerField()
+
+class Concrete(MixinA, MixinB):
+    pass
+
+c = Concrete()
+reveal_type(c.value)  # revealed: str
+```

--- a/crates/ty_python_semantic/resources/mdtest/django/nullable_fields.md
+++ b/crates/ty_python_semantic/resources/mdtest/django/nullable_fields.md
@@ -1,0 +1,193 @@
+# Django Model Nullable Fields
+
+```toml
+[environment]
+python-version = "3.11"
+python = "/.venv"
+```
+
+## Nullable fields resolve to T | None
+
+When a field is declared with `null=True`, accessing it on an instance returns `T | None` rather
+than just `T`.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField, IntegerField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+
+class IntegerField(Field[int, int]):
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+```
+
+```py
+from django.db.models import Model, CharField, IntegerField
+
+class Post(Model):
+    title = CharField(max_length=200)
+    subtitle = CharField(max_length=200, null=True)
+    views = IntegerField()
+    rank = IntegerField(null=True)
+
+p = Post()
+reveal_type(p.title)  # revealed: str
+reveal_type(p.subtitle)  # revealed: str | None
+reveal_type(p.views)  # revealed: int
+reveal_type(p.rank)  # revealed: int | None
+```
+
+## NullBooleanField is always nullable
+
+`NullBooleanField` stores `True`, `False`, or `NULL` at the database level. Unlike other fields
+where `null=True` must be explicit, `NullBooleanField` is intrinsically nullable regardless of the
+`null=` argument.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import NullBooleanField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class NullBooleanField(Field[bool | None, bool | None]):
+    def __init__(self, *, blank: bool = False, default=None): ...
+```
+
+```py
+from django.db.models import Model, NullBooleanField
+
+class Flag(Model):
+    active = NullBooleanField()
+
+f = Flag()
+reveal_type(f.active)  # revealed: bool | None
+```
+
+## NullBooleanField with explicit null=False is still nullable
+
+`NullBooleanField` is intrinsically nullable regardless of an explicit `null=False` argument.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import NullBooleanField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class NullBooleanField(Field[bool | None, bool | None]):
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None): ...
+```
+
+```py
+from django.db.models import Model, NullBooleanField
+
+class Toggle(Model):
+    active = NullBooleanField(null=False)
+
+t = Toggle()
+reveal_type(t.active)  # revealed: bool | None
+```

--- a/crates/ty_python_semantic/resources/mdtest/django/string_fk_refs.md
+++ b/crates/ty_python_semantic/resources/mdtest/django/string_fk_refs.md
@@ -1,0 +1,321 @@
+# Django String FK References
+
+```toml
+[environment]
+python-version = "3.11"
+python = "/.venv"
+```
+
+## ForeignKey with string "self" reference
+
+`ForeignKey("self", ...)` creates a self-referential relation. The field type resolves to the
+enclosing model class.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField
+from django.db.models.fields.related import ForeignKey
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/related.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_To = TypeVar("_To")
+
+class ForeignKey(Generic[_To]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "ForeignKey[_To]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _To: ...
+    def __get__(self, instance, owner): ...
+    def __init__(self, to, *, on_delete, null: bool = False, related_name: str = "", db_column: str = ""): ...
+```
+
+```py
+from django.db.models import Model, CharField, ForeignKey
+
+class Category(Model):
+    name = CharField(max_length=100)
+    parent = ForeignKey("self", on_delete=None, null=True)
+
+c = Category()
+reveal_type(c.parent)  # revealed: Category | None
+```
+
+## ForeignKey with string model name in same file
+
+Passing a class name as a string (`ForeignKey("Author", ...)`) handles forward references to models
+defined later in the same file.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField
+from django.db.models.fields.related import ForeignKey
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/related.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_To = TypeVar("_To")
+
+class ForeignKey(Generic[_To]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "ForeignKey[_To]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _To: ...
+    def __get__(self, instance, owner): ...
+    def __init__(self, to, *, on_delete, null: bool = False, related_name: str = "", db_column: str = ""): ...
+```
+
+```py
+from django.db.models import Model, CharField, ForeignKey
+
+class Author(Model):
+    name = CharField(max_length=100)
+
+class Book(Model):
+    author = ForeignKey("Author", on_delete=None)
+
+b = Book()
+reveal_type(b.author)  # revealed: Author
+```
+
+## ForeignKey with settings.AUTH_USER_MODEL
+
+`ForeignKey(settings.AUTH_USER_MODEL, ...)` passes a runtime string attribute as the target. The
+model cannot be statically resolved, so the field type is `Unknown`.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields.related import ForeignKey
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/related.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_To = TypeVar("_To")
+
+class ForeignKey(Generic[_To]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "ForeignKey[_To]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _To: ...
+    def __get__(self, instance, owner): ...
+    def __init__(self, to, *, on_delete, null: bool = False, related_name: str = "", db_column: str = ""): ...
+```
+
+```py
+from django.db.models import Model, ForeignKey
+
+class settings:
+    AUTH_USER_MODEL: str = "auth.User"
+
+class Profile(Model):
+    user = ForeignKey(settings.AUTH_USER_MODEL, on_delete=None)
+
+p = Profile()
+reveal_type(p.user)  # revealed: Unknown
+```
+
+## Unresolvable string reference falls back gracefully
+
+When a string reference cannot be resolved to a class in scope, the field type is `Unknown`.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields.related import ForeignKey
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/related.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_To = TypeVar("_To")
+
+class ForeignKey(Generic[_To]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "ForeignKey[_To]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _To: ...
+    def __get__(self, instance, owner): ...
+    def __init__(self, to, *, on_delete, null: bool = False, related_name: str = "", db_column: str = ""): ...
+```
+
+```py
+from django.db.models import Model, ForeignKey
+
+class Article(Model):
+    related = ForeignKey("NoSuchModel", on_delete=None)
+
+a = Article()
+reveal_type(a.related)  # revealed: Unknown
+```
+
+## Dotted app-label string references resolve to Unknown
+
+`ForeignKey("app_label.ModelName", ...)` uses Django's cross-app reference format. Dotted paths
+cannot be resolved statically and produce `Unknown`.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields.related import ForeignKey
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/related.py`:
+
+```py
+class ForeignKey:
+    def __init__(self, to, *, on_delete, null: bool = False): ...
+```
+
+```py
+from django.db.models import Model, ForeignKey
+
+class Order(Model):
+    user = ForeignKey("accounts.User", on_delete=None)
+
+o = Order()
+reveal_type(o.user)  # revealed: Unknown
+```

--- a/crates/ty_python_semantic/resources/mdtest/django/synthesized_attrs.md
+++ b/crates/ty_python_semantic/resources/mdtest/django/synthesized_attrs.md
@@ -1,0 +1,485 @@
+# Django Synthesized Model Attributes
+
+```toml
+[environment]
+python-version = "3.11"
+python = "/.venv"
+```
+
+## Default pk and id resolve to int
+
+Models without an explicit primary key field get `pk` and `id` synthesized as `int`.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField, AutoField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None): ...
+
+class AutoField(Field[int, int]):
+    pass
+```
+
+```py
+from django.db.models import Model, CharField
+
+class Product(Model):
+    name = CharField(max_length=50)
+
+p = Product()
+reveal_type(p.pk)  # revealed: int
+reveal_type(p.id)  # revealed: int
+```
+
+## UUIDField(primary_key=True) makes pk return uuid.UUID
+
+When a model sets a `UUIDField` as the primary key, `pk` reflects that type.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import AutoField, UUIDField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+import uuid
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class AutoField(Field[int, int]):
+    pass
+
+class UUIDField(Field[uuid.UUID, uuid.UUID]):
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None, primary_key: bool = False): ...
+```
+
+```py
+from uuid import UUID
+from django.db.models import Model, UUIDField
+
+class Document(Model):
+    id = UUIDField(primary_key=True)
+
+d = Document()
+reveal_type(d.pk)  # revealed: UUID
+reveal_type(d.id)  # revealed: UUID
+```
+
+## CharField(primary_key=True) makes pk return str
+
+When a model uses a `CharField` as the primary key, `pk` returns `str`.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(
+        self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None, primary_key: bool = False
+    ): ...
+```
+
+```py
+from django.db.models import Model, CharField
+
+class Country(Model):
+    code = CharField(max_length=2, primary_key=True)
+
+c = Country()
+reveal_type(c.pk)  # revealed: str
+reveal_type(c.code)  # revealed: str
+```
+
+## Inherited custom PK propagates pk type to child
+
+When a parent model defines a custom primary key, child models inherit it. `pk` on child instances
+returns the same type.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField, UUIDField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+import uuid
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(
+        self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None, primary_key: bool = False
+    ): ...
+
+class UUIDField(Field[uuid.UUID, uuid.UUID]):
+    def __init__(self, *, null: bool = False, blank: bool = False, default=None, primary_key: bool = False): ...
+```
+
+```py
+from uuid import UUID
+from django.db.models import Model, UUIDField, CharField
+
+class BaseEntity(Model):
+    id = UUIDField(primary_key=True)
+
+class ChildEntity(BaseEntity):
+    name = CharField(max_length=100)
+
+c = ChildEntity()
+reveal_type(c.pk)  # revealed: UUID
+```
+
+## Inherited custom PK suppresses implicit id on child
+
+When a parent model defines a custom primary key that is not named `id`, child models inherit that
+primary key and do not get an implicit `id` attribute.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+class CharField:
+    def __init__(self, *, max_length: int = 255, primary_key: bool = False, null: bool = False): ...
+```
+
+```py
+from django.db.models import Model, CharField
+
+class BaseWithCustomPK(Model):
+    code = CharField(max_length=2, primary_key=True)
+
+class ChildOfCustomPK(BaseWithCustomPK):
+    name = CharField(max_length=100)
+
+c = ChildOfCustomPK()
+reveal_type(c.pk)  # revealed: str
+reveal_type(c.code)  # revealed: str
+
+# error: [unresolved-attribute]
+reveal_type(c.id)  # revealed: Unknown
+```
+
+## CharField(primary_key=True) overrides the implicit auto pk
+
+Explicitly setting `primary_key=True` on a `CharField` suppresses the auto-generated integer `id`,
+so both `pk` and the named field are `str`, not `int`.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+from typing import Generic, TypeVar, overload
+
+_ST = TypeVar("_ST")
+_GT = TypeVar("_GT")
+
+class Field(Generic[_ST, _GT]):
+    @overload
+    def __get__(self, instance: None, owner: type) -> "Field[_ST, _GT]": ...
+    @overload
+    def __get__(self, instance: object, owner: type) -> _GT: ...
+    def __get__(self, instance, owner): ...
+    def __set__(self, instance: object, value: _ST) -> None: ...
+
+class CharField(Field[str, str]):
+    def __init__(
+        self, *, max_length: int = 255, null: bool = False, blank: bool = False, default=None, primary_key: bool = False
+    ): ...
+```
+
+```py
+from django.db.models import Model, CharField
+
+class Currency(Model):
+    code = CharField(max_length=3, primary_key=True)
+    name = CharField(max_length=50)
+
+c = Currency()
+reveal_type(c.pk)  # revealed: str
+reveal_type(c.code)  # revealed: str
+```
+
+## BigAutoField and SmallAutoField resolve to int
+
+Explicit auto-field variants are recognized as integer primary keys.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import BigAutoField, SmallAutoField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+class BigAutoField:
+    def __init__(self, *, primary_key: bool = False): ...
+
+class SmallAutoField:
+    def __init__(self, *, primary_key: bool = False): ...
+```
+
+```py
+from django.db.models import Model, BigAutoField, SmallAutoField
+
+class LargeTable(Model):
+    id = BigAutoField(primary_key=True)
+
+class SmallTable(Model):
+    id = SmallAutoField(primary_key=True)
+
+t = LargeTable()
+reveal_type(t.id)  # revealed: int
+reveal_type(t.pk)  # revealed: int
+
+s = SmallTable()
+reveal_type(s.id)  # revealed: int
+reveal_type(s.pk)  # revealed: int
+```
+
+## Custom primary key suppresses implicit id
+
+When a model uses a custom primary key, `obj.id` is not a valid attribute and `obj.pk` resolves to
+the custom field's type.
+
+`/.venv/<path-to-site-packages>/django/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/__init__.py`:
+
+```py
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/__init__.py`:
+
+```py
+from django.db.models.base import Model
+from django.db.models.fields import CharField
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/base.py`:
+
+```py
+class Model:
+    pass
+```
+
+`/.venv/<path-to-site-packages>/django/db/models/fields/__init__.py`:
+
+```py
+class CharField:
+    def __init__(self, *, max_length: int = 255, primary_key: bool = False, null: bool = False): ...
+```
+
+```py
+from django.db.models import Model, CharField
+
+class Country(Model):
+    code = CharField(max_length=2, primary_key=True)
+
+c = Country()
+reveal_type(c.pk)  # revealed: str
+reveal_type(c.code)  # revealed: str
+
+# error: [unresolved-attribute]
+reveal_type(c.id)  # revealed: Unknown
+```

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -52,6 +52,7 @@ use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast};
 use ruff_text_size::TextRange;
 
+mod django_model;
 mod dynamic_literal;
 mod known;
 mod named_tuple;

--- a/crates/ty_python_semantic/src/types/class/django_model.rs
+++ b/crates/ty_python_semantic/src/types/class/django_model.rs
@@ -1,0 +1,400 @@
+use ruff_db::{files::File, parsed::parsed_module};
+use ruff_python_ast as ast;
+use ruff_python_ast::name::Name;
+use ty_module_resolver::KnownModule;
+
+use crate::{
+    Db, FxIndexMap,
+    place::known_module_symbol,
+    semantic_index::global_scope,
+    types::{
+        ClassLiteral, KnownClass, Type, UnionType, class::StaticClassLiteral, member::class_member,
+    },
+};
+
+/// The category of a Django model field, used to determine the Python type
+/// that accessing the field on a model instance should produce.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+pub(super) enum DjangoFieldKind {
+    // character / text
+    Char,
+    Binary,
+    // numeric
+    Integer,
+    Float,
+    Bool,
+    Decimal,
+    Auto,
+    // date / time
+    Date,
+    DateTime,
+    Time,
+    // other scalars
+    Uuid,
+    Json,
+    // TODO: `FileField`/`ImageField` return `FieldFile`/`ImageFieldFile` at runtime;
+    // model these once we have stubs for `django.db.models.fields.files`.
+    Opaque,
+    // relational
+    ForeignKey,
+    OneToOne,
+}
+
+/// A single Django model field declaration with its resolved Python type information.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+pub(super) struct DjangoFieldInfo<'db> {
+    pub name: Name,
+    pub kind: DjangoFieldKind,
+    pub nullable: bool,
+    pub primary_key: bool,
+    /// For `ForeignKey` or `OneToOneField`, the resolved instance type of the target model.
+    /// `None` for non-relational fields.
+    pub related_model: Option<Type<'db>>,
+}
+
+/// Return an instance of the stdlib class `module.class_name`, falling back to `Unknown`
+/// if the class cannot be resolved in typeshed.
+fn resolve_stdlib_instance<'db>(
+    db: &'db dyn Db,
+    module: KnownModule,
+    class_name: &str,
+) -> Type<'db> {
+    known_module_symbol(db, module, class_name)
+        .place
+        .ignore_possibly_undefined()
+        .and_then(|ty| ty.to_instance(db))
+        .unwrap_or_else(Type::unknown)
+}
+
+impl<'db> DjangoFieldInfo<'db> {
+    /// Return the Python value type for this field when accessed on a model instance.
+    pub(super) fn instance_type(&self, db: &'db dyn Db) -> Type<'db> {
+        let base = match self.kind {
+            DjangoFieldKind::Char => KnownClass::Str.to_instance(db),
+            DjangoFieldKind::Integer | DjangoFieldKind::Auto => KnownClass::Int.to_instance(db),
+            DjangoFieldKind::Float => KnownClass::Float.to_instance(db),
+            DjangoFieldKind::Bool => KnownClass::Bool.to_instance(db),
+            DjangoFieldKind::Date => resolve_stdlib_instance(db, KnownModule::Datetime, "date"),
+            DjangoFieldKind::DateTime => {
+                resolve_stdlib_instance(db, KnownModule::Datetime, "datetime")
+            }
+            DjangoFieldKind::Time => resolve_stdlib_instance(db, KnownModule::Datetime, "time"),
+            DjangoFieldKind::Decimal => {
+                resolve_stdlib_instance(db, KnownModule::Decimal, "Decimal")
+            }
+            DjangoFieldKind::Uuid => resolve_stdlib_instance(db, KnownModule::Uuid, "UUID"),
+            DjangoFieldKind::Binary => KnownClass::Bytes.to_instance(db),
+            DjangoFieldKind::Json | DjangoFieldKind::Opaque => Type::unknown(),
+            DjangoFieldKind::ForeignKey | DjangoFieldKind::OneToOne => {
+                self.related_model.unwrap_or_else(Type::unknown)
+            }
+        };
+
+        if self.nullable {
+            UnionType::from_two_elements(db, base, Type::none(db))
+        } else {
+            base
+        }
+    }
+}
+
+/// Map a Django field class name (e.g. `"CharField"`) to its [`DjangoFieldKind`].
+fn field_class_to_kind(name: &str) -> Option<DjangoFieldKind> {
+    Some(match name {
+        "CharField"
+        | "TextField"
+        | "SlugField"
+        | "URLField"
+        | "EmailField"
+        | "GenericIPAddressField"
+        | "IPAddressField"
+        | "FilePathField" => DjangoFieldKind::Char,
+
+        "FileField" | "ImageField" => DjangoFieldKind::Opaque,
+
+        "IntegerField"
+        | "SmallIntegerField"
+        | "BigIntegerField"
+        | "PositiveIntegerField"
+        | "PositiveSmallIntegerField"
+        | "PositiveBigIntegerField" => DjangoFieldKind::Integer,
+
+        "FloatField" => DjangoFieldKind::Float,
+        "BooleanField" | "NullBooleanField" => DjangoFieldKind::Bool,
+        "DateField" => DjangoFieldKind::Date,
+        "DateTimeField" => DjangoFieldKind::DateTime,
+        "TimeField" => DjangoFieldKind::Time,
+        "DecimalField" => DjangoFieldKind::Decimal,
+        "UUIDField" => DjangoFieldKind::Uuid,
+        "JSONField" => DjangoFieldKind::Json,
+        "BinaryField" => DjangoFieldKind::Binary,
+        "AutoField" | "BigAutoField" | "SmallAutoField" => DjangoFieldKind::Auto,
+        "ForeignKey" | "ForeignObject" => DjangoFieldKind::ForeignKey,
+        "OneToOneField" => DjangoFieldKind::OneToOne,
+        // TODO: `ManyToManyField` returns a manager at runtime, not a model instance;
+        // synthesizing its type requires modelling `RelatedManager`.
+        _ => return None,
+    })
+}
+
+/// Walk the MRO of `class_name` to find a recognized Django field base class.
+fn resolve_custom_field_kind(db: &dyn Db, file: File, class_name: &str) -> Option<DjangoFieldKind> {
+    let scope = global_scope(db, file);
+    let ty = class_member(db, scope, class_name).ignore_possibly_undefined()?;
+    let Type::ClassLiteral(ClassLiteral::Static(lit)) = ty else {
+        return None;
+    };
+
+    for base in lit.iter_mro(db, None) {
+        if let Some(class_type) = base.into_class()
+            && let Some((base_lit, _)) = class_type.static_class_literal(db)
+            && let Some(kind) = field_class_to_kind(base_lit.name(db).as_str())
+        {
+            return Some(kind);
+        }
+    }
+
+    None
+}
+
+/// Resolve the target model for a `ForeignKey` or `OneToOneField`.
+///
+/// Handles `ForeignKey(Author)`, `ForeignKey(to=Author)`, `ForeignKey("Author")`,
+/// and `ForeignKey("self")`. Returns `Unknown` for targets that cannot be statically
+/// resolved (dotted cross-app references, `settings.AUTH_USER_MODEL`).
+fn resolve_related_model<'db>(
+    db: &'db dyn Db,
+    file: File,
+    self_class: StaticClassLiteral<'db>,
+    call_expr: &ast::ExprCall,
+) -> Type<'db> {
+    let scope = global_scope(db, file);
+    let resolve_name = |name: &str| -> Type<'db> {
+        class_member(db, scope, name)
+            .ignore_possibly_undefined()
+            .and_then(|ty| ty.to_instance(db))
+            .unwrap_or_else(Type::unknown)
+    };
+
+    // The `to=` keyword takes precedence, matching Django's argument resolution order.
+    let to_kwarg = call_expr
+        .arguments
+        .keywords
+        .iter()
+        .find_map(|kw| (kw.arg.as_deref() == Some("to")).then_some(&kw.value));
+    let target_expr = to_kwarg.or_else(|| call_expr.arguments.args.first());
+
+    match target_expr {
+        Some(ast::Expr::Name(name_expr)) => resolve_name(name_expr.id.as_str()),
+        Some(ast::Expr::StringLiteral(string_lit)) => {
+            let value = string_lit.value.to_str();
+            if value == "self" {
+                Type::instance(db, self_class.apply_optional_specialization(db, None))
+            } else if value.contains('.') {
+                // Dotted cross-app references (e.g. "myapp.Author") cannot be
+                // resolved without Django's app registry.
+                Type::unknown()
+            } else {
+                resolve_name(value)
+            }
+        }
+        _ => Type::unknown(),
+    }
+}
+
+/// Collect all Django field declarations across the class hierarchy.
+///
+/// Iterates the MRO in ancestor-first order so that child fields with the same
+/// name override parent fields.
+fn collect_all_django_fields<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+) -> Vec<DjangoFieldInfo<'db>> {
+    let mut fields: FxIndexMap<Name, DjangoFieldInfo<'db>> = FxIndexMap::default();
+
+    for base in class.iter_mro(db, None).rev() {
+        let Some(class_type) = base.into_class() else {
+            continue;
+        };
+        let Some((base_lit, _)) = class_type.static_class_literal(db) else {
+            continue;
+        };
+        if base_lit.is_known(db, KnownClass::DjangoModel) || !base_lit.is_django_model(db) {
+            continue;
+        }
+        for field in base_lit.django_model_fields(db) {
+            fields.insert(field.name.clone(), field.clone());
+        }
+    }
+
+    fields.into_values().collect()
+}
+
+/// Return the type of `pk`: the field with `primary_key=True`, falling back to
+/// any `AutoField`, falling back to `int`. Nullability is always stripped.
+fn resolve_pk_type<'db>(db: &'db dyn Db, fields: &[DjangoFieldInfo<'db>]) -> Type<'db> {
+    fields
+        .iter()
+        .find(|f| f.primary_key)
+        .or_else(|| {
+            fields
+                .iter()
+                .find(|f| matches!(f.kind, DjangoFieldKind::Auto))
+        })
+        .map(|f| {
+            DjangoFieldInfo {
+                nullable: false,
+                ..f.clone()
+            }
+            .instance_type(db)
+        })
+        .unwrap_or_else(|| KnownClass::Int.to_instance(db))
+}
+
+/// Extract the target name and call expression from a field assignment in a model
+/// class body, returning `None` for statements that are not field assignments.
+fn extract_field_assignment(stmt: &ast::Stmt) -> Option<(Name, &ast::ExprCall)> {
+    match stmt {
+        ast::Stmt::Assign(assign) => {
+            let [target] = assign.targets.as_slice() else {
+                return None;
+            };
+            let ast::Expr::Name(name) = target else {
+                return None;
+            };
+            let ast::Expr::Call(call) = assign.value.as_ref() else {
+                return None;
+            };
+            Some((name.id.clone(), call))
+        }
+        ast::Stmt::AnnAssign(ann_assign) => {
+            let ast::Expr::Name(name) = ann_assign.target.as_ref() else {
+                return None;
+            };
+            let ast::Expr::Call(call) = ann_assign.value.as_deref()? else {
+                return None;
+            };
+            Some((name.id.clone(), call))
+        }
+        _ => None,
+    }
+}
+
+#[salsa::tracked]
+impl<'db> StaticClassLiteral<'db> {
+    /// Return the Django field declarations in this class's own body, excluding
+    /// inherited fields.
+    ///
+    /// Use [`collect_all_django_fields`] to include inherited fields.
+    #[salsa::tracked(returns(deref), cycle_initial=|_, _, _| Box::default(), heap_size=ruff_memory_usage::heap_size)]
+    pub(super) fn django_model_fields(self, db: &'db dyn Db) -> Box<[DjangoFieldInfo<'db>]> {
+        let file = self.file(db);
+        let module = parsed_module(db, file).load(db);
+        let class_stmt = self.node(db, &module);
+
+        let mut fields = Vec::new();
+
+        for stmt in &class_stmt.body {
+            let Some((target_name, call_expr)) = extract_field_assignment(stmt) else {
+                continue;
+            };
+
+            // We can only match the trailing identifier (e.g. `CharField` from
+            // `models.CharField(...)`) because full attribute resolution is not
+            // available inside a `#[salsa::tracked]` method.
+            let field_class_name = match call_expr.func.as_ref() {
+                ast::Expr::Name(name) => name.id.to_string(),
+                ast::Expr::Attribute(attr) => attr.attr.to_string(),
+                _ => continue,
+            };
+
+            let Some(kind) = field_class_to_kind(&field_class_name)
+                .or_else(|| resolve_custom_field_kind(db, file, &field_class_name))
+            else {
+                continue;
+            };
+
+            let mut nullable = false;
+            let mut primary_key = false;
+            for keyword in &call_expr.arguments.keywords {
+                let Some(arg_name) = keyword.arg.as_deref() else {
+                    continue;
+                };
+                let is_true = matches!(
+                    keyword.value,
+                    ast::Expr::BooleanLiteral(ast::ExprBooleanLiteral { value: true, .. })
+                );
+                match arg_name {
+                    "null" if is_true => nullable = true,
+                    "primary_key" if is_true => primary_key = true,
+                    _ => {}
+                }
+            }
+
+            // `NullBooleanField` is intrinsically nullable regardless of whether
+            // `null=True` was explicitly passed. Deprecated since Django 3.1.
+            if field_class_name == "NullBooleanField" {
+                nullable = true;
+            }
+
+            let related_model = if matches!(
+                kind,
+                DjangoFieldKind::ForeignKey | DjangoFieldKind::OneToOne
+            ) {
+                Some(resolve_related_model(db, file, self, call_expr))
+            } else {
+                None
+            };
+
+            fields.push(DjangoFieldInfo {
+                name: target_name,
+                kind,
+                nullable,
+                primary_key,
+                related_model,
+            });
+        }
+
+        fields.into_boxed_slice()
+    }
+}
+
+/// Return the synthesized instance-member type for a Django model field, or `None`
+/// if `name` is not a recognized field or `class` is not a Django model.
+pub(super) fn synthesize_django_instance_member<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+    name: &str,
+) -> Option<Type<'db>> {
+    if !class.is_django_model(db) || class.is_known(db, KnownClass::DjangoModel) {
+        return None;
+    }
+
+    match name {
+        "pk" => {
+            let all_fields = collect_all_django_fields(db, class);
+            Some(resolve_pk_type(db, &all_fields))
+        }
+        "id" => {
+            let all_fields = collect_all_django_fields(db, class);
+            if let Some(field) = all_fields.iter().find(|f| f.name.as_str() == "id") {
+                Some(field.instance_type(db))
+            } else if all_fields.iter().any(|f| f.primary_key) {
+                // Django only synthesizes an implicit `id` field when no field in the
+                // hierarchy has `primary_key=True`.
+                None
+            } else {
+                Some(KnownClass::Int.to_instance(db))
+            }
+        }
+        // Regular fields only search this class's own body; inherited fields are
+        // found by the caller's MRO walk via `own_instance_member` on each ancestor.
+        // `pk` and `id` above must inspect the full hierarchy because determining
+        // the primary key requires cross-class knowledge.
+        _ => class
+            .django_model_fields(db)
+            .iter()
+            .find(|f| f.name.as_str() == name)
+            .map(|f| f.instance_type(db)),
+    }
+}

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -137,6 +137,8 @@ pub enum KnownClass {
     ConstraintSet,
     GenericContext,
     Specialization,
+    // django.db.models
+    DjangoModel,
 }
 
 impl KnownClass {
@@ -248,7 +250,8 @@ impl KnownClass {
             | Self::GenericContext
             | Self::Specialization
             | Self::ProtocolMeta
-            | Self::TypedDictFallback => Some(Truthiness::Ambiguous),
+            | Self::TypedDictFallback
+            | Self::DjangoModel => Some(Truthiness::Ambiguous),
 
             Self::Tuple => None,
         }
@@ -341,7 +344,8 @@ impl KnownClass {
             | KnownClass::BuiltinFunctionType
             | KnownClass::ProtocolMeta
             | KnownClass::Template
-            | KnownClass::Path => false,
+            | KnownClass::Path
+            | KnownClass::DjangoModel => false,
         }
     }
 
@@ -431,7 +435,8 @@ impl KnownClass {
             | KnownClass::BuiltinFunctionType
             | KnownClass::ProtocolMeta
             | KnownClass::Template
-            | KnownClass::Path => false,
+            | KnownClass::Path
+            | KnownClass::DjangoModel => false,
         }
     }
 
@@ -520,7 +525,8 @@ impl KnownClass {
             | KnownClass::BuiltinFunctionType
             | KnownClass::ProtocolMeta
             | KnownClass::Template
-            | KnownClass::Path => false,
+            | KnownClass::Path
+            | KnownClass::DjangoModel => false,
         }
     }
 
@@ -622,7 +628,8 @@ impl KnownClass {
             | Self::Template
             | Self::Path
             | Self::Mapping
-            | Self::Sequence => false,
+            | Self::Sequence
+            | Self::DjangoModel => false,
         }
     }
 
@@ -714,7 +721,8 @@ impl KnownClass {
             | KnownClass::Path
             | KnownClass::ConstraintSet
             | KnownClass::GenericContext
-            | KnownClass::Specialization => false,
+            | KnownClass::Specialization
+            | KnownClass::DjangoModel => false,
             KnownClass::NamedTupleFallback | KnownClass::TypedDictFallback => true,
         }
     }
@@ -833,6 +841,7 @@ impl KnownClass {
             Self::Template => "Template",
             Self::Path => "Path",
             Self::ProtocolMeta => "_ProtocolMeta",
+            Self::DjangoModel => "Model",
         }
     }
 
@@ -848,6 +857,9 @@ impl KnownClass {
                     class: known_class,
                     db,
                 } = *self;
+                if known_class == KnownClass::DjangoModel {
+                    return write!(f, "django.db.models.Model");
+                }
                 write!(
                     f,
                     "{module}.{class}",
@@ -977,6 +989,10 @@ impl KnownClass {
         self,
         db: &dyn Db,
     ) -> Result<StaticClassLiteral<'_>, KnownClassLookupError<'_>> {
+        // `DjangoModel` has no typeshed stub, so skip the symbol lookup.
+        if self == Self::DjangoModel {
+            return Err(KnownClassLookupError::ClassNotFound);
+        }
         let symbol = known_module_symbol(db, self.canonical_module(db), self.name(db)).place;
         match symbol {
             Place::Defined(DefinedPlace {
@@ -1212,6 +1228,10 @@ impl KnownClass {
             | Self::Specialization => KnownModule::TyExtensions,
             Self::Template => KnownModule::Templatelib,
             Self::Path => KnownModule::Pathlib,
+            // `DjangoModel` is not in typeshed; this sentinel value is never reached because
+            // `try_to_class_literal_without_logging` and `display` both early-return for
+            // `DjangoModel`, and `check_module` returns `false` for it.
+            Self::DjangoModel => KnownModule::Builtins,
         }
     }
 
@@ -1303,7 +1323,8 @@ impl KnownClass {
             | Self::BuiltinFunctionType
             | Self::ProtocolMeta
             | Self::Template
-            | Self::Path => Some(false),
+            | Self::Path
+            | Self::DjangoModel => Some(false),
 
             Self::Tuple => None,
         }
@@ -1398,7 +1419,8 @@ impl KnownClass {
             | Self::BuiltinFunctionType
             | Self::ProtocolMeta
             | Self::Template
-            | Self::Path => false,
+            | Self::Path
+            | Self::DjangoModel => false,
         }
     }
 
@@ -1507,15 +1529,20 @@ impl KnownClass {
             "Template" => &[Self::Template],
             "Path" => &[Self::Path],
             "_ProtocolMeta" => &[Self::ProtocolMeta],
+            "Model" => &[Self::DjangoModel],
             _ => return None,
         };
 
-        let module = file_to_module(db, file)?.known(db)?;
-
-        candidates
-            .iter()
-            .copied()
-            .find(|&candidate| candidate.check_module(db, module))
+        let module = file_to_module(db, file)?;
+        let known_module = module.known(db);
+        let module_name = module.name(db);
+        candidates.iter().copied().find(|&candidate| {
+            if let Some(known) = known_module {
+                candidate.check_module(db, known)
+            } else {
+                candidate.check_django_module(module_name.as_str())
+            }
+        })
     }
 
     /// Return `true` if the module of `self` matches `module`
@@ -1605,6 +1632,17 @@ impl KnownClass {
             | Self::ProtocolMeta
             | Self::NewType => matches!(module, KnownModule::Typing | KnownModule::TypingExtensions),
             Self::Deprecated => matches!(module, KnownModule::Warnings | KnownModule::TypingExtensions),
+            Self::DjangoModel => false,
+        }
+    }
+
+    /// Return `true` if this class can come from the given third-party module name.
+    fn check_django_module(self, module_name: &str) -> bool {
+        match self {
+            Self::DjangoModel => {
+                module_name == "django.db.models" || module_name == "django.db.models.base"
+            }
+            _ => false,
         }
     }
 
@@ -1832,6 +1870,10 @@ mod tests {
                 source: PythonVersionSource::default(),
             });
         for class in KnownClass::iter() {
+            // Third-party; not in typeshed.
+            if class == KnownClass::DjangoModel {
+                continue;
+            }
             let class_name = class.name(&db);
             let class_module =
                 resolve_module_confident(&db, &class.canonical_module(&db).name()).unwrap();
@@ -1860,6 +1902,10 @@ mod tests {
             });
 
         for class in KnownClass::iter() {
+            if class == KnownClass::DjangoModel {
+                continue;
+            }
+
             // Check the class can be looked up successfully
             class.try_to_class_literal_without_logging(&db).unwrap();
 
@@ -1885,6 +1931,7 @@ mod tests {
         // This makes the test far faster as it minimizes the number of times
         // we need to change the Python version in the loop.
         let mut classes: Vec<(KnownClass, PythonVersion)> = KnownClass::iter()
+            .filter(|&class| class != KnownClass::DjangoModel)
             .map(|class| {
                 let version_added = match class {
                     KnownClass::Template => PythonVersion::PY314,

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -124,6 +124,16 @@ impl<'db> StaticClassLiteral<'db> {
         })
     }
 
+    /// Return `true` if this class inherits from `django.db.models.Model`.
+    #[salsa::tracked(cycle_initial=|_, _, _| false, heap_size=ruff_memory_usage::heap_size)]
+    pub(crate) fn is_django_model(self, db: &'db dyn Db) -> bool {
+        self.iter_mro(db, None).any(|base| {
+            base.into_class()
+                .and_then(|c| c.static_class_literal(db))
+                .is_some_and(|(lit, _)| lit.is_known(db, KnownClass::DjangoModel))
+        })
+    }
+
     /// Returns `true` if this class is a dataclass-like class.
     ///
     /// This covers `@dataclass`-decorated classes, as well as classes created via
@@ -341,7 +351,11 @@ impl<'db> StaticClassLiteral<'db> {
     /// ## Note
     /// Only call this function from queries in the same file or your
     /// query depends on the AST of another file (bad!).
-    fn node<'ast>(self, db: &'db dyn Db, module: &'ast ParsedModuleRef) -> &'ast ast::StmtClassDef {
+    pub(super) fn node<'ast>(
+        self,
+        db: &'db dyn Db,
+        module: &'ast ParsedModuleRef,
+    ) -> &'ast ast::StmtClassDef {
         let scope = self.body_scope(db);
         scope.node(db).expect_class().node(module)
     }
@@ -1134,6 +1148,15 @@ impl<'db> StaticClassLiteral<'db> {
                     return Member::definitely_declared(value_ty);
                 }
             }
+        }
+
+        // TODO(astral-sh/ty#1018): This override is needed for instance access because
+        // attribute resolution combines class-body and instance-member results. As a
+        // side-effect, class-level access (e.g. `Article.title`) also returns the
+        // synthesized instance type rather than the descriptor. This is technically
+        // wrong but acceptable until class-vs-instance access can be distinguished.
+        if let Some(ty) = super::django_model::synthesize_django_instance_member(db, self, name) {
+            return Member::definitely_declared(ty);
         }
 
         member
@@ -2265,6 +2288,12 @@ impl<'db> StaticClassLiteral<'db> {
         // TODO: There are many things that are not yet implemented here:
         // - `typing.Final`
         // - Proper diagnostics
+
+        // Django model fields are synthesized from AST-level field assignments
+        // (e.g. `title = CharField(...)`) rather than inferred from the descriptor type.
+        if let Some(ty) = super::django_model::synthesize_django_instance_member(db, self, name) {
+            return Member::definitely_declared(ty);
+        }
 
         let body_scope = self.body_scope(db);
         let table = place_table(db, body_scope);


### PR DESCRIPTION
## Summary

Part of https://github.com/astral-sh/ty/issues/1018

First of three planned PRs for Django model support. This one adds field scanning and instance member synthesis, so accessing `title = CharField(max_length=100)` on a model instance resolves to `str` rather than the raw descriptor.

`NamedTuple`, `TypedDict`, and dataclass synthesis all work through `own_synthesized_member`, which handles members that don't exist in the class body. Django fields do exist in the body as descriptor assignments, so I put the hooks in `own_instance_member` and `own_class_member` instead. The `own_class_member` hook is necessary because attribute resolution combines class-body and instance-member results; without it, instance access produces unions like `Unknown | CharField | str`. The downside is that class-level access (`Article.title`) also gets the synthesized type; I've left a TODO referencing ty#1018 for this.

`ManyToManyField` is deferred since it returns a manager rather than a model instance. Cross-app dotted FK references resolve to `Unknown`. Adds `KnownClass::DjangoModel` and `KnownModule::Datetime`/`Decimal`.

## Test Plan

Added mdtests.