### PR TITLE
Add ContextVar caveat to RUF029 docs

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/unused_async.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unused_async.rs
@@ -30,6 +30,18 @@ use crate::rules::fastapi::rules::is_fastapi_route;
 /// def foo():
 ///     bar()
 /// ```
+///
+/// ## Note
+/// Removing `async` from a function changes the execution context it runs in.
+/// This can alter observable behavior when the function interacts with
+/// [`contextvars.ContextVar`]. Async tasks run in a *copy* of the parent
+/// context, so a `ContextVar.set()` inside an `async` function is invisible
+/// to the caller, whereas the same call in a regular (sync) function mutates
+/// the caller's context directly. If the function relies on this isolation
+/// (or lack thereof), removing `async` will change program semantics even
+/// though no `await` is present.
+///
+/// See [#23196](https://github.com/astral-sh/ruff/issues/23196) for more details.
 #[derive(ViolationMetadata)]
 #[violation_metadata(preview_since = "v0.4.0")]
 pub(crate) struct UnusedAsync {


### PR DESCRIPTION
## Summary
- Adds a "Note" section to the RUF029 (`unused-async`) rule documentation warning about `contextvars.ContextVar` edge cases
- Explains that removing `async` changes the execution context: async tasks run in a copy of the parent context, so `ContextVar.set()` behaves differently in sync vs async functions
- Links to the originating issue for further context

Closes #23196

## Test plan
- [ ] Verify the doc comment renders correctly in the generated documentation
- [ ] No code logic changes; documentation-only update

🤖 Generated with [Claude Code](https://claude.com/claude-code)