### PR TITLE
[ty] Preserve constrained TypeVar mappings at ** call sites

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2060,6 +2060,72 @@ def _(t: type[Foo | Bar]) -> None:
     t(a="baz")
 ```
 
+## Constrained class-object constructors
+
+Constrained `type[T]` constructor calls keep the relationship between the constructor target and
+other arguments typed as the same `T`:
+
+```py
+from typing import TypeVar, TypedDict
+
+class Foo(TypedDict):
+    foo: int
+
+class Bar(TypedDict):
+    bar: int
+
+T = TypeVar("T", Foo, Bar)
+
+def _(t: type[T], kwargs: T) -> None:
+    t(**kwargs)
+```
+
+The same unpacked key information should be preserved at ordinary `**kwargs` call sites:
+
+```py
+from typing import TypeVar, TypedDict
+
+class Foo(TypedDict):
+    foo: int
+
+class Bar(TypedDict):
+    bar: str
+
+class MaybeFoo(TypedDict, total=False):
+    foo: int
+
+class BadBar(TypedDict):
+    bar: int
+
+T = TypeVar("T", Foo, Bar)
+U = TypeVar("U", Foo, BadBar)
+
+def needs_both(*, foo: int, bar: str) -> None:
+    pass
+
+def needs_foo(*, foo: int) -> None:
+    pass
+
+def foo_only(*, foo: int = 0) -> None:
+    pass
+
+def typed_bar(*, foo: int = 0, bar: str = "") -> None:
+    pass
+
+def _(kwargs: T, maybe_foo: MaybeFoo, other_kwargs: U) -> None:
+    # error: [missing-argument] "No arguments provided for required parameters `foo`, `bar` of function `needs_both`"
+    needs_both(**kwargs)
+
+    # error: [missing-argument] "No argument provided for required parameter `foo` of function `needs_foo`"
+    needs_foo(**maybe_foo)
+
+    # error: [unknown-argument] "Argument `bar` does not match any known parameter of function `foo_only`"
+    foo_only(**kwargs)
+
+    # error: [invalid-argument-type] "Argument to function `typed_bar` is incorrect"
+    typed_bar(**other_kwargs)
+```
+
 Upper-bounded `type[T]` constructor calls still validate the bound `TypedDict` schema:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -408,6 +408,38 @@ accepts_person({"name": "Alice", "age": 30})
 house.owner = {"name": "Alice", "age": 30}
 ```
 
+Keyword arguments should override a positional mapping, and `TypedDict` constructor inputs should
+preserve shared required keys:
+
+```py
+from typing import TypedDict
+
+class ChildWithOptionalCount(TypedDict, total=False):
+    count: int
+
+ChildWithOptionalCount({"count": "wrong"}, count=1)
+
+class Base(TypedDict):
+    name: str
+
+class ChildKwargs(TypedDict):
+    name: str
+    count: int
+
+class MaybeName(TypedDict, total=False):
+    name: str
+
+def _(
+    base: Base,
+    maybe_name: MaybeName,
+):
+    ChildKwargs(base, count=1)
+    ChildKwargs(**base, count=1)
+
+    # error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `ChildKwargs` constructor"
+    ChildKwargs(**maybe_name, count=1)
+```
+
 All of these are missing the required `age` field:
 
 ```py
@@ -521,6 +553,28 @@ a_person = {"name": "Alice", "age": 30, "extra": True}
 
 # error: [invalid-key] "Unknown key "extra" for TypedDict `Person`"
 (a_person := {"name": "Alice", "age": 30, "extra": True})
+```
+
+## Mixed positional and unpacked keyword constructors
+
+These calls mix a positional `TypedDict` argument with unpacked keyword arguments. They should
+validate normally and produce ordinary diagnostics:
+
+```py
+from typing import TypedDict
+
+class MixedTarget(TypedDict):
+    x: int
+    y: int
+
+class MaybeY(TypedDict, total=False):
+    y: int
+
+def _(target: MixedTarget, maybe_y: MaybeY):
+    MixedTarget(target, **maybe_y)
+
+    # error: [missing-typed-dict-key] "Missing required key 'y' in TypedDict `MixedTarget` constructor"
+    MixedTarget({"x": 1}, **maybe_y)
 ```
 
 ## Union of `TypedDict`

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2398,25 +2398,30 @@ def _(node: Node, person: Person):
 _: Node = Person(name="Alice", parent=Node(name="Bob", parent=Person(name="Charlie", parent=None)))
 ```
 
-TypedDict constructor calls should also use field type context when inferring nested recursive
-values:
+TypedDict constructor calls should also use field type context when inferring nested values:
 
 ```py
-from typing import Any, List, TypedDict, Union
-from typing_extensions import NotRequired
+from typing import TypedDict
 
 class Comparison(TypedDict):
     field: str
-    op: NotRequired[str]
-    value: Any
+    value: object
 
 class Logical(TypedDict):
-    op: NotRequired[str]
-    conditions: List["Filter"]
+    primary: Comparison
+    conditions: list[Comparison]
 
-Filter = Union[Comparison, Logical]
+logical_from_literal = Logical(
+    primary=Comparison(field="a", value="b"),
+    conditions=[Comparison(field="c", value="d")],
+)
+logical_from_dict_call = Logical(dict(primary=dict(field="a", value="b"), conditions=[dict(field="c", value="d")]))
 
-logical = Logical(conditions=[Comparison(field="a", value="b")])
+# error: [missing-typed-dict-key]
+missing_primary_from_dict_call = Logical(primary=dict(field="a"), conditions=[dict(field="c", value="d")])
+
+# error: [missing-typed-dict-key]
+missing_primary_from_literal = Logical(primary={"field": "a"}, conditions=[dict(field="c", value="d")])
 ```
 
 ## Function/assignment syntax

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2398,6 +2398,27 @@ def _(node: Node, person: Person):
 _: Node = Person(name="Alice", parent=Node(name="Bob", parent=Person(name="Charlie", parent=None)))
 ```
 
+TypedDict constructor calls should also use field type context when inferring nested recursive
+values:
+
+```py
+from typing import Any, List, TypedDict, Union
+from typing_extensions import NotRequired
+
+class Comparison(TypedDict):
+    field: str
+    op: NotRequired[str]
+    value: Any
+
+class Logical(TypedDict):
+    op: NotRequired[str]
+    conditions: List["Filter"]
+
+Filter = Union[Comparison, Logical]
+
+logical = Logical(conditions=[Comparison(field="a", value="b")])
+```
+
 ## Function/assignment syntax
 
 TypedDicts can be created using the functional syntax:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2043,6 +2043,38 @@ def accepts_typed_dict_class(t_person: type[Person]) -> None:
 accepts_typed_dict_class(Person)
 ```
 
+Calling a union of `TypedDict` class objects validates each constructor arm:
+
+```py
+from typing import TypedDict
+
+class Foo(TypedDict):
+    a: int
+
+class Bar(TypedDict):
+    a: int
+
+def _(t: type[Foo | Bar]) -> None:
+    # error: [invalid-argument-type] "Invalid argument to key "a" with declared type `int` on TypedDict `Foo`: value of type `Literal["baz"]`"
+    # error: [invalid-argument-type] "Invalid argument to key "a" with declared type `int` on TypedDict `Bar`: value of type `Literal["baz"]`"
+    t(a="baz")
+```
+
+Upper-bounded `type[T]` constructor calls still validate the bound `TypedDict` schema:
+
+```py
+from typing import TypeVar, TypedDict
+
+class NeedsInt(TypedDict):
+    a: int
+
+T = TypeVar("T", bound=NeedsInt)
+
+def _(t: type[T]) -> None:
+    # error: [invalid-argument-type] "Invalid argument to key "a" with declared type `int` on TypedDict `NeedsInt`: value of type `Literal["x"]`"
+    t(a="x")
+```
+
 ## Subclassing
 
 `TypedDict` types can be subclassed. The subclass can add new keys:

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -48,6 +48,7 @@ use crate::types::signatures::{
     CallableSignature, Parameter, ParameterForm, ParameterKind, Parameters,
 };
 use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
+use crate::types::typed_dict::{double_starred_key_and_value_types, unpacked_typed_dict_keys};
 use crate::types::typevar::BoundTypeVarIdentity;
 use crate::types::{
     BoundMethodType, BoundTypeVarInstance, CallableType, ClassLiteral, DATACLASS_FLAGS,
@@ -3538,9 +3539,36 @@ impl ArgumentForms {
     }
 }
 
+/// Tracks how confidently a parameter has been provided by the current argument list.
+///
+/// This is primarily used for `**kwargs` matching, where a `TypedDict`-shaped source may expose a
+/// key only on some arms or only optionally.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum ParameterProvision {
+    /// No argument has been matched to this parameter.
+    #[default]
+    Absent,
+    /// An argument may provide this parameter, but it is not guaranteed to do so.
+    Possible,
+    /// An argument definitely provides this parameter.
+    Definite,
+}
+
+impl ParameterProvision {
+    /// Returns `true` if the parameter participates in argument matching and type checking.
+    const fn is_matched(self) -> bool {
+        !matches!(self, Self::Absent)
+    }
+
+    /// Returns `true` if this provision is strong enough to suppress `missing-argument`.
+    const fn satisfies_missing_argument(self) -> bool {
+        matches!(self, Self::Definite)
+    }
+}
+
 #[derive(Default, Clone, Copy)]
 struct ParameterInfo {
-    matched: bool,
+    provision: ParameterProvision,
     suppress_missing_error: bool,
 }
 
@@ -3631,6 +3659,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         parameter: &Parameter<'db>,
         positional: bool,
         variable_argument_length: bool,
+        provision: ParameterProvision,
     ) {
         if !matches!(argument, Argument::Synthetic) {
             let adjusted_argument_index = argument_index - self.num_synthetic_args;
@@ -3643,7 +3672,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                 }
             }
         }
-        if self.parameter_info[parameter_index].matched {
+        if self.parameter_info[parameter_index].provision.is_matched() {
             if !parameter.is_variadic() && !parameter.is_keyword_variadic() {
                 self.errors.push(BindingError::ParameterAlreadyAssigned {
                     argument_index: self.get_argument_index(argument_index),
@@ -3664,7 +3693,9 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         matched_argument.parameters.push(parameter_index);
         matched_argument.types.push(argument_type);
         matched_argument.matched = true;
-        self.parameter_info[parameter_index].matched = true;
+        self.parameter_info[parameter_index].provision = self.parameter_info[parameter_index]
+            .provision
+            .max(provision);
     }
 
     fn match_positional(
@@ -3696,6 +3727,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             parameter,
             !parameter.is_variadic(),
             variable_argument_length,
+            ParameterProvision::Definite,
         );
         Ok(())
     }
@@ -3706,6 +3738,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         argument: Argument<'a>,
         argument_type: Option<Type<'db>>,
         name: &str,
+        provision: ParameterProvision,
     ) -> Result<(), ()> {
         let Some((parameter_index, parameter)) = self
             .parameters
@@ -3737,6 +3770,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             parameter,
             false,
             false,
+            provision,
         );
         Ok(())
     }
@@ -3970,19 +4004,29 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         argument_index: usize,
         argument_type: Option<Type<'db>>,
     ) {
-        if let Some(Type::TypedDict(typed_dict)) = argument_type {
-            // Special case TypedDict because we know which keys are present.
-            for (name, field) in typed_dict.items(db) {
+        if let Some(argument_type) = argument_type
+            && let Some(unpacked_keys) = unpacked_typed_dict_keys(db, argument_type)
+        {
+            // Special case TypedDict-shaped kwargs because we know which keys may be present.
+            // Keys that are not required in every arm still participate in duplicate and type
+            // checking, but they cannot satisfy a required parameter on their own.
+            for (name, unpacked_key) in unpacked_keys {
                 let _ = self.match_keyword(
                     argument_index,
                     Argument::Keywords,
-                    Some(field.declared_ty),
+                    Some(unpacked_key.value_ty),
                     name.as_str(),
+                    if unpacked_key.is_required {
+                        ParameterProvision::Definite
+                    } else {
+                        ParameterProvision::Possible
+                    },
                 );
             }
         } else {
             for (parameter_index, parameter) in self.parameters.iter().enumerate() {
-                if self.parameter_info[parameter_index].matched && !parameter.is_keyword_variadic()
+                if self.parameter_info[parameter_index].provision.is_matched()
+                    && !parameter.is_keyword_variadic()
                 {
                     continue;
                 }
@@ -4015,6 +4059,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                     parameter,
                     false,
                     true,
+                    ParameterProvision::Definite,
                 );
             }
         }
@@ -4038,12 +4083,12 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         for (
             index,
             ParameterInfo {
-                matched,
+                provision,
                 suppress_missing_error,
             },
         ) in self.parameter_info.iter().copied().enumerate()
         {
-            if !matched {
+            if !provision.satisfies_missing_argument() {
                 if suppress_missing_error {
                     continue;
                 }
@@ -4759,72 +4804,36 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         argument: Argument<'a>,
         argument_type: Type<'db>,
     ) {
-        if let Type::TypedDict(typed_dict) = argument_type {
-            for (argument_type, parameter_index) in typed_dict
-                .items(self.db)
-                .values()
-                .map(|field| field.declared_ty)
-                .zip(&self.argument_matches[argument_index].parameters)
-            {
-                self.check_argument_type(
-                    constraints,
-                    argument_index,
-                    adjusted_argument_index,
-                    argument,
-                    argument_type,
-                    *parameter_index,
-                );
-            }
+        if argument_type.as_paramspec_typevar(self.db).is_none() {
+            let Some((key_type, _)) = double_starred_key_and_value_types(self.db, argument_type)
+            else {
+                return;
+            };
 
-            return;
+            if !key_type
+                .when_assignable_to(
+                    self.db,
+                    KnownClass::Str.to_instance(self.db),
+                    constraints,
+                    self.inferable_typevars,
+                )
+                .is_always_satisfied(self.db)
+            {
+                self.errors.push(BindingError::InvalidKeyType {
+                    argument_index: adjusted_argument_index,
+                    provided_ty: key_type,
+                });
+            }
         }
 
-        let value_type_paramspec =
-            if let Some(paramspec) = argument_type.as_paramspec_typevar(self.db) {
-                Some(paramspec)
-            } else {
-                let Some((key_type, _)) = argument_type.unpack_keys_and_items(self.db) else {
-                    return;
-                };
-
-                if !key_type
-                    .when_assignable_to(
-                        self.db,
-                        KnownClass::Str.to_instance(self.db),
-                        constraints,
-                        self.inferable_typevars,
-                    )
-                    .is_always_satisfied(self.db)
-                {
-                    self.errors.push(BindingError::InvalidKeyType {
-                        argument_index: adjusted_argument_index,
-                        provided_ty: key_type,
-                    });
-                }
-
-                None
-            };
-
-        for parameter_index in &self.argument_matches[argument_index].parameters {
-            let value_type = if let Some(value_type) = value_type_paramspec {
-                value_type
-            } else {
-                let parameter_name = self.signature.parameters()[*parameter_index]
-                    .keyword_name()
-                    .map(Name::as_str);
-
-                argument_type
-                    .getitem_dunder_call(self.db, parameter_name)
-                    .unwrap_or(Type::unknown())
-            };
-
+        for (parameter_index, value_type) in self.argument_matches[argument_index].iter() {
             self.check_argument_type(
                 constraints,
                 argument_index,
                 adjusted_argument_index,
-                Argument::Keywords,
-                value_type,
-                *parameter_index,
+                argument,
+                value_type.unwrap_or_else(Type::unknown),
+                parameter_index,
             );
         }
     }
@@ -4966,7 +4975,13 @@ impl<'db> Binding<'db> {
                     let _ = matcher.match_positional(argument_index, argument, None, false);
                 }
                 Argument::Keyword(name) => {
-                    let _ = matcher.match_keyword(argument_index, argument, None, name);
+                    let _ = matcher.match_keyword(
+                        argument_index,
+                        argument,
+                        None,
+                        name,
+                        ParameterProvision::Definite,
+                    );
                 }
                 Argument::Variadic => {
                     let _ = matcher.match_variadic(

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6888,14 +6888,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             call_expression_tcx,
         );
 
+        let typed_dict_constructor_targets =
+            self.collect_typed_dict_constructor_targets(callable_type);
+
         // Validate `TypedDict` constructor calls after argument type inference.
-        if let Some(class) = class
-            && class.is_typed_dict(self.db())
-        {
+        for typed_dict in typed_dict_constructor_targets {
             let mut speculative = self.speculate();
             validate_typed_dict_constructor(
                 &self.context,
-                TypedDictType::new(class),
+                typed_dict,
                 arguments,
                 func.as_ref().into(),
                 |expr, tcx| speculative.infer_expression(expr, tcx),
@@ -6999,6 +7000,78 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             },
             _ => return_ty,
         }
+    }
+
+    fn collect_typed_dict_constructor_targets(
+        &self,
+        callable_type: Type<'db>,
+    ) -> Vec<TypedDictType<'db>> {
+        fn push<'db>(
+            builder: &TypeInferenceBuilder<'db, '_>,
+            class: ClassType<'db>,
+            seen: &mut FxHashSet<TypedDictType<'db>>,
+            targets: &mut Vec<TypedDictType<'db>>,
+        ) {
+            if class.is_typed_dict(builder.db()) {
+                let typed_dict = TypedDictType::new(class);
+                if seen.insert(typed_dict) {
+                    targets.push(typed_dict);
+                }
+            }
+        }
+
+        fn inner<'db>(
+            builder: &TypeInferenceBuilder<'db, '_>,
+            callable_type: Type<'db>,
+            seen: &mut FxHashSet<TypedDictType<'db>>,
+            targets: &mut Vec<TypedDictType<'db>>,
+        ) {
+            let db = builder.db();
+
+            match callable_type.resolve_type_alias(db) {
+                Type::ClassLiteral(class) => {
+                    push(builder, ClassType::NonGeneric(class), seen, targets);
+                }
+                Type::GenericAlias(alias) => {
+                    push(builder, ClassType::Generic(alias), seen, targets);
+                }
+                Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
+                    SubclassOfInner::Class(class) => {
+                        push(builder, class, seen, targets);
+                    }
+                    SubclassOfInner::Dynamic(_) => {}
+                    SubclassOfInner::TypeVar(_) => {
+                        // Recover the single class that `type[T]` already exposes through
+                        // `into_class()`, so upper-bounded `TypedDict` constructors continue to
+                        // validate. We intentionally avoid walking constraints independently here,
+                        // because that would lose the correlation between the constructor target
+                        // and other arguments typed as the same `T`.
+                        if let Some(class) = subclass_of.subclass_of().into_class(db) {
+                            push(builder, class, seen, targets);
+                        }
+                    }
+                },
+                Type::Union(union) => {
+                    for element in union.elements(db) {
+                        inner(builder, *element, seen, targets);
+                    }
+                }
+                Type::Intersection(intersection) => {
+                    for element in intersection.positive_elements_or_object(db) {
+                        inner(builder, element, seen, targets);
+                    }
+                }
+                Type::TypeAlias(alias) => {
+                    inner(builder, alias.value_type(db), seen, targets);
+                }
+                _ => {}
+            }
+        }
+
+        let mut seen = FxHashSet::default();
+        let mut targets = Vec::new();
+        inner(self, callable_type, &mut seen, &mut targets);
+        targets
     }
 
     fn infer_starred_expression(

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -96,7 +96,10 @@ use crate::types::special_form::TypeQualifier;
 use crate::types::subclass_of::SubclassOfInner;
 use crate::types::tuple::{Tuple, TupleLength, TupleSpecBuilder, TupleType};
 use crate::types::type_alias::{ManualPEP695TypeAliasType, PEP695TypeAliasType};
-use crate::types::typed_dict::{validate_typed_dict_constructor, validate_typed_dict_dict_literal};
+use crate::types::typed_dict::{
+    double_starred_key_and_value_types, validate_typed_dict_constructor,
+    validate_typed_dict_dict_literal,
+};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarConstraints, TypeVarIdentity};
 use crate::types::{
     CallDunderError, CallableBinding, CallableType, CallableTypes, ClassType, DynamicType,
@@ -5779,7 +5782,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let unpack_ty = infer_elt_expression(self, (1, value_expr, tcx));
 
                 let Some((unpacked_key_ty, unpacked_value_ty)) =
-                    unpack_ty.unpack_keys_and_items(self.db())
+                    double_starred_key_and_value_types(self.db(), unpack_ty)
                 else {
                     if let Some(builder) =
                         self.context.report_lint(&INVALID_ARGUMENT_TYPE, value_expr)
@@ -6550,7 +6553,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let mapping_type = self.expression_type(&keyword.value);
 
             if mapping_type.as_paramspec_typevar(self.db()).is_some()
-                || mapping_type.unpack_keys_and_items(self.db()).is_some()
+                || double_starred_key_and_value_types(self.db(), mapping_type).is_some()
             {
                 continue;
             }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6900,6 +6900,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 func.as_ref().into(),
                 |expr, tcx| speculative.infer_expression(expr, tcx),
             );
+            self.extend(speculative);
         }
 
         let mut bindings = match bindings_result {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6892,12 +6892,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if let Some(class) = class
             && class.is_typed_dict(self.db())
         {
+            let mut speculative = self.speculate();
             validate_typed_dict_constructor(
                 &self.context,
                 TypedDictType::new(class),
                 arguments,
                 func.as_ref().into(),
-                |expr| self.expression_type(expr),
+                |expr, tcx| speculative.infer_expression(expr, tcx),
             );
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -45,7 +45,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 typed_dict,
                 arguments,
                 func.into(),
-                |expr| self.expression_type(expr),
+                |expr, _| self.expression_type(expr),
             );
 
             return Some(Type::TypedDict(typed_dict));

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -18,7 +18,7 @@ use super::diagnostic::{
 };
 use super::infer::infer_deferred_types;
 use super::{
-    ApplyTypeMappingVisitor, IntersectionType, Type, TypeMapping, TypeQualifiers,
+    ApplyTypeMappingVisitor, IntersectionType, Type, TypeMapping, TypeQualifiers, UnionBuilder,
     definition_expression_type, visitor,
 };
 use crate::Db;
@@ -823,12 +823,14 @@ struct UnpackedTypedDictKey<'db> {
 }
 
 /// Extracts `TypedDict` keys, their value types, and whether they are required when unpacked as
-/// `**kwargs`, resolving type aliases and handling intersections.
+/// `**kwargs`, resolving type aliases and handling intersections and unions.
 ///
 /// For intersections, returns ALL declared keys from ALL `TypedDict` types (union of keys),
 /// because unpacking a value of an intersection type may expose any key declared by any
 /// constituent `TypedDict`. For keys that appear in multiple `TypedDict`s, the value types are
 /// intersected, and the key is considered required if any constituent `TypedDict` requires it.
+/// For unions, returns all keys that may appear in any arm, unioning value types for shared keys,
+/// and a key is only considered required if every arm requires it.
 fn extract_unpacked_typed_dict_keys<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
@@ -883,8 +885,47 @@ fn extract_unpacked_typed_dict_keys<'db>(
 
             Some(result)
         }
-        // TODO: handle unions by checking all TypedDict elements separately
-        Type::Union(_) => None,
+        Type::Union(union) => {
+            let key_maps: Vec<_> = union
+                .elements(db)
+                .iter()
+                .map(|element| extract_unpacked_typed_dict_keys(db, *element))
+                .collect::<Option<_>>()?;
+
+            let all_keys: OrderSet<Name> = key_maps
+                .iter()
+                .flat_map(|key_map| key_map.keys().cloned())
+                .collect();
+            let mut result = BTreeMap::new();
+
+            for key in all_keys {
+                let mut value_ty = UnionBuilder::new(db);
+                let mut is_required = true;
+                let mut saw_key = false;
+
+                for key_map in &key_maps {
+                    if let Some(unpacked_key) = key_map.get(&key) {
+                        saw_key = true;
+                        value_ty = value_ty.add(unpacked_key.value_ty);
+                        is_required &= unpacked_key.is_required;
+                    } else {
+                        is_required = false;
+                    }
+                }
+
+                if saw_key {
+                    result.insert(
+                        key,
+                        UnpackedTypedDictKey {
+                            value_ty: value_ty.build(),
+                            is_required,
+                        },
+                    );
+                }
+            }
+
+            Some(result)
+        }
         Type::TypeAlias(alias) => extract_unpacked_typed_dict_keys(db, alias.value_type(db)),
         // All other types cannot contain a TypedDict
         Type::Dynamic(_)
@@ -917,6 +958,80 @@ fn extract_unpacked_typed_dict_keys<'db>(
     }
 }
 
+/// Infers each unpacked `**kwargs` constructor argument exactly once.
+///
+/// Mixed positional-and-keyword `TypedDict` construction needs to inspect unpacked keyword types
+/// in multiple validation passes. Precomputing them avoids re-inference in speculative builders.
+fn infer_unpacked_keyword_types<'db>(
+    arguments: &Arguments,
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+) -> Vec<Option<Type<'db>>> {
+    arguments
+        .keywords
+        .iter()
+        .map(|keyword| {
+            keyword
+                .arg
+                .is_none()
+                .then(|| expression_type_fn(&keyword.value, TypeContext::default()))
+        })
+        .collect()
+}
+
+/// Collects constructor keys that are guaranteed to be provided by keyword arguments.
+///
+/// Explicit keyword arguments always provide their key. For `**kwargs`, only required keys are
+/// guaranteed to be present; optional keys may be omitted at runtime and cannot suppress missing
+/// key diagnostics for the positional mapping.
+fn collect_guaranteed_keyword_keys<'db>(
+    db: &'db dyn Db,
+    arguments: &Arguments,
+    unpacked_keyword_types: &[Option<Type<'db>>],
+) -> OrderSet<Name> {
+    debug_assert_eq!(arguments.keywords.len(), unpacked_keyword_types.len());
+
+    let mut provided_keys: OrderSet<Name> = arguments
+        .keywords
+        .iter()
+        .filter_map(|keyword| keyword.arg.as_ref().map(|arg| arg.id.clone()))
+        .collect();
+
+    for unpacked_type in unpacked_keyword_types.iter().copied().flatten() {
+        if let Some(unpacked_keys) = extract_unpacked_typed_dict_keys(db, unpacked_type) {
+            provided_keys.extend(
+                unpacked_keys
+                    .into_iter()
+                    .filter_map(|(key, unpacked_key)| unpacked_key.is_required.then_some(key)),
+            );
+        }
+    }
+
+    provided_keys
+}
+
+/// Returns a `TypedDict` schema with `excluded_keys` removed.
+///
+/// This is used for mixed positional-and-keyword constructor calls, where guaranteed keyword
+/// arguments override any same-named keys from the positional mapping.
+fn typed_dict_without_keys<'db>(
+    db: &'db dyn Db,
+    typed_dict: TypedDictType<'db>,
+    excluded_keys: &OrderSet<Name>,
+) -> TypedDictType<'db> {
+    if excluded_keys.is_empty() {
+        return typed_dict;
+    }
+
+    let filtered_items = typed_dict
+        .items(db)
+        .iter()
+        .filter(|(name, _)| !excluded_keys.contains(*name))
+        .map(|(name, field)| (name.clone(), field.clone()))
+        .collect();
+
+    TypedDictType::from_schema_items(db, filtered_items)
+}
+
 pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
     context: &InferContext<'db, 'ast>,
     typed_dict: TypedDictType<'db>,
@@ -926,23 +1041,70 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
 ) {
     let db = context.db();
 
-    // Check for a single positional argument that is a dict literal
-    let has_positional_dict_literal = arguments.args.len() == 1 && arguments.args[0].is_dict_expr();
+    // Check for a single positional argument, and whether it's a dict literal.
+    let has_single_positional_arg = arguments.args.len() == 1;
+    let has_positional_dict_literal = has_single_positional_arg && arguments.args[0].is_dict_expr();
 
-    // Check for a single positional argument (not a dict literal)
-    let is_single_positional_arg =
-        arguments.args.len() == 1 && arguments.keywords.is_empty() && !has_positional_dict_literal;
+    let unpacked_keyword_types = infer_unpacked_keyword_types(arguments, &mut expression_type_fn);
 
-    if has_positional_dict_literal {
+    if has_single_positional_arg && !arguments.keywords.is_empty() {
+        // Mixed positional-and-keyword construction: guaranteed keyword-provided keys override the
+        // positional mapping, so validate the positional argument against the remaining schema.
+        let keyword_keys = collect_guaranteed_keyword_keys(db, arguments, &unpacked_keyword_types);
+        let mut provided_keys = if has_positional_dict_literal {
+            validate_from_dict_literal(
+                context,
+                typed_dict,
+                arguments,
+                error_node,
+                &mut expression_type_fn,
+                &keyword_keys,
+            )
+        } else {
+            let arg = &arguments.args[0];
+            let arg_ty = expression_type_fn(arg, TypeContext::default());
+            let positional_target = typed_dict_without_keys(db, typed_dict, &keyword_keys);
+            let positional_target_ty = Type::TypedDict(positional_target);
+
+            if !arg_ty.is_assignable_to(db, positional_target_ty) {
+                if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, arg) {
+                    builder.into_diagnostic(format_args!(
+                        "Argument of type `{}` is not assignable to `{}`",
+                        arg_ty.display(db),
+                        positional_target_ty.display(db),
+                    ));
+                }
+            }
+
+            positional_target
+                .items(db)
+                .iter()
+                .filter_map(|(key_name, field)| field.is_required().then_some(key_name.clone()))
+                .collect()
+        };
+
+        provided_keys.extend(validate_from_keywords(
+            context,
+            typed_dict,
+            arguments,
+            error_node,
+            &unpacked_keyword_types,
+            &mut expression_type_fn,
+        ));
+        validate_typed_dict_required_keys(context, typed_dict, &provided_keys, error_node);
+    } else if has_positional_dict_literal {
+        // Single positional dict literal: validate keys and value types directly from the literal,
+        // which also allows us to report extra keys that aren't in the `TypedDict` schema.
         let provided_keys = validate_from_dict_literal(
             context,
             typed_dict,
             arguments,
             error_node,
             &mut expression_type_fn,
+            &OrderSet::new(),
         );
         validate_typed_dict_required_keys(context, typed_dict, &provided_keys, error_node);
-    } else if is_single_positional_arg {
+    } else if has_single_positional_arg {
         // Single positional argument: check if assignable to the target TypedDict.
         // This handles TypedDict, intersections, unions, and type aliases correctly.
         // Assignability already checks for required keys and type compatibility,
@@ -961,11 +1123,14 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
             }
         }
     } else {
+        // Keyword-only construction: validate each keyword argument, then check for missing
+        // required keys.
         let provided_keys = validate_from_keywords(
             context,
             typed_dict,
             arguments,
             error_node,
+            &unpacked_keyword_types,
             &mut expression_type_fn,
         );
         validate_typed_dict_required_keys(context, typed_dict, &provided_keys, error_node);
@@ -980,6 +1145,7 @@ fn validate_from_dict_literal<'db, 'ast>(
     arguments: &'ast Arguments,
     typed_dict_node: AnyNodeRef<'ast>,
     expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+    ignored_keys: &OrderSet<Name>,
 ) -> OrderSet<Name> {
     let mut provided_keys = OrderSet::new();
     let items = typed_dict.items(context.db());
@@ -993,6 +1159,9 @@ fn validate_from_dict_literal<'db, 'ast>(
                 }) = key_expr
             {
                 let key = key_value.to_str();
+                if ignored_keys.contains(key) {
+                    continue;
+                }
                 provided_keys.insert(Name::new(key));
 
                 let value_tcx = items
@@ -1027,10 +1196,12 @@ fn validate_from_keywords<'db, 'ast>(
     typed_dict: TypedDictType<'db>,
     arguments: &'ast Arguments,
     typed_dict_node: AnyNodeRef<'ast>,
+    unpacked_keyword_types: &[Option<Type<'db>>],
     expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) -> OrderSet<Name> {
     let db = context.db();
     let items = typed_dict.items(db);
+    debug_assert_eq!(arguments.keywords.len(), unpacked_keyword_types.len());
 
     // Collect keys from explicit keyword arguments
     let mut provided_keys: OrderSet<Name> = arguments
@@ -1040,7 +1211,11 @@ fn validate_from_keywords<'db, 'ast>(
         .collect();
 
     // Validate that each key is assigned a type that is compatible with the key's value type
-    for keyword in &arguments.keywords {
+    for (keyword, unpacked_type) in arguments
+        .keywords
+        .iter()
+        .zip(unpacked_keyword_types.iter().copied())
+    {
         if let Some(arg_name) = &keyword.arg {
             // Explicit keyword argument: e.g., `name="Alice"`
             let value_tcx = items
@@ -1066,7 +1241,9 @@ fn validate_from_keywords<'db, 'ast>(
             // Unlike positional TypedDict arguments, unpacking passes all keys as explicit
             // keyword arguments, so extra keys should be flagged as errors (consistent with
             // explicitly providing those keys).
-            let unpacked_type = expression_type_fn(&keyword.value, TypeContext::default());
+            let Some(unpacked_type) = unpacked_type else {
+                continue;
+            };
 
             // Never and Dynamic types are special: they can have any keys, so we skip
             // validation and mark all required keys as provided.

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -922,7 +922,7 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
     typed_dict: TypedDictType<'db>,
     arguments: &'ast Arguments,
     error_node: AnyNodeRef<'ast>,
-    expression_type_fn: impl Fn(&ast::Expr) -> Type<'db>,
+    mut expression_type_fn: impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) {
     let db = context.db();
 
@@ -939,7 +939,7 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
             typed_dict,
             arguments,
             error_node,
-            &expression_type_fn,
+            &mut expression_type_fn,
         );
         validate_typed_dict_required_keys(context, typed_dict, &provided_keys, error_node);
     } else if is_single_positional_arg {
@@ -948,7 +948,7 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
         // Assignability already checks for required keys and type compatibility,
         // so we don't need separate validation.
         let arg = &arguments.args[0];
-        let arg_ty = expression_type_fn(arg);
+        let arg_ty = expression_type_fn(arg, TypeContext::default());
         let target_ty = Type::TypedDict(typed_dict);
 
         if !arg_ty.is_assignable_to(db, target_ty) {
@@ -966,7 +966,7 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
             typed_dict,
             arguments,
             error_node,
-            &expression_type_fn,
+            &mut expression_type_fn,
         );
         validate_typed_dict_required_keys(context, typed_dict, &provided_keys, error_node);
     }
@@ -979,9 +979,10 @@ fn validate_from_dict_literal<'db, 'ast>(
     typed_dict: TypedDictType<'db>,
     arguments: &'ast Arguments,
     typed_dict_node: AnyNodeRef<'ast>,
-    expression_type_fn: &impl Fn(&ast::Expr) -> Type<'db>,
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) -> OrderSet<Name> {
     let mut provided_keys = OrderSet::new();
+    let items = typed_dict.items(context.db());
 
     if let ast::Expr::Dict(dict_expr) = &arguments.args[0] {
         // Validate dict entries
@@ -994,8 +995,11 @@ fn validate_from_dict_literal<'db, 'ast>(
                 let key = key_value.to_str();
                 provided_keys.insert(Name::new(key));
 
-                // Get the already-inferred argument type
-                let value_ty = expression_type_fn(&dict_item.value);
+                let value_tcx = items
+                    .get(key)
+                    .map(|field| TypeContext::new(Some(field.declared_ty)))
+                    .unwrap_or_default();
+                let value_ty = expression_type_fn(&dict_item.value, value_tcx);
                 TypedDictKeyAssignment {
                     context,
                     typed_dict,
@@ -1023,9 +1027,10 @@ fn validate_from_keywords<'db, 'ast>(
     typed_dict: TypedDictType<'db>,
     arguments: &'ast Arguments,
     typed_dict_node: AnyNodeRef<'ast>,
-    expression_type_fn: &impl Fn(&ast::Expr) -> Type<'db>,
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) -> OrderSet<Name> {
     let db = context.db();
+    let items = typed_dict.items(db);
 
     // Collect keys from explicit keyword arguments
     let mut provided_keys: OrderSet<Name> = arguments
@@ -1038,7 +1043,11 @@ fn validate_from_keywords<'db, 'ast>(
     for keyword in &arguments.keywords {
         if let Some(arg_name) = &keyword.arg {
             // Explicit keyword argument: e.g., `name="Alice"`
-            let value_ty = expression_type_fn(&keyword.value);
+            let value_tcx = items
+                .get(arg_name.id.as_str())
+                .map(|field| TypeContext::new(Some(field.declared_ty)))
+                .unwrap_or_default();
+            let value_ty = expression_type_fn(&keyword.value, value_tcx);
             TypedDictKeyAssignment {
                 context,
                 typed_dict,
@@ -1057,7 +1066,7 @@ fn validate_from_keywords<'db, 'ast>(
             // Unlike positional TypedDict arguments, unpacking passes all keys as explicit
             // keyword arguments, so extra keys should be flagged as errors (consistent with
             // explicitly providing those keys).
-            let unpacked_type = expression_type_fn(&keyword.value);
+            let unpacked_type = expression_type_fn(&keyword.value, TypeContext::default());
 
             // Never and Dynamic types are special: they can have any keys, so we skip
             // validation and mark all required keys as provided.

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -18,8 +18,8 @@ use super::diagnostic::{
 };
 use super::infer::infer_deferred_types;
 use super::{
-    ApplyTypeMappingVisitor, IntersectionType, Type, TypeMapping, TypeQualifiers, UnionBuilder,
-    definition_expression_type, visitor,
+    ApplyTypeMappingVisitor, IntersectionType, Type, TypeMapping, TypeQualifiers,
+    TypeVarBoundOrConstraints, UnionBuilder, definition_expression_type, visitor,
 };
 use crate::Db;
 use crate::semantic_index::definition::Definition;
@@ -817,9 +817,53 @@ pub(super) fn validate_typed_dict_required_keys<'db, 'ast>(
 }
 
 #[derive(Debug, Clone, Copy)]
-struct UnpackedTypedDictKey<'db> {
-    value_ty: Type<'db>,
-    is_required: bool,
+pub(crate) struct UnpackedTypedDictKey<'db> {
+    pub(crate) value_ty: Type<'db>,
+    pub(crate) is_required: bool,
+}
+
+/// Merges unpacked `TypedDict` key maps using union semantics.
+///
+/// This is used for both `A | B` and constrained `TypeVar`s whose constraints are all
+/// `TypedDict`-shaped: a key is present if any arm provides it, its value type is the union of
+/// the arm-specific value types, and it is only required if every arm requires it.
+fn merge_union_unpacked_typed_dict_key_maps<'db>(
+    db: &'db dyn Db,
+    key_maps: &[BTreeMap<Name, UnpackedTypedDictKey<'db>>],
+) -> BTreeMap<Name, UnpackedTypedDictKey<'db>> {
+    let all_keys: OrderSet<Name> = key_maps
+        .iter()
+        .flat_map(|key_map| key_map.keys().cloned())
+        .collect();
+    let mut result = BTreeMap::new();
+
+    for key in all_keys {
+        let mut value_ty = UnionBuilder::new(db);
+        let mut is_required = true;
+        let mut saw_key = false;
+
+        for key_map in key_maps {
+            if let Some(unpacked_key) = key_map.get(&key) {
+                saw_key = true;
+                value_ty = value_ty.add(unpacked_key.value_ty);
+                is_required &= unpacked_key.is_required;
+            } else {
+                is_required = false;
+            }
+        }
+
+        if saw_key {
+            result.insert(
+                key,
+                UnpackedTypedDictKey {
+                    value_ty: value_ty.build(),
+                    is_required,
+                },
+            );
+        }
+    }
+
+    result
 }
 
 /// Extracts `TypedDict` keys, their value types, and whether they are required when unpacked as
@@ -831,7 +875,7 @@ struct UnpackedTypedDictKey<'db> {
 /// intersected, and the key is considered required if any constituent `TypedDict` requires it.
 /// For unions, returns all keys that may appear in any arm, unioning value types for shared keys,
 /// and a key is only considered required if every arm requires it.
-fn extract_unpacked_typed_dict_keys<'db>(
+pub(crate) fn unpacked_typed_dict_keys<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
 ) -> Option<BTreeMap<Name, UnpackedTypedDictKey<'db>>> {
@@ -857,7 +901,7 @@ fn extract_unpacked_typed_dict_keys<'db>(
             let all_key_maps: Vec<_> = intersection
                 .positive(db)
                 .iter()
-                .filter_map(|element| extract_unpacked_typed_dict_keys(db, *element))
+                .filter_map(|element| unpacked_typed_dict_keys(db, *element))
                 .collect();
 
             if all_key_maps.is_empty() {
@@ -889,44 +933,27 @@ fn extract_unpacked_typed_dict_keys<'db>(
             let key_maps: Vec<_> = union
                 .elements(db)
                 .iter()
-                .map(|element| extract_unpacked_typed_dict_keys(db, *element))
+                .map(|element| unpacked_typed_dict_keys(db, *element))
                 .collect::<Option<_>>()?;
 
-            let all_keys: OrderSet<Name> = key_maps
-                .iter()
-                .flat_map(|key_map| key_map.keys().cloned())
-                .collect();
-            let mut result = BTreeMap::new();
-
-            for key in all_keys {
-                let mut value_ty = UnionBuilder::new(db);
-                let mut is_required = true;
-                let mut saw_key = false;
-
-                for key_map in &key_maps {
-                    if let Some(unpacked_key) = key_map.get(&key) {
-                        saw_key = true;
-                        value_ty = value_ty.add(unpacked_key.value_ty);
-                        is_required &= unpacked_key.is_required;
-                    } else {
-                        is_required = false;
-                    }
-                }
-
-                if saw_key {
-                    result.insert(
-                        key,
-                        UnpackedTypedDictKey {
-                            value_ty: value_ty.build(),
-                            is_required,
-                        },
-                    );
-                }
-            }
-
-            Some(result)
+            Some(merge_union_unpacked_typed_dict_key_maps(db, &key_maps))
         }
-        Type::TypeAlias(alias) => extract_unpacked_typed_dict_keys(db, alias.value_type(db)),
+        Type::TypeAlias(alias) => unpacked_typed_dict_keys(db, alias.value_type(db)),
+        Type::TypeVar(typevar) => match typevar.typevar(db).bound_or_constraints(db) {
+            Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                unpacked_typed_dict_keys(db, bound)
+            }
+            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                let key_maps: Vec<_> = constraints
+                    .elements(db)
+                    .iter()
+                    .map(|constraint| unpacked_typed_dict_keys(db, *constraint))
+                    .collect::<Option<_>>()?;
+
+                Some(merge_union_unpacked_typed_dict_key_maps(db, &key_maps))
+            }
+            None => None,
+        },
         // All other types cannot contain a TypedDict
         Type::Dynamic(_)
         | Type::Divergent(_)
@@ -950,11 +977,33 @@ fn extract_unpacked_typed_dict_keys<'db>(
         | Type::AlwaysTruthy
         | Type::AlwaysFalsy
         | Type::LiteralValue(_)
-        | Type::TypeVar(_)
         | Type::BoundSuper(_)
         | Type::TypeIs(_)
         | Type::TypeGuard(_)
         | Type::NewTypeInstance(_) => None,
+    }
+}
+
+/// Returns the key and value types of an object unpacked using `**`.
+///
+/// For `TypedDict`-shaped values, preserve the exact unpacked schema before falling back to the
+/// generic mapping model based on `keys()` and `__getitem__`.
+pub(crate) fn double_starred_key_and_value_types<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+) -> Option<(Type<'db>, Type<'db>)> {
+    if let Some(unpacked_keys) = unpacked_typed_dict_keys(db, ty) {
+        let mut key_tys = UnionBuilder::new(db);
+        let mut value_tys = UnionBuilder::new(db);
+
+        for (key, unpacked_key) in unpacked_keys {
+            key_tys = key_tys.add(Type::string_literal(db, key.as_str()));
+            value_tys = value_tys.add(unpacked_key.value_ty);
+        }
+
+        Some((key_tys.build(), value_tys.build()))
+    } else {
+        ty.unpack_keys_and_items(db)
     }
 }
 
@@ -997,7 +1046,7 @@ fn collect_guaranteed_keyword_keys<'db>(
         .collect();
 
     for unpacked_type in unpacked_keyword_types.iter().copied().flatten() {
-        if let Some(unpacked_keys) = extract_unpacked_typed_dict_keys(db, unpacked_type) {
+        if let Some(unpacked_keys) = unpacked_typed_dict_keys(db, unpacked_type) {
             provided_keys.extend(
                 unpacked_keys
                     .into_iter()
@@ -1253,8 +1302,7 @@ fn validate_from_keywords<'db, 'ast>(
                         provided_keys.insert(key_name.clone());
                     }
                 }
-            } else if let Some(unpacked_keys) = extract_unpacked_typed_dict_keys(db, unpacked_type)
-            {
+            } else if let Some(unpacked_keys) = unpacked_typed_dict_keys(db, unpacked_type) {
                 for (key_name, unpacked_key) in &unpacked_keys {
                     if unpacked_key.is_required {
                         provided_keys.insert(key_name.clone());

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -948,8 +948,8 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
         // Assignability already checks for required keys and type compatibility,
         // so we don't need separate validation.
         let arg = &arguments.args[0];
-        let arg_ty = expression_type_fn(arg, TypeContext::default());
         let target_ty = Type::TypedDict(typed_dict);
+        let arg_ty = expression_type_fn(arg, TypeContext::new(Some(target_ty)));
 
         if !arg_ty.is_assignable_to(db, target_ty) {
             if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, arg) {


### PR DESCRIPTION
## Summary

This PR improves support for `**kwargs` in cases where `kwargs` is a constrained TypeVar. We now compute the exact keys instead of falling back to the generic mapping case.
