### PR TITLE
[ty] Support partially specialized type context for collection literals

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -630,18 +630,38 @@ def _():
 
     # revealed: list[int | X]
     # revealed: list[str | X]
-    x2 = two_lists_default(reveal_type(lst(X())), reveal_type(lst(X())))
+    x2 = two_lists(reveal_type([X()]), reveal_type([X()]))
     reveal_type(x2)  # revealed: X
 
-    # revealed: dict[int | X, Any]
-    # revealed: dict[str | X, Any]
-    x3 = two_dicts(reveal_type(dct(X(), X())), reveal_type(dct(X(), X())))
+    # revealed: list[int | X]
+    # revealed: list[str | X]
+    x3 = two_lists_default(reveal_type(lst(X())), reveal_type(lst(X())))
     reveal_type(x3)  # revealed: X
+
+    # revealed: list[int | X]
+    # revealed: list[str | X]
+    x4 = two_lists_default(reveal_type([X()]), reveal_type([X()]))
+    reveal_type(x4)  # revealed: X
 
     # revealed: dict[int | X, Any]
     # revealed: dict[str | X, Any]
-    x4 = two_dicts_default(reveal_type(dct(X(), X())), reveal_type(dct(X(), X())))
-    reveal_type(x4)  # revealed: X
+    x5 = two_dicts(reveal_type(dct(X(), X())), reveal_type(dct(X(), X())))
+    reveal_type(x5)  # revealed: X
+
+    # revealed: dict[int | X, Any]
+    # revealed: dict[str | X, Any]
+    x6 = two_dicts(reveal_type({X(): X()}), reveal_type({X(): X()}))
+    reveal_type(x6)  # revealed: X
+
+    # revealed: dict[int | X, Any]
+    # revealed: dict[str | X, Any]
+    x7 = two_dicts_default(reveal_type(dct(X(), X())), reveal_type(dct(X(), X())))
+    reveal_type(x7)  # revealed: X
+
+    # revealed: dict[int | X, Any]
+    # revealed: dict[str | X, Any]
+    x8 = two_dicts_default(reveal_type({X(): X()}), reveal_type({X(): X()}))
+    reveal_type(x8)  # revealed: X
 ```
 
 ## Prefer the declared type of generic classes and callables

--- a/crates/ty_python_semantic/resources/mdtest/external/numpy.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/numpy.md
@@ -15,7 +15,8 @@ dependencies = ["numpy==2.3.0"]
 import numpy as np
 
 xs = np.array([1, 2, 3])
-reveal_type(xs)  # revealed: ndarray[tuple[Any, ...], dtype[Any]]
+# TODO: should be `ndarray[tuple[Any, ...], dtype[Any]]`
+reveal_type(xs)  # revealed: ndarray[tuple[Any, ...], dtype[Unknown]]
 
 xs = np.array([1.0, 2.0, 3.0], dtype=np.float64)
 # TODO: should be `ndarray[tuple[Any, ...], dtype[float64]]`

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6327,12 +6327,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // We use a forward assignability check (`collection_instance ≤ tcx`) to infer what each
         // typevar maps to in the type context. For example, if the type context is `list[int]` and
         // `collection_instance` is `list[T]`, the check produces `T = int`.
-        //
-        // Variance is determined from the constraint bounds: a constraint with only an upper bound
-        // (`lower = Never`) indicates a covariant position, while a constraint with only a lower
-        // bound (`upper = object`) indicates contravariant. This correctly handles cases where the
-        // type context is a covariant superclass of the collection (e.g., `Sequence[Any]` as type
-        // context for `list[T]`).
         let (elt_tcx_constraints, elt_tcx_variance) = {
             let mut elt_tcx_constraints: FxHashMap<
                 BoundTypeVarIdentity<'db>,
@@ -6343,18 +6337,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             if let Some(tcx) = tcx.annotation
                 && tcx.class_specialization(self.db()).is_some()
-                // Skip constraint extraction when the type context contains UnspecializedTypeVar
-                // placeholders (from partially-specialized parameter types during multi-inference
-                // for overloaded calls). The assignability check would walk through protocol
-                // supertypes and produce constraints contaminated by the placeholder, which
-                // collapse to `Any` during solution extraction and bypass downstream filters.
-                //
-                // TODO: UnspecializedTypeVar should be removed entirely once the
-                // SpecializationBuilder uses constraint sets internally, at which point the
-                // typevars that it currently replaces can instead be existentially quantified away
-                // (as is already done for generic callable assignability in
-                // `check_signature_pair`).
-                && !tcx.has_unspecialized_type_var(self.db())
             {
                 let db = self.db();
                 let collection_instance = Type::instance(db, ClassType::Generic(collection_alias));


### PR DESCRIPTION
This regressed in https://github.com/astral-sh/ruff/pull/23848 because we didn't have any test coverage for the collection literal case.