### PR TITLE
[ty] Reject deleting`Final` attributes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/del.md
+++ b/crates/ty_python_semantic/resources/mdtest/del.md
@@ -286,6 +286,37 @@ fallback_instance_attribute = FallbackInstanceAttribute()
 del fallback_instance_attribute.x
 ```
 
+### Final attributes
+
+```py
+from typing import Final
+
+class FinalAttribute:
+    def __init__(self) -> None:
+        self.x: Final[int] = 1
+
+class FinalAttributeWithDelAttr:
+    def __init__(self) -> None:
+        self.x: Final[int] = 1
+
+    def __delattr__(self, name: str) -> None:
+        pass
+
+class FinalClassAttribute:
+    x: Final[int] = 1
+
+final_attribute = FinalAttribute()
+# error: [invalid-assignment] "Cannot delete final attribute `x` on type `FinalAttribute`"
+del final_attribute.x
+
+final_attribute_with_delattr = FinalAttributeWithDelAttr()
+# error: [invalid-assignment] "Cannot delete final attribute `x` on type `FinalAttributeWithDelAttr`"
+del final_attribute_with_delattr.x
+
+# error: [invalid-assignment] "Cannot delete final attribute `x` on type `<class 'FinalClassAttribute'>`"
+del FinalClassAttribute.x
+```
+
 ### Metaclass `__delattr__`
 
 ```py

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2815,7 +2815,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
 
                 match delattr_dunder_call_result {
-                    Ok(_) | Err(CallDunderError::PossiblyUnbound(_)) => return true,
+                    Ok(_) | Err(CallDunderError::PossiblyUnbound(_)) => {
+                        if self.validate_final_attribute_deletion(
+                            target,
+                            object_ty,
+                            attribute,
+                            emit_diagnostics,
+                        ) {
+                            return false;
+                        }
+                        return true;
+                    }
                     Err(CallDunderError::CallError(kind, _bindings)) => {
                         if emit_diagnostics {
                             report_bad_dunder_delattr_call(
@@ -2829,6 +2839,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         return false;
                     }
                     Err(CallDunderError::MethodNotAvailable) => {}
+                }
+
+                if self.validate_final_attribute_deletion(
+                    target,
+                    object_ty,
+                    attribute,
+                    emit_diagnostics,
+                ) {
+                    return false;
                 }
 
                 if let Some(PlaceAndQualifiers {

--- a/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
@@ -204,6 +204,41 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         false
     }
+
+    fn invalid_deletion_of_final_attribute(
+        &self,
+        object_ty: Type<'db>,
+        target: &ast::ExprAttribute,
+        attribute: &str,
+        qualifiers: TypeQualifiers,
+        emit_diagnostics: bool,
+    ) -> bool {
+        if !qualifiers.contains(TypeQualifiers::FINAL) {
+            return false;
+        }
+
+        if emit_diagnostics {
+            let db = self.db();
+            let final_declaration = self.precise_final_attribute_declaration(object_ty, attribute);
+
+            if let Some(builder) = self
+                .context
+                .report_lint(&INVALID_ASSIGNMENT, target.range())
+            {
+                let mut diagnostic = builder.into_diagnostic(format_args!(
+                    "Cannot delete final attribute `{attribute}` on type `{}`",
+                    object_ty.display(db)
+                ));
+                diagnostic.set_primary_message("`Final` attributes cannot be deleted");
+                if let Some(final_declaration) = final_declaration {
+                    self.annotate_final_declaration(&mut diagnostic, final_declaration);
+                }
+            }
+        }
+
+        true
+    }
+
     pub(super) fn validate_final_attribute_assignment(
         &mut self,
         target: &ast::ExprAttribute,
@@ -230,5 +265,35 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 fallback_attr.qualifiers,
             );
         }
+    }
+
+    pub(super) fn validate_final_attribute_deletion(
+        &self,
+        target: &ast::ExprAttribute,
+        object_ty: Type<'db>,
+        attribute: &str,
+        emit_diagnostics: bool,
+    ) -> bool {
+        let Some((meta_attr, fallback_attr)) =
+            self.assignment_attribute_members(object_ty, attribute)
+        else {
+            return false;
+        };
+
+        self.invalid_deletion_of_final_attribute(
+            object_ty,
+            target,
+            attribute,
+            meta_attr.qualifiers,
+            emit_diagnostics,
+        ) || fallback_attr.is_some_and(|fallback_attr| {
+            self.invalid_deletion_of_final_attribute(
+                object_ty,
+                target,
+                attribute,
+                fallback_attr.qualifiers,
+                emit_diagnostics,
+            )
+        })
     }
 }


### PR DESCRIPTION
## Summary

We now error when attempting to delete a `Final` attribute, as in:

```python
from typing import Final

class FinalAttribute:
    def __init__(self) -> None:
        self.x: Final[int] = 1

final_attribute = FinalAttribute()
# error: [invalid-assignment] "Cannot delete final attribute `x` on type `FinalAttribute`"
del final_attribute.x
```
