### PR TITLE
[ty] Fix stack overflow in type walker for recursive generic protocols

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3314,6 +3314,31 @@ def f(c: C[int]) -> None:
     takes_c(c)
 ```
 
+### Recursive generic sub-protocol with `cast()` and unbound super call
+
+This snippet caused a stack overflow via infinite recursion in the type walker.
+The combination of a sub-protocol whose method calls `cast()` on the unbound
+parent protocol method triggers constraint solving, which walks the protocol
+interface. Because the return type wraps `T` in `list[T]`, each recursive step
+produces a distinct specialization (`Proto[list[T]]`, `Proto[list[list[T]]]`,
+etc.), defeating exact-match cycle detection and causing unbounded stack growth.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol, cast
+
+class Proto[T](Protocol):
+    def method(self) -> "Proto[list[T]]": ...
+
+class Sub[T](Proto[T], Protocol):
+    def method(self) -> "Sub[list[T]]":
+        return cast(Sub[list[T]], Proto.method(self))  # error: [redundant-cast]
+```
+
 ### Recursive legacy generic protocol
 
 ```py

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -273,17 +273,35 @@ pub(crate) fn walk_type_with_recursion_guard<'db>(
                 // If we have already seen this type, we can skip it.
                 return;
             }
+            let prev_depth = recursion_guard.depth.get();
+            if prev_depth >= MAX_TYPE_WALK_DEPTH {
+                // Bail out to prevent stack overflow from recursive generic protocols
+                // that produce infinitely many distinct specializations (e.g.,
+                // `Protocol[T]` whose members reference `Protocol[list[T]]`).
+                return;
+            }
+            recursion_guard.depth.set(prev_depth + 1);
             walk_non_atomic_type(db, non_atomic_type, visitor);
+            recursion_guard.depth.set(prev_depth);
         }
     }
 }
 
+/// Maximum nesting depth for type walking. This prevents stack overflow when
+/// walking recursive generic protocol types that produce infinitely many
+/// distinct specializations (e.g., a protocol whose callable members return
+/// the same protocol with wrapped type parameters).
+const MAX_TYPE_WALK_DEPTH: u32 = 64;
+
 #[derive(Default, Debug)]
-pub(crate) struct TypeCollector<'db>(RefCell<FxHashSet<Type<'db>>>);
+pub(crate) struct TypeCollector<'db> {
+    seen: RefCell<FxHashSet<Type<'db>>>,
+    depth: Cell<u32>,
+}
 
 impl<'db> TypeCollector<'db> {
     pub(crate) fn type_was_already_seen(&self, ty: Type<'db>) -> bool {
-        !self.0.borrow_mut().insert(ty)
+        !self.seen.borrow_mut().insert(ty)
     }
 }
 


### PR DESCRIPTION
## Summary

Recursive generic protocols whose members reference the same protocol with a wrapped type parameter (e.g., Proto[T] with a method returning Proto[list[T]]) can produce infinitely many distinct specializations during type walking. The existing TypeCollector recursion guard checks for exact type matches, but since each level creates a new specialization (Proto[list[T]] → Proto[list[list[T]]] → ...), the guard never sees a repeat and the walk recurses until the stack overflows.

This is the same class of problem as https://github.com/astral-sh/ty/issues/1736 (which was fixed with a depth limit in CycleDetector for type _mapping_), but occurring in the type _walker_ used by CollectReachability during constraint cyclicity checking. The trigger is a sub-protocol that calls cast() on an unbound parent protocol method — this invokes constraint solving, which calls is_cyclic_impl, which uses CollectReachability (the only visitor with should_visit_lazy_type_attributes = true), which walks the protocol interface and hits the unbounded recursion.

The fix adds a depth counter to TypeCollector and bails out at depth 64, matching the approach already used by CycleDetector.

## Test Plan

Added a regression test in protocols.md ("Recursive generic sub-protocol with cast() and unbound super call") that stack-overflows on main and passes with the fix.

## AI disclaimer

I used claude code to diagnose why ty was crashing on our internal codebase, reduce the crash to a minimal test case, propose a fix, and generate the PR descriptions above.  I read and understand the description and it looks reasonable to me, but I don't pretend to understand the ty codebase very well, and it's possible that something is off about this PR.  I hope it's helpful anyway.

FWIW, this is another potential fix that initially looked necessary, but wasn't actually necessary to get ty to not crash on our codebase.  I'm not sure if this is a valid issue with the code or not, but I'm leaving it here in case it's helpful (and sorry if it's just noise):

> Fix 1: types.rs — Missing cycle detection for ProtocolInstance in apply_type_mapping_impl
>
> The Type::apply_type_mapping_impl match arm for ProtocolInstance was the only recursive type that didn't wrap its call in visitor.visit(). Compare with NewTypeInstance and TypeAlias which both call visitor.visit(self, type_mapping, || { ... }) to register with the CycleDetector. Without this, the CycleDetector (which has a depth limit of 64) was never consulted for protocol instances, so recursive protocols could create infinitely many new specializations.
>
> The fix: wrap the ProtocolInstance case in visitor.visit(), same pattern as the other recursive types.
