### PR TITLE
[ty] Use `map`, not `__map`, as the name of the mapping parameter in `TypedDict` `__init__` methods

### DIFF
--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -1252,7 +1252,7 @@ mod tests {
 
         assert_snapshot!(test.hover(), @r#"
         class Movie(
-            __map: Movie,
+            map: Movie,
             /,
             *,
             title: str = ...,
@@ -1261,7 +1261,7 @@ mod tests {
         ---------------------------------------------
         ```python
         class Movie(
-            __map: Movie,
+            map: Movie,
             /,
             *,
             title: str = ...,
@@ -1298,7 +1298,7 @@ mod tests {
 
         assert_snapshot!(test.hover(), @r#"
         class Movie(
-            __map: Movie,
+            map: Movie,
             /,
             *,
             title: str = ...,
@@ -1307,7 +1307,7 @@ mod tests {
         ---------------------------------------------
         ```python
         class Movie(
-            __map: Movie,
+            map: Movie,
             /,
             *,
             title: str = ...,

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -52,7 +52,7 @@ keys into invalid named parameters:
 from typing import TypedDict
 
 Config = TypedDict("Config", {"in": int, "x-y": str, "ok": int})
-# revealed: Overload[(self: Config, __map: Config, /, *, ok: int = ..., **kwargs) -> None, (self: Config, /, *, ok: int, **kwargs) -> None]
+# revealed: Overload[(self: Config, map: Config, /, *, ok: int = ..., **kwargs) -> None, (self: Config, /, *, ok: int, **kwargs) -> None]
 reveal_type(Config.__init__)
 ```
 

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -107,8 +107,8 @@ fn synthesize_typed_dict_init<'db>(
     let self_param =
         Parameter::positional_only(Some(Name::new_static("self"))).with_annotated_type(instance_ty);
 
-    let map_param = Parameter::positional_only(Some(Name::new_static("__map")))
-        .with_annotated_type(instance_ty);
+    let map_param =
+        Parameter::positional_only(Some(Name::new_static("map"))).with_annotated_type(instance_ty);
 
     let params_with_default = keyword_fields.iter().map(|(name, field)| {
         Parameter::keyword_only((*name).clone())


### PR DESCRIPTION
## Summary

`__map` feels like a reference to the pre-PEP-570 convention for specifying positional-only parameters. But this parameter is already clearly denoted as positional-only without that, because of the fact that it appears before the `/` in the parameter list. I think `map` is a clearer name here

## Test Plan

mdtests and snapshots updated
