### PR TITLE
fix(notebook): clamp cell offsets to prevent panic on inverted ranges

### DIFF
--- a/crates/ruff_notebook/src/notebook.rs
+++ b/crates/ruff_notebook/src/notebook.rs
@@ -264,6 +264,19 @@ impl Notebook {
                 Ordering::Equal => (),
             }
         }
+
+        // Ensure offsets remain monotonically non-decreasing after adjustment.
+        // Adjacent offsets can invert when different source markers with opposing
+        // deltas are applied to consecutive cell boundaries, causing a panic in
+        // `update_cell_content`. Clamp each offset to be at least as large as the
+        // preceding one so that every cell spans a valid (possibly empty) range.
+        // See: https://github.com/astral-sh/ruff/issues/24406
+        for i in 1..self.cell_offsets.len() {
+            let prev = self.cell_offsets[i - 1];
+            if self.cell_offsets[i] < prev {
+                self.cell_offsets[i] = prev;
+            }
+        }
     }
 
     /// Update the cell contents with the transformed content.


### PR DESCRIPTION
## Summary

Fixes #24406.

The panic occurs in `update_cell_content` when a cell's `start` offset exceeds its `end` offset (e.g. `6035..6034`). The root cause is in `update_cell_offsets`: it adjusts each cell-boundary offset independently using the "closest" source marker. When two adjacent boundaries fall within the influence of **different** markers with **opposing** deltas (one expanding, one shrinking), the offsets can cross after adjustment, producing an invalid range.

This PR adds a forward monotonicity clamping pass immediately after the adjustment loop:

```rust
for i in 1..self.cell_offsets.len() {
    let prev = self.cell_offsets[i - 1];
    if self.cell_offsets[i] < prev {
        self.cell_offsets[i] = prev;
    }
}
```

When offsets invert, the clamped cell gets empty content rather than causing a panic. The happy path (no inversions) is completely unaffected.

## Test Plan

- Reproduce with the notebook from issue #24406 — should lint without panicking after this change.
- Existing notebook tests should continue to pass.