### PR TITLE
Rename patterns and arguments source order iterator method

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -1895,7 +1895,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
                         }
                     }
                     Some(typing::Callable::Cast) => {
-                        for (i, arg) in arguments.arguments_source_order().enumerate() {
+                        for (i, arg) in arguments.iter_source_order().enumerate() {
                             match (i, arg) {
                                 (0, ArgOrKeyword::Arg(arg)) => self.visit_cast_type_argument(arg),
                                 (_, ArgOrKeyword::Arg(arg)) => self.visit_non_type_definition(arg),
@@ -1912,7 +1912,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
                         }
                     }
                     Some(typing::Callable::NewType) => {
-                        for (i, arg) in arguments.arguments_source_order().enumerate() {
+                        for (i, arg) in arguments.iter_source_order().enumerate() {
                             match (i, arg) {
                                 (1, ArgOrKeyword::Arg(arg)) => self.visit_type_definition(arg),
                                 (_, ArgOrKeyword::Arg(arg)) => self.visit_non_type_definition(arg),
@@ -1957,7 +1957,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
                     }
                     Some(typing::Callable::TypeAliasType) => {
                         // Ex) TypeAliasType("Json", "Union[dict[str, Json]]", type_params=())
-                        for (i, arg) in arguments.arguments_source_order().enumerate() {
+                        for (i, arg) in arguments.iter_source_order().enumerate() {
                             match (i, arg) {
                                 (1, ArgOrKeyword::Arg(arg)) => self.visit_type_definition(arg),
                                 (_, ArgOrKeyword::Arg(arg)) => self.visit_non_type_definition(arg),

--- a/crates/ruff_linter/src/fix/edits.rs
+++ b/crates/ruff_linter/src/fix/edits.rs
@@ -214,13 +214,13 @@ pub(crate) fn remove_argument<T: Ranged>(
 ) -> Result<Edit> {
     // Partition into arguments before and after the argument to remove.
     let (before, after): (Vec<_>, Vec<_>) = arguments
-        .arguments_source_order()
+        .iter_source_order()
         .map(|arg| arg.range())
         .filter(|range| argument.range() != *range)
         .partition(|range| range.start() < argument.start());
 
     let arg = arguments
-        .arguments_source_order()
+        .iter_source_order()
         .find(|arg| arg.range() == argument.range())
         .context("Unable to find argument")?;
 
@@ -275,7 +275,7 @@ pub(crate) fn add_argument(argument: &str, arguments: &Arguments, tokens: &Token
     if let Some(ast::Keyword { range, value, .. }) = arguments.keywords.first() {
         let keyword = parenthesized_range(value.into(), arguments.into(), tokens).unwrap_or(*range);
         Edit::insertion(format!("{argument}, "), keyword.start())
-    } else if let Some(last) = arguments.arguments_source_order().last() {
+    } else if let Some(last) = arguments.iter_source_order().last() {
         // Case 1: existing arguments, so append after the last argument.
         let last = parenthesized_range(last.value().into(), arguments.into(), tokens)
             .unwrap_or(last.range());

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/generic_not_last_base_class.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/generic_not_last_base_class.rs
@@ -141,7 +141,7 @@ pub(crate) fn generic_not_last_base_class(checker: &Checker, class_def: &ast::St
     // where we would naively try to put `Generic[T]` after `*[str]`, which is also after a keyword
     // argument, causing the error.
     if bases
-        .arguments_source_order()
+        .iter_source_order()
         .any(|arg| arg.value().is_starred_expr())
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/builtin_open.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/builtin_open.rs
@@ -163,7 +163,7 @@ pub(crate) fn builtin_open(checker: &Checker, call: &ExprCall, segments: &[&str]
 
         let open_args = itertools::join(
             call.arguments
-                .arguments_source_order()
+                .iter_source_order()
                 .enumerate()
                 .filter_map(|(i, arg)| args(i, arg)),
             ", ",

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_chmod.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_chmod.rs
@@ -132,10 +132,7 @@ pub(crate) fn os_chmod(checker: &Checker, call: &ExprCall, segments: &[&str]) {
             _ => None,
         };
 
-        let chmod_args = itertools::join(
-            call.arguments.arguments_source_order().filter_map(args),
-            ", ",
-        );
+        let chmod_args = itertools::join(call.arguments.iter_source_order().filter_map(args), ", ");
 
         let replacement = if is_pathlib_path_call(checker, path_arg) {
             format!("{path_code}.chmod({chmod_args})")

--- a/crates/ruff_linter/src/rules/ruff/rules/default_factory_kwarg.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/default_factory_kwarg.rs
@@ -159,7 +159,7 @@ fn convert_to_positional(
         let insertion_edit = Edit::insertion(
             format!("{}, ", locator.slice(&default_factory.value)),
             call.arguments
-                .arguments_source_order()
+                .iter_source_order()
                 .next()
                 .ok_or_else(|| anyhow::anyhow!("`default_factory` keyword argument not found"))?
                 .start(),

--- a/crates/ruff_linter/src/rules/ruff/rules/legacy_form_pytest_raises.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/legacy_form_pytest_raises.rs
@@ -239,7 +239,7 @@ fn generate_with_statement(
 
     let (func_args, func_keywords): (Vec<_>, Vec<_>) = legacy_call
         .arguments
-        .arguments_source_order()
+        .iter_source_order()
         .skip(if expected.is_some() { 2 } else { 1 })
         .partition_map(|arg_or_keyword| match arg_or_keyword {
             ast::ArgOrKeyword::Arg(expr) => Either::Left(expr.clone()),

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -271,7 +271,7 @@ impl ast::PatternArguments {
     where
         V: SourceOrderVisitor<'a> + ?Sized,
     {
-        for pattern_or_keyword in self.patterns_source_order() {
+        for pattern_or_keyword in self.iter_source_order() {
             match pattern_or_keyword {
                 crate::PatternOrKeyword::Pattern(pattern) => visitor.visit_pattern(pattern),
                 crate::PatternOrKeyword::Keyword(keyword) => {
@@ -326,7 +326,7 @@ impl ast::Arguments {
     where
         V: SourceOrderVisitor<'a> + ?Sized,
     {
-        for arg_or_keyword in self.arguments_source_order() {
+        for arg_or_keyword in self.iter_source_order() {
             match arg_or_keyword {
                 ArgOrKeyword::Arg(arg) => visitor.visit_expr(arg),
                 ArgOrKeyword::Keyword(keyword) => visitor.visit_keyword(keyword),

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2879,7 +2879,7 @@ pub struct PatternKeyword {
 
 impl PatternArguments {
     /// Returns an iterator over the patterns and keywords in source order.
-    pub fn patterns_source_order(&self) -> PatternArgumentsSourceOrder<'_> {
+    pub fn iter_source_order(&self) -> PatternArgumentsSourceOrder<'_> {
         PatternArgumentsSourceOrder {
             patterns: &self.patterns,
             keywords: &self.keywords,
@@ -2889,7 +2889,7 @@ impl PatternArguments {
     }
 }
 
-/// The iterator returned by [`PatternArguments::patterns_source_order`].
+/// The iterator returned by [`PatternArguments::iter_source_order`].
 #[derive(Clone)]
 pub struct PatternArgumentsSourceOrder<'a> {
     patterns: &'a [Pattern],
@@ -3487,7 +3487,7 @@ impl Arguments {
             .or_else(|| self.find_positional(position).map(ArgOrKeyword::from))
     }
 
-    /// Return the positional and keyword arguments in the order of declaration.
+    /// Iterates over the positional and keyword arguments in the order of declaration.
     ///
     /// Positional arguments are generally before keyword arguments, but star arguments are an
     /// exception:
@@ -3521,7 +3521,7 @@ impl Arguments {
     /// 2
     /// {'4': 5}
     /// ```
-    pub fn arguments_source_order(&self) -> ArgumentsSourceOrder<'_> {
+    pub fn iter_source_order(&self) -> ArgumentsSourceOrder<'_> {
         ArgumentsSourceOrder {
             args: &self.args,
             keywords: &self.keywords,
@@ -3543,7 +3543,7 @@ impl Arguments {
     }
 }
 
-/// The iterator returned by [`Arguments::arguments_source_order`].
+/// The iterator returned by [`Arguments::iter_source_order`].
 #[derive(Clone)]
 pub struct ArgumentsSourceOrder<'a> {
     args: &'a [Expr],

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -321,7 +321,7 @@ impl<'a> Generator<'a> {
                     if let Some(arguments) = arguments {
                         self.p("(");
                         let mut first = true;
-                        for arg_or_keyword in arguments.arguments_source_order() {
+                        for arg_or_keyword in arguments.iter_source_order() {
                             match arg_or_keyword {
                                 ArgOrKeyword::Arg(arg) => {
                                     self.p_delim(&mut first, ", ");
@@ -1217,7 +1217,7 @@ impl<'a> Generator<'a> {
                 } else {
                     let mut first = true;
 
-                    for arg_or_keyword in arguments.arguments_source_order() {
+                    for arg_or_keyword in arguments.iter_source_order() {
                         match arg_or_keyword {
                             ArgOrKeyword::Arg(arg) => {
                                 self.p_delim(&mut first, ", ");

--- a/crates/ruff_python_formatter/src/other/arguments.rs
+++ b/crates/ruff_python_formatter/src/other/arguments.rs
@@ -61,7 +61,7 @@ impl FormatNodeRule<Arguments> for FormatArguments {
                     };
                 }
                 _ => {
-                    for arg_or_keyword in item.arguments_source_order() {
+                    for arg_or_keyword in item.iter_source_order() {
                         match arg_or_keyword {
                             ArgOrKeyword::Arg(arg) => {
                                 joiner.entry(arg, &arg.format());

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -492,7 +492,7 @@ impl<'a> SourceOrderVisitor<'a> for InlayHintVisitor<'a, '_> {
 
                 self.visit_expr(&call.func);
 
-                for (index, arg_or_keyword) in call.arguments.arguments_source_order().enumerate() {
+                for (index, arg_or_keyword) in call.arguments.iter_source_order().enumerate() {
                     if let Some((name, parameter_label_offset)) = details.argument_names.get(&index)
                         && !arg_matches_name(&arg_or_keyword, name)
                     {

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -977,8 +977,7 @@ impl SourceOrderVisitor<'_> for SemanticTokenVisitor<'_> {
                 // Determine whether each argument should be considered a type form or a value
                 // based on the position.
                 let argument_forms = call_argument_forms(self.model, call);
-                for (argument, form) in call.arguments.arguments_source_order().zip(argument_forms)
-                {
+                for (argument, form) in call.arguments.iter_source_order().zip(argument_forms) {
                     match form {
                         CallArgumentForm::Type => self.visit_annotation(argument.value()),
                         CallArgumentForm::Unknown | CallArgumentForm::Value => match argument {

--- a/crates/ty_ide/src/signature_help.rs
+++ b/crates/ty_ide/src/signature_help.rs
@@ -171,7 +171,7 @@ fn get_call_expr(
 fn get_argument_index(call_expr: &ast::ExprCall, offset: TextSize) -> usize {
     let mut current_arg = 0;
 
-    for (i, arg) in call_expr.arguments.arguments_source_order().enumerate() {
+    for (i, arg) in call_expr.arguments.iter_source_order().enumerate() {
         if offset <= arg.end() {
             return i;
         }

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -122,7 +122,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         mut infer_argument_type: impl FnMut(&ast::ArgOrKeyword, &ast::Expr) -> Type<'db>,
     ) -> Self {
         arguments
-            .arguments_source_order()
+            .iter_source_order()
             .map(|arg_or_keyword| match arg_or_keyword {
                 ast::ArgOrKeyword::Arg(arg) => match arg {
                     ast::Expr::Starred(ast::ExprStarred { value, .. }) => {
@@ -152,7 +152,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         mut infer_argument_type: impl FnMut(&ast::Expr) -> Type<'db>,
     ) -> Self {
         arguments
-            .arguments_source_order()
+            .iter_source_order()
             .map(|arg_or_keyword| match arg_or_keyword {
                 ast::ArgOrKeyword::Arg(arg) => match arg {
                     ast::Expr::Starred(ast::ExprStarred { value, .. }) => {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -6096,7 +6096,7 @@ impl<'db> BindingError<'db> {
             (ast::AnyNodeRef::ExprCall(call_node), Some(argument_index)) => Some(
                 call_node
                     .arguments
-                    .arguments_source_order()
+                    .iter_source_order()
                     .nth(argument_index)
                     .expect("argument index should not be out of range"),
             ),

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4464,7 +4464,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let iter = itertools::izip!(
             arguments.iter_mut(),
             argument_forms.iter().copied(),
-            ast_arguments.arguments_source_order()
+            ast_arguments.iter_source_order()
         );
 
         for ((_, argument_types), argument_form, ast_argument) in iter {
@@ -8958,7 +8958,7 @@ enum ArgumentsIter<'a> {
 
 impl<'a> ArgumentsIter<'a> {
     fn from_ast(arguments: &'a ast::Arguments) -> Self {
-        Self::FromAst(arguments.arguments_source_order())
+        Self::FromAst(arguments.iter_source_order())
     }
 
     fn synthesized(arguments: &'a [ArgOrKeyword<'a>]) -> Self {


### PR DESCRIPTION
## Summary

Rename `arguments_source_order` to `iter_source_order` because it avoids repeating the word `arguments` at the call site (`arguments.arguments_source_order` vs `arguments.iter_source_order()`). 
It also is more consistent with the standard `iter`, `iter_mut`, ... methods. 

And the same for `patterns_source_order`.

## Test Plan

`cargo test`
