### PR TITLE
[ty] Add snapshots for `__init_subclass__` diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -516,12 +516,11 @@ with Child().create() as child:
 
 ### `__init_subclass__`
 
-The [`__init_subclass__`] method is implicitly a classmethod:
+#### Basics
 
-```toml
-[environment]
-python-version = "3.12"
-```
+<!-- snapshot-diagnostics -->
+
+The [`__init_subclass__`] method is implicitly a classmethod:
 
 ```py
 class Base:
@@ -554,10 +553,27 @@ class Valid(RequiresArg, arg=1): ...
 
 # error: [missing-argument]
 # error: [unknown-argument]
-class IncorrectArg(RequiresArg, not_arg="foo"): ...
+class IncorrectArg(RequiresArg, not_arg="foo"):
+    a = 1
+    b = 2
+    c = 3
+    d = 4
+    e = 5
+    f = 6
+    g = 7
+    h = 8
+    i = 9
+    j = 10
 ```
 
+#### Multiple inheritance
+
 For multiple inheritance, the first resolved `__init_subclass__` method is used.
+
+```toml
+[environment]
+python-version = "3.12"
+```
 
 ```py
 class Empty: ...

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_`__init_subclass__`_-_Basics_(a1fb03132e42b69e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_`__init_subclass__`_-_Basics_(a1fb03132e42b69e).snap
@@ -1,0 +1,159 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: methods.md - Methods - `@classmethod` - `__init_subclass__` - Basics
+mdtest path: crates/ty_python_semantic/resources/mdtest/call/methods.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | class Base:
+ 2 |     def __init_subclass__(cls, **kwargs):
+ 3 |         super().__init_subclass__(**kwargs)
+ 4 |         cls.custom_attribute: int = 0
+ 5 | 
+ 6 | class Derived(Base):
+ 7 |     pass
+ 8 | 
+ 9 | reveal_type(Derived.custom_attribute)  # revealed: int
+10 | class Empty: ...
+11 | 
+12 | class RequiresArg:
+13 |     def __init_subclass__(cls, arg: int): ...
+14 | 
+15 | class NoArg:
+16 |     def __init_subclass__(cls): ...
+17 | 
+18 | # Single-base definitions
+19 | class MissingArg(RequiresArg): ...  # error: [missing-argument]
+20 | class InvalidType(RequiresArg, arg="foo"): ...  # error: [invalid-argument-type]
+21 | class Valid(RequiresArg, arg=1): ...
+22 | 
+23 | # error: [missing-argument]
+24 | # error: [unknown-argument]
+25 | class IncorrectArg(RequiresArg, not_arg="foo"):
+26 |     a = 1
+27 |     b = 2
+28 |     c = 3
+29 |     d = 4
+30 |     e = 5
+31 |     f = 6
+32 |     g = 7
+33 |     h = 8
+34 |     i = 9
+35 |     j = 10
+```
+
+# Diagnostics
+
+```
+error[missing-argument]: No argument provided for required parameter `arg` of function `__init_subclass__`
+  --> src/mdtest_snippet.py:19:1
+   |
+18 | # Single-base definitions
+19 | class MissingArg(RequiresArg): ...  # error: [missing-argument]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+20 | class InvalidType(RequiresArg, arg="foo"): ...  # error: [invalid-argument-type]
+21 | class Valid(RequiresArg, arg=1): ...
+   |
+info: Parameter declared here
+  --> src/mdtest_snippet.py:13:32
+   |
+12 | class RequiresArg:
+13 |     def __init_subclass__(cls, arg: int): ...
+   |                                ^^^^^^^^
+14 |
+15 | class NoArg:
+   |
+
+```
+
+```
+error[invalid-argument-type]: Argument to function `__init_subclass__` is incorrect
+  --> src/mdtest_snippet.py:20:1
+   |
+18 | # Single-base definitions
+19 | class MissingArg(RequiresArg): ...  # error: [missing-argument]
+20 | class InvalidType(RequiresArg, arg="foo"): ...  # error: [invalid-argument-type]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["foo"]`
+21 | class Valid(RequiresArg, arg=1): ...
+   |
+info: Function defined here
+  --> src/mdtest_snippet.py:13:9
+   |
+12 | class RequiresArg:
+13 |     def __init_subclass__(cls, arg: int): ...
+   |         ^^^^^^^^^^^^^^^^^      -------- Parameter declared here
+14 |
+15 | class NoArg:
+   |
+
+```
+
+```
+error[missing-argument]: No argument provided for required parameter `arg` of function `__init_subclass__`
+  --> src/mdtest_snippet.py:25:1
+   |
+23 |   # error: [missing-argument]
+24 |   # error: [unknown-argument]
+25 | / class IncorrectArg(RequiresArg, not_arg="foo"):
+26 | |     a = 1
+27 | |     b = 2
+28 | |     c = 3
+29 | |     d = 4
+30 | |     e = 5
+31 | |     f = 6
+32 | |     g = 7
+33 | |     h = 8
+34 | |     i = 9
+35 | |     j = 10
+   | |__________^
+   |
+info: Parameter declared here
+  --> src/mdtest_snippet.py:13:32
+   |
+12 | class RequiresArg:
+13 |     def __init_subclass__(cls, arg: int): ...
+   |                                ^^^^^^^^
+14 |
+15 | class NoArg:
+   |
+
+```
+
+```
+error[unknown-argument]: Argument `not_arg` does not match any known parameter of function `__init_subclass__`
+  --> src/mdtest_snippet.py:25:1
+   |
+23 |   # error: [missing-argument]
+24 |   # error: [unknown-argument]
+25 | / class IncorrectArg(RequiresArg, not_arg="foo"):
+26 | |     a = 1
+27 | |     b = 2
+28 | |     c = 3
+29 | |     d = 4
+30 | |     e = 5
+31 | |     f = 6
+32 | |     g = 7
+33 | |     h = 8
+34 | |     i = 9
+35 | |     j = 10
+   | |__________^
+   |
+info: Function signature here
+  --> src/mdtest_snippet.py:13:9
+   |
+12 | class RequiresArg:
+13 |     def __init_subclass__(cls, arg: int): ...
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+14 |
+15 | class NoArg:
+   |
+
+```


### PR DESCRIPTION
## Summary

If you pass incorrect keyword arguments when creating a class, we emit a diagnostic for the bad implicit call to `__init_subclass__`. That's great, except the range of this diagnostic is currently the whole class node, which can be huge if the class has lots of statements in it (most classes do).

This PR adds some snapshots that demonstrate this issue. I'll improve the diagnostic range in a followup PR after the baseline has been established in our test suite.
