### PR TITLE
[ty] Respect mixed positional and keyword arguments in TypedDict constructor

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -475,6 +475,38 @@ Record({VALUE_KEY: "x"}, count=1)
 Record({VALUE_KEY: 1}, count=1)
 ```
 
+Keyword arguments should override a positional mapping, and `TypedDict` constructor inputs should
+preserve shared required keys:
+
+```py
+from typing import TypedDict
+
+class ChildWithOptionalCount(TypedDict, total=False):
+    count: int
+
+ChildWithOptionalCount({"count": "wrong"}, count=1)
+
+class Base(TypedDict):
+    name: str
+
+class ChildKwargs(TypedDict):
+    name: str
+    count: int
+
+class MaybeName(TypedDict, total=False):
+    name: str
+
+def _(
+    base: Base,
+    maybe_name: MaybeName,
+):
+    ChildKwargs(base, count=1)
+    ChildKwargs(**base, count=1)
+
+    # error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `ChildKwargs` constructor"
+    ChildKwargs(**maybe_name, count=1)
+```
+
 All of these are missing the required `age` field:
 
 ```py
@@ -588,6 +620,28 @@ a_person = {"name": "Alice", "age": 30, "extra": True}
 
 # error: [invalid-key] "Unknown key "extra" for TypedDict `Person`"
 (a_person := {"name": "Alice", "age": 30, "extra": True})
+```
+
+## Mixed positional and unpacked keyword constructors
+
+These calls mix a positional `TypedDict` argument with unpacked keyword arguments. They should
+validate normally and produce ordinary diagnostics:
+
+```py
+from typing import TypedDict
+
+class MixedTarget(TypedDict):
+    x: int
+    y: int
+
+class MaybeY(TypedDict, total=False):
+    y: int
+
+def _(target: MixedTarget, maybe_y: MaybeY):
+    MixedTarget(target, **maybe_y)
+
+    # error: [missing-typed-dict-key] "Missing required key 'y' in TypedDict `MixedTarget` constructor"
+    MixedTarget({"x": 1}, **maybe_y)
 ```
 
 ## Union of `TypedDict`

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -507,6 +507,81 @@ def _(
     ChildKwargs(**maybe_name, count=1)
 ```
 
+TypedDict positional arguments in mixed constructors should validate their declared keys:
+
+```py
+from typing import TypedDict
+
+class Target(TypedDict):
+    a: int
+    b: int
+
+class Source(TypedDict):
+    a: int
+
+class BadSource(TypedDict):
+    a: str
+
+class MaybeSource(TypedDict, total=False):
+    a: int
+
+class WiderSource(TypedDict):
+    a: int
+    extra: str
+
+class WiderBadSource(TypedDict):
+    a: str
+    extra: str
+
+def _(
+    source: Source,
+    bad: BadSource,
+    maybe: MaybeSource,
+    wide: WiderSource,
+    wide_bad: WiderBadSource,
+    cond: bool,
+):
+    Target(source, b=2)
+    Target(source if cond else {"a": 1}, b=2)
+    Target(source if cond else {"a": 1, "b": 0}, b=2)
+    Target(source if cond else {"a": 1, "b": "shadowed"}, b=2)
+    Target(wide, b=2)
+
+    # error: [invalid-argument-type] "Invalid argument to key "a" with declared type `int` on TypedDict `Target`: value of type `str`"
+    Target(bad, b=2)
+
+    # error: [invalid-argument-type] "Invalid argument to key "a" with declared type `int` on TypedDict `Target`: value of type `str`"
+    Target(wide_bad, b=2)
+
+    # error: [missing-typed-dict-key] "Missing required key 'a' in TypedDict `Target` constructor"
+    Target(maybe, b=2)
+```
+
+Mixed constructors should stay lenient for non-`TypedDict` positional mappings once the keyword
+arguments cover the full schema:
+
+```py
+from typing import TypedDict
+
+class FullFromKeywords(TypedDict):
+    a: int
+
+def _(mapping: dict[str, str]):
+    FullFromKeywords(mapping, a=1)
+```
+
+Conditional plain-dict positional mappings should not be validated as `TypedDict` literals:
+
+```py
+from typing import TypedDict
+
+class ConditionalTarget(TypedDict):
+    a: int
+
+def _(cond: bool):
+    ConditionalTarget({"x": 1} if cond else {}, a=1)
+```
+
 All of these are missing the required `age` field:
 
 ```py
@@ -628,7 +703,8 @@ These calls mix a positional `TypedDict` argument with unpacked keyword argument
 validate normally and produce ordinary diagnostics:
 
 ```py
-from typing import TypedDict
+from typing import Any, TypedDict
+from typing_extensions import Never
 
 class MixedTarget(TypedDict):
     x: int
@@ -637,8 +713,10 @@ class MixedTarget(TypedDict):
 class MaybeY(TypedDict, total=False):
     y: int
 
-def _(target: MixedTarget, maybe_y: MaybeY):
+def _(target: MixedTarget, maybe_y: MaybeY, kwargs: Any, never_kwargs: Never, cond: bool):
     MixedTarget(target, **maybe_y)
+    MixedTarget(maybe_y if cond else {}, **kwargs)
+    MixedTarget(maybe_y if cond else {}, **never_kwargs)
 
     # error: [missing-typed-dict-key] "Missing required key 'y' in TypedDict `MixedTarget` constructor"
     MixedTarget({"x": 1}, **maybe_y)

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -292,6 +292,20 @@ reveal_type(eve3a)  # revealed: Person
 reveal_type(eve3b)  # revealed: Person
 ```
 
+Constructor calls with multiple positional arguments should be rejected, including for empty
+`TypedDict`s:
+
+```py
+class Empty(TypedDict):
+    pass
+
+# error: [too-many-positional-arguments] "Too many positional arguments to TypedDict `Empty` constructor: expected 1, got 2"
+Empty({}, {})
+
+# error: [too-many-positional-arguments] "Too many positional arguments to TypedDict `Person` constructor: expected 1, got 2"
+Person({}, {})
+```
+
 Also, the value types ​​declared in a `TypedDict` affect generic call inference:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -584,18 +584,6 @@ def _(mapping: dict[str, str]):
     FullFromKeywords(mapping, a=1)
 ```
 
-Conditional plain-dict positional mappings should not be validated as `TypedDict` literals:
-
-```py
-from typing import TypedDict
-
-class ConditionalTarget(TypedDict):
-    a: int
-
-def _(cond: bool):
-    ConditionalTarget({"x": 1} if cond else {}, a=1)
-```
-
 All of these are missing the required `age` field:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -722,6 +722,20 @@ def _(target: MixedTarget, maybe_y: MaybeY, kwargs: Any, never_kwargs: Never, co
 
     # error: [missing-typed-dict-key] "Missing required key 'y' in TypedDict `MixedTarget` constructor"
     MixedTarget({"x": 1}, **maybe_y)
+
+class TD(TypedDict):
+    a: int
+
+def _(td: TD):
+    # TODO: this should pass like the explicit-keyword and `**TypedDict` cases below.
+    # error: [invalid-argument-type] "Invalid argument to key "a" with declared type `int` on TypedDict `TD`: value of type `Literal["foo"]`"
+    TD({"a": "foo"}, **{"a": 1})
+
+    TD({"a": "foo"}, a=1)
+    TD({"a": "foo"}, **td)
+
+def _(x: Any):
+    TD({"a": "foo"}, **x)
 ```
 
 ## Union of `TypedDict`

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -111,6 +111,8 @@ use ty_python_core::{
     place_table, unpack::UnpackPosition,
 };
 
+use self::typed_dict::{TypedDictConstructorBindingStrategy, TypedDictConstructorForm};
+
 mod annotation_expression;
 mod binary_expressions;
 mod class;
@@ -6721,7 +6723,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         call_arguments
     }
-
     fn infer_call_expression(
         &mut self,
         call_expression: &ast::ExprCall,
@@ -7039,32 +7040,36 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             &bindings,
         );
 
-        let is_typed_dict_constructor = class.is_some_and(|class| class.is_typed_dict(self.db()));
-        let has_mixed_typed_dict_literal_argument = is_typed_dict_constructor
-            && arguments.args.len() == 1
-            && arguments.args[0].is_dict_expr()
-            && !arguments.keywords.is_empty();
-
-        // Validate `TypedDict` constructor calls before general argument inference so the field
+        // Prepare `TypedDict` constructor calls before general argument inference so the field
         // type context becomes the canonical inference for constructor values.
-        if let Some(class) = class
-            && is_typed_dict_constructor
-        {
-            let typed_dict = TypedDictType::new(class);
-            self.infer_typed_dict_constructor_values(typed_dict, arguments, func.as_ref().into());
-        }
+        let typed_dict_binding_strategy =
+            class
+                .filter(|class| class.is_typed_dict(self.db()))
+                .map(|class| {
+                    let typed_dict = TypedDictType::new(class);
+                    let form = TypedDictConstructorForm::from_arguments(arguments);
+                    self.prepare_typed_dict_constructor(
+                        typed_dict,
+                        form,
+                        arguments,
+                        func.as_ref().into(),
+                    )
+                });
 
         let bindings_result = self.infer_and_check_argument_types(
             ArgumentsIter::from_ast(arguments),
             &mut call_arguments,
-            &mut |builder, (_, expr, tcx)| {
-                if has_mixed_typed_dict_literal_argument && expr.is_dict_expr() {
+            &mut |builder, (_, expr, tcx)| match typed_dict_binding_strategy {
+                Some(TypedDictConstructorBindingStrategy::SkipPreparedPositionalDictLiteral(
+                    dict_literal,
+                )) if expr.node_index().load() == dict_literal => {
                     builder.try_expression_type(expr).unwrap_or(Type::unknown())
-                } else if is_typed_dict_constructor {
-                    builder.get_or_infer_expression(expr, tcx)
-                } else {
-                    builder.infer_expression(expr, tcx)
                 }
+                Some(
+                    TypedDictConstructorBindingStrategy::ReusePreparedExpressions
+                    | TypedDictConstructorBindingStrategy::SkipPreparedPositionalDictLiteral(_),
+                ) => builder.get_or_infer_expression(expr, tcx),
+                None => builder.infer_expression(expr, tcx),
             },
             &mut bindings,
             call_expression_tcx,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -73,6 +73,9 @@ use crate::types::function::{
 use crate::types::generics::{InferableTypeVars, SpecializationBuilder, bind_typevar};
 use crate::types::infer::builder::named_tuple::NamedTupleKind;
 use crate::types::infer::builder::paramspec_validation::validate_paramspec_components;
+use crate::types::infer::builder::typed_dict::{
+    TypedDictConstructorBindingStrategy, TypedDictConstructorForm,
+};
 use crate::types::infer::{nearest_enclosing_class, nearest_enclosing_function};
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::newtype::NewType;
@@ -110,8 +113,6 @@ use ty_python_core::{
     ApplicableConstraints, EnclosingSnapshotResult, EvaluationMode, SemanticIndex, Truthiness,
     place_table, unpack::UnpackPosition,
 };
-
-use self::typed_dict::{TypedDictConstructorBindingStrategy, TypedDictConstructorForm};
 
 mod annotation_expression;
 mod binary_expressions;
@@ -6723,6 +6724,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         call_arguments
     }
+
     fn infer_call_expression(
         &mut self,
         call_expression: &ast::ExprCall,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7052,7 +7052,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     form,
                     arguments,
                     func.as_ref().into(),
-                )
+                );
             })
             .is_some();
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -73,9 +73,7 @@ use crate::types::function::{
 use crate::types::generics::{InferableTypeVars, SpecializationBuilder, bind_typevar};
 use crate::types::infer::builder::named_tuple::NamedTupleKind;
 use crate::types::infer::builder::paramspec_validation::validate_paramspec_components;
-use crate::types::infer::builder::typed_dict::{
-    TypedDictConstructorBindingStrategy, TypedDictConstructorForm,
-};
+use crate::types::infer::builder::typed_dict::TypedDictConstructorForm;
 use crate::types::infer::{nearest_enclosing_class, nearest_enclosing_function};
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::newtype::NewType;
@@ -7044,34 +7042,29 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // Prepare `TypedDict` constructor calls before general argument inference so the field
         // type context becomes the canonical inference for constructor values.
-        let typed_dict_binding_strategy =
-            class
-                .filter(|class| class.is_typed_dict(self.db()))
-                .map(|class| {
-                    let typed_dict = TypedDictType::new(class);
-                    let form = TypedDictConstructorForm::from_arguments(arguments);
-                    self.prepare_typed_dict_constructor(
-                        typed_dict,
-                        form,
-                        arguments,
-                        func.as_ref().into(),
-                    )
-                });
+        let has_prepared_typed_dict_constructor = class
+            .filter(|class| class.is_typed_dict(self.db()))
+            .map(|class| {
+                let typed_dict = TypedDictType::new(class);
+                let form = TypedDictConstructorForm::from_arguments(arguments);
+                self.prepare_typed_dict_constructor(
+                    typed_dict,
+                    form,
+                    arguments,
+                    func.as_ref().into(),
+                )
+            })
+            .is_some();
 
         let bindings_result = self.infer_and_check_argument_types(
             ArgumentsIter::from_ast(arguments),
             &mut call_arguments,
-            &mut |builder, (_, expr, tcx)| match typed_dict_binding_strategy {
-                Some(TypedDictConstructorBindingStrategy::SkipPreparedPositionalDictLiteral(
-                    dict_literal,
-                )) if expr.node_index().load() == dict_literal => {
-                    builder.try_expression_type(expr).unwrap_or(Type::unknown())
+            &mut |builder, (_, expr, tcx)| {
+                if has_prepared_typed_dict_constructor {
+                    builder.get_or_infer_expression(expr, tcx)
+                } else {
+                    builder.infer_expression(expr, tcx)
                 }
-                Some(
-                    TypedDictConstructorBindingStrategy::ReusePreparedExpressions
-                    | TypedDictConstructorBindingStrategy::SkipPreparedPositionalDictLiteral(_),
-                ) => builder.get_or_infer_expression(expr, tcx),
-                None => builder.infer_expression(expr, tcx),
             },
             &mut bindings,
             call_expression_tcx,

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -36,13 +36,19 @@ pub(super) enum TypedDictConstructorForm<'expr> {
     MixedLiteralAndKeywords(&'expr ast::ExprDict),
     /// // Ex) `TD(other, y=2)`
     MixedPositionalAndKeywords,
+    /// // Ex) `TD(arg1, arg2)`
+    MultiplePositionalArguments,
 }
 
 impl<'expr> TypedDictConstructorForm<'expr> {
     /// Return the constructor form for `arguments`.
     pub(super) fn from_arguments(arguments: &'expr ast::Arguments) -> Self {
         let [argument] = &arguments.args[..] else {
-            return Self::KeywordOnly;
+            return if arguments.args.is_empty() {
+                Self::KeywordOnly
+            } else {
+                Self::MultiplePositionalArguments
+            };
         };
 
         match (argument, arguments.keywords.is_empty()) {
@@ -392,7 +398,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             TypedDictConstructorForm::MixedLiteralAndKeywords(dict_expr) => {
                 self.infer_typed_dict_constructor_dict_literal_values(typed_dict, dict_expr);
             }
-            TypedDictConstructorForm::KeywordOnly => {}
+            TypedDictConstructorForm::KeywordOnly
+            | TypedDictConstructorForm::MultiplePositionalArguments => {}
         }
 
         if !arguments.keywords.is_empty() {
@@ -416,7 +423,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             TypedDictConstructorForm::KeywordOnly
             | TypedDictConstructorForm::LiteralOnly(_)
             | TypedDictConstructorForm::SinglePositional(_)
-            | TypedDictConstructorForm::MixedPositionalAndKeywords => {
+            | TypedDictConstructorForm::MixedPositionalAndKeywords
+            | TypedDictConstructorForm::MultiplePositionalArguments => {
                 TypedDictConstructorBindingStrategy::ReusePreparedExpressions
             }
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -22,6 +22,46 @@ use crate::types::{
 };
 use ty_python_core::definition::Definition;
 
+/// The shape of a `TypedDict` constructor call that affects how we prepare it for inference.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum TypedDictConstructorForm<'expr> {
+    /// // Ex) `TD(x=1)`
+    KeywordOnly,
+    /// // Ex) `TD({"x": 1})`
+    LiteralOnly(&'expr ast::Expr),
+    /// // Ex) `TD(other)`
+    SinglePositional(&'expr ast::Expr),
+    /// // Ex) `TD({"x": 1}, y=2)`
+    MixedLiteralAndKeywords(&'expr ast::ExprDict),
+    /// // Ex) `TD(other, y=2)`
+    MixedPositionalAndKeywords,
+}
+
+impl<'expr> TypedDictConstructorForm<'expr> {
+    /// Return the constructor form for `arguments`.
+    pub(super) fn from_arguments(arguments: &'expr ast::Arguments) -> Self {
+        let [argument] = &arguments.args[..] else {
+            return Self::KeywordOnly;
+        };
+
+        match (argument, arguments.keywords.is_empty()) {
+            (ast::Expr::Dict(_), true) => Self::LiteralOnly(argument),
+            (ast::Expr::Dict(dict_expr), false) => Self::MixedLiteralAndKeywords(dict_expr),
+            (_, true) => Self::SinglePositional(argument),
+            (_, false) => Self::MixedPositionalAndKeywords,
+        }
+    }
+}
+
+/// How general call binding should treat arguments after `TypedDict`-specific preparation.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum TypedDictConstructorBindingStrategy {
+    /// Reuse the cached results from `TypedDict`-specific preparation.
+    ReusePreparedExpressions,
+    /// Skip re-inferring the outer positional dict literal with this node index.
+    SkipPreparedPositionalDictLiteral(NodeIndex),
+}
+
 impl<'db> TypeInferenceBuilder<'db, '_> {
     /// Infer a `TypedDict(name, fields)` call expression.
     ///
@@ -298,31 +338,74 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         .map(|_| Type::TypedDict(typed_dict))
     }
 
-    /// Infer subexpressions of a `TypedDict` constructor call before general argument inference.
+    /// Prepare a `TypedDict` constructor call before general argument inference.
     ///
     /// This gives constructor values the declared field type as context, then validates the full
-    /// call once. A lone positional dict literal is inferred as a `TypedDict` expression directly,
-    /// while mixed dict-literal and keyword calls infer the nested key and value expressions
-    /// without re-inferring the outer dict literal later during argument binding.
-    pub(super) fn infer_typed_dict_constructor_values<'expr>(
+    /// call once when needed. A lone positional dict literal is inferred as a `TypedDict`
+    /// expression directly, while mixed dict-literal and keyword calls infer the nested key and
+    /// value expressions without re-inferring the outer dict literal later during argument
+    /// binding.
+    pub(super) fn prepare_typed_dict_constructor<'expr>(
         &mut self,
         typed_dict: TypedDictType<'db>,
+        form: TypedDictConstructorForm<'expr>,
         arguments: &'expr ast::Arguments,
         error_node: AnyNodeRef<'expr>,
-    ) {
-        if arguments.args.len() == 1 && arguments.keywords.is_empty() {
-            let target_ty = Type::TypedDict(typed_dict);
-            let argument = &arguments.args[0];
-            self.get_or_infer_expression(argument, TypeContext::new(Some(target_ty)));
-            if argument.is_dict_expr() {
-                return;
+    ) -> TypedDictConstructorBindingStrategy {
+        match form {
+            TypedDictConstructorForm::LiteralOnly(argument) => {
+                let target_ty = Type::TypedDict(typed_dict);
+                self.get_or_infer_expression(argument, TypeContext::new(Some(target_ty)));
+                return TypedDictConstructorBindingStrategy::ReusePreparedExpressions;
             }
-        } else if arguments.args.len() == 1
-            && let ast::Expr::Dict(dict_expr) = &arguments.args[0]
-        {
-            self.infer_typed_dict_constructor_dict_literal_values(typed_dict, dict_expr);
+            TypedDictConstructorForm::SinglePositional(argument) => {
+                let target_ty = Type::TypedDict(typed_dict);
+                self.get_or_infer_expression(argument, TypeContext::new(Some(target_ty)));
+            }
+            TypedDictConstructorForm::MixedLiteralAndKeywords(dict_expr) => {
+                self.infer_typed_dict_constructor_dict_literal_values(typed_dict, dict_expr);
+            }
+            TypedDictConstructorForm::MixedPositionalAndKeywords
+            | TypedDictConstructorForm::KeywordOnly => {}
         }
 
+        if !arguments.keywords.is_empty() {
+            self.infer_typed_dict_constructor_keyword_values(typed_dict, arguments);
+        }
+
+        validate_typed_dict_constructor(
+            &self.context,
+            typed_dict,
+            arguments,
+            error_node,
+            |expr, _| self.expression_type(expr),
+        );
+
+        match form {
+            TypedDictConstructorForm::MixedLiteralAndKeywords(dict_expr) => {
+                TypedDictConstructorBindingStrategy::SkipPreparedPositionalDictLiteral(
+                    dict_expr.node_index().load(),
+                )
+            }
+            TypedDictConstructorForm::KeywordOnly
+            | TypedDictConstructorForm::LiteralOnly(_)
+            | TypedDictConstructorForm::SinglePositional(_)
+            | TypedDictConstructorForm::MixedPositionalAndKeywords => {
+                TypedDictConstructorBindingStrategy::ReusePreparedExpressions
+            }
+        }
+    }
+
+    /// Infer keyword argument values for a `TypedDict` constructor.
+    ///
+    /// Named keywords are inferred against the declared type of the matching `TypedDict` field.
+    /// Unpacked `**kwargs` and unknown keys fall back to default inference because they do not
+    /// map to a single field declaration at this stage.
+    fn infer_typed_dict_constructor_keyword_values(
+        &mut self,
+        typed_dict: TypedDictType<'db>,
+        arguments: &ast::Arguments,
+    ) {
         let items = typed_dict.items(self.db());
         for keyword in &arguments.keywords {
             let value_tcx = keyword
@@ -333,14 +416,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .unwrap_or_default();
             self.get_or_infer_expression(&keyword.value, value_tcx);
         }
-
-        validate_typed_dict_constructor(
-            &self.context,
-            typed_dict,
-            arguments,
-            error_node,
-            |expr, _| self.expression_type(expr),
-        );
     }
 
     /// Infer the key and value expressions of a positional dict literal passed to a

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -60,15 +60,6 @@ impl<'expr> TypedDictConstructorForm<'expr> {
     }
 }
 
-/// How general call binding should treat arguments after `TypedDict`-specific preparation.
-#[derive(Debug, Clone, Copy)]
-pub(super) enum TypedDictConstructorBindingStrategy {
-    /// Reuse the cached results from `TypedDict`-specific preparation.
-    ReusePreparedExpressions,
-    /// Skip re-inferring the outer positional dict literal with this node index.
-    SkipPreparedPositionalDictLiteral(NodeIndex),
-}
-
 impl<'db> TypeInferenceBuilder<'db, '_> {
     /// Infer a `TypedDict(name, fields)` call expression.
     ///
@@ -358,12 +349,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         form: TypedDictConstructorForm<'expr>,
         arguments: &'expr ast::Arguments,
         error_node: AnyNodeRef<'expr>,
-    ) -> TypedDictConstructorBindingStrategy {
+    ) {
         match form {
             TypedDictConstructorForm::LiteralOnly(argument) => {
                 let target_ty = Type::TypedDict(typed_dict);
                 self.get_or_infer_expression(argument, TypeContext::new(Some(target_ty)));
-                return TypedDictConstructorBindingStrategy::ReusePreparedExpressions;
+                return;
             }
             TypedDictConstructorForm::SinglePositional(argument) => {
                 let target_ty = Type::TypedDict(typed_dict);
@@ -387,6 +378,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
             TypedDictConstructorForm::MixedLiteralAndKeywords(dict_expr) => {
                 self.infer_typed_dict_constructor_dict_literal_values(typed_dict, dict_expr);
+                self.store_expression_type(&arguments.args[0], Type::unknown());
             }
             TypedDictConstructorForm::KeywordOnly
             | TypedDictConstructorForm::MultiplePositionalArguments => {}
@@ -403,21 +395,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             error_node,
             |expr, _| self.expression_type(expr),
         );
-
-        match form {
-            TypedDictConstructorForm::MixedLiteralAndKeywords(dict_expr) => {
-                TypedDictConstructorBindingStrategy::SkipPreparedPositionalDictLiteral(
-                    dict_expr.node_index().load(),
-                )
-            }
-            TypedDictConstructorForm::KeywordOnly
-            | TypedDictConstructorForm::LiteralOnly(_)
-            | TypedDictConstructorForm::SinglePositional(_)
-            | TypedDictConstructorForm::MixedPositionalAndKeywords
-            | TypedDictConstructorForm::MultiplePositionalArguments => {
-                TypedDictConstructorBindingStrategy::ReusePreparedExpressions
-            }
-        }
     }
 
     /// Infer keyword argument values for a `TypedDict` constructor.

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -19,7 +19,7 @@ use crate::types::typed_dict::{
     validate_typed_dict_dict_literal,
 };
 use crate::types::{
-    IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictType, UnionType,
+    IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictType,
 };
 use ty_python_core::definition::Definition;
 
@@ -370,9 +370,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 self.get_or_infer_expression(argument, TypeContext::new(Some(target_ty)));
             }
             TypedDictConstructorForm::MixedPositionalAndKeywords => {
-                // Infer the positional argument against a schema that relaxes keys overridden by
-                // later keywords, while also keeping a plain-dict fallback available so conditional
-                // dict-literal branches don't eagerly validate as `TypedDict` literals.
                 let unpacked_keyword_types =
                     infer_unpacked_keyword_types(arguments, &mut |expr, tcx| {
                         self.get_or_infer_expression(expr, tcx)
@@ -385,14 +382,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 );
                 let positional_target =
                     typed_dict_with_relaxed_keys(self.db(), typed_dict, &keyword_keys);
-                let target_ty = UnionType::from_two_elements(
-                    self.db(),
-                    Type::TypedDict(positional_target),
-                    KnownClass::Dict.to_specialized_instance(
-                        self.db(),
-                        &[KnownClass::Str.to_instance(self.db()), Type::object()],
-                    ),
-                );
+                let target_ty = Type::TypedDict(positional_target);
                 self.get_or_infer_expression(&arguments.args[0], TypeContext::new(Some(target_ty)));
             }
             TypedDictConstructorForm::MixedLiteralAndKeywords(dict_expr) => {

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -14,11 +14,12 @@ use crate::types::diagnostic::{
 use crate::types::infer::builder::DeferredExpressionState;
 use crate::types::special_form::TypeQualifier;
 use crate::types::typed_dict::{
-    TypedDictSchema, functional_typed_dict_field, validate_typed_dict_constructor,
+    TypedDictSchema, collect_guaranteed_keyword_keys, functional_typed_dict_field,
+    infer_unpacked_keyword_types, typed_dict_with_relaxed_keys, validate_typed_dict_constructor,
     validate_typed_dict_dict_literal,
 };
 use crate::types::{
-    IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictType,
+    IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictType, UnionType,
 };
 use ty_python_core::definition::Definition;
 
@@ -362,11 +363,36 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let target_ty = Type::TypedDict(typed_dict);
                 self.get_or_infer_expression(argument, TypeContext::new(Some(target_ty)));
             }
+            TypedDictConstructorForm::MixedPositionalAndKeywords => {
+                // Infer the positional argument against a schema that relaxes keys overridden by
+                // later keywords, while also keeping a plain-dict fallback available so conditional
+                // dict-literal branches don't eagerly validate as `TypedDict` literals.
+                let unpacked_keyword_types =
+                    infer_unpacked_keyword_types(arguments, &mut |expr, tcx| {
+                        self.get_or_infer_expression(expr, tcx)
+                    });
+                let keyword_keys = collect_guaranteed_keyword_keys(
+                    self.db(),
+                    typed_dict,
+                    arguments,
+                    &unpacked_keyword_types,
+                );
+                let positional_target =
+                    typed_dict_with_relaxed_keys(self.db(), typed_dict, &keyword_keys);
+                let target_ty = UnionType::from_two_elements(
+                    self.db(),
+                    Type::TypedDict(positional_target),
+                    KnownClass::Dict.to_specialized_instance(
+                        self.db(),
+                        &[KnownClass::Str.to_instance(self.db()), Type::object()],
+                    ),
+                );
+                self.get_or_infer_expression(&arguments.args[0], TypeContext::new(Some(target_ty)));
+            }
             TypedDictConstructorForm::MixedLiteralAndKeywords(dict_expr) => {
                 self.infer_typed_dict_constructor_dict_literal_values(typed_dict, dict_expr);
             }
-            TypedDictConstructorForm::MixedPositionalAndKeywords
-            | TypedDictConstructorForm::KeywordOnly => {}
+            TypedDictConstructorForm::KeywordOnly => {}
         }
 
         if !arguments.keywords.is_empty() {

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -18,7 +18,7 @@ use super::diagnostic::{
 };
 use super::infer::infer_deferred_types;
 use super::{
-    ApplyTypeMappingVisitor, IntersectionType, Type, TypeMapping, TypeQualifiers,
+    ApplyTypeMappingVisitor, IntersectionType, Type, TypeMapping, TypeQualifiers, UnionBuilder,
     definition_expression_type, visitor,
 };
 use crate::Db;
@@ -823,12 +823,14 @@ struct UnpackedTypedDictKey<'db> {
 }
 
 /// Extracts `TypedDict` keys, their value types, and whether they are required when unpacked as
-/// `**kwargs`, resolving type aliases and handling intersections.
+/// `**kwargs`, resolving type aliases and handling intersections and unions.
 ///
 /// For intersections, returns ALL declared keys from ALL `TypedDict` types (union of keys),
 /// because unpacking a value of an intersection type may expose any key declared by any
 /// constituent `TypedDict`. For keys that appear in multiple `TypedDict`s, the value types are
 /// intersected, and the key is considered required if any constituent `TypedDict` requires it.
+/// For unions, returns all keys that may appear in any arm, unioning value types for shared keys,
+/// and a key is only considered required if every arm requires it.
 fn extract_unpacked_typed_dict_keys<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
@@ -883,8 +885,47 @@ fn extract_unpacked_typed_dict_keys<'db>(
 
             Some(result)
         }
-        // TODO: handle unions by checking all TypedDict elements separately
-        Type::Union(_) => None,
+        Type::Union(union) => {
+            let key_maps: Vec<_> = union
+                .elements(db)
+                .iter()
+                .map(|element| extract_unpacked_typed_dict_keys(db, *element))
+                .collect::<Option<_>>()?;
+
+            let all_keys: OrderSet<Name> = key_maps
+                .iter()
+                .flat_map(|key_map| key_map.keys().cloned())
+                .collect();
+            let mut result = BTreeMap::new();
+
+            for key in all_keys {
+                let mut value_ty = UnionBuilder::new(db);
+                let mut is_required = true;
+                let mut saw_key = false;
+
+                for key_map in &key_maps {
+                    if let Some(unpacked_key) = key_map.get(&key) {
+                        saw_key = true;
+                        value_ty = value_ty.add(unpacked_key.value_ty);
+                        is_required &= unpacked_key.is_required;
+                    } else {
+                        is_required = false;
+                    }
+                }
+
+                if saw_key {
+                    result.insert(
+                        key,
+                        UnpackedTypedDictKey {
+                            value_ty: value_ty.build(),
+                            is_required,
+                        },
+                    );
+                }
+            }
+
+            Some(result)
+        }
         Type::TypeAlias(alias) => extract_unpacked_typed_dict_keys(db, alias.value_type(db)),
         // All other types cannot contain a TypedDict
         Type::Dynamic(_)
@@ -917,6 +958,80 @@ fn extract_unpacked_typed_dict_keys<'db>(
     }
 }
 
+/// Infers each unpacked `**kwargs` constructor argument exactly once.
+///
+/// Mixed positional-and-keyword `TypedDict` construction needs to inspect unpacked keyword types
+/// in multiple validation passes. Precomputing them avoids re-inference in speculative builders.
+fn infer_unpacked_keyword_types<'db>(
+    arguments: &Arguments,
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+) -> Vec<Option<Type<'db>>> {
+    arguments
+        .keywords
+        .iter()
+        .map(|keyword| {
+            keyword
+                .arg
+                .is_none()
+                .then(|| expression_type_fn(&keyword.value, TypeContext::default()))
+        })
+        .collect()
+}
+
+/// Collects constructor keys that are guaranteed to be provided by keyword arguments.
+///
+/// Explicit keyword arguments always provide their key. For `**kwargs`, only required keys are
+/// guaranteed to be present; optional keys may be omitted at runtime and cannot suppress missing
+/// key diagnostics for the positional mapping.
+fn collect_guaranteed_keyword_keys<'db>(
+    db: &'db dyn Db,
+    arguments: &Arguments,
+    unpacked_keyword_types: &[Option<Type<'db>>],
+) -> OrderSet<Name> {
+    debug_assert_eq!(arguments.keywords.len(), unpacked_keyword_types.len());
+
+    let mut provided_keys: OrderSet<Name> = arguments
+        .keywords
+        .iter()
+        .filter_map(|keyword| keyword.arg.as_ref().map(|arg| arg.id.clone()))
+        .collect();
+
+    for unpacked_type in unpacked_keyword_types.iter().copied().flatten() {
+        if let Some(unpacked_keys) = extract_unpacked_typed_dict_keys(db, unpacked_type) {
+            provided_keys.extend(
+                unpacked_keys
+                    .into_iter()
+                    .filter_map(|(key, unpacked_key)| unpacked_key.is_required.then_some(key)),
+            );
+        }
+    }
+
+    provided_keys
+}
+
+/// Returns a `TypedDict` schema with `excluded_keys` removed.
+///
+/// This is used for mixed positional-and-keyword constructor calls, where guaranteed keyword
+/// arguments override any same-named keys from the positional mapping.
+fn typed_dict_without_keys<'db>(
+    db: &'db dyn Db,
+    typed_dict: TypedDictType<'db>,
+    excluded_keys: &OrderSet<Name>,
+) -> TypedDictType<'db> {
+    if excluded_keys.is_empty() {
+        return typed_dict;
+    }
+
+    let filtered_items = typed_dict
+        .items(db)
+        .iter()
+        .filter(|(name, _)| !excluded_keys.contains(*name))
+        .map(|(name, field)| (name.clone(), field.clone()))
+        .collect();
+
+    TypedDictType::from_schema_items(db, filtered_items)
+}
+
 pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
     context: &InferContext<'db, 'ast>,
     typed_dict: TypedDictType<'db>,
@@ -926,34 +1041,70 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
 ) {
     let db = context.db();
 
-    // Check for a single positional argument that is a dict literal
-    let has_positional_dict_literal = arguments.args.len() == 1 && arguments.args[0].is_dict_expr();
+    // Check for a single positional argument, and whether it's a dict literal.
+    let has_single_positional_arg = arguments.args.len() == 1;
+    let has_positional_dict_literal = has_single_positional_arg && arguments.args[0].is_dict_expr();
 
-    // Check for a single positional argument (not a dict literal)
-    let is_single_positional_arg =
-        arguments.args.len() == 1 && arguments.keywords.is_empty() && !has_positional_dict_literal;
+    let unpacked_keyword_types = infer_unpacked_keyword_types(arguments, &mut expression_type_fn);
 
-    if has_positional_dict_literal {
-        let mut provided_keys = validate_from_dict_literal(
+    if has_single_positional_arg && !arguments.keywords.is_empty() {
+        // Mixed positional-and-keyword construction: guaranteed keyword-provided keys override the
+        // positional mapping, so validate the positional argument against the remaining schema.
+        let keyword_keys = collect_guaranteed_keyword_keys(db, arguments, &unpacked_keyword_types);
+        let mut provided_keys = if has_positional_dict_literal {
+            validate_from_dict_literal(
+                context,
+                typed_dict,
+                arguments,
+                error_node,
+                &mut expression_type_fn,
+                &keyword_keys,
+            )
+        } else {
+            let arg = &arguments.args[0];
+            let arg_ty = expression_type_fn(arg, TypeContext::default());
+            let positional_target = typed_dict_without_keys(db, typed_dict, &keyword_keys);
+            let positional_target_ty = Type::TypedDict(positional_target);
+
+            if !arg_ty.is_assignable_to(db, positional_target_ty) {
+                if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, arg) {
+                    builder.into_diagnostic(format_args!(
+                        "Argument of type `{}` is not assignable to `{}`",
+                        arg_ty.display(db),
+                        positional_target_ty.display(db),
+                    ));
+                }
+            }
+
+            positional_target
+                .items(db)
+                .iter()
+                .filter_map(|(key_name, field)| field.is_required().then_some(key_name.clone()))
+                .collect()
+        };
+
+        provided_keys.extend(validate_from_keywords(
             context,
             typed_dict,
             arguments,
             error_node,
+            &unpacked_keyword_types,
             &mut expression_type_fn,
-        );
-
-        for key in validate_from_keywords(
-            context,
-            typed_dict,
-            arguments,
-            error_node,
-            &mut expression_type_fn,
-        ) {
-            provided_keys.insert(key);
-        }
-
+        ));
         validate_typed_dict_required_keys(context, typed_dict, &provided_keys, error_node);
-    } else if is_single_positional_arg {
+    } else if has_positional_dict_literal {
+        // Single positional dict literal: validate keys and value types directly from the literal,
+        // which also allows us to report extra keys that aren't in the `TypedDict` schema.
+        let provided_keys = validate_from_dict_literal(
+            context,
+            typed_dict,
+            arguments,
+            error_node,
+            &mut expression_type_fn,
+            &OrderSet::new(),
+        );
+        validate_typed_dict_required_keys(context, typed_dict, &provided_keys, error_node);
+    } else if has_single_positional_arg {
         // Single positional argument: check if assignable to the target TypedDict.
         // This handles TypedDict, intersections, unions, and type aliases correctly.
         // Assignability already checks for required keys and type compatibility,
@@ -972,11 +1123,14 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
             }
         }
     } else {
+        // Keyword-only construction: validate each keyword argument, then check for missing
+        // required keys.
         let provided_keys = validate_from_keywords(
             context,
             typed_dict,
             arguments,
             error_node,
+            &unpacked_keyword_types,
             &mut expression_type_fn,
         );
         validate_typed_dict_required_keys(context, typed_dict, &provided_keys, error_node);
@@ -991,6 +1145,7 @@ fn validate_from_dict_literal<'db, 'ast>(
     arguments: &'ast Arguments,
     typed_dict_node: AnyNodeRef<'ast>,
     expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+    ignored_keys: &OrderSet<Name>,
 ) -> OrderSet<Name> {
     let mut provided_keys = OrderSet::new();
     let items = typed_dict.items(context.db());
@@ -1003,6 +1158,9 @@ fn validate_from_dict_literal<'db, 'ast>(
                     expression_type_fn(key_expr, TypeContext::default()).as_string_literal()
             {
                 let key = key_value.value(context.db());
+                if ignored_keys.contains(key) {
+                    continue;
+                }
                 provided_keys.insert(Name::new(key));
 
                 let value_tcx = items
@@ -1037,10 +1195,12 @@ fn validate_from_keywords<'db, 'ast>(
     typed_dict: TypedDictType<'db>,
     arguments: &'ast Arguments,
     typed_dict_node: AnyNodeRef<'ast>,
+    unpacked_keyword_types: &[Option<Type<'db>>],
     expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) -> OrderSet<Name> {
     let db = context.db();
     let items = typed_dict.items(db);
+    debug_assert_eq!(arguments.keywords.len(), unpacked_keyword_types.len());
 
     // Collect keys from explicit keyword arguments
     let mut provided_keys: OrderSet<Name> = arguments
@@ -1050,7 +1210,11 @@ fn validate_from_keywords<'db, 'ast>(
         .collect();
 
     // Validate that each key is assigned a type that is compatible with the key's value type
-    for keyword in &arguments.keywords {
+    for (keyword, unpacked_type) in arguments
+        .keywords
+        .iter()
+        .zip(unpacked_keyword_types.iter().copied())
+    {
         if let Some(arg_name) = &keyword.arg {
             // Explicit keyword argument: e.g., `name="Alice"`
             let value_tcx = items
@@ -1076,7 +1240,9 @@ fn validate_from_keywords<'db, 'ast>(
             // Unlike positional TypedDict arguments, unpacking passes all keys as explicit
             // keyword arguments, so extra keys should be flagged as errors (consistent with
             // explicitly providing those keys).
-            let unpacked_type = expression_type_fn(&keyword.value, TypeContext::default());
+            let Some(unpacked_type) = unpacked_type else {
+                continue;
+            };
 
             // Never and Dynamic types are special: they can have any keys, so we skip
             // validation and mark all required keys as provided.

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -13,8 +13,8 @@ use ruff_text_size::Ranged;
 use super::class::{ClassLiteral, ClassType, CodeGeneratorKind, Field};
 use super::context::InferContext;
 use super::diagnostic::{
-    self, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, report_invalid_key_on_typed_dict,
-    report_missing_typed_dict_key,
+    self, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, TOO_MANY_POSITIONAL_ARGUMENTS,
+    report_invalid_key_on_typed_dict, report_missing_typed_dict_key,
 };
 use super::infer::infer_deferred_types;
 use super::{
@@ -1185,6 +1185,22 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
     mut expression_type_fn: impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) {
     let db = context.db();
+    let typed_dict_ty = Type::TypedDict(typed_dict);
+
+    if arguments.args.len() > 1 {
+        if let Some(builder) =
+            context.report_lint(&TOO_MANY_POSITIONAL_ARGUMENTS, &arguments.args[1])
+        {
+            builder.into_diagnostic(format_args!(
+                "Too many positional arguments to TypedDict `{}` constructor: expected 1, got {}",
+                typed_dict_ty.display(db),
+                arguments.args.len(),
+            ));
+        }
+        // TODO: Consider validating the first positional argument too, without producing
+        // duplicate TypedDict diagnostics for invalid multi-positional calls.
+        return;
+    }
 
     // Check for a single positional argument, and whether it's a dict literal.
     let has_single_positional_arg = arguments.args.len() == 1;
@@ -1273,15 +1289,14 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
         // Assignability already checks for required keys and type compatibility,
         // so we don't need separate validation.
         let arg = &arguments.args[0];
-        let target_ty = Type::TypedDict(typed_dict);
-        let arg_ty = expression_type_fn(arg, TypeContext::new(Some(target_ty)));
+        let arg_ty = expression_type_fn(arg, TypeContext::new(Some(typed_dict_ty)));
 
-        if !arg_ty.is_assignable_to(db, target_ty) {
+        if !arg_ty.is_assignable_to(db, typed_dict_ty) {
             if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, arg) {
                 builder.into_diagnostic(format_args!(
                     "Argument of type `{}` is not assignable to `{}`",
                     arg_ty.display(db),
-                    target_ty.display(db),
+                    typed_dict_ty.display(db),
                 ));
             }
         }

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1032,6 +1032,12 @@ fn typed_dict_without_keys<'db>(
     TypedDictType::from_schema_items(db, filtered_items)
 }
 
+/// Validates a `TypedDict` constructor call.
+///
+/// This handles keyword-only construction, a single positional mapping argument, and mixed
+/// positional-and-keyword calls. Dictionary literals are validated entry-by-entry so we can report
+/// extra keys and per-field type mismatches precisely; non-literal positional arguments fall back
+/// to assignability against the target `TypedDict`.
 pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
     context: &InferContext<'db, 'ast>,
     typed_dict: TypedDictType<'db>,
@@ -1062,9 +1068,9 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
             )
         } else {
             let arg = &arguments.args[0];
-            let arg_ty = expression_type_fn(arg, TypeContext::default());
             let positional_target = typed_dict_without_keys(db, typed_dict, &keyword_keys);
             let positional_target_ty = Type::TypedDict(positional_target);
+            let arg_ty = expression_type_fn(arg, TypeContext::new(Some(positional_target_ty)));
 
             if !arg_ty.is_assignable_to(db, positional_target_ty) {
                 if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, arg) {

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1004,6 +1004,9 @@ pub(super) fn collect_guaranteed_keyword_keys<'db>(
                     field.is_required().then_some(key_name.clone())
                 }),
             );
+        // TODO: also extract guaranteed keys from unpacked dict literals like `**{"a": 1}`.
+        // Today we only suppress positional-key diagnostics for explicit keywords and unpacked
+        // TypedDicts, which makes those literal-unpack cases inconsistent with equivalent calls.
         } else if let Some(unpacked_keys) = extract_unpacked_typed_dict_keys(db, unpacked_type) {
             provided_keys.extend(
                 unpacked_keys

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -962,7 +962,7 @@ fn extract_unpacked_typed_dict_keys<'db>(
 ///
 /// Mixed positional-and-keyword `TypedDict` construction needs to inspect unpacked keyword types
 /// in multiple validation passes. Precomputing them avoids re-inference in speculative builders.
-fn infer_unpacked_keyword_types<'db>(
+pub(super) fn infer_unpacked_keyword_types<'db>(
     arguments: &Arguments,
     expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) -> Vec<Option<Type<'db>>> {
@@ -983,8 +983,9 @@ fn infer_unpacked_keyword_types<'db>(
 /// Explicit keyword arguments always provide their key. For `**kwargs`, only required keys are
 /// guaranteed to be present; optional keys may be omitted at runtime and cannot suppress missing
 /// key diagnostics for the positional mapping.
-fn collect_guaranteed_keyword_keys<'db>(
+pub(super) fn collect_guaranteed_keyword_keys<'db>(
     db: &'db dyn Db,
+    typed_dict: TypedDictType<'db>,
     arguments: &Arguments,
     unpacked_keyword_types: &[Option<Type<'db>>],
 ) -> OrderSet<Name> {
@@ -997,7 +998,13 @@ fn collect_guaranteed_keyword_keys<'db>(
         .collect();
 
     for unpacked_type in unpacked_keyword_types.iter().copied().flatten() {
-        if let Some(unpacked_keys) = extract_unpacked_typed_dict_keys(db, unpacked_type) {
+        if unpacked_type.is_never() || unpacked_type.is_dynamic() {
+            provided_keys.extend(
+                typed_dict.items(db).iter().filter_map(|(key_name, field)| {
+                    field.is_required().then_some(key_name.clone())
+                }),
+            );
+        } else if let Some(unpacked_keys) = extract_unpacked_typed_dict_keys(db, unpacked_type) {
             provided_keys.extend(
                 unpacked_keys
                     .into_iter()
@@ -1013,7 +1020,7 @@ fn collect_guaranteed_keyword_keys<'db>(
 ///
 /// This is used for mixed positional-and-keyword constructor calls, where guaranteed keyword
 /// arguments override any same-named keys from the positional mapping.
-fn typed_dict_without_keys<'db>(
+pub(super) fn typed_dict_without_keys<'db>(
     db: &'db dyn Db,
     typed_dict: TypedDictType<'db>,
     excluded_keys: &OrderSet<Name>,
@@ -1030,6 +1037,138 @@ fn typed_dict_without_keys<'db>(
         .collect();
 
     TypedDictType::from_schema_items(db, filtered_items)
+}
+
+/// Returns a `TypedDict` schema for mixed positional-constructor inference.
+///
+/// Keys that are guaranteed to be overridden by later keyword arguments stay in the schema as
+/// optional `object` fields. This preserves missing-key context for the remaining fields while
+/// avoiding premature validation of shadowed keys inside nested dict-literal branches.
+pub(super) fn typed_dict_with_relaxed_keys<'db>(
+    db: &'db dyn Db,
+    typed_dict: TypedDictType<'db>,
+    relaxed_keys: &OrderSet<Name>,
+) -> TypedDictType<'db> {
+    if relaxed_keys.is_empty() {
+        return typed_dict;
+    }
+
+    let relaxed_items = typed_dict
+        .items(db)
+        .iter()
+        .map(|(name, field)| {
+            let mut field = field.clone();
+            if relaxed_keys.contains(name) {
+                field = field.with_required(false);
+                field.declared_ty = Type::object();
+            }
+            (name.clone(), field)
+        })
+        .collect();
+
+    TypedDictType::from_schema_items(db, relaxed_items)
+}
+
+fn full_object_ty_annotation(ty: Type<'_>) -> Option<Type<'_>> {
+    (ty.is_union() || ty.is_intersection()).then_some(ty)
+}
+
+/// AST nodes attached to a `TypedDict` key assignment diagnostic.
+///
+/// Example: for `Target(source, b=2)`, this bundles the full constructor call together with the
+/// expression nodes that should be highlighted for the key and value being validated.
+#[derive(Clone, Copy)]
+struct TypedDictAssignmentNodes<'ast> {
+    /// The outer `TypedDict` constructor or unpacking site.
+    ///
+    /// Example: this is the `Target(source, b=2)` call when validating a mixed constructor.
+    typed_dict: AnyNodeRef<'ast>,
+    /// The syntax node used to label the key location in diagnostics.
+    ///
+    /// Example: this is the `b=2` keyword for an explicit key, or the `source` expression when a
+    /// positional `TypedDict` supplies the key.
+    key: AnyNodeRef<'ast>,
+    /// The syntax node used to label the value location in diagnostics.
+    ///
+    /// Example: this is the `2` in `Target(source, b=2)`, or the `source` expression when the
+    /// positional argument provides both the key and value type information.
+    value: AnyNodeRef<'ast>,
+}
+
+/// Validates a set of extracted `TypedDict`-like keys against a constructor target.
+///
+/// This is shared by `**kwargs` validation and mixed constructor calls where the first positional
+/// argument is itself `TypedDict`-shaped. It reports per-key diagnostics using the supplied
+/// nodes and returns the subset of keys that are guaranteed to be present.
+fn validate_extracted_typed_dict_keys<'db, 'ast>(
+    context: &InferContext<'db, 'ast>,
+    typed_dict: TypedDictType<'db>,
+    unpacked_keys: &BTreeMap<Name, UnpackedTypedDictKey<'db>>,
+    nodes: TypedDictAssignmentNodes<'ast>,
+    full_object_ty: Option<Type<'db>>,
+    ignored_keys: &OrderSet<Name>,
+) -> OrderSet<Name> {
+    let mut provided_keys = OrderSet::new();
+
+    for (key_name, unpacked_key) in unpacked_keys {
+        if ignored_keys.contains(key_name) {
+            continue;
+        }
+        if unpacked_key.is_required {
+            provided_keys.insert(key_name.clone());
+        }
+        TypedDictKeyAssignment {
+            context,
+            typed_dict,
+            full_object_ty,
+            key: key_name.as_str(),
+            value_ty: unpacked_key.value_ty,
+            typed_dict_node: nodes.typed_dict,
+            key_node: nodes.key,
+            value_node: nodes.value,
+            assignment_kind: TypedDictAssignmentKind::Constructor,
+            emit_diagnostic: true,
+        }
+        .validate();
+    }
+
+    provided_keys
+}
+
+/// Validates a mixed-constructor positional argument when its type can be viewed as a `TypedDict`.
+///
+/// If `arg_ty` exposes concrete `TypedDict` keys, only keys that overlap the constructor target
+/// are validated directly. This preserves the structural leniency of positional `TypedDict`
+/// arguments while still checking declared keys precisely in mixed calls. Returns `None` when the
+/// argument is not `TypedDict`-shaped and the caller should fall back to ordinary assignability
+/// checks.
+fn validate_from_typed_dict_argument<'db, 'ast>(
+    context: &InferContext<'db, 'ast>,
+    typed_dict: TypedDictType<'db>,
+    arg: &'ast ast::Expr,
+    arg_ty: Type<'db>,
+    typed_dict_node: AnyNodeRef<'ast>,
+    ignored_keys: &OrderSet<Name>,
+) -> Option<OrderSet<Name>> {
+    let db = context.db();
+    let typed_dict_items = typed_dict.items(db);
+    let unpacked_keys = extract_unpacked_typed_dict_keys(db, arg_ty)?
+        .into_iter()
+        .filter(|(key_name, _)| typed_dict_items.contains_key(key_name))
+        .collect();
+
+    Some(validate_extracted_typed_dict_keys(
+        context,
+        typed_dict,
+        &unpacked_keys,
+        TypedDictAssignmentNodes {
+            typed_dict: typed_dict_node,
+            key: arg.into(),
+            value: arg.into(),
+        },
+        full_object_ty_annotation(arg_ty),
+        ignored_keys,
+    ))
 }
 
 /// Validates a `TypedDict` constructor call.
@@ -1056,7 +1195,8 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
     if has_single_positional_arg && !arguments.keywords.is_empty() {
         // Mixed positional-and-keyword construction: guaranteed keyword-provided keys override the
         // positional mapping, so validate the positional argument against the remaining schema.
-        let keyword_keys = collect_guaranteed_keyword_keys(db, arguments, &unpacked_keyword_types);
+        let keyword_keys =
+            collect_guaranteed_keyword_keys(db, typed_dict, arguments, &unpacked_keyword_types);
         let mut provided_keys = if has_positional_dict_literal {
             validate_from_dict_literal(
                 context,
@@ -1068,25 +1208,42 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
             )
         } else {
             let arg = &arguments.args[0];
+            let positional_inference_target =
+                typed_dict_with_relaxed_keys(db, typed_dict, &keyword_keys);
             let positional_target = typed_dict_without_keys(db, typed_dict, &keyword_keys);
+            let positional_target_is_empty = positional_target.items(db).is_empty();
             let positional_target_ty = Type::TypedDict(positional_target);
-            let arg_ty = expression_type_fn(arg, TypeContext::new(Some(positional_target_ty)));
+            let positional_inference_target_ty = Type::TypedDict(positional_inference_target);
+            let arg_ty =
+                expression_type_fn(arg, TypeContext::new(Some(positional_inference_target_ty)));
 
-            if !arg_ty.is_assignable_to(db, positional_target_ty) {
-                if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, arg) {
-                    builder.into_diagnostic(format_args!(
-                        "Argument of type `{}` is not assignable to `{}`",
-                        arg_ty.display(db),
-                        positional_target_ty.display(db),
-                    ));
+            if let Some(provided_keys) = validate_from_typed_dict_argument(
+                context,
+                typed_dict,
+                arg,
+                arg_ty,
+                error_node,
+                &keyword_keys,
+            ) {
+                provided_keys
+            } else {
+                if !positional_target_is_empty && !arg_ty.is_assignable_to(db, positional_target_ty)
+                {
+                    if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, arg) {
+                        builder.into_diagnostic(format_args!(
+                            "Argument of type `{}` is not assignable to `{}`",
+                            arg_ty.display(db),
+                            positional_target_ty.display(db),
+                        ));
+                    }
                 }
-            }
 
-            positional_target
-                .items(db)
-                .iter()
-                .filter_map(|(key_name, field)| field.is_required().then_some(key_name.clone()))
-                .collect()
+                positional_target
+                    .items(db)
+                    .iter()
+                    .filter_map(|(key_name, field)| field.is_required().then_some(key_name.clone()))
+                    .collect()
+            }
         };
 
         provided_keys.extend(validate_from_keywords(
@@ -1260,24 +1417,18 @@ fn validate_from_keywords<'db, 'ast>(
                 }
             } else if let Some(unpacked_keys) = extract_unpacked_typed_dict_keys(db, unpacked_type)
             {
-                for (key_name, unpacked_key) in &unpacked_keys {
-                    if unpacked_key.is_required {
-                        provided_keys.insert(key_name.clone());
-                    }
-                    TypedDictKeyAssignment {
-                        context,
-                        typed_dict,
-                        full_object_ty: None,
-                        key: key_name.as_str(),
-                        value_ty: unpacked_key.value_ty,
-                        typed_dict_node,
-                        key_node: keyword.into(),
-                        value_node: (&keyword.value).into(),
-                        assignment_kind: TypedDictAssignmentKind::Constructor,
-                        emit_diagnostic: true,
-                    }
-                    .validate();
-                }
+                provided_keys.extend(validate_extracted_typed_dict_keys(
+                    context,
+                    typed_dict,
+                    &unpacked_keys,
+                    TypedDictAssignmentNodes {
+                        typed_dict: typed_dict_node,
+                        key: keyword.into(),
+                        value: (&keyword.value).into(),
+                    },
+                    full_object_ty_annotation(unpacked_type),
+                    &OrderSet::new(),
+                ));
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR ensures that we allow the following by adding a path for mixed positional and keyword arguments:

```python
from typing import TypedDict

class Base(TypedDict):
    name: str

class ChildKwargs(TypedDict):
    name: str
    count: int

def _(base: Base):
    ok_union_mapping = ChildKwargs(base, count=1)
```

Closes https://github.com/astral-sh/ty/issues/3225.
