### PR TITLE
fix(pydoclint): suppress DOC201 for generators with only bare/None returns

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
@@ -216,8 +216,9 @@ class Spam:
         return cls()
 
 
-# DOC201 - OK (generator with only bare return; no Returns section needed)
-def generator_bare_return(x: int):
+# DOC201 - OK (generator with only bare return; Iterable annotation is not Iterator/Generator)
+# Regression test for https://github.com/astral-sh/ruff/issues/21336
+def generator_bare_return(x: int) -> Iterable[int]:
     """Yield integers up to x.
 
     Args:
@@ -228,8 +229,8 @@ def generator_bare_return(x: int):
     return
 
 
-# DOC201 - OK (generator with explicit return None; no Returns section needed)
-def generator_explicit_none(x: int):
+# DOC201 - OK (generator with explicit return None; same annotation)
+def generator_explicit_none(x: int) -> Iterable[int]:
     """Yield integers up to x.
 
     Args:

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
@@ -214,3 +214,27 @@ class Spam:
     def __new__(cls) -> 'Spam':
         """New!!"""
         return cls()
+
+
+# DOC201 - OK (generator with only bare return; no Returns section needed)
+def generator_bare_return(x: int):
+    """Yield integers up to x.
+
+    Args:
+        x (int): Upper bound.
+    """
+    for i in range(x):
+        yield i
+    return
+
+
+# DOC201 - OK (generator with explicit return None; no Returns section needed)
+def generator_explicit_none(x: int):
+    """Yield integers up to x.
+
+    Args:
+        x (int): Upper bound.
+    """
+    for i in range(x):
+        yield i
+    return None

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_numpy.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_numpy.py
@@ -234,3 +234,31 @@ def generator_function_4():
 def not_a_generator() -> Iterator[int]:
     """"No returns documented here, oh no"""
     return (x for x in range(42))
+
+
+# DOC201 - OK (generator with only bare return; no Returns section needed)
+def generator_bare_return(x: int):
+    """Yield integers up to x.
+
+    Parameters
+    ----------
+    x : int
+        Upper bound.
+    """
+    for i in range(x):
+        yield i
+    return
+
+
+# DOC201 - OK (generator with explicit return None; no Returns section needed)
+def generator_explicit_none(x: int):
+    """Yield integers up to x.
+
+    Parameters
+    ----------
+    x : int
+        Upper bound.
+    """
+    for i in range(x):
+        yield i
+    return None

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_numpy.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_numpy.py
@@ -236,8 +236,9 @@ def not_a_generator() -> Iterator[int]:
     return (x for x in range(42))
 
 
-# DOC201 - OK (generator with only bare return; no Returns section needed)
-def generator_bare_return(x: int):
+# DOC201 - OK (generator with only bare return; Iterable annotation is not Iterator/Generator)
+# Regression test for https://github.com/astral-sh/ruff/issues/21336
+def generator_bare_return(x: int) -> Iterable[int]:
     """Yield integers up to x.
 
     Parameters
@@ -250,8 +251,8 @@ def generator_bare_return(x: int):
     return
 
 
-# DOC201 - OK (generator with explicit return None; no Returns section needed)
-def generator_explicit_none(x: int):
+# DOC201 - OK (generator with explicit return None; same annotation)
+def generator_explicit_none(x: int) -> Iterable[int]:
     """Yield integers up to x.
 
     Parameters

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -1287,6 +1287,13 @@ pub(crate) fn check_docstring(
                                     returns,
                                     semantic,
                                 )
+                                && !(
+                                    !body_entries.yields.is_empty()
+                                        && body_entries
+                                            .returns
+                                            .iter()
+                                            .all(ReturnEntry::is_none_return)
+                                )
                             {
                                 checker
                                     .report_diagnostic(DocstringMissingReturns, docstring.range());


### PR DESCRIPTION
## Summary

Fixes #21336.

Generator functions that contain `yield` statements but whose only `return` statements are bare (`return`) or explicit `return None` were incorrectly triggering DOC201 (docstring-missing-returns).

A generator's bare/None return just signals the end of iteration — it carries no return value. Requiring a `Returns` section in that case is a false positive.

### Root cause

The DOC201 check in `check_docstring.rs` has two branches based on whether the function carries a return-type annotation:

1. **Unannotated (`None` branch)** — already correct: fires only when at least one return carries a non-None value.
2. **Annotated (`Some(returns)` branch)** — missing the generator guard. When the annotation is not a "none-like" type (e.g. `-> Iterable[int]`) the check fires even when every `return` in the body is bare or `return None` and the function contains at least one `yield`.

### Fix

Added a guard in the `Some(returns)` branch that skips DOC201 when:
- the function body contains at least one `yield` expression, **and**
- every `return` in the body is a none-return (bare `return` or `return None`)

```rust
&& !(
    !body_entries.yields.is_empty()
        && body_entries
            .returns
            .iter()
            .all(ReturnEntry::is_none_return)
)
```

### Test cases

Added regression tests to `DOC201_google.py` and `DOC201_numpy.py` — generator functions annotated with `-> Iterable[int]` (which is not covered by the existing `is_generator_function_annotated_as_returning_none` helper) that end with a bare `return` or `return None`. Both should be DOC201-clean after this fix.

> **Note:** snapshot files may need regeneration via `cargo insta review` after running `cargo test` if any existing fixtures exercised this path.