### PR TITLE
[WIP] Support Ruff configuration in PEP 723 metadata

### DIFF
--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -2,7 +2,7 @@
 
 use ruff_python_ast::script::ScriptTag;
 use ruff_workspace::configuration::Configuration;
-use ruff_workspace::pyproject::parse_script_metadata;
+use ruff_workspace::pyproject::{get_minimum_supported_version, parse_script_metadata};
 use std::borrow::Cow;
 use std::fs::File;
 use std::io;
@@ -253,10 +253,30 @@ pub(crate) fn lint_path(
     let settings = match source_kind {
         SourceKind::Python { ref code, is_stub } if !is_stub => {
             if let Some(script_tag) = ScriptTag::parse(code.as_bytes()) {
-                let options = parse_script_metadata(&script_tag.metadata)?;
-                let configuration =
-                    Configuration::from_options(options, Some(path), &settings.project_root)?;
-                &configuration.into_settings(&settings.project_root)?.linter
+                let metadata = parse_script_metadata(&script_tag.metadata)?;
+                let target_version = metadata
+                    .requires_python
+                    .as_ref()
+                    .and_then(get_minimum_supported_version);
+                let ruff = metadata.tool.and_then(|tool| tool.ruff);
+
+                match (ruff, target_version) {
+                    (None, None) => settings,
+                    (None, Some(target_version)) => {
+                        &settings.clone().with_target_version(target_version.into())
+                    }
+                    (Some(ruff), None) => {
+                        let configuration =
+                            Configuration::from_options(ruff, Some(path), &settings.project_root)?;
+                        &configuration.into_settings(&settings.project_root)?.linter
+                    }
+                    (Some(mut ruff), Some(target_version)) => {
+                        ruff.target_version = Some(target_version);
+                        let configuration =
+                            Configuration::from_options(ruff, Some(path), &settings.project_root)?;
+                        &configuration.into_settings(&settings.project_root)?.linter
+                    }
+                }
             } else {
                 settings
             }

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_family = "wasm", allow(dead_code))]
 
+use ruff_python_ast::script::ScriptTag;
+use ruff_workspace::configuration::Configuration;
+use ruff_workspace::pyproject::parse_script_metadata;
 use std::borrow::Cow;
 use std::fs::File;
 use std::io;
@@ -245,6 +248,20 @@ pub(crate) fn lint_path(
         Err(err) => {
             return Ok(Diagnostics::from_source_error(&err, Some(path), settings));
         }
+    };
+
+    let settings = match source_kind {
+        SourceKind::Python { ref code, is_stub } if !is_stub => {
+            if let Some(script_tag) = ScriptTag::parse(code.as_bytes()) {
+                let options = parse_script_metadata(&script_tag.metadata)?;
+                let configuration =
+                    Configuration::from_options(options, Some(path), &settings.project_root)?;
+                &configuration.into_settings(&settings.project_root)?.linter
+            } else {
+                settings
+            }
+        }
+        _ => settings,
     };
 
     // Lint the file.

--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -4437,3 +4437,231 @@ fn preview_default_rules() -> Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn lint_script() -> Result<()> {
+    let case = CliTest::with_files([
+        (
+            "ruff.toml",
+            r#"
+[lint]
+select = ["B","Q"]
+"#,
+        ),
+        (
+            "script.py",
+            r#"
+# /// script
+# dependencies = []
+# [tool.ruff.lint]
+# select = ["Q000"]
+# [tool.ruff.lint.flake8-quotes]
+# inline-quotes = "single"
+# ///
+a = "abcba".strip("aba")
+"#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(
+        case.check_command()
+            .arg("script.py")
+            , @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    script.py:9:5: Q000 [*] Double quotes found but single quotes preferred
+    script.py:9:19: Q000 [*] Double quotes found but single quotes preferred
+    Found 2 errors.
+    [*] 2 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn lint_script_requires_python() -> Result<()> {
+    let pyproject_311_metadata_none = CliTest::with_files([
+        (
+            "pyproject.toml",
+            r#"
+[project]
+requires-python = ">=3.11"
+"#,
+        ),
+        (
+            "script.py",
+            r#"
+# /// script
+# dependencies = []
+# [tool.ruff.lint]
+# select = ["UP006"]
+# ///
+from typing import List; foo: List[int]
+"#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(
+        pyproject_311_metadata_none.check_command()
+            .arg("script.py")
+            , @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    script.py:7:31: UP006 [*] Use `list` instead of `List` for type annotation
+    Found 1 error.
+    [*] 1 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "###);
+
+    let pyproject_311_metadata_38 = CliTest::with_files([
+        (
+            "pyproject.toml",
+            r#"
+[project]
+requires-python = ">=3.11"
+"#,
+        ),
+        (
+            "script.py",
+            r#"
+# /// script
+# dependencies = []
+# requires-python = ">=3.8"
+# [tool.ruff.lint]
+# select = ["UP006"]
+# ///
+from typing import List; foo: List[int]
+"#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(
+        pyproject_311_metadata_38.check_command()
+            .arg("script.py")
+            , @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    "###);
+
+    let pyproject_38_metadata_311 = CliTest::with_files([
+        (
+            "pyproject.toml",
+            r#"
+[project]
+requires-python = ">=3.8"
+"#,
+        ),
+        (
+            "script.py",
+            r#"
+# /// script
+# dependencies = []
+# requires-python = ">= 3.11"
+# [tool.ruff.lint]
+# select = ["UP006"]
+# ///
+from typing import List; foo: List[int]
+"#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(
+        pyproject_38_metadata_311.check_command()
+            .arg("script.py")
+            , @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    script.py:8:31: UP006 [*] Use `list` instead of `List` for type annotation
+    Found 1 error.
+    [*] 1 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "###);
+
+    Ok(())
+}
+#[test]
+
+fn lint_script_with_extend() -> Result<()> {
+    let case = CliTest::with_files([
+        (
+            "ruff.toml",
+            r#"
+[lint]
+select = ["B","Q"]
+"#,
+        ),
+        (
+            "script.py",
+            r#"
+# /// script
+# dependencies = []
+# [tool.ruff]
+# extend = "ruff.toml"
+# [tool.ruff.lint.flake8-quotes]
+# inline-quotes = "single"
+# ///
+a = "abcba".strip("aba")
+"#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(
+        case.check_command()
+            .arg("script.py")
+            , @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn lint_script_cli_overrides() -> Result<()> {
+    let case = CliTest::with_file(
+        "script.py",
+        r#"
+# /// script
+# dependencies = []
+# [tool.ruff.lint]
+# select = ["Q000"]
+# [tool.ruff.lint.flake8-quotes]
+# inline-quotes = "single"
+# ///
+a = "abcba".strip("aba")
+"#,
+    )?;
+
+    assert_cmd_snapshot!(
+        case.check_command()
+            .args(["--ignore","ALL"])
+            .arg("script.py")
+            , @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    script.py:9:5: Q000 [*] Double quotes found but single quotes preferred
+    script.py:9:19: Q000 [*] Double quotes found but single quotes preferred
+    Found 2 errors.
+    [*] 2 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "###);
+
+    Ok(())
+}

--- a/crates/ruff_python_ast/src/script.rs
+++ b/crates/ruff_python_ast/src/script.rs
@@ -14,7 +14,7 @@ pub struct ScriptTag {
     /// The content of the script before the metadata block.
     prelude: String,
     /// The metadata block.
-    metadata: String,
+    pub metadata: String,
     /// The content of the script after the metadata block.
     postlude: String,
 }

--- a/crates/ruff_workspace/src/pyproject.rs
+++ b/crates/ruff_workspace/src/pyproject.rs
@@ -14,8 +14,8 @@ use ruff_linter::settings::types::{PythonVersion, RequiredVersion};
 use crate::options::{Options, validate_required_version};
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-struct Tools {
-    ruff: Option<Options>,
+pub struct Tools {
+    pub ruff: Option<Options>,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -32,9 +32,9 @@ pub struct Pyproject {
 
 #[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct ScriptMetadata {
-    tool: Option<Tools>,
+    pub tool: Option<Tools>,
     #[serde(alias = "requires-python", alias = "requires_python")]
-    requires_python: Option<VersionSpecifiers>,
+    pub requires_python: Option<VersionSpecifiers>,
 }
 
 impl Pyproject {
@@ -83,7 +83,7 @@ fn parse_pyproject_toml<P: AsRef<Path>>(path: P) -> Result<Pyproject> {
 }
 
 /// Parse PEP 723 script metadata
-pub fn parse_script_metadata(contents: &str) -> Result<Options> {
+pub fn parse_script_metadata(contents: &str) -> Result<ScriptMetadata> {
     // Parse the TOML document once into a spanned representation so we can:
     // - Inspect `required-version` without triggering strict deserialization errors.
     // - Deserialize with precise spans (line/column and excerpt) on errors.
@@ -101,13 +101,7 @@ pub fn parse_script_metadata(contents: &str) -> Result<Options> {
             err
         })
         .with_context(|| "Failed to parse inline metadata")?;
-    let mut ruff = metadata.tool.and_then(|tool| tool.ruff).unwrap_or_default();
-    if ruff.target_version.is_none() {
-        if let Some(requires_python) = metadata.requires_python {
-            ruff.target_version = get_minimum_supported_version(&requires_python);
-        }
-    }
-    Ok(ruff)
+    Ok(metadata)
 }
 
 /// Return `true` if a `pyproject.toml` contains a `[tool.ruff]` section.
@@ -271,7 +265,9 @@ fn get_fallback_target_version(dir: &Path) -> Option<PythonVersion> {
 }
 
 /// Infer the minimum supported [`PythonVersion`] from a `requires-python` specifier.
-fn get_minimum_supported_version(requires_version: &VersionSpecifiers) -> Option<PythonVersion> {
+pub fn get_minimum_supported_version(
+    requires_version: &VersionSpecifiers,
+) -> Option<PythonVersion> {
     /// Truncate a version to its major and minor components.
     fn major_minor(version: &Version) -> Option<Version> {
         let major = version.release().first()?;

--- a/crates/ruff_workspace/src/pyproject.rs
+++ b/crates/ruff_workspace/src/pyproject.rs
@@ -30,6 +30,13 @@ pub struct Pyproject {
     project: Option<Project>,
 }
 
+#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ScriptMetadata {
+    tool: Option<Tools>,
+    #[serde(alias = "requires-python", alias = "requires_python")]
+    requires_python: Option<VersionSpecifiers>,
+}
+
 impl Pyproject {
     pub const fn new(options: Options) -> Self {
         Self {
@@ -73,6 +80,34 @@ fn parse_ruff_toml<P: AsRef<Path>>(path: P) -> Result<Options> {
 /// Parse a `pyproject.toml` file.
 fn parse_pyproject_toml<P: AsRef<Path>>(path: P) -> Result<Pyproject> {
     parse_toml(path, &["tool", "ruff"])
+}
+
+/// Parse PEP 723 script metadata
+pub fn parse_script_metadata(contents: &str) -> Result<Options> {
+    // Parse the TOML document once into a spanned representation so we can:
+    // - Inspect `required-version` without triggering strict deserialization errors.
+    // - Deserialize with precise spans (line/column and excerpt) on errors.
+    let root =
+        toml::de::DeTable::parse(contents).with_context(|| "Failed to parse inline metadata")?;
+
+    check_required_version(root.get_ref(), &["tool", "ruff"])?;
+
+    let deserializer = toml::de::Deserializer::from(root);
+    let metadata = ScriptMetadata::deserialize(deserializer)
+        .map_err(|mut err| {
+            // `Deserializer::from` doesn't have access to the original input, but we do.
+            // Attach it so TOML errors include line/column and a source excerpt.
+            err.set_input(Some(contents));
+            err
+        })
+        .with_context(|| "Failed to parse inline metadata")?;
+    let mut ruff = metadata.tool.and_then(|tool| tool.ruff).unwrap_or_default();
+    if ruff.target_version.is_none() {
+        if let Some(requires_python) = metadata.requires_python {
+            ruff.target_version = get_minimum_supported_version(&requires_python);
+        }
+    }
+    Ok(ruff)
 }
 
 /// Return `true` if a `pyproject.toml` contains a `[tool.ruff]` section.


### PR DESCRIPTION
Towards #10457

Current plan is to allow CLI overrides but not yet allow hierarchical configuration (i.e. we should error on `extends = ...` in the script metadata).

(Do not look at this hacky implementation just yet - just trying to get the desired behavior sorted out first and see what the ecosystem hits look like along the way).