### PR TITLE
Fix: mark SIM114 autofix as unsafe when comments would be lost

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM114.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM114.py
@@ -157,3 +157,35 @@ elif True:
     print(1)
 else:
     print(2)
+
+
+# See: https://github.com/astral-sh/ruff/issues/19576
+# Comments between branches should trigger an unsafe fix.
+if x == 1:
+    b
+# This is an important comment between branches
+elif x == 2:
+    b
+
+# Inline comment on the following elif test should trigger an unsafe fix.
+if x == 1:
+    b
+elif x == 2:  # trailing comment on elif
+    b
+
+# Comments in multi-line conditions should trigger an unsafe fix.
+if isinstance(exc, HTTPError) and (
+    exc.status == 408  # request timeout
+    or exc.status == 429  # too many requests
+):
+    b
+elif isinstance(exc, SSLError):
+    b
+
+# Differing body comments should trigger an unsafe fix.
+if x == 1:
+    # reason A
+    b
+elif x == 2:
+    # reason B
+    b

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
@@ -13,7 +13,7 @@ use ruff_text_size::{Ranged, TextRange};
 
 use crate::Locator;
 use crate::checkers::ast::Checker;
-use crate::{Edit, Fix, FixAvailability, Violation};
+use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 
 /// ## What it does
 /// Checks for `if` branches with identical arm bodies.
@@ -35,6 +35,13 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// if x == 1 or x == 2:
 ///     print("Hello")
 /// ```
+///
+/// ## Fix safety
+///
+/// This rule's fix is marked as unsafe if the `if`/`elif` branches contain
+/// comments that would be deleted by merging the branches (e.g., comments
+/// between the branches, inline comments on the condition, or differing
+/// comments in the bodies). Otherwise, the fix can be applied safely.
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.246")]
 pub(crate) struct IfWithSameArms;
@@ -73,7 +80,7 @@ pub(crate) fn if_with_same_arms(checker: &Checker, stmt_if: &ast::StmtIf) {
             continue;
         }
 
-        // ...and the same comments
+        // Check if body comments differ — if so, the fix removes comments
         let first_comments = checker
             .comment_ranges()
             .comments_in_range(body_range(&current_branch, checker.locator()))
@@ -84,9 +91,24 @@ pub(crate) fn if_with_same_arms(checker: &Checker, stmt_if: &ast::StmtIf) {
             .comments_in_range(body_range(following_branch, checker.locator()))
             .iter()
             .map(|range| checker.locator().slice(*range));
-        if !first_comments.eq(second_comments) {
-            continue;
-        }
+        let has_different_body_comments = !first_comments.eq(second_comments);
+
+        // Check for comments between the branches or on the following branch's
+        // test line (e.g., inline comments in conditions, trailing comments on
+        // the elif line). These would be lost when the fix merges the branches.
+        let has_non_body_comments = !checker
+            .comment_ranges()
+            .comments_in_range(TextRange::new(
+                checker.locator().full_line_end(current_branch.end()),
+                checker.locator().line_end(following_branch.test.end()),
+            ))
+            .is_empty();
+
+        let applicability = if has_different_body_comments || has_non_body_comments {
+            Applicability::Unsafe
+        } else {
+            Applicability::Safe
+        };
 
         let mut diagnostic = checker.report_diagnostic(
             IfWithSameArms,
@@ -100,6 +122,7 @@ pub(crate) fn if_with_same_arms(checker: &Checker, stmt_if: &ast::StmtIf) {
                 following_branch,
                 checker.locator(),
                 checker.tokens(),
+                applicability,
             )
         });
     }
@@ -112,6 +135,7 @@ fn merge_branches(
     following_branch: &IfElifBranch,
     locator: &Locator,
     tokens: &ruff_python_ast::token::Tokens,
+    applicability: Applicability,
 ) -> Result<Fix> {
     // Identify the colon (`:`) at the end of the current branch's test.
     let Some(current_branch_colon) =
@@ -164,9 +188,10 @@ fn merge_branches(
             None
         };
 
-    Ok(Fix::safe_edits(
+    Ok(Fix::applicable_edits(
         deletion_edit,
         parenthesize_edit.into_iter().chain(Some(insertion_edit)),
+        applicability,
     ))
 }
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM114_SIM114.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM114_SIM114.py.snap
@@ -47,6 +47,7 @@ help: Combine `if` branches
 8  |     b
 9  |
 10 | if x == 1:
+note: This is an unsafe fix and may change runtime behavior
 
 SIM114 [*] Combine `if` branches using logical `or` operator
   --> SIM114.py:12:1
@@ -316,6 +317,34 @@ help: Combine `if` branches
 74 |
 
 SIM114 [*] Combine `if` branches using logical `or` operator
+   --> SIM114.py:107:1
+    |
+105 |       errors = 1
+106 |
+107 | / if a:
+108 | |     # Ignore branches with diverging comments because it means we're repeating
+109 | |     # the bodies because we have different reasons for each branch
+110 | |     x = 1
+111 | | elif c:
+112 | |     x = 1
+    | |_________^
+    |
+help: Combine `if` branches
+104 | else:
+105 |     errors = 1
+106 |
+    - if a:
+107 + if a or c:
+108 |     # Ignore branches with diverging comments because it means we're repeating
+109 |     # the bodies because we have different reasons for each branch
+    -     x = 1
+    - elif c:
+110 |     x = 1
+111 |
+112 |
+note: This is an unsafe fix and may change runtime behavior
+
+SIM114 [*] Combine `if` branches using logical `or` operator
    --> SIM114.py:118:5
     |
 116 |       a = True
@@ -406,6 +435,7 @@ help: Combine `if` branches
 139 |     b
 140 |
 141 |
+note: This is an unsafe fix and may change runtime behavior
 
 SIM114 [*] Combine `if` branches using logical `or` operator
    --> SIM114.py:144:1
@@ -468,3 +498,108 @@ help: Combine `if` branches
 155 |     print(1)
 156 | else:
 157 |     print(2)
+
+SIM114 [*] Combine `if` branches using logical `or` operator
+   --> SIM114.py:164:1
+    |
+162 |   # See: https://github.com/astral-sh/ruff/issues/19576
+163 |   # Comments between branches should trigger an unsafe fix.
+164 | / if x == 1:
+165 | |     b
+166 | | # This is an important comment between branches
+167 | | elif x == 2:
+168 | |     b
+    | |_____^
+169 |
+170 |   # Inline comment on the following elif test should trigger an unsafe fix.
+    |
+help: Combine `if` branches
+161 |
+162 | # See: https://github.com/astral-sh/ruff/issues/19576
+163 | # Comments between branches should trigger an unsafe fix.
+    - if x == 1:
+    -     b
+    - # This is an important comment between branches
+    - elif x == 2:
+164 + if x == 1 or x == 2:
+165 |     b
+166 |
+167 | # Inline comment on the following elif test should trigger an unsafe fix.
+note: This is an unsafe fix and may change runtime behavior
+
+SIM114 [*] Combine `if` branches using logical `or` operator
+   --> SIM114.py:171:1
+    |
+170 |   # Inline comment on the following elif test should trigger an unsafe fix.
+171 | / if x == 1:
+172 | |     b
+173 | | elif x == 2:  # trailing comment on elif
+174 | |     b
+    | |_____^
+175 |
+176 |   # Comments in multi-line conditions should trigger an unsafe fix.
+    |
+help: Combine `if` branches
+168 |     b
+169 |
+170 | # Inline comment on the following elif test should trigger an unsafe fix.
+    - if x == 1:
+    -     b
+    - elif x == 2:  # trailing comment on elif
+171 + if x == 1 or x == 2:
+172 |     b
+173 |
+174 | # Comments in multi-line conditions should trigger an unsafe fix.
+note: This is an unsafe fix and may change runtime behavior
+
+SIM114 [*] Combine `if` branches using logical `or` operator
+   --> SIM114.py:177:1
+    |
+176 |   # Comments in multi-line conditions should trigger an unsafe fix.
+177 | / if isinstance(exc, HTTPError) and (
+178 | |     exc.status == 408  # request timeout
+179 | |     or exc.status == 429  # too many requests
+180 | | ):
+181 | |     b
+182 | | elif isinstance(exc, SSLError):
+183 | |     b
+    | |_____^
+184 |
+185 |   # Differing body comments should trigger an unsafe fix.
+    |
+help: Combine `if` branches
+177 | if isinstance(exc, HTTPError) and (
+178 |     exc.status == 408  # request timeout
+179 |     or exc.status == 429  # too many requests
+    - ):
+    -     b
+    - elif isinstance(exc, SSLError):
+180 + ) or isinstance(exc, SSLError):
+181 |     b
+182 |
+183 | # Differing body comments should trigger an unsafe fix.
+
+SIM114 [*] Combine `if` branches using logical `or` operator
+   --> SIM114.py:186:1
+    |
+185 |   # Differing body comments should trigger an unsafe fix.
+186 | / if x == 1:
+187 | |     # reason A
+188 | |     b
+189 | | elif x == 2:
+190 | |     # reason B
+191 | |     b
+    | |_____^
+    |
+help: Combine `if` branches
+183 |     b
+184 |
+185 | # Differing body comments should trigger an unsafe fix.
+    - if x == 1:
+186 + if x == 1 or x == 2:
+187 |     # reason A
+    -     b
+    - elif x == 2:
+    -     # reason B
+188 |     b
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Fixes #19576.

SIM114's autofix deletes comments when merging if/elif branches that have the same body. For example, a comment sitting between the two branches or a trailing comment on the elif line just gets silently dropped. The fix was marked as safe, so tools applying it automatically would lose those comments without warning.

This PR changes it so the fix is marked unsafe whenever comments would be lost — specifically:

- Comments between the branches (block comments before the elif)
- Inline/trailing comments on the elif line itself
- Cases where the two bodies have different comments inside them (previously these were just skipped entirely and no diagnostic was emitted)

The actual mechanism: instead of always using `Fix::safe_edits`, I check for comments in the range between the end of the current branch and the start of the following branch's body. If any are found (or if body comments differ), the fix gets `Applicability::Unsafe`. Otherwise it stays safe. This follows the same pattern as other rules like `starmap_zip`.

Added 4 test cases covering the different comment scenarios. Existing tests updated where the fix applicability changed from safe to unsafe.