### PR TITLE
fix(pydoclint): suppress DOC201 for generators with only bare/None returns

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
@@ -216,8 +216,9 @@ class Spam:
         return cls()
 
 
-# DOC201 - OK (generator with only bare return; no Returns section needed)
-def generator_bare_return(x: int):
+# DOC201 - OK (generator with only bare return; Iterable annotation is not Iterator/Generator)
+# Regression test for https://github.com/astral-sh/ruff/issues/21336
+def generator_bare_return(x: int) -> Iterable[int]:
     """Yield integers up to x.
 
     Args:
@@ -228,8 +229,8 @@ def generator_bare_return(x: int):
     return
 
 
-# DOC201 - OK (generator with explicit return None; no Returns section needed)
-def generator_explicit_none(x: int):
+# DOC201 - OK (generator with explicit return None; same annotation)
+def generator_explicit_none(x: int) -> Iterable[int]:
     """Yield integers up to x.
 
     Args:

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
@@ -214,3 +214,27 @@ class Spam:
     def __new__(cls) -> 'Spam':
         """New!!"""
         return cls()
+
+
+# DOC201 - OK (generator with only bare return; no Returns section needed)
+def generator_bare_return(x: int):
+    """Yield integers up to x.
+
+    Args:
+        x (int): Upper bound.
+    """
+    for i in range(x):
+        yield i
+    return
+
+
+# DOC201 - OK (generator with explicit return None; no Returns section needed)
+def generator_explicit_none(x: int):
+    """Yield integers up to x.
+
+    Args:
+        x (int): Upper bound.
+    """
+    for i in range(x):
+        yield i
+    return None

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_numpy.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_numpy.py
@@ -234,3 +234,31 @@ def generator_function_4():
 def not_a_generator() -> Iterator[int]:
     """"No returns documented here, oh no"""
     return (x for x in range(42))
+
+
+# DOC201 - OK (generator with only bare return; no Returns section needed)
+def generator_bare_return(x: int):
+    """Yield integers up to x.
+
+    Parameters
+    ----------
+    x : int
+        Upper bound.
+    """
+    for i in range(x):
+        yield i
+    return
+
+
+# DOC201 - OK (generator with explicit return None; no Returns section needed)
+def generator_explicit_none(x: int):
+    """Yield integers up to x.
+
+    Parameters
+    ----------
+    x : int
+        Upper bound.
+    """
+    for i in range(x):
+        yield i
+    return None

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_numpy.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_numpy.py
@@ -236,8 +236,9 @@ def not_a_generator() -> Iterator[int]:
     return (x for x in range(42))
 
 
-# DOC201 - OK (generator with only bare return; no Returns section needed)
-def generator_bare_return(x: int):
+# DOC201 - OK (generator with only bare return; Iterable annotation is not Iterator/Generator)
+# Regression test for https://github.com/astral-sh/ruff/issues/21336
+def generator_bare_return(x: int) -> Iterable[int]:
     """Yield integers up to x.
 
     Parameters
@@ -250,8 +251,8 @@ def generator_bare_return(x: int):
     return
 
 
-# DOC201 - OK (generator with explicit return None; no Returns section needed)
-def generator_explicit_none(x: int):
+# DOC201 - OK (generator with explicit return None; same annotation)
+def generator_explicit_none(x: int) -> Iterable[int]:
     """Yield integers up to x.
 
     Parameters

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -1287,6 +1287,13 @@ pub(crate) fn check_docstring(
                                     returns,
                                     semantic,
                                 )
+                                && !(
+                                    !body_entries.yields.is_empty()
+                                        && body_entries
+                                            .returns
+                                            .iter()
+                                            .all(ReturnEntry::is_none_return)
+                                )
                             {
                                 checker
                                     .report_diagnostic(DocstringMissingReturns, docstring.range());


### PR DESCRIPTION
## summary

fixes #21336
generator functions that only have bare/None returns were getting flagged with DOC201. a bare `return` in a generator signals end of iteration rather than a return value, so requiring a `Returns` section is a false positive
the fix skips DOC201 when the function has at least one `yield` and every `return` is bare or `return None`

## test plan

added fixture cases in `DOC201_google.py` and `DOC201_numpy.py` for generators annotated `-> Iterable[int]` ending with bare/None returns