### PR TITLE
fix(FURB122): suppress diagnostic when named expression rebinds loop variable

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB122.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB122.py
@@ -214,3 +214,23 @@ def _():
     with open("file", "w") as f:
         for line in ((1,) if True else (2,)):
             f.write(f"{line}")
+
+
+# Named expression rebinding loop variable — fix would be a syntax error
+# https://github.com/astral-sh/ruff/issues/21107
+def _():
+    with (
+        open("furb122.py", encoding="utf-8") as src,
+        open("furb122.txt", "w", encoding="utf-8") as dst,
+    ):
+        for line in src:
+            dst.write(line := line.upper())
+
+
+def _():
+    with (
+        open("furb122.py", encoding="utf-8") as src,
+        open("furb122.txt", "w", encoding="utf-8") as dst,
+    ):
+        for line in src:
+            dst.write(str(line := line.upper()))

--- a/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs
@@ -1,4 +1,5 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
+use ruff_python_ast::helpers::any_over_expr;
 use ruff_python_ast::{Expr, ExprList, ExprName, ExprTuple, Stmt, StmtFor};
 use ruff_python_semantic::analyze::typing;
 use ruff_python_semantic::{Binding, ScopeId, SemanticModel, TypingOnlyBindingsStatus};
@@ -195,6 +196,22 @@ fn for_loop_writes(
             )
         }
         (for_target, write_arg) => {
+            // If `write_arg` contains a named expression (`:=`) whose target
+            // rebinds a loop variable, the rewrite to a generator expression
+            // would be a syntax error: "assignment expression cannot rebind
+            // comprehension iteration variable".
+            // See: https://github.com/astral-sh/ruff/issues/21107
+            if any_over_expr(write_arg, |expr| {
+                let Expr::Named(named) = expr else {
+                    return false;
+                };
+                let Expr::Name(target) = named.target.as_ref() else {
+                    return false;
+                };
+                binding_names.iter().any(|b| b.id == target.id)
+            }) {
+                return;
+            }
             format!(
                 "{}.writelines({} for {} in {})",
                 locator.slice(io_object_name),


### PR DESCRIPTION
## Summary

Fixes #21107.

The FURB122 autofix rewrites `for line in src: f.write(expr)` into `f.writelines(expr for line in src)`. When `expr` contains a named expression (`:=`) whose target rebinds the loop variable (e.g., `f.write(line := line.upper())`), this produces invalid Python:

```python
f.writelines(line := line.upper() for line in src)
#            ^^^^
# SyntaxError: assignment expression cannot rebind comprehension iteration variable 'line'
```

This PR suppresses the diagnostic entirely when the write argument contains a named expression that would rebind a comprehension iteration variable, using the existing `any_over_expr` utility to detect named expressions recursively within the write argument.

## Test Plan

Added two test cases to the `FURB122.py` fixture (in the OK section, since these should no longer trigger the diagnostic):

1. Direct walrus operator as write argument: `dst.write(line := line.upper())`
2. Nested walrus inside a function call: `dst.write(str(line := line.upper()))`

Both verify that FURB122 is not reported when the autofix would produce a syntax error.