### PR TITLE
[ty] Preserve TypedDict keys through dict unpacking

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -489,6 +489,51 @@ Record({VALUE_KEY: "x"}, count=1)
 Record({VALUE_KEY: 1}, count=1)
 ```
 
+TypedDict constructor validation should also validate nested `TypedDict` literals inside `**{...}`:
+
+```py
+from typing import Dict, TypedDict, Union
+
+class Inner(TypedDict):
+    x: int
+
+class Outer(TypedDict):
+    inner: Inner
+
+source: Inner = {"x": 1}
+
+Outer(**{"inner": {"x": 1}})
+Outer(**{"inner": dict(x=1)})
+Outer(**{"inner": {**source}})
+Outer(**{"inner": {"x": "bad", **{"x": 1}}})
+
+# error: [missing-typed-dict-key]
+Outer(**{"inner": {}})
+
+# error: [invalid-argument-type]
+Outer(**{"inner": {"x": "bad"}})
+
+class OuterWithFallback(TypedDict):
+    inner: Union[Inner, Dict[str, object]]
+
+OuterWithFallback(**{"inner": {}})
+OuterWithFallback(**{"inner": {**source}})
+```
+
+Later merged non-`TypedDict` mappings should still be able to overwrite earlier checked keys:
+
+```py
+from typing import TypedDict
+
+class NameTD(TypedDict):
+    name: str
+
+mapping: dict[str, int] = {"name": 1}
+
+# error: [invalid-argument-type]
+NameTD(**{"name": "ok", **mapping})
+```
+
 Keyword arguments should override a positional mapping, and `TypedDict` constructor inputs should
 preserve shared required keys:
 
@@ -519,6 +564,25 @@ def _(
 
     # error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `ChildKwargs` constructor"
     ChildKwargs(**maybe_name, count=1)
+```
+
+TypedDict constructor validation should support unpacked dict literals with non-identifier keys:
+
+```py
+from typing import TypedDict
+
+KeywordTD = TypedDict("KeywordTD", {"in": int, "x-y": int})
+
+KeywordTD(**{"in": 1, "x-y": 2})
+
+# error: [missing-typed-dict-key] "Missing required key 'x-y' in TypedDict `KeywordTD` constructor"
+KeywordTD(**{"in": 1})
+
+# error: [invalid-argument-type] "Invalid argument to key "in" with declared type `int` on TypedDict `KeywordTD`: value of type `Literal["bad"]`"
+KeywordTD(**{"in": "bad", "x-y": 2})
+
+# error: [invalid-key] "Unknown key "extra" for TypedDict `KeywordTD`"
+KeywordTD(**{"in": 1, "x-y": 2, "extra": 3})
 ```
 
 TypedDict positional arguments in mixed constructors should validate their declared keys:
@@ -727,8 +791,6 @@ class TD(TypedDict):
     a: int
 
 def _(td: TD):
-    # TODO: this should pass like the explicit-keyword and `**TypedDict` cases below.
-    # error: [invalid-argument-type] "Invalid argument to key "a" with declared type `int` on TypedDict `TD`: value of type `Literal["foo"]`"
     TD({"a": "foo"}, **{"a": 1})
 
     TD({"a": "foo"}, a=1)
@@ -736,6 +798,25 @@ def _(td: TD):
 
 def _(x: Any):
     TD({"a": "foo"}, **x)
+```
+
+An optional key that is definitely present in a merged unpack should still relax the positional
+schema:
+
+```py
+from typing import Any, TypedDict
+from typing_extensions import NotRequired
+
+class MixedOptionalTarget(TypedDict):
+    x: int
+    opt: NotRequired[str]
+
+class MixedOptionalSource(TypedDict):
+    x: int
+    opt: int
+
+def _(source: MixedOptionalSource, kwargs: Any):
+    MixedOptionalTarget(source, **{"opt": "ok", **kwargs})
 ```
 
 ## Union of `TypedDict`
@@ -940,6 +1021,78 @@ def duplicate_name_keys(
 
     # error: [parameter-already-assigned]
     return DuplicateNeedsName(**left, **right)
+```
+
+Merged unpacked dict literals should preserve dict overwrite semantics within a single `**{...}`:
+
+```py
+from typing import TypedDict
+
+class MergeTarget(TypedDict):
+    name: str
+
+class GoodName(TypedDict):
+    name: str
+
+class BadName(TypedDict):
+    name: int
+
+class MaybeGoodName(TypedDict, total=False):
+    name: str
+
+def _(
+    good: GoodName,
+    bad: BadName,
+    maybe_good: MaybeGoodName,
+):
+    MergeTarget(**{"name": "a", **good})
+    MergeTarget(**{**bad, "name": "ok"})
+    MergeTarget(**{"name": 1, **good})
+
+    # error: [invalid-argument-type] "Invalid argument to key "name" with declared type `str` on TypedDict `MergeTarget`: value of type `Literal[1]`"
+    MergeTarget(**{"name": 1, **maybe_good})
+```
+
+Merged unpacked dict literals should stay gradual when a later `Any` or `Never` unpack may overwrite
+earlier keys:
+
+```py
+from typing import Any, Never, TypedDict
+
+class GradualMergeTarget(TypedDict):
+    name: str
+
+class GradualBadName(TypedDict):
+    name: int
+
+def _(bad: GradualBadName, dyn: Any, never: Never):
+    GradualMergeTarget(**{**bad, **dyn})
+    GradualMergeTarget(**{**bad, **never})
+    GradualMergeTarget(**{"name": 1, **dyn})
+    GradualMergeTarget(**{"name": 1, **never})
+```
+
+Definite keys inside a merged unpack should still count as guaranteed after a later `Any` or `Never`
+unpack:
+
+```py
+from typing import Any, Never, TypedDict
+
+class DuplicateAfterDynamic(TypedDict):
+    name: str
+
+class HasName(TypedDict):
+    name: str
+
+def _(left: HasName, dyn: Any, never: Never):
+    # error: [parameter-already-assigned]
+    DuplicateAfterDynamic(**{"name": "x", **dyn}, name="y")
+
+    # error: [parameter-already-assigned]
+    DuplicateAfterDynamic(**{**left, **dyn}, name="y")
+
+    # error: [parameter-already-assigned]
+    DuplicateAfterDynamic(**{"name": "x", **never}, **{"name": "y"})
 ```
 
 Unpacking a TypedDict with extra keys flags the extra keys as errors, for consistency with the

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -507,11 +507,20 @@ Outer(**{"inner": dict(x=1)})
 Outer(**{"inner": {**source}})
 Outer(**{"inner": {"x": "bad", **{"x": 1}}})
 
+assigned: Outer = {**{"inner": {"x": 1}}}
+Outer({**{"inner": {"x": 1}}})
+
 # error: [missing-typed-dict-key]
 Outer(**{"inner": {}})
 
 # error: [invalid-argument-type]
 Outer(**{"inner": {"x": "bad"}})
+
+# error: [missing-typed-dict-key]
+assigned_missing: Outer = {**{"inner": {}}}
+
+# error: [invalid-argument-type]
+Outer({**{"inner": {"x": "bad"}}})
 
 class OuterWithFallback(TypedDict):
     inner: Union[Inner, Dict[str, object]]
@@ -583,6 +592,21 @@ KeywordTD(**{"in": "bad", "x-y": 2})
 
 # error: [invalid-key] "Unknown key "extra" for TypedDict `KeywordTD`"
 KeywordTD(**{"in": 1, "x-y": 2, "extra": 3})
+```
+
+Malformed unpacked keyword literals should still trigger the shared `**kwargs` validation:
+
+```py
+from typing import TypedDict
+
+class SharedKwargsTD(TypedDict):
+    x: int
+
+# error: [invalid-argument-type]
+SharedKwargsTD(**{"x": 1, 1: 2})
+
+# error: [invalid-argument-type]
+SharedKwargsTD(**{"x": 1, **42})
 ```
 
 TypedDict positional arguments in mixed constructors should validate their declared keys:
@@ -763,6 +787,37 @@ a_person = {"name": "Alice", "age": 30, "extra": True}
 (a_person := {"name": "Alice", "age": 30, "extra": True})
 ```
 
+Merged dict literals should preserve required keys contributed by unpacked `TypedDict`s:
+
+```py
+from typing import TypedDict
+
+class MergeSource(TypedDict):
+    aaa: int
+    bbb: int
+
+class MergeTarget(TypedDict):
+    aaa: int
+    bbb: int
+    ccc: int
+
+class MergeExtraSource(TypedDict):
+    aaa: int
+    bbb: int
+    extra: int
+
+def _(source: MergeSource):
+    merged: MergeTarget = {**source, "ccc": 3}
+    MergeTarget({**source, "ccc": 3})
+
+def _(source: MergeExtraSource):
+    # error: [invalid-key] "Unknown key "extra" for TypedDict `MergeTarget`"
+    merged: MergeTarget = {**source, "ccc": 3}
+
+    # error: [invalid-key] "Unknown key "extra" for TypedDict `MergeTarget`"
+    MergeTarget({**source, "ccc": 3})
+```
+
 ## Mixed positional and unpacked keyword constructors
 
 These calls mix a positional `TypedDict` argument with unpacked keyword arguments. They should
@@ -817,6 +872,69 @@ class MixedOptionalSource(TypedDict):
 
 def _(source: MixedOptionalSource, kwargs: Any):
     MixedOptionalTarget(source, **{"opt": "ok", **kwargs})
+```
+
+Mixed constructors should preserve field-directed inference for nested literals in unpacked keyword
+dicts:
+
+```py
+from typing import TypedDict
+
+class InnerA(TypedDict):
+    x: int
+
+class InnerB(TypedDict):
+    y: int
+
+class OuterUnion(TypedDict):
+    inner: InnerA | InnerB
+
+def _(existing: OuterUnion):
+    OuterUnion(existing, **{"inner": {"x": 1}})
+```
+
+Merged unpacks should preserve dict-fallback arms for nested `dict(...)` values:
+
+```py
+from typing import Dict, TypedDict
+
+class InnerFallback(TypedDict):
+    x: int
+
+class OuterFallback(TypedDict):
+    inner: InnerFallback | Dict[str, int]
+
+def _(existing: OuterFallback):
+    OuterFallback(**{"inner": dict(y=1)})
+    OuterFallback(existing, **{"inner": dict(y=1)})
+```
+
+Merged unpacks should re-infer nested `dict(...)` values with their field context:
+
+```py
+from typing import Dict, TypedDict
+
+class InnerMerged(TypedDict):
+    x: int
+
+class OuterMerged(TypedDict):
+    inner: InnerMerged
+
+assigned: OuterMerged = {**{"inner": dict(x=1)}}
+
+OuterMerged({**{"inner": dict(x=1)}})
+```
+
+Keyword-only `dict(...)` calls in `TypedDict` unions should still infer real value expressions:
+
+```py
+from typing import Dict, TypedDict, Union
+
+class DictUnionTD(TypedDict):
+    x: int
+
+# error: [unsupported-operator]
+u: Union[DictUnionTD, Dict[str, int]] = dict(x=1 + "a")
 ```
 
 ## Union of `TypedDict`
@@ -1072,6 +1190,21 @@ def _(bad: GradualBadName, dyn: Any, never: Never):
     GradualMergeTarget(**{"name": 1, **never})
 ```
 
+Dynamic union arms inside merged unpacks should stay gradual too:
+
+```py
+from typing import Any, TypedDict, Union
+
+class GradualUnionTarget(TypedDict):
+    name: str
+
+class HasName(TypedDict):
+    name: str
+
+def _(existing: GradualUnionTarget, kwargs: Union[Any, HasName]):
+    GradualUnionTarget(existing, **{"name": 1, **kwargs})
+```
+
 Definite keys inside a merged unpack should still count as guaranteed after a later `Any` or `Never`
 unpack:
 
@@ -1210,6 +1343,42 @@ def unpack_never(data: Never) -> Info:
 
 def unpack_any(data: Any) -> Info:
     return Info(**data)
+```
+
+Mapping unpacks should report exact extra keys, preserve union key/value correlation, and avoid
+treating exact keys as definite overwrites:
+
+```py
+from collections import defaultdict
+from typing import Literal, Mapping, Never, TypedDict, Union, cast
+
+class MappingTarget(TypedDict):
+    name: str
+    count: int
+
+def _(
+    extra: Mapping[Literal["extra"], int],
+    extra_defaultdict: defaultdict[Literal["extra"], int],
+    union_mapping: Union[Mapping[Literal["name"], str], Mapping[Literal["count"], int]],
+    maybe_name: Mapping[Literal["name"], str],
+    impossible_keys: Mapping[Never, int],
+    impossible_extra: Mapping[Literal["extra"], Never],
+):
+    MappingTarget(name="ok", count=1, **union_mapping)
+    MappingTarget(name="ok", count=1, **impossible_keys)
+    MappingTarget(name="ok", count=1, **impossible_extra)
+
+    # error: [invalid-argument-type] "Argument expression after ** must be a mapping with `str` key type: Found `int`"
+    MappingTarget(name="ok", count=1, **cast(Mapping[int, int], {}))
+
+    # error: [invalid-key] "Unknown key "extra" for TypedDict `MappingTarget`"
+    MappingTarget(name="ok", count=1, **extra)
+
+    # error: [invalid-key] "Unknown key "extra" for TypedDict `MappingTarget`"
+    MappingTarget(name="ok", count=1, **extra_defaultdict)
+
+    # error: [invalid-argument-type] "Invalid argument to key "name" with declared type `str` on TypedDict `MappingTarget`: value of type `Literal[1]`"
+    MappingTarget(**{"name": 1, "count": 1, **maybe_name})
 ```
 
 PEP 695 type aliases to TypedDict types are also supported:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -489,60 +489,6 @@ Record({VALUE_KEY: "x"}, count=1)
 Record({VALUE_KEY: 1}, count=1)
 ```
 
-TypedDict constructor validation should also validate nested `TypedDict` literals inside `**{...}`:
-
-```py
-from typing import Dict, TypedDict, Union
-
-class Inner(TypedDict):
-    x: int
-
-class Outer(TypedDict):
-    inner: Inner
-
-source: Inner = {"x": 1}
-
-Outer(**{"inner": {"x": 1}})
-Outer(**{"inner": dict(x=1)})
-Outer(**{"inner": {**source}})
-Outer(**{"inner": {"x": "bad", **{"x": 1}}})
-
-assigned: Outer = {**{"inner": {"x": 1}}}
-Outer({**{"inner": {"x": 1}}})
-
-# error: [missing-typed-dict-key]
-Outer(**{"inner": {}})
-
-# error: [invalid-argument-type]
-Outer(**{"inner": {"x": "bad"}})
-
-# error: [missing-typed-dict-key]
-assigned_missing: Outer = {**{"inner": {}}}
-
-# error: [invalid-argument-type]
-Outer({**{"inner": {"x": "bad"}}})
-
-class OuterWithFallback(TypedDict):
-    inner: Union[Inner, Dict[str, object]]
-
-OuterWithFallback(**{"inner": {}})
-OuterWithFallback(**{"inner": {**source}})
-```
-
-Later merged non-`TypedDict` mappings should still be able to overwrite earlier checked keys:
-
-```py
-from typing import TypedDict
-
-class NameTD(TypedDict):
-    name: str
-
-mapping: dict[str, int] = {"name": 1}
-
-# error: [invalid-argument-type]
-NameTD(**{"name": "ok", **mapping})
-```
-
 Keyword arguments should override a positional mapping, and `TypedDict` constructor inputs should
 preserve shared required keys:
 
@@ -853,88 +799,13 @@ def _(td: TD):
 
 def _(x: Any):
     TD({"a": "foo"}, **x)
-```
 
-An optional key that is definitely present in a merged unpack should still relax the positional
-schema:
+class ExplicitDictValueTarget(TypedDict):
+    a: int
+    b: object
 
-```py
-from typing import Any, TypedDict
-from typing_extensions import NotRequired
-
-class MixedOptionalTarget(TypedDict):
-    x: int
-    opt: NotRequired[str]
-
-class MixedOptionalSource(TypedDict):
-    x: int
-    opt: int
-
-def _(source: MixedOptionalSource, kwargs: Any):
-    MixedOptionalTarget(source, **{"opt": "ok", **kwargs})
-```
-
-Mixed constructors should preserve field-directed inference for nested literals in unpacked keyword
-dicts:
-
-```py
-from typing import TypedDict
-
-class InnerA(TypedDict):
-    x: int
-
-class InnerB(TypedDict):
-    y: int
-
-class OuterUnion(TypedDict):
-    inner: InnerA | InnerB
-
-def _(existing: OuterUnion):
-    OuterUnion(existing, **{"inner": {"x": 1}})
-```
-
-Merged unpacks should preserve dict-fallback arms for nested `dict(...)` values:
-
-```py
-from typing import Dict, TypedDict
-
-class InnerFallback(TypedDict):
-    x: int
-
-class OuterFallback(TypedDict):
-    inner: InnerFallback | Dict[str, int]
-
-def _(existing: OuterFallback):
-    OuterFallback(**{"inner": dict(y=1)})
-    OuterFallback(existing, **{"inner": dict(y=1)})
-```
-
-Merged unpacks should re-infer nested `dict(...)` values with their field context:
-
-```py
-from typing import Dict, TypedDict
-
-class InnerMerged(TypedDict):
-    x: int
-
-class OuterMerged(TypedDict):
-    inner: InnerMerged
-
-assigned: OuterMerged = {**{"inner": dict(x=1)}}
-
-OuterMerged({**{"inner": dict(x=1)}})
-```
-
-Keyword-only `dict(...)` calls in `TypedDict` unions should still infer real value expressions:
-
-```py
-from typing import Dict, TypedDict, Union
-
-class DictUnionTD(TypedDict):
-    x: int
-
-# error: [unsupported-operator]
-u: Union[DictUnionTD, Dict[str, int]] = dict(x=1 + "a")
+def _(flag: bool):
+    ExplicitDictValueTarget({"a": 1} if flag else {"a": 2}, b={"a": 1})
 ```
 
 ## Union of `TypedDict`
@@ -1171,63 +1042,6 @@ def _(
     MergeTarget(**{"name": 1, **maybe_good})
 ```
 
-Merged unpacked dict literals should stay gradual when a later `Any` or `Never` unpack may overwrite
-earlier keys:
-
-```py
-from typing import Any, Never, TypedDict
-
-class GradualMergeTarget(TypedDict):
-    name: str
-
-class GradualBadName(TypedDict):
-    name: int
-
-def _(bad: GradualBadName, dyn: Any, never: Never):
-    GradualMergeTarget(**{**bad, **dyn})
-    GradualMergeTarget(**{**bad, **never})
-    GradualMergeTarget(**{"name": 1, **dyn})
-    GradualMergeTarget(**{"name": 1, **never})
-```
-
-Dynamic union arms inside merged unpacks should stay gradual too:
-
-```py
-from typing import Any, TypedDict, Union
-
-class GradualUnionTarget(TypedDict):
-    name: str
-
-class HasName(TypedDict):
-    name: str
-
-def _(existing: GradualUnionTarget, kwargs: Union[Any, HasName]):
-    GradualUnionTarget(existing, **{"name": 1, **kwargs})
-```
-
-Definite keys inside a merged unpack should still count as guaranteed after a later `Any` or `Never`
-unpack:
-
-```py
-from typing import Any, Never, TypedDict
-
-class DuplicateAfterDynamic(TypedDict):
-    name: str
-
-class HasName(TypedDict):
-    name: str
-
-def _(left: HasName, dyn: Any, never: Never):
-    # error: [parameter-already-assigned]
-    DuplicateAfterDynamic(**{"name": "x", **dyn}, name="y")
-
-    # error: [parameter-already-assigned]
-    DuplicateAfterDynamic(**{**left, **dyn}, name="y")
-
-    # error: [parameter-already-assigned]
-    DuplicateAfterDynamic(**{"name": "x", **never}, **{"name": "y"})
-```
-
 Unpacking a TypedDict with extra keys flags the extra keys as errors, for consistency with the
 behavior when passing all keys as explicit keyword arguments:
 
@@ -1343,42 +1157,6 @@ def unpack_never(data: Never) -> Info:
 
 def unpack_any(data: Any) -> Info:
     return Info(**data)
-```
-
-Mapping unpacks should report exact extra keys, preserve union key/value correlation, and avoid
-treating exact keys as definite overwrites:
-
-```py
-from collections import defaultdict
-from typing import Literal, Mapping, Never, TypedDict, Union, cast
-
-class MappingTarget(TypedDict):
-    name: str
-    count: int
-
-def _(
-    extra: Mapping[Literal["extra"], int],
-    extra_defaultdict: defaultdict[Literal["extra"], int],
-    union_mapping: Union[Mapping[Literal["name"], str], Mapping[Literal["count"], int]],
-    maybe_name: Mapping[Literal["name"], str],
-    impossible_keys: Mapping[Never, int],
-    impossible_extra: Mapping[Literal["extra"], Never],
-):
-    MappingTarget(name="ok", count=1, **union_mapping)
-    MappingTarget(name="ok", count=1, **impossible_keys)
-    MappingTarget(name="ok", count=1, **impossible_extra)
-
-    # error: [invalid-argument-type] "Argument expression after ** must be a mapping with `str` key type: Found `int`"
-    MappingTarget(name="ok", count=1, **cast(Mapping[int, int], {}))
-
-    # error: [invalid-key] "Unknown key "extra" for TypedDict `MappingTarget`"
-    MappingTarget(name="ok", count=1, **extra)
-
-    # error: [invalid-key] "Unknown key "extra" for TypedDict `MappingTarget`"
-    MappingTarget(name="ok", count=1, **extra_defaultdict)
-
-    # error: [invalid-argument-type] "Invalid argument to key "name" with declared type `str` on TypedDict `MappingTarget`: value of type `Literal[1]`"
-    MappingTarget(**{"name": 1, "count": 1, **maybe_name})
 ```
 
 PEP 695 type aliases to TypedDict types are also supported:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -800,6 +800,15 @@ def _(td: TD):
 def _(x: Any):
     TD({"a": "foo"}, **x)
 
+class OptionalOverrideTarget(TypedDict, total=False):
+    a: int
+
+class BadOptionalSource(TypedDict):
+    a: str
+
+def _(source: BadOptionalSource, kwargs: Any):
+    OptionalOverrideTarget(source, **{"a": 1, **kwargs})
+
 class ExplicitDictValueTarget(TypedDict):
     a: int
     b: object

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7217,7 +7217,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> CallArguments<'a, 'db> {
         let call_arguments =
             CallArguments::from_arguments(arguments, |arg_or_keyword, splatted_value| {
-                let ty = self.infer_expression(splatted_value, TypeContext::default());
+                let ty = self.get_or_infer_expression(splatted_value, TypeContext::default());
                 if let ast::ArgOrKeyword::Arg(argument) = arg_or_keyword
                     && argument.is_starred_expr()
                 {
@@ -7359,11 +7359,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return self.infer_typeddict_call_expression(call_expression, None);
         }
 
-        // We don't call `Type::try_call`, because we want to perform type inference on the
-        // arguments after matching them to parameters, but before checking that the argument types
-        // are assignable to any parameter annotations.
-        let mut call_arguments = self.prepare_call_arguments(arguments);
-
         if callable_type.is_notimplemented(self.db()) {
             if let Some(builder) = self
                 .context
@@ -7381,6 +7376,34 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             return Type::unknown();
         }
+
+        let class = match callable_type {
+            Type::ClassLiteral(class) => Some(ClassType::NonGeneric(class)),
+            Type::GenericAlias(generic) => Some(ClassType::Generic(generic)),
+            Type::SubclassOf(subclass) => subclass.subclass_of().into_class(self.db()),
+            _ => None,
+        };
+
+        // Prepare `TypedDict` constructor calls before variadic argument setup so field-directed
+        // value inference becomes canonical before `**kwargs` expressions are inferred.
+        let has_prepared_typed_dict_constructor = class
+            .filter(|class| class.is_typed_dict(self.db()))
+            .map(|class| {
+                let typed_dict = TypedDictType::new(class);
+                let form = TypedDictConstructorForm::from_arguments(arguments);
+                self.prepare_typed_dict_constructor(
+                    typed_dict,
+                    form,
+                    arguments,
+                    func.as_ref().into(),
+                );
+            })
+            .is_some();
+
+        // We don't call `Type::try_call`, because we want to perform type inference on the
+        // arguments after matching them to parameters, but before checking that the argument types
+        // are assignable to any parameter annotations.
+        let mut call_arguments = self.prepare_call_arguments(arguments);
 
         // Special handling for `TypedDict` method calls
         if let ast::Expr::Attribute(ast::ExprAttribute { value, attr, .. }) = func.as_ref() {
@@ -7500,13 +7523,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             _ => {}
         }
 
-        let class = match callable_type {
-            Type::ClassLiteral(class) => Some(ClassType::NonGeneric(class)),
-            Type::GenericAlias(generic) => Some(ClassType::Generic(generic)),
-            Type::SubclassOf(subclass) => subclass.subclass_of().into_class(self.db()),
-            _ => None,
-        };
-
         if let Some(class) = class {
             // It might look odd here that we emit an error for class-literals and generic aliases but not
             // `type[]` types. But it's deliberate! The typing spec explicitly mandates that `type[]` types
@@ -7582,22 +7598,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             call_expression,
             &bindings,
         );
-
-        // Prepare `TypedDict` constructor calls before general argument inference so the field
-        // type context becomes the canonical inference for constructor values.
-        let has_prepared_typed_dict_constructor = class
-            .filter(|class| class.is_typed_dict(self.db()))
-            .map(|class| {
-                let typed_dict = TypedDictType::new(class);
-                let form = TypedDictConstructorForm::from_arguments(arguments);
-                self.prepare_typed_dict_constructor(
-                    typed_dict,
-                    form,
-                    arguments,
-                    func.as_ref().into(),
-                );
-            })
-            .is_some();
 
         let bindings_result = self.infer_and_check_argument_types(
             ArgumentsIter::from_ast(arguments),

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7216,25 +7216,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         &mut self,
         arguments: &'a ast::Arguments,
     ) -> CallArguments<'a, 'db> {
-        let call_arguments = CallArguments::from_arguments(
-            arguments,
-            |arg_or_keyword, splatted_value| {
-                let ty = if matches!(arg_or_keyword, ast::ArgOrKeyword::Keyword(keyword) if keyword.arg.is_none())
-                    && splatted_value.is_dict_expr()
-                    && self
-                        .try_expression_type(splatted_value)
-                        .is_some_and(|ty| ty.is_unknown())
-                {
-                    self.expressions.remove(&splatted_value.into());
-                    if let Some(expression_cache) = &self.expression_cache {
-                        expression_cache
-                            .borrow_mut()
-                            .remove(&(splatted_value.into(), TypeContext::default()));
-                    }
-                    self.infer_expression(splatted_value, TypeContext::default())
-                } else {
-                    self.get_or_infer_expression(splatted_value, TypeContext::default())
-                };
+        let call_arguments =
+            CallArguments::from_arguments(arguments, |arg_or_keyword, splatted_value| {
+                let ty = self.get_or_infer_expression(splatted_value, TypeContext::default());
                 if let ast::ArgOrKeyword::Arg(argument) = arg_or_keyword
                     && argument.is_starred_expr()
                 {
@@ -7244,8 +7228,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
 
                 ty
-            },
-        );
+            });
 
         for arg in &arguments.args {
             if let ast::Expr::Starred(ast::ExprStarred { value, .. }) = arg {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6116,6 +6116,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             item_types
                 .get(&elt.node_index().load())
                 .copied()
+                .or_else(|| builder.try_expression_type(elt))
                 .unwrap_or_else(|| builder.infer_expression(elt, tcx))
         };
 
@@ -7215,9 +7216,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         &mut self,
         arguments: &'a ast::Arguments,
     ) -> CallArguments<'a, 'db> {
-        let call_arguments =
-            CallArguments::from_arguments(arguments, |arg_or_keyword, splatted_value| {
-                let ty = self.get_or_infer_expression(splatted_value, TypeContext::default());
+        let call_arguments = CallArguments::from_arguments(
+            arguments,
+            |arg_or_keyword, splatted_value| {
+                let ty = if matches!(arg_or_keyword, ast::ArgOrKeyword::Keyword(keyword) if keyword.arg.is_none())
+                    && splatted_value.is_dict_expr()
+                    && self
+                        .try_expression_type(splatted_value)
+                        .is_some_and(|ty| ty.is_unknown())
+                {
+                    self.expressions.remove(&splatted_value.into());
+                    if let Some(expression_cache) = &self.expression_cache {
+                        expression_cache
+                            .borrow_mut()
+                            .remove(&(splatted_value.into(), TypeContext::default()));
+                    }
+                    self.infer_expression(splatted_value, TypeContext::default())
+                } else {
+                    self.get_or_infer_expression(splatted_value, TypeContext::default())
+                };
                 if let ast::ArgOrKeyword::Arg(argument) = arg_or_keyword
                     && argument.is_starred_expr()
                 {
@@ -7227,7 +7244,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
 
                 ty
-            });
+            },
+        );
 
         for arg in &arguments.args {
             if let ast::Expr::Starred(ast::ExprStarred { value, .. }) = arg {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6674,7 +6674,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> CallArguments<'a, 'db> {
         let call_arguments =
             CallArguments::from_arguments(arguments, |arg_or_keyword, splatted_value| {
-                let ty = self.infer_expression(splatted_value, TypeContext::default());
+                let ty = self.get_or_infer_expression(splatted_value, TypeContext::default());
                 if let ast::ArgOrKeyword::Arg(argument) = arg_or_keyword
                     && argument.is_starred_expr()
                 {
@@ -6816,11 +6816,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return self.infer_typeddict_call_expression(call_expression, None);
         }
 
-        // We don't call `Type::try_call`, because we want to perform type inference on the
-        // arguments after matching them to parameters, but before checking that the argument types
-        // are assignable to any parameter annotations.
-        let mut call_arguments = self.prepare_call_arguments(arguments);
-
         if callable_type.is_notimplemented(self.db()) {
             if let Some(builder) = self
                 .context
@@ -6838,6 +6833,34 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             return Type::unknown();
         }
+
+        let class = match callable_type {
+            Type::ClassLiteral(class) => Some(ClassType::NonGeneric(class)),
+            Type::GenericAlias(generic) => Some(ClassType::Generic(generic)),
+            Type::SubclassOf(subclass) => subclass.subclass_of().into_class(self.db()),
+            _ => None,
+        };
+
+        // Prepare `TypedDict` constructor calls before variadic argument setup so field-directed
+        // value inference becomes canonical before `**kwargs` expressions are inferred.
+        let has_prepared_typed_dict_constructor = class
+            .filter(|class| class.is_typed_dict(self.db()))
+            .map(|class| {
+                let typed_dict = TypedDictType::new(class);
+                let form = TypedDictConstructorForm::from_arguments(arguments);
+                self.prepare_typed_dict_constructor(
+                    typed_dict,
+                    form,
+                    arguments,
+                    func.as_ref().into(),
+                );
+            })
+            .is_some();
+
+        // We don't call `Type::try_call`, because we want to perform type inference on the
+        // arguments after matching them to parameters, but before checking that the argument types
+        // are assignable to any parameter annotations.
+        let mut call_arguments = self.prepare_call_arguments(arguments);
 
         // Special handling for `TypedDict` method calls
         if let ast::Expr::Attribute(ast::ExprAttribute { value, attr, .. }) = func.as_ref() {
@@ -6957,13 +6980,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             _ => {}
         }
 
-        let class = match callable_type {
-            Type::ClassLiteral(class) => Some(ClassType::NonGeneric(class)),
-            Type::GenericAlias(generic) => Some(ClassType::Generic(generic)),
-            Type::SubclassOf(subclass) => subclass.subclass_of().into_class(self.db()),
-            _ => None,
-        };
-
         if let Some(class) = class {
             // It might look odd here that we emit an error for class-literals and generic aliases but not
             // `type[]` types. But it's deliberate! The typing spec explicitly mandates that `type[]` types
@@ -7039,22 +7055,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             call_expression,
             &bindings,
         );
-
-        // Prepare `TypedDict` constructor calls before general argument inference so the field
-        // type context becomes the canonical inference for constructor values.
-        let has_prepared_typed_dict_constructor = class
-            .filter(|class| class.is_typed_dict(self.db()))
-            .map(|class| {
-                let typed_dict = TypedDictType::new(class);
-                let form = TypedDictConstructorForm::from_arguments(arguments);
-                self.prepare_typed_dict_constructor(
-                    typed_dict,
-                    form,
-                    arguments,
-                    func.as_ref().into(),
-                );
-            })
-            .is_some();
 
         let bindings_result = self.infer_and_check_argument_types(
             ArgumentsIter::from_ast(arguments),

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -40,7 +40,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             // back.
             let supports_typed_dict_context = {
                 let mut speculative_builder = self.speculate();
-                infer_unpacked_keyword_types(arguments, &mut |expr, tcx| {
+                infer_unpacked_keyword_types(arguments, |expr, tcx| {
                     speculative_builder.infer_expression(expr, tcx)
                 })
                 .into_iter()

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -1,3 +1,4 @@
+use ordermap::OrderSet;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, AnyNodeRef, HasNodeIndex, NodeIndex};
 use rustc_hash::FxHashMap;
@@ -14,14 +15,26 @@ use crate::types::diagnostic::{
 use crate::types::infer::builder::DeferredExpressionState;
 use crate::types::special_form::TypeQualifier;
 use crate::types::typed_dict::{
-    TypedDictSchema, collect_guaranteed_keyword_keys, functional_typed_dict_field,
-    infer_unpacked_keyword_types, typed_dict_with_relaxed_keys, validate_typed_dict_constructor,
+    MappingStringKeys, TypedDictSchema, collect_guaranteed_keyword_keys,
+    extract_unpacked_mapping_key_value_types, extract_unpacked_typed_dict_keys,
+    functional_typed_dict_field, infer_unpacked_keyword_types, mapping_string_keys,
+    typed_dict_with_relaxed_keys, validate_typed_dict_constructor,
     validate_typed_dict_dict_literal,
 };
 use crate::types::{
     IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictType,
 };
 use ty_python_core::definition::Definition;
+
+enum TypedDictConstructorValuePlanStep<'expr, 'db> {
+    Infer {
+        expr: &'expr ast::Expr,
+        tcx: TypeContext<'db>,
+    },
+    StoreUnknown {
+        expr: &'expr ast::Expr,
+    },
+}
 
 /// The shape of a `TypedDict` constructor call that affects how we prepare it for inference.
 #[derive(Debug, Clone, Copy)]
@@ -61,6 +74,24 @@ impl<'expr> TypedDictConstructorForm<'expr> {
 }
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
+    fn execute_typed_dict_constructor_value_plan(
+        &mut self,
+        plan: Vec<TypedDictConstructorValuePlanStep<'_, 'db>>,
+    ) {
+        for step in plan {
+            match step {
+                TypedDictConstructorValuePlanStep::Infer { expr, tcx } => {
+                    self.get_or_infer_expression(expr, tcx);
+                }
+                TypedDictConstructorValuePlanStep::StoreUnknown { expr } => {
+                    if self.try_expression_type(expr).is_none() {
+                        self.store_expression_type(expr, Type::unknown());
+                    }
+                }
+            }
+        }
+    }
+
     /// Infer a `TypedDict(name, fields)` call expression.
     ///
     /// This method *does not* call `infer_expression` on the object being called;
@@ -370,6 +401,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     typed_dict,
                     arguments,
                     &unpacked_keyword_types,
+                    &mut |expr, tcx| self.get_or_infer_expression(expr, tcx),
                 );
                 let positional_target =
                     typed_dict_with_relaxed_keys(self.db(), typed_dict, &keyword_keys);
@@ -400,23 +432,165 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     /// Infer keyword argument values for a `TypedDict` constructor.
     ///
     /// Named keywords are inferred against the declared type of the matching `TypedDict` field.
-    /// Unpacked `**kwargs` and unknown keys fall back to default inference because they do not
-    /// map to a single field declaration at this stage.
+    /// Literal `**{...}` entries are inferred against matching field types as well; other unpacked
+    /// `**kwargs` and unknown keys fall back to default inference.
     fn infer_typed_dict_constructor_keyword_values(
         &mut self,
         typed_dict: TypedDictType<'db>,
         arguments: &ast::Arguments,
     ) {
         let items = typed_dict.items(self.db());
+        let mut plan = Vec::new();
         for keyword in &arguments.keywords {
-            let value_tcx = keyword
-                .arg
-                .as_ref()
-                .and_then(|arg_name| items.get(arg_name.id.as_str()))
-                .map(|field| TypeContext::new(Some(field.declared_ty)))
-                .unwrap_or_default();
-            self.get_or_infer_expression(&keyword.value, value_tcx);
+            if let Some(arg_name) = &keyword.arg {
+                let value_tcx = items
+                    .get(arg_name.id.as_str())
+                    .map(|field| TypeContext::new(Some(field.declared_ty)))
+                    .unwrap_or_default();
+                plan.push(TypedDictConstructorValuePlanStep::Infer {
+                    expr: &keyword.value,
+                    tcx: value_tcx,
+                });
+            } else {
+                self.plan_typed_dict_constructor_unpacked_keyword_values(
+                    typed_dict,
+                    &keyword.value,
+                    &mut plan,
+                );
+            }
         }
+
+        self.execute_typed_dict_constructor_value_plan(plan);
+    }
+
+    /// Plan value inference for an unpacked `**kwargs` constructor argument.
+    fn plan_typed_dict_constructor_unpacked_keyword_values<'expr>(
+        &mut self,
+        typed_dict: TypedDictType<'db>,
+        expr: &'expr ast::Expr,
+        plan: &mut Vec<TypedDictConstructorValuePlanStep<'expr, 'db>>,
+    ) {
+        let mut shadowed_keys = OrderSet::new();
+        self.plan_typed_dict_constructor_merged_unpacked_keyword_values(
+            typed_dict,
+            expr,
+            &mut shadowed_keys,
+            plan,
+        );
+        if expr.is_dict_expr() {
+            plan.push(TypedDictConstructorValuePlanStep::StoreUnknown { expr });
+        }
+    }
+
+    fn shadow_typed_dict_constructor_keys_from_mapping(
+        &self,
+        typed_dict: TypedDictType<'db>,
+        key_ty: Type<'db>,
+        shadowed_keys: &mut OrderSet<Name>,
+    ) {
+        let typed_dict_items = typed_dict.items(self.db());
+        match mapping_string_keys(self.db(), key_ty) {
+            MappingStringKeys::NoString => {}
+            MappingStringKeys::Exact(keys) => {
+                for key in keys {
+                    if typed_dict_items.contains_key(&key) {
+                        shadowed_keys.insert(key);
+                    }
+                }
+            }
+            MappingStringKeys::AnyString => {
+                shadowed_keys.extend(typed_dict_items.keys().cloned());
+            }
+        }
+    }
+
+    /// Walks a merged `**{...}` literal from right to left so overwrite semantics match runtime.
+    fn plan_typed_dict_constructor_merged_unpacked_keyword_values<'expr>(
+        &mut self,
+        typed_dict: TypedDictType<'db>,
+        expr: &'expr ast::Expr,
+        shadowed_keys: &mut OrderSet<Name>,
+        plan: &mut Vec<TypedDictConstructorValuePlanStep<'expr, 'db>>,
+    ) {
+        let items = typed_dict.items(self.db());
+
+        if let ast::Expr::Dict(dict_expr) = expr {
+            for item in dict_expr.items.iter().rev() {
+                if let Some(key_expr) = &item.key {
+                    let key_ty = self.get_or_infer_expression(key_expr, TypeContext::default());
+                    if let Some(key) = key_ty
+                        .as_string_literal()
+                        .map(|key| Name::new(key.value(self.db())))
+                        && !shadowed_keys.contains(&key)
+                    {
+                        shadowed_keys.insert(key.clone());
+                        if let Some(field) = items.get(key.as_str()) {
+                            if item.value.is_dict_expr()
+                                && let Some(nested_typed_dict) = field
+                                    .declared_ty
+                                    .resolve_type_alias(self.db())
+                                    .as_typed_dict()
+                            {
+                                self.plan_typed_dict_constructor_unpacked_keyword_values(
+                                    nested_typed_dict,
+                                    &item.value,
+                                    plan,
+                                );
+                            } else {
+                                plan.push(TypedDictConstructorValuePlanStep::Infer {
+                                    expr: &item.value,
+                                    tcx: TypeContext::new(Some(field.declared_ty)),
+                                });
+                            }
+                        } else {
+                            plan.push(TypedDictConstructorValuePlanStep::Infer {
+                                expr: &item.value,
+                                tcx: TypeContext::default(),
+                            });
+                        }
+                    } else {
+                        plan.push(TypedDictConstructorValuePlanStep::Infer {
+                            expr: &item.value,
+                            tcx: TypeContext::default(),
+                        });
+                    }
+                } else {
+                    if item.value.is_dict_expr() {
+                        self.plan_typed_dict_constructor_merged_unpacked_keyword_values(
+                            typed_dict,
+                            &item.value,
+                            shadowed_keys,
+                            plan,
+                        );
+                    } else {
+                        let unpacked_ty =
+                            self.get_or_infer_expression(&item.value, TypeContext::default());
+                        if unpacked_ty.is_never() || unpacked_ty.is_dynamic() {
+                            shadowed_keys.extend(items.keys().cloned());
+                        } else if let Some(unpacked_keys) =
+                            extract_unpacked_typed_dict_keys(self.db(), unpacked_ty)
+                        {
+                            for (key, unpacked_key) in unpacked_keys {
+                                if unpacked_key.is_required() {
+                                    shadowed_keys.insert(key);
+                                }
+                            }
+                        } else if let Some((key_ty, _)) =
+                            extract_unpacked_mapping_key_value_types(self.db(), unpacked_ty)
+                        {
+                            self.shadow_typed_dict_constructor_keys_from_mapping(
+                                typed_dict,
+                                key_ty,
+                                shadowed_keys,
+                            );
+                        }
+                    }
+                }
+            }
+            return;
+        }
+
+        self.get_or_infer_expression(expr, TypeContext::default());
     }
 
     /// Infer the key and value expressions of a positional dict literal passed to a

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -1,4 +1,3 @@
-use ordermap::OrderSet;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, AnyNodeRef, HasNodeIndex, NodeIndex};
 use rustc_hash::FxHashMap;
@@ -15,25 +14,14 @@ use crate::types::diagnostic::{
 use crate::types::infer::builder::DeferredExpressionState;
 use crate::types::special_form::TypeQualifier;
 use crate::types::typed_dict::{
-    TypedDictSchema, collect_guaranteed_keyword_keys, extract_unpacked_mapping_key_value_types,
-    extract_unpacked_typed_dict_keys_from_value_type, functional_typed_dict_field,
-    typed_dict_with_relaxed_keys, unpacked_keyword_is_gradual, validate_typed_dict_constructor,
+    TypedDictSchema, collect_guaranteed_keyword_keys, functional_typed_dict_field,
+    infer_unpacked_keyword_types, typed_dict_with_relaxed_keys, validate_typed_dict_constructor,
     validate_typed_dict_dict_literal,
 };
 use crate::types::{
     IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictType,
 };
 use ty_python_core::definition::Definition;
-
-enum TypedDictConstructorValuePlanStep<'expr, 'db> {
-    Infer {
-        expr: &'expr ast::Expr,
-        tcx: TypeContext<'db>,
-    },
-    StoreUnknown {
-        expr: &'expr ast::Expr,
-    },
-}
 
 /// The shape of a `TypedDict` constructor call that affects how we prepare it for inference.
 #[derive(Debug, Clone, Copy)]
@@ -73,129 +61,6 @@ impl<'expr> TypedDictConstructorForm<'expr> {
 }
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
-    fn typed_dict_field_uses_default_context(
-        &mut self,
-        expr: &ast::Expr,
-        declared_ty: Type<'db>,
-    ) -> bool {
-        let ast::Expr::Call(call) = expr else {
-            return false;
-        };
-        let ast::Expr::Name(name) = call.func.as_ref() else {
-            return false;
-        };
-        if name.id.as_str() != "dict" {
-            return false;
-        }
-
-        let Type::Union(union) = declared_ty.resolve_type_alias(self.db()) else {
-            return false;
-        };
-
-        let union_elements = union.elements(self.db());
-        union_elements.iter().any(Type::is_typed_dict)
-            && union_elements.iter().any(|element| {
-                !element.is_typed_dict() && element.is_instance_of(self.db(), KnownClass::Dict)
-            })
-    }
-
-    fn infer_typed_dict_value_expression(
-        &mut self,
-        expr: &ast::Expr,
-        tcx: TypeContext<'db>,
-    ) -> Type<'db> {
-        let tcx = if let Some(declared_ty) = tcx.annotation
-            && self.typed_dict_field_uses_default_context(expr, declared_ty)
-        {
-            TypeContext::default()
-        } else {
-            tcx
-        };
-
-        if tcx.annotation.is_some()
-            && matches!(expr, ast::Expr::Call(_))
-            && self
-                .try_expression_type(expr)
-                .is_some_and(|ty| ty.is_instance_of(self.db(), KnownClass::Dict))
-        {
-            let mut speculative_builder = self.speculate();
-            let ty = speculative_builder.infer_expression(expr, tcx);
-            self.extend(speculative_builder);
-            ty
-        } else {
-            self.get_or_infer_expression(expr, tcx)
-        }
-    }
-
-    fn infer_merged_typed_dict_literal_values(
-        &mut self,
-        typed_dict: TypedDictType<'db>,
-        dict_expr: &ast::ExprDict,
-        shadowed_keys: &mut OrderSet<Name>,
-    ) {
-        let items = typed_dict.items(self.db());
-
-        for item in dict_expr.items.iter().rev() {
-            if let Some(key_expr) = &item.key {
-                let key_ty = self.get_or_infer_expression(key_expr, TypeContext::default());
-                if let Some(key) = key_ty
-                    .as_string_literal()
-                    .map(|key| Name::new(key.value(self.db())))
-                    && !shadowed_keys.contains(&key)
-                {
-                    shadowed_keys.insert(key.clone());
-                    if let Some(field) = items.get(key.as_str()) {
-                        self.infer_typed_dict_value_expression(
-                            &item.value,
-                            TypeContext::new(Some(field.declared_ty)),
-                        );
-                    } else {
-                        self.get_or_infer_expression(&item.value, TypeContext::default());
-                    }
-                } else {
-                    self.get_or_infer_expression(&item.value, TypeContext::default());
-                }
-            } else if let ast::Expr::Dict(nested_dict_expr) = &item.value {
-                self.infer_merged_typed_dict_literal_values(
-                    typed_dict,
-                    nested_dict_expr,
-                    shadowed_keys,
-                );
-            } else {
-                let unpacked_ty = self.get_or_infer_expression(&item.value, TypeContext::default());
-                if unpacked_keyword_is_gradual(self.db(), unpacked_ty) {
-                    shadowed_keys.extend(items.keys().cloned());
-                } else if let Some(unpacked_keys) =
-                    extract_unpacked_typed_dict_keys_from_value_type(self.db(), unpacked_ty)
-                {
-                    for (key, unpacked_key) in unpacked_keys {
-                        if unpacked_key.is_required() {
-                            shadowed_keys.insert(key);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    fn execute_typed_dict_constructor_value_plan(
-        &mut self,
-        plan: Vec<TypedDictConstructorValuePlanStep<'_, 'db>>,
-    ) {
-        for step in plan {
-            match step {
-                TypedDictConstructorValuePlanStep::Infer { expr, tcx } => {
-                    self.infer_typed_dict_value_expression(expr, tcx);
-                }
-                TypedDictConstructorValuePlanStep::StoreUnknown { expr } => {
-                    if self.try_expression_type(expr).is_none() {
-                        self.store_expression_type(expr, Type::unknown());
-                    }
-                }
-            }
-        }
-    }
-
     /// Infer a `TypedDict(name, fields)` call expression.
     ///
     /// This method *does not* call `infer_expression` on the object being called;
@@ -455,28 +320,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 && let Some(key) = key_ty.as_string_literal()
                 && let Some(field) = typed_dict_items.get(key.value(self.db()))
             {
-                self.infer_typed_dict_value_expression(
-                    &item.value,
-                    TypeContext::new(Some(field.declared_ty)),
-                )
+                self.infer_expression(&item.value, TypeContext::new(Some(field.declared_ty)))
             } else {
                 self.infer_expression(&item.value, TypeContext::default())
             };
 
             item_types.insert(item.value.node_index().load(), value_ty);
-        }
-
-        for item in items {
-            if item.key.is_none()
-                && let ast::Expr::Dict(nested_dict_expr) = &item.value
-            {
-                let mut shadowed_keys = OrderSet::new();
-                self.infer_merged_typed_dict_literal_values(
-                    typed_dict,
-                    nested_dict_expr,
-                    &mut shadowed_keys,
-                );
-            }
         }
 
         validate_typed_dict_dict_literal(
@@ -488,7 +337,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 item_types
                     .get(&expr.node_index().load())
                     .copied()
-                    .or_else(|| self.try_expression_type(expr))
                     .unwrap_or_else(|| {
                         let _ = tcx;
                         Type::unknown()
@@ -524,15 +372,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 self.get_or_infer_expression(argument, TypeContext::new(Some(target_ty)));
             }
             TypedDictConstructorForm::MixedPositionalAndKeywords => {
-                let unpacked_keyword_types = arguments
-                    .keywords
-                    .iter()
-                    .map(|keyword| {
-                        (keyword.arg.is_none() && !keyword.value.is_dict_expr()).then(|| {
-                            self.get_or_infer_expression(&keyword.value, TypeContext::default())
-                        })
-                    })
-                    .collect::<Vec<_>>();
+                let unpacked_keyword_types =
+                    infer_unpacked_keyword_types(arguments, &mut |expr, tcx| {
+                        self.get_or_infer_expression(expr, tcx)
+                    });
                 let keyword_keys = collect_guaranteed_keyword_keys(
                     self.db(),
                     typed_dict,
@@ -569,140 +412,23 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     /// Infer keyword argument values for a `TypedDict` constructor.
     ///
     /// Named keywords are inferred against the declared type of the matching `TypedDict` field.
-    /// Literal `**{...}` entries are inferred against matching field types as well; other unpacked
-    /// `**kwargs` and unknown keys fall back to default inference.
+    /// Unpacked `**kwargs` and unknown keys fall back to default inference because they do not
+    /// map to a single field declaration at this stage.
     pub(super) fn infer_typed_dict_constructor_keyword_values(
         &mut self,
         typed_dict: TypedDictType<'db>,
         arguments: &ast::Arguments,
     ) {
         let items = typed_dict.items(self.db());
-        let mut plan = Vec::new();
         for keyword in &arguments.keywords {
-            if let Some(arg_name) = &keyword.arg {
-                let value_tcx = items
-                    .get(arg_name.id.as_str())
-                    .map(|field| TypeContext::new(Some(field.declared_ty)))
-                    .unwrap_or_default();
-                plan.push(TypedDictConstructorValuePlanStep::Infer {
-                    expr: &keyword.value,
-                    tcx: value_tcx,
-                });
-            } else {
-                self.plan_typed_dict_constructor_unpacked_keyword_values(
-                    typed_dict,
-                    &keyword.value,
-                    &mut plan,
-                );
-            }
+            let value_tcx = keyword
+                .arg
+                .as_ref()
+                .and_then(|arg_name| items.get(arg_name.id.as_str()))
+                .map(|field| TypeContext::new(Some(field.declared_ty)))
+                .unwrap_or_default();
+            self.get_or_infer_expression(&keyword.value, value_tcx);
         }
-
-        self.execute_typed_dict_constructor_value_plan(plan);
-    }
-
-    /// Plan value inference for an unpacked `**kwargs` constructor argument.
-    fn plan_typed_dict_constructor_unpacked_keyword_values<'expr>(
-        &mut self,
-        typed_dict: TypedDictType<'db>,
-        expr: &'expr ast::Expr,
-        plan: &mut Vec<TypedDictConstructorValuePlanStep<'expr, 'db>>,
-    ) {
-        let mut shadowed_keys = OrderSet::new();
-        self.plan_typed_dict_constructor_merged_unpacked_keyword_values(
-            typed_dict,
-            expr,
-            &mut shadowed_keys,
-            plan,
-        );
-        if expr.is_dict_expr() {
-            plan.push(TypedDictConstructorValuePlanStep::StoreUnknown { expr });
-        }
-    }
-
-    /// Walks a merged `**{...}` literal from right to left so overwrite semantics match runtime.
-    fn plan_typed_dict_constructor_merged_unpacked_keyword_values<'expr>(
-        &mut self,
-        typed_dict: TypedDictType<'db>,
-        expr: &'expr ast::Expr,
-        shadowed_keys: &mut OrderSet<Name>,
-        plan: &mut Vec<TypedDictConstructorValuePlanStep<'expr, 'db>>,
-    ) {
-        let items = typed_dict.items(self.db());
-
-        if let ast::Expr::Dict(dict_expr) = expr {
-            for item in dict_expr.items.iter().rev() {
-                if let Some(key_expr) = &item.key {
-                    let key_ty = self.get_or_infer_expression(key_expr, TypeContext::default());
-                    if let Some(key) = key_ty
-                        .as_string_literal()
-                        .map(|key| Name::new(key.value(self.db())))
-                        && !shadowed_keys.contains(&key)
-                    {
-                        shadowed_keys.insert(key.clone());
-                        if let Some(field) = items.get(key.as_str()) {
-                            if item.value.is_dict_expr()
-                                && let Some(nested_typed_dict) = field
-                                    .declared_ty
-                                    .resolve_type_alias(self.db())
-                                    .as_typed_dict()
-                            {
-                                self.plan_typed_dict_constructor_unpacked_keyword_values(
-                                    nested_typed_dict,
-                                    &item.value,
-                                    plan,
-                                );
-                            } else {
-                                plan.push(TypedDictConstructorValuePlanStep::Infer {
-                                    expr: &item.value,
-                                    tcx: TypeContext::new(Some(field.declared_ty)),
-                                });
-                            }
-                        } else {
-                            plan.push(TypedDictConstructorValuePlanStep::Infer {
-                                expr: &item.value,
-                                tcx: TypeContext::default(),
-                            });
-                        }
-                    } else {
-                        plan.push(TypedDictConstructorValuePlanStep::Infer {
-                            expr: &item.value,
-                            tcx: TypeContext::default(),
-                        });
-                    }
-                } else {
-                    if item.value.is_dict_expr() {
-                        self.plan_typed_dict_constructor_merged_unpacked_keyword_values(
-                            typed_dict,
-                            &item.value,
-                            shadowed_keys,
-                            plan,
-                        );
-                    } else {
-                        let unpacked_ty =
-                            self.get_or_infer_expression(&item.value, TypeContext::default());
-                        if unpacked_keyword_is_gradual(self.db(), unpacked_ty) {
-                            shadowed_keys.extend(items.keys().cloned());
-                        } else if let Some(unpacked_keys) =
-                            extract_unpacked_typed_dict_keys_from_value_type(self.db(), unpacked_ty)
-                        {
-                            for (key, unpacked_key) in unpacked_keys {
-                                if unpacked_key.is_required() {
-                                    shadowed_keys.insert(key);
-                                }
-                            }
-                        } else if extract_unpacked_mapping_key_value_types(self.db(), unpacked_ty)
-                            .is_some()
-                        {
-                            // General mappings can omit any candidate key, so they don't
-                            // definitely shadow earlier items during constructor inference.
-                        }
-                    }
-                }
-            }
-            return;
-        }
-
-        self.get_or_infer_expression(expr, TypeContext::default());
     }
 
     /// Infer the key and value expressions of a positional dict literal passed to a
@@ -729,20 +455,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .and_then(|key| items.get(key.value(self.db())))
                 .map(|field| TypeContext::new(Some(field.declared_ty)))
                 .unwrap_or_default();
-            self.infer_typed_dict_value_expression(&item.value, value_tcx);
-        }
-
-        for item in &dict_expr.items {
-            if item.key.is_none()
-                && let ast::Expr::Dict(nested_dict_expr) = &item.value
-            {
-                let mut shadowed_keys = OrderSet::new();
-                self.infer_merged_typed_dict_literal_values(
-                    typed_dict,
-                    nested_dict_expr,
-                    &mut shadowed_keys,
-                );
-            }
+            self.get_or_infer_expression(&item.value, value_tcx);
         }
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -333,7 +333,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             typed_dict,
             dict,
             dict.into(),
-            &mut |expr: &ast::Expr, tcx: TypeContext<'db>| {
+            |expr: &ast::Expr, tcx: TypeContext<'db>| {
                 item_types
                     .get(&expr.node_index().load())
                     .copied()
@@ -373,7 +373,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
             TypedDictConstructorForm::MixedPositionalAndKeywords => {
                 let unpacked_keyword_types =
-                    infer_unpacked_keyword_types(arguments, &mut |expr, tcx| {
+                    infer_unpacked_keyword_types(arguments, |expr, tcx| {
                         self.get_or_infer_expression(expr, tcx)
                     });
                 let keyword_keys = collect_guaranteed_keyword_keys(

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -1,3 +1,4 @@
+use ordermap::OrderSet;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, AnyNodeRef, HasNodeIndex, NodeIndex};
 use rustc_hash::FxHashMap;
@@ -14,14 +15,26 @@ use crate::types::diagnostic::{
 use crate::types::infer::builder::DeferredExpressionState;
 use crate::types::special_form::TypeQualifier;
 use crate::types::typed_dict::{
-    TypedDictSchema, collect_guaranteed_keyword_keys, functional_typed_dict_field,
-    infer_unpacked_keyword_types, typed_dict_with_relaxed_keys, validate_typed_dict_constructor,
+    MappingStringKeys, TypedDictSchema, collect_guaranteed_keyword_keys,
+    extract_unpacked_mapping_key_value_types, extract_unpacked_typed_dict_keys_from_value_type,
+    functional_typed_dict_field, infer_unpacked_keyword_types, mapping_string_keys,
+    typed_dict_with_relaxed_keys, validate_typed_dict_constructor,
     validate_typed_dict_dict_literal,
 };
 use crate::types::{
     IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictType,
 };
 use ty_python_core::definition::Definition;
+
+enum TypedDictConstructorValuePlanStep<'expr, 'db> {
+    Infer {
+        expr: &'expr ast::Expr,
+        tcx: TypeContext<'db>,
+    },
+    StoreUnknown {
+        expr: &'expr ast::Expr,
+    },
+}
 
 /// The shape of a `TypedDict` constructor call that affects how we prepare it for inference.
 #[derive(Debug, Clone, Copy)]
@@ -61,6 +74,24 @@ impl<'expr> TypedDictConstructorForm<'expr> {
 }
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
+    fn execute_typed_dict_constructor_value_plan(
+        &mut self,
+        plan: Vec<TypedDictConstructorValuePlanStep<'_, 'db>>,
+    ) {
+        for step in plan {
+            match step {
+                TypedDictConstructorValuePlanStep::Infer { expr, tcx } => {
+                    self.get_or_infer_expression(expr, tcx);
+                }
+                TypedDictConstructorValuePlanStep::StoreUnknown { expr } => {
+                    if self.try_expression_type(expr).is_none() {
+                        self.store_expression_type(expr, Type::unknown());
+                    }
+                }
+            }
+        }
+    }
+
     /// Infer a `TypedDict(name, fields)` call expression.
     ///
     /// This method *does not* call `infer_expression` on the object being called;
@@ -372,6 +403,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     typed_dict,
                     arguments,
                     &unpacked_keyword_types,
+                    &mut |expr, tcx| self.get_or_infer_expression(expr, tcx),
                 );
                 let positional_target =
                     typed_dict_with_relaxed_keys(self.db(), typed_dict, &keyword_keys);
@@ -402,23 +434,165 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     /// Infer keyword argument values for a `TypedDict` constructor.
     ///
     /// Named keywords are inferred against the declared type of the matching `TypedDict` field.
-    /// Unpacked `**kwargs` and unknown keys fall back to default inference because they do not
-    /// map to a single field declaration at this stage.
+    /// Literal `**{...}` entries are inferred against matching field types as well; other unpacked
+    /// `**kwargs` and unknown keys fall back to default inference.
     pub(super) fn infer_typed_dict_constructor_keyword_values(
         &mut self,
         typed_dict: TypedDictType<'db>,
         arguments: &ast::Arguments,
     ) {
         let items = typed_dict.items(self.db());
+        let mut plan = Vec::new();
         for keyword in &arguments.keywords {
-            let value_tcx = keyword
-                .arg
-                .as_ref()
-                .and_then(|arg_name| items.get(arg_name.id.as_str()))
-                .map(|field| TypeContext::new(Some(field.declared_ty)))
-                .unwrap_or_default();
-            self.get_or_infer_expression(&keyword.value, value_tcx);
+            if let Some(arg_name) = &keyword.arg {
+                let value_tcx = items
+                    .get(arg_name.id.as_str())
+                    .map(|field| TypeContext::new(Some(field.declared_ty)))
+                    .unwrap_or_default();
+                plan.push(TypedDictConstructorValuePlanStep::Infer {
+                    expr: &keyword.value,
+                    tcx: value_tcx,
+                });
+            } else {
+                self.plan_typed_dict_constructor_unpacked_keyword_values(
+                    typed_dict,
+                    &keyword.value,
+                    &mut plan,
+                );
+            }
         }
+
+        self.execute_typed_dict_constructor_value_plan(plan);
+    }
+
+    /// Plan value inference for an unpacked `**kwargs` constructor argument.
+    fn plan_typed_dict_constructor_unpacked_keyword_values<'expr>(
+        &mut self,
+        typed_dict: TypedDictType<'db>,
+        expr: &'expr ast::Expr,
+        plan: &mut Vec<TypedDictConstructorValuePlanStep<'expr, 'db>>,
+    ) {
+        let mut shadowed_keys = OrderSet::new();
+        self.plan_typed_dict_constructor_merged_unpacked_keyword_values(
+            typed_dict,
+            expr,
+            &mut shadowed_keys,
+            plan,
+        );
+        if expr.is_dict_expr() {
+            plan.push(TypedDictConstructorValuePlanStep::StoreUnknown { expr });
+        }
+    }
+
+    fn shadow_typed_dict_constructor_keys_from_mapping(
+        &self,
+        typed_dict: TypedDictType<'db>,
+        key_ty: Type<'db>,
+        shadowed_keys: &mut OrderSet<Name>,
+    ) {
+        let typed_dict_items = typed_dict.items(self.db());
+        match mapping_string_keys(self.db(), key_ty) {
+            MappingStringKeys::NoString => {}
+            MappingStringKeys::Exact(keys) => {
+                for key in keys {
+                    if typed_dict_items.contains_key(&key) {
+                        shadowed_keys.insert(key);
+                    }
+                }
+            }
+            MappingStringKeys::AnyString => {
+                shadowed_keys.extend(typed_dict_items.keys().cloned());
+            }
+        }
+    }
+
+    /// Walks a merged `**{...}` literal from right to left so overwrite semantics match runtime.
+    fn plan_typed_dict_constructor_merged_unpacked_keyword_values<'expr>(
+        &mut self,
+        typed_dict: TypedDictType<'db>,
+        expr: &'expr ast::Expr,
+        shadowed_keys: &mut OrderSet<Name>,
+        plan: &mut Vec<TypedDictConstructorValuePlanStep<'expr, 'db>>,
+    ) {
+        let items = typed_dict.items(self.db());
+
+        if let ast::Expr::Dict(dict_expr) = expr {
+            for item in dict_expr.items.iter().rev() {
+                if let Some(key_expr) = &item.key {
+                    let key_ty = self.get_or_infer_expression(key_expr, TypeContext::default());
+                    if let Some(key) = key_ty
+                        .as_string_literal()
+                        .map(|key| Name::new(key.value(self.db())))
+                        && !shadowed_keys.contains(&key)
+                    {
+                        shadowed_keys.insert(key.clone());
+                        if let Some(field) = items.get(key.as_str()) {
+                            if item.value.is_dict_expr()
+                                && let Some(nested_typed_dict) = field
+                                    .declared_ty
+                                    .resolve_type_alias(self.db())
+                                    .as_typed_dict()
+                            {
+                                self.plan_typed_dict_constructor_unpacked_keyword_values(
+                                    nested_typed_dict,
+                                    &item.value,
+                                    plan,
+                                );
+                            } else {
+                                plan.push(TypedDictConstructorValuePlanStep::Infer {
+                                    expr: &item.value,
+                                    tcx: TypeContext::new(Some(field.declared_ty)),
+                                });
+                            }
+                        } else {
+                            plan.push(TypedDictConstructorValuePlanStep::Infer {
+                                expr: &item.value,
+                                tcx: TypeContext::default(),
+                            });
+                        }
+                    } else {
+                        plan.push(TypedDictConstructorValuePlanStep::Infer {
+                            expr: &item.value,
+                            tcx: TypeContext::default(),
+                        });
+                    }
+                } else {
+                    if item.value.is_dict_expr() {
+                        self.plan_typed_dict_constructor_merged_unpacked_keyword_values(
+                            typed_dict,
+                            &item.value,
+                            shadowed_keys,
+                            plan,
+                        );
+                    } else {
+                        let unpacked_ty =
+                            self.get_or_infer_expression(&item.value, TypeContext::default());
+                        if unpacked_ty.is_never() || unpacked_ty.is_dynamic() {
+                            shadowed_keys.extend(items.keys().cloned());
+                        } else if let Some(unpacked_keys) =
+                            extract_unpacked_typed_dict_keys_from_value_type(self.db(), unpacked_ty)
+                        {
+                            for (key, unpacked_key) in unpacked_keys {
+                                if unpacked_key.is_required() {
+                                    shadowed_keys.insert(key);
+                                }
+                            }
+                        } else if let Some((key_ty, _)) =
+                            extract_unpacked_mapping_key_value_types(self.db(), unpacked_ty)
+                        {
+                            self.shadow_typed_dict_constructor_keys_from_mapping(
+                                typed_dict,
+                                key_ty,
+                                shadowed_keys,
+                            );
+                        }
+                    }
+                }
+            }
+            return;
+        }
+
+        self.get_or_infer_expression(expr, TypeContext::default());
     }
 
     /// Infer the key and value expressions of a positional dict literal passed to a

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -15,10 +15,9 @@ use crate::types::diagnostic::{
 use crate::types::infer::builder::DeferredExpressionState;
 use crate::types::special_form::TypeQualifier;
 use crate::types::typed_dict::{
-    MappingStringKeys, TypedDictSchema, collect_guaranteed_keyword_keys,
-    extract_unpacked_mapping_key_value_types, extract_unpacked_typed_dict_keys_from_value_type,
-    functional_typed_dict_field, infer_unpacked_keyword_types, mapping_string_keys,
-    typed_dict_with_relaxed_keys, validate_typed_dict_constructor,
+    TypedDictSchema, collect_guaranteed_keyword_keys, extract_unpacked_mapping_key_value_types,
+    extract_unpacked_typed_dict_keys_from_value_type, functional_typed_dict_field,
+    typed_dict_with_relaxed_keys, unpacked_keyword_is_gradual, validate_typed_dict_constructor,
     validate_typed_dict_dict_literal,
 };
 use crate::types::{
@@ -74,6 +73,111 @@ impl<'expr> TypedDictConstructorForm<'expr> {
 }
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
+    fn typed_dict_field_uses_default_context(
+        &mut self,
+        expr: &ast::Expr,
+        declared_ty: Type<'db>,
+    ) -> bool {
+        let ast::Expr::Call(call) = expr else {
+            return false;
+        };
+        let ast::Expr::Name(name) = call.func.as_ref() else {
+            return false;
+        };
+        if name.id.as_str() != "dict" {
+            return false;
+        }
+
+        let Type::Union(union) = declared_ty.resolve_type_alias(self.db()) else {
+            return false;
+        };
+
+        let union_elements = union.elements(self.db());
+        union_elements.iter().any(Type::is_typed_dict)
+            && union_elements.iter().any(|element| {
+                !element.is_typed_dict() && element.is_instance_of(self.db(), KnownClass::Dict)
+            })
+    }
+
+    fn infer_typed_dict_value_expression(
+        &mut self,
+        expr: &ast::Expr,
+        tcx: TypeContext<'db>,
+    ) -> Type<'db> {
+        let tcx = if let Some(declared_ty) = tcx.annotation
+            && self.typed_dict_field_uses_default_context(expr, declared_ty)
+        {
+            TypeContext::default()
+        } else {
+            tcx
+        };
+
+        if tcx.annotation.is_some()
+            && matches!(expr, ast::Expr::Call(_))
+            && self
+                .try_expression_type(expr)
+                .is_some_and(|ty| ty.is_instance_of(self.db(), KnownClass::Dict))
+        {
+            let mut speculative_builder = self.speculate();
+            let ty = speculative_builder.infer_expression(expr, tcx);
+            self.extend(speculative_builder);
+            ty
+        } else {
+            self.get_or_infer_expression(expr, tcx)
+        }
+    }
+
+    fn infer_merged_typed_dict_literal_values(
+        &mut self,
+        typed_dict: TypedDictType<'db>,
+        dict_expr: &ast::ExprDict,
+        shadowed_keys: &mut OrderSet<Name>,
+    ) {
+        let items = typed_dict.items(self.db());
+
+        for item in dict_expr.items.iter().rev() {
+            if let Some(key_expr) = &item.key {
+                let key_ty = self.get_or_infer_expression(key_expr, TypeContext::default());
+                if let Some(key) = key_ty
+                    .as_string_literal()
+                    .map(|key| Name::new(key.value(self.db())))
+                    && !shadowed_keys.contains(&key)
+                {
+                    shadowed_keys.insert(key.clone());
+                    if let Some(field) = items.get(key.as_str()) {
+                        self.infer_typed_dict_value_expression(
+                            &item.value,
+                            TypeContext::new(Some(field.declared_ty)),
+                        );
+                    } else {
+                        self.get_or_infer_expression(&item.value, TypeContext::default());
+                    }
+                } else {
+                    self.get_or_infer_expression(&item.value, TypeContext::default());
+                }
+            } else if let ast::Expr::Dict(nested_dict_expr) = &item.value {
+                self.infer_merged_typed_dict_literal_values(
+                    typed_dict,
+                    nested_dict_expr,
+                    shadowed_keys,
+                );
+            } else {
+                let unpacked_ty = self.get_or_infer_expression(&item.value, TypeContext::default());
+                if unpacked_keyword_is_gradual(self.db(), unpacked_ty) {
+                    shadowed_keys.extend(items.keys().cloned());
+                } else if let Some(unpacked_keys) =
+                    extract_unpacked_typed_dict_keys_from_value_type(self.db(), unpacked_ty)
+                {
+                    for (key, unpacked_key) in unpacked_keys {
+                        if unpacked_key.is_required() {
+                            shadowed_keys.insert(key);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     fn execute_typed_dict_constructor_value_plan(
         &mut self,
         plan: Vec<TypedDictConstructorValuePlanStep<'_, 'db>>,
@@ -81,7 +185,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         for step in plan {
             match step {
                 TypedDictConstructorValuePlanStep::Infer { expr, tcx } => {
-                    self.get_or_infer_expression(expr, tcx);
+                    self.infer_typed_dict_value_expression(expr, tcx);
                 }
                 TypedDictConstructorValuePlanStep::StoreUnknown { expr } => {
                     if self.try_expression_type(expr).is_none() {
@@ -351,7 +455,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 && let Some(key) = key_ty.as_string_literal()
                 && let Some(field) = typed_dict_items.get(key.value(self.db()))
             {
-                self.infer_expression(&item.value, TypeContext::new(Some(field.declared_ty)))
+                self.infer_typed_dict_value_expression(
+                    &item.value,
+                    TypeContext::new(Some(field.declared_ty)),
+                )
             } else {
                 self.infer_expression(&item.value, TypeContext::default())
             };
@@ -359,12 +466,35 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             item_types.insert(item.value.node_index().load(), value_ty);
         }
 
-        validate_typed_dict_dict_literal(&self.context, typed_dict, dict, dict.into(), |expr| {
-            item_types
-                .get(&expr.node_index().load())
-                .copied()
-                .unwrap_or(Type::unknown())
-        })
+        for item in items {
+            if item.key.is_none()
+                && let ast::Expr::Dict(nested_dict_expr) = &item.value
+            {
+                let mut shadowed_keys = OrderSet::new();
+                self.infer_merged_typed_dict_literal_values(
+                    typed_dict,
+                    nested_dict_expr,
+                    &mut shadowed_keys,
+                );
+            }
+        }
+
+        validate_typed_dict_dict_literal(
+            &self.context,
+            typed_dict,
+            dict,
+            dict.into(),
+            &mut |expr: &ast::Expr, tcx: TypeContext<'db>| {
+                item_types
+                    .get(&expr.node_index().load())
+                    .copied()
+                    .or_else(|| self.try_expression_type(expr))
+                    .unwrap_or_else(|| {
+                        let _ = tcx;
+                        Type::unknown()
+                    })
+            },
+        )
         .ok()
         .map(|_| Type::TypedDict(typed_dict))
     }
@@ -394,10 +524,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 self.get_or_infer_expression(argument, TypeContext::new(Some(target_ty)));
             }
             TypedDictConstructorForm::MixedPositionalAndKeywords => {
-                let unpacked_keyword_types =
-                    infer_unpacked_keyword_types(arguments, &mut |expr, tcx| {
-                        self.get_or_infer_expression(expr, tcx)
-                    });
+                let unpacked_keyword_types = arguments
+                    .keywords
+                    .iter()
+                    .map(|keyword| {
+                        (keyword.arg.is_none() && !keyword.value.is_dict_expr()).then(|| {
+                            self.get_or_infer_expression(&keyword.value, TypeContext::default())
+                        })
+                    })
+                    .collect::<Vec<_>>();
                 let keyword_keys = collect_guaranteed_keyword_keys(
                     self.db(),
                     typed_dict,
@@ -484,28 +619,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
     }
 
-    fn shadow_typed_dict_constructor_keys_from_mapping(
-        &self,
-        typed_dict: TypedDictType<'db>,
-        key_ty: Type<'db>,
-        shadowed_keys: &mut OrderSet<Name>,
-    ) {
-        let typed_dict_items = typed_dict.items(self.db());
-        match mapping_string_keys(self.db(), key_ty) {
-            MappingStringKeys::NoString => {}
-            MappingStringKeys::Exact(keys) => {
-                for key in keys {
-                    if typed_dict_items.contains_key(&key) {
-                        shadowed_keys.insert(key);
-                    }
-                }
-            }
-            MappingStringKeys::AnyString => {
-                shadowed_keys.extend(typed_dict_items.keys().cloned());
-            }
-        }
-    }
-
     /// Walks a merged `**{...}` literal from right to left so overwrite semantics match runtime.
     fn plan_typed_dict_constructor_merged_unpacked_keyword_values<'expr>(
         &mut self,
@@ -567,7 +680,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     } else {
                         let unpacked_ty =
                             self.get_or_infer_expression(&item.value, TypeContext::default());
-                        if unpacked_ty.is_never() || unpacked_ty.is_dynamic() {
+                        if unpacked_keyword_is_gradual(self.db(), unpacked_ty) {
                             shadowed_keys.extend(items.keys().cloned());
                         } else if let Some(unpacked_keys) =
                             extract_unpacked_typed_dict_keys_from_value_type(self.db(), unpacked_ty)
@@ -577,14 +690,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                     shadowed_keys.insert(key);
                                 }
                             }
-                        } else if let Some((key_ty, _)) =
-                            extract_unpacked_mapping_key_value_types(self.db(), unpacked_ty)
+                        } else if extract_unpacked_mapping_key_value_types(self.db(), unpacked_ty)
+                            .is_some()
                         {
-                            self.shadow_typed_dict_constructor_keys_from_mapping(
-                                typed_dict,
-                                key_ty,
-                                shadowed_keys,
-                            );
+                            // General mappings can omit any candidate key, so they don't
+                            // definitely shadow earlier items during constructor inference.
                         }
                     }
                 }
@@ -619,7 +729,20 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .and_then(|key| items.get(key.value(self.db())))
                 .map(|field| TypeContext::new(Some(field.declared_ty)))
                 .unwrap_or_default();
-            self.get_or_infer_expression(&item.value, value_tcx);
+            self.infer_typed_dict_value_expression(&item.value, value_tcx);
+        }
+
+        for item in &dict_expr.items {
+            if item.key.is_none()
+                && let ast::Expr::Dict(nested_dict_expr) = &item.value
+            {
+                let mut shadowed_keys = OrderSet::new();
+                self.infer_merged_typed_dict_literal_values(
+                    typed_dict,
+                    nested_dict_expr,
+                    &mut shadowed_keys,
+                );
+            }
         }
     }
 

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -10,7 +10,7 @@ use ruff_python_ast::Arguments;
 use ruff_python_ast::{self as ast, AnyNodeRef, StmtClassDef, name::Name};
 use ruff_text_size::Ranged;
 
-use super::class::{ClassLiteral, ClassType, CodeGeneratorKind, Field};
+use super::class::{ClassLiteral, ClassType, CodeGeneratorKind, Field, KnownClass};
 use super::context::InferContext;
 use super::diagnostic::{
     self, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, PARAMETER_ALREADY_ASSIGNED,
@@ -26,6 +26,7 @@ use crate::types::TypeContext;
 use crate::types::TypeDefinition;
 use crate::types::class::FieldKind;
 use crate::types::constraints::{ConstraintSet, IteratorConstraintsExtension};
+use crate::types::generics::InferableTypeVars;
 use crate::types::relation::{DisjointnessChecker, TypeRelation, TypeRelationChecker};
 use ty_python_core::definition::Definition;
 
@@ -817,9 +818,16 @@ pub(super) fn validate_typed_dict_required_keys<'db, 'ast>(
 }
 
 #[derive(Debug, Clone, Copy)]
-struct UnpackedTypedDictKey<'db> {
+pub(super) struct UnpackedTypedDictKey<'db> {
     value_ty: Type<'db>,
     is_required: bool,
+}
+
+impl UnpackedTypedDictKey<'_> {
+    /// Returns whether this unpacked key is guaranteed to be present.
+    pub(super) fn is_required(self) -> bool {
+        self.is_required
+    }
 }
 
 /// Extracts `TypedDict` keys, their value types, and whether they are required when unpacked as
@@ -831,7 +839,7 @@ struct UnpackedTypedDictKey<'db> {
 /// intersected, and the key is considered required if any constituent `TypedDict` requires it.
 /// For unions, returns all keys that may appear in any arm, unioning value types for shared keys,
 /// and a key is only considered required if every arm requires it.
-fn extract_unpacked_typed_dict_keys<'db>(
+pub(super) fn extract_unpacked_typed_dict_keys<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
 ) -> Option<BTreeMap<Name, UnpackedTypedDictKey<'db>>> {
@@ -988,6 +996,7 @@ pub(super) fn collect_guaranteed_keyword_keys<'db>(
     typed_dict: TypedDictType<'db>,
     arguments: &Arguments,
     unpacked_keyword_types: &[Option<Type<'db>>],
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) -> OrderSet<Name> {
     debug_assert_eq!(arguments.keywords.len(), unpacked_keyword_types.len());
 
@@ -997,26 +1006,93 @@ pub(super) fn collect_guaranteed_keyword_keys<'db>(
         .filter_map(|keyword| keyword.arg.as_ref().map(|arg| arg.id.clone()))
         .collect();
 
-    for unpacked_type in unpacked_keyword_types.iter().copied().flatten() {
-        if unpacked_type.is_never() || unpacked_type.is_dynamic() {
-            provided_keys.extend(
-                typed_dict.items(db).iter().filter_map(|(key_name, field)| {
-                    field.is_required().then_some(key_name.clone())
-                }),
-            );
-        // TODO: also extract guaranteed keys from unpacked dict literals like `**{"a": 1}`.
-        // Today we only suppress positional-key diagnostics for explicit keywords and unpacked
-        // TypedDicts, which makes those literal-unpack cases inconsistent with equivalent calls.
-        } else if let Some(unpacked_keys) = extract_unpacked_typed_dict_keys(db, unpacked_type) {
-            provided_keys.extend(
-                unpacked_keys
-                    .into_iter()
-                    .filter_map(|(key, unpacked_key)| unpacked_key.is_required.then_some(key)),
-            );
-        }
+    for (keyword, unpacked_type) in arguments
+        .keywords
+        .iter()
+        .zip(unpacked_keyword_types.iter().copied())
+    {
+        let Some(unpacked_type) = unpacked_type else {
+            continue;
+        };
+
+        provided_keys.extend(collect_guaranteed_keys_from_unpacked_keyword(
+            db,
+            typed_dict,
+            &keyword.value,
+            unpacked_type,
+            expression_type_fn,
+        ));
     }
 
     provided_keys
+}
+
+/// Collects keys definitely present in the final mapping produced by one `**kwargs` argument.
+fn collect_guaranteed_keys_from_unpacked_keyword<'db>(
+    db: &'db dyn Db,
+    typed_dict: TypedDictType<'db>,
+    expr: &ast::Expr,
+    unpacked_type: Type<'db>,
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+) -> OrderSet<Name> {
+    let mut provided_keys = OrderSet::new();
+    collect_guaranteed_keys_from_merged_unpacked_keyword(
+        db,
+        typed_dict,
+        expr,
+        unpacked_type,
+        &mut provided_keys,
+        expression_type_fn,
+    );
+    provided_keys
+}
+
+/// Collects keys guaranteed by one unpacked constructor argument, honoring merged `**{...}`
+/// overwrite semantics.
+fn collect_guaranteed_keys_from_merged_unpacked_keyword<'db>(
+    db: &'db dyn Db,
+    typed_dict: TypedDictType<'db>,
+    expr: &ast::Expr,
+    unpacked_type: Type<'db>,
+    provided_keys: &mut OrderSet<Name>,
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+) {
+    if let ast::Expr::Dict(dict_expr) = expr {
+        for item in dict_expr.items.iter().rev() {
+            if let Some(key_expr) = &item.key {
+                let key_ty = expression_type_fn(key_expr, TypeContext::default());
+                if let Some(key_literal) = key_ty.as_string_literal() {
+                    provided_keys.insert(Name::new(key_literal.value(db)));
+                }
+            } else {
+                let nested_ty = expression_type_fn(&item.value, TypeContext::default());
+                collect_guaranteed_keys_from_merged_unpacked_keyword(
+                    db,
+                    typed_dict,
+                    &item.value,
+                    nested_ty,
+                    provided_keys,
+                    expression_type_fn,
+                );
+            }
+        }
+        return;
+    }
+
+    if unpacked_type.is_never() || unpacked_type.is_dynamic() {
+        provided_keys.extend(
+            typed_dict
+                .items(db)
+                .iter()
+                .filter_map(|(key_name, field)| field.is_required().then_some(key_name.clone())),
+        );
+    } else if let Some(unpacked_keys) = extract_unpacked_typed_dict_keys(db, unpacked_type) {
+        for (key, unpacked_key) in unpacked_keys {
+            if unpacked_key.is_required {
+                provided_keys.insert(key);
+            }
+        }
+    }
 }
 
 /// Returns a `TypedDict` schema with `excluded_keys` removed.
@@ -1264,8 +1340,13 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
     if has_single_positional_arg && !arguments.keywords.is_empty() {
         // Mixed positional-and-keyword construction: guaranteed keyword-provided keys override the
         // positional mapping, so validate the positional argument against the remaining schema.
-        let keyword_keys =
-            collect_guaranteed_keyword_keys(db, typed_dict, arguments, &unpacked_keyword_types);
+        let keyword_keys = collect_guaranteed_keyword_keys(
+            db,
+            typed_dict,
+            arguments,
+            &unpacked_keyword_types,
+            &mut expression_type_fn,
+        );
         let mut provided_keys = if has_positional_dict_literal {
             validate_from_dict_literal(
                 context,
@@ -1479,42 +1560,368 @@ fn validate_from_keywords<'db, 'ast>(
             let Some(unpacked_type) = unpacked_type else {
                 continue;
             };
-
-            // Never and Dynamic types are special: they can have any keys, so we skip
-            // validation and mark all required keys as provided.
-            if unpacked_type.is_never() || unpacked_type.is_dynamic() {
-                for (key_name, field) in typed_dict.items(db) {
-                    if field.is_required() {
-                        guaranteed_keys.entry(key_name.clone()).or_insert(None);
-                    }
-                }
-            } else if let Some(unpacked_keys) = extract_unpacked_typed_dict_keys(db, unpacked_type)
-            {
-                for key_name in validate_extracted_typed_dict_keys(
-                    context,
-                    typed_dict,
-                    &unpacked_keys,
-                    TypedDictAssignmentNodes {
-                        typed_dict: typed_dict_node,
-                        key: keyword.into(),
-                        value: (&keyword.value).into(),
-                    },
-                    full_object_ty_annotation(unpacked_type),
-                    &OrderSet::new(),
-                ) {
-                    record_guaranteed_typed_dict_constructor_key(
-                        context,
-                        typed_dict,
-                        &mut guaranteed_keys,
-                        key_name,
-                        keyword_node,
-                    );
-                }
-            }
+            validate_unpacked_keyword_argument(
+                context,
+                typed_dict,
+                &keyword.value,
+                unpacked_type,
+                TypedDictAssignmentNodes {
+                    typed_dict: typed_dict_node,
+                    key: keyword.into(),
+                    value: (&keyword.value).into(),
+                },
+                &mut guaranteed_keys,
+                expression_type_fn,
+            );
         }
     }
 
     guaranteed_keys.into_keys().collect()
+}
+
+/// Validates one unpacked `**kwargs` constructor argument and merges its definite keys into the
+/// constructor-level duplicate tracking.
+fn validate_unpacked_keyword_argument<'db, 'ast>(
+    context: &InferContext<'db, 'ast>,
+    typed_dict: TypedDictType<'db>,
+    expr: &'ast ast::Expr,
+    unpacked_type: Type<'db>,
+    nodes: TypedDictAssignmentNodes<'ast>,
+    guaranteed_keys: &mut BTreeMap<Name, Option<AnyNodeRef<'ast>>>,
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+) {
+    let mut unpacked_guaranteed_keys = BTreeMap::new();
+    let mut shadowed_keys = OrderSet::new();
+    validate_merged_unpacked_keyword_argument(
+        context,
+        typed_dict,
+        expr,
+        unpacked_type,
+        nodes,
+        &mut unpacked_guaranteed_keys,
+        &mut shadowed_keys,
+        expression_type_fn,
+    );
+
+    for (key_name, key_node) in unpacked_guaranteed_keys {
+        if let Some(key_node) = key_node {
+            record_guaranteed_typed_dict_constructor_key(
+                context,
+                typed_dict,
+                guaranteed_keys,
+                key_name,
+                key_node,
+            );
+        } else {
+            guaranteed_keys.entry(key_name).or_insert(None);
+        }
+    }
+}
+
+/// Validates one unpacked constructor argument while preserving merged `**{...}` overwrite
+/// semantics.
+#[expect(clippy::too_many_arguments)]
+fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
+    context: &InferContext<'db, 'ast>,
+    typed_dict: TypedDictType<'db>,
+    expr: &'ast ast::Expr,
+    unpacked_type: Type<'db>,
+    nodes: TypedDictAssignmentNodes<'ast>,
+    guaranteed_keys: &mut BTreeMap<Name, Option<AnyNodeRef<'ast>>>,
+    shadowed_keys: &mut OrderSet<Name>,
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+) {
+    let db = context.db();
+    let items = typed_dict.items(db);
+
+    if let ast::Expr::Dict(dict_expr) = expr {
+        for item in dict_expr.items.iter().rev() {
+            if let Some(key_expr) = &item.key {
+                let key_ty = expression_type_fn(key_expr, TypeContext::default());
+                let Some(key_literal) = key_ty.as_string_literal() else {
+                    continue;
+                };
+
+                let key = Name::new(key_literal.value(db));
+                let is_shadowed = shadowed_keys.contains(&key);
+
+                if !is_shadowed {
+                    let field = items.get(key.as_str());
+                    let value_tcx = items
+                        .get(key.as_str())
+                        .map(|field| TypeContext::new(Some(field.declared_ty)))
+                        .unwrap_or_default();
+                    let value_ty = expression_type_fn(&item.value, value_tcx);
+                    validate_nested_unpacked_typed_dict_literal(
+                        context,
+                        field.map(|field| field.declared_ty),
+                        &item.value,
+                        expression_type_fn,
+                    );
+                    TypedDictKeyAssignment {
+                        context,
+                        typed_dict,
+                        full_object_ty: None,
+                        key: key.as_str(),
+                        value_ty,
+                        typed_dict_node: nodes.typed_dict,
+                        key_node: key_expr.into(),
+                        value_node: (&item.value).into(),
+                        assignment_kind: TypedDictAssignmentKind::Constructor,
+                        emit_diagnostic: true,
+                    }
+                    .validate();
+                }
+                guaranteed_keys
+                    .entry(key.clone())
+                    .and_modify(|node| {
+                        if node.is_none() {
+                            *node = Some(key_expr.into());
+                        }
+                    })
+                    .or_insert(Some(key_expr.into()));
+                shadowed_keys.insert(key);
+            } else {
+                let nested_ty = expression_type_fn(&item.value, TypeContext::default());
+                validate_merged_unpacked_keyword_argument(
+                    context,
+                    typed_dict,
+                    &item.value,
+                    nested_ty,
+                    TypedDictAssignmentNodes {
+                        typed_dict: nodes.typed_dict,
+                        key: (&item.value).into(),
+                        value: (&item.value).into(),
+                    },
+                    guaranteed_keys,
+                    shadowed_keys,
+                    expression_type_fn,
+                );
+            }
+        }
+        return;
+    }
+
+    // Never and Dynamic types are special: they can have any keys, so we skip
+    // validation and mark all required keys as provided.
+    if unpacked_type.is_never() || unpacked_type.is_dynamic() {
+        shadowed_keys.extend(items.keys().cloned());
+        for (key_name, field) in items {
+            if field.is_required() {
+                guaranteed_keys.entry(key_name.clone()).or_insert(None);
+            }
+        }
+    } else if let Some(unpacked_keys) = extract_unpacked_typed_dict_keys(db, unpacked_type) {
+        let ignored_keys = shadowed_keys.clone();
+        validate_extracted_typed_dict_keys(
+            context,
+            typed_dict,
+            &unpacked_keys,
+            nodes,
+            full_object_ty_annotation(unpacked_type),
+            &ignored_keys,
+        );
+
+        for (key_name, unpacked_key) in unpacked_keys {
+            if unpacked_key.is_required() {
+                guaranteed_keys
+                    .entry(key_name.clone())
+                    .and_modify(|node| {
+                        if node.is_none() {
+                            *node = Some(nodes.key);
+                        }
+                    })
+                    .or_insert(Some(nodes.key));
+                shadowed_keys.insert(key_name);
+            }
+        }
+    } else if let Some((key_ty, value_ty)) =
+        extract_unpacked_mapping_key_value_types(db, unpacked_type)
+    {
+        validate_mapping_overwrite(
+            context,
+            typed_dict,
+            unpacked_type,
+            key_ty,
+            value_ty,
+            nodes,
+            shadowed_keys,
+        );
+    }
+}
+
+pub(super) fn extract_unpacked_mapping_key_value_types<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+) -> Option<(Type<'db>, Type<'db>)> {
+    match ty.resolve_type_alias(db) {
+        Type::Union(union) => {
+            let mut key_builder = UnionBuilder::new(db);
+            let mut value_builder = UnionBuilder::new(db);
+
+            for element in union.elements(db) {
+                let [key_ty, value_ty] = element
+                    .known_specialization(db, KnownClass::Dict)
+                    .or_else(|| element.known_specialization(db, KnownClass::Mapping))?
+                    .types(db)
+                else {
+                    return None;
+                };
+                key_builder = key_builder.add(*key_ty);
+                value_builder = value_builder.add(*value_ty);
+            }
+
+            Some((key_builder.build(), value_builder.build()))
+        }
+        ty => {
+            let specialization = ty
+                .known_specialization(db, KnownClass::Dict)
+                .or_else(|| ty.known_specialization(db, KnownClass::Mapping))?;
+            let [key_ty, value_ty] = specialization.types(db) else {
+                return None;
+            };
+            Some((*key_ty, *value_ty))
+        }
+    }
+}
+
+fn validate_mapping_overwrite<'db, 'ast>(
+    context: &InferContext<'db, 'ast>,
+    typed_dict: TypedDictType<'db>,
+    unpacked_type: Type<'db>,
+    key_ty: Type<'db>,
+    value_ty: Type<'db>,
+    nodes: TypedDictAssignmentNodes<'ast>,
+    shadowed_keys: &mut OrderSet<Name>,
+) {
+    let db = context.db();
+    let typed_dict_items = typed_dict.items(db);
+
+    match mapping_string_keys(db, key_ty) {
+        MappingStringKeys::NoString => return,
+        MappingStringKeys::Exact(keys) => {
+            for key in keys {
+                if shadowed_keys.contains(&key) {
+                    continue;
+                }
+                if typed_dict_items.contains_key(&key) {
+                    TypedDictKeyAssignment {
+                        context,
+                        typed_dict,
+                        full_object_ty: full_object_ty_annotation(unpacked_type),
+                        key: key.as_str(),
+                        value_ty,
+                        typed_dict_node: nodes.typed_dict,
+                        key_node: nodes.key,
+                        value_node: nodes.value,
+                        assignment_kind: TypedDictAssignmentKind::Constructor,
+                        emit_diagnostic: true,
+                    }
+                    .validate();
+                    shadowed_keys.insert(key);
+                }
+            }
+        }
+        MappingStringKeys::AnyString => {
+            for (key_name, _) in typed_dict_items {
+                if shadowed_keys.contains(key_name) {
+                    continue;
+                }
+                TypedDictKeyAssignment {
+                    context,
+                    typed_dict,
+                    full_object_ty: full_object_ty_annotation(unpacked_type),
+                    key: key_name.as_str(),
+                    value_ty,
+                    typed_dict_node: nodes.typed_dict,
+                    key_node: nodes.key,
+                    value_node: nodes.value,
+                    assignment_kind: TypedDictAssignmentKind::Constructor,
+                    emit_diagnostic: true,
+                }
+                .validate();
+                shadowed_keys.insert(key_name.clone());
+            }
+        }
+    }
+}
+
+pub(super) enum MappingStringKeys {
+    NoString,
+    Exact(Vec<Name>),
+    AnyString,
+}
+
+pub(super) fn mapping_string_keys<'db>(db: &'db dyn Db, key_ty: Type<'db>) -> MappingStringKeys {
+    let string_overlap = key_ty.filter_disjoint_elements(
+        db,
+        KnownClass::Str.to_instance(db),
+        InferableTypeVars::None,
+    );
+    if string_overlap.is_never() {
+        return MappingStringKeys::NoString;
+    }
+
+    if let Some(key_literal) = string_overlap.as_string_literal() {
+        return MappingStringKeys::Exact(vec![Name::new(key_literal.value(db))]);
+    }
+
+    let Type::Union(union) = string_overlap.resolve_type_alias(db) else {
+        return MappingStringKeys::AnyString;
+    };
+
+    union
+        .elements(db)
+        .iter()
+        .map(|element| {
+            element
+                .as_string_literal()
+                .map(|literal| Name::new(literal.value(db)))
+        })
+        .collect::<Option<Vec<_>>>()
+        .map_or(MappingStringKeys::AnyString, MappingStringKeys::Exact)
+}
+
+fn validate_nested_unpacked_typed_dict_literal<'db, 'ast>(
+    context: &InferContext<'db, 'ast>,
+    declared_ty: Option<Type<'db>>,
+    value_expr: &'ast ast::Expr,
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+) {
+    let Some(declared_ty) = declared_ty else {
+        return;
+    };
+    let ast::Expr::Dict(_) = value_expr else {
+        return;
+    };
+    let Some(nested_typed_dict) = declared_ty.resolve_type_alias(context.db()).as_typed_dict()
+    else {
+        return;
+    };
+
+    let nested_typed_dict_node: AnyNodeRef<'ast> = value_expr.into();
+    let mut guaranteed_keys = BTreeMap::new();
+    validate_unpacked_keyword_argument(
+        context,
+        nested_typed_dict,
+        value_expr,
+        Type::TypedDict(nested_typed_dict),
+        TypedDictAssignmentNodes {
+            typed_dict: nested_typed_dict_node,
+            key: nested_typed_dict_node,
+            value: nested_typed_dict_node,
+        },
+        &mut guaranteed_keys,
+        expression_type_fn,
+    );
+    let provided_keys: OrderSet<Name> = guaranteed_keys.into_keys().collect();
+
+    validate_typed_dict_required_keys(
+        context,
+        nested_typed_dict,
+        &provided_keys,
+        nested_typed_dict_node,
+    );
 }
 
 /// Validates a `TypedDict` dictionary literal assignment,

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1084,6 +1084,17 @@ pub(super) fn infer_unpacked_keyword_types<'db>(
         .collect()
 }
 
+pub(super) fn unpacked_keyword_is_gradual<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    match ty.resolve_type_alias(db) {
+        ty if ty.is_never() || ty.is_dynamic() => true,
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .any(|element| element.resolve_type_alias(db).is_dynamic()),
+        _ => false,
+    }
+}
+
 /// Collects constructor keys that are guaranteed to be provided by keyword arguments.
 ///
 /// Explicit keyword arguments always provide their key. For `**kwargs`, only required keys are
@@ -1109,7 +1120,11 @@ pub(super) fn collect_guaranteed_keyword_keys<'db>(
         .iter()
         .zip(unpacked_keyword_types.iter().copied())
     {
-        let Some(unpacked_type) = unpacked_type else {
+        let unpacked_type = if keyword.value.is_dict_expr() {
+            Type::unknown()
+        } else if let Some(unpacked_type) = unpacked_type {
+            unpacked_type
+        } else {
             continue;
         };
 
@@ -1177,7 +1192,7 @@ fn collect_guaranteed_keys_from_merged_unpacked_keyword<'db>(
         return;
     }
 
-    if unpacked_type.is_never() || unpacked_type.is_dynamic() {
+    if unpacked_keyword_is_gradual(db, unpacked_type) {
         provided_keys.extend(
             typed_dict
                 .items(db)
@@ -1563,69 +1578,32 @@ fn validate_from_dict_literal<'db, 'ast>(
     expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
     ignored_keys: &OrderSet<Name>,
 ) -> OrderSet<Name> {
-    let mut provided_keys = OrderSet::new();
-    let items = typed_dict.items(context.db());
-    let mut shadowed_keys = ignored_keys.clone();
-
     if let ast::Expr::Dict(dict_expr) = &arguments.args[0] {
-        // Validate dict entries
-        for dict_item in dict_expr.items.iter().rev() {
-            if let Some(ref key_expr) = dict_item.key
-                && let Some(key_value) =
-                    expression_type_fn(key_expr, TypeContext::default()).as_string_literal()
-            {
-                let key = Name::new(key_value.value(context.db()));
-                if shadowed_keys.contains(&key) {
-                    continue;
-                }
-                shadowed_keys.insert(key.clone());
-                provided_keys.insert(key.clone());
+        let dict_node: AnyNodeRef<'ast> = dict_expr.into();
+        let mut provided_keys = BTreeMap::new();
+        let mut shadowed_keys = ignored_keys.clone();
+        let mut valid = true;
 
-                let value_tcx = items
-                    .get(key.as_str())
-                    .map(|field| TypeContext::new(Some(field.declared_ty)))
-                    .unwrap_or_default();
-                let value_ty = expression_type_fn(&dict_item.value, value_tcx);
-                TypedDictKeyAssignment {
-                    context,
-                    typed_dict,
-                    full_object_ty: None,
-                    key: key.as_str(),
-                    value_ty,
-                    typed_dict_node,
-                    key_node: key_expr.into(),
-                    value_node: (&dict_item.value).into(),
-                    assignment_kind: TypedDictAssignmentKind::Constructor,
-                    emit_diagnostic: true,
-                }
-                .validate();
-            } else if dict_item.key.is_none() {
-                let unpacked_ty = expression_type_fn(&dict_item.value, TypeContext::default());
-                if let Some(unpacked_keys) =
-                    extract_unpacked_typed_dict_keys_from_value_type(context.db(), unpacked_ty)
-                {
-                    let (unpacked_provided_keys, _) = validate_extracted_typed_dict_keys(
-                        context,
-                        typed_dict,
-                        &unpacked_keys,
-                        TypedDictAssignmentNodes {
-                            typed_dict: typed_dict_node,
-                            key: (&dict_item.value).into(),
-                            value: (&dict_item.value).into(),
-                        },
-                        full_object_ty_annotation(unpacked_ty),
-                        &shadowed_keys,
-                    );
-                    provided_keys.extend(unpacked_provided_keys);
-                    shadowed_keys.extend(unpacked_keys.into_iter().filter_map(
-                        |(key_name, unpacked_key)| unpacked_key.is_required.then_some(key_name),
-                    ));
-                }
-            }
-        }
+        validate_merged_dict_literal(
+            context,
+            typed_dict,
+            dict_expr,
+            TypedDictAssignmentNodes {
+                typed_dict: typed_dict_node,
+                key: dict_node,
+                value: dict_node,
+            },
+            &mut provided_keys,
+            &mut shadowed_keys,
+            expression_type_fn,
+            false,
+            &mut valid,
+        );
+
+        return provided_keys.into_keys().collect();
     }
 
-    provided_keys
+    OrderSet::new()
 }
 
 /// Validates a `TypedDict` constructor call with keywords
@@ -1720,6 +1698,7 @@ fn validate_unpacked_keyword_argument<'db, 'ast>(
 ) {
     let mut unpacked_guaranteed_keys = BTreeMap::new();
     let mut shadowed_keys = OrderSet::new();
+    let mut valid = true;
     validate_merged_unpacked_keyword_argument(
         context,
         typed_dict,
@@ -1729,6 +1708,7 @@ fn validate_unpacked_keyword_argument<'db, 'ast>(
         &mut unpacked_guaranteed_keys,
         &mut shadowed_keys,
         expression_type_fn,
+        &mut valid,
     );
 
     for (key_name, key_node) in unpacked_guaranteed_keys {
@@ -1746,6 +1726,89 @@ fn validate_unpacked_keyword_argument<'db, 'ast>(
     }
 }
 
+#[expect(clippy::too_many_arguments)]
+fn validate_merged_dict_literal<'db, 'ast>(
+    context: &InferContext<'db, 'ast>,
+    typed_dict: TypedDictType<'db>,
+    dict_expr: &'ast ast::ExprDict,
+    nodes: TypedDictAssignmentNodes<'ast>,
+    guaranteed_keys: &mut BTreeMap<Name, Option<AnyNodeRef<'ast>>>,
+    shadowed_keys: &mut OrderSet<Name>,
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+    validate_nested_literals: bool,
+    valid: &mut bool,
+) {
+    let db = context.db();
+    let items = typed_dict.items(db);
+
+    for item in dict_expr.items.iter().rev() {
+        if let Some(key_expr) = &item.key {
+            let key_ty = expression_type_fn(key_expr, TypeContext::default());
+            let Some(key_literal) = key_ty.as_string_literal() else {
+                continue;
+            };
+
+            let key = Name::new(key_literal.value(db));
+            let is_shadowed = shadowed_keys.contains(&key);
+
+            if !is_shadowed {
+                let field = items.get(key.as_str());
+                let value_tcx = field
+                    .map(|field| TypeContext::new(Some(field.declared_ty)))
+                    .unwrap_or_default();
+                let value_ty = expression_type_fn(&item.value, value_tcx);
+                if validate_nested_literals {
+                    validate_nested_unpacked_typed_dict_literal(
+                        context,
+                        field.map(|field| field.declared_ty),
+                        &item.value,
+                        expression_type_fn,
+                    );
+                }
+                *valid &= TypedDictKeyAssignment {
+                    context,
+                    typed_dict,
+                    full_object_ty: None,
+                    key: key.as_str(),
+                    value_ty,
+                    typed_dict_node: nodes.typed_dict,
+                    key_node: key_expr.into(),
+                    value_node: (&item.value).into(),
+                    assignment_kind: TypedDictAssignmentKind::Constructor,
+                    emit_diagnostic: true,
+                }
+                .validate();
+            }
+            guaranteed_keys
+                .entry(key.clone())
+                .and_modify(|node| {
+                    if node.is_none() {
+                        *node = Some(key_expr.into());
+                    }
+                })
+                .or_insert(Some(key_expr.into()));
+            shadowed_keys.insert(key);
+        } else {
+            let nested_ty = expression_type_fn(&item.value, TypeContext::default());
+            validate_merged_unpacked_keyword_argument(
+                context,
+                typed_dict,
+                &item.value,
+                nested_ty,
+                TypedDictAssignmentNodes {
+                    typed_dict: nodes.typed_dict,
+                    key: (&item.value).into(),
+                    value: (&item.value).into(),
+                },
+                guaranteed_keys,
+                shadowed_keys,
+                expression_type_fn,
+                valid,
+            );
+        }
+    }
+}
+
 /// Validates one unpacked constructor argument while preserving merged `**{...}` overwrite
 /// semantics.
 #[expect(clippy::too_many_arguments)]
@@ -1758,81 +1821,29 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
     guaranteed_keys: &mut BTreeMap<Name, Option<AnyNodeRef<'ast>>>,
     shadowed_keys: &mut OrderSet<Name>,
     expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+    valid: &mut bool,
 ) {
     let db = context.db();
     let items = typed_dict.items(db);
 
     if let ast::Expr::Dict(dict_expr) = expr {
-        for item in dict_expr.items.iter().rev() {
-            if let Some(key_expr) = &item.key {
-                let key_ty = expression_type_fn(key_expr, TypeContext::default());
-                let Some(key_literal) = key_ty.as_string_literal() else {
-                    continue;
-                };
-
-                let key = Name::new(key_literal.value(db));
-                let is_shadowed = shadowed_keys.contains(&key);
-
-                if !is_shadowed {
-                    let field = items.get(key.as_str());
-                    let value_tcx = items
-                        .get(key.as_str())
-                        .map(|field| TypeContext::new(Some(field.declared_ty)))
-                        .unwrap_or_default();
-                    let value_ty = expression_type_fn(&item.value, value_tcx);
-                    validate_nested_unpacked_typed_dict_literal(
-                        context,
-                        field.map(|field| field.declared_ty),
-                        &item.value,
-                        expression_type_fn,
-                    );
-                    TypedDictKeyAssignment {
-                        context,
-                        typed_dict,
-                        full_object_ty: None,
-                        key: key.as_str(),
-                        value_ty,
-                        typed_dict_node: nodes.typed_dict,
-                        key_node: key_expr.into(),
-                        value_node: (&item.value).into(),
-                        assignment_kind: TypedDictAssignmentKind::Constructor,
-                        emit_diagnostic: true,
-                    }
-                    .validate();
-                }
-                guaranteed_keys
-                    .entry(key.clone())
-                    .and_modify(|node| {
-                        if node.is_none() {
-                            *node = Some(key_expr.into());
-                        }
-                    })
-                    .or_insert(Some(key_expr.into()));
-                shadowed_keys.insert(key);
-            } else {
-                let nested_ty = expression_type_fn(&item.value, TypeContext::default());
-                validate_merged_unpacked_keyword_argument(
-                    context,
-                    typed_dict,
-                    &item.value,
-                    nested_ty,
-                    TypedDictAssignmentNodes {
-                        typed_dict: nodes.typed_dict,
-                        key: (&item.value).into(),
-                        value: (&item.value).into(),
-                    },
-                    guaranteed_keys,
-                    shadowed_keys,
-                    expression_type_fn,
-                );
-            }
-        }
+        validate_merged_dict_literal(
+            context,
+            typed_dict,
+            dict_expr,
+            nodes,
+            guaranteed_keys,
+            shadowed_keys,
+            expression_type_fn,
+            true,
+            valid,
+        );
         return;
     }
 
     // Never and Dynamic types are special: they can have any keys, so we skip
     // validation and mark all required keys as provided.
-    if unpacked_type.is_never() || unpacked_type.is_dynamic() {
+    if unpacked_keyword_is_gradual(db, unpacked_type) {
         shadowed_keys.extend(items.keys().cloned());
         for (key_name, field) in items {
             if field.is_required() {
@@ -1843,7 +1854,7 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
         extract_unpacked_typed_dict_keys_from_value_type(db, unpacked_type)
     {
         let ignored_keys = shadowed_keys.clone();
-        validate_extracted_typed_dict_keys(
+        let (_, unpacked_valid) = validate_extracted_typed_dict_keys(
             context,
             typed_dict,
             &unpacked_keys,
@@ -1851,6 +1862,7 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
             full_object_ty_annotation(unpacked_type),
             &ignored_keys,
         );
+        *valid &= unpacked_valid;
 
         for (key_name, unpacked_key) in unpacked_keys {
             if unpacked_key.is_required() {
@@ -1865,113 +1877,207 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
                 shadowed_keys.insert(key_name);
             }
         }
-    } else if let Some((key_ty, value_ty)) =
-        extract_unpacked_mapping_key_value_types(db, unpacked_type)
-    {
+    } else if let Some(mapping_keys) = extract_unpacked_mapping_key_value_types(db, unpacked_type) {
         validate_mapping_overwrite(
             context,
             typed_dict,
             unpacked_type,
-            key_ty,
-            value_ty,
+            &mapping_keys,
             nodes,
             shadowed_keys,
+            valid,
         );
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct UnpackedMappingKeyValueTypes<'db> {
+    exact_string_keys: BTreeMap<Name, Type<'db>>,
+    any_string_value: Option<Type<'db>>,
+}
+
+impl<'db> UnpackedMappingKeyValueTypes<'db> {
+    fn add_exact_key(&mut self, db: &'db dyn Db, key: Name, value_ty: Type<'db>) {
+        match self.exact_string_keys.entry(key) {
+            Entry::Vacant(entry) => {
+                entry.insert(value_ty);
+            }
+            Entry::Occupied(mut entry) => {
+                let merged = UnionBuilder::new(db)
+                    .add(*entry.get())
+                    .add(value_ty)
+                    .build();
+                entry.insert(merged);
+            }
+        }
+    }
+
+    fn add_any_string_value(&mut self, db: &'db dyn Db, value_ty: Type<'db>) {
+        let merged = self
+            .any_string_value
+            .map(|existing| UnionBuilder::new(db).add(existing).add(value_ty).build())
+            .unwrap_or(value_ty);
+        self.any_string_value = Some(merged);
+    }
+
+    fn exact_value_ty(&self, db: &'db dyn Db, key: &Name) -> Option<Type<'db>> {
+        let exact_value = self.exact_string_keys.get(key).copied();
+        match (exact_value, self.any_string_value) {
+            (Some(exact_value), Some(any_string_value)) => Some(
+                UnionBuilder::new(db)
+                    .add(exact_value)
+                    .add(any_string_value)
+                    .build(),
+            ),
+            (Some(exact_value), None) => Some(exact_value),
+            (None, Some(any_string_value)) => Some(any_string_value),
+            (None, None) => None,
+        }
     }
 }
 
 pub(super) fn extract_unpacked_mapping_key_value_types<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
-) -> Option<(Type<'db>, Type<'db>)> {
+) -> Option<UnpackedMappingKeyValueTypes<'db>> {
+    fn mapping_specialization<'db>(
+        db: &'db dyn Db,
+        ty: Type<'db>,
+    ) -> Option<super::Specialization<'db>> {
+        ty.known_specialization(db, KnownClass::Dict)
+            .or_else(|| ty.known_specialization(db, KnownClass::Mapping))
+            .or_else(|| {
+                ty.nominal_class(db)?.iter_mro(db).find_map(|base| {
+                    let class = base.into_class()?;
+                    let (_, specialization) = class.static_class_literal_specialized(db, None)?;
+                    if class.is_known(db, KnownClass::Dict)
+                        || class.is_known(db, KnownClass::Mapping)
+                    {
+                        specialization
+                    } else {
+                        None
+                    }
+                })
+            })
+    }
+
+    let mut mapping_keys = UnpackedMappingKeyValueTypes::default();
+
     match ty.resolve_type_alias(db) {
         Type::Union(union) => {
-            let mut key_builder = UnionBuilder::new(db);
-            let mut value_builder = UnionBuilder::new(db);
-
             for element in union.elements(db) {
-                let [key_ty, value_ty] = element
-                    .known_specialization(db, KnownClass::Dict)
-                    .or_else(|| element.known_specialization(db, KnownClass::Mapping))?
-                    .types(db)
-                else {
+                let [key_ty, value_ty] = mapping_specialization(db, *element)?.types(db) else {
                     return None;
                 };
-                key_builder = key_builder.add(*key_ty);
-                value_builder = value_builder.add(*value_ty);
-            }
 
-            Some((key_builder.build(), value_builder.build()))
+                match mapping_string_keys(db, *key_ty) {
+                    MappingStringKeys::NoString => (),
+                    MappingStringKeys::Exact(keys) => {
+                        for key in keys {
+                            mapping_keys.add_exact_key(db, key, *value_ty);
+                        }
+                    }
+                    MappingStringKeys::AnyString => {
+                        mapping_keys.add_any_string_value(db, *value_ty);
+                    }
+                }
+            }
         }
         ty => {
-            let specialization = ty
-                .known_specialization(db, KnownClass::Dict)
-                .or_else(|| ty.known_specialization(db, KnownClass::Mapping))?;
+            let specialization = mapping_specialization(db, ty)?;
             let [key_ty, value_ty] = specialization.types(db) else {
                 return None;
             };
-            Some((*key_ty, *value_ty))
+
+            match mapping_string_keys(db, *key_ty) {
+                MappingStringKeys::NoString => (),
+                MappingStringKeys::Exact(keys) => {
+                    for key in keys {
+                        mapping_keys.add_exact_key(db, key, *value_ty);
+                    }
+                }
+                MappingStringKeys::AnyString => {
+                    mapping_keys.add_any_string_value(db, *value_ty);
+                }
+            }
         }
     }
+
+    Some(mapping_keys)
 }
 
 fn validate_mapping_overwrite<'db, 'ast>(
     context: &InferContext<'db, 'ast>,
     typed_dict: TypedDictType<'db>,
     unpacked_type: Type<'db>,
-    key_ty: Type<'db>,
-    value_ty: Type<'db>,
+    mapping_keys: &UnpackedMappingKeyValueTypes<'db>,
     nodes: TypedDictAssignmentNodes<'ast>,
     shadowed_keys: &mut OrderSet<Name>,
+    valid: &mut bool,
 ) {
     let db = context.db();
     let typed_dict_items = typed_dict.items(db);
 
-    match mapping_string_keys(db, key_ty) {
-        MappingStringKeys::NoString => return,
-        MappingStringKeys::Exact(keys) => {
-            for key in keys {
-                if shadowed_keys.contains(&key) {
-                    continue;
-                }
-                if typed_dict_items.contains_key(&key) {
-                    TypedDictKeyAssignment {
-                        context,
-                        typed_dict,
-                        full_object_ty: full_object_ty_annotation(unpacked_type),
-                        key: key.as_str(),
-                        value_ty,
-                        typed_dict_node: nodes.typed_dict,
-                        key_node: nodes.key,
-                        value_node: nodes.value,
-                        assignment_kind: TypedDictAssignmentKind::Constructor,
-                        emit_diagnostic: true,
-                    }
-                    .validate();
-                    shadowed_keys.insert(key);
-                }
-            }
+    for key in mapping_keys.exact_string_keys.keys() {
+        if shadowed_keys.contains(key) {
+            continue;
         }
-        MappingStringKeys::AnyString => {
-            for (key_name, _) in typed_dict_items {
-                if shadowed_keys.contains(key_name) {
-                    continue;
-                }
-                TypedDictKeyAssignment {
-                    context,
-                    typed_dict,
-                    full_object_ty: full_object_ty_annotation(unpacked_type),
-                    key: key_name.as_str(),
-                    value_ty,
-                    typed_dict_node: nodes.typed_dict,
-                    key_node: nodes.key,
-                    value_node: nodes.value,
-                    assignment_kind: TypedDictAssignmentKind::Constructor,
-                    emit_diagnostic: true,
-                }
-                .validate();
-                shadowed_keys.insert(key_name.clone());
+
+        let Some(value_ty) = mapping_keys.exact_value_ty(db, key) else {
+            continue;
+        };
+        if value_ty.is_never() {
+            continue;
+        }
+
+        if typed_dict_items.contains_key(key) {
+            *valid &= TypedDictKeyAssignment {
+                context,
+                typed_dict,
+                full_object_ty: full_object_ty_annotation(unpacked_type),
+                key: key.as_str(),
+                value_ty,
+                typed_dict_node: nodes.typed_dict,
+                key_node: nodes.key,
+                value_node: nodes.value,
+                assignment_kind: TypedDictAssignmentKind::Constructor,
+                emit_diagnostic: true,
             }
+            .validate();
+        } else {
+            report_invalid_key_on_typed_dict(
+                context,
+                nodes.typed_dict,
+                nodes.key,
+                Type::TypedDict(typed_dict),
+                full_object_ty_annotation(unpacked_type),
+                Type::string_literal(db, key.as_str()),
+                typed_dict_items,
+            );
+            *valid = false;
+        }
+    }
+
+    if let Some(any_string_value) = mapping_keys.any_string_value {
+        for key_name in typed_dict_items.keys() {
+            if shadowed_keys.contains(key_name)
+                || mapping_keys.exact_string_keys.contains_key(key_name)
+            {
+                continue;
+            }
+            *valid &= TypedDictKeyAssignment {
+                context,
+                typed_dict,
+                full_object_ty: full_object_ty_annotation(unpacked_type),
+                key: key_name.as_str(),
+                value_ty: any_string_value,
+                typed_dict_node: nodes.typed_dict,
+                key_node: nodes.key,
+                value_node: nodes.value,
+                assignment_kind: TypedDictAssignmentKind::Constructor,
+                emit_diagnostic: true,
+            }
+            .validate();
         }
     }
 }
@@ -1983,20 +2089,21 @@ pub(super) enum MappingStringKeys {
 }
 
 pub(super) fn mapping_string_keys<'db>(db: &'db dyn Db, key_ty: Type<'db>) -> MappingStringKeys {
-    let string_overlap = key_ty.filter_disjoint_elements(
-        db,
-        KnownClass::Str.to_instance(db),
-        InferableTypeVars::None,
-    );
-    if string_overlap.is_never() {
+    let string_ty = KnownClass::Str.to_instance(db);
+    if !key_ty.is_assignable_to(db, string_ty) {
         return MappingStringKeys::NoString;
     }
 
-    if let Some(key_literal) = string_overlap.as_string_literal() {
+    let string_keys = key_ty.filter_disjoint_elements(db, string_ty, InferableTypeVars::None);
+    if string_keys.is_never() {
+        return MappingStringKeys::NoString;
+    }
+
+    if let Some(key_literal) = string_keys.as_string_literal() {
         return MappingStringKeys::Exact(vec![Name::new(key_literal.value(db))]);
     }
 
-    let Type::Union(union) = string_overlap.resolve_type_alias(db) else {
+    let Type::Union(union) = string_keys.resolve_type_alias(db) else {
         return MappingStringKeys::AnyString;
     };
 
@@ -2061,64 +2168,29 @@ pub(super) fn validate_typed_dict_dict_literal<'db>(
     typed_dict: TypedDictType<'db>,
     dict_expr: &ast::ExprDict,
     typed_dict_node: AnyNodeRef,
-    expression_type_fn: impl Fn(&ast::Expr) -> Type<'db>,
+    mut expression_type_fn: impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) -> Result<OrderSet<Name>, OrderSet<Name>> {
     let mut valid = true;
-    let mut provided_keys = OrderSet::new();
+    let mut provided_keys = BTreeMap::new();
     let mut shadowed_keys = OrderSet::new();
 
-    // Validate each key-value pair in the dictionary literal
-    for item in dict_expr.items.iter().rev() {
-        if let Some(key_expr) = &item.key
-            && let Some(key_str) = expression_type_fn(key_expr).as_string_literal()
-        {
-            let key = Name::new(key_str.value(context.db()));
-            if shadowed_keys.contains(&key) {
-                continue;
-            }
-            shadowed_keys.insert(key.clone());
-            provided_keys.insert(key.clone());
+    validate_merged_dict_literal(
+        context,
+        typed_dict,
+        dict_expr,
+        TypedDictAssignmentNodes {
+            typed_dict: typed_dict_node,
+            key: typed_dict_node,
+            value: typed_dict_node,
+        },
+        &mut provided_keys,
+        &mut shadowed_keys,
+        &mut expression_type_fn,
+        false,
+        &mut valid,
+    );
 
-            let value_ty = expression_type_fn(&item.value);
-
-            valid &= TypedDictKeyAssignment {
-                context,
-                typed_dict,
-                full_object_ty: None,
-                key: key.as_str(),
-                value_ty,
-                typed_dict_node,
-                key_node: key_expr.into(),
-                value_node: (&item.value).into(),
-                assignment_kind: TypedDictAssignmentKind::Constructor,
-                emit_diagnostic: true,
-            }
-            .validate();
-        } else if item.key.is_none() {
-            let unpacked_ty = expression_type_fn(&item.value);
-            if let Some(unpacked_keys) =
-                extract_unpacked_typed_dict_keys_from_value_type(context.db(), unpacked_ty)
-            {
-                let (unpacked_provided_keys, unpacked_valid) = validate_extracted_typed_dict_keys(
-                    context,
-                    typed_dict,
-                    &unpacked_keys,
-                    TypedDictAssignmentNodes {
-                        typed_dict: typed_dict_node,
-                        key: (&item.value).into(),
-                        value: (&item.value).into(),
-                    },
-                    full_object_ty_annotation(unpacked_ty),
-                    &shadowed_keys,
-                );
-                valid &= unpacked_valid;
-                provided_keys.extend(unpacked_provided_keys);
-                shadowed_keys.extend(unpacked_keys.into_iter().filter_map(
-                    |(key_name, unpacked_key)| unpacked_key.is_required.then_some(key_name),
-                ));
-            }
-        }
-    }
+    let provided_keys: OrderSet<Name> = provided_keys.into_keys().collect();
 
     valid &=
         validate_typed_dict_required_keys(context, typed_dict, &provided_keys, typed_dict_node);

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1062,7 +1062,7 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_kwargs_annotation<'db>(
 /// in multiple validation passes. Precomputing them avoids re-inference in speculative builders.
 pub(super) fn infer_unpacked_keyword_types<'db>(
     arguments: &Arguments,
-    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+    mut expression_type_fn: impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) -> Vec<Option<Type<'db>>> {
     arguments
         .keywords
@@ -1124,14 +1124,12 @@ pub(super) fn collect_guaranteed_keyword_keys<'db>(
             continue;
         };
 
-        let mut shadowed_keys = OrderSet::new();
         collect_guaranteed_keys_from_merged_unpacked_keyword(
             db,
             typed_dict,
             &keyword.value,
             unpacked_type,
             &mut provided_keys,
-            &mut shadowed_keys,
             expression_type_fn,
         );
     }
@@ -1139,15 +1137,13 @@ pub(super) fn collect_guaranteed_keyword_keys<'db>(
     provided_keys
 }
 
-/// Collects keys guaranteed by one unpacked constructor argument, honoring merged `**{...}`
-/// overwrite semantics.
+/// Collects keys guaranteed by one unpacked constructor argument.
 fn collect_guaranteed_keys_from_merged_unpacked_keyword<'db>(
     db: &'db dyn Db,
     typed_dict: TypedDictType<'db>,
     expr: &ast::Expr,
     unpacked_type: Type<'db>,
     provided_keys: &mut OrderSet<Name>,
-    shadowed_keys: &mut OrderSet<Name>,
     expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) {
     if let ast::Expr::Dict(dict_expr) = expr {
@@ -1155,11 +1151,7 @@ fn collect_guaranteed_keys_from_merged_unpacked_keyword<'db>(
             if let Some(key_expr) = &item.key {
                 let key_ty = expression_type_fn(key_expr, TypeContext::default());
                 if let Some(key_literal) = key_ty.as_string_literal() {
-                    let key = Name::new(key_literal.value(db));
-                    if !shadowed_keys.contains(&key) {
-                        provided_keys.insert(key.clone());
-                        shadowed_keys.insert(key);
-                    }
+                    provided_keys.insert(Name::new(key_literal.value(db)));
                 }
             } else {
                 let nested_ty = expression_type_fn(&item.value, TypeContext::default());
@@ -1169,7 +1161,6 @@ fn collect_guaranteed_keys_from_merged_unpacked_keyword<'db>(
                     &item.value,
                     nested_ty,
                     provided_keys,
-                    shadowed_keys,
                     expression_type_fn,
                 );
             }
@@ -1178,19 +1169,13 @@ fn collect_guaranteed_keys_from_merged_unpacked_keyword<'db>(
     }
 
     if unpacked_keyword_is_gradual(db, unpacked_type) {
-        for (key_name, field) in typed_dict.items(db) {
-            if field.is_required() && !shadowed_keys.contains(key_name) {
-                provided_keys.insert(key_name.clone());
-            }
-            shadowed_keys.insert(key_name.clone());
-        }
+        provided_keys.extend(typed_dict.items(db).keys().cloned());
     } else if let Some(unpacked_keys) =
         extract_unpacked_typed_dict_keys_from_value_type(db, unpacked_type)
     {
         for (key, unpacked_key) in unpacked_keys {
-            if unpacked_key.is_required && !shadowed_keys.contains(&key) {
-                provided_keys.insert(key.clone());
-                shadowed_keys.insert(key);
+            if unpacked_key.is_required {
+                provided_keys.insert(key);
             }
         }
     }
@@ -1774,14 +1759,12 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
         );
     }
 
-    // Never and Dynamic types are special: they can have any keys, so we skip
-    // validation and mark all required keys as provided.
+    // Never and Dynamic types are special: they can have any keys, so we skip validation and mark
+    // all target keys as provided.
     if unpacked_keyword_is_gradual(db, unpacked_type) {
         shadowed_keys.extend(items.keys().cloned());
-        for (key_name, field) in items {
-            if field.is_required() {
-                guaranteed_keys.entry(key_name.clone()).or_insert(None);
-            }
+        for key_name in items.keys() {
+            guaranteed_keys.entry(key_name.clone()).or_insert(None);
         }
         return true;
     } else if let Some(unpacked_keys) =

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -10,7 +10,7 @@ use ruff_python_ast::Arguments;
 use ruff_python_ast::{self as ast, AnyNodeRef, StmtClassDef, name::Name};
 use ruff_text_size::Ranged;
 
-use super::class::{ClassLiteral, ClassType, CodeGeneratorKind, Field};
+use super::class::{ClassLiteral, ClassType, CodeGeneratorKind, Field, KnownClass};
 use super::context::InferContext;
 use super::diagnostic::{
     self, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, PARAMETER_ALREADY_ASSIGNED,
@@ -26,6 +26,7 @@ use crate::types::TypeContext;
 use crate::types::TypeDefinition;
 use crate::types::class::FieldKind;
 use crate::types::constraints::{ConstraintSet, IteratorConstraintsExtension};
+use crate::types::generics::InferableTypeVars;
 use crate::types::relation::{DisjointnessChecker, TypeRelation, TypeRelationChecker};
 use ty_python_core::definition::Definition;
 
@@ -864,6 +865,13 @@ pub(crate) struct UnpackedTypedDictKey<'db> {
     pub(crate) definition: Option<Definition<'db>>,
 }
 
+impl UnpackedTypedDictKey<'_> {
+    /// Returns whether this unpacked key is guaranteed to be present.
+    pub(super) fn is_required(self) -> bool {
+        self.is_required
+    }
+}
+
 /// Extracts `TypedDict` keys, their value types, and whether they are required when an unpacked
 /// `**kwargs` value has this type, resolving type aliases and handling intersections and unions.
 ///
@@ -1086,6 +1094,7 @@ pub(super) fn collect_guaranteed_keyword_keys<'db>(
     typed_dict: TypedDictType<'db>,
     arguments: &Arguments,
     unpacked_keyword_types: &[Option<Type<'db>>],
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) -> OrderSet<Name> {
     debug_assert_eq!(arguments.keywords.len(), unpacked_keyword_types.len());
 
@@ -1095,28 +1104,95 @@ pub(super) fn collect_guaranteed_keyword_keys<'db>(
         .filter_map(|keyword| keyword.arg.as_ref().map(|arg| arg.id.clone()))
         .collect();
 
-    for unpacked_type in unpacked_keyword_types.iter().copied().flatten() {
-        if unpacked_type.is_never() || unpacked_type.is_dynamic() {
-            provided_keys.extend(
-                typed_dict.items(db).iter().filter_map(|(key_name, field)| {
-                    field.is_required().then_some(key_name.clone())
-                }),
-            );
-        // TODO: also extract guaranteed keys from unpacked dict literals like `**{"a": 1}`.
-        // Today we only suppress positional-key diagnostics for explicit keywords and unpacked
-        // TypedDicts, which makes those literal-unpack cases inconsistent with equivalent calls.
-        } else if let Some(unpacked_keys) =
-            extract_unpacked_typed_dict_keys_from_value_type(db, unpacked_type)
-        {
-            provided_keys.extend(
-                unpacked_keys
-                    .into_iter()
-                    .filter_map(|(key, unpacked_key)| unpacked_key.is_required.then_some(key)),
-            );
-        }
+    for (keyword, unpacked_type) in arguments
+        .keywords
+        .iter()
+        .zip(unpacked_keyword_types.iter().copied())
+    {
+        let Some(unpacked_type) = unpacked_type else {
+            continue;
+        };
+
+        provided_keys.extend(collect_guaranteed_keys_from_unpacked_keyword(
+            db,
+            typed_dict,
+            &keyword.value,
+            unpacked_type,
+            expression_type_fn,
+        ));
     }
 
     provided_keys
+}
+
+/// Collects keys definitely present in the final mapping produced by one `**kwargs` argument.
+fn collect_guaranteed_keys_from_unpacked_keyword<'db>(
+    db: &'db dyn Db,
+    typed_dict: TypedDictType<'db>,
+    expr: &ast::Expr,
+    unpacked_type: Type<'db>,
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+) -> OrderSet<Name> {
+    let mut provided_keys = OrderSet::new();
+    collect_guaranteed_keys_from_merged_unpacked_keyword(
+        db,
+        typed_dict,
+        expr,
+        unpacked_type,
+        &mut provided_keys,
+        expression_type_fn,
+    );
+    provided_keys
+}
+
+/// Collects keys guaranteed by one unpacked constructor argument, honoring merged `**{...}`
+/// overwrite semantics.
+fn collect_guaranteed_keys_from_merged_unpacked_keyword<'db>(
+    db: &'db dyn Db,
+    typed_dict: TypedDictType<'db>,
+    expr: &ast::Expr,
+    unpacked_type: Type<'db>,
+    provided_keys: &mut OrderSet<Name>,
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+) {
+    if let ast::Expr::Dict(dict_expr) = expr {
+        for item in dict_expr.items.iter().rev() {
+            if let Some(key_expr) = &item.key {
+                let key_ty = expression_type_fn(key_expr, TypeContext::default());
+                if let Some(key_literal) = key_ty.as_string_literal() {
+                    provided_keys.insert(Name::new(key_literal.value(db)));
+                }
+            } else {
+                let nested_ty = expression_type_fn(&item.value, TypeContext::default());
+                collect_guaranteed_keys_from_merged_unpacked_keyword(
+                    db,
+                    typed_dict,
+                    &item.value,
+                    nested_ty,
+                    provided_keys,
+                    expression_type_fn,
+                );
+            }
+        }
+        return;
+    }
+
+    if unpacked_type.is_never() || unpacked_type.is_dynamic() {
+        provided_keys.extend(
+            typed_dict
+                .items(db)
+                .iter()
+                .filter_map(|(key_name, field)| field.is_required().then_some(key_name.clone())),
+        );
+    } else if let Some(unpacked_keys) =
+        extract_unpacked_typed_dict_keys_from_value_type(db, unpacked_type)
+    {
+        for (key, unpacked_key) in unpacked_keys {
+            if unpacked_key.is_required {
+                provided_keys.insert(key);
+            }
+        }
+    }
 }
 
 /// Returns a `TypedDict` schema with `excluded_keys` removed.
@@ -1368,8 +1444,13 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
     if has_single_positional_arg && !arguments.keywords.is_empty() {
         // Mixed positional-and-keyword construction: guaranteed keyword-provided keys override the
         // positional mapping, so validate the positional argument against the remaining schema.
-        let keyword_keys =
-            collect_guaranteed_keyword_keys(db, typed_dict, arguments, &unpacked_keyword_types);
+        let keyword_keys = collect_guaranteed_keyword_keys(
+            db,
+            typed_dict,
+            arguments,
+            &unpacked_keyword_types,
+            &mut expression_type_fn,
+        );
         let mut provided_keys = if has_positional_dict_literal {
             validate_from_dict_literal(
                 context,
@@ -1607,45 +1688,370 @@ fn validate_from_keywords<'db, 'ast>(
             let Some(unpacked_type) = unpacked_type else {
                 continue;
             };
-
-            // Never and Dynamic types are special: they can have any keys, so we skip
-            // validation and mark all required keys as provided.
-            if unpacked_type.is_never() || unpacked_type.is_dynamic() {
-                for (key_name, field) in typed_dict.items(db) {
-                    if field.is_required() {
-                        guaranteed_keys.entry(key_name.clone()).or_insert(None);
-                    }
-                }
-            } else if let Some(unpacked_keys) =
-                extract_unpacked_typed_dict_keys_from_value_type(db, unpacked_type)
-            {
-                for key_name in validate_extracted_typed_dict_keys(
-                    context,
-                    typed_dict,
-                    &unpacked_keys,
-                    TypedDictAssignmentNodes {
-                        typed_dict: typed_dict_node,
-                        key: keyword.into(),
-                        value: (&keyword.value).into(),
-                    },
-                    full_object_ty_annotation(unpacked_type),
-                    &OrderSet::new(),
-                )
-                .0
-                {
-                    record_guaranteed_typed_dict_constructor_key(
-                        context,
-                        typed_dict,
-                        &mut guaranteed_keys,
-                        key_name,
-                        keyword_node,
-                    );
-                }
-            }
+            validate_unpacked_keyword_argument(
+                context,
+                typed_dict,
+                &keyword.value,
+                unpacked_type,
+                TypedDictAssignmentNodes {
+                    typed_dict: typed_dict_node,
+                    key: keyword.into(),
+                    value: (&keyword.value).into(),
+                },
+                &mut guaranteed_keys,
+                expression_type_fn,
+            );
         }
     }
 
     guaranteed_keys.into_keys().collect()
+}
+
+/// Validates one unpacked `**kwargs` constructor argument and merges its definite keys into the
+/// constructor-level duplicate tracking.
+fn validate_unpacked_keyword_argument<'db, 'ast>(
+    context: &InferContext<'db, 'ast>,
+    typed_dict: TypedDictType<'db>,
+    expr: &'ast ast::Expr,
+    unpacked_type: Type<'db>,
+    nodes: TypedDictAssignmentNodes<'ast>,
+    guaranteed_keys: &mut BTreeMap<Name, Option<AnyNodeRef<'ast>>>,
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+) {
+    let mut unpacked_guaranteed_keys = BTreeMap::new();
+    let mut shadowed_keys = OrderSet::new();
+    validate_merged_unpacked_keyword_argument(
+        context,
+        typed_dict,
+        expr,
+        unpacked_type,
+        nodes,
+        &mut unpacked_guaranteed_keys,
+        &mut shadowed_keys,
+        expression_type_fn,
+    );
+
+    for (key_name, key_node) in unpacked_guaranteed_keys {
+        if let Some(key_node) = key_node {
+            record_guaranteed_typed_dict_constructor_key(
+                context,
+                typed_dict,
+                guaranteed_keys,
+                key_name,
+                key_node,
+            );
+        } else {
+            guaranteed_keys.entry(key_name).or_insert(None);
+        }
+    }
+}
+
+/// Validates one unpacked constructor argument while preserving merged `**{...}` overwrite
+/// semantics.
+#[expect(clippy::too_many_arguments)]
+fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
+    context: &InferContext<'db, 'ast>,
+    typed_dict: TypedDictType<'db>,
+    expr: &'ast ast::Expr,
+    unpacked_type: Type<'db>,
+    nodes: TypedDictAssignmentNodes<'ast>,
+    guaranteed_keys: &mut BTreeMap<Name, Option<AnyNodeRef<'ast>>>,
+    shadowed_keys: &mut OrderSet<Name>,
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+) {
+    let db = context.db();
+    let items = typed_dict.items(db);
+
+    if let ast::Expr::Dict(dict_expr) = expr {
+        for item in dict_expr.items.iter().rev() {
+            if let Some(key_expr) = &item.key {
+                let key_ty = expression_type_fn(key_expr, TypeContext::default());
+                let Some(key_literal) = key_ty.as_string_literal() else {
+                    continue;
+                };
+
+                let key = Name::new(key_literal.value(db));
+                let is_shadowed = shadowed_keys.contains(&key);
+
+                if !is_shadowed {
+                    let field = items.get(key.as_str());
+                    let value_tcx = items
+                        .get(key.as_str())
+                        .map(|field| TypeContext::new(Some(field.declared_ty)))
+                        .unwrap_or_default();
+                    let value_ty = expression_type_fn(&item.value, value_tcx);
+                    validate_nested_unpacked_typed_dict_literal(
+                        context,
+                        field.map(|field| field.declared_ty),
+                        &item.value,
+                        expression_type_fn,
+                    );
+                    TypedDictKeyAssignment {
+                        context,
+                        typed_dict,
+                        full_object_ty: None,
+                        key: key.as_str(),
+                        value_ty,
+                        typed_dict_node: nodes.typed_dict,
+                        key_node: key_expr.into(),
+                        value_node: (&item.value).into(),
+                        assignment_kind: TypedDictAssignmentKind::Constructor,
+                        emit_diagnostic: true,
+                    }
+                    .validate();
+                }
+                guaranteed_keys
+                    .entry(key.clone())
+                    .and_modify(|node| {
+                        if node.is_none() {
+                            *node = Some(key_expr.into());
+                        }
+                    })
+                    .or_insert(Some(key_expr.into()));
+                shadowed_keys.insert(key);
+            } else {
+                let nested_ty = expression_type_fn(&item.value, TypeContext::default());
+                validate_merged_unpacked_keyword_argument(
+                    context,
+                    typed_dict,
+                    &item.value,
+                    nested_ty,
+                    TypedDictAssignmentNodes {
+                        typed_dict: nodes.typed_dict,
+                        key: (&item.value).into(),
+                        value: (&item.value).into(),
+                    },
+                    guaranteed_keys,
+                    shadowed_keys,
+                    expression_type_fn,
+                );
+            }
+        }
+        return;
+    }
+
+    // Never and Dynamic types are special: they can have any keys, so we skip
+    // validation and mark all required keys as provided.
+    if unpacked_type.is_never() || unpacked_type.is_dynamic() {
+        shadowed_keys.extend(items.keys().cloned());
+        for (key_name, field) in items {
+            if field.is_required() {
+                guaranteed_keys.entry(key_name.clone()).or_insert(None);
+            }
+        }
+    } else if let Some(unpacked_keys) =
+        extract_unpacked_typed_dict_keys_from_value_type(db, unpacked_type)
+    {
+        let ignored_keys = shadowed_keys.clone();
+        validate_extracted_typed_dict_keys(
+            context,
+            typed_dict,
+            &unpacked_keys,
+            nodes,
+            full_object_ty_annotation(unpacked_type),
+            &ignored_keys,
+        );
+
+        for (key_name, unpacked_key) in unpacked_keys {
+            if unpacked_key.is_required() {
+                guaranteed_keys
+                    .entry(key_name.clone())
+                    .and_modify(|node| {
+                        if node.is_none() {
+                            *node = Some(nodes.key);
+                        }
+                    })
+                    .or_insert(Some(nodes.key));
+                shadowed_keys.insert(key_name);
+            }
+        }
+    } else if let Some((key_ty, value_ty)) =
+        extract_unpacked_mapping_key_value_types(db, unpacked_type)
+    {
+        validate_mapping_overwrite(
+            context,
+            typed_dict,
+            unpacked_type,
+            key_ty,
+            value_ty,
+            nodes,
+            shadowed_keys,
+        );
+    }
+}
+
+pub(super) fn extract_unpacked_mapping_key_value_types<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+) -> Option<(Type<'db>, Type<'db>)> {
+    match ty.resolve_type_alias(db) {
+        Type::Union(union) => {
+            let mut key_builder = UnionBuilder::new(db);
+            let mut value_builder = UnionBuilder::new(db);
+
+            for element in union.elements(db) {
+                let [key_ty, value_ty] = element
+                    .known_specialization(db, KnownClass::Dict)
+                    .or_else(|| element.known_specialization(db, KnownClass::Mapping))?
+                    .types(db)
+                else {
+                    return None;
+                };
+                key_builder = key_builder.add(*key_ty);
+                value_builder = value_builder.add(*value_ty);
+            }
+
+            Some((key_builder.build(), value_builder.build()))
+        }
+        ty => {
+            let specialization = ty
+                .known_specialization(db, KnownClass::Dict)
+                .or_else(|| ty.known_specialization(db, KnownClass::Mapping))?;
+            let [key_ty, value_ty] = specialization.types(db) else {
+                return None;
+            };
+            Some((*key_ty, *value_ty))
+        }
+    }
+}
+
+fn validate_mapping_overwrite<'db, 'ast>(
+    context: &InferContext<'db, 'ast>,
+    typed_dict: TypedDictType<'db>,
+    unpacked_type: Type<'db>,
+    key_ty: Type<'db>,
+    value_ty: Type<'db>,
+    nodes: TypedDictAssignmentNodes<'ast>,
+    shadowed_keys: &mut OrderSet<Name>,
+) {
+    let db = context.db();
+    let typed_dict_items = typed_dict.items(db);
+
+    match mapping_string_keys(db, key_ty) {
+        MappingStringKeys::NoString => return,
+        MappingStringKeys::Exact(keys) => {
+            for key in keys {
+                if shadowed_keys.contains(&key) {
+                    continue;
+                }
+                if typed_dict_items.contains_key(&key) {
+                    TypedDictKeyAssignment {
+                        context,
+                        typed_dict,
+                        full_object_ty: full_object_ty_annotation(unpacked_type),
+                        key: key.as_str(),
+                        value_ty,
+                        typed_dict_node: nodes.typed_dict,
+                        key_node: nodes.key,
+                        value_node: nodes.value,
+                        assignment_kind: TypedDictAssignmentKind::Constructor,
+                        emit_diagnostic: true,
+                    }
+                    .validate();
+                    shadowed_keys.insert(key);
+                }
+            }
+        }
+        MappingStringKeys::AnyString => {
+            for (key_name, _) in typed_dict_items {
+                if shadowed_keys.contains(key_name) {
+                    continue;
+                }
+                TypedDictKeyAssignment {
+                    context,
+                    typed_dict,
+                    full_object_ty: full_object_ty_annotation(unpacked_type),
+                    key: key_name.as_str(),
+                    value_ty,
+                    typed_dict_node: nodes.typed_dict,
+                    key_node: nodes.key,
+                    value_node: nodes.value,
+                    assignment_kind: TypedDictAssignmentKind::Constructor,
+                    emit_diagnostic: true,
+                }
+                .validate();
+                shadowed_keys.insert(key_name.clone());
+            }
+        }
+    }
+}
+
+pub(super) enum MappingStringKeys {
+    NoString,
+    Exact(Vec<Name>),
+    AnyString,
+}
+
+pub(super) fn mapping_string_keys<'db>(db: &'db dyn Db, key_ty: Type<'db>) -> MappingStringKeys {
+    let string_overlap = key_ty.filter_disjoint_elements(
+        db,
+        KnownClass::Str.to_instance(db),
+        InferableTypeVars::None,
+    );
+    if string_overlap.is_never() {
+        return MappingStringKeys::NoString;
+    }
+
+    if let Some(key_literal) = string_overlap.as_string_literal() {
+        return MappingStringKeys::Exact(vec![Name::new(key_literal.value(db))]);
+    }
+
+    let Type::Union(union) = string_overlap.resolve_type_alias(db) else {
+        return MappingStringKeys::AnyString;
+    };
+
+    union
+        .elements(db)
+        .iter()
+        .map(|element| {
+            element
+                .as_string_literal()
+                .map(|literal| Name::new(literal.value(db)))
+        })
+        .collect::<Option<Vec<_>>>()
+        .map_or(MappingStringKeys::AnyString, MappingStringKeys::Exact)
+}
+
+fn validate_nested_unpacked_typed_dict_literal<'db, 'ast>(
+    context: &InferContext<'db, 'ast>,
+    declared_ty: Option<Type<'db>>,
+    value_expr: &'ast ast::Expr,
+    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
+) {
+    let Some(declared_ty) = declared_ty else {
+        return;
+    };
+    let ast::Expr::Dict(_) = value_expr else {
+        return;
+    };
+    let Some(nested_typed_dict) = declared_ty.resolve_type_alias(context.db()).as_typed_dict()
+    else {
+        return;
+    };
+
+    let nested_typed_dict_node: AnyNodeRef<'ast> = value_expr.into();
+    let mut guaranteed_keys = BTreeMap::new();
+    validate_unpacked_keyword_argument(
+        context,
+        nested_typed_dict,
+        value_expr,
+        Type::TypedDict(nested_typed_dict),
+        TypedDictAssignmentNodes {
+            typed_dict: nested_typed_dict_node,
+            key: nested_typed_dict_node,
+            value: nested_typed_dict_node,
+        },
+        &mut guaranteed_keys,
+        expression_type_fn,
+    );
+    let provided_keys: OrderSet<Name> = guaranteed_keys.into_keys().collect();
+
+    validate_typed_dict_required_keys(
+        context,
+        nested_typed_dict,
+        &provided_keys,
+        nested_typed_dict_node,
+    );
 }
 
 /// Validates a `TypedDict` dictionary literal assignment,

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -10,7 +10,7 @@ use ruff_python_ast::Arguments;
 use ruff_python_ast::{self as ast, AnyNodeRef, StmtClassDef, name::Name};
 use ruff_text_size::Ranged;
 
-use super::class::{ClassLiteral, ClassType, CodeGeneratorKind, Field, KnownClass};
+use super::class::{ClassLiteral, ClassType, CodeGeneratorKind, Field};
 use super::context::InferContext;
 use super::diagnostic::{
     self, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, PARAMETER_ALREADY_ASSIGNED,
@@ -26,7 +26,6 @@ use crate::types::TypeContext;
 use crate::types::TypeDefinition;
 use crate::types::class::FieldKind;
 use crate::types::constraints::{ConstraintSet, IteratorConstraintsExtension};
-use crate::types::generics::InferableTypeVars;
 use crate::types::relation::{DisjointnessChecker, TypeRelation, TypeRelationChecker};
 use ty_python_core::definition::Definition;
 
@@ -865,13 +864,6 @@ pub(crate) struct UnpackedTypedDictKey<'db> {
     pub(crate) definition: Option<Definition<'db>>,
 }
 
-impl UnpackedTypedDictKey<'_> {
-    /// Returns whether this unpacked key is guaranteed to be present.
-    pub(super) fn is_required(self) -> bool {
-        self.is_required
-    }
-}
-
 /// Extracts `TypedDict` keys, their value types, and whether they are required when an unpacked
 /// `**kwargs` value has this type, resolving type aliases and handling intersections and unions.
 ///
@@ -1120,6 +1112,10 @@ pub(super) fn collect_guaranteed_keyword_keys<'db>(
         .iter()
         .zip(unpacked_keyword_types.iter().copied())
     {
+        if keyword.arg.is_some() {
+            continue;
+        }
+
         let unpacked_type = if keyword.value.is_dict_expr() {
             Type::unknown()
         } else if let Some(unpacked_type) = unpacked_type {
@@ -1128,35 +1124,18 @@ pub(super) fn collect_guaranteed_keyword_keys<'db>(
             continue;
         };
 
-        provided_keys.extend(collect_guaranteed_keys_from_unpacked_keyword(
+        let mut shadowed_keys = OrderSet::new();
+        collect_guaranteed_keys_from_merged_unpacked_keyword(
             db,
             typed_dict,
             &keyword.value,
             unpacked_type,
+            &mut provided_keys,
+            &mut shadowed_keys,
             expression_type_fn,
-        ));
+        );
     }
 
-    provided_keys
-}
-
-/// Collects keys definitely present in the final mapping produced by one `**kwargs` argument.
-fn collect_guaranteed_keys_from_unpacked_keyword<'db>(
-    db: &'db dyn Db,
-    typed_dict: TypedDictType<'db>,
-    expr: &ast::Expr,
-    unpacked_type: Type<'db>,
-    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
-) -> OrderSet<Name> {
-    let mut provided_keys = OrderSet::new();
-    collect_guaranteed_keys_from_merged_unpacked_keyword(
-        db,
-        typed_dict,
-        expr,
-        unpacked_type,
-        &mut provided_keys,
-        expression_type_fn,
-    );
     provided_keys
 }
 
@@ -1168,6 +1147,7 @@ fn collect_guaranteed_keys_from_merged_unpacked_keyword<'db>(
     expr: &ast::Expr,
     unpacked_type: Type<'db>,
     provided_keys: &mut OrderSet<Name>,
+    shadowed_keys: &mut OrderSet<Name>,
     expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) {
     if let ast::Expr::Dict(dict_expr) = expr {
@@ -1175,7 +1155,11 @@ fn collect_guaranteed_keys_from_merged_unpacked_keyword<'db>(
             if let Some(key_expr) = &item.key {
                 let key_ty = expression_type_fn(key_expr, TypeContext::default());
                 if let Some(key_literal) = key_ty.as_string_literal() {
-                    provided_keys.insert(Name::new(key_literal.value(db)));
+                    let key = Name::new(key_literal.value(db));
+                    if !shadowed_keys.contains(&key) {
+                        provided_keys.insert(key.clone());
+                        shadowed_keys.insert(key);
+                    }
                 }
             } else {
                 let nested_ty = expression_type_fn(&item.value, TypeContext::default());
@@ -1185,6 +1169,7 @@ fn collect_guaranteed_keys_from_merged_unpacked_keyword<'db>(
                     &item.value,
                     nested_ty,
                     provided_keys,
+                    shadowed_keys,
                     expression_type_fn,
                 );
             }
@@ -1193,18 +1178,19 @@ fn collect_guaranteed_keys_from_merged_unpacked_keyword<'db>(
     }
 
     if unpacked_keyword_is_gradual(db, unpacked_type) {
-        provided_keys.extend(
-            typed_dict
-                .items(db)
-                .iter()
-                .filter_map(|(key_name, field)| field.is_required().then_some(key_name.clone())),
-        );
+        for (key_name, field) in typed_dict.items(db) {
+            if field.is_required() && !shadowed_keys.contains(key_name) {
+                provided_keys.insert(key_name.clone());
+            }
+            shadowed_keys.insert(key_name.clone());
+        }
     } else if let Some(unpacked_keys) =
         extract_unpacked_typed_dict_keys_from_value_type(db, unpacked_type)
     {
         for (key, unpacked_key) in unpacked_keys {
-            if unpacked_key.is_required {
-                provided_keys.insert(key);
+            if unpacked_key.is_required && !shadowed_keys.contains(&key) {
+                provided_keys.insert(key.clone());
+                shadowed_keys.insert(key);
             }
         }
     }
@@ -1452,25 +1438,26 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
 
     // Check for a single positional argument, and whether it's a dict literal.
     let has_single_positional_arg = arguments.args.len() == 1;
-    let has_positional_dict_literal = has_single_positional_arg && arguments.args[0].is_dict_expr();
+    let positional_dict_literal = arguments.args.first().and_then(ast::Expr::as_dict_expr);
 
     let unpacked_keyword_types = infer_unpacked_keyword_types(arguments, &mut expression_type_fn);
 
     if has_single_positional_arg && !arguments.keywords.is_empty() {
         // Mixed positional-and-keyword construction: guaranteed keyword-provided keys override the
         // positional mapping, so validate the positional argument against the remaining schema.
-        let keyword_keys = collect_guaranteed_keyword_keys(
-            db,
+        let keyword_keys = validate_from_keywords(
+            context,
             typed_dict,
             arguments,
+            error_node,
             &unpacked_keyword_types,
             &mut expression_type_fn,
         );
-        let mut provided_keys = if has_positional_dict_literal {
+        let mut provided_keys = if let Some(dict_expr) = positional_dict_literal {
             validate_from_dict_literal(
                 context,
                 typed_dict,
-                arguments,
+                dict_expr,
                 error_node,
                 &mut expression_type_fn,
                 &keyword_keys,
@@ -1515,22 +1502,15 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
             }
         };
 
-        provided_keys.extend(validate_from_keywords(
-            context,
-            typed_dict,
-            arguments,
-            error_node,
-            &unpacked_keyword_types,
-            &mut expression_type_fn,
-        ));
+        provided_keys.extend(keyword_keys);
         validate_typed_dict_required_keys(context, typed_dict, &provided_keys, error_node);
-    } else if has_positional_dict_literal {
+    } else if let Some(dict_expr) = positional_dict_literal {
         // Single positional dict literal: validate keys and value types directly from the literal,
         // which also allows us to report extra keys that aren't in the `TypedDict` schema.
         let provided_keys = validate_from_dict_literal(
             context,
             typed_dict,
-            arguments,
+            dict_expr,
             error_node,
             &mut expression_type_fn,
             &OrderSet::new(),
@@ -1573,37 +1553,30 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
 fn validate_from_dict_literal<'db, 'ast>(
     context: &InferContext<'db, 'ast>,
     typed_dict: TypedDictType<'db>,
-    arguments: &'ast Arguments,
+    dict_expr: &'ast ast::ExprDict,
     typed_dict_node: AnyNodeRef<'ast>,
     expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
     ignored_keys: &OrderSet<Name>,
 ) -> OrderSet<Name> {
-    if let ast::Expr::Dict(dict_expr) = &arguments.args[0] {
-        let dict_node: AnyNodeRef<'ast> = dict_expr.into();
-        let mut provided_keys = BTreeMap::new();
-        let mut shadowed_keys = ignored_keys.clone();
-        let mut valid = true;
+    let dict_node: AnyNodeRef<'ast> = dict_expr.into();
+    let mut provided_keys = BTreeMap::new();
+    let mut shadowed_keys = ignored_keys.clone();
 
-        validate_merged_dict_literal(
-            context,
-            typed_dict,
-            dict_expr,
-            TypedDictAssignmentNodes {
-                typed_dict: typed_dict_node,
-                key: dict_node,
-                value: dict_node,
-            },
-            &mut provided_keys,
-            &mut shadowed_keys,
-            expression_type_fn,
-            false,
-            &mut valid,
-        );
+    validate_merged_dict_literal(
+        context,
+        typed_dict,
+        dict_expr,
+        TypedDictAssignmentNodes {
+            typed_dict: typed_dict_node,
+            key: dict_node,
+            value: dict_node,
+        },
+        &mut provided_keys,
+        &mut shadowed_keys,
+        expression_type_fn,
+    );
 
-        return provided_keys.into_keys().collect();
-    }
-
-    OrderSet::new()
+    provided_keys.into_keys().collect()
 }
 
 /// Validates a `TypedDict` constructor call with keywords
@@ -1652,7 +1625,7 @@ fn validate_from_keywords<'db, 'ast>(
                 key: arg_name.as_str(),
                 value_ty,
                 typed_dict_node,
-                key_node: keyword.into(),
+                key_node: keyword_node,
                 value_node: (&keyword.value).into(),
                 assignment_kind: TypedDictAssignmentKind::Constructor,
                 emit_diagnostic: true,
@@ -1666,67 +1639,44 @@ fn validate_from_keywords<'db, 'ast>(
             let Some(unpacked_type) = unpacked_type else {
                 continue;
             };
-            validate_unpacked_keyword_argument(
+            // Keep one unpack local while applying merged-dict overwrite semantics, then compare
+            // the resulting keys against neighboring constructor keywords.
+            let mut unpacked_guaranteed_keys = BTreeMap::new();
+            let mut shadowed_keys = OrderSet::new();
+            validate_merged_unpacked_keyword_argument(
                 context,
                 typed_dict,
                 &keyword.value,
                 unpacked_type,
                 TypedDictAssignmentNodes {
                     typed_dict: typed_dict_node,
-                    key: keyword.into(),
+                    key: keyword_node,
                     value: (&keyword.value).into(),
                 },
-                &mut guaranteed_keys,
+                &mut unpacked_guaranteed_keys,
+                &mut shadowed_keys,
                 expression_type_fn,
             );
+
+            for (key_name, key_node) in unpacked_guaranteed_keys {
+                if let Some(key_node) = key_node {
+                    record_guaranteed_typed_dict_constructor_key(
+                        context,
+                        typed_dict,
+                        &mut guaranteed_keys,
+                        key_name,
+                        key_node,
+                    );
+                } else {
+                    guaranteed_keys.entry(key_name).or_insert(None);
+                }
+            }
         }
     }
 
     guaranteed_keys.into_keys().collect()
 }
 
-/// Validates one unpacked `**kwargs` constructor argument and merges its definite keys into the
-/// constructor-level duplicate tracking.
-fn validate_unpacked_keyword_argument<'db, 'ast>(
-    context: &InferContext<'db, 'ast>,
-    typed_dict: TypedDictType<'db>,
-    expr: &'ast ast::Expr,
-    unpacked_type: Type<'db>,
-    nodes: TypedDictAssignmentNodes<'ast>,
-    guaranteed_keys: &mut BTreeMap<Name, Option<AnyNodeRef<'ast>>>,
-    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
-) {
-    let mut unpacked_guaranteed_keys = BTreeMap::new();
-    let mut shadowed_keys = OrderSet::new();
-    let mut valid = true;
-    validate_merged_unpacked_keyword_argument(
-        context,
-        typed_dict,
-        expr,
-        unpacked_type,
-        nodes,
-        &mut unpacked_guaranteed_keys,
-        &mut shadowed_keys,
-        expression_type_fn,
-        &mut valid,
-    );
-
-    for (key_name, key_node) in unpacked_guaranteed_keys {
-        if let Some(key_node) = key_node {
-            record_guaranteed_typed_dict_constructor_key(
-                context,
-                typed_dict,
-                guaranteed_keys,
-                key_name,
-                key_node,
-            );
-        } else {
-            guaranteed_keys.entry(key_name).or_insert(None);
-        }
-    }
-}
-
-#[expect(clippy::too_many_arguments)]
 fn validate_merged_dict_literal<'db, 'ast>(
     context: &InferContext<'db, 'ast>,
     typed_dict: TypedDictType<'db>,
@@ -1735,11 +1685,10 @@ fn validate_merged_dict_literal<'db, 'ast>(
     guaranteed_keys: &mut BTreeMap<Name, Option<AnyNodeRef<'ast>>>,
     shadowed_keys: &mut OrderSet<Name>,
     expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
-    validate_nested_literals: bool,
-    valid: &mut bool,
-) {
+) -> bool {
     let db = context.db();
     let items = typed_dict.items(db);
+    let mut valid = true;
 
     for item in dict_expr.items.iter().rev() {
         if let Some(key_expr) = &item.key {
@@ -1757,15 +1706,7 @@ fn validate_merged_dict_literal<'db, 'ast>(
                     .map(|field| TypeContext::new(Some(field.declared_ty)))
                     .unwrap_or_default();
                 let value_ty = expression_type_fn(&item.value, value_tcx);
-                if validate_nested_literals {
-                    validate_nested_unpacked_typed_dict_literal(
-                        context,
-                        field.map(|field| field.declared_ty),
-                        &item.value,
-                        expression_type_fn,
-                    );
-                }
-                *valid &= TypedDictKeyAssignment {
+                valid &= TypedDictKeyAssignment {
                     context,
                     typed_dict,
                     full_object_ty: None,
@@ -1778,19 +1719,14 @@ fn validate_merged_dict_literal<'db, 'ast>(
                     emit_diagnostic: true,
                 }
                 .validate();
+                guaranteed_keys
+                    .entry(key.clone())
+                    .or_insert(Some(key_expr.into()));
             }
-            guaranteed_keys
-                .entry(key.clone())
-                .and_modify(|node| {
-                    if node.is_none() {
-                        *node = Some(key_expr.into());
-                    }
-                })
-                .or_insert(Some(key_expr.into()));
             shadowed_keys.insert(key);
         } else {
             let nested_ty = expression_type_fn(&item.value, TypeContext::default());
-            validate_merged_unpacked_keyword_argument(
+            valid &= validate_merged_unpacked_keyword_argument(
                 context,
                 typed_dict,
                 &item.value,
@@ -1803,10 +1739,11 @@ fn validate_merged_dict_literal<'db, 'ast>(
                 guaranteed_keys,
                 shadowed_keys,
                 expression_type_fn,
-                valid,
             );
         }
     }
+
+    valid
 }
 
 /// Validates one unpacked constructor argument while preserving merged `**{...}` overwrite
@@ -1821,13 +1758,12 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
     guaranteed_keys: &mut BTreeMap<Name, Option<AnyNodeRef<'ast>>>,
     shadowed_keys: &mut OrderSet<Name>,
     expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
-    valid: &mut bool,
-) {
+) -> bool {
     let db = context.db();
     let items = typed_dict.items(db);
 
     if let ast::Expr::Dict(dict_expr) = expr {
-        validate_merged_dict_literal(
+        return validate_merged_dict_literal(
             context,
             typed_dict,
             dict_expr,
@@ -1835,10 +1771,7 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
             guaranteed_keys,
             shadowed_keys,
             expression_type_fn,
-            true,
-            valid,
         );
-        return;
     }
 
     // Never and Dynamic types are special: they can have any keys, so we skip
@@ -1850,6 +1783,7 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
                 guaranteed_keys.entry(key_name.clone()).or_insert(None);
             }
         }
+        return true;
     } else if let Some(unpacked_keys) =
         extract_unpacked_typed_dict_keys_from_value_type(db, unpacked_type)
     {
@@ -1862,10 +1796,9 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
             full_object_ty_annotation(unpacked_type),
             &ignored_keys,
         );
-        *valid &= unpacked_valid;
 
         for (key_name, unpacked_key) in unpacked_keys {
-            if unpacked_key.is_required() {
+            if unpacked_key.is_required && !ignored_keys.contains(&key_name) {
                 guaranteed_keys
                     .entry(key_name.clone())
                     .and_modify(|node| {
@@ -1877,288 +1810,11 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
                 shadowed_keys.insert(key_name);
             }
         }
-    } else if let Some(mapping_keys) = extract_unpacked_mapping_key_value_types(db, unpacked_type) {
-        validate_mapping_overwrite(
-            context,
-            typed_dict,
-            unpacked_type,
-            &mapping_keys,
-            nodes,
-            shadowed_keys,
-            valid,
-        );
-    }
-}
 
-#[derive(Debug, Default)]
-pub(super) struct UnpackedMappingKeyValueTypes<'db> {
-    exact_string_keys: BTreeMap<Name, Type<'db>>,
-    any_string_value: Option<Type<'db>>,
-}
-
-impl<'db> UnpackedMappingKeyValueTypes<'db> {
-    fn add_exact_key(&mut self, db: &'db dyn Db, key: Name, value_ty: Type<'db>) {
-        match self.exact_string_keys.entry(key) {
-            Entry::Vacant(entry) => {
-                entry.insert(value_ty);
-            }
-            Entry::Occupied(mut entry) => {
-                let merged = UnionBuilder::new(db)
-                    .add(*entry.get())
-                    .add(value_ty)
-                    .build();
-                entry.insert(merged);
-            }
-        }
+        return unpacked_valid;
     }
 
-    fn add_any_string_value(&mut self, db: &'db dyn Db, value_ty: Type<'db>) {
-        let merged = self
-            .any_string_value
-            .map(|existing| UnionBuilder::new(db).add(existing).add(value_ty).build())
-            .unwrap_or(value_ty);
-        self.any_string_value = Some(merged);
-    }
-
-    fn exact_value_ty(&self, db: &'db dyn Db, key: &Name) -> Option<Type<'db>> {
-        let exact_value = self.exact_string_keys.get(key).copied();
-        match (exact_value, self.any_string_value) {
-            (Some(exact_value), Some(any_string_value)) => Some(
-                UnionBuilder::new(db)
-                    .add(exact_value)
-                    .add(any_string_value)
-                    .build(),
-            ),
-            (Some(exact_value), None) => Some(exact_value),
-            (None, Some(any_string_value)) => Some(any_string_value),
-            (None, None) => None,
-        }
-    }
-}
-
-pub(super) fn extract_unpacked_mapping_key_value_types<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-) -> Option<UnpackedMappingKeyValueTypes<'db>> {
-    fn mapping_specialization<'db>(
-        db: &'db dyn Db,
-        ty: Type<'db>,
-    ) -> Option<super::Specialization<'db>> {
-        ty.known_specialization(db, KnownClass::Dict)
-            .or_else(|| ty.known_specialization(db, KnownClass::Mapping))
-            .or_else(|| {
-                ty.nominal_class(db)?.iter_mro(db).find_map(|base| {
-                    let class = base.into_class()?;
-                    let (_, specialization) = class.static_class_literal_specialized(db, None)?;
-                    if class.is_known(db, KnownClass::Dict)
-                        || class.is_known(db, KnownClass::Mapping)
-                    {
-                        specialization
-                    } else {
-                        None
-                    }
-                })
-            })
-    }
-
-    let mut mapping_keys = UnpackedMappingKeyValueTypes::default();
-
-    match ty.resolve_type_alias(db) {
-        Type::Union(union) => {
-            for element in union.elements(db) {
-                let [key_ty, value_ty] = mapping_specialization(db, *element)?.types(db) else {
-                    return None;
-                };
-
-                match mapping_string_keys(db, *key_ty) {
-                    MappingStringKeys::NoString => (),
-                    MappingStringKeys::Exact(keys) => {
-                        for key in keys {
-                            mapping_keys.add_exact_key(db, key, *value_ty);
-                        }
-                    }
-                    MappingStringKeys::AnyString => {
-                        mapping_keys.add_any_string_value(db, *value_ty);
-                    }
-                }
-            }
-        }
-        ty => {
-            let specialization = mapping_specialization(db, ty)?;
-            let [key_ty, value_ty] = specialization.types(db) else {
-                return None;
-            };
-
-            match mapping_string_keys(db, *key_ty) {
-                MappingStringKeys::NoString => (),
-                MappingStringKeys::Exact(keys) => {
-                    for key in keys {
-                        mapping_keys.add_exact_key(db, key, *value_ty);
-                    }
-                }
-                MappingStringKeys::AnyString => {
-                    mapping_keys.add_any_string_value(db, *value_ty);
-                }
-            }
-        }
-    }
-
-    Some(mapping_keys)
-}
-
-fn validate_mapping_overwrite<'db, 'ast>(
-    context: &InferContext<'db, 'ast>,
-    typed_dict: TypedDictType<'db>,
-    unpacked_type: Type<'db>,
-    mapping_keys: &UnpackedMappingKeyValueTypes<'db>,
-    nodes: TypedDictAssignmentNodes<'ast>,
-    shadowed_keys: &mut OrderSet<Name>,
-    valid: &mut bool,
-) {
-    let db = context.db();
-    let typed_dict_items = typed_dict.items(db);
-
-    for key in mapping_keys.exact_string_keys.keys() {
-        if shadowed_keys.contains(key) {
-            continue;
-        }
-
-        let Some(value_ty) = mapping_keys.exact_value_ty(db, key) else {
-            continue;
-        };
-        if value_ty.is_never() {
-            continue;
-        }
-
-        if typed_dict_items.contains_key(key) {
-            *valid &= TypedDictKeyAssignment {
-                context,
-                typed_dict,
-                full_object_ty: full_object_ty_annotation(unpacked_type),
-                key: key.as_str(),
-                value_ty,
-                typed_dict_node: nodes.typed_dict,
-                key_node: nodes.key,
-                value_node: nodes.value,
-                assignment_kind: TypedDictAssignmentKind::Constructor,
-                emit_diagnostic: true,
-            }
-            .validate();
-        } else {
-            report_invalid_key_on_typed_dict(
-                context,
-                nodes.typed_dict,
-                nodes.key,
-                Type::TypedDict(typed_dict),
-                full_object_ty_annotation(unpacked_type),
-                Type::string_literal(db, key.as_str()),
-                typed_dict_items,
-            );
-            *valid = false;
-        }
-    }
-
-    if let Some(any_string_value) = mapping_keys.any_string_value {
-        for key_name in typed_dict_items.keys() {
-            if shadowed_keys.contains(key_name)
-                || mapping_keys.exact_string_keys.contains_key(key_name)
-            {
-                continue;
-            }
-            *valid &= TypedDictKeyAssignment {
-                context,
-                typed_dict,
-                full_object_ty: full_object_ty_annotation(unpacked_type),
-                key: key_name.as_str(),
-                value_ty: any_string_value,
-                typed_dict_node: nodes.typed_dict,
-                key_node: nodes.key,
-                value_node: nodes.value,
-                assignment_kind: TypedDictAssignmentKind::Constructor,
-                emit_diagnostic: true,
-            }
-            .validate();
-        }
-    }
-}
-
-pub(super) enum MappingStringKeys {
-    NoString,
-    Exact(Vec<Name>),
-    AnyString,
-}
-
-pub(super) fn mapping_string_keys<'db>(db: &'db dyn Db, key_ty: Type<'db>) -> MappingStringKeys {
-    let string_ty = KnownClass::Str.to_instance(db);
-    if !key_ty.is_assignable_to(db, string_ty) {
-        return MappingStringKeys::NoString;
-    }
-
-    let string_keys = key_ty.filter_disjoint_elements(db, string_ty, InferableTypeVars::None);
-    if string_keys.is_never() {
-        return MappingStringKeys::NoString;
-    }
-
-    if let Some(key_literal) = string_keys.as_string_literal() {
-        return MappingStringKeys::Exact(vec![Name::new(key_literal.value(db))]);
-    }
-
-    let Type::Union(union) = string_keys.resolve_type_alias(db) else {
-        return MappingStringKeys::AnyString;
-    };
-
-    union
-        .elements(db)
-        .iter()
-        .map(|element| {
-            element
-                .as_string_literal()
-                .map(|literal| Name::new(literal.value(db)))
-        })
-        .collect::<Option<Vec<_>>>()
-        .map_or(MappingStringKeys::AnyString, MappingStringKeys::Exact)
-}
-
-fn validate_nested_unpacked_typed_dict_literal<'db, 'ast>(
-    context: &InferContext<'db, 'ast>,
-    declared_ty: Option<Type<'db>>,
-    value_expr: &'ast ast::Expr,
-    expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
-) {
-    let Some(declared_ty) = declared_ty else {
-        return;
-    };
-    let ast::Expr::Dict(_) = value_expr else {
-        return;
-    };
-    let Some(nested_typed_dict) = declared_ty.resolve_type_alias(context.db()).as_typed_dict()
-    else {
-        return;
-    };
-
-    let nested_typed_dict_node: AnyNodeRef<'ast> = value_expr.into();
-    let mut guaranteed_keys = BTreeMap::new();
-    validate_unpacked_keyword_argument(
-        context,
-        nested_typed_dict,
-        value_expr,
-        Type::TypedDict(nested_typed_dict),
-        TypedDictAssignmentNodes {
-            typed_dict: nested_typed_dict_node,
-            key: nested_typed_dict_node,
-            value: nested_typed_dict_node,
-        },
-        &mut guaranteed_keys,
-        expression_type_fn,
-    );
-    let provided_keys: OrderSet<Name> = guaranteed_keys.into_keys().collect();
-
-    validate_typed_dict_required_keys(
-        context,
-        nested_typed_dict,
-        &provided_keys,
-        nested_typed_dict_node,
-    );
+    true
 }
 
 /// Validates a `TypedDict` dictionary literal assignment,
@@ -2170,11 +1826,10 @@ pub(super) fn validate_typed_dict_dict_literal<'db>(
     typed_dict_node: AnyNodeRef,
     mut expression_type_fn: impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) -> Result<OrderSet<Name>, OrderSet<Name>> {
-    let mut valid = true;
     let mut provided_keys = BTreeMap::new();
     let mut shadowed_keys = OrderSet::new();
 
-    validate_merged_dict_literal(
+    let mut valid = validate_merged_dict_literal(
         context,
         typed_dict,
         dict_expr,
@@ -2186,8 +1841,6 @@ pub(super) fn validate_typed_dict_dict_literal<'db>(
         &mut provided_keys,
         &mut shadowed_keys,
         &mut expression_type_fn,
-        false,
-        &mut valid,
     );
 
     let provided_keys: OrderSet<Name> = provided_keys.into_keys().collect();


### PR DESCRIPTION
## Summary

This PR adds `TypedDict` constructor support for unpacked dict literals, including keys that can't be written as ordinary keyword arguments:

```py
KeywordTD = TypedDict("KeywordTD", {"in": int, "x-y": int})

KeywordTD(**{"in": 1, "x-y": 2})
```

Previously, these calls went through the generic `**kwargs` path, so we'd miss required keys, fail to validate values
precisely, etc.

The implementation now walks merged dict literals with runtime overwrite semantics, so cases like `**{**bad, "name": "ok"}` are validated against the final value for each key.