### PR TITLE
[ty] Respect property deleters in attribute deletion checks

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/del.md
+++ b/crates/ty_python_semantic/resources/mdtest/del.md
@@ -169,6 +169,87 @@ c = C()
 reveal_type(c.x)  # revealed: int
 ```
 
+### Custom deleters
+
+```py
+from typing import NamedTuple, NoReturn
+
+class ReadOnlyProperty:
+    @property
+    def x(self) -> int:
+        return 1
+
+class SupportsDelete:
+    @property
+    def x(self) -> int:
+        return 1
+
+    @x.deleter
+    def x(self) -> None:
+        pass
+
+class SupportsCustomDelete:
+    @property
+    def x(self) -> int:
+        return 1
+
+    def __delattr__(self, name: str) -> None:
+        pass
+
+class RejectsDelete:
+    @property
+    def x(self) -> int:
+        return 1
+
+    def __delattr__(self, name: str) -> NoReturn:
+        raise AttributeError(name)
+
+class DeletableNamedTuple(NamedTuple):
+    x: int
+
+    def __delattr__(self, name: str) -> None:
+        pass
+
+class Weird:
+    def __delete__(self, instance: object, extra: object) -> None:
+        pass
+
+class FallbackInstanceAttribute:
+    def __init__(self) -> None:
+        self.x = Weird()
+
+class BadDelAttr:
+    x: int = 1
+
+    # error: [invalid-method-override] "Invalid override of method `__delattr__`: Definition is incompatible with `object.__delattr__`"
+    def __delattr__(self, name: int) -> None:
+        pass
+
+read_only = ReadOnlyProperty()
+# error: [invalid-assignment] "Cannot delete read-only property `x` on object of type `ReadOnlyProperty`"
+del read_only.x
+
+supports_delete = SupportsDelete()
+del supports_delete.x
+
+supports_custom_delete = SupportsCustomDelete()
+del supports_custom_delete.x
+
+rejects_delete = RejectsDelete()
+# error: [invalid-assignment] "Cannot delete attribute `x` on type `RejectsDelete` whose `__delattr__` method returns `Never`/`NoReturn`"
+del rejects_delete.x
+
+fallback_instance_attribute = FallbackInstanceAttribute()
+del fallback_instance_attribute.x
+
+bad_delattr = BadDelAttr()
+# error: [invalid-assignment] "Cannot delete attribute `x` on type `BadDelAttr` with custom `__delattr__` method."
+del bad_delattr.x
+
+deletable_namedtuple = DeletableNamedTuple(1)
+del deletable_namedtuple.x
+```
+
 ## Delete items
 
 ### Basic item deletion

--- a/crates/ty_python_semantic/resources/mdtest/del.md
+++ b/crates/ty_python_semantic/resources/mdtest/del.md
@@ -169,10 +169,10 @@ c = C()
 reveal_type(c.x)  # revealed: int
 ```
 
-### Custom deleters
+### Property deleters
 
 ```py
-from typing import NamedTuple, NoReturn
+from typing import NoReturn
 
 class ReadOnlyProperty:
     @property
@@ -187,6 +187,44 @@ class SupportsDelete:
     @x.deleter
     def x(self) -> None:
         pass
+
+class RejectsDescriptorDelete:
+    @property
+    def x(self) -> int:
+        return 1
+
+    @x.deleter
+    def x(self) -> NoReturn:
+        raise AttributeError("x")
+
+class ExplicitNoneDeleter:
+    def get(self) -> int:
+        return 1
+
+    keyword = property(get, fdel=None)
+    positional = property(get, None, None)
+
+read_only = ReadOnlyProperty()
+# error: [invalid-assignment] "Cannot delete read-only property `x` on object of type `ReadOnlyProperty`"
+del read_only.x
+
+supports_delete = SupportsDelete()
+del supports_delete.x
+
+rejects_descriptor_delete = RejectsDescriptorDelete()
+del rejects_descriptor_delete.x
+
+explicit_none_deleter = ExplicitNoneDeleter()
+# error: [invalid-assignment] "Cannot delete read-only property `keyword` on object of type `ExplicitNoneDeleter`"
+del explicit_none_deleter.keyword
+# error: [invalid-assignment] "Cannot delete read-only property `positional` on object of type `ExplicitNoneDeleter`"
+del explicit_none_deleter.positional
+```
+
+### Instance `__delattr__`
+
+```py
+from typing import NamedTuple, NoReturn
 
 class SupportsCustomDelete:
     @property
@@ -204,20 +242,6 @@ class RejectsDelete:
     def __delattr__(self, name: str) -> NoReturn:
         raise AttributeError(name)
 
-class DeletableNamedTuple(NamedTuple):
-    x: int
-
-    def __delattr__(self, name: str) -> None:
-        pass
-
-class Weird:
-    def __delete__(self, instance: object, extra: object) -> None:
-        pass
-
-class FallbackInstanceAttribute:
-    def __init__(self) -> None:
-        self.x = Weird()
-
 class BadDelAttr:
     x: int = 1
 
@@ -225,12 +249,11 @@ class BadDelAttr:
     def __delattr__(self, name: int) -> None:
         pass
 
-read_only = ReadOnlyProperty()
-# error: [invalid-assignment] "Cannot delete read-only property `x` on object of type `ReadOnlyProperty`"
-del read_only.x
+class DeletableNamedTuple(NamedTuple):
+    x: int
 
-supports_delete = SupportsDelete()
-del supports_delete.x
+    def __delattr__(self, name: str) -> None:
+        pass
 
 supports_custom_delete = SupportsCustomDelete()
 del supports_custom_delete.x
@@ -239,15 +262,43 @@ rejects_delete = RejectsDelete()
 # error: [invalid-assignment] "Cannot delete attribute `x` on type `RejectsDelete` whose `__delattr__` method returns `Never`/`NoReturn`"
 del rejects_delete.x
 
-fallback_instance_attribute = FallbackInstanceAttribute()
-del fallback_instance_attribute.x
-
 bad_delattr = BadDelAttr()
 # error: [invalid-assignment] "Cannot delete attribute `x` on type `BadDelAttr` with custom `__delattr__` method."
 del bad_delattr.x
 
 deletable_namedtuple = DeletableNamedTuple(1)
 del deletable_namedtuple.x
+```
+
+### Descriptor `__delete__`
+
+```py
+class Weird:
+    def __delete__(self, instance: object, extra: object) -> None:
+        pass
+
+class FallbackInstanceAttribute:
+    def __init__(self) -> None:
+        self.x = Weird()
+
+fallback_instance_attribute = FallbackInstanceAttribute()
+del fallback_instance_attribute.x
+```
+
+### Metaclass `__delattr__`
+
+```py
+from typing import NoReturn
+
+class RejectsClassDeleteMeta(type):
+    def __delattr__(self, name: str) -> NoReturn:
+        raise AttributeError(name)
+
+class RejectsClassDelete(metaclass=RejectsClassDeleteMeta):
+    x: int = 1
+
+# error: [invalid-assignment] "Cannot delete attribute `x` on type `<class 'RejectsClassDelete'>` whose `__delattr__` method returns `Never`/`NoReturn`"
+del RejectsClassDelete.x
 ```
 
 ## Delete items

--- a/crates/ty_python_semantic/resources/mdtest/del.md
+++ b/crates/ty_python_semantic/resources/mdtest/del.md
@@ -212,6 +212,7 @@ supports_delete = SupportsDelete()
 del supports_delete.x
 
 rejects_descriptor_delete = RejectsDescriptorDelete()
+# TODO: this should be an error once properties with `Never`/`NoReturn` deleters are rejected
 del rejects_descriptor_delete.x
 
 explicit_none_deleter = ExplicitNoneDeleter()
@@ -263,7 +264,7 @@ rejects_delete = RejectsDelete()
 del rejects_delete.x
 
 bad_delattr = BadDelAttr()
-# error: [invalid-assignment] "Cannot delete attribute `x` on type `BadDelAttr` with custom `__delattr__` method."
+# error: [invalid-assignment] "Cannot delete attribute `x` on type `BadDelAttr` with custom `__delattr__` method"
 del bad_delattr.x
 
 deletable_namedtuple = DeletableNamedTuple(1)
@@ -290,12 +291,21 @@ del fallback_instance_attribute.x
 ```py
 from typing import NoReturn
 
+class SupportsClassDeleteMeta(type):
+    def __delattr__(self, name: str) -> None:
+        pass
+
+class SupportsClassDelete(metaclass=SupportsClassDeleteMeta):
+    x: int = 1
+
 class RejectsClassDeleteMeta(type):
     def __delattr__(self, name: str) -> NoReturn:
         raise AttributeError(name)
 
 class RejectsClassDelete(metaclass=RejectsClassDeleteMeta):
     x: int = 1
+
+del SupportsClassDelete.x
 
 # error: [invalid-assignment] "Cannot delete attribute `x` on type `<class 'RejectsClassDelete'>` whose `__delattr__` method returns `Never`/`NoReturn`"
 del RejectsClassDelete.x

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_assignment_details.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_assignment_details.md
@@ -364,6 +364,18 @@ def _(source: list[str]):
     target: Iterable[bytes] = source  # error: [invalid-assignment]
 ```
 
+## Deleting a read-only property
+
+```py
+class C:
+    @property
+    def attr(self) -> int:
+        return 1
+
+c = C()
+del c.attr  # error: [invalid-assignment]
+```
+
 ## Invariant generic classes
 
 We show a special diagnostic hint for invariant generic classes. For example, if you try to assign a

--- a/crates/ty_python_semantic/resources/mdtest/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/final.md
@@ -1164,8 +1164,7 @@ class Bad(Base):  # error: [abstract-method-in-final-class]
     pass
 ```
 
-Similarly, a property with an abstract deleter is also abstract. However, we don't yet support
-property deleters, so this is a TODO test:
+Similarly, a property with an abstract deleter (but concrete getter and setter) is also abstract:
 
 ```py
 from abc import ABC, abstractmethod
@@ -1185,8 +1184,13 @@ class Base(ABC):
     def value(self) -> None: ...
 
 @final
-# TODO: should emit [abstract-method-in-final-class]
-class Bad(Base):
+class Good(Base):
+    @Base.value.deleter
+    def value(self) -> None:
+        pass
+
+@final
+class Bad(Base):  # error: [abstract-method-in-final-class]
     pass
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -84,6 +84,8 @@ reveal_type(Person.age)  # revealed: property
 alice.id = 42
 # error: [invalid-assignment]
 bob.age = None
+# error: [invalid-assignment]
+del alice.id
 ```
 
 Alternative functional syntax with a list of tuples:

--- a/crates/ty_python_semantic/resources/mdtest/properties.md
+++ b/crates/ty_python_semantic/resources/mdtest/properties.md
@@ -112,8 +112,7 @@ c.my_property = "b"
 
 ## `property.deleter`
 
-We do not support `property.deleter` yet, but we make sure that it does not invalidate the getter or
-setter:
+We support `property.deleter`, and it preserves the getter and setter:
 
 ```py
 class C:
@@ -131,6 +130,7 @@ class C:
 
 c = C()
 reveal_type(c.my_property)  # revealed: int
+del c.my_property
 c.my_property = 2
 # error: [invalid-assignment]
 c.my_property = "a"

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_assignment_d…_-_Invalid_assignment_d…_-_Deleting_a_read-only…_(f18c593c933d9fae).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_assignment_d…_-_Invalid_assignment_d…_-_Deleting_a_read-only…_(f18c593c933d9fae).snap
@@ -1,0 +1,44 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: invalid_assignment_details.md - Invalid assignment diagnostics - Deleting a read-only property
+mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_assignment_details.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | class C:
+2 |     @property
+3 |     def attr(self) -> int:
+4 |         return 1
+5 | 
+6 | c = C()
+7 | del c.attr  # error: [invalid-assignment]
+```
+
+# Diagnostics
+
+```
+error[invalid-assignment]: Cannot delete read-only property `attr` on object of type `C`
+ --> src/mdtest_snippet.py:7:5
+  |
+6 | c = C()
+7 | del c.attr  # error: [invalid-assignment]
+  |     ^^^^^^ Attempted deletion of `C.attr` here
+  |
+ ::: src/mdtest_snippet.py:3:9
+  |
+1 | class C:
+2 |     @property
+3 |     def attr(self) -> int:
+  |         ---- Property `C.attr` defined here with no deleter
+4 |         return 1
+  |
+
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -543,6 +543,7 @@ pub(crate) use todo_type;
 pub struct PropertyInstanceType<'db> {
     pub getter: Option<Type<'db>>,
     pub setter: Option<Type<'db>>,
+    pub deleter: Option<Type<'db>>,
 }
 
 fn walk_property_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
@@ -555,6 +556,9 @@ fn walk_property_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     }
     if let Some(setter) = property.setter(db) {
         visitor.visit_type(db, setter);
+    }
+    if let Some(deleter) = property.deleter(db) {
+        visitor.visit_type(db, deleter);
     }
 }
 
@@ -575,7 +579,10 @@ impl<'db> PropertyInstanceType<'db> {
         let setter = self
             .setter(db)
             .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
-        Self::new(db, getter, setter)
+        let deleter = self
+            .deleter(db)
+            .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
+        Self::new(db, getter, setter, deleter)
     }
 
     fn recursive_type_normalized_impl(
@@ -600,7 +607,15 @@ impl<'db> PropertyInstanceType<'db> {
             ),
             None => None,
         };
-        Some(Self::new(db, getter, setter))
+        let deleter = match self.deleter(db) {
+            Some(ty) if nested => Some(ty.recursive_type_normalized_impl(db, div, true)?),
+            Some(ty) => Some(
+                ty.recursive_type_normalized_impl(db, div, true)
+                    .unwrap_or(div),
+            ),
+            None => None,
+        };
+        Some(Self::new(db, getter, setter, deleter))
     }
 
     fn find_legacy_typevars_impl(
@@ -614,6 +629,9 @@ impl<'db> PropertyInstanceType<'db> {
             ty.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
         }
         if let Some(ty) = self.setter(db) {
+            ty.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+        }
+        if let Some(ty) = self.deleter(db) {
             ty.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
         }
     }
@@ -2411,6 +2429,12 @@ impl<'db> Type<'db> {
                         ))
                         .into(),
                     ),
+                    (Some(KnownClass::Property), "__delete__") => Some(
+                        Place::bound(Type::WrapperDescriptor(
+                            WrapperDescriptorKind::PropertyDunderDelete,
+                        ))
+                        .into(),
+                    ),
 
                     _ => Some(class.class_member(db, name, policy)),
                 }
@@ -3178,6 +3202,10 @@ impl<'db> Type<'db> {
                 Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderSet(property)),
             )
             .into(),
+            Type::PropertyInstance(property) if name == "__delete__" => Place::bound(
+                Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(property)),
+            )
+            .into(),
 
             Type::LiteralValue(literal) if literal.is_string() && name == "startswith" => {
                 let string_literal = literal.as_string().unwrap();
@@ -3260,6 +3288,14 @@ impl<'db> Type<'db> {
                 ))
                 .into()
             }
+            Type::ClassLiteral(class)
+                if name == "__delete__" && class.is_known(db, KnownClass::Property) =>
+            {
+                Place::bound(Type::WrapperDescriptor(
+                    WrapperDescriptorKind::PropertyDunderDelete,
+                ))
+                .into()
+            }
             Type::BoundMethod(bound_method) => match name_str {
                 "__self__" => Place::bound(bound_method.self_instance(db)).into(),
                 "__func__" => Place::bound(Type::FunctionLiteral(bound_method.function(db))).into(),
@@ -3316,6 +3352,9 @@ impl<'db> Type<'db> {
             }
             Type::PropertyInstance(property) if name == "fset" => {
                 Place::bound(property.setter(db).unwrap_or(Type::none(db))).into()
+            }
+            Type::PropertyInstance(property) if name == "fdel" => {
+                Place::bound(property.deleter(db).unwrap_or(Type::none(db))).into()
             }
 
             Type::LiteralValue(literal)
@@ -5648,6 +5687,11 @@ impl<'db> Type<'db> {
                     property.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 ))
             }
+            Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(property)) => {
+                Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(
+                    property.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                ))
+            }
 
             Type::Callable(callable) => {
                 Type::Callable(callable.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
@@ -5893,7 +5937,8 @@ impl<'db> Type<'db> {
 
             Type::KnownBoundMethod(
                 KnownBoundMethodType::PropertyDunderGet(property)
-                | KnownBoundMethodType::PropertyDunderSet(property),
+                | KnownBoundMethodType::PropertyDunderSet(property)
+                | KnownBoundMethodType::PropertyDunderDelete(property),
             ) => {
                 property.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
@@ -6189,8 +6234,9 @@ impl<'db> Type<'db> {
 
             Self::PropertyInstance(property) => property
                 .getter(db)
-                .and_then(|getter|getter.definition(db))
-                .or_else(||property.setter(db).and_then(|setter|setter.definition(db))),
+                .and_then(|getter| getter.definition(db))
+                .or_else(|| property.setter(db).and_then(|setter| setter.definition(db)))
+                .or_else(|| property.deleter(db).and_then(|deleter| deleter.definition(db))),
 
             Self::LiteralValue(_)
             // TODO: For enum literals, it would be even better to jump to the definition of the specific member
@@ -6392,6 +6438,7 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
                 .getter(db)
                 .iter()
                 .chain(&property_instance_type.setter(db))
+                .chain(&property_instance_type.deleter(db))
                 .map(|ty| ty.variance_of(db, typevar))
                 .collect(),
             Type::SubclassOf(subclass_of_type) => subclass_of_type.variance_of(db, typevar),

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -121,6 +121,24 @@ impl<'db> CallError<'db> {
                 _ => None,
             })
     }
+
+    /// Returns `Some(property)` if the call error was caused by an attempt to delete a property
+    /// that has no deleter, and `None` otherwise.
+    pub(crate) fn as_attempt_to_delete_property_with_no_deleter(
+        &self,
+    ) -> Option<PropertyInstanceType<'db>> {
+        if self.0 != CallErrorKind::BindingError {
+            return None;
+        }
+        self.1
+            .iter_flat()
+            .flatten()
+            .flat_map(bind::Binding::errors)
+            .find_map(|error| match error {
+                BindingError::PropertyHasNoDeleter(property) => Some(*property),
+                _ => None,
+            })
+    }
 }
 
 /// The reason why calling a type failed.

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1266,6 +1266,26 @@ impl<'db> Bindings<'db> {
                         }
                     }
 
+                    Type::WrapperDescriptor(WrapperDescriptorKind::PropertyDunderDelete) => {
+                        if let [Some(Type::PropertyInstance(property)), Some(instance), ..] =
+                            overload.parameter_types()
+                        {
+                            if let Some(deleter) = property.deleter(db) {
+                                if let Err(_call_error) =
+                                    deleter.try_call(db, &CallArguments::positional([*instance]))
+                                {
+                                    overload.errors.push(BindingError::InternalCallError(
+                                        "calling the deleter failed",
+                                    ));
+                                }
+                            } else {
+                                overload
+                                    .errors
+                                    .push(BindingError::PropertyHasNoDeleter(*property));
+                            }
+                        }
+                    }
+
                     Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderSet(property)) => {
                         if let [Some(instance), Some(value), ..] = overload.parameter_types() {
                             if let Some(setter) = property.setter(db) {
@@ -1280,6 +1300,26 @@ impl<'db> Bindings<'db> {
                                 overload
                                     .errors
                                     .push(BindingError::PropertyHasNoSetter(property));
+                            }
+                        }
+                    }
+
+                    Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(
+                        property,
+                    )) => {
+                        if let [Some(instance), ..] = overload.parameter_types() {
+                            if let Some(deleter) = property.deleter(db) {
+                                if let Err(_call_error) =
+                                    deleter.try_call(db, &CallArguments::positional([*instance]))
+                                {
+                                    overload.errors.push(BindingError::InternalCallError(
+                                        "calling the deleter failed",
+                                    ));
+                                }
+                            } else {
+                                overload
+                                    .errors
+                                    .push(BindingError::PropertyHasNoDeleter(property));
                             }
                         }
                     }
@@ -1341,6 +1381,7 @@ impl<'db> Bindings<'db> {
                                                 db,
                                                 property.getter(db),
                                                 Some(*setter),
+                                                property.deleter(db),
                                             ));
                                     }
                                     overload.set_return_type(ty_property);
@@ -1355,15 +1396,26 @@ impl<'db> Bindings<'db> {
                                                 db,
                                                 Some(*getter),
                                                 property.setter(db),
+                                                property.deleter(db),
                                             ));
                                     }
                                     overload.set_return_type(ty_property);
                                 }
                             }
                             "deleter" => {
-                                // TODO: we do not store deleters yet
-                                let ty_property = bound_method.self_instance(db);
-                                overload.set_return_type(ty_property);
+                                if let [Some(_), Some(deleter)] = overload.parameter_types() {
+                                    let mut ty_property = bound_method.self_instance(db);
+                                    if let Type::PropertyInstance(property) = ty_property {
+                                        ty_property =
+                                            Type::PropertyInstance(PropertyInstanceType::new(
+                                                db,
+                                                property.getter(db),
+                                                property.setter(db),
+                                                Some(*deleter),
+                                            ));
+                                    }
+                                    overload.set_return_type(ty_property);
+                                }
                             }
                             _ => {
                                 // Fall back to typeshed stubs for all other methods
@@ -2313,11 +2365,12 @@ impl<'db> Bindings<'db> {
                         }
 
                         Some(KnownClass::Property) => {
-                            if let [getter, setter, ..] = overload.parameter_types() {
+                            if let [getter, setter, deleter, ..] = overload.parameter_types() {
                                 let getter = getter.filter(|ty| !ty.is_none(db));
                                 let setter = setter.filter(|ty| !ty.is_none(db));
+                                let deleter = deleter.filter(|ty| !ty.is_none(db));
                                 overload.set_return_type(Type::PropertyInstance(
-                                    PropertyInstanceType::new(db, getter, setter),
+                                    PropertyInstanceType::new(db, getter, setter, deleter),
                                 ));
                             }
                         }
@@ -5341,12 +5394,19 @@ impl<'db> CallableDescription<'db> {
                     name: "`__get__` of property",
                 })
             }
+            Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(_)) => {
+                Some(CallableDescription {
+                    kind: "method wrapper",
+                    name: "`__delete__` of property",
+                })
+            }
             Type::WrapperDescriptor(kind) => Some(CallableDescription {
                 kind: "wrapper descriptor",
                 name: match kind {
                     WrapperDescriptorKind::FunctionTypeDunderGet => "FunctionType.__get__",
                     WrapperDescriptorKind::PropertyDunderGet => "property.__get__",
                     WrapperDescriptorKind::PropertyDunderSet => "property.__set__",
+                    WrapperDescriptorKind::PropertyDunderDelete => "property.__delete__",
                 },
             }),
             _ => None,
@@ -5457,6 +5517,7 @@ pub(crate) enum BindingError<'db> {
         argument_index: Option<usize>,
     },
     PropertyHasNoSetter(PropertyInstanceType<'db>),
+    PropertyHasNoDeleter(PropertyInstanceType<'db>),
     /// The call itself might be well constructed, but an error occurred while evaluating the call.
     /// We use this variant to report errors in `property.__get__` and `property.__set__`, which
     /// can occur when the call to the underlying getter/setter fails.
@@ -5513,7 +5574,8 @@ impl BindingError<'_> {
             | BindingError::InvalidDataclassApplication(..)
             | BindingError::MissingArguments { .. }
             | BindingError::UnmatchedOverload
-            | BindingError::PropertyHasNoSetter(..) => {}
+            | BindingError::PropertyHasNoSetter(..)
+            | BindingError::PropertyHasNoDeleter(..) => {}
         }
     }
 }
@@ -5561,6 +5623,7 @@ impl<'db> BindingError<'db> {
             // Semantic errors: the overload matched, but the usage is invalid
             Self::InvalidDataclassApplication(_)
             | Self::PropertyHasNoSetter(_)
+            | Self::PropertyHasNoDeleter(_)
             | Self::CalledTopCallable(_)
             | Self::InternalCallError(_) => false,
 
@@ -6008,6 +6071,17 @@ impl<'db> BindingError<'db> {
 
             Self::PropertyHasNoSetter(_) => {
                 BindingError::InternalCallError("property has no setter").report_diagnostic(
+                    context,
+                    node,
+                    callable_ty,
+                    callable_description,
+                    compound_diag,
+                    matching_overload,
+                );
+            }
+
+            Self::PropertyHasNoDeleter(_) => {
+                BindingError::InternalCallError("property has no deleter").report_diagnostic(
                     context,
                     node,
                     callable_ty,

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1029,13 +1029,18 @@ impl<'db> ClassType<'db> {
                     method.function(db).as_abstract_method(db, defining_class)
                 }
                 Type::PropertyInstance(property) => {
-                    // A property is abstract if either its getter or setter is abstract.
+                    // A property is abstract if any of its accessors is abstract.
                     property
                         .getter(db)
                         .and_then(|getter| type_as_abstract_method(db, getter, defining_class))
                         .or_else(|| {
                             property.setter(db).and_then(|setter| {
                                 type_as_abstract_method(db, setter, defining_class)
+                            })
+                        })
+                        .or_else(|| {
+                            property.deleter(db).and_then(|deleter| {
+                                type_as_abstract_method(db, deleter, defining_class)
                             })
                         })
                 }

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -579,6 +579,6 @@ fn create_field_property<'db>(db: &'db dyn Db, field_ty: Type<'db>) -> Type<'db>
         field_ty,
     );
     let property_getter = Type::single_callable(db, property_getter_signature);
-    let property = PropertyInstanceType::new(db, Some(property_getter), None);
+    let property = PropertyInstanceType::new(db, Some(property_getter), None, None);
     Type::PropertyInstance(property)
 }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1069,7 +1069,7 @@ impl<'db> StaticClassLiteral<'db> {
                     field.declared_ty,
                 );
                 let property_getter = Type::single_callable(db, property_getter_signature);
-                let property = PropertyInstanceType::new(db, Some(property_getter), None);
+                let property = PropertyInstanceType::new(db, Some(property_getter), None, None);
                 return Member::definitely_declared(Type::PropertyInstance(property));
             }
         }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3799,7 +3799,7 @@ pub(super) fn report_bad_dunder_delattr_call(
     };
     let db = context.db();
     let mut diagnostic = builder.into_diagnostic(format_args!(
-        "Cannot delete attribute `{attribute}` on type `{}` with custom `__delattr__` method.",
+        "Cannot delete attribute `{attribute}` on type `{}` with custom `__delattr__` method",
         object_type.display(db),
     ));
     if binding_error {

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3749,6 +3749,71 @@ pub(super) fn report_bad_dunder_set_call<'db>(
     }
 }
 
+pub(super) fn report_bad_dunder_delete_call<'db>(
+    context: &InferContext<'db, '_>,
+    dunder_delete_failure: &CallError<'db>,
+    attribute: &str,
+    object_type: Type<'db>,
+    target: &ast::ExprAttribute,
+) {
+    let Some(builder) = context.report_lint(&INVALID_ASSIGNMENT, target) else {
+        return;
+    };
+    let db = context.db();
+    if let Some(property) = dunder_delete_failure.as_attempt_to_delete_property_with_no_deleter() {
+        let object_type = object_type.display(db);
+        let mut diagnostic = builder.into_diagnostic(format_args!(
+            "Cannot delete read-only property `{attribute}` on object of type `{object_type}`",
+        ));
+        if let Some(file_range) = property
+            .getter(db)
+            .and_then(|getter| getter.definition(db))
+            .or_else(|| property.setter(db).and_then(|setter| setter.definition(db)))
+            .and_then(|definition| definition.focus_range(db))
+        {
+            diagnostic.annotate(Annotation::secondary(Span::from(file_range)).message(
+                format_args!("Property `{object_type}.{attribute}` defined here with no deleter"),
+            ));
+            diagnostic.set_primary_message(format_args!(
+                "Attempted deletion of `{object_type}.{attribute}` here"
+            ));
+        }
+    } else {
+        builder.into_diagnostic(format_args!(
+            "Invalid deletion of data descriptor attribute \
+            `{attribute}` on type `{}` with custom `__delete__` method",
+            object_type.display(db)
+        ));
+    }
+}
+
+pub(super) fn report_bad_dunder_delattr_call(
+    context: &InferContext<'_, '_>,
+    attribute: &str,
+    object_type: Type,
+    target: &ast::ExprAttribute,
+    binding_error: bool,
+) {
+    let Some(builder) = context.report_lint(&INVALID_ASSIGNMENT, target) else {
+        return;
+    };
+    let db = context.db();
+    let mut diagnostic = builder.into_diagnostic(format_args!(
+        "Cannot delete attribute `{attribute}` on type `{}` with custom `__delattr__` method.",
+        object_type.display(db),
+    ));
+    if binding_error {
+        diagnostic.info(format_args!(
+            "Type `{}` has a `__delattr__` method, but it cannot be called with the expected arguments",
+            object_type.display(db)
+        ));
+        diagnostic.info(
+            "Expected a signature at least as permissive as \
+            `def __delattr__(self, name: str, /) -> None`",
+        );
+    }
+}
+
 pub(super) fn report_invalid_return_type(
     context: &InferContext,
     object_range: impl Ranged,
@@ -5640,8 +5705,8 @@ pub(super) fn report_overridden_final_method<'db>(
     diagnostic.sub(sub);
 
     // It's tempting to autofix properties as well,
-    // but you'd want to delete the `@my_property.deleter` as well as the getter and the deleter,
-    // and we don't model property deleters at all right now.
+    // but you'd want to delete the `@my_property.deleter` as well as the getter and the setter,
+    // and we don't yet track those definitions precisely enough to offer a safe fix.
     //
     // We also only provide autofixes if the subclass member is a function definition (not an
     // assignment like `method = some_function`). If it's an assignment, the function type

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1085,9 +1085,19 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         "property",
                         Type::PropertyInstance(property),
                         property
-                            .getter(self.db)
+                            .setter(self.db)
                             .and_then(Type::as_function_literal)
-                            .map(|getter| &**getter.name(self.db)),
+                            .map(|setter| &**setter.name(self.db)),
+                    ),
+                    KnownBoundMethodType::PropertyDunderDelete(property) => (
+                        KnownClass::Property,
+                        "__delete__",
+                        "property",
+                        Type::PropertyInstance(property),
+                        property
+                            .deleter(self.db)
+                            .and_then(Type::as_function_literal)
+                            .map(|deleter| &**deleter.name(self.db)),
                     ),
                     KnownBoundMethodType::StrStartswith(literal) => (
                         KnownClass::Property,
@@ -1152,6 +1162,9 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     }
                     WrapperDescriptorKind::PropertyDunderSet => {
                         ("__set__", "property", KnownClass::Property)
+                    }
+                    WrapperDescriptorKind::PropertyDunderDelete => {
+                        ("__delete__", "property", KnownClass::Property)
                     }
                 };
                 f.write_char('<')?;

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -69,13 +69,14 @@ use crate::types::diagnostic::{
     INVALID_TYPE_VARIABLE_CONSTRAINTS, POSSIBLY_MISSING_IMPLICIT_CALL, POSSIBLY_MISSING_SUBMODULE,
     UNDEFINED_REVEAL, UNRESOLVED_ATTRIBUTE, UNRESOLVED_GLOBAL, UNRESOLVED_REFERENCE,
     UNSUPPORTED_OPERATOR, UNUSED_AWAITABLE, hint_if_stdlib_attribute_exists_on_other_versions,
-    report_attempted_protocol_instantiation, report_bad_dunder_set_call,
-    report_call_to_abstract_method, report_cannot_pop_required_field_on_typed_dict,
-    report_invalid_assignment, report_invalid_attribute_assignment,
-    report_invalid_class_match_pattern, report_invalid_exception_caught,
-    report_invalid_exception_cause, report_invalid_exception_raised,
-    report_invalid_exception_tuple_caught, report_invalid_generator_yield_type,
-    report_invalid_key_on_typed_dict, report_invalid_type_checking_constant,
+    report_attempted_protocol_instantiation, report_bad_dunder_delattr_call,
+    report_bad_dunder_delete_call, report_bad_dunder_set_call, report_call_to_abstract_method,
+    report_cannot_pop_required_field_on_typed_dict, report_invalid_assignment,
+    report_invalid_attribute_assignment, report_invalid_class_match_pattern,
+    report_invalid_exception_caught, report_invalid_exception_cause,
+    report_invalid_exception_raised, report_invalid_exception_tuple_caught,
+    report_invalid_generator_yield_type, report_invalid_key_on_typed_dict,
+    report_invalid_type_checking_constant,
     report_match_pattern_against_non_runtime_checkable_protocol,
     report_match_pattern_against_typed_dict, report_possibly_missing_attribute,
     report_possibly_unresolved_reference, report_unsupported_augmented_assignment,
@@ -2714,6 +2715,175 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     false
                 }
             }
+        }
+    }
+
+    fn validate_attribute_deletion(
+        &mut self,
+        target: &ast::ExprAttribute,
+        object_ty: Type<'db>,
+        attribute: &str,
+        emit_diagnostics: bool,
+    ) -> bool {
+        let db = self.db();
+
+        match object_ty {
+            Type::Union(union) => {
+                for element_ty in union.elements(db) {
+                    if !self.validate_attribute_deletion(target, *element_ty, attribute, false) {
+                        if emit_diagnostics {
+                            self.validate_attribute_deletion(target, *element_ty, attribute, true);
+                        }
+                        return false;
+                    }
+                }
+                true
+            }
+
+            Type::Intersection(intersection) => {
+                if intersection.positive(db).iter().any(|element_ty| {
+                    self.validate_attribute_deletion(target, *element_ty, attribute, false)
+                }) {
+                    true
+                } else {
+                    if emit_diagnostics && let Some(element_ty) = intersection.positive(db).first()
+                    {
+                        self.validate_attribute_deletion(target, *element_ty, attribute, true);
+                    }
+                    false
+                }
+            }
+
+            Type::TypeAlias(alias) => self.validate_attribute_deletion(
+                target,
+                alias.value_type(db),
+                attribute,
+                emit_diagnostics,
+            ),
+
+            Type::NominalInstance(..)
+            | Type::ProtocolInstance(_)
+            | Type::LiteralValue(..)
+            | Type::SpecialForm(..)
+            | Type::KnownInstance(..)
+            | Type::PropertyInstance(..)
+            | Type::FunctionLiteral(..)
+            | Type::Callable(..)
+            | Type::BoundMethod(_)
+            | Type::KnownBoundMethod(_)
+            | Type::WrapperDescriptor(_)
+            | Type::DataclassDecorator(_)
+            | Type::DataclassTransformer(_)
+            | Type::TypeVar(..)
+            | Type::AlwaysTruthy
+            | Type::AlwaysFalsy
+            | Type::TypeIs(_)
+            | Type::TypeGuard(_)
+            | Type::TypedDict(_)
+            | Type::NewTypeInstance(_) => {
+                let delattr_dunder_call_result = object_ty.try_call_dunder_with_policy(
+                    db,
+                    "__delattr__",
+                    &mut CallArguments::positional([Type::string_literal(db, attribute)]),
+                    TypeContext::default(),
+                    MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+                );
+
+                match &delattr_dunder_call_result {
+                    Ok(result) if result.return_type(db).is_never() => {
+                        if emit_diagnostics
+                            && let Some(builder) =
+                                self.context.report_lint(&INVALID_ASSIGNMENT, target)
+                        {
+                            builder.into_diagnostic(format_args!(
+                                "Cannot delete attribute `{attribute}` on type `{}` \
+                                 whose `__delattr__` method returns `Never`/`NoReturn`",
+                                object_ty.display(db),
+                            ));
+                        }
+                        return false;
+                    }
+                    Err(err) if err.return_type(db).is_some_and(|ty| ty.is_never()) => {
+                        if emit_diagnostics
+                            && let Some(builder) =
+                                self.context.report_lint(&INVALID_ASSIGNMENT, target)
+                        {
+                            builder.into_diagnostic(format_args!(
+                                "Cannot delete attribute `{attribute}` on type `{}` \
+                                 whose `__delattr__` method returns `Never`/`NoReturn`",
+                                object_ty.display(db),
+                            ));
+                        }
+                        return false;
+                    }
+                    _ => {}
+                }
+
+                match delattr_dunder_call_result {
+                    Ok(_) | Err(CallDunderError::PossiblyUnbound(_)) => return true,
+                    Err(CallDunderError::CallError(kind, _bindings)) => {
+                        if emit_diagnostics {
+                            report_bad_dunder_delattr_call(
+                                &self.context,
+                                attribute,
+                                object_ty,
+                                target,
+                                kind == CallErrorKind::BindingError,
+                            );
+                        }
+                        return false;
+                    }
+                    Err(CallDunderError::MethodNotAvailable) => {}
+                }
+
+                if let Some(PlaceAndQualifiers {
+                    place:
+                        Place::Defined(DefinedPlace {
+                            ty: attr_ty,
+                            definedness: Definedness::AlwaysDefined,
+                            ..
+                        }),
+                    ..
+                }) = self
+                    .assignment_attribute_members(object_ty, attribute)
+                    .map(|(meta_attr, _)| meta_attr)
+                {
+                    let attr_ty = attr_ty.bind_self_typevars(db, object_ty);
+                    match attr_ty.try_call_dunder(
+                        db,
+                        "__delete__",
+                        CallArguments::positional([object_ty]),
+                        TypeContext::default(),
+                    ) {
+                        Ok(_) | Err(CallDunderError::PossiblyUnbound(_)) => return true,
+                        Err(CallDunderError::CallError(kind, bindings)) => {
+                            if emit_diagnostics {
+                                let failure = CallError(kind, bindings);
+                                report_bad_dunder_delete_call(
+                                    &self.context,
+                                    &failure,
+                                    attribute,
+                                    object_ty,
+                                    target,
+                                );
+                            }
+                            return false;
+                        }
+                        Err(CallDunderError::MethodNotAvailable) => {}
+                    }
+                }
+
+                true
+            }
+
+            Type::ClassLiteral(..)
+            | Type::GenericAlias(..)
+            | Type::SubclassOf(..)
+            | Type::Dynamic(..)
+            | Type::Divergent(_)
+            | Type::Never
+            | Type::ModuleLiteral(..)
+            | Type::BoundSuper(..) => true,
         }
     }
 
@@ -8115,7 +8285,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     fn infer_attribute_expression(&mut self, attribute: &ast::ExprAttribute) -> Type<'db> {
         let ast::ExprAttribute {
             value,
-            attr: _,
+            attr,
             range: _,
             node_index: _,
             ctx,
@@ -8129,6 +8299,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             ExprContext::Del => {
                 self.infer_attribute_load(attribute);
+                self.validate_attribute_deletion(
+                    attribute,
+                    self.expression_type(value),
+                    attr.as_str(),
+                    true,
+                );
                 Type::Never
             }
             ExprContext::Invalid => {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2765,6 +2765,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             | Type::ProtocolInstance(_)
             | Type::LiteralValue(..)
             | Type::SpecialForm(..)
+            | Type::ClassLiteral(..)
+            | Type::GenericAlias(..)
+            | Type::SubclassOf(..)
             | Type::KnownInstance(..)
             | Type::PropertyInstance(..)
             | Type::FunctionLiteral(..)
@@ -2849,12 +2852,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .map(|(meta_attr, _)| meta_attr)
                 {
                     let attr_ty = attr_ty.bind_self_typevars(db, object_ty);
-                    match attr_ty.try_call_dunder(
+                    let delete_dunder_call_result = attr_ty.try_call_dunder(
                         db,
                         "__delete__",
                         CallArguments::positional([object_ty]),
                         TypeContext::default(),
-                    ) {
+                    );
+
+                    match delete_dunder_call_result {
                         Ok(_) | Err(CallDunderError::PossiblyUnbound(_)) => return true,
                         Err(CallDunderError::CallError(kind, bindings)) => {
                             if emit_diagnostics {
@@ -2876,10 +2881,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 true
             }
 
-            Type::ClassLiteral(..)
-            | Type::GenericAlias(..)
-            | Type::SubclassOf(..)
-            | Type::Dynamic(..)
+            Type::Dynamic(..)
             | Type::Divergent(_)
             | Type::Never
             | Type::ModuleLiteral(..)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2730,10 +2730,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         match object_ty {
             Type::Union(union) => {
                 for element_ty in union.elements(db) {
-                    if !self.validate_attribute_deletion(target, *element_ty, attribute, false) {
-                        if emit_diagnostics {
-                            self.validate_attribute_deletion(target, *element_ty, attribute, true);
-                        }
+                    if !self.validate_attribute_deletion(
+                        target,
+                        *element_ty,
+                        attribute,
+                        emit_diagnostics,
+                    ) {
                         return false;
                     }
                 }
@@ -2754,6 +2756,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
+            // Type aliases need their own arm so aliased unions and intersections reuse the
+            // specialized handling above. `NewType` instances don't: dunder lookup and attribute
+            // fallback already delegate through the concrete base type when needed.
             Type::TypeAlias(alias) => self.validate_attribute_deletion(
                 target,
                 alias.value_type(db),
@@ -2792,34 +2797,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
                 );
 
-                match &delattr_dunder_call_result {
-                    Ok(result) if result.return_type(db).is_never() => {
-                        if emit_diagnostics
-                            && let Some(builder) =
-                                self.context.report_lint(&INVALID_ASSIGNMENT, target)
-                        {
-                            builder.into_diagnostic(format_args!(
-                                "Cannot delete attribute `{attribute}` on type `{}` \
-                                 whose `__delattr__` method returns `Never`/`NoReturn`",
-                                object_ty.display(db),
-                            ));
-                        }
-                        return false;
+                let returns_never = match &delattr_dunder_call_result {
+                    Ok(result) => result.return_type(db).is_never(),
+                    Err(err) => err.return_type(db).is_some_and(|ty| ty.is_never()),
+                };
+                if returns_never {
+                    if emit_diagnostics
+                        && let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target)
+                    {
+                        builder.into_diagnostic(format_args!(
+                            "Cannot delete attribute `{attribute}` on type `{}` \
+                             whose `__delattr__` method returns `Never`/`NoReturn`",
+                            object_ty.display(db),
+                        ));
                     }
-                    Err(err) if err.return_type(db).is_some_and(|ty| ty.is_never()) => {
-                        if emit_diagnostics
-                            && let Some(builder) =
-                                self.context.report_lint(&INVALID_ASSIGNMENT, target)
-                        {
-                            builder.into_diagnostic(format_args!(
-                                "Cannot delete attribute `{attribute}` on type `{}` \
-                                 whose `__delattr__` method returns `Never`/`NoReturn`",
-                                object_ty.display(db),
-                            ));
-                        }
-                        return false;
-                    }
-                    _ => {}
+                    return false;
                 }
 
                 match delattr_dunder_call_result {

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -133,6 +133,8 @@ pub enum KnownBoundMethodType<'db> {
     PropertyDunderGet(PropertyInstanceType<'db>),
     /// Method wrapper for `some_property.__set__`
     PropertyDunderSet(PropertyInstanceType<'db>),
+    /// Method wrapper for `some_property.__delete__`
+    PropertyDunderDelete(PropertyInstanceType<'db>),
     /// Method wrapper for `str.startswith`.
     /// We treat this method specially because we want to be able to infer precise Boolean
     /// literal return types if the instance and the prefix are both string literals, and
@@ -165,6 +167,9 @@ pub(super) fn walk_method_wrapper_type<'db, V: visitor::TypeVisitor<'db> + ?Size
             visitor.visit_property_instance_type(db, property);
         }
         KnownBoundMethodType::PropertyDunderSet(property) => {
+            visitor.visit_property_instance_type(db, property);
+        }
+        KnownBoundMethodType::PropertyDunderDelete(property) => {
             visitor.visit_property_instance_type(db, property);
         }
         KnownBoundMethodType::StrStartswith(string_literal) => {
@@ -210,6 +215,11 @@ impl<'db> KnownBoundMethodType<'db> {
                     property.recursive_type_normalized_impl(db, div, nested)?,
                 ))
             }
+            KnownBoundMethodType::PropertyDunderDelete(property) => {
+                Some(KnownBoundMethodType::PropertyDunderDelete(
+                    property.recursive_type_normalized_impl(db, div, nested)?,
+                ))
+            }
             KnownBoundMethodType::StrStartswith(_)
             | KnownBoundMethodType::ConstraintSetRange
             | KnownBoundMethodType::ConstraintSetAlways
@@ -226,7 +236,8 @@ impl<'db> KnownBoundMethodType<'db> {
             KnownBoundMethodType::FunctionTypeDunderGet(_)
             | KnownBoundMethodType::FunctionTypeDunderCall(_)
             | KnownBoundMethodType::PropertyDunderGet(_)
-            | KnownBoundMethodType::PropertyDunderSet(_) => KnownClass::MethodWrapperType,
+            | KnownBoundMethodType::PropertyDunderSet(_)
+            | KnownBoundMethodType::PropertyDunderDelete(_) => KnownClass::MethodWrapperType,
             KnownBoundMethodType::StrStartswith(_) => KnownClass::BuiltinFunctionType,
             KnownBoundMethodType::ConstraintSetRange
             | KnownBoundMethodType::ConstraintSetAlways
@@ -309,6 +320,18 @@ impl<'db> KnownBoundMethodType<'db> {
                             Parameter::positional_only(Some(Name::new_static("instance")))
                                 .with_annotated_type(Type::object()),
                             Parameter::positional_only(Some(Name::new_static("value")))
+                                .with_annotated_type(Type::object()),
+                        ],
+                    ),
+                    Type::unknown(),
+                )))
+            }
+            KnownBoundMethodType::PropertyDunderDelete(_) => {
+                Either::Right(std::iter::once(Signature::new(
+                    Parameters::new(
+                        db,
+                        [
+                            Parameter::positional_only(Some(Name::new_static("instance")))
                                 .with_annotated_type(Type::object()),
                         ],
                     ),
@@ -447,6 +470,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             | (
                 KnownBoundMethodType::PropertyDunderSet(source_property),
                 KnownBoundMethodType::PropertyDunderSet(target_property),
+            )
+            | (
+                KnownBoundMethodType::PropertyDunderDelete(source_property),
+                KnownBoundMethodType::PropertyDunderDelete(target_property),
             ) => self.check_property_instance_pair(db, source_property, target_property),
 
             (KnownBoundMethodType::StrStartswith(_), KnownBoundMethodType::StrStartswith(_)) => {
@@ -483,6 +510,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 | KnownBoundMethodType::FunctionTypeDunderCall(_)
                 | KnownBoundMethodType::PropertyDunderGet(_)
                 | KnownBoundMethodType::PropertyDunderSet(_)
+                | KnownBoundMethodType::PropertyDunderDelete(_)
                 | KnownBoundMethodType::StrStartswith(_)
                 | KnownBoundMethodType::ConstraintSetRange
                 | KnownBoundMethodType::ConstraintSetAlways
@@ -494,6 +522,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 | KnownBoundMethodType::FunctionTypeDunderCall(_)
                 | KnownBoundMethodType::PropertyDunderGet(_)
                 | KnownBoundMethodType::PropertyDunderSet(_)
+                | KnownBoundMethodType::PropertyDunderDelete(_)
                 | KnownBoundMethodType::StrStartswith(_)
                 | KnownBoundMethodType::ConstraintSetRange
                 | KnownBoundMethodType::ConstraintSetAlways
@@ -515,6 +544,8 @@ pub enum WrapperDescriptorKind {
     PropertyDunderGet,
     /// `property.__set__`
     PropertyDunderSet,
+    /// `property.__delete__`
+    PropertyDunderDelete,
 }
 
 impl WrapperDescriptorKind {
@@ -587,6 +618,20 @@ impl WrapperDescriptorKind {
                                 .with_annotated_type(object),
                             Parameter::positional_only(Some(Name::new_static("value")))
                                 .with_annotated_type(object),
+                        ],
+                    ),
+                    Type::unknown(),
+                )))
+            }
+            WrapperDescriptorKind::PropertyDunderDelete => {
+                Either::Right(std::iter::once(Signature::new(
+                    Parameters::new(
+                        db,
+                        [
+                            Parameter::positional_only(Some(Name::new_static("self")))
+                                .with_annotated_type(KnownClass::Property.to_instance(db)),
+                            Parameter::positional_only(Some(Name::new_static("instance")))
+                                .with_annotated_type(Type::object()),
                         ],
                     ),
                     Type::unknown(),

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -217,7 +217,7 @@ impl<'db> ProtocolInterface<'db> {
                     ty,
                 );
                 let property_getter = Type::single_callable(db, property_getter_signature);
-                let property = PropertyInstanceType::new(db, Some(property_getter), None);
+                let property = PropertyInstanceType::new(db, Some(property_getter), None, None);
                 (
                     Name::new(name),
                     ProtocolMemberData {
@@ -555,7 +555,12 @@ impl<'db> ProtocolMemberKind<'db> {
                     (Some(curr), None) => Some(curr.recursive_type_normalized(db, cycle)),
                     (None, _) => None,
                 };
-                Self::Property(PropertyInstanceType::new(db, getter, setter))
+                let deleter = match (curr.deleter(db), prev.deleter(db)) {
+                    (Some(curr), Some(prev)) => Some(curr.cycle_normalized(db, prev, cycle)),
+                    (Some(curr), None) => Some(curr.recursive_type_normalized(db, cycle)),
+                    (None, _) => None,
+                };
+                Self::Property(PropertyInstanceType::new(db, getter, setter, deleter))
             }
             (Self::Other(curr), Self::Other(prev)) => {
                 Self::Other(curr.cycle_normalized(db, *prev, cycle))

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -279,7 +279,8 @@ impl<'db> Type<'db> {
             | Type::Callable(_)
             | Type::KnownBoundMethod(
                 KnownBoundMethodType::PropertyDunderGet(_)
-                | KnownBoundMethodType::PropertyDunderSet(_),
+                | KnownBoundMethodType::PropertyDunderSet(_)
+                | KnownBoundMethodType::PropertyDunderDelete(_),
             )
             | Type::PropertyInstance(_)
             | Type::BoundSuper(_)
@@ -1594,7 +1595,13 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         check_optional_methods(source.getter(db), target.getter(db)).and(
             db,
             self.constraints,
-            || check_optional_methods(source.setter(db), target.setter(db)),
+            || {
+                check_optional_methods(source.setter(db), target.setter(db)).and(
+                    db,
+                    self.constraints,
+                    || check_optional_methods(source.deleter(db), target.deleter(db)),
+                )
+            },
         )
     }
 
@@ -1965,6 +1972,10 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             | (
                 Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderSet(left)),
                 Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderSet(right)),
+            )
+            | (
+                Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(left)),
+                Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(right)),
             ) => self.check_property_instance_pair(db, left, right),
 
             // any single-valued type is disjoint from another single-valued type
@@ -2475,7 +2486,11 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         };
 
         check_optional_methods(left.getter(db), right.getter(db)).or(db, self.constraints, || {
-            check_optional_methods(left.setter(db), right.setter(db))
+            check_optional_methods(left.setter(db), right.setter(db)).or(
+                db,
+                self.constraints,
+                || check_optional_methods(left.deleter(db), right.deleter(db)),
+            )
         })
     }
 }


### PR DESCRIPTION
## Summary

This PR adds support for deleter properties, so we now error on the following:

```python
class ReadOnlyProperty:
    @property
    def x(self) -> int:
        return 1

read_only = ReadOnlyProperty()
# error: [invalid-assignment] "Cannot delete read-only property `x` on object of type `ReadOnlyProperty`"
del read_only.x
```

While this looks like a lot of code, it ends up being a fairly mechanical change -- almost every line corresponds to a similar line for setters and/or getters, with the exception of `validate_attribute_deletion`.
