### PR TITLE
[ty] Add cycle detector for binary inference expressions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -645,3 +645,15 @@ type CallableGuard = TypeGuard[Callable[[], CallableGuard]]
 reveal_type(CallableIs)  # revealed: TypeAliasType
 reveal_type(CallableGuard)  # revealed: TypeAliasType
 ```
+
+### Recursive alias in binary operators doesn't stack overflow
+
+```py
+from typing import reveal_type
+
+type A = int | A
+
+def foo(x: A):
+    reveal_type(x + 1)  # revealed: int
+    reveal_type(1 + x)  # revealed: int
+```

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -4,6 +4,7 @@ use super::TypeInferenceBuilder;
 use crate::Db;
 use crate::types::call::CallArguments;
 use crate::types::constraints::ConstraintSetBuilder;
+use crate::types::cyclic::CycleDetector;
 use crate::types::diagnostic::{
     DIVISION_BY_ZERO, report_unsupported_augmented_assignment, report_unsupported_binary_operation,
 };
@@ -21,6 +22,9 @@ enum BinaryExpressionOperandTypes<'db> {
     Inferred(Type<'db>, Type<'db>),
     TypedDictResult(Type<'db>),
 }
+
+type BinaryExpressionVisitor<'db> =
+    CycleDetector<ast::Operator, (Type<'db>, ast::Operator, Type<'db>), Option<Type<'db>>>;
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
     pub(super) fn infer_binary_expression(
@@ -290,10 +294,29 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     pub(super) fn infer_binary_expression_type(
         &mut self,
         node: AnyNodeRef<'_>,
+        emitted_division_by_zero_diagnostic: bool,
+        left_ty: Type<'db>,
+        right_ty: Type<'db>,
+        op: ast::Operator,
+    ) -> Option<Type<'db>> {
+        self.infer_binary_expression_type_impl(
+            node,
+            emitted_division_by_zero_diagnostic,
+            left_ty,
+            right_ty,
+            op,
+            &BinaryExpressionVisitor::new(Some(Type::Never)),
+        )
+    }
+
+    fn infer_binary_expression_type_impl(
+        &mut self,
+        node: AnyNodeRef<'_>,
         mut emitted_division_by_zero_diagnostic: bool,
         left_ty: Type<'db>,
         right_ty: Type<'db>,
         op: ast::Operator,
+        visitor: &BinaryExpressionVisitor<'db>,
     ) -> Option<Type<'db>> {
         let db = self.db();
 
@@ -319,39 +342,47 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         match (left_ty, right_ty, op) {
             (Type::Union(lhs_union), rhs, _) => lhs_union.try_map(db, |lhs_element| {
-                self.infer_binary_expression_type(
+                self.infer_binary_expression_type_impl(
                     node,
                     emitted_division_by_zero_diagnostic,
                     *lhs_element,
                     rhs,
                     op,
+                    visitor,
                 )
             }),
             (lhs, Type::Union(rhs_union), _) => rhs_union.try_map(db, |rhs_element| {
-                self.infer_binary_expression_type(
+                self.infer_binary_expression_type_impl(
                     node,
                     emitted_division_by_zero_diagnostic,
                     lhs,
                     *rhs_element,
                     op,
+                    visitor,
                 )
             }),
 
-            (Type::TypeAlias(alias), rhs, _) => self.infer_binary_expression_type(
-                node,
-                emitted_division_by_zero_diagnostic,
-                alias.value_type(db),
-                rhs,
-                op,
-            ),
+            (Type::TypeAlias(alias), rhs, _) => visitor.visit((left_ty, op, right_ty), || {
+                self.infer_binary_expression_type_impl(
+                    node,
+                    emitted_division_by_zero_diagnostic,
+                    alias.value_type(db),
+                    rhs,
+                    op,
+                    visitor,
+                )
+            }),
 
-            (lhs, Type::TypeAlias(alias), _) => self.infer_binary_expression_type(
-                node,
-                emitted_division_by_zero_diagnostic,
-                lhs,
-                alias.value_type(db),
-                op,
-            ),
+            (lhs, Type::TypeAlias(alias), _) => visitor.visit((left_ty, op, right_ty), || {
+                self.infer_binary_expression_type_impl(
+                    node,
+                    emitted_division_by_zero_diagnostic,
+                    lhs,
+                    alias.value_type(db),
+                    op,
+                    visitor,
+                )
+            }),
 
             (Type::TypedDict(left_typed_dict), rhs, ast::Operator::BitOr)
                 if rhs.is_assignable_to(db, Type::TypedDict(left_typed_dict)) =>
@@ -440,12 +471,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             left_ty,
                             constraints,
                             |constraint| {
-                                self.infer_binary_expression_type(
+                                self.infer_binary_expression_type_impl(
                                     node,
                                     emitted_division_by_zero_diagnostic,
                                     constraint,
                                     rhs,
                                     op,
+                                    visitor,
                                 )
                             },
                         )
@@ -467,12 +499,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             right_ty,
                             constraints,
                             |constraint| {
-                                self.infer_binary_expression_type(
+                                self.infer_binary_expression_type_impl(
                                     node,
                                     emitted_division_by_zero_diagnostic,
                                     lhs,
                                     constraint,
                                     op,
+                                    visitor,
                                 )
                             },
                         )
@@ -495,12 +528,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     .map(|outcome| outcome.return_type(db))
                     .ok()
                     .or_else(|| {
-                        self.infer_binary_expression_type(
+                        self.infer_binary_expression_type_impl(
                             node,
                             emitted_division_by_zero_diagnostic,
                             newtype.concrete_base_type(db),
                             rhs,
                             op,
+                            visitor,
                         )
                     })
             }
@@ -509,12 +543,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     .map(|outcome| outcome.return_type(db))
                     .ok()
                     .or_else(|| {
-                        self.infer_binary_expression_type(
+                        self.infer_binary_expression_type_impl(
                             node,
                             emitted_division_by_zero_diagnostic,
                             lhs,
                             newtype.concrete_base_type(db),
                             op,
+                            visitor,
                         )
                     })
             }


### PR DESCRIPTION
## Summary

Fixes the example from https://github.com/astral-sh/ty/issues/3196#issuecomment-4172614167:

```python
from typing import reveal_type

type A = int | A

def foo(x: A):
    reveal_type(x+1)
```