### PR TITLE
[ty] no special-casing for dataclasses.field if it's not in field_specifiers

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/fields.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/fields.md
@@ -198,19 +198,6 @@ c = Child(1, name="Alice")
 reveal_type(c._)  # revealed: int
 ```
 
-## The `field` function
-
-```py
-from dataclasses import field
-
-def get_default() -> str:
-    return "default"
-
-reveal_type(field(default=1))  # revealed: dataclasses.Field[Literal[1]]
-reveal_type(field(default=None))  # revealed: dataclasses.Field[None]
-reveal_type(field(default_factory=get_default))  # revealed: dataclasses.Field[str]
-```
-
 ## dataclass_transform field_specifiers
 
 If `field_specifiers` is not specified, it defaults to an empty tuple, meaning no field specifiers
@@ -219,7 +206,7 @@ are supported and `dataclasses.field` and `dataclasses.Field` should not be acce
 ```py
 from typing_extensions import dataclass_transform
 from dataclasses import field, dataclass
-from typing import TypeVar
+from typing import Any, TypeVar
 
 T = TypeVar("T")
 
@@ -233,8 +220,27 @@ def create_model(*, init: bool = True):
 class A:
     name: str = field(init=False)
 
-# field(init=False) should be ignored for dataclass_transform without explicit field_specifiers
-reveal_type(A.__init__)  # revealed: (self: A, name: str) -> None
+# Without explicit field_specifiers, field(init=False) is an ordinary default RHS.
+reveal_type(A.__init__)  # revealed: (self: A, name: str = ...) -> None
+
+class OtherFieldInfo:
+    def __init__(self, default: Any = None, **kwargs: Any) -> None: ...
+
+def other_field(default: Any = None, **kwargs: Any) -> OtherFieldInfo:
+    return OtherFieldInfo(default=default, **kwargs)
+
+@dataclass_transform(field_specifiers=(other_field, OtherFieldInfo))
+def create_model_with_other_specifiers(*, init: bool = True):
+    def deco(cls: type[T]) -> type[T]:
+        return cls
+    return deco
+
+@create_model_with_other_specifiers()
+class C:
+    name: str = field(init=False)
+
+# Even with other active field_specifiers, an unlisted RHS is an ordinary default value.
+reveal_type(C.__init__)  # revealed: (self: C, name: str = ...) -> None
 
 @dataclass
 class B:
@@ -247,8 +253,11 @@ reveal_type(B.__init__)  # revealed: (self: B) -> None
 Test constructor calls:
 
 ```py
-# This should NOT error because field(init=False) is ignored for A
+# These should NOT error because A's `field(...)` call is treated like any other default value
+A()
 A(name="foo")
+C()
+C(name="foo")
 
 # This should error because field(init=False) is respected for B
 # error: [unknown-argument]

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1364,9 +1364,8 @@ impl<'db> Bindings<'db> {
                         }
                     }
 
-                    function @ Type::FunctionLiteral(function_type)
-                        if dataclass_field_specifiers.contains(&function)
-                            || function_type.is_known(db, KnownFunction::Field) =>
+                    function @ Type::FunctionLiteral(_)
+                        if dataclass_field_specifiers.contains(&function) =>
                     {
                         // Helper to get the type of a keyword argument by name. We first try to get it from
                         // the parameter binding (for explicit parameters), and then fall back to checking the

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1789,20 +1789,10 @@ impl<'db> StaticClassLiteral<'db> {
                 let mut converter = None;
                 if let Some(Type::KnownInstance(KnownInstanceType::Field(field))) = default_ty {
                     default_ty = field.default_type(db);
-                    if self
-                        .dataclass_params(db)
-                        .map(|params| params.field_specifiers(db).is_empty())
-                        .unwrap_or(false)
-                    {
-                        // This happens when constructing a `dataclass` with a `dataclass_transform`
-                        // without defining the `field_specifiers`, meaning it should ignore
-                        // `dataclasses.field` and `dataclasses.Field`.
-                    } else {
-                        init = field.init(db);
-                        kw_only = field.kw_only(db);
-                        alias = field.alias(db);
-                        converter = field.converter(db);
-                    }
+                    init = field.init(db);
+                    kw_only = field.kw_only(db);
+                    alias = field.alias(db);
+                    converter = field.converter(db);
                 }
 
                 let kind = match field_policy {


### PR DESCRIPTION
Fixes https://github.com/astral-sh/ty/issues/3201

## Summary

A call to `dataclasses.field()` outside the context of a dataclass-transformed class where it is listed in `field_specifiers` of the dataclass-transformer (this of course includes the stdlib `dataclasses.dataclass` transformer) should not be special-cased. This was causing us to wrongly consider `field_name: ... = field(...)` as a field without a default, rather than a field with a default, when `field` was not listed in `field_specifiers`.

## Test Plan

Added/updated mdtests.
