### PR TITLE
Restrict PYI034 for in-place operations to enclosing class

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI034.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI034.py
@@ -392,3 +392,8 @@ class UsesStringizedForwardReferences:
     def __enter__(self) -> "UsesStringizedForwardReferences": ...    # PYI034
     async def __aenter__(self) -> "UsesStringizedForwardReferences": ...  # PYI034
     def __iadd__(self, other) -> "UsesStringizedForwardReferences": ...  # PYI034
+
+
+class InPlaceOperationReturningOtherTypeAtRuntime:
+    def __iadd__(self, other: int) -> int:
+        return 1

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI034.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI034.pyi
@@ -277,3 +277,7 @@ class MetaclassInWhichSelfCannotBeUsed7(django.db.models.base.ModelBase):
 class MetaclassInWhichSelfCannotBeUsed8(django.db.models.base.ModelBase):
     def __new__(cls, name: builtins.str, bases: tuple, attributes: dict, /, **kw) -> MetaclassInWhichSelfCannotBeUsed8:
         ...
+
+
+class StubInPlaceOperationReturningOtherType:
+    def __iadd__(self, other: int) -> int: ...  # Y034 "__iadd__" methods in classes like "StubInPlaceOperationReturningOtherType" usually return "self" at runtime. Consider using "typing_extensions.Self" in "StubInPlaceOperationReturningOtherType.__iadd__", e.g. "def __iadd__(self, other: int) -> Self: ..."

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI034.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI034.pyi
@@ -280,4 +280,4 @@ class MetaclassInWhichSelfCannotBeUsed8(django.db.models.base.ModelBase):
 
 
 class StubInPlaceOperationReturningOtherType:
-    def __iadd__(self, other: int) -> int: ...  # Y034 "__iadd__" methods in classes like "StubInPlaceOperationReturningOtherType" usually return "self" at runtime. Consider using "typing_extensions.Self" in "StubInPlaceOperationReturningOtherType.__iadd__", e.g. "def __iadd__(self, other: int) -> Self: ..."
+    def __iadd__(self, other: int) -> int: ...

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
@@ -42,9 +42,8 @@ use ruff_text_size::Ranged;
 /// Specifically, this check enforces that the return type of the following
 /// methods is `Self`:
 ///
-/// 1. In stub files, in-place binary-operation dunder methods, like `__iadd__`,
-///    `__imul__`, etc. In runtime files, these methods are only flagged if they
-///    return the enclosing class name.
+/// 1. In-place binary-operation dunder methods, like `__iadd__`, `__imul__`, etc.,
+///    if those methods return the class name.
 /// 1. `__new__`, `__enter__`, and `__aenter__`, if those methods return the
 ///    class name.
 /// 1. `__iter__` methods that return `Iterator`, despite the class inheriting
@@ -194,7 +193,7 @@ pub(crate) fn non_self_return_type(
 
     // In-place methods that are expected to return `Self`.
     if is_inplace_bin_op(name) {
-        if is_bad_inplace_return_type(checker, returns, &class_def.name) {
+        if is_name_or_stringized_name(returns, &class_def.name, checker) {
             add_diagnostic(checker, stmt, returns, class_def, name);
         }
         return;
@@ -321,15 +320,6 @@ fn is_inplace_bin_op(name: &str) -> bool {
     )
 }
 
-/// Return `true` if the return type for an in-place operator should be replaced with `Self`.
-fn is_bad_inplace_return_type(checker: &Checker, returns: &ast::Expr, class_name: &str) -> bool {
-    if checker.source_type.is_stub() {
-        !is_self(returns, checker)
-    } else {
-        is_name_or_stringized_name(returns, class_name, checker)
-    }
-}
-
 /// Return `true` if the given expression resolves to the given name.
 fn is_name(expr: &ast::Expr, name: &str) -> bool {
     let ast::Expr::Name(ast::ExprName { id, .. }) = expr else {
@@ -341,13 +331,6 @@ fn is_name(expr: &ast::Expr, name: &str) -> bool {
 /// Return `true` if the given expression resolves to the given name,
 fn is_name_or_stringized_name(expr: &ast::Expr, name: &str, checker: &Checker) -> bool {
     checker.match_maybe_stringized_annotation(expr, |expr| is_name(expr, name))
-}
-
-/// Return `true` if the given expression resolves to `typing.Self`.
-fn is_self(expr: &ast::Expr, checker: &Checker) -> bool {
-    checker.match_maybe_stringized_annotation(expr, |expr| {
-        checker.semantic().match_typing_expr(expr, "Self")
-    })
 }
 
 /// Return `true` if the given class extends `collections.abc.Iterator`.

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
@@ -42,7 +42,9 @@ use ruff_text_size::Ranged;
 /// Specifically, this check enforces that the return type of the following
 /// methods is `Self`:
 ///
-/// 1. In-place binary-operation dunder methods, like `__iadd__`, `__imul__`, etc.
+/// 1. In stub files, in-place binary-operation dunder methods, like `__iadd__`,
+///    `__imul__`, etc. In runtime files, these methods are only flagged if they
+///    return the enclosing class name.
 /// 1. `__new__`, `__enter__`, and `__aenter__`, if those methods return the
 ///    class name.
 /// 1. `__iter__` methods that return `Iterator`, despite the class inheriting
@@ -192,7 +194,7 @@ pub(crate) fn non_self_return_type(
 
     // In-place methods that are expected to return `Self`.
     if is_inplace_bin_op(name) {
-        if !is_self(returns, checker) {
+        if is_bad_inplace_return_type(checker, returns, &class_def.name) {
             add_diagnostic(checker, stmt, returns, class_def, name);
         }
         return;
@@ -317,6 +319,15 @@ fn is_inplace_bin_op(name: &str) -> bool {
             | "__ixor__"
             | "__ior__"
     )
+}
+
+/// Return `true` if the return type for an in-place operator should be replaced with `Self`.
+fn is_bad_inplace_return_type(checker: &Checker, returns: &ast::Expr, class_name: &str) -> bool {
+    if checker.source_type.is_stub() {
+        !is_self(returns, checker)
+    } else {
+        is_name_or_stringized_name(returns, class_name, checker)
+    }
 }
 
 /// Return `true` if the given expression resolves to the given name.

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI034_PYI034.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI034_PYI034.py.snap
@@ -511,6 +511,7 @@ help: Use `Self` as return type
 392 +     def __enter__(self) -> typing.Self: ...    # PYI034
 393 |     async def __aenter__(self) -> "UsesStringizedForwardReferences": ...  # PYI034
 394 |     def __iadd__(self, other) -> "UsesStringizedForwardReferences": ...  # PYI034
+395 |
 note: This is an unsafe fix and may change runtime behavior
 
 PYI034 [*] `__aenter__` methods in classes like `UsesStringizedForwardReferences` usually return `self` at runtime
@@ -529,6 +530,8 @@ help: Use `Self` as return type
     -     async def __aenter__(self) -> "UsesStringizedForwardReferences": ...  # PYI034
 393 +     async def __aenter__(self) -> typing.Self: ...  # PYI034
 394 |     def __iadd__(self, other) -> "UsesStringizedForwardReferences": ...  # PYI034
+395 |
+396 |
 note: This is an unsafe fix and may change runtime behavior
 
 PYI034 [*] `__iadd__` methods in classes like `UsesStringizedForwardReferences` usually return `self` at runtime
@@ -545,4 +548,7 @@ help: Use `Self` as return type
 393 |     async def __aenter__(self) -> "UsesStringizedForwardReferences": ...  # PYI034
     -     def __iadd__(self, other) -> "UsesStringizedForwardReferences": ...  # PYI034
 394 +     def __iadd__(self, other) -> typing.Self: ...  # PYI034
+395 |
+396 |
+397 | class InPlaceOperationReturningOtherTypeAtRuntime:
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI034_PYI034.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI034_PYI034.pyi.snap
@@ -453,18 +453,3 @@ help: Use `Self` as return type
 256 |
 257 | # Test case based on issue #20781 - metaclass that triggers IsMetaclass::Maybe
 note: This is a display-only fix and is likely to be incorrect
-
-PYI034 [*] `__iadd__` methods in classes like `StubInPlaceOperationReturningOtherType` usually return `self` at runtime
-   --> PYI034.pyi:283:9
-    |
-282 | class StubInPlaceOperationReturningOtherType:
-283 |     def __iadd__(self, other: int) -> int: ...  # Y034 "__iadd__" methods in classes like "StubInPlaceOperationReturningOtherType" us…
-    |         ^^^^^^^^
-    |
-help: Use `Self` as return type
-280 |
-281 |
-282 | class StubInPlaceOperationReturningOtherType:
-    -     def __iadd__(self, other: int) -> int: ...  # Y034 "__iadd__" methods in classes like "StubInPlaceOperationReturningOtherType" usually return "self" at runtime. Consider using "typing_extensions.Self" in "StubInPlaceOperationReturningOtherType.__iadd__", e.g. "def __iadd__(self, other: int) -> Self: ..."
-283 +     def __iadd__(self, other: int) -> typing.Self: ...  # Y034 "__iadd__" methods in classes like "StubInPlaceOperationReturningOtherType" usually return "self" at runtime. Consider using "typing_extensions.Self" in "StubInPlaceOperationReturningOtherType.__iadd__", e.g. "def __iadd__(self, other: int) -> Self: ..."
-note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI034_PYI034.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI034_PYI034.pyi.snap
@@ -453,3 +453,18 @@ help: Use `Self` as return type
 256 |
 257 | # Test case based on issue #20781 - metaclass that triggers IsMetaclass::Maybe
 note: This is a display-only fix and is likely to be incorrect
+
+PYI034 [*] `__iadd__` methods in classes like `StubInPlaceOperationReturningOtherType` usually return `self` at runtime
+   --> PYI034.pyi:283:9
+    |
+282 | class StubInPlaceOperationReturningOtherType:
+283 |     def __iadd__(self, other: int) -> int: ...  # Y034 "__iadd__" methods in classes like "StubInPlaceOperationReturningOtherType" us…
+    |         ^^^^^^^^
+    |
+help: Use `Self` as return type
+280 |
+281 |
+282 | class StubInPlaceOperationReturningOtherType:
+    -     def __iadd__(self, other: int) -> int: ...  # Y034 "__iadd__" methods in classes like "StubInPlaceOperationReturningOtherType" usually return "self" at runtime. Consider using "typing_extensions.Self" in "StubInPlaceOperationReturningOtherType.__iadd__", e.g. "def __iadd__(self, other: int) -> Self: ..."
+283 +     def __iadd__(self, other: int) -> typing.Self: ...  # Y034 "__iadd__" methods in classes like "StubInPlaceOperationReturningOtherType" usually return "self" at runtime. Consider using "typing_extensions.Self" in "StubInPlaceOperationReturningOtherType.__iadd__", e.g. "def __iadd__(self, other: int) -> Self: ..."
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

In `.py` and `.pyi` files, we now only flag cases in which the return type is the enclosing class, like:

```python
class A:
    def __iadd__(self) -> A:
        return self
```

As opposed to:

```python
class A:
    def __iadd__(self) -> int:
        return self
```

Closes https://github.com/astral-sh/ruff/issues/24462.
