### PR TITLE
[ty] fix PEP 695 type aliases in with statement

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/with/sync.md
+++ b/crates/ty_python_semantic/resources/mdtest/with/sync.md
@@ -40,6 +40,46 @@ def _(flag: bool):
         reveal_type(f)  # revealed: str | int
 ```
 
+## Type aliases preserve context manager behavior
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Self, TypeAlias
+from typing_extensions import TypeAliasType
+
+class A:
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None: ...
+
+class B:
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None: ...
+
+UnionAB1: TypeAlias = A | B
+type UnionAB2 = A | B
+UnionAB3 = TypeAliasType("UnionAB3", A | B)
+
+def f1(x: UnionAB1) -> None:
+    with x as y:
+        reveal_type(y)  # revealed: A | B
+
+def f2(x: UnionAB2) -> None:
+    with x as y:
+        reveal_type(y)  # revealed: A | B
+
+def f3(x: UnionAB3) -> None:
+    with x as y:
+        reveal_type(y)  # revealed: A | B
+```
+
 ## Context manager without an `__enter__` or `__exit__` method
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3284,6 +3284,10 @@ impl<'db> Type<'db> {
                     .member_lookup_with_policy(db, name, policy)
             }
 
+            Type::TypeAlias(alias) => alias
+                .value_type(db)
+                .member_lookup_with_policy(db, name, policy),
+
             _ if policy.no_instance_fallback() => self.invoke_descriptor_protocol(
                 db,
                 name_str,
@@ -3291,10 +3295,6 @@ impl<'db> Type<'db> {
                 InstanceFallbackShadowsNonDataDescriptor::No,
                 policy,
             ),
-
-            Type::TypeAlias(alias) => alias
-                .value_type(db)
-                .member_lookup_with_policy(db, name, policy),
 
             Type::LiteralValue(literal)
                 if literal.as_enum().is_some()


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/3213

Unpack PEP 695 type aliases earlier in member lookup, so that it takes effect for dunder lookups also.

## Test Plan

Added regression test.
