### PR TITLE
[flake8-bugbear] Fix `break`/`continue` handling in `loop-iterator-mutation` (`B909`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B909.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B909.py
@@ -273,3 +273,33 @@ def fail_try_finally(some_list):
             return
         finally:
             some_list.append(item)
+
+# should not error - `finally: return` unconditionally exits, so the `try`
+# body's mutation never reaches another iteration
+def pass_try_finally_return(items):
+    for item in items:
+        try:
+            items.append(item)
+        finally:
+            return
+
+# should error - nested loop's body has a `return` but no `break`, so the
+# outer mutation can reach another iteration if the `return` doesn't fire
+def fail_nested_return_bypasses_else(outer, inner):
+    for item in outer:
+        outer.append(item)
+        for y in inner:
+            if y:
+                return
+        else:
+            return
+
+# should error - nested loop's body can `raise`, which also skips `else`
+def fail_nested_raise_bypasses_else(outer, inner):
+    for item in outer:
+        outer.append(item)
+        for y in inner:
+            if y:
+                raise ValueError
+        else:
+            return

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
@@ -116,27 +116,32 @@ pub(crate) fn loop_iterator_mutation(checker: &Checker, stmt_for: &StmtFor) {
     }
 }
 
-/// Whether `body` contains a `break` that would exit the enclosing loop
-/// (not one inside a further-nested loop). When absent, the loop's `else`
-/// clause is guaranteed to run.
-fn body_has_reachable_break(body: &[Stmt]) -> bool {
-    let mut finder = BreakFinder::default();
+/// Whether `body` contains a `break`, `return`, or `raise` that would cause
+/// the enclosing loop's `else` clause to be skipped.
+///
+/// See [the Python tutorial on `else` clauses on loops][else-clauses].
+///
+/// [else-clauses]: https://docs.python.org/3/tutorial/controlflow.html#else-clauses-on-loops
+fn body_may_skip_else(body: &[Stmt]) -> bool {
+    let mut finder = SkipsElseFinder::default();
     finder.visit_body(body);
     finder.found
 }
 
 #[derive(Default)]
-struct BreakFinder {
+struct SkipsElseFinder {
     found: bool,
 }
 
-impl StatementVisitor<'_> for BreakFinder {
+impl StatementVisitor<'_> for SkipsElseFinder {
     fn visit_stmt(&mut self, stmt: &Stmt) {
         if self.found {
             return;
         }
         match stmt {
-            Stmt::Break(_) => self.found = true,
+            // `break`/`return`/`raise` all skip the enclosing loop's
+            // `else` clause; see Python docs on `else` clauses for loops.
+            Stmt::Break(_) | Stmt::Return(_) | Stmt::Raise(_) => self.found = true,
             // Don't look inside nested loop bodies, but do check their
             // `else` clause — a `break` there targets the enclosing loop.
             Stmt::For(StmtFor { orelse, .. }) | Stmt::While(StmtWhile { orelse, .. }) => {
@@ -148,6 +153,14 @@ impl StatementVisitor<'_> for BreakFinder {
             _ => statement_visitor::walk_stmt(self, stmt),
         }
     }
+}
+
+/// Whether `body` has an unconditional terminator at its top level.
+/// Used to decide if a `try` statement's `finally` clause always exits the
+/// enclosing control flow (loop or function).
+fn unconditionally_terminates(body: &[Stmt]) -> bool {
+    body.iter()
+        .any(|stmt| matches!(stmt, Stmt::Return(_) | Stmt::Raise(_) | Stmt::Break(_)))
 }
 
 /// Returns `true` if the method mutates when called on an iterator.
@@ -304,7 +317,10 @@ impl<'a> Visitor<'a> for LoopMutationsVisitor<'a> {
         for stmt in body {
             self.visit_stmt(stmt);
             // After a terminator, remaining statements are unreachable.
-            if matches!(stmt, Stmt::Break(_) | Stmt::Return(_) | Stmt::Continue(_)) {
+            if matches!(
+                stmt,
+                Stmt::Break(_) | Stmt::Return(_) | Stmt::Continue(_) | Stmt::Raise(_)
+            ) {
                 break;
             }
         }
@@ -353,10 +369,11 @@ impl<'a> Visitor<'a> for LoopMutationsVisitor<'a> {
                 self.loop_depth -= 1;
                 self.merge_branch_into(saved_branch);
 
-                // If the body never breaks, the else clause always runs,
-                // so a terminator there can clear earlier mutations.
+                // If the body may `break`, `return`, or `raise`, the `else`
+                // clause may not run, so its terminators must not clear
+                // mutations from the body.
                 if !orelse.is_empty() {
-                    if body_has_reachable_break(body) {
+                    if body_may_skip_else(body) {
                         self.enter_new_branch();
                         self.visit_body(orelse);
                         self.merge_branch_into(saved_branch);
@@ -381,7 +398,7 @@ impl<'a> Visitor<'a> for LoopMutationsVisitor<'a> {
                 self.merge_branch_into(saved_branch);
 
                 if !orelse.is_empty() {
-                    if body_has_reachable_break(body) {
+                    if body_may_skip_else(body) {
                         self.enter_new_branch();
                         self.visit_body(orelse);
                         self.merge_branch_into(saved_branch);
@@ -457,6 +474,16 @@ impl<'a> Visitor<'a> for LoopMutationsVisitor<'a> {
                     self.enter_new_branch();
                     self.visit_body(finalbody);
                     self.merge_branch_into(saved_branch);
+
+                    // If `finally` unconditionally terminates (e.g., ends in
+                    // `return`), the entire `try` statement always exits the
+                    // enclosing control flow, so earlier mutations never
+                    // reach another iteration.
+                    if unconditionally_terminates(finalbody)
+                        && let Some(mutations) = self.mutations.get_mut(&saved_branch)
+                    {
+                        mutations.clear();
+                    }
                 }
             }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B909_B909.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B909_B909.py.snap
@@ -502,4 +502,28 @@ B909 Mutation to loop iterable `some_list` during iteration
 274 |         finally:
 275 |             some_list.append(item)
     |             ^^^^^^^^^^^^^^^^
+276 |
+277 | # should not error - `finally: return` unconditionally exits, so the `try`
+    |
+
+B909 Mutation to loop iterable `outer` during iteration
+   --> B909.py:290:9
+    |
+288 | def fail_nested_return_bypasses_else(outer, inner):
+289 |     for item in outer:
+290 |         outer.append(item)
+    |         ^^^^^^^^^^^^
+291 |         for y in inner:
+292 |             if y:
+    |
+
+B909 Mutation to loop iterable `outer` during iteration
+   --> B909.py:300:9
+    |
+298 | def fail_nested_raise_bypasses_else(outer, inner):
+299 |     for item in outer:
+300 |         outer.append(item)
+    |         ^^^^^^^^^^^^
+301 |         for y in inner:
+302 |             if y:
     |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Fixes #12402.                               
 
B909's branch tracking had a few issues: the branch counter wasn't restored after if blocks, continue wasn't handled as a terminator, nested loop break/continue was incorrectly treated as exiting the outer loop, and there was no branch isolation for for/else, while/else, or try/except/else/finally.

Fixed by tracking loop_depth so nested break only affects the inner loop, giving each arm of forking statements its own branch (merged back into the parent on exit), and pre-scanning loop bodies to determine whether else is unconditional. 

## Test Plan

Added 8 fixture cases covering nested break/continue, for/else, while/else, and try/except/else/finally.
