### PR TITLE
Fix misleading SIM107 documentation example

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
@@ -33,8 +33,6 @@ use crate::checkers::ast::Checker;
 ///         return_value = n**2
 ///     except Exception:
 ///         return_value = "An exception occurred"
-///     finally:
-///         return_value = -1
 ///     return return_value
 /// ```
 ///


### PR DESCRIPTION
## Summary
- The "Use instead" example for SIM107 had `return_value = -1` in the `finally` block, which always overwrites whatever was set in `try` or `except` — making the "corrected" code behave identically to the bad example (always returning -1).
- Remove the `finally` block from the "Use instead" example so it actually demonstrates the correct pattern: assign in `try`/`except`, then return after the block.

Closes #22325

## Test plan
- Visual inspection of the doc comment change.
- No behavioral code changes; only documentation fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)