### PR TITLE
[ty] Fix ParamSpec defaults and alias variance

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -154,12 +154,22 @@ python-version = "3.12"
 from typing import Callable, Generic
 from typing_extensions import ParamSpec
 
-P = ParamSpec("P", default=[str])
+PList = ParamSpec("PList", default=[str])
+PEllipsis = ParamSpec("PEllipsis", default=...)
+PAnother = ParamSpec("PAnother", default=PList)
 
-class C(Generic[P]):
-    x: Callable[P, None]
+class C1(Generic[PList]):
+    x: Callable[PList, None]
 
-reveal_type(C().x)  # revealed: (str, /) -> None
+class C2(Generic[PEllipsis]):
+    x: Callable[PEllipsis, None]
+
+class C3(Generic[PList, PAnother]):
+    x: Callable[PAnother, None]
+
+reveal_type(C1().x)  # revealed: (str, /) -> None
+reveal_type(C2().x)  # revealed: (...) -> None
+reveal_type(C3().x)  # revealed: (str, /) -> None
 ```
 
 ### Forward references in stub files
@@ -478,19 +488,66 @@ reveal_type(TypeVarAndParamSpec[int, Any]().attr)  # revealed: (...) -> int
 ```
 
 `...` has the same gradual behavior when used as a `ParamSpec` argument in a generic class,
-regardless of the inferred variance of the `ParamSpec`.
+regardless of the variance of the `ParamSpec`.
 
 ```py
 from typing import Callable, Generic, ParamSpec
 
+# legacy ParamSpec with no variance specified is invariant
 P = ParamSpec("P")
 
 class Command(Generic[P]):
     callback: Callable[P, None]
 
+# confirm that Command is invariant in P
+def _(of_int: Command[int], of_bool: Command[bool]) -> None:
+    a: Command[int] = of_bool  # error: [invalid-assignment]
+    b: Command[bool] = of_int  # error: [invalid-assignment]
+
+# but gradual signature is still assignable in both directions
 def _(concrete: Command[[str]], gradual: Command[...]) -> None:
     a: Command[...] = concrete
     b: Command[[str]] = gradual
+```
+
+`ParamSpec` specializations in generic classes are compared using the callable parameter relation.
+This avoids rejecting wrappers around callbacks that are safe to use with a positional-only callback
+protocol.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from collections.abc import Callable
+from typing import Final
+
+class Job[**P]:
+    target: Final[Callable[P, None]]
+
+    def __init__(self, target: Callable[P, None]) -> None:
+        self.target = target
+
+def named(x: int) -> None:
+    pass
+
+def defaulted(x: int | None = None) -> None:
+    pass
+
+def wrong(x: str) -> None:
+    pass
+
+named_job = Job(named)
+defaulted_job = Job(defaulted)
+wrong_job = Job(wrong)
+
+def takes_int_job(job: Job[[int]]) -> None:
+    pass
+
+takes_int_job(named_job)
+takes_int_job(defaulted_job)
+takes_int_job(wrong_job)  # error: [invalid-argument-type]
 ```
 
 ## `ParamSpec` cannot specialize a `TypeVar`, and vice versa

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -151,16 +151,15 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Callable, Generic, assert_type
+from typing import Callable, Generic
 from typing_extensions import ParamSpec
 
-DefaultP = ParamSpec("DefaultP", default=[str, int])
+P = ParamSpec("P", default=[str])
 
-class ClassParamSpec(Generic[DefaultP]):
-    x: Callable[DefaultP, None]
+class C(Generic[P]):
+    x: Callable[P, None]
 
-assert_type(ClassParamSpec(), ClassParamSpec[str, int])
-assert_type(ClassParamSpec[[bool, bool]](), ClassParamSpec[bool, bool])
+reveal_type(C().x)  # revealed: (str, /) -> None
 ```
 
 ### Forward references in stub files
@@ -482,20 +481,16 @@ reveal_type(TypeVarAndParamSpec[int, Any]().attr)  # revealed: (...) -> int
 regardless of the inferred variance of the `ParamSpec`.
 
 ```py
-from typing import Any, Callable, Generic, ParamSpec, TypeVar
+from typing import Callable, Generic, ParamSpec
 
 P = ParamSpec("P")
-T = TypeVar("T")
-R = TypeVar("R")
 
-class Command(Generic[T, P, R]):
-    callback: Callable[P, R]
+class Command(Generic[P]):
+    callback: Callable[P, None]
 
-def accepts_gradual(command: Command[int, [str], object]) -> None:
-    gradual: Command[Any, ..., Any] = command
-
-def accepts_concrete(command: Command[Any, ..., Any]) -> None:
-    concrete: Command[int, [str], object] = command
+def _(concrete: Command[[str]], gradual: Command[...]) -> None:
+    a: Command[...] = concrete
+    b: Command[[str]] = gradual
 ```
 
 ## `ParamSpec` cannot specialize a `TypeVar`, and vice versa

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -143,6 +143,26 @@ P4 = ExtParamSpec("P4", default=P3)
 P5 = ExtParamSpec("P5", default=int)
 ```
 
+### `typing_extensions.ParamSpec` defaults specialize generic classes
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, Generic, assert_type
+from typing_extensions import ParamSpec
+
+DefaultP = ParamSpec("DefaultP", default=[str, int])
+
+class ClassParamSpec(Generic[DefaultP]):
+    x: Callable[DefaultP, None]
+
+assert_type(ClassParamSpec(), ClassParamSpec[str, int])
+assert_type(ClassParamSpec[[bool, bool]](), ClassParamSpec[bool, bool])
+```
+
 ### Forward references in stub files
 
 Stubs natively support forward references, so patterns that would raise `NameError` at runtime are

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -478,6 +478,26 @@ both mypy and Pyright allow this and there are usages of this in the wild e.g.,
 reveal_type(TypeVarAndParamSpec[int, Any]().attr)  # revealed: (...) -> int
 ```
 
+`...` has the same gradual behavior when used as a `ParamSpec` argument in a generic class,
+regardless of the inferred variance of the `ParamSpec`.
+
+```py
+from typing import Any, Callable, Generic, ParamSpec, TypeVar
+
+P = ParamSpec("P")
+T = TypeVar("T")
+R = TypeVar("R")
+
+class Command(Generic[T, P, R]):
+    callback: Callable[P, R]
+
+def accepts_gradual(command: Command[int, [str], object]) -> None:
+    gradual: Command[Any, ..., Any] = command
+
+def accepts_concrete(command: Command[Any, ..., Any]) -> None:
+    concrete: Command[int, [str], object] = command
+```
+
 ## `ParamSpec` cannot specialize a `TypeVar`, and vice versa
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
@@ -477,8 +477,8 @@ from typing import Callable, Concatenate
 class Box[**P]:
     attr: Callable[P, None]
 
-def not_bare_ellipsis[**P](y: Box[Concatenate[int, ...]]) -> None:
-    concrete: Box[P] = y  # error: [invalid-assignment]
+def f[**P](x: Box[Concatenate[int, ...]]) -> None:
+    y: Box[P] = x  # error: [invalid-assignment]
 ```
 
 ## `Concatenate` in type aliases

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
@@ -468,6 +468,19 @@ def with_paramspec[**P2](f: Foo[Concatenate[int, P2]]) -> None:
     reveal_type(f.attr)  # revealed: (int, /, *args: P2@with_paramspec.args, **kwargs: P2@with_paramspec.kwargs) -> None
 ```
 
+`Concatenate` with a gradual tail is not equivalent to a bare gradual `ParamSpec` value because the
+fixed prefix still needs to be checked.
+
+```py
+from typing import Callable, Concatenate
+
+class Box[**P]:
+    attr: Callable[P, None]
+
+def not_bare_ellipsis[**P](y: Box[Concatenate[int, ...]]) -> None:
+    concrete: Box[P] = y  # error: [invalid-assignment]
+```
+
 ## `Concatenate` in type aliases
 
 ### Using `type` statement (PEP 695)

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -394,6 +394,61 @@ both mypy and Pyright allow this and there are usages of this in the wild e.g.,
 reveal_type(TypeVarAndParamSpec[int, Any]().attr)  # revealed: (...) -> int
 ```
 
+`...` has the same gradual behavior when used as a `ParamSpec` argument in a generic class,
+regardless of the variance of the `ParamSpec`.
+
+```py
+from typing import Callable
+
+class Command[**P]:
+    callback: Callable[P, None]
+
+# confirm that Command is invariant in P
+def _(of_int: Command[int], of_bool: Command[bool]) -> None:
+    a: Command[int] = of_bool  # error: [invalid-assignment]
+    b: Command[bool] = of_int  # error: [invalid-assignment]
+
+# but gradual signature is still assignable in both directions
+def _(concrete: Command[[str]], gradual: Command[...]) -> None:
+    a: Command[...] = concrete
+    b: Command[[str]] = gradual
+```
+
+`ParamSpec` specializations in generic classes are compared using the callable parameter relation.
+This avoids rejecting wrappers around callbacks that are safe to use with a positional-only callback
+protocol.
+
+```py
+from collections.abc import Callable
+from typing import Final
+
+class Job[**P]:
+    target: Final[Callable[P, None]]
+
+    def __init__(self, target: Callable[P, None]) -> None:
+        self.target = target
+
+def named(x: int) -> None:
+    pass
+
+def defaulted(x: int | None = None) -> None:
+    pass
+
+def wrong(x: str) -> None:
+    pass
+
+named_job = Job(named)
+defaulted_job = Job(defaulted)
+wrong_job = Job(wrong)
+
+def takes_int_job(job: Job[[int]]) -> None:
+    pass
+
+takes_int_job(named_job)
+takes_int_job(defaulted_job)
+takes_int_job(wrong_job)  # error: [invalid-argument-type]
+```
+
 ## `ParamSpec` cannot specialize a `TypeVar`, and vice versa
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -800,36 +800,20 @@ python-version = "3.13"
 
 ```py
 from collections.abc import Callable
-from typing import Any, Generic, ParamSpec, TypeVar, cast
+from typing import Any, ParamSpec, TypeVar, cast
 
 P = ParamSpec("P")
 R = TypeVar("R")
 
-class Task(Generic[P, R]):
-    def __init__(
-        self,
-        fn: Callable[P, R] | classmethod[Any, P, R],
-    ) -> None:
-        if isinstance(fn, classmethod):
-            fn = cast(Callable[P, R], fn.__func__)
+def f(fn: Callable[P, R] | classmethod[Any, P, R]) -> Callable[P, R]:
+    if isinstance(fn, classmethod):
+        fn = cast(Callable[P, R], fn.__func__)
 
-        reveal_type(fn)  # revealed: (**P@Task) -> R@Task
+    if not callable(fn):
+        raise TypeError
 
-        if not callable(fn):
-            raise TypeError
-
-        reveal_type(fn)  # revealed: (**P@Task) -> R@Task
-        self.fn = fn
-
-def task(fn: Callable[P, R]) -> Task[P, R]:
-    return Task(fn)
-
-@task
-def f(x: int) -> str:
-    return str(x)
-
-reveal_type(f.fn)  # revealed: (x: int) -> str
-reveal_type(f.fn(1))  # revealed: str
+    reveal_type(fn)  # revealed: (**P@f) -> R@f
+    return fn
 ```
 
 ## Narrowing with TypedDict unions

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -787,6 +787,51 @@ def _(x: object):
         reveal_type(x.y)  # revealed: tuple[A, object]
 ```
 
+## Narrowing generic `classmethod`
+
+After an `isinstance(..., classmethod)` branch unwraps and replaces a generic `classmethod`, the
+false-branch residual should be impossible. This avoids retaining a `classmethod[...] & Top[...]`
+arm that later causes `call-top-callable` false positives.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from collections.abc import Callable
+from typing import Any, Generic, ParamSpec, TypeVar, cast
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+class Task(Generic[P, R]):
+    def __init__(
+        self,
+        fn: Callable[P, R] | classmethod[Any, P, R],
+    ) -> None:
+        if isinstance(fn, classmethod):
+            fn = cast(Callable[P, R], fn.__func__)
+
+        reveal_type(fn)  # revealed: (**P@Task) -> R@Task
+
+        if not callable(fn):
+            raise TypeError
+
+        reveal_type(fn)  # revealed: (**P@Task) -> R@Task
+        self.fn = fn
+
+def task(fn: Callable[P, R]) -> Task[P, R]:
+    return Task(fn)
+
+@task
+def f(x: int) -> str:
+    return str(x)
+
+reveal_type(f.fn)  # revealed: (x: int) -> str
+reveal_type(f.fn(1))  # revealed: str
+```
+
 ## Narrowing with TypedDict unions
 
 Narrowing unions of `int` and multiple TypedDicts using `isinstance(x, dict)` should not panic

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1483,6 +1483,27 @@ def f(func: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> None:
     static_assert(not is_assignable_to(dict[str, Unknown], TypeOf[kwargs]))
 ```
 
+The gradual `...` form of a `ParamSpec` argument is assignable to and from a concrete `ParamSpec`
+value when it appears in a generic class. This is assignability consistency, not subtyping.
+
+```py
+from ty_extensions import static_assert, is_assignable_to, is_subtype_of
+from typing import Any, Callable, Generic, ParamSpec, TypeVar
+
+P = ParamSpec("P")
+T = TypeVar("T")
+R = TypeVar("R")
+
+class Command(Generic[T, P, R]):
+    callback: Callable[P, R]
+
+static_assert(is_assignable_to(Command[int, [str], object], Command[Any, ..., Any]))
+static_assert(is_assignable_to(Command[Any, ..., Any], Command[int, [str], object]))
+
+static_assert(not is_subtype_of(Command[int, [str], object], Command[Any, ..., Any]))
+static_assert(not is_subtype_of(Command[Any, ..., Any], Command[int, [str], object]))
+```
+
 ## `Concatenate`
 
 ### Self-assignability

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1483,63 +1483,6 @@ def f(func: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> None:
     static_assert(not is_assignable_to(dict[str, Unknown], TypeOf[kwargs]))
 ```
 
-The gradual `...` form of a `ParamSpec` argument is assignable to and from a concrete `ParamSpec`
-value when it appears in a generic class. This is assignability consistency, not subtyping.
-
-```py
-from ty_extensions import static_assert, is_assignable_to, is_subtype_of
-from typing import Callable, Generic, ParamSpec
-
-P = ParamSpec("P")
-
-class Command(Generic[P]):
-    callback: Callable[P, None]
-
-static_assert(is_assignable_to(Command[[str]], Command[...]))
-static_assert(is_assignable_to(Command[...], Command[[str]]))
-
-static_assert(not is_subtype_of(Command[[str]], Command[...]))
-static_assert(not is_subtype_of(Command[...], Command[[str]]))
-```
-
-`ParamSpec` specializations in generic classes are compared using the callable parameter relation.
-This avoids rejecting wrappers around callbacks that are safe to use with a positional-only callback
-protocol.
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-from collections.abc import Callable
-from typing import Final
-from ty_extensions import TypeOf, static_assert, is_assignable_to
-
-class Job[**P]:
-    target: Final[Callable[P, None]]
-
-    def __init__(self, target: Callable[P, None]) -> None:
-        self.target = target
-
-def named(x: int) -> None:
-    pass
-
-def defaulted(x: int | None = None) -> None:
-    pass
-
-def wrong(x: str) -> None:
-    pass
-
-named_job = Job(named)
-defaulted_job = Job(defaulted)
-wrong_job = Job(wrong)
-
-static_assert(is_assignable_to(TypeOf[named_job], Job[[int]]))
-static_assert(is_assignable_to(TypeOf[defaulted_job], Job[[int]]))
-static_assert(not is_assignable_to(TypeOf[wrong_job], Job[[int]]))
-```
-
 ## `Concatenate`
 
 ### Self-assignability

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1488,20 +1488,18 @@ value when it appears in a generic class. This is assignability consistency, not
 
 ```py
 from ty_extensions import static_assert, is_assignable_to, is_subtype_of
-from typing import Any, Callable, Generic, ParamSpec, TypeVar
+from typing import Callable, Generic, ParamSpec
 
 P = ParamSpec("P")
-T = TypeVar("T")
-R = TypeVar("R")
 
-class Command(Generic[T, P, R]):
-    callback: Callable[P, R]
+class Command(Generic[P]):
+    callback: Callable[P, None]
 
-static_assert(is_assignable_to(Command[int, [str], object], Command[Any, ..., Any]))
-static_assert(is_assignable_to(Command[Any, ..., Any], Command[int, [str], object]))
+static_assert(is_assignable_to(Command[[str]], Command[...]))
+static_assert(is_assignable_to(Command[...], Command[[str]]))
 
-static_assert(not is_subtype_of(Command[int, [str], object], Command[Any, ..., Any]))
-static_assert(not is_subtype_of(Command[Any, ..., Any], Command[int, [str], object]))
+static_assert(not is_subtype_of(Command[[str]], Command[...]))
+static_assert(not is_subtype_of(Command[...], Command[[str]]))
 ```
 
 `ParamSpec` specializations in generic classes are compared using the callable parameter relation.
@@ -1514,38 +1512,32 @@ python-version = "3.12"
 ```
 
 ```py
-from collections.abc import Callable, Coroutine
-from datetime import datetime
-from typing import Any, Final
+from collections.abc import Callable
+from typing import Final
 from ty_extensions import TypeOf, static_assert, is_assignable_to
 
-class Job[**P, R]:
-    target: Final[Callable[P, R]]
+class Job[**P]:
+    target: Final[Callable[P, None]]
 
-    def __init__(self, target: Callable[P, R]) -> None:
+    def __init__(self, target: Callable[P, None]) -> None:
         self.target = target
 
-def named(now: datetime) -> None:
+def named(x: int) -> None:
     pass
 
-def defaulted(now: datetime | None = None) -> None:
+def defaulted(x: int | None = None) -> None:
     pass
 
-async def async_callback(now: datetime) -> None:
-    pass
-
-def exception_callback(_: Exception | None = None) -> None:
+def wrong(x: str) -> None:
     pass
 
 named_job = Job(named)
 defaulted_job = Job(defaulted)
-async_job = Job(async_callback)
-exception_job = Job(exception_callback)
+wrong_job = Job(wrong)
 
-static_assert(is_assignable_to(TypeOf[named_job], Job[[datetime], None]))
-static_assert(is_assignable_to(TypeOf[defaulted_job], Job[[datetime], None]))
-static_assert(is_assignable_to(TypeOf[async_job], Job[[datetime], Coroutine[Any, Any, None] | None]))
-static_assert(not is_assignable_to(TypeOf[exception_job], Job[[datetime], None]))
+static_assert(is_assignable_to(TypeOf[named_job], Job[[int]]))
+static_assert(is_assignable_to(TypeOf[defaulted_job], Job[[int]]))
+static_assert(not is_assignable_to(TypeOf[wrong_job], Job[[int]]))
 ```
 
 ## `Concatenate`

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1504,6 +1504,50 @@ static_assert(not is_subtype_of(Command[int, [str], object], Command[Any, ..., A
 static_assert(not is_subtype_of(Command[Any, ..., Any], Command[int, [str], object]))
 ```
 
+`ParamSpec` specializations in generic classes are compared using the callable parameter relation.
+This avoids rejecting wrappers around callbacks that are safe to use with a positional-only callback
+protocol.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from collections.abc import Callable, Coroutine
+from datetime import datetime
+from typing import Any, Final
+from ty_extensions import TypeOf, static_assert, is_assignable_to
+
+class Job[**P, R]:
+    target: Final[Callable[P, R]]
+
+    def __init__(self, target: Callable[P, R]) -> None:
+        self.target = target
+
+def named(now: datetime) -> None:
+    pass
+
+def defaulted(now: datetime | None = None) -> None:
+    pass
+
+async def async_callback(now: datetime) -> None:
+    pass
+
+def exception_callback(_: Exception | None = None) -> None:
+    pass
+
+named_job = Job(named)
+defaulted_job = Job(defaulted)
+async_job = Job(async_callback)
+exception_job = Job(exception_callback)
+
+static_assert(is_assignable_to(TypeOf[named_job], Job[[datetime], None]))
+static_assert(is_assignable_to(TypeOf[defaulted_job], Job[[datetime], None]))
+static_assert(is_assignable_to(TypeOf[async_job], Job[[datetime], Coroutine[Any, Any, None] | None]))
+static_assert(not is_assignable_to(TypeOf[exception_job], Job[[datetime], None]))
+```
+
 ## `Concatenate`
 
 ### Self-assignability

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1247,7 +1247,7 @@ impl<'db> Specialization<'db> {
             .variables(db)
             .zip(self.types(db))
             .map(|(bound_typevar, vartype)| {
-                match bound_typevar.variance(db) {
+                match specialization_variance(db, bound_typevar) {
                     TypeVarVariance::Bivariant => {
                         // With bivariance, all specializations are subtypes of each other,
                         // so any materialization is acceptable.
@@ -1369,7 +1369,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 //   - contravariant: verify that target_type <: source_type
                 //   - invariant: verify that source_type <: target_type AND target_type <: source_type
                 //   - bivariant: skip, can't make subtyping/assignability false
-                match bound_typevar.variance(db) {
+                match specialization_variance(db, bound_typevar) {
                     TypeVarVariance::Invariant => self.check_relation_in_invariant_position(
                         db,
                         *source_type,
@@ -1564,6 +1564,21 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 })
             }
         }
+    }
+}
+
+fn specialization_variance<'db>(
+    db: &'db dyn Db,
+    bound_typevar: BoundTypeVarInstance<'db>,
+) -> TypeVarVariance {
+    let variance = bound_typevar.variance(db);
+    if bound_typevar.is_paramspec(db) {
+        // `ParamSpec` specializations are represented as callable-shaped values. Their relation
+        // and materialization already use callable parameter contravariance, so flip the generic
+        // variance here to avoid applying that direction twice.
+        variance.flip()
+    } else {
+        variance
     }
 }
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -3,6 +3,7 @@ use ruff_python_ast::name::Name;
 use rustc_hash::FxHashSet;
 
 use crate::place::{DefinedPlace, Place};
+use crate::types::callable::CallableTypeKind;
 use crate::types::constraints::{
     ConstraintSetBuilder, IteratorConstraintsExtension, OptionConstraintsExtension,
     OwnedConstraintSet,
@@ -11,6 +12,7 @@ use crate::types::cyclic::PairVisitor;
 use crate::types::enums::is_single_member_enum;
 use crate::types::function::FunctionDecorators;
 use crate::types::set_theoretic::RecursivelyDefined;
+use crate::types::signatures::ParametersKind;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -1064,6 +1066,19 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     })
             }
 
+            // A gradual `ParamSpec` value (`...`) is assignability-consistent with any concrete
+            // `ParamSpec` value. This only applies to fixed `ParamSpec` values in already-
+            // specialized generic aliases; inferable `ParamSpec`s are handled by the inference
+            // paths below.
+            (Type::TypeVar(bound_typevar), other) | (other, Type::TypeVar(bound_typevar))
+                if self.relation.is_assignability()
+                    && !bound_typevar.is_inferable(db, self.inferable)
+                    && bound_typevar.is_paramspec(db)
+                    && Self::is_gradual_paramspec_value(db, other) =>
+            {
+                self.always()
+            }
+
             // A fully static typevar is a subtype of its upper bound, and to something similar to
             // the union of its constraints. An unbound, unconstrained, fully static typevar has an
             // implicit upper bound of `object` (which is handled above).
@@ -1872,6 +1887,28 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             disjointness_visitor: self.disjointness_visitor,
             materialization_visitor: self.materialization_visitor,
         }
+    }
+
+    /// Return `true` if `ty` is the gradual `...` value for a `ParamSpec`.
+    ///
+    /// For example, in `Command[Any, ..., Any]`, the middle type argument is represented as a
+    /// callable-shaped `ParamSpec` value with gradual parameters. That value is assignability-
+    /// consistent with a concrete `ParamSpec` specialization such as the middle type argument in
+    /// `Command[int, [str], object]`.
+    ///
+    /// This intentionally does not match arbitrary gradual callables like `Callable[..., object]`
+    /// or prefixed gradual forms like `Callable[Concatenate[int, ...], object]`; it only matches
+    /// the internal value used to represent a bare `...` `ParamSpec` specialization.
+    fn is_gradual_paramspec_value(db: &'db dyn Db, ty: Type<'db>) -> bool {
+        let Type::Callable(callable) = ty else {
+            return false;
+        };
+
+        callable.kind(db) == CallableTypeKind::ParamSpecValue
+            && callable
+                .signatures(db)
+                .iter()
+                .all(|signature| signature.parameters().kind() == ParametersKind::Gradual)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1079,6 +1079,16 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.always()
             }
 
+            // Any concrete specialization of a `ParamSpec` is a subtype of the top
+            // materialization of a `ParamSpec` value.
+            (Type::TypeVar(bound_typevar), other)
+                if !bound_typevar.is_inferable(db, self.inferable)
+                    && bound_typevar.is_paramspec(db)
+                    && Self::is_top_paramspec_value(db, other) =>
+            {
+                self.always()
+            }
+
             // A fully static typevar is a subtype of its upper bound, and to something similar to
             // the union of its constraints. An unbound, unconstrained, fully static typevar has an
             // implicit upper bound of `object` (which is handled above).
@@ -1909,6 +1919,19 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 .signatures(db)
                 .iter()
                 .all(|signature| signature.parameters().kind() == ParametersKind::Gradual)
+    }
+
+    /// Returns `true` if `ty` is the top materialization of a `ParamSpec` value.
+    fn is_top_paramspec_value(db: &'db dyn Db, ty: Type<'db>) -> bool {
+        let Type::Callable(callable) = ty else {
+            return false;
+        };
+
+        callable.kind(db) == CallableTypeKind::ParamSpecValue
+            && callable
+                .signatures(db)
+                .iter()
+                .all(|signature| signature.parameters().kind() == ParametersKind::Top)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1070,7 +1070,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // `ParamSpec` value. This only applies to fixed `ParamSpec` values in already-
             // specialized generic aliases; inferable `ParamSpec`s are handled by the inference
             // paths below.
-            (Type::TypeVar(bound_typevar), other) | (other, Type::TypeVar(bound_typevar))
+            (Type::TypeVar(bound_typevar), Type::Callable(other))
+            | (Type::Callable(other), Type::TypeVar(bound_typevar))
                 if self.relation.is_assignability()
                     && !bound_typevar.is_inferable(db, self.inferable)
                     && bound_typevar.is_paramspec(db)
@@ -1081,7 +1082,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // Any concrete specialization of a `ParamSpec` is a subtype of the top
             // materialization of a `ParamSpec` value.
-            (Type::TypeVar(bound_typevar), other)
+            (Type::TypeVar(bound_typevar), Type::Callable(other))
                 if !bound_typevar.is_inferable(db, self.inferable)
                     && bound_typevar.is_paramspec(db)
                     && Self::is_top_paramspec_value(db, other) =>
@@ -1899,7 +1900,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         }
     }
 
-    /// Return `true` if `ty` is the gradual `...` value for a `ParamSpec`.
+    /// Return `true` if `callable` is the gradual `...` value for a `ParamSpec`.
     ///
     /// For example, in `Command[Any, ..., Any]`, the middle type argument is represented as a
     /// callable-shaped `ParamSpec` value with gradual parameters. That value is assignability-
@@ -1909,11 +1910,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     /// This intentionally does not match arbitrary gradual callables like `Callable[..., object]`
     /// or prefixed gradual forms like `Callable[Concatenate[int, ...], object]`; it only matches
     /// the internal value used to represent a bare `...` `ParamSpec` specialization.
-    fn is_gradual_paramspec_value(db: &'db dyn Db, ty: Type<'db>) -> bool {
-        let Type::Callable(callable) = ty else {
-            return false;
-        };
-
+    fn is_gradual_paramspec_value(db: &'db dyn Db, callable: CallableType<'db>) -> bool {
         callable.kind(db) == CallableTypeKind::ParamSpecValue
             && callable
                 .signatures(db)
@@ -1921,12 +1918,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 .all(|signature| signature.parameters().kind() == ParametersKind::Gradual)
     }
 
-    /// Returns `true` if `ty` is the top materialization of a `ParamSpec` value.
-    fn is_top_paramspec_value(db: &'db dyn Db, ty: Type<'db>) -> bool {
-        let Type::Callable(callable) = ty else {
-            return false;
-        };
-
+    /// Returns `true` if `callable` is the top materialization of a `ParamSpec` value.
+    fn is_top_paramspec_value(db: &'db dyn Db, callable: CallableType<'db>) -> bool {
         callable.kind(db) == CallableTypeKind::ParamSpecValue
             && callable
                 .signatures(db)

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -13,7 +13,7 @@
 use std::collections::BTreeMap;
 use std::slice::Iter;
 
-use itertools::{EitherOrBoth, Itertools};
+use itertools::{Either, EitherOrBoth, Itertools};
 use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec_inline};
 
@@ -866,18 +866,36 @@ impl<'db> VarianceInferable<'db> for &Signature<'db> {
             "Checking variance of `{tvar}` in `{self:?}`",
             tvar = typevar.typevar(db).name(db)
         );
-        itertools::chain(
-            self.parameters
-                .iter()
-                .filter_map(|parameter| match parameter.form {
-                    ParameterForm::Type => None,
-                    ParameterForm::Value => Some(
-                        parameter
-                            .annotated_type()
+
+        let parameter_variance = |parameter: &Parameter<'db>| match parameter.form {
+            ParameterForm::Type => None,
+            ParameterForm::Value => Some(
+                parameter
+                    .annotated_type()
+                    .with_polarity(TypeVarVariance::Contravariant)
+                    .variance_of(db, typevar),
+            ),
+        };
+
+        let parameter_variances = if let Some((prefix_parameters, paramspec)) =
+            self.parameters.as_paramspec_with_prefix()
+        {
+            Either::Left(
+                prefix_parameters
+                    .iter()
+                    .filter_map(parameter_variance)
+                    .chain(std::iter::once(
+                        Type::TypeVar(paramspec)
                             .with_polarity(TypeVarVariance::Contravariant)
                             .variance_of(db, typevar),
-                    ),
-                }),
+                    )),
+            )
+        } else {
+            Either::Right(self.parameters.iter().filter_map(parameter_variance))
+        };
+
+        itertools::chain(
+            parameter_variances,
             Some(self.return_ty.variance_of(db, typevar)),
         )
         .collect()

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -305,6 +305,8 @@ fn type_alias_variance() {
     db.write_dedented(
         "/src/a.py",
         r#"
+from typing import Callable, Concatenate
+
 class Covariant[T]:
     def get(self) -> T:
         raise ValueError
@@ -326,6 +328,9 @@ type CovariantAlias[T] = Covariant[T]
 type ContravariantAlias[T] = Contravariant[T]
 type InvariantAlias[T] = Invariant[T]
 type BivariantAlias[T] = Bivariant[T]
+type ParamSpecContravariantAlias[**P] = Callable[P, None]
+type ParamSpecConcatenateAlias[**P] = Callable[Concatenate[int, P], None]
+type ParamSpecBivariantAlias[**P] = int
 
 type RecursiveAlias[T] = None | list[RecursiveAlias[T]]
 type RecursiveAlias2[T] = None | list[T] | list[RecursiveAlias2[T]]
@@ -357,6 +362,27 @@ type RecursiveAlias2[T] = None | list[T] | list[RecursiveAlias2[T]]
     assert_eq!(
         KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(bivariant))
             .variance_of(&db, get_bound_typevar(&db, bivariant)),
+        TypeVarVariance::Bivariant
+    );
+
+    let paramspec_contravariant = get_type_alias(&db, "ParamSpecContravariantAlias");
+    assert_eq!(
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(paramspec_contravariant))
+            .variance_of(&db, get_bound_typevar(&db, paramspec_contravariant)),
+        TypeVarVariance::Contravariant
+    );
+
+    let paramspec_concatenate = get_type_alias(&db, "ParamSpecConcatenateAlias");
+    assert_eq!(
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(paramspec_concatenate))
+            .variance_of(&db, get_bound_typevar(&db, paramspec_concatenate)),
+        TypeVarVariance::Contravariant
+    );
+
+    let paramspec_bivariant = get_type_alias(&db, "ParamSpecBivariantAlias");
+    assert_eq!(
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(paramspec_bivariant))
+            .variance_of(&db, get_bound_typevar(&db, paramspec_bivariant)),
         TypeVarVariance::Bivariant
     );
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -577,7 +577,10 @@ impl<'db> TypeVarInstance<'db> {
                 let known_class = func_ty.as_class_literal().and_then(|cls| cls.known(db));
                 let expr = &call_expr.arguments.find_keyword("default")?.value;
                 let default_type = definition_expression_type(db, definition, expr);
-                if known_class == Some(KnownClass::ParamSpec) {
+                if matches!(
+                    known_class,
+                    Some(KnownClass::ParamSpec | KnownClass::ExtensionsParamSpec)
+                ) {
                     convert_type_to_paramspec_value(db, default_type)
                 } else {
                     default_type


### PR DESCRIPTION
## Summary

This PR fixes several ParamSpec variance and gradual-specialization edge cases that fell out of https://github.com/astral-sh/ruff/pull/24319.

We also now treat `typing_extensions.ParamSpec` defaults like `typing.ParamSpec` defaults, which I think was an oversight.
