### PR TITLE
[ty] Check inherited `NamedTuple` field conflicts

### DIFF
--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -8,7 +8,7 @@
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22abstract-method-in-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2404" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2439" target="_blank">View source</a>
 </small>
 
 
@@ -49,7 +49,7 @@ class Derived(Base):  # Error: `Derived` does not implement `method`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-protocol-member%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L655" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L656" target="_blank">View source</a>
 </small>
 
 
@@ -90,7 +90,7 @@ class SubProto(BaseProto, Protocol):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22assert-type-unspellable-subtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2540" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2575" target="_blank">View source</a>
 </small>
 
 
@@ -126,7 +126,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Preview (since <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a>) ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-abstract-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2439" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2474" target="_blank">View source</a>
 </small>
 
 
@@ -175,7 +175,7 @@ Foo.method()  # Error: cannot call abstract classmethod
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-non-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L171" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L172" target="_blank">View source</a>
 </small>
 
 
@@ -199,7 +199,7 @@ Calling a non-callable object will raise a `TypeError` at runtime.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.7">0.0.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-top-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L189" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L190" target="_blank">View source</a>
 </small>
 
 
@@ -230,7 +230,7 @@ def f(x: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-argument-forms%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L240" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L241" target="_blank">View source</a>
 </small>
 
 
@@ -262,7 +262,7 @@ f(int)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-declarations%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L266" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L267" target="_blank">View source</a>
 </small>
 
 
@@ -293,7 +293,7 @@ a = 1
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L291" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L292" target="_blank">View source</a>
 </small>
 
 
@@ -325,7 +325,7 @@ class C(A, B): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-class-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L317" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L318" target="_blank">View source</a>
 </small>
 
 
@@ -357,7 +357,7 @@ class B(A): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-type-alias-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L343" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L344" target="_blank">View source</a>
 </small>
 
 
@@ -385,7 +385,7 @@ type B = A
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22dataclass-field-order%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L461" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L462" target="_blank">View source</a>
 </small>
 
 
@@ -417,7 +417,7 @@ class Example:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.16">0.0.1-alpha.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22deprecated%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L387" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L388" target="_blank">View source</a>
 </small>
 
 
@@ -444,7 +444,7 @@ old_func()  # emits [deprecated] diagnostic
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22division-by-zero%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L365" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L366" target="_blank">View source</a>
 </small>
 
 
@@ -473,7 +473,7 @@ false positives it can produce.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L408" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L409" target="_blank">View source</a>
 </small>
 
 
@@ -500,7 +500,7 @@ class B(A, A): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-kw-only%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L429" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L430" target="_blank">View source</a>
 </small>
 
 
@@ -538,7 +538,7 @@ class A:  # Crash at runtime
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22empty-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L969" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1004" target="_blank">View source</a>
 </small>
 
 
@@ -609,7 +609,7 @@ def foo() -> "intt\b": ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-on-non-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2351" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2386" target="_blank">View source</a>
 </small>
 
 
@@ -641,7 +641,7 @@ def my_function() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-without-value%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2377" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2412" target="_blank">View source</a>
 </small>
 
 
@@ -736,7 +736,7 @@ def test(): -> "Literal[5]":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22inconsistent-mro%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L738" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L773" target="_blank">View source</a>
 </small>
 
 
@@ -766,7 +766,7 @@ class C(A, B): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22index-out-of-bounds%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L762" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L797" target="_blank">View source</a>
 </small>
 
 
@@ -792,7 +792,7 @@ t[3]  # IndexError: tuple index out of range
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.33">0.0.1-alpha.33</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ineffective-final%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2323" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2358" target="_blank">View source</a>
 </small>
 
 
@@ -826,7 +826,7 @@ class MyClass: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22instance-layout-conflict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L544" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L545" target="_blank">View source</a>
 </small>
 
 
@@ -915,7 +915,7 @@ an atypical memory layout.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-argument-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L900" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L935" target="_blank">View source</a>
 </small>
 
 
@@ -942,7 +942,7 @@ func("foo")  # error: [invalid-argument-type]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-assignment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1009" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1044" target="_blank">View source</a>
 </small>
 
 
@@ -970,7 +970,7 @@ a: int = ''
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-attribute-access%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2869" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2904" target="_blank">View source</a>
 </small>
 
 
@@ -1004,7 +1004,7 @@ C.instance_var = 3  # error: Cannot assign to instance variable
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-await%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1031" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1066" target="_blank">View source</a>
 </small>
 
 
@@ -1040,7 +1040,7 @@ asyncio.run(main())
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1061" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1096" target="_blank">View source</a>
 </small>
 
 
@@ -1064,7 +1064,7 @@ class A(42): ...  # error: [invalid-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-context-manager%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1145" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1180" target="_blank">View source</a>
 </small>
 
 
@@ -1091,7 +1091,7 @@ with 1:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L513" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L514" target="_blank">View source</a>
 </small>
 
 
@@ -1128,7 +1128,7 @@ class Foo(NamedTuple):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L487" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L488" target="_blank">View source</a>
 </small>
 
 
@@ -1160,7 +1160,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-declaration%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1166" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1201" target="_blank">View source</a>
 </small>
 
 
@@ -1189,7 +1189,7 @@ a: str
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-enum-member-annotation%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1225" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1260" target="_blank">View source</a>
 </small>
 
 
@@ -1238,7 +1238,7 @@ class Pet(Enum):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-exception-caught%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1189" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1224" target="_blank">View source</a>
 </small>
 
 
@@ -1282,7 +1282,7 @@ except ZeroDivisionError:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.28">0.0.1-alpha.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-explicit-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2482" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2517" target="_blank">View source</a>
 </small>
 
 
@@ -1324,7 +1324,7 @@ class D(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.35">0.0.1-alpha.35</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-frozen-dataclass-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3227" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3262" target="_blank">View source</a>
 </small>
 
 
@@ -1368,7 +1368,7 @@ class NonFrozenChild(FrozenBase):  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1309" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1344" target="_blank">View source</a>
 </small>
 
 
@@ -1406,7 +1406,7 @@ class D(Generic[U, T]): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-enum%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1267" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1302" target="_blank">View source</a>
 </small>
 
 
@@ -1485,7 +1485,7 @@ a = 20 / 0  # type: ignore
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.17">0.0.1-alpha.17</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L783" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L818" target="_blank">View source</a>
 </small>
 
 
@@ -1524,7 +1524,7 @@ carol = Person(name="Carol", aeg=25)  # typo!
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-positional-parameter%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3305" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3340" target="_blank">View source</a>
 </small>
 
 
@@ -1585,7 +1585,7 @@ def f(x, y, /):  # Python 3.8+ syntax
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1366" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1401" target="_blank">View source</a>
 </small>
 
 
@@ -1620,7 +1620,7 @@ def f(t: TypeVar("U")): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-match-pattern%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1770" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1805" target="_blank">View source</a>
 </small>
 
 
@@ -1648,7 +1648,7 @@ match x:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1494" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1529" target="_blank">View source</a>
 </small>
 
 
@@ -1682,7 +1682,7 @@ class B(metaclass=f): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-method-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3129" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3164" target="_blank">View source</a>
 </small>
 
 
@@ -1789,7 +1789,7 @@ Correct use of `@override` is enforced by ty's [`invalid-explicit-override`](#in
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-named-tuple%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L690" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L691" target="_blank">View source</a>
 </small>
 
 
@@ -1837,13 +1837,54 @@ without a type annotation will raise an `AttributeError` at runtime.
 AttributeError: Cannot overwrite NamedTuple attribute _asdict
 ```
 
+## `invalid-named-tuple-override`
+
+<small>
+Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
+Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.31">0.0.31</a> ·
+<a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-named-tuple-override%22" target="_blank">Related issues</a> ·
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L739" target="_blank">View source</a>
+</small>
+
+
+**What it does**
+
+Checks for subclass members that override inherited `NamedTuple` fields.
+
+**Why is this bad?**
+
+Reusing an inherited `NamedTuple` field name in a subclass creates a
+class where tuple indexing and `repr()` still reflect the original
+field, while attribute access follows the subclass member.
+
+**Default level**
+
+This rule is a warning by default because these overrides do not make
+the class invalid at runtime.
+
+**Examples**
+
+```python
+from typing import NamedTuple
+
+class User(NamedTuple):
+    name: str
+
+class Admin(User):
+    name = "shadowed"  # error: [invalid-named-tuple-override]
+
+admin = Admin("Alice")
+admin.name  # "shadowed"
+admin[0]  # "Alice"
+```
+
 ## `invalid-newtype`
 
 <small>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.27">0.0.1-alpha.27</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-newtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1439" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1474" target="_blank">View source</a>
 </small>
 
 
@@ -1873,7 +1914,7 @@ Baz = NewType("Baz", int | str)  # error: invalid base for `typing.NewType`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1521" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1556" target="_blank">View source</a>
 </small>
 
 
@@ -1923,7 +1964,7 @@ def foo(x: int) -> int: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-parameter-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1620" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1655" target="_blank">View source</a>
 </small>
 
 
@@ -1949,7 +1990,7 @@ def f(a: int = ''): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-paramspec%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1394" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1429" target="_blank">View source</a>
 </small>
 
 
@@ -1980,7 +2021,7 @@ P2 = ParamSpec("S2")  # error: ParamSpec name must match the variable it's assig
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L626" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L627" target="_blank">View source</a>
 </small>
 
 
@@ -2014,7 +2055,7 @@ TypeError: Protocols can only inherit from other protocols, got <class 'int'>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-raise%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1640" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1675" target="_blank">View source</a>
 </small>
 
 
@@ -2063,7 +2104,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-return-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L921" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L956" target="_blank">View source</a>
 </small>
 
 
@@ -2092,7 +2133,7 @@ def func() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-super-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1683" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1718" target="_blank">View source</a>
 </small>
 
 
@@ -2188,7 +2229,7 @@ class C: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.10">0.0.10</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-total-ordering%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3265" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3300" target="_blank">View source</a>
 </small>
 
 
@@ -2234,7 +2275,7 @@ class MyClass:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.6">0.0.1-alpha.6</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-alias-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1418" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1453" target="_blank">View source</a>
 </small>
 
 
@@ -2261,7 +2302,7 @@ NewAlias = TypeAliasType(get_name(), int)        # error: TypeAliasType name mus
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2030" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2065" target="_blank">View source</a>
 </small>
 
 
@@ -2308,7 +2349,7 @@ Bar[int]  # error: too few arguments
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-checking-constant%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1722" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1757" target="_blank">View source</a>
 </small>
 
 
@@ -2338,7 +2379,7 @@ TYPE_CHECKING = ''
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-form%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1746" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1781" target="_blank">View source</a>
 </small>
 
 
@@ -2368,7 +2409,7 @@ b: Annotated[int]  # `Annotated` expects at least two arguments
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-guard-call%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1820" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1855" target="_blank">View source</a>
 </small>
 
 
@@ -2402,7 +2443,7 @@ f(10)  # Error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-guard-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1792" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1827" target="_blank">View source</a>
 </small>
 
 
@@ -2436,7 +2477,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-bound%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1889" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1924" target="_blank">View source</a>
 </small>
 
 
@@ -2467,7 +2508,7 @@ def g[U, T: U](): ...  # error: [invalid-type-variable-bound]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-constraints%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1848" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1883" target="_blank">View source</a>
 </small>
 
 
@@ -2514,7 +2555,7 @@ U = TypeVar('U', list[int], int)  # valid constrained Type
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1914" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1949" target="_blank">View source</a>
 </small>
 
 
@@ -2546,7 +2587,7 @@ U = TypeVar("U", int, str, default=bytes)  # error: [invalid-type-variable-defau
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.28">0.0.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-field%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3075" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3110" target="_blank">View source</a>
 </small>
 
 
@@ -2577,7 +2618,7 @@ class Child(Base):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-header%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3100" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3135" target="_blank">View source</a>
 </small>
 
 
@@ -2612,7 +2653,7 @@ def f(x: dict):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.9">0.0.9</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-statement%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3050" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3085" target="_blank">View source</a>
 </small>
 
 
@@ -2643,7 +2684,7 @@ class Foo(TypedDict):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.25">0.0.25</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-yield%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L944" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L979" target="_blank">View source</a>
 </small>
 
 
@@ -2674,7 +2715,7 @@ def gen() -> Iterator[int]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L816" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L851" target="_blank">View source</a>
 </small>
 
 
@@ -2729,7 +2770,7 @@ def h(arg2: type):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-typed-dict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L864" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L899" target="_blank">View source</a>
 </small>
 
 
@@ -2772,7 +2813,7 @@ def g(arg: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22mismatched-type-name%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1463" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1498" target="_blank">View source</a>
 </small>
 
 
@@ -2810,7 +2851,7 @@ Movie = TypedDict("Film", {"title": str})  # error: [mismatched-type-name]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1970" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2005" target="_blank">View source</a>
 </small>
 
 
@@ -2835,7 +2876,7 @@ func()  # TypeError: func() missing 1 required positional argument: 'x'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-typed-dict-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3023" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3058" target="_blank">View source</a>
 </small>
 
 
@@ -2868,7 +2909,7 @@ alice["age"]  # KeyError
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22no-matching-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1989" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2024" target="_blank">View source</a>
 </small>
 
 
@@ -2897,7 +2938,7 @@ func("string")  # error: [no-matching-overload]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22non-callable-init-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1340" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1375" target="_blank">View source</a>
 </small>
 
 
@@ -2930,7 +2971,7 @@ class Sub(Super): ...  # error: [non-callable-init-subclass]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-iterable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2071" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2106" target="_blank">View source</a>
 </small>
 
 
@@ -2956,7 +2997,7 @@ for i in 34:  # TypeError: 'int' object is not iterable
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-subscriptable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2012" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2047" target="_blank">View source</a>
 </small>
 
 
@@ -2980,7 +3021,7 @@ Subscripting an object that does not support it will raise a `TypeError` at runt
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2269" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2304" target="_blank">View source</a>
 </small>
 
 
@@ -3013,7 +3054,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2296" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2331" target="_blank">View source</a>
 </small>
 
 
@@ -3046,7 +3087,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22parameter-already-assigned%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2122" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2157" target="_blank">View source</a>
 </small>
 
 
@@ -3073,7 +3114,7 @@ f(1, x=2)  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22positional-only-parameter-as-kwarg%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2696" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2731" target="_blank">View source</a>
 </small>
 
 
@@ -3100,7 +3141,7 @@ f(x=1)  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2143" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2178" target="_blank">View source</a>
 </small>
 
 
@@ -3133,7 +3174,7 @@ A.c  # AttributeError: type object 'A' has no attribute 'c'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-implicit-call%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L214" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L215" target="_blank">View source</a>
 </small>
 
 
@@ -3165,7 +3206,7 @@ A()[0]  # TypeError: 'A' object is not subscriptable
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2190" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2225" target="_blank">View source</a>
 </small>
 
 
@@ -3202,7 +3243,7 @@ from module import a  # ImportError: cannot import name 'a' from 'module'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.23">0.0.23</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-submodule%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2169" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2204" target="_blank">View source</a>
 </small>
 
 
@@ -3229,7 +3270,7 @@ html.parser  # AttributeError: module 'html' has no attribute 'parser'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2220" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2255" target="_blank">View source</a>
 </small>
 
 
@@ -3293,7 +3334,7 @@ def test(): -> "int":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-cast%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2897" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2932" target="_blank">View source</a>
 </small>
 
 
@@ -3320,7 +3361,7 @@ cast(int, f())  # Redundant
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-final-classvar%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2918" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2953" target="_blank">View source</a>
 </small>
 
 
@@ -3352,7 +3393,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22shadowed-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2944" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2979" target="_blank">View source</a>
 </small>
 
 
@@ -3386,7 +3427,7 @@ class Outer[T]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22static-assert-error%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2845" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2880" target="_blank">View source</a>
 </small>
 
 
@@ -3416,7 +3457,7 @@ static_assert(int(2.0 * 3.0) == 6)  # error: does not have a statically known tr
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2246" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2281" target="_blank">View source</a>
 </small>
 
 
@@ -3445,7 +3486,7 @@ class B(A): ...  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.30">0.0.1-alpha.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22super-call-in-named-tuple-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2630" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2665" target="_blank">View source</a>
 </small>
 
 
@@ -3479,7 +3520,7 @@ class F(NamedTuple):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22too-many-positional-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2570" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2605" target="_blank">View source</a>
 </small>
 
 
@@ -3506,7 +3547,7 @@ f("foo")  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22type-assertion-failure%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2518" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2553" target="_blank">View source</a>
 </small>
 
 
@@ -3534,7 +3575,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unavailable-implicit-super-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2591" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2626" target="_blank">View source</a>
 </small>
 
 
@@ -3580,7 +3621,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unbound-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1940" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1975" target="_blank">View source</a>
 </small>
 
 
@@ -3617,7 +3658,7 @@ class C(Generic[T]):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22undefined-reveal%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2657" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2692" target="_blank">View source</a>
 </small>
 
 
@@ -3641,7 +3682,7 @@ reveal_type(1)  # NameError: name 'reveal_type' is not defined
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unknown-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2675" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2710" target="_blank">View source</a>
 </small>
 
 
@@ -3668,7 +3709,7 @@ f(x=1, y=2)  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2717" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2752" target="_blank">View source</a>
 </small>
 
 
@@ -3696,7 +3737,7 @@ A().foo  # AttributeError: 'A' object has no attribute 'foo'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.15">0.0.1-alpha.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-global%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2971" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3006" target="_blank">View source</a>
 </small>
 
 
@@ -3754,7 +3795,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2739" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2774" target="_blank">View source</a>
 </small>
 
 
@@ -3779,7 +3820,7 @@ import foo  # ModuleNotFoundError: No module named 'foo'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2758" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2793" target="_blank">View source</a>
 </small>
 
 
@@ -3804,7 +3845,7 @@ print(x)  # NameError: name 'x' is not defined
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.7">0.0.1-alpha.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1079" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1114" target="_blank">View source</a>
 </small>
 
 
@@ -3843,7 +3884,7 @@ class D(C): ...  # error: [unsupported-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-bool-conversion%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2091" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2126" target="_blank">View source</a>
 </small>
 
 
@@ -3880,7 +3921,7 @@ b1 < b2 < b1  # exception raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-dynamic-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1112" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1147" target="_blank">View source</a>
 </small>
 
 
@@ -3920,7 +3961,7 @@ def factory(base: type[Base]) -> type:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-operator%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2777" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2812" target="_blank">View source</a>
 </small>
 
 
@@ -3948,7 +3989,7 @@ A() + A()  # TypeError: unsupported operand type(s) for +: 'A' and 'A'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Preview (since <a href="https://github.com/astral-sh/ty/releases/tag/0.0.21">0.0.21</a>) ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-awaitable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2799" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2834" target="_blank">View source</a>
 </small>
 
 
@@ -4054,7 +4095,7 @@ to `false`.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22useless-overload-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1564" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1599" target="_blank">View source</a>
 </small>
 
 
@@ -4117,7 +4158,7 @@ def foo(x: int | str) -> int | str:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22zero-stepsize-in-slice%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2826" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2861" target="_blank">View source</a>
 </small>
 
 

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -1129,8 +1129,23 @@ class TypingChild(TypingBase):
     id: int = 0
 ```
 
-Once an earlier base has already overridden the name, we do not emit a second conflict for later
-subclasses:
+The same check applies through deeper inheritance chains:
+
+```py
+from typing import NamedTuple
+
+class Base(NamedTuple):
+    name: str
+
+class Intermediate(Base):
+    unrelated: bytes
+
+class Sub(Intermediate):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `name` inherited from `Base`"
+    name: int
+```
+
+Later subclasses still get their own conflict if an earlier base has already overridden the name:
 
 ```py
 from typing import NamedTuple
@@ -1142,6 +1157,7 @@ class ShadowingMid(ShadowTupleBase):
     name = "shadowed"
 
 class ShadowedChild(ShadowingMid):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `name` inherited from `ShadowTupleBase`"
     name: int
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -1067,8 +1067,8 @@ reveal_type(alice.level)  # revealed: int
 alice = SuperUser(1, "Alice", 3)
 ```
 
-Bare annotated subclass fields may not reuse `NamedTuple` field names from the base class, but
-ordinary bound overrides still work:
+Annotated subclass fields may not reuse `NamedTuple` field names from the base class, whether or not
+they also bind a value:
 
 ```py
 from typing import NamedTuple
@@ -1083,24 +1083,112 @@ class SuperUser(User):
     level: int
 
     # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `User`"
-    id: int
+    id: int = 0
 
-    name: str = "foo"
+    title: str = "staff"
 
     @property
-    def age(self) -> int:
+    def display_age(self) -> int:
         return super().age or 42
 
 james = SuperUser(0, "James", 42, "Jimmy")
-reveal_type(james.age)  # revealed: int
+reveal_type(james.display_age)  # revealed: int
 
-james.name = "Bob"
+james.title = "Boss"
 
 # error: [invalid-assignment] "Cannot assign to read-only property `nickname` on object of type `SuperUser`"
 james.nickname = "Bob"
 ```
 
-Writable descriptor-valued shadows are allowed:
+Plain assignments on the same class are also rejected:
+
+```py
+from typing import NamedTuple
+
+class PlainAssignmentBase(NamedTuple):
+    name: str
+
+class PlainAssignmentChild(PlainAssignmentBase):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `name` inherited from `PlainAssignmentBase`"
+    name = "shadowed"
+```
+
+Other class-body redefinitions on the same class are also rejected:
+
+```py
+from typing import NamedTuple
+
+value = 0
+
+class NonAssignmentBase(NamedTuple):
+    id: int
+    name: str
+    value: int
+
+class MethodChild(NonAssignmentBase):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `NonAssignmentBase`"
+    def id(self) -> int:
+        return 0
+
+class PropertyChild(NonAssignmentBase):
+    @property
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `name` inherited from `NonAssignmentBase`"
+    def name(self) -> str:
+        return "shadowed"
+
+class AugmentedAssignmentChild(NonAssignmentBase):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `value` inherited from `NonAssignmentBase`"
+    value += 1
+```
+
+Conditional redefinitions are rejected if the name may still be present at the end of the class
+body, but later-deleted redefinitions are ignored:
+
+```py
+from typing import NamedTuple
+
+def coinflip() -> bool:
+    return True
+
+class VanishingBase(NamedTuple):
+    id: int
+
+class ConditionalDeclarationChild(VanishingBase):
+    if coinflip():
+        # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `VanishingBase`"
+        id: int
+
+class ConditionalAssignmentChild(VanishingBase):
+    if coinflip():
+        # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `VanishingBase`"
+        id = 1
+
+class ConditionalMethodChild(VanishingBase):
+    if coinflip():
+        # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `VanishingBase`"
+        def id(self) -> int:
+            return 0
+
+class DeletedAssignmentChild(VanishingBase):
+    id = 1
+    del id
+```
+
+Split declaration and binding pairs are only diagnosed once:
+
+```py
+from typing import NamedTuple
+
+class SplitBase(NamedTuple):
+    id: int
+
+class SplitChild(SplitBase):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `SplitBase`"
+    id: int
+    id = 0
+```
+
+Descriptor-valued annotated shadows on the same class are also rejected:
 
 ```py
 from typing import Any, NamedTuple
@@ -1109,26 +1197,23 @@ class WritableDescriptorBase(NamedTuple):
     data: int
 
 class WritableDescriptorChild(WritableDescriptorBase):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `data` inherited from `WritableDescriptorBase`"
     data: Any = property(lambda self: 0, lambda self, value: None)
+```
+
+An earlier base that already defines a writable descriptor still stops the conflict check:
+
+```py
+from typing import NamedTuple
+
+class WritableDescriptorBase(NamedTuple):
+    data: int
 
 class WritableDescriptorMixin:
     data = property(lambda self: 0, lambda self, value: None)
 
 class WritableMixinChild(WritableDescriptorMixin, WritableDescriptorBase):
     data: int
-```
-
-Read-only descriptor-valued bound overrides are still rejected:
-
-```py
-from typing import Any, NamedTuple
-
-class ReadOnlyDescriptorBase(NamedTuple):
-    data: int
-
-class ReadOnlyDescriptorChild(ReadOnlyDescriptorBase):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `data` inherited from `ReadOnlyDescriptorBase`"
-    data: Any = property(lambda self: 0)
 ```
 
 The same conflict check applies when the inherited `NamedTuple` comes from the functional forms:
@@ -1157,13 +1242,14 @@ from typing import NamedTuple
 ShadowTupleBase = NamedTuple("ShadowTupleBase", [("name", str)])
 
 class ShadowingMid(ShadowTupleBase):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `name` inherited from `ShadowTupleBase`"
     name = "shadowed"
 
 class ShadowedChild(ShadowingMid):
     name: int
 ```
 
-An annotation-only base does not stop the conflict check:
+An earlier base that declares the name also stops the conflict check:
 
 ```py
 from typing import NamedTuple
@@ -1175,11 +1261,10 @@ class AnnotationTupleBase(NamedTuple):
     key: int
 
 class AnnotationOnlyChild(AnnotationOnlyMixin, AnnotationTupleBase):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `key` inherited from `AnnotationTupleBase`"
     key: int
 ```
 
-A read-only descriptor in an earlier base does not stop the conflict check:
+A read-only descriptor in an earlier base also stops the conflict check:
 
 ```py
 from typing import NamedTuple
@@ -1191,11 +1276,10 @@ class DescriptorTupleBase(NamedTuple):
     field: int
 
 class DescriptorShadowChild(ReadOnlyMixin, DescriptorTupleBase):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `field` inherited from `DescriptorTupleBase`"
     field: int
 ```
 
-A conditionally bound earlier base also does not stop the conflict check:
+A statically false conditional binding in an earlier base does not stop the conflict check:
 
 ```py
 from typing import NamedTuple
@@ -1214,7 +1298,27 @@ class ConditionalShadowChild(MaybeShadowMixin, ConditionalTupleBase):
     value: int
 ```
 
-Mixed writable and read-only bindings in an earlier base do not stop the conflict check:
+An earlier base with a conditional binding that may still be present at the end of the class body
+does stop the conflict check:
+
+```py
+from typing import NamedTuple
+
+def coinflip() -> bool:
+    return True
+
+class MaybeShadowRuntimeMixin:
+    if coinflip():
+        value = 1
+
+class ConditionalRuntimeTupleBase(NamedTuple):
+    value: int
+
+class ConditionalRuntimeShadowChild(MaybeShadowRuntimeMixin, ConditionalRuntimeTupleBase):
+    value: int
+```
+
+Mixed bindings in an earlier base also stop the conflict check:
 
 ```py
 from typing import NamedTuple
@@ -1231,7 +1335,6 @@ class MixedShadowTupleBase(NamedTuple):
     data: int
 
 class MixedShadowChild(MixedShadowMixin, MixedShadowTupleBase):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `data` inherited from `MixedShadowTupleBase`"
     data: int
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -1082,26 +1082,26 @@ class User(NamedTuple):
     nickname: str
 
 class AnnotatedAttributeChild(User):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `User`"
+    # error: [invalid-named-tuple-override] "Cannot override NamedTuple field `id` inherited from `User`"
     id: int
 
 class AnnotatedDefaultChild(User):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `name` inherited from `User`"
+    # error: [invalid-named-tuple-override] "Cannot override NamedTuple field `name` inherited from `User`"
     name: str = "foo"
 
 class PropertyChild(User):
     @property
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `age` inherited from `User`"
+    # error: [invalid-named-tuple-override] "Cannot override NamedTuple field `age` inherited from `User`"
     def age(self) -> int:
         return super().age or 42
 
 class MethodChild(User):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `nickname` inherited from `User`"
+    # error: [invalid-named-tuple-override] "Cannot override NamedTuple field `nickname` inherited from `User`"
     def nickname(self) -> str:
         return "Bob"
 
 class PlainAssignmentChild(User):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `name` inherited from `User`"
+    # error: [invalid-named-tuple-override] "Cannot override NamedTuple field `name` inherited from `User`"
     name = "shadowed"
 
 class DistinctFieldChild(User):
@@ -1125,7 +1125,7 @@ from typing import NamedTuple
 TypingBase = NamedTuple("TypingBase", [("id", int)])
 
 class TypingChild(TypingBase):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `TypingBase`"
+    # error: [invalid-named-tuple-override] "Cannot override NamedTuple field `id` inherited from `TypingBase`"
     id: int = 0
 ```
 
@@ -1141,7 +1141,7 @@ class Intermediate(Base):
     unrelated: bytes
 
 class Sub(Intermediate):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `name` inherited from `Base`"
+    # error: [invalid-named-tuple-override] "Cannot override NamedTuple field `name` inherited from `Base`"
     name: int
 ```
 
@@ -1153,11 +1153,11 @@ from typing import NamedTuple
 ShadowTupleBase = NamedTuple("ShadowTupleBase", [("name", str)])
 
 class ShadowingMid(ShadowTupleBase):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `name` inherited from `ShadowTupleBase`"
+    # error: [invalid-named-tuple-override] "Cannot override NamedTuple field `name` inherited from `ShadowTupleBase`"
     name = "shadowed"
 
 class ShadowedChild(ShadowingMid):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `name` inherited from `ShadowTupleBase`"
+    # error: [invalid-named-tuple-override] "Cannot override NamedTuple field `name` inherited from `ShadowTupleBase`"
     name: int
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -1067,8 +1067,10 @@ reveal_type(alice.level)  # revealed: int
 alice = SuperUser(1, "Alice", 3)
 ```
 
-Annotated subclass fields may not reuse `NamedTuple` field names from the base class, whether or not
-they also bind a value:
+Any subclass member that reuses an inherited `NamedTuple` field name is rejected. This is a
+special-cased `NamedTuple` diagnostic rather than a Liskov-substitution check: at runtime, these
+overrides can make attribute access disagree with tuple indexing and `repr`, and modeling all of
+those split views precisely would add a lot of complexity for a pattern that is usually a mistake.
 
 ```py
 from typing import NamedTuple
@@ -1079,162 +1081,56 @@ class User(NamedTuple):
     age: int | None
     nickname: str
 
-class SuperUser(User):
-    level: int
-
+class AnnotatedAttributeChild(User):
     # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `User`"
-    id: int = 0
+    id: int
 
-    title: str = "staff"
+class AnnotatedDefaultChild(User):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `name` inherited from `User`"
+    name: str = "foo"
 
+class PropertyChild(User):
     @property
-    def display_age(self) -> int:
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `age` inherited from `User`"
+    def age(self) -> int:
         return super().age or 42
 
-james = SuperUser(0, "James", 42, "Jimmy")
-reveal_type(james.display_age)  # revealed: int
+class MethodChild(User):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `nickname` inherited from `User`"
+    def nickname(self) -> str:
+        return "Bob"
 
+class PlainAssignmentChild(User):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `name` inherited from `User`"
+    name = "shadowed"
+
+class DistinctFieldChild(User):
+    title: str = "staff"
+
+james = DistinctFieldChild(0, "James", 42, "Jimmy")
 james.title = "Boss"
 
-# error: [invalid-assignment] "Cannot assign to read-only property `nickname` on object of type `SuperUser`"
+# error: [invalid-assignment] "Cannot assign to read-only property `nickname` on object of type `DistinctFieldChild`"
 james.nickname = "Bob"
 ```
 
-Plain assignments on the same class are also rejected:
-
-```py
-from typing import NamedTuple
-
-class PlainAssignmentBase(NamedTuple):
-    name: str
-
-class PlainAssignmentChild(PlainAssignmentBase):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `name` inherited from `PlainAssignmentBase`"
-    name = "shadowed"
-```
-
-Other class-body redefinitions on the same class are also rejected:
-
-```py
-from typing import NamedTuple
-
-value = 0
-
-class NonAssignmentBase(NamedTuple):
-    id: int
-    name: str
-    value: int
-
-class MethodChild(NonAssignmentBase):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `NonAssignmentBase`"
-    def id(self) -> int:
-        return 0
-
-class PropertyChild(NonAssignmentBase):
-    @property
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `name` inherited from `NonAssignmentBase`"
-    def name(self) -> str:
-        return "shadowed"
-
-class AugmentedAssignmentChild(NonAssignmentBase):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `value` inherited from `NonAssignmentBase`"
-    value += 1
-```
-
-Conditional redefinitions are rejected if the name may still be present at the end of the class
-body, but later-deleted redefinitions are ignored:
-
-```py
-from typing import NamedTuple
-
-def coinflip() -> bool:
-    return True
-
-class VanishingBase(NamedTuple):
-    id: int
-
-class ConditionalDeclarationChild(VanishingBase):
-    if coinflip():
-        # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `VanishingBase`"
-        id: int
-
-class ConditionalAssignmentChild(VanishingBase):
-    if coinflip():
-        # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `VanishingBase`"
-        id = 1
-
-class ConditionalMethodChild(VanishingBase):
-    if coinflip():
-        # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `VanishingBase`"
-        def id(self) -> int:
-            return 0
-
-class DeletedAssignmentChild(VanishingBase):
-    id = 1
-    del id
-```
-
-Split declaration and binding pairs are only diagnosed once:
-
-```py
-from typing import NamedTuple
-
-class SplitBase(NamedTuple):
-    id: int
-
-class SplitChild(SplitBase):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `SplitBase`"
-    id: int
-    id = 0
-```
-
-Descriptor-valued annotated shadows on the same class are also rejected:
-
-```py
-from typing import Any, NamedTuple
-
-class WritableDescriptorBase(NamedTuple):
-    data: int
-
-class WritableDescriptorChild(WritableDescriptorBase):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `data` inherited from `WritableDescriptorBase`"
-    data: Any = property(lambda self: 0, lambda self, value: None)
-```
-
-An earlier base that already defines a writable descriptor still stops the conflict check:
-
-```py
-from typing import NamedTuple
-
-class WritableDescriptorBase(NamedTuple):
-    data: int
-
-class WritableDescriptorMixin:
-    data = property(lambda self: 0, lambda self, value: None)
-
-class WritableMixinChild(WritableDescriptorMixin, WritableDescriptorBase):
-    data: int
-```
+This broad rule also means we do not need to model cases where the subclass would expose one value
+through `obj.x` but a different value through `obj[0]` and `repr(obj)`.
 
 The same conflict check applies when the inherited `NamedTuple` comes from the functional forms:
 
 ```py
-from collections import namedtuple
 from typing import NamedTuple
 
-TypingBase = NamedTuple("TypingBase", [("id", int), ("name", str)])
-CollectionsBase = namedtuple("CollectionsBase", ["key", "value"])
+TypingBase = NamedTuple("TypingBase", [("id", int)])
 
 class TypingChild(TypingBase):
     # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `TypingBase`"
-    id: int
-
-class CollectionsChild(CollectionsBase):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `key` inherited from `CollectionsBase`"
-    key: int
+    id: int = 0
 ```
 
-An earlier base that already defines the name stops the conflict check:
+Once an earlier base has already overridden the name, we do not emit a second conflict for later
+subclasses:
 
 ```py
 from typing import NamedTuple
@@ -1247,111 +1143,6 @@ class ShadowingMid(ShadowTupleBase):
 
 class ShadowedChild(ShadowingMid):
     name: int
-```
-
-An earlier base that declares the name also stops the conflict check:
-
-```py
-from typing import NamedTuple
-
-class AnnotationOnlyMixin:
-    key: int
-
-class AnnotationTupleBase(NamedTuple):
-    key: int
-
-class AnnotationOnlyChild(AnnotationOnlyMixin, AnnotationTupleBase):
-    key: int
-```
-
-A read-only descriptor in an earlier base also stops the conflict check:
-
-```py
-from typing import NamedTuple
-
-class ReadOnlyMixin:
-    field = property(lambda self: 0)
-
-class DescriptorTupleBase(NamedTuple):
-    field: int
-
-class DescriptorShadowChild(ReadOnlyMixin, DescriptorTupleBase):
-    field: int
-```
-
-A statically false conditional binding in an earlier base does not stop the conflict check:
-
-```py
-from typing import NamedTuple
-
-flag = False
-
-class MaybeShadowMixin:
-    if flag:
-        value = 1
-
-class ConditionalTupleBase(NamedTuple):
-    value: int
-
-class ConditionalShadowChild(MaybeShadowMixin, ConditionalTupleBase):
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `value` inherited from `ConditionalTupleBase`"
-    value: int
-```
-
-An earlier base with a conditional binding that may still be present at the end of the class body
-does stop the conflict check:
-
-```py
-from typing import NamedTuple
-
-def coinflip() -> bool:
-    return True
-
-class MaybeShadowRuntimeMixin:
-    if coinflip():
-        value = 1
-
-class ConditionalRuntimeTupleBase(NamedTuple):
-    value: int
-
-class ConditionalRuntimeShadowChild(MaybeShadowRuntimeMixin, ConditionalRuntimeTupleBase):
-    value: int
-```
-
-Mixed bindings in an earlier base also stop the conflict check:
-
-```py
-from typing import NamedTuple
-
-flag = False
-
-class MixedShadowMixin:
-    if flag:
-        data = 1
-    else:
-        data = property(lambda self: 0)
-
-class MixedShadowTupleBase(NamedTuple):
-    data: int
-
-class MixedShadowChild(MixedShadowMixin, MixedShadowTupleBase):
-    data: int
-```
-
-Ignoring one conflict does not suppress later ones:
-
-```py
-from typing import NamedTuple
-
-class DoubleConflictBase(NamedTuple):
-    left: int
-    right: int
-
-class DoubleConflictChild(DoubleConflictBase):
-    left: int  # ty: ignore[invalid-named-tuple]
-
-    # error: [invalid-named-tuple] "Cannot override NamedTuple field `right` inherited from `DoubleConflictBase`"
-    right: int
 ```
 
 ### Generic named tuples

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -1067,8 +1067,8 @@ reveal_type(alice.level)  # revealed: int
 alice = SuperUser(1, "Alice", 3)
 ```
 
-TODO: If any fields added by the subclass conflict with those in the base class, that should be
-flagged.
+Bare annotated subclass fields may not reuse `NamedTuple` field names from the base class, but
+ordinary bound overrides still work:
 
 ```py
 from typing import NamedTuple
@@ -1080,34 +1080,175 @@ class User(NamedTuple):
     nickname: str
 
 class SuperUser(User):
-    # TODO: this should be an error because it implies that the `id` attribute on
-    # `SuperUser` is mutable, but the read-only `id` property from the superclass
-    # has not been overridden in the class body
+    level: int
+
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `User`"
     id: int
 
-    # this is fine; overriding a read-only attribute with a mutable one
-    # does not conflict with the Liskov Substitution Principle
     name: str = "foo"
 
-    # this is also fine
     @property
     def age(self) -> int:
         return super().age or 42
 
-    def now_called_robert(self):
-        self.name = "Robert"  # fine because overridden with a mutable attribute
-
-        # error: 9 [invalid-assignment] "Cannot assign to read-only property `nickname` on object of type `Self@now_called_robert`"
-        self.nickname = "Bob"
-
 james = SuperUser(0, "James", 42, "Jimmy")
+reveal_type(james.age)  # revealed: int
 
-# fine because the property on the superclass was overridden with a mutable attribute
-# on the subclass
-james.name = "Robert"
+james.name = "Bob"
 
 # error: [invalid-assignment] "Cannot assign to read-only property `nickname` on object of type `SuperUser`"
 james.nickname = "Bob"
+```
+
+Writable descriptor-valued shadows are allowed:
+
+```py
+from typing import Any, NamedTuple
+
+class WritableDescriptorBase(NamedTuple):
+    data: int
+
+class WritableDescriptorChild(WritableDescriptorBase):
+    data: Any = property(lambda self: 0, lambda self, value: None)
+
+class WritableDescriptorMixin:
+    data = property(lambda self: 0, lambda self, value: None)
+
+class WritableMixinChild(WritableDescriptorMixin, WritableDescriptorBase):
+    data: int
+```
+
+Read-only descriptor-valued bound overrides are still rejected:
+
+```py
+from typing import Any, NamedTuple
+
+class ReadOnlyDescriptorBase(NamedTuple):
+    data: int
+
+class ReadOnlyDescriptorChild(ReadOnlyDescriptorBase):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `data` inherited from `ReadOnlyDescriptorBase`"
+    data: Any = property(lambda self: 0)
+```
+
+The same conflict check applies when the inherited `NamedTuple` comes from the functional forms:
+
+```py
+from collections import namedtuple
+from typing import NamedTuple
+
+TypingBase = NamedTuple("TypingBase", [("id", int), ("name", str)])
+CollectionsBase = namedtuple("CollectionsBase", ["key", "value"])
+
+class TypingChild(TypingBase):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `id` inherited from `TypingBase`"
+    id: int
+
+class CollectionsChild(CollectionsBase):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `key` inherited from `CollectionsBase`"
+    key: int
+```
+
+An earlier base that already defines the name stops the conflict check:
+
+```py
+from typing import NamedTuple
+
+ShadowTupleBase = NamedTuple("ShadowTupleBase", [("name", str)])
+
+class ShadowingMid(ShadowTupleBase):
+    name = "shadowed"
+
+class ShadowedChild(ShadowingMid):
+    name: int
+```
+
+An annotation-only base does not stop the conflict check:
+
+```py
+from typing import NamedTuple
+
+class AnnotationOnlyMixin:
+    key: int
+
+class AnnotationTupleBase(NamedTuple):
+    key: int
+
+class AnnotationOnlyChild(AnnotationOnlyMixin, AnnotationTupleBase):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `key` inherited from `AnnotationTupleBase`"
+    key: int
+```
+
+A read-only descriptor in an earlier base does not stop the conflict check:
+
+```py
+from typing import NamedTuple
+
+class ReadOnlyMixin:
+    field = property(lambda self: 0)
+
+class DescriptorTupleBase(NamedTuple):
+    field: int
+
+class DescriptorShadowChild(ReadOnlyMixin, DescriptorTupleBase):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `field` inherited from `DescriptorTupleBase`"
+    field: int
+```
+
+A conditionally bound earlier base also does not stop the conflict check:
+
+```py
+from typing import NamedTuple
+
+flag = False
+
+class MaybeShadowMixin:
+    if flag:
+        value = 1
+
+class ConditionalTupleBase(NamedTuple):
+    value: int
+
+class ConditionalShadowChild(MaybeShadowMixin, ConditionalTupleBase):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `value` inherited from `ConditionalTupleBase`"
+    value: int
+```
+
+Mixed writable and read-only bindings in an earlier base do not stop the conflict check:
+
+```py
+from typing import NamedTuple
+
+flag = False
+
+class MixedShadowMixin:
+    if flag:
+        data = 1
+    else:
+        data = property(lambda self: 0)
+
+class MixedShadowTupleBase(NamedTuple):
+    data: int
+
+class MixedShadowChild(MixedShadowMixin, MixedShadowTupleBase):
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `data` inherited from `MixedShadowTupleBase`"
+    data: int
+```
+
+Ignoring one conflict does not suppress later ones:
+
+```py
+from typing import NamedTuple
+
+class DoubleConflictBase(NamedTuple):
+    left: int
+    right: int
+
+class DoubleConflictChild(DoubleConflictBase):
+    left: int  # ty: ignore[invalid-named-tuple]
+
+    # error: [invalid-named-tuple] "Cannot override NamedTuple field `right` inherited from `DoubleConflictBase`"
+    right: int
 ```
 
 ### Generic named tuples

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -446,6 +446,14 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
         self.spec(db).fields(db)
     }
 
+    /// Returns the field declared directly on this dynamic named tuple, if any.
+    pub(crate) fn own_field(self, db: &'db dyn Db, name: &Name) -> Option<NamedTupleField<'db>> {
+        self.fields(db)
+            .iter()
+            .find(|field| field.name == *name)
+            .cloned()
+    }
+
     pub(super) fn has_known_fields(self, db: &'db dyn Db) -> bool {
         self.spec(db).has_known_fields(db)
     }

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -447,11 +447,8 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
     }
 
     /// Returns the field declared directly on this dynamic named tuple, if any.
-    pub(crate) fn own_field(self, db: &'db dyn Db, name: &Name) -> Option<NamedTupleField<'db>> {
-        self.fields(db)
-            .iter()
-            .find(|field| field.name == *name)
-            .cloned()
+    pub(crate) fn field(self, db: &'db dyn Db, name: &Name) -> Option<&'db NamedTupleField<'db>> {
+        self.fields(db).iter().find(|field| field.name == *name)
     }
 
     pub(super) fn has_known_fields(self, db: &'db dyn Db) -> bool {

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -98,6 +98,7 @@ pub(crate) fn register_lints(registry: &mut LintRegistryBuilder) {
     registry.register_lint(&INVALID_PARAMETER_DEFAULT);
     registry.register_lint(&INVALID_PROTOCOL);
     registry.register_lint(&INVALID_NAMED_TUPLE);
+    registry.register_lint(&INVALID_NAMED_TUPLE_OVERRIDE);
     registry.register_lint(&INVALID_RAISE);
     registry.register_lint(&INVALID_SUPER_ARGUMENT);
     registry.register_lint(&INVALID_TYPE_ARGUMENTS);
@@ -732,6 +733,40 @@ declare_lint! {
         summary: "detects invalid `NamedTuple` class definitions",
         status: LintStatus::stable("0.0.1-alpha.19"),
         default_level: Level::Error,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Checks for subclass members that override inherited `NamedTuple` fields.
+    ///
+    /// ## Why is this bad?
+    /// Reusing an inherited `NamedTuple` field name in a subclass creates a
+    /// class where tuple indexing and `repr()` still reflect the original
+    /// field, while attribute access follows the subclass member.
+    ///
+    /// ## Default level
+    /// This rule is a warning by default because these overrides do not make
+    /// the class invalid at runtime.
+    ///
+    /// ## Examples
+    /// ```python
+    /// from typing import NamedTuple
+    ///
+    /// class User(NamedTuple):
+    ///     name: str
+    ///
+    /// class Admin(User):
+    ///     name = "shadowed"  # error: [invalid-named-tuple-override]
+    ///
+    /// admin = Admin("Alice")
+    /// admin.name  # "shadowed"
+    /// admin[0]  # "Alice"
+    /// ```
+    pub(crate) static INVALID_NAMED_TUPLE_OVERRIDE = {
+        summary: "detects subclass members that override inherited `NamedTuple` fields",
+        status: LintStatus::stable("0.0.31"),
+        default_level: Level::Warn,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -12,10 +12,10 @@ use rustc_hash::FxHashSet;
 use crate::{
     Db,
     lint::LintId,
-    place::{DefinedPlace, Place},
+    place::{DefinedPlace, Definedness, Place, place_from_bindings},
     types::{
-        CallableType, ClassBase, ClassType, KnownClass, Parameter, Parameters, Signature,
-        StaticClassLiteral, Type, TypeContext, TypeQualifiers,
+        CallableType, ClassBase, ClassLiteral, ClassType, KnownClass, Parameter, Parameters,
+        Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
         call::CallArguments,
         class::{CodeGeneratorKind, FieldKind},
         constraints::ConstraintSetBuilder,
@@ -67,6 +67,10 @@ pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticCla
         return;
     }
 
+    if configuration.check_invalid_named_tuple_overrides() {
+        check_named_tuple_subclass_field_conflicts(context, class);
+    }
+
     let class_specialized = class.identity_specialization(db);
     let scope = class.body_scope(db);
     let own_class_members: FxHashSet<_> = all_end_of_scope_members(db, scope).collect();
@@ -81,6 +85,181 @@ pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticCla
             scope,
             &member,
         );
+    }
+}
+
+/// Reports `invalid-named-tuple` when a subclass reuses an inherited
+/// `NamedTuple` field name that still participates in attribute assignment.
+fn check_named_tuple_subclass_field_conflicts<'db>(
+    context: &InferContext<'db, '_>,
+    class: StaticClassLiteral<'db>,
+) {
+    let db = context.db();
+
+    for (field_name, field) in class.own_fields(db, None, CodeGeneratorKind::NamedTuple) {
+        if class_has_definite_writable_shadow(db, ClassType::NonGeneric(class.into()), &field_name)
+        {
+            continue;
+        }
+
+        let Some((superclass, overridden_field_declaration)) =
+            conflicting_named_tuple_field_in_mro(db, class, &field_name)
+        else {
+            continue;
+        };
+
+        let diagnostic_range = field
+            .first_declaration
+            .map(|definition| definition.kind(db).full_range(context.module()))
+            .unwrap_or_else(|| class.header_range(db));
+        let Some(builder) = context.report_lint(&INVALID_NAMED_TUPLE, diagnostic_range) else {
+            continue;
+        };
+
+        let mut diagnostic = builder.into_diagnostic(format_args!(
+            "Cannot override NamedTuple field `{field_name}` inherited from `{}`",
+            superclass.name(db)
+        ));
+        diagnostic
+            .info("Subclass fields are not allowed to reuse inherited NamedTuple field names");
+        if let Some(first_declaration) = overridden_field_declaration
+            && first_declaration.file(db) == context.file()
+        {
+            diagnostic.annotate(
+                Annotation::secondary(
+                    context.span(first_declaration.kind(db).full_range(context.module())),
+                )
+                .message(format_args!(
+                    "Inherited NamedTuple field `{field_name}` declared here",
+                )),
+            );
+        }
+    }
+}
+
+/// Returns the first inherited `NamedTuple` field in the MRO that is still
+/// relevant for writes to `field_name`.
+fn conflicting_named_tuple_field_in_mro<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+    field_name: &Name,
+) -> Option<(ClassType<'db>, Option<Definition<'db>>)> {
+    for class_base in class.iter_mro(db, None).skip(1) {
+        let Some(superclass) = class_base.into_class() else {
+            continue;
+        };
+
+        if class_has_definite_writable_shadow(db, superclass, field_name) {
+            return None;
+        }
+
+        if let Some(overridden_field_declaration) =
+            named_tuple_field_declaration(db, superclass, field_name)
+        {
+            return Some((superclass, overridden_field_declaration));
+        }
+    }
+
+    None
+}
+
+/// Returns whether `shadowing_class` definitely handles writes to `field_name`
+/// before an inherited `NamedTuple` field can reject them.
+fn class_has_definite_writable_shadow<'db>(
+    db: &'db dyn Db,
+    shadowing_class: ClassType<'db>,
+    field_name: &Name,
+) -> bool {
+    let (class_literal, specialization) = shadowing_class.class_literal_and_specialization(db);
+
+    match class_literal {
+        ClassLiteral::Static(class_literal) => {
+            if CodeGeneratorKind::NamedTuple.matches(db, class_literal.into(), specialization)
+                && class_literal
+                    .own_fields(db, specialization, CodeGeneratorKind::NamedTuple)
+                    .contains_key(field_name)
+            {
+                return false;
+            }
+
+            let body_scope = class_literal.body_scope(db);
+            let Some(symbol_id) = place_table(db, body_scope).symbol_id(field_name.as_str()) else {
+                return false;
+            };
+
+            let Place::Defined(defined) = place_from_bindings(
+                db,
+                use_def_map(db, body_scope).end_of_scope_symbol_bindings(symbol_id),
+            )
+            .place
+            else {
+                return false;
+            };
+
+            defined.is_definitely_defined()
+                && type_definitely_handles_named_tuple_shadow_assignment(db, defined.ty)
+        }
+        ClassLiteral::Dynamic(class_literal) => class_literal
+            .members(db)
+            .iter()
+            .find(|(member_name, _)| member_name == field_name)
+            .is_some_and(|(_, ty)| type_definitely_handles_named_tuple_shadow_assignment(db, *ty)),
+        ClassLiteral::DynamicNamedTuple(_) => false,
+        ClassLiteral::DynamicTypedDict(_) => false,
+        ClassLiteral::DynamicEnum(_) => false,
+    }
+}
+
+/// Returns whether values of `ty` definitely absorb instance writes that would
+/// otherwise hit an inherited `NamedTuple` field.
+fn type_definitely_handles_named_tuple_shadow_assignment<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+) -> bool {
+    match ty {
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|elem| type_definitely_handles_named_tuple_shadow_assignment(db, *elem)),
+        Type::PropertyInstance(property) => property.setter(db).is_some(),
+        Type::Dynamic(_) | Type::Divergent(_) | Type::Never => false,
+        _ => {
+            matches!(
+                ty.class_member(db, "__set__".into()).place,
+                Place::Defined(DefinedPlace {
+                    definedness: Definedness::AlwaysDefined,
+                    ..
+                })
+            ) || !ty.may_be_data_descriptor(db)
+        }
+    }
+}
+
+/// Returns the declaration for a `NamedTuple` field owned directly by
+/// `superclass`.
+fn named_tuple_field_declaration<'db>(
+    db: &'db dyn Db,
+    superclass: ClassType<'db>,
+    field_name: &Name,
+) -> Option<Option<Definition<'db>>> {
+    let (superclass_literal, superclass_specialization) =
+        superclass.class_literal_and_specialization(db);
+
+    if !CodeGeneratorKind::NamedTuple.matches(db, superclass_literal, superclass_specialization) {
+        return None;
+    }
+
+    match superclass_literal {
+        ClassLiteral::Static(superclass_literal) => superclass_literal
+            .own_fields(db, superclass_specialization, CodeGeneratorKind::NamedTuple)
+            .get(field_name)
+            .map(|field| field.first_declaration),
+        ClassLiteral::DynamicNamedTuple(namedtuple) => namedtuple
+            .own_field(db, field_name)
+            .map(|_| namedtuple.definition(db)),
+        ClassLiteral::Dynamic(_) | ClassLiteral::DynamicTypedDict(_) | ClassLiteral::DynamicEnum(_) => {
+            None
+        }
     }
 }
 
@@ -156,7 +335,7 @@ fn check_class_declaration<'db>(
     // annotations) or define methods with these names will raise an `AttributeError` at runtime.
     match class_kind {
         Some(CodeGeneratorKind::NamedTuple) => {
-            if configuration.check_prohibited_named_tuple_attrs()
+            if configuration.check_invalid_named_tuple_overrides()
                 && PROHIBITED_NAMEDTUPLE_ATTRS.contains(&member.name.as_str())
                 && let Some(symbol_id) = place_table(db, class_scope).symbol_id(&member.name)
                 && let Some(bad_definition) = use_def_map(db, class_scope)
@@ -530,7 +709,7 @@ bitflags! {
         const LISKOV_METHODS = 1 << 0;
         const EXPLICIT_OVERRIDE = 1 << 1;
         const FINAL_METHOD_OVERRIDDEN = 1 << 2;
-        const PROHIBITED_NAMED_TUPLE_ATTR = 1 << 3;
+        const INVALID_NAMED_TUPLE_OVERRIDE = 1 << 3;
         const INVALID_DATACLASS = 1 << 4;
         const FINAL_VARIABLE_OVERRIDDEN = 1 << 5;
         const INVALID_ENUM_VALUE = 1 << 6;
@@ -554,7 +733,7 @@ impl From<&InferContext<'_, '_>> for OverrideRulesConfig {
             config |= OverrideRulesConfig::FINAL_METHOD_OVERRIDDEN;
         }
         if rule_selection.is_enabled(LintId::of(&INVALID_NAMED_TUPLE)) {
-            config |= OverrideRulesConfig::PROHIBITED_NAMED_TUPLE_ATTR;
+            config |= OverrideRulesConfig::INVALID_NAMED_TUPLE_OVERRIDE;
         }
         if rule_selection.is_enabled(LintId::of(&INVALID_DATACLASS)) {
             config |= OverrideRulesConfig::INVALID_DATACLASS;
@@ -583,8 +762,10 @@ impl OverrideRulesConfig {
         self.contains(OverrideRulesConfig::FINAL_METHOD_OVERRIDDEN)
     }
 
-    const fn check_prohibited_named_tuple_attrs(self) -> bool {
-        self.contains(OverrideRulesConfig::PROHIBITED_NAMED_TUPLE_ATTR)
+    /// Returns whether inherited `NamedTuple` field conflicts should be
+    /// diagnosed.
+    const fn check_invalid_named_tuple_overrides(self) -> bool {
+        self.contains(OverrideRulesConfig::INVALID_NAMED_TUPLE_OVERRIDE)
     }
 
     const fn check_invalid_dataclasses(self) -> bool {

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -111,7 +111,7 @@ fn conflicting_named_tuple_field_in_mro<'db>(
                     }
                 }
                 ClassLiteral::DynamicNamedTuple(namedtuple) => {
-                    if namedtuple.own_field(db, field_name).is_some() {
+                    if namedtuple.field(db, field_name).is_some() {
                         return Some((superclass, namedtuple.definition(db)));
                     }
                 }

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -22,8 +22,8 @@ use crate::{
         context::InferContext,
         diagnostic::{
             INVALID_ASSIGNMENT, INVALID_DATACLASS, INVALID_EXPLICIT_OVERRIDE,
-            INVALID_METHOD_OVERRIDE, INVALID_NAMED_TUPLE, OVERRIDE_OF_FINAL_METHOD,
-            OVERRIDE_OF_FINAL_VARIABLE, report_invalid_method_override,
+            INVALID_METHOD_OVERRIDE, INVALID_NAMED_TUPLE, INVALID_NAMED_TUPLE_OVERRIDE,
+            OVERRIDE_OF_FINAL_METHOD, OVERRIDE_OF_FINAL_VARIABLE, report_invalid_method_override,
             report_overridden_final_method, report_overridden_final_variable,
         },
         enums::{EnumMetadata, enum_metadata},
@@ -196,7 +196,7 @@ fn check_class_declaration<'db>(
     // annotations) or define methods with these names will raise an `AttributeError` at runtime.
     match class_kind {
         Some(CodeGeneratorKind::NamedTuple) => {
-            if configuration.check_invalid_named_tuple_overrides()
+            if configuration.check_invalid_named_tuple_definitions()
                 && PROHIBITED_NAMEDTUPLE_ATTRS.contains(&member.name.as_str())
                 && let Some(symbol_id) = place_table(db, class_scope).symbol_id(&member.name)
                 && let Some(bad_definition) = use_def_map(db, class_scope)
@@ -226,11 +226,11 @@ fn check_class_declaration<'db>(
         Some(CodeGeneratorKind::TypedDict) | None => {}
     }
 
-    if configuration.check_invalid_named_tuple_overrides()
+    if configuration.check_invalid_named_tuple_field_overrides()
         && let Some((superclass, overridden_field_declaration)) =
             conflicting_named_tuple_field_in_mro(db, literal, &member.name)
         && let Some(builder) = context.report_lint(
-            &INVALID_NAMED_TUPLE,
+            &INVALID_NAMED_TUPLE_OVERRIDE,
             first_reachable_definition.focus_range(db, context.module()),
         )
     {
@@ -600,10 +600,11 @@ bitflags! {
         const LISKOV_METHODS = 1 << 0;
         const EXPLICIT_OVERRIDE = 1 << 1;
         const FINAL_METHOD_OVERRIDDEN = 1 << 2;
-        const INVALID_NAMED_TUPLE_OVERRIDE = 1 << 3;
-        const INVALID_DATACLASS = 1 << 4;
-        const FINAL_VARIABLE_OVERRIDDEN = 1 << 5;
-        const INVALID_ENUM_VALUE = 1 << 6;
+        const INVALID_NAMED_TUPLE = 1 << 3;
+        const NAMED_TUPLE_FIELD_OVERRIDE = 1 << 4;
+        const INVALID_DATACLASS = 1 << 5;
+        const FINAL_VARIABLE_OVERRIDDEN = 1 << 6;
+        const INVALID_ENUM_VALUE = 1 << 7;
     }
 }
 
@@ -624,7 +625,10 @@ impl From<&InferContext<'_, '_>> for OverrideRulesConfig {
             config |= OverrideRulesConfig::FINAL_METHOD_OVERRIDDEN;
         }
         if rule_selection.is_enabled(LintId::of(&INVALID_NAMED_TUPLE)) {
-            config |= OverrideRulesConfig::INVALID_NAMED_TUPLE_OVERRIDE;
+            config |= OverrideRulesConfig::INVALID_NAMED_TUPLE;
+        }
+        if rule_selection.is_enabled(LintId::of(&INVALID_NAMED_TUPLE_OVERRIDE)) {
+            config |= OverrideRulesConfig::NAMED_TUPLE_FIELD_OVERRIDE;
         }
         if rule_selection.is_enabled(LintId::of(&INVALID_DATACLASS)) {
             config |= OverrideRulesConfig::INVALID_DATACLASS;
@@ -653,8 +657,12 @@ impl OverrideRulesConfig {
         self.contains(OverrideRulesConfig::FINAL_METHOD_OVERRIDDEN)
     }
 
-    const fn check_invalid_named_tuple_overrides(self) -> bool {
-        self.contains(OverrideRulesConfig::INVALID_NAMED_TUPLE_OVERRIDE)
+    const fn check_invalid_named_tuple_definitions(self) -> bool {
+        self.contains(OverrideRulesConfig::INVALID_NAMED_TUPLE)
+    }
+
+    const fn check_invalid_named_tuple_field_overrides(self) -> bool {
+        self.contains(OverrideRulesConfig::NAMED_TUPLE_FIELD_OVERRIDE)
     }
 
     const fn check_invalid_dataclasses(self) -> bool {

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -12,8 +12,7 @@ use rustc_hash::FxHashSet;
 use crate::{
     Db,
     lint::LintId,
-    place::{DefinedPlace, Place},
-    reachability::ReachabilityConstraintsExtension,
+    place::{DefinedPlace, Place, place_from_bindings, place_from_declarations},
     types::{
         CallableType, ClassBase, ClassLiteral, ClassType, KnownClass, Parameter, Parameters,
         Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
@@ -58,11 +57,9 @@ const PROHIBITED_NAMEDTUPLE_ATTRS: &[&str] = &[
     "_source",
 ];
 
-/// Checks a class body for invalid override-related behavior.
-///
-/// TODO: Support dynamic class literals. If we allow dynamic classes to define attributes in their
-/// namespace dictionary, we should also check whether those attributes are valid overrides of
-/// attributes in their superclasses.
+// TODO: Support dynamic class literals. If we allow dynamic classes to define attributes in their
+// namespace dictionary, we should also check whether those attributes are valid overrides of
+// attributes in their superclasses.
 pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticClassLiteral<'db>) {
     let db = context.db();
     let configuration = OverrideRulesConfig::from(context);
@@ -135,9 +132,15 @@ fn conflicting_named_tuple_field_in_mro<'db>(
                 .members(db)
                 .iter()
                 .any(|(member_name, _)| member_name == field_name),
-            ClassLiteral::DynamicNamedTuple(_)
-            | ClassLiteral::DynamicTypedDict(_)
-            | ClassLiteral::DynamicEnum(_) => false,
+            ClassLiteral::DynamicNamedTuple(_) | ClassLiteral::DynamicTypedDict(_) => false,
+            ClassLiteral::DynamicEnum(enum_lit) => {
+                let spec = enum_lit.spec(db);
+                !spec.has_known_members(db)
+                    || spec
+                        .members(db)
+                        .iter()
+                        .any(|(member_name, _)| member_name == field_name)
+            }
         };
 
         if shadows_name {
@@ -157,34 +160,14 @@ fn class_body_first_end_of_scope_definition<'db>(
 ) -> Option<Definition<'db>> {
     let symbol_id = place_table(db, class_scope).symbol_id(field_name.as_str())?;
     let use_def = use_def_map(db, class_scope);
-    let mut declarations = use_def.end_of_scope_symbol_declarations(symbol_id);
-    let predicates = declarations.predicates();
-    let reachability_constraints = declarations.reachability_constraints();
-
-    if let Some(definition) = declarations.find_map(|declaration| {
-        (!reachability_constraints
-            .evaluate(db, predicates, declaration.reachability_constraint)
-            .is_always_false())
-        .then(|| declaration.declaration.definition())
-        .flatten()
-    }) {
-        return Some(definition);
-    }
-
-    let mut bindings = use_def.end_of_scope_symbol_bindings(symbol_id);
-    let predicates = bindings.predicates();
-    let reachability_constraints = bindings.reachability_constraints();
-
-    bindings.find_map(|binding| {
-        (!reachability_constraints
-            .evaluate(db, predicates, binding.reachability_constraint)
-            .is_always_false())
-        .then(|| binding.binding.definition())
-        .flatten()
-    })
+    place_from_declarations(db, use_def.end_of_scope_symbol_declarations(symbol_id))
+        .first_declaration
+        .or_else(|| {
+            place_from_bindings(db, use_def.end_of_scope_symbol_bindings(symbol_id))
+                .first_definition
+        })
 }
 
-/// Checks override-related rules for a single class member definition.
 fn check_class_declaration<'db>(
     context: &InferContext<'db, '_>,
     configuration: OverrideRulesConfig,
@@ -716,8 +699,6 @@ impl OverrideRulesConfig {
         self.contains(OverrideRulesConfig::FINAL_METHOD_OVERRIDDEN)
     }
 
-    /// Returns whether inherited `NamedTuple` field conflicts should be
-    /// diagnosed.
     const fn check_invalid_named_tuple_overrides(self) -> bool {
         self.contains(OverrideRulesConfig::INVALID_NAMED_TUPLE_OVERRIDE)
     }

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -12,7 +12,8 @@ use rustc_hash::FxHashSet;
 use crate::{
     Db,
     lint::LintId,
-    place::{DefinedPlace, Definedness, Place, place_from_bindings},
+    place::{DefinedPlace, Place},
+    reachability::ReachabilityConstraintsExtension,
     types::{
         CallableType, ClassBase, ClassLiteral, ClassType, KnownClass, Parameter, Parameters,
         Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
@@ -57,18 +58,16 @@ const PROHIBITED_NAMEDTUPLE_ATTRS: &[&str] = &[
     "_source",
 ];
 
-// TODO: Support dynamic class literals. If we allow dynamic classes to define attributes in their
-// namespace dictionary, we should also check whether those attributes are valid overrides of
-// attributes in their superclasses.
+/// Checks a class body for invalid override-related behavior.
+///
+/// TODO: Support dynamic class literals. If we allow dynamic classes to define attributes in their
+/// namespace dictionary, we should also check whether those attributes are valid overrides of
+/// attributes in their superclasses.
 pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticClassLiteral<'db>) {
     let db = context.db();
     let configuration = OverrideRulesConfig::from(context);
     if configuration.no_rules_enabled() {
         return;
-    }
-
-    if configuration.check_invalid_named_tuple_overrides() {
-        check_named_tuple_subclass_field_conflicts(context, class);
     }
 
     let class_specialized = class.identity_specialization(db);
@@ -88,57 +87,8 @@ pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticCla
     }
 }
 
-/// Reports `invalid-named-tuple` when a subclass reuses an inherited
-/// `NamedTuple` field name that still participates in attribute assignment.
-fn check_named_tuple_subclass_field_conflicts<'db>(
-    context: &InferContext<'db, '_>,
-    class: StaticClassLiteral<'db>,
-) {
-    let db = context.db();
-
-    for (field_name, field) in class.own_fields(db, None, CodeGeneratorKind::NamedTuple) {
-        if class_has_definite_writable_shadow(db, ClassType::NonGeneric(class.into()), &field_name)
-        {
-            continue;
-        }
-
-        let Some((superclass, overridden_field_declaration)) =
-            conflicting_named_tuple_field_in_mro(db, class, &field_name)
-        else {
-            continue;
-        };
-
-        let diagnostic_range = field
-            .first_declaration
-            .map(|definition| definition.kind(db).full_range(context.module()))
-            .unwrap_or_else(|| class.header_range(db));
-        let Some(builder) = context.report_lint(&INVALID_NAMED_TUPLE, diagnostic_range) else {
-            continue;
-        };
-
-        let mut diagnostic = builder.into_diagnostic(format_args!(
-            "Cannot override NamedTuple field `{field_name}` inherited from `{}`",
-            superclass.name(db)
-        ));
-        diagnostic
-            .info("Subclass fields are not allowed to reuse inherited NamedTuple field names");
-        if let Some(first_declaration) = overridden_field_declaration
-            && first_declaration.file(db) == context.file()
-        {
-            diagnostic.annotate(
-                Annotation::secondary(
-                    context.span(first_declaration.kind(db).full_range(context.module())),
-                )
-                .message(format_args!(
-                    "Inherited NamedTuple field `{field_name}` declared here",
-                )),
-            );
-        }
-    }
-}
-
-/// Returns the first inherited `NamedTuple` field in the MRO that is still
-/// relevant for writes to `field_name`.
+/// Returns the first inherited `NamedTuple` field in the MRO that remains visible for
+/// `field_name`, together with its declaration definition when one is available.
 fn conflicting_named_tuple_field_in_mro<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
@@ -149,120 +99,92 @@ fn conflicting_named_tuple_field_in_mro<'db>(
             continue;
         };
 
-        if class_has_definite_writable_shadow(db, superclass, field_name) {
-            return None;
+        let (superclass_literal, superclass_specialization) =
+            superclass.class_literal_and_specialization(db);
+
+        if CodeGeneratorKind::NamedTuple.matches(db, superclass_literal, superclass_specialization)
+        {
+            match superclass_literal {
+                ClassLiteral::Static(superclass_literal) => {
+                    if let Some(field) = superclass_literal
+                        .own_fields(db, superclass_specialization, CodeGeneratorKind::NamedTuple)
+                        .get(field_name)
+                    {
+                        return Some((superclass, field.first_declaration));
+                    }
+                }
+                ClassLiteral::DynamicNamedTuple(namedtuple) => {
+                    if namedtuple.own_field(db, field_name).is_some() {
+                        return Some((superclass, namedtuple.definition(db)));
+                    }
+                }
+                ClassLiteral::Dynamic(_)
+                | ClassLiteral::DynamicTypedDict(_)
+                | ClassLiteral::DynamicEnum(_) => {}
+            }
         }
 
-        if let Some(overridden_field_declaration) =
-            named_tuple_field_declaration(db, superclass, field_name)
-        {
-            return Some((superclass, overridden_field_declaration));
+        let shadows_name = match superclass_literal {
+            ClassLiteral::Static(superclass_literal) => class_body_first_end_of_scope_definition(
+                db,
+                superclass_literal.body_scope(db),
+                field_name,
+            )
+            .is_some(),
+            ClassLiteral::Dynamic(class_literal) => class_literal
+                .members(db)
+                .iter()
+                .any(|(member_name, _)| member_name == field_name),
+            ClassLiteral::DynamicNamedTuple(_)
+            | ClassLiteral::DynamicTypedDict(_)
+            | ClassLiteral::DynamicEnum(_) => false,
+        };
+
+        if shadows_name {
+            return None;
         }
     }
 
     None
 }
 
-/// Returns whether `shadowing_class` definitely handles writes to `field_name`
-/// before an inherited `NamedTuple` field can reject them.
-fn class_has_definite_writable_shadow<'db>(
+/// Returns the first end-of-scope definition for `field_name` in `class_scope`, preferring a
+/// declaration over a binding when both are present.
+fn class_body_first_end_of_scope_definition<'db>(
     db: &'db dyn Db,
-    shadowing_class: ClassType<'db>,
+    class_scope: ScopeId<'db>,
     field_name: &Name,
-) -> bool {
-    let (class_literal, specialization) = shadowing_class.class_literal_and_specialization(db);
+) -> Option<Definition<'db>> {
+    let symbol_id = place_table(db, class_scope).symbol_id(field_name.as_str())?;
+    let use_def = use_def_map(db, class_scope);
+    let mut declarations = use_def.end_of_scope_symbol_declarations(symbol_id);
+    let predicates = declarations.predicates();
+    let reachability_constraints = declarations.reachability_constraints();
 
-    match class_literal {
-        ClassLiteral::Static(class_literal) => {
-            if CodeGeneratorKind::NamedTuple.matches(db, class_literal.into(), specialization)
-                && class_literal
-                    .own_fields(db, specialization, CodeGeneratorKind::NamedTuple)
-                    .contains_key(field_name)
-            {
-                return false;
-            }
-
-            let body_scope = class_literal.body_scope(db);
-            let Some(symbol_id) = place_table(db, body_scope).symbol_id(field_name.as_str()) else {
-                return false;
-            };
-
-            let Place::Defined(defined) = place_from_bindings(
-                db,
-                use_def_map(db, body_scope).end_of_scope_symbol_bindings(symbol_id),
-            )
-            .place
-            else {
-                return false;
-            };
-
-            defined.is_definitely_defined()
-                && type_definitely_handles_named_tuple_shadow_assignment(db, defined.ty)
-        }
-        ClassLiteral::Dynamic(class_literal) => class_literal
-            .members(db)
-            .iter()
-            .find(|(member_name, _)| member_name == field_name)
-            .is_some_and(|(_, ty)| type_definitely_handles_named_tuple_shadow_assignment(db, *ty)),
-        ClassLiteral::DynamicNamedTuple(_) => false,
-        ClassLiteral::DynamicTypedDict(_) => false,
-        ClassLiteral::DynamicEnum(_) => false,
+    if let Some(definition) = declarations.find_map(|declaration| {
+        (!reachability_constraints
+            .evaluate(db, predicates, declaration.reachability_constraint)
+            .is_always_false())
+        .then(|| declaration.declaration.definition())
+        .flatten()
+    }) {
+        return Some(definition);
     }
+
+    let mut bindings = use_def.end_of_scope_symbol_bindings(symbol_id);
+    let predicates = bindings.predicates();
+    let reachability_constraints = bindings.reachability_constraints();
+
+    bindings.find_map(|binding| {
+        (!reachability_constraints
+            .evaluate(db, predicates, binding.reachability_constraint)
+            .is_always_false())
+        .then(|| binding.binding.definition())
+        .flatten()
+    })
 }
 
-/// Returns whether values of `ty` definitely absorb instance writes that would
-/// otherwise hit an inherited `NamedTuple` field.
-fn type_definitely_handles_named_tuple_shadow_assignment<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-) -> bool {
-    match ty {
-        Type::Union(union) => union
-            .elements(db)
-            .iter()
-            .all(|elem| type_definitely_handles_named_tuple_shadow_assignment(db, *elem)),
-        Type::PropertyInstance(property) => property.setter(db).is_some(),
-        Type::Dynamic(_) | Type::Divergent(_) | Type::Never => false,
-        _ => {
-            matches!(
-                ty.class_member(db, "__set__".into()).place,
-                Place::Defined(DefinedPlace {
-                    definedness: Definedness::AlwaysDefined,
-                    ..
-                })
-            ) || !ty.may_be_data_descriptor(db)
-        }
-    }
-}
-
-/// Returns the declaration for a `NamedTuple` field owned directly by
-/// `superclass`.
-fn named_tuple_field_declaration<'db>(
-    db: &'db dyn Db,
-    superclass: ClassType<'db>,
-    field_name: &Name,
-) -> Option<Option<Definition<'db>>> {
-    let (superclass_literal, superclass_specialization) =
-        superclass.class_literal_and_specialization(db);
-
-    if !CodeGeneratorKind::NamedTuple.matches(db, superclass_literal, superclass_specialization) {
-        return None;
-    }
-
-    match superclass_literal {
-        ClassLiteral::Static(superclass_literal) => superclass_literal
-            .own_fields(db, superclass_specialization, CodeGeneratorKind::NamedTuple)
-            .get(field_name)
-            .map(|field| field.first_declaration),
-        ClassLiteral::DynamicNamedTuple(namedtuple) => namedtuple
-            .own_field(db, field_name)
-            .map(|_| namedtuple.definition(db)),
-        ClassLiteral::Dynamic(_) | ClassLiteral::DynamicTypedDict(_) | ClassLiteral::DynamicEnum(_) => {
-            None
-        }
-    }
-}
-
+/// Checks override-related rules for a single class member definition.
 fn check_class_declaration<'db>(
     context: &InferContext<'db, '_>,
     configuration: OverrideRulesConfig,
@@ -363,6 +285,38 @@ fn check_class_declaration<'db>(
             policy,
         ),
         Some(CodeGeneratorKind::TypedDict) | None => {}
+    }
+
+    if configuration.check_invalid_named_tuple_overrides()
+        && class_body_first_end_of_scope_definition(db, class_scope, &member.name)
+            .is_some_and(|definition| definition == *first_reachable_definition)
+        && let Some((superclass, overridden_field_declaration)) =
+            conflicting_named_tuple_field_in_mro(db, literal, &member.name)
+        && let Some(builder) = context.report_lint(
+            &INVALID_NAMED_TUPLE,
+            first_reachable_definition.focus_range(db, context.module()),
+        )
+    {
+        let mut diagnostic = builder.into_diagnostic(format_args!(
+            "Cannot override NamedTuple field `{}` inherited from `{}`",
+            member.name,
+            superclass.name(db)
+        ));
+        diagnostic
+            .info("Subclass members are not allowed to reuse inherited NamedTuple field names");
+        if let Some(first_declaration) = overridden_field_declaration
+            && first_declaration.file(db) == context.file()
+        {
+            diagnostic.annotate(
+                Annotation::secondary(
+                    context.span(first_declaration.kind(db).full_range(context.module())),
+                )
+                .message(format_args!(
+                    "Inherited NamedTuple field `{}` declared here",
+                    member.name
+                )),
+            );
+        }
     }
 
     // Check for invalid Enum member values.

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -12,7 +12,7 @@ use rustc_hash::FxHashSet;
 use crate::{
     Db,
     lint::LintId,
-    place::{DefinedPlace, Place, place_from_bindings, place_from_declarations},
+    place::{DefinedPlace, Place},
     types::{
         CallableType, ClassBase, ClassLiteral, ClassType, KnownClass, Parameter, Parameters,
         Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
@@ -84,8 +84,7 @@ pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticCla
     }
 }
 
-/// Returns the first inherited `NamedTuple` field in the MRO that remains visible for
-/// `field_name`, together with its declaration definition when one is available.
+/// Returns the first inherited `NamedTuple` field in the MRO for `field_name`.
 fn conflicting_named_tuple_field_in_mro<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
@@ -120,52 +119,9 @@ fn conflicting_named_tuple_field_in_mro<'db>(
                 | ClassLiteral::DynamicEnum(_) => {}
             }
         }
-
-        let shadows_name = match superclass_literal {
-            ClassLiteral::Static(superclass_literal) => class_body_first_end_of_scope_definition(
-                db,
-                superclass_literal.body_scope(db),
-                field_name,
-            )
-            .is_some(),
-            ClassLiteral::Dynamic(class_literal) => class_literal
-                .members(db)
-                .iter()
-                .any(|(member_name, _)| member_name == field_name),
-            ClassLiteral::DynamicNamedTuple(_) | ClassLiteral::DynamicTypedDict(_) => false,
-            ClassLiteral::DynamicEnum(enum_lit) => {
-                let spec = enum_lit.spec(db);
-                !spec.has_known_members(db)
-                    || spec
-                        .members(db)
-                        .iter()
-                        .any(|(member_name, _)| member_name == field_name)
-            }
-        };
-
-        if shadows_name {
-            return None;
-        }
     }
 
     None
-}
-
-/// Returns the first end-of-scope definition for `field_name` in `class_scope`, preferring a
-/// declaration over a binding when both are present.
-fn class_body_first_end_of_scope_definition<'db>(
-    db: &'db dyn Db,
-    class_scope: ScopeId<'db>,
-    field_name: &Name,
-) -> Option<Definition<'db>> {
-    let symbol_id = place_table(db, class_scope).symbol_id(field_name.as_str())?;
-    let use_def = use_def_map(db, class_scope);
-    place_from_declarations(db, use_def.end_of_scope_symbol_declarations(symbol_id))
-        .first_declaration
-        .or_else(|| {
-            place_from_bindings(db, use_def.end_of_scope_symbol_bindings(symbol_id))
-                .first_definition
-        })
 }
 
 fn check_class_declaration<'db>(
@@ -271,8 +227,6 @@ fn check_class_declaration<'db>(
     }
 
     if configuration.check_invalid_named_tuple_overrides()
-        && class_body_first_end_of_scope_definition(db, class_scope, &member.name)
-            .is_some_and(|definition| definition == *first_reachable_definition)
         && let Some((superclass, overridden_field_declaration)) =
             conflicting_named_tuple_field_in_mro(db, literal, &member.name)
         && let Some(builder) = context.report_lint(

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -500,6 +500,7 @@ def collect_ty_diagnostics(
             "--error=invalid-enum-member-annotation",
             "--error=invalid-legacy-positional-parameter",
             "--error=mismatched-type-name",
+            "--error=invalid-named-tuple-override",
             "--error=deprecated",
             "--error=redundant-final-classvar",
             "--exit-zero",

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -820,6 +820,16 @@
             }
           ]
         },
+        "invalid-named-tuple-override": {
+          "title": "detects subclass members that override inherited `NamedTuple` fields",
+          "description": "## What it does\nChecks for subclass members that override inherited `NamedTuple` fields.\n\n## Why is this bad?\nReusing an inherited `NamedTuple` field name in a subclass creates a\nclass where tuple indexing and `repr()` still reflect the original\nfield, while attribute access follows the subclass member.\n\n## Default level\nThis rule is a warning by default because these overrides do not make\nthe class invalid at runtime.\n\n## Examples\n```python\nfrom typing import NamedTuple\n\nclass User(NamedTuple):\n    name: str\n\nclass Admin(User):\n    name = \"shadowed\"  # error: [invalid-named-tuple-override]\n\nadmin = Admin(\"Alice\")\nadmin.name  # \"shadowed\"\nadmin[0]  # \"Alice\"\n```",
+          "default": "warn",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Level"
+            }
+          ]
+        },
         "invalid-newtype": {
           "title": "detects invalid NewType definitions",
           "description": "## What it does\nChecks for the creation of invalid `NewType`s\n\n## Why is this bad?\nThere are several requirements that you must follow when creating a `NewType`.\n\n## Examples\n```python\nfrom typing import NewType\n\ndef get_name() -> str: ...\n\nFoo = NewType(\"Foo\", int)        # okay\nBar = NewType(get_name(), int)   # error: The first argument to `NewType` must be a string literal\nBaz = NewType(\"Baz\", int | str)  # error: invalid base for `typing.NewType`\n```",


### PR DESCRIPTION
## Summary

Per the spec:

> A named tuple class can be subclassed, but any fields added by the subclass are not considered part of the named tuple type. Type checkers should enforce that these newly-added fields do not conflict with the named tuple fields in the base class.

The spec then provides this example:

```python
class Point(NamedTuple):
    x: int
    y: int
    units: str = "meters"

class PointWithName(Point):
    name: str  # OK
    x: int  # Type error (invalid override of named tuple field)
```

We take a slightly more expansive view here, rejecting any attributes (with or without an annotation, with or without a default) and properties in a `NamedTuple` subclass. This seems to match Pyright and Pyrefly, though Mypy doesn't flag these.

Shadowing an attribute in this way leads to odd behavior that is probably never what you want, e.g.:

```python
from typing import NamedTuple

class A(NamedTuple):
    x: int

class B(A):
    x: int = 42

b = B(1)

print(b.x)  # 42
print(b[0])  # 1
print(repr(b))  # B(x=1)

b.x = 99

print(b.x)  # 99
print(b[0])  # 1
print(repr(b))  # B(x=1)
```