### PR TITLE
docs(PLR0124): clarify that self-comparison behavior depends on __eq__

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
@@ -12,8 +12,9 @@ use crate::fix::snippet::SourceCodeSnippet;
 /// Checks for operations that compare a name to itself.
 ///
 /// ## Why is this bad?
-/// Comparing a name to itself always results in the same value, and is likely
-/// a mistake.
+/// For most objects, comparing a name to itself results in the same value,
+/// and is likely a mistake. Note that objects with a custom `__eq__`
+/// implementation (like `math.nan`) may not follow this pattern.
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
## Summary

This PR addresses the documentation issue raised in #22160.

### Changes

- Updated the `PLR0124` (comparison-with-itself) rule documentation to clarify that self-comparison behavior depends on the object's `__eq__` implementation
- Changed "always results in the same value" to "for most objects, comparing a name to itself results in the same value"
- Added a note about objects with custom `__eq__` implementations (like `math.nan`) that may not follow this pattern

### Motivation

As discussed in #22160, the previous wording ("always results in the same value") was technically inaccurate since Python objects can override `__eq__` to behave differently. The maintainer @MichaReiser suggested this change.

The updated documentation is more precise while still conveying that self-comparisons are usually a mistake.

Closes #22160