### PR TITLE
[ty] Fix type[T] inference for TypedDict protocol bounds

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1973,6 +1973,27 @@ def accepts_typed_dict_class(t_person: type[Person]) -> None:
 accepts_typed_dict_class(Person)
 ```
 
+## Protocol bounds
+
+`TypedDict` classes should also satisfy protocol bounds that model these special properties:
+
+```py
+from typing import ClassVar, Generic, Protocol, TypeVar, TypedDict
+
+class HasRequiredKeys(Protocol):
+    __required_keys__: ClassVar[frozenset[str]]
+
+T = TypeVar("T", bound=HasRequiredKeys)
+
+class Box(Generic[T]):
+    def __init__(self, value: type[T]) -> None: ...
+
+class D(TypedDict):
+    x: int
+
+reveal_type(Box(D))  # revealed: Box[D]
+```
+
 ## Subclassing
 
 `TypedDict` types can be subclassed. The subclass can add new keys:

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2171,8 +2171,23 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             (Type::SubclassOf(subclass_of), ty) | (ty, Type::SubclassOf(subclass_of))
                 if subclass_of.is_type_var() =>
             {
-                let formal_instance = Type::TypeVar(subclass_of.into_type_var().unwrap());
+                let bound_typevar = subclass_of.into_type_var().unwrap();
+                let formal_instance = Type::TypeVar(bound_typevar);
                 if let Some(actual_instance) = ty.to_instance(self.db) {
+                    if actual_instance.is_typed_dict()
+                        && let Some(TypeVarBoundOrConstraints::UpperBound(bound)) =
+                            bound_typevar.typevar(self.db).bound_or_constraints(self.db)
+                        && actual_instance
+                            .when_assignable_to(self.db, bound, self.constraints, self.inferable)
+                            .is_never_satisfied(self.db)
+                        && ty
+                            .when_assignable_to(self.db, bound, self.constraints, self.inferable)
+                            .is_always_satisfied(self.db)
+                    {
+                        self.add_type_mapping(bound_typevar, actual_instance, polarity, f);
+                        return Ok(());
+                    }
+
                     return self.infer_map_impl(
                         formal_instance,
                         actual_instance,


### PR DESCRIPTION
## Summary

My understanding after reasoning through this for a while (with limited prior experience around this part of the codebase): typically, when solving for `type[T]`, given a class, we convert to the instance of that class, then infer `T` from that instance type.

This fails specifically for cases like:

```python
class TypedDictLikeV1(Protocol):
    __required_keys__: ClassVar[frozenset[str]]
    __optional_keys__: ClassVar[frozenset[str]]
```

Because `__required_keys__` exists on the `TypedDict` class, but _not_ on instances, apparently:

```pycon
>>> from typing import TypedDict
>>> class Foo(TypedDict):
...     bar: int
...
>>> Foo.__required_keys__
frozenset({'bar'})
>>> Foo(bar=1).__required_keys__
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    Foo(bar=1).__required_keys__
AttributeError: 'dict' object has no attribute '__required_keys__'
```

This PR adds a special case to the specialization code for `TypedDict` such that if the instance doesn't satisfy the bound, but the class object does, we allow it to satisfy `type[T]`.

This does _not_ change protocol matching for instances, because if we did make the same change there, we'd be misrepresenting whether `__required_keys__` is available on `TypedDict` instances.

Closes https://github.com/astral-sh/ty/issues/2826.
