### PR TITLE
[ty] Allow `Final` variable assignments in `__post_init__`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -753,6 +753,22 @@ class C:
 reveal_type(C().x)  # revealed: int
 ```
 
+Redeclaring an existing dataclass field as `Final` in `__post_init__` should ideally be an error,
+since the field is not actually `Final`:
+
+```py
+from dataclasses import dataclass
+from typing import Final
+
+@dataclass
+class D:
+    x: str
+
+    def __post_init__(self):
+        # TODO: this should be an error (conflicting declaration)
+        self.x: Final[str] = "bar"
+```
+
 `__post_init__` methods in non-dataclasses are not affected:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -731,11 +731,10 @@ class C:
         self.x: Final[int] = 1
 ```
 
-### Dataclass `__post_init__`
+### `__post_init__`
 
-Dataclass-like `__post_init__` methods run as part of instance initialization, so they may declare
-and assign `Final` instance attributes. A plain method named `__post_init__` does not get this
-special case.
+`__post_init__` is a dunder that runs as part of instance initialization, so `Final` instance
+attributes may be declared and assigned in it, regardless of whether the class is a dataclass:
 
 ```py
 from dataclasses import dataclass
@@ -753,6 +752,14 @@ class C:
 reveal_type(C().x)  # revealed: int
 ```
 
+```py
+from typing import Final
+
+class NonDataclass:
+    def __post_init__(self):
+        self.x: Final[int] = 1
+```
+
 Redeclaring an existing dataclass field as `Final` in `__post_init__` should ideally be an error,
 since the field is not actually `Final`:
 
@@ -767,17 +774,6 @@ class D:
     def __post_init__(self):
         # TODO: this should be an error (conflicting declaration)
         self.x: Final[str] = "bar"
-```
-
-`__post_init__` methods in non-dataclasses are not affected:
-
-```py
-from typing import Final
-
-class NonDataclass:
-    def __post_init__(self):
-        # error: [invalid-assignment]
-        self.x: Final[int] = 1
 ```
 
 ### Protocol members

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -760,6 +760,21 @@ class NonDataclass:
         self.x: Final[int] = 1
 ```
 
+Assigning to a `Final` attribute via the class literal on a dataclass-like class mentions
+`__post_init__` in the diagnostic:
+
+```py
+from dataclasses import dataclass
+from typing import Final
+
+@dataclass
+class E:
+    x: Final[int] = 1
+
+# error: [invalid-assignment] "`Final` attributes can only be assigned in the class body, `__init__`, or `__post_init__` on dataclass-like classes"
+E.x = 2
+```
+
 Redeclaring an existing dataclass field as `Final` in `__post_init__` should ideally be an error,
 since the field is not actually `Final`:
 

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -731,6 +731,33 @@ class C:
         self.x: Final[int] = 1
 ```
 
+### Dataclass `__post_init__`
+
+Dataclass-like `__post_init__` methods run as part of instance initialization, so they may declare
+and assign `Final` instance attributes. A plain method named `__post_init__` does not get this
+special case.
+
+```py
+from dataclasses import dataclass
+from typing import Final
+
+@dataclass
+class C:
+    def __post_init__(self):
+        self.x: Final[int] = 1
+
+    def f(self):
+        # error: [invalid-assignment]
+        self.x = 2
+
+reveal_type(C().x)  # revealed: int
+
+class D:
+    def __post_init__(self):
+        # error: [invalid-assignment]
+        self.x: Final[int] = 1
+```
+
 ### Protocol members
 
 Assignments to `Final` protocol members are also invalid, both through a protocol-typed value and

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -751,8 +751,14 @@ class C:
         self.x = 2
 
 reveal_type(C().x)  # revealed: int
+```
 
-class D:
+`__post_init__` methods in non-dataclasses are not affected:
+
+```py
+from typing import Final
+
+class NonDataclass:
     def __post_init__(self):
         # error: [invalid-assignment]
         self.x: Final[int] = 1

--- a/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
@@ -13,17 +13,6 @@ use crate::{
 };
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
-    /// Returns `true` if `object_ty` belongs to a dataclass-like class whose `__post_init__`
-    /// method should be treated as part of instance initialization for `Final` attributes.
-    fn final_attribute_allows_post_init(&self, object_ty: Type<'db>) -> bool {
-        let db = self.db();
-
-        object_ty.nominal_class(db).is_some_and(|cls| {
-            cls.static_class_literal(db)
-                .is_some_and(|(class_literal, _)| class_literal.is_dataclass_like(db))
-        })
-    }
-
     /// Add a secondary annotation to a diagnostic pointing to the `Final` declaration site.
     fn annotate_final_declaration(
         &self,
@@ -132,16 +121,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // TODO: Use the full assignment statement range for these diagnostics instead of
         // just the attribute target range.
 
-        let is_in_allowed_initializer = self.current_function_definition().is_some_and(|func| {
-            if func.name.id == "__init__" {
-                true
-            } else {
-                func.name.id == "__post_init__" && self.final_attribute_allows_post_init(object_ty)
-            }
-        });
+        let is_in_allowed_initializer = self
+            .current_function_definition()
+            .is_some_and(|func| func.name.id == "__init__" || func.name.id == "__post_init__");
 
         let report_not_in_init = || {
-            let allows_post_init = self.final_attribute_allows_post_init(object_ty);
+            let is_dataclass_like = object_ty.nominal_class(db).is_some_and(|cls| {
+                cls.static_class_literal(db)
+                    .is_some_and(|(class_literal, _)| class_literal.is_dataclass_like(db))
+            });
             let Some(builder) = self
                 .context
                 .report_lint(&INVALID_ASSIGNMENT, target.range())
@@ -152,7 +140,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 "Cannot assign to final attribute `{attribute}` on type `{}`",
                 object_ty.display(db)
             ));
-            diagnostic.set_primary_message(if allows_post_init {
+            diagnostic.set_primary_message(if is_dataclass_like {
                 "`Final` attributes can only be assigned in the class body, `__init__`, or `__post_init__` on dataclass-like classes"
             } else {
                 "`Final` attributes can only be assigned in the class body or `__init__`"

--- a/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
@@ -13,6 +13,18 @@ use crate::{
 };
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
+    /// Returns `true` if `object_ty` belongs to a dataclass-like class whose `__post_init__`
+    /// method should be treated as part of instance initialization for `Final` attributes.
+    fn final_attribute_allows_post_init(&self, object_ty: Type<'db>) -> bool {
+        let db = self.db();
+
+        object_ty
+            .nominal_class(db)
+            .or_else(|| object_ty.to_class_type(db))
+            .and_then(|class_ty| class_ty.static_class_literal(db))
+            .is_some_and(|(class_literal, _)| class_literal.is_dataclass_like(db))
+    }
+
     /// Add a secondary annotation to a diagnostic pointing to the `Final` declaration site.
     fn annotate_final_declaration(
         &self,
@@ -123,11 +135,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // TODO: Use the full assignment statement range for these diagnostics instead of
         // just the attribute target range.
 
-        let is_in_init = self
-            .current_function_definition()
-            .is_some_and(|func| func.name.id == "__init__");
+        let is_in_allowed_initializer = self.current_function_definition().is_some_and(|func| {
+            if func.name.id == "__init__" {
+                true
+            } else {
+                func.name.id == "__post_init__" && self.final_attribute_allows_post_init(object_ty)
+            }
+        });
 
         let report_not_in_init = || {
+            let allows_post_init = self.final_attribute_allows_post_init(object_ty);
             let Some(builder) = self
                 .context
                 .report_lint(&INVALID_ASSIGNMENT, target.range())
@@ -138,15 +155,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 "Cannot assign to final attribute `{attribute}` on type `{}`",
                 object_ty.display(db)
             ));
-            diagnostic.set_primary_message(
-                "`Final` attributes can only be assigned in the class body or `__init__`",
-            );
+            diagnostic.set_primary_message(if allows_post_init {
+                "`Final` attributes can only be assigned in the class body, `__init__`, or `__post_init__` on dataclass-like classes"
+            } else {
+                "`Final` attributes can only be assigned in the class body or `__init__`"
+            });
             if let Some(final_declaration) = final_declaration {
                 self.annotate_final_declaration(&mut diagnostic, final_declaration);
             }
         };
 
-        if !is_in_init {
+        if !is_in_allowed_initializer {
             report_not_in_init();
             return true;
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
@@ -126,10 +126,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .is_some_and(|func| func.name.id == "__init__" || func.name.id == "__post_init__");
 
         let report_not_in_init = || {
-            let is_dataclass_like = object_ty.nominal_class(db).is_some_and(|cls| {
-                cls.static_class_literal(db)
-                    .is_some_and(|(class_literal, _)| class_literal.is_dataclass_like(db))
-            });
+            let is_dataclass_like = object_ty
+                .nominal_class(db)
+                .or_else(|| object_ty.to_class_type(db))
+                .and_then(|cls| cls.static_class_literal(db))
+                .is_some_and(|(class_literal, _)| class_literal.is_dataclass_like(db));
             let Some(builder) = self
                 .context
                 .report_lint(&INVALID_ASSIGNMENT, target.range())

--- a/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
@@ -18,11 +18,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     fn final_attribute_allows_post_init(&self, object_ty: Type<'db>) -> bool {
         let db = self.db();
 
-        object_ty
-            .nominal_class(db)
-            .or_else(|| object_ty.to_class_type(db))
-            .and_then(|class_ty| class_ty.static_class_literal(db))
-            .is_some_and(|(class_literal, _)| class_literal.is_dataclass_like(db))
+        object_ty.nominal_class(db).is_some_and(|cls| {
+            cls.static_class_literal(db)
+                .is_some_and(|(class_literal, _)| class_literal.is_dataclass_like(db))
+        })
     }
 
     /// Add a secondary annotation to a diagnostic pointing to the `Final` declaration site.
@@ -57,9 +56,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         attribute: &str,
     ) -> Option<Definition<'db>> {
         let db = self.db();
-        let class_ty = object_ty
-            .nominal_class(db)
-            .or_else(|| object_ty.to_class_type(db))?;
+        let class_ty = object_ty.nominal_class(db)?;
 
         for base in class_ty.iter_mro(db) {
             let Some(class) = base.into_class() else {


### PR DESCRIPTION
## Summary

As long as the `__post_init__` is in a dataclass, e.g., the following is accepted:

```python
from dataclasses import dataclass
from typing import Final

@dataclass
class Test:
    def __post_init__(self):
        self.test_int: Final[int] = 0
```

Closes https://github.com/astral-sh/ty/issues/3247.
