### PR TITLE
[ty] Add support for validating members from dynamic classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -738,6 +738,86 @@ NoSlots = type("NoSlots", (), {})
 StringSlots = type("StringSlots", (), {"__slots__": "x"})
 ```
 
+Dynamic class members defined in the namespace dictionary are also checked as overrides of
+superclass members:
+
+```py
+from typing import Final, final
+
+class Base:
+    value: Final[int] = 1
+
+    @final
+    def final_method(self) -> None: ...
+    def method(self, x: int) -> None: ...
+
+def bad(self, x: str) -> None: ...
+def final_override(self) -> None: ...
+
+Dyn1 = type("Dyn1", (Base,), {"method": bad})  # error: [invalid-method-override]
+Dyn2 = type("Dyn2", (Base,), {"final_method": final_override})  # error: [override-of-final-method]
+Dyn3 = type("Dyn3", (Base,), {"value": 2})  # error: [override-of-final-variable]
+```
+
+Dangling `type()` calls and annotated assignments also emit dynamic override diagnostics:
+
+```py
+from typing import Final, final
+
+class Base:
+    value: Final[int] = 1
+
+    @final
+    def final_method(self) -> None: ...
+    def method(self, x: int) -> None: ...
+
+def bad(self, x: str) -> None: ...
+def good(self, x: int) -> None: ...
+def final_override(self) -> None: ...
+
+type("DynExpr", (Base,), {"method": bad})  # error: [invalid-method-override]
+DynAnn: type = type("DynAnn", (Base,), {"final_method": final_override})  # error: [override-of-final-method]
+DynShadowed = type("DynShadowed", (Base,), {"method": bad, "method": good})
+DynUnpacked = type("DynUnpacked", (Base,), {**{"method": bad}})  # error: [invalid-method-override]
+DynUnpackedShadowed = type("DynUnpackedShadowed", (Base,), {"method": bad, **{"method": good}})
+DynUO = type("DynUO", (Base,), {**{"method": good}, "method": bad})  # error: [invalid-method-override]
+# error: [invalid-argument-type]
+# error: [override-of-final-variable]
+DynNonStringKey = type("DynNonStringKey", (Base,), {"value": 2, 1: 3})
+```
+
+Only guaranteed namespace keys from `TypedDict` namespaces are checked for overrides:
+
+```py
+from typing import Final, TypedDict
+
+class Base:
+    value: Final[int] = 1
+
+class OptionalNamespace(TypedDict, total=False):
+    value: int
+
+class RequiredNamespace(TypedDict):
+    value: int
+
+optional_namespace: OptionalNamespace = {}
+required_namespace: RequiredNamespace = {"value": 2}
+
+DynOptional = type("DynOptional", (Base,), optional_namespace)
+DynRequired = type("DynRequired", (Base,), required_namespace)  # error: [override-of-final-variable]
+```
+
+Inherited `NamedTuple` field names are also rejected for dynamic subclasses:
+
+```py
+from typing import NamedTuple
+
+class Base(NamedTuple):
+    name: str
+
+DynNamedTuple = type("DynNamedTuple", (Base,), {"name": "shadowed"})  # error: [invalid-named-tuple-override]
+```
+
 Dynamic classes with non-empty `__slots__` cannot coexist with other disjoint bases:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -846,6 +846,111 @@ NoSlots = type("NoSlots", (), {})
 StringSlots = type("StringSlots", (), {"__slots__": "x"})
 ```
 
+Dynamic class members defined in the namespace dictionary are also checked as overrides of
+superclass members:
+
+```py
+from typing import Final, final
+
+class Base:
+    value: Final[int] = 1
+
+    @final
+    def final_method(self) -> None: ...
+    def method(self, x: int) -> None: ...
+
+def bad(self, x: str) -> None: ...
+def final_override(self) -> None: ...
+
+Dyn1 = type("Dyn1", (Base,), {"method": bad})  # error: [invalid-method-override]
+Dyn2 = type("Dyn2", (Base,), {"final_method": final_override})  # error: [override-of-final-method]
+Dyn3 = type("Dyn3", (Base,), {"value": 2})  # error: [override-of-final-variable]
+
+class StaticBase:
+    @staticmethod
+    def method(x: int) -> None: ...
+
+class ClassBase:
+    @classmethod
+    def method(cls, x: int) -> None: ...
+
+def bad_static(x: str) -> None: ...
+def bad_class(cls, x: str) -> None: ...
+
+DynStatic = type("DynStatic", (StaticBase,), {"method": staticmethod(bad_static)})  # error: [invalid-method-override]
+DynClass = type("DynClass", (ClassBase,), {"method": classmethod(bad_class)})  # error: [invalid-method-override]
+```
+
+Dynamic override checks are skipped when the dynamic class has invalid bases:
+
+```py
+class Base:
+    def method(self, x: int) -> None: ...
+
+def bad(self, x: str) -> None: ...
+
+DynDuplicateBase = type("DynDuplicateBase", (Base, Base), {"method": bad})  # error: [duplicate-base]
+```
+
+Dangling `type()` calls and annotated assignments also emit dynamic override diagnostics:
+
+```py
+from typing import Final, final
+
+class Base:
+    value: Final[int] = 1
+
+    @final
+    def final_method(self) -> None: ...
+    def method(self, x: int) -> None: ...
+
+def bad(self, x: str) -> None: ...
+def good(self, x: int) -> None: ...
+def final_override(self) -> None: ...
+
+type("DynExpr", (Base,), {"method": bad})  # error: [invalid-method-override]
+DynAnn: type = type("DynAnn", (Base,), {"final_method": final_override})  # error: [override-of-final-method]
+DynShadowed = type("DynShadowed", (Base,), {"method": bad, "method": good})
+DynUnpacked = type("DynUnpacked", (Base,), {**{"method": bad}})  # error: [invalid-method-override]
+DynUnpackedShadowed = type("DynUnpackedShadowed", (Base,), {"method": bad, **{"method": good}})
+DynUO = type("DynUO", (Base,), {**{"method": good}, "method": bad})  # error: [invalid-method-override]
+# error: [invalid-argument-type]
+# error: [override-of-final-variable]
+DynNonStringKey = type("DynNonStringKey", (Base,), {"value": 2, 1: 3})
+```
+
+Only guaranteed namespace keys from `TypedDict` namespaces are checked for overrides:
+
+```py
+from typing import Final, TypedDict
+
+class Base:
+    value: Final[int] = 1
+
+class OptionalNamespace(TypedDict, total=False):
+    value: int
+
+class RequiredNamespace(TypedDict):
+    value: int
+
+optional_namespace: OptionalNamespace = {}
+required_namespace: RequiredNamespace = {"value": 2}
+
+DynOptional = type("DynOptional", (Base,), optional_namespace)
+DynRequired = type("DynRequired", (Base,), required_namespace)  # error: [override-of-final-variable]
+```
+
+Inherited `NamedTuple` field names are also rejected for dynamic subclasses:
+
+```py
+from typing import NamedTuple
+
+class Base(NamedTuple):
+    name: str
+
+DynNamedTuple = type("DynNamedTuple", (Base,), {"name": "shadowed"})  # error: [invalid-named-tuple-override]
+```
+
 Dynamic classes with non-empty `__slots__` cannot coexist with other disjoint bases:
 
 ```py

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1,7 +1,8 @@
 use std::fmt::Write;
 
 pub(crate) use self::dynamic_literal::{
-    DynamicClassAnchor, DynamicClassLiteral, DynamicMetaclassConflict, dynamic_class_bases_argument,
+    DynamicClassAnchor, DynamicClassLiteral, DynamicClassMember, DynamicMetaclassConflict,
+    dynamic_class_bases_argument,
 };
 pub(super) use self::enum_literal::{DynamicEnumAnchor, DynamicEnumLiteral, EnumSpec};
 pub use self::known::KnownClass;

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -64,9 +64,15 @@ pub struct DynamicClassLiteral<'db> {
     pub anchor: DynamicClassAnchor<'db>,
 
     /// The class members extracted from the namespace argument.
-    /// Each entry is a (name, type) pair extracted from the dict literal.
+    /// Each entry records the member name, inferred type, and source range
+    /// for the namespace entry that defined it.
     #[returns(deref)]
-    pub members: Box<[(Name, Type<'db>)]>,
+    pub members: Box<[DynamicClassMember<'db>]>,
+
+    /// Dynamic namespace members that are guaranteed to survive as final assignments and are
+    /// therefore safe to use for override diagnostics.
+    #[returns(deref)]
+    pub override_members: Box<[DynamicClassMember<'db>]>,
 
     /// Whether the namespace is dynamic (not a literal dict, or contains
     /// non-string-literal keys). When true, attribute lookups on this class
@@ -106,6 +112,20 @@ pub enum DynamicClassAnchor<'db> {
 }
 
 impl get_size2::GetSize for DynamicClassLiteral<'_> {}
+
+/// A member recovered from the namespace passed to a dynamic class constructor.
+///
+/// For example, the namespace in `type("C", (), {"x": 1})` contributes a member named `x`
+/// with the inferred type of `1` and the source range of the value expression.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+pub struct DynamicClassMember<'db> {
+    /// The string key used for the namespace entry.
+    pub name: Name,
+    /// The inferred type of the namespace value.
+    pub ty: Type<'db>,
+    /// The range to use when reporting diagnostics for this namespace entry.
+    pub range: TextRange,
+}
 
 /// Returns the `bases` argument for a dynamic class constructor call.
 ///
@@ -404,7 +424,7 @@ impl<'db> DynamicClassLiteral<'db> {
         // return Unknown since we can't know what attributes might be defined.
         self.members(db)
             .iter()
-            .find_map(|(member_name, ty)| (name == member_name).then_some(*ty))
+            .find_map(|member| (name == member.name).then_some(member.ty))
             .or_else(|| self.has_dynamic_namespace(db).then(Type::unknown))
             .map(Member::definitely_declared)
             .unwrap_or_default()
@@ -436,10 +456,10 @@ impl<'db> DynamicClassLiteral<'db> {
     /// ```
     pub(super) fn as_disjoint_base(self, db: &'db dyn Db) -> Option<DisjointBase<'db>> {
         // Check if __slots__ is in the members
-        for (name, ty) in self.members(db) {
-            if name.as_str() == "__slots__" {
+        for member in self.members(db) {
+            if member.name.as_str() == "__slots__" {
                 // Check if the slots are non-empty
-                let is_non_empty = match ty {
+                let is_non_empty = match member.ty {
                     // __slots__ = ("a", "b")
                     Type::NominalInstance(nominal) => nominal.tuple_spec(db).is_some_and(|spec| {
                         spec.len().into_fixed_length().is_some_and(|len| len > 0)
@@ -482,6 +502,7 @@ impl<'db> DynamicClassLiteral<'db> {
             self.name(db).clone(),
             self.anchor(db).clone(),
             self.members(db),
+            self.override_members(db),
             self.has_dynamic_namespace(db),
             dataclass_params,
         )

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -64,9 +64,15 @@ pub struct DynamicClassLiteral<'db> {
     pub anchor: DynamicClassAnchor<'db>,
 
     /// The class members extracted from the namespace argument.
-    /// Each entry is a (name, type) pair extracted from the dict literal.
+    /// Each entry records the member name, inferred type, and source range
+    /// for the namespace entry that defined it.
     #[returns(deref)]
-    pub members: Box<[(Name, Type<'db>)]>,
+    pub members: Box<[DynamicClassMember<'db>]>,
+
+    /// Dynamic namespace members that are guaranteed to survive as final assignments and are
+    /// therefore safe to use for override diagnostics.
+    #[returns(deref)]
+    pub override_members: Box<[DynamicClassMember<'db>]>,
 
     /// Whether the namespace is dynamic (not a literal dict, or contains
     /// non-string-literal keys). When true, attribute lookups on this class
@@ -106,6 +112,13 @@ pub enum DynamicClassAnchor<'db> {
 }
 
 impl get_size2::GetSize for DynamicClassLiteral<'_> {}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+pub struct DynamicClassMember<'db> {
+    pub name: Name,
+    pub ty: Type<'db>,
+    pub range: TextRange,
+}
 
 /// Returns the `bases` argument for a dynamic class constructor call.
 ///
@@ -404,7 +417,7 @@ impl<'db> DynamicClassLiteral<'db> {
         // return Unknown since we can't know what attributes might be defined.
         self.members(db)
             .iter()
-            .find_map(|(member_name, ty)| (name == member_name).then_some(*ty))
+            .find_map(|member| (name == member.name).then_some(member.ty))
             .or_else(|| self.has_dynamic_namespace(db).then(Type::unknown))
             .map(Member::definitely_declared)
             .unwrap_or_default()
@@ -436,10 +449,10 @@ impl<'db> DynamicClassLiteral<'db> {
     /// ```
     pub(super) fn as_disjoint_base(self, db: &'db dyn Db) -> Option<DisjointBase<'db>> {
         // Check if __slots__ is in the members
-        for (name, ty) in self.members(db) {
-            if name.as_str() == "__slots__" {
+        for member in self.members(db) {
+            if member.name.as_str() == "__slots__" {
                 // Check if the slots are non-empty
-                let is_non_empty = match ty {
+                let is_non_empty = match member.ty {
                     // __slots__ = ("a", "b")
                     Type::NominalInstance(nominal) => nominal.tuple_spec(db).is_some_and(|spec| {
                         spec.len().into_fixed_length().is_some_and(|len| len > 0)
@@ -482,6 +495,7 @@ impl<'db> DynamicClassLiteral<'db> {
             self.name(db).clone(),
             self.anchor(db).clone(),
             self.members(db),
+            self.override_members(db),
             self.has_dynamic_namespace(db),
             dataclass_params,
         )

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -5688,12 +5688,15 @@ pub(super) fn report_invalid_method_override<'db>(
     superclass_method_kind: MethodKind,
     error_context: impl FnOnce() -> ErrorContextTree<'db>,
 ) {
-    let db = context.db();
+    let signature_span = |function: FunctionType<'db>| {
+        function
+            .literal(context.db())
+            .last_definition
+            .spans(context.db())
+            .signature
+    };
 
-    let signature_span =
-        |function: FunctionType<'db>| function.literal(db).last_definition.spans(db).signature;
-
-    let subclass_definition_kind = subclass_definition.kind(db);
+    let subclass_definition_kind = subclass_definition.kind(context.db());
     let subclass_definition_signature_span = signature_span(subclass_function);
 
     // If the function was originally defined elsewhere and simply assigned
@@ -5703,12 +5706,87 @@ pub(super) fn report_invalid_method_override<'db>(
             .range()
             .unwrap_or_else(|| {
                 subclass_function
-                    .node(db, context.file(), context.module())
+                    .node(context.db(), context.file(), context.module())
                     .range
             })
     } else {
-        subclass_definition.full_range(db, context.module()).range()
+        subclass_definition
+            .full_range(context.db(), context.module())
+            .range()
     };
+
+    report_invalid_method_override_impl(
+        context,
+        member,
+        subclass,
+        diagnostic_range,
+        (!subclass_definition_kind.is_function_def()).then_some(subclass_definition_signature_span),
+        superclass,
+        superclass_type,
+        superclass_method_kind,
+        error_context,
+    );
+}
+
+/// Reports an invalid method override at an arbitrary source range.
+///
+/// This is used when the overriding member is not a normal function definition, such as a
+/// namespace value in a dynamic class:
+///
+/// ```python
+/// class Base:
+///     def method(self, x: int) -> None: ...
+///
+/// def bad(self, x: str) -> None: ...
+///
+/// C = type("C", (Base,), {"method": bad})
+/// ```
+///
+/// The diagnostic should point at the namespace value rather than at a `def` statement.
+#[expect(clippy::too_many_arguments)]
+pub(super) fn report_invalid_method_override_at_range<'db>(
+    context: &InferContext<'db, '_>,
+    member: &str,
+    subclass: ClassType<'db>,
+    range: TextRange,
+    superclass: ClassType<'db>,
+    superclass_type: Type<'db>,
+    superclass_method_kind: MethodKind,
+    error_context: impl FnOnce() -> ErrorContextTree<'db>,
+) {
+    report_invalid_method_override_impl(
+        context,
+        member,
+        subclass,
+        range,
+        None,
+        superclass,
+        superclass_type,
+        superclass_method_kind,
+        error_context,
+    );
+}
+
+/// Shared implementation for invalid method override diagnostics.
+///
+/// Static class definitions pass a signature span when the diagnostic should also annotate the
+/// underlying function signature. Dynamic classes pass only the namespace value range.
+#[expect(clippy::too_many_arguments)]
+pub(super) fn report_invalid_method_override_impl<'db>(
+    context: &InferContext<'db, '_>,
+    member: &str,
+    subclass: ClassType<'db>,
+    diagnostic_range: TextRange,
+    subclass_signature_span: Option<Span>,
+    superclass: ClassType<'db>,
+    superclass_type: Type<'db>,
+    superclass_method_kind: MethodKind,
+    error_context: impl FnOnce() -> ErrorContextTree<'db>,
+) {
+    let db = context.db();
+
+    let signature_span =
+        |function: FunctionType<'db>| function.literal(db).last_definition.spans(db).signature;
 
     let Some(builder) = context.report_lint(&INVALID_METHOD_OVERRIDE, diagnostic_range) else {
         return;
@@ -5762,9 +5840,9 @@ pub(super) fn report_invalid_method_override<'db>(
 
     diagnostic.info("This violates the Liskov Substitution Principle");
 
-    if !subclass_definition_kind.is_function_def() {
+    if let Some(subclass_signature_span) = subclass_signature_span {
         diagnostic.annotate(
-            Annotation::secondary(subclass_definition_signature_span)
+            Annotation::secondary(subclass_signature_span)
                 .message(format_args!("Signature of `{class_name}.{member}`")),
         );
     }
@@ -5866,6 +5944,40 @@ pub(super) fn report_invalid_method_override<'db>(
     }
 }
 
+/// Reports an override of a final method at an arbitrary source range.
+///
+/// Dynamic class namespaces use this for values that replace final methods:
+///
+/// ```python
+/// from typing import final
+///
+/// class Base:
+///     @final
+///     def method(self) -> None: ...
+///
+/// def replacement(self) -> None: ...
+///
+/// C = type("C", (Base,), {"method": replacement})
+/// ```
+pub(super) fn report_overridden_final_method_at_range<'db>(
+    context: &InferContext<'db, '_>,
+    member: &str,
+    range: TextRange,
+    superclass: ClassType<'db>,
+    subclass: ClassType<'db>,
+    superclass_method_defs: &[FunctionType<'db>],
+) {
+    report_overridden_final_method_impl(
+        context,
+        member,
+        range,
+        None,
+        superclass,
+        subclass,
+        superclass_method_defs,
+    );
+}
+
 pub(super) fn report_overridden_final_method<'db>(
     context: &InferContext<'db, '_>,
     member: &str,
@@ -5894,11 +6006,37 @@ pub(super) fn report_overridden_final_method<'db>(
     };
 
     let subclass_definition = property_getter_definition.unwrap_or(subclass_definition);
+    let range = subclass_definition
+        .focus_range(db, context.module())
+        .range();
 
-    let Some(builder) = context.report_lint(
-        &OVERRIDE_OF_FINAL_METHOD,
-        subclass_definition.focus_range(db, context.module()),
-    ) else {
+    report_overridden_final_method_impl(
+        context,
+        member,
+        range,
+        Some((subclass_definition, subclass_type)),
+        superclass,
+        subclass,
+        superclass_method_defs,
+    );
+}
+
+/// Shared implementation for final method override diagnostics.
+///
+/// `subclass_details` is present for static class definitions, where an autofix can sometimes be
+/// offered, and absent for dynamic namespace entries.
+pub(super) fn report_overridden_final_method_impl<'db>(
+    context: &InferContext<'db, '_>,
+    member: &str,
+    range: TextRange,
+    subclass_details: Option<(Definition<'db>, Type<'db>)>,
+    superclass: ClassType<'db>,
+    subclass: ClassType<'db>,
+    superclass_method_defs: &[FunctionType<'db>],
+) {
+    let db = context.db();
+
+    let Some(builder) = context.report_lint(&OVERRIDE_OF_FINAL_METHOD, range) else {
         return;
     };
 
@@ -5954,6 +6092,11 @@ pub(super) fn report_overridden_final_method<'db>(
     }
 
     diagnostic.sub(sub);
+
+    let Some((subclass_definition, subclass_type)) = subclass_details else {
+        diagnostic.help(format_args!("Remove the override of `{member}`"));
+        return;
+    };
 
     // It's tempting to autofix properties as well,
     // but you'd want to delete the `@my_property.deleter` as well as the getter and the setter,
@@ -6056,17 +6199,14 @@ pub(super) fn report_overridden_final_method<'db>(
 pub(super) fn report_overridden_final_variable<'db>(
     context: &InferContext<'db, '_>,
     member: &str,
-    subclass_definition: Definition<'db>,
+    range: TextRange,
     superclass: ClassType<'db>,
     subclass: ClassType<'db>,
     superclass_definition: Option<Definition<'db>>,
 ) {
     let db = context.db();
 
-    let Some(builder) = context.report_lint(
-        &OVERRIDE_OF_FINAL_VARIABLE,
-        subclass_definition.focus_range(db, context.module()),
-    ) else {
+    let Some(builder) = context.report_lint(&OVERRIDE_OF_FINAL_VARIABLE, range) else {
         return;
     };
 

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -5559,12 +5559,15 @@ pub(super) fn report_invalid_method_override<'db>(
     superclass_type: Type<'db>,
     superclass_method_kind: MethodKind,
 ) {
-    let db = context.db();
+    let signature_span = |function: FunctionType<'db>| {
+        function
+            .literal(context.db())
+            .last_definition
+            .spans(context.db())
+            .signature
+    };
 
-    let signature_span =
-        |function: FunctionType<'db>| function.literal(db).last_definition.spans(db).signature;
-
-    let subclass_definition_kind = subclass_definition.kind(db);
+    let subclass_definition_kind = subclass_definition.kind(context.db());
     let subclass_definition_signature_span = signature_span(subclass_function);
 
     // If the function was originally defined elsewhere and simply assigned
@@ -5574,12 +5577,63 @@ pub(super) fn report_invalid_method_override<'db>(
             .range()
             .unwrap_or_else(|| {
                 subclass_function
-                    .node(db, context.file(), context.module())
+                    .node(context.db(), context.file(), context.module())
                     .range
             })
     } else {
-        subclass_definition.full_range(db, context.module()).range()
+        subclass_definition
+            .full_range(context.db(), context.module())
+            .range()
     };
+
+    report_invalid_method_override_impl(
+        context,
+        member,
+        subclass,
+        diagnostic_range,
+        (!subclass_definition_kind.is_function_def()).then_some(subclass_definition_signature_span),
+        superclass,
+        superclass_type,
+        superclass_method_kind,
+    );
+}
+
+pub(super) fn report_invalid_method_override_at_range<'db>(
+    context: &InferContext<'db, '_>,
+    member: &str,
+    subclass: ClassType<'db>,
+    range: TextRange,
+    superclass: ClassType<'db>,
+    superclass_type: Type<'db>,
+    superclass_method_kind: MethodKind,
+) {
+    report_invalid_method_override_impl(
+        context,
+        member,
+        subclass,
+        range,
+        None,
+        superclass,
+        superclass_type,
+        superclass_method_kind,
+    );
+}
+
+#[expect(clippy::too_many_arguments)]
+pub(super) fn report_invalid_method_override_impl<'db>(
+    context: &InferContext<'db, '_>,
+    member: &str,
+    subclass: ClassType<'db>,
+    diagnostic_range: TextRange,
+    subclass_signature_span: Option<Span>,
+    superclass: ClassType<'db>,
+    superclass_type: Type<'db>,
+    superclass_method_kind: MethodKind,
+) {
+    let db = context.db();
+
+    let signature_span =
+        |function: FunctionType<'db>| function.literal(db).last_definition.spans(db).signature;
 
     let class_name = subclass.name(db);
     let superclass_name = superclass.name(db);
@@ -5630,9 +5684,9 @@ pub(super) fn report_invalid_method_override<'db>(
 
     diagnostic.info("This violates the Liskov Substitution Principle");
 
-    if !subclass_definition_kind.is_function_def() {
+    if let Some(subclass_signature_span) = subclass_signature_span {
         diagnostic.annotate(
-            Annotation::secondary(subclass_definition_signature_span)
+            Annotation::secondary(subclass_signature_span)
                 .message(format_args!("Signature of `{class_name}.{member}`")),
         );
     }
@@ -5734,6 +5788,25 @@ pub(super) fn report_invalid_method_override<'db>(
     }
 }
 
+pub(super) fn report_overridden_final_method_at_range<'db>(
+    context: &InferContext<'db, '_>,
+    member: &str,
+    range: TextRange,
+    superclass: ClassType<'db>,
+    subclass: ClassType<'db>,
+    superclass_method_defs: &[FunctionType<'db>],
+) {
+    report_overridden_final_method_impl(
+        context,
+        member,
+        range,
+        None,
+        superclass,
+        subclass,
+        superclass_method_defs,
+    );
+}
+
 pub(super) fn report_overridden_final_method<'db>(
     context: &InferContext<'db, '_>,
     member: &str,
@@ -5762,11 +5835,33 @@ pub(super) fn report_overridden_final_method<'db>(
     };
 
     let subclass_definition = property_getter_definition.unwrap_or(subclass_definition);
+    let range = subclass_definition
+        .focus_range(db, context.module())
+        .range();
 
-    let Some(builder) = context.report_lint(
-        &OVERRIDE_OF_FINAL_METHOD,
-        subclass_definition.focus_range(db, context.module()),
-    ) else {
+    report_overridden_final_method_impl(
+        context,
+        member,
+        range,
+        Some((subclass_definition, subclass_type)),
+        superclass,
+        subclass,
+        superclass_method_defs,
+    );
+}
+
+pub(super) fn report_overridden_final_method_impl<'db>(
+    context: &InferContext<'db, '_>,
+    member: &str,
+    range: TextRange,
+    subclass_details: Option<(Definition<'db>, Type<'db>)>,
+    superclass: ClassType<'db>,
+    subclass: ClassType<'db>,
+    superclass_method_defs: &[FunctionType<'db>],
+) {
+    let db = context.db();
+
+    let Some(builder) = context.report_lint(&OVERRIDE_OF_FINAL_METHOD, range) else {
         return;
     };
 
@@ -5822,6 +5917,11 @@ pub(super) fn report_overridden_final_method<'db>(
     }
 
     diagnostic.sub(sub);
+
+    let Some((subclass_definition, subclass_type)) = subclass_details else {
+        diagnostic.help(format_args!("Remove the override of `{member}`"));
+        return;
+    };
 
     // It's tempting to autofix properties as well,
     // but you'd want to delete the `@my_property.deleter` as well as the getter and the setter,
@@ -5919,12 +6019,47 @@ pub(super) fn report_overridden_final_variable<'db>(
     subclass: ClassType<'db>,
     superclass_definition: Option<Definition<'db>>,
 ) {
+    report_overridden_final_variable_impl(
+        context,
+        member,
+        subclass_definition
+            .focus_range(context.db(), context.module())
+            .range(),
+        superclass,
+        subclass,
+        superclass_definition,
+    );
+}
+
+pub(super) fn report_overridden_final_variable_at_range<'db>(
+    context: &InferContext<'db, '_>,
+    member: &str,
+    range: TextRange,
+    superclass: ClassType<'db>,
+    subclass: ClassType<'db>,
+    superclass_definition: Option<Definition<'db>>,
+) {
+    report_overridden_final_variable_impl(
+        context,
+        member,
+        range,
+        superclass,
+        subclass,
+        superclass_definition,
+    );
+}
+
+pub(super) fn report_overridden_final_variable_impl<'db>(
+    context: &InferContext<'db, '_>,
+    member: &str,
+    range: TextRange,
+    superclass: ClassType<'db>,
+    subclass: ClassType<'db>,
+    superclass_definition: Option<Definition<'db>>,
+) {
     let db = context.db();
 
-    let Some(builder) = context.report_lint(
-        &OVERRIDE_OF_FINAL_VARIABLE,
-        subclass_definition.focus_range(db, context.module()),
-    ) else {
+    let Some(builder) = context.report_lint(&OVERRIDE_OF_FINAL_VARIABLE, range) else {
         return;
     };
 

--- a/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
@@ -1,6 +1,6 @@
 use crate::types::class::{
-    ClassLiteral, DynamicClassAnchor, DynamicClassLiteral, DynamicMetaclassConflict,
-    dynamic_class_bases_argument,
+    ClassLiteral, DynamicClassAnchor, DynamicClassLiteral, DynamicClassMember,
+    DynamicMetaclassConflict, dynamic_class_bases_argument,
 };
 use crate::types::diagnostic::{
     INVALID_ARGUMENT_TYPE, NO_MATCHING_OVERLOAD, report_conflicting_metaclass_from_bases,
@@ -143,9 +143,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .map(|kw| &kw.value)
         });
         let has_exec_body = exec_body_arg.is_some_and(|arg| !arg.is_none_literal_expr());
-        let members: Box<[(ast::name::Name, Type<'db>)]> = Box::new([]);
-        let dynamic_class =
-            DynamicClassLiteral::new(db, name.clone(), anchor, members, has_exec_body, None);
+        let members: Box<[DynamicClassMember<'db>]> = Box::new([]);
+        let override_members: Box<[DynamicClassMember<'db>]> = Box::new([]);
+        let dynamic_class = DynamicClassLiteral::new(
+            db,
+            name.clone(),
+            anchor,
+            members,
+            override_members,
+            has_exec_body,
+            None,
+        );
 
         // For dangling calls, validate bases eagerly. For assigned calls, validation is
         // deferred along with bases inference.

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/dynamic_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/dynamic_class.rs
@@ -6,8 +6,9 @@ use crate::types::{
         IncompatibleBases, report_conflicting_metaclass_from_bases, report_instance_layout_conflict,
     },
     infer::builder::dynamic_class::report_dynamic_mro_errors,
+    overrides,
 };
-use ty_python_core::definition::{Definition, DefinitionKind};
+use ty_python_core::definition::Definition;
 
 /// Iterate over all dynamic class definitions (created using `type()` calls) to check that
 /// the definition will not cause an exception to be raised at runtime. This needs to be done
@@ -18,10 +19,6 @@ pub(crate) fn check_dynamic_class_definition<'db>(
 ) {
     let db = context.db();
 
-    let DefinitionKind::Assignment(assignment) = definition.kind(db) else {
-        return;
-    };
-
     let ty = binding_type(db, definition);
 
     // Check if it's a dynamic class with a Definition anchor.
@@ -29,13 +26,15 @@ pub(crate) fn check_dynamic_class_definition<'db>(
         return;
     };
 
-    // Only check classes with Definition anchors (i.e., assigned `type()` calls).
-    // Dangling `type()` calls are validated eagerly during inference.
+    // Only check classes with Definition anchors. Dangling `type()` calls are validated eagerly
+    // during inference.
     let DynamicClassAnchor::Definition(_) = dynamic_class.anchor(db) else {
         return;
     };
 
-    let value = assignment.value(context.module());
+    let Some(value) = definition.kind(db).value(context.module()) else {
+        return;
+    };
     let Some(call_expr) = value.as_call_expr() else {
         return;
     };
@@ -88,4 +87,6 @@ pub(crate) fn check_dynamic_class_definition<'db>(
             base2.display(db),
         );
     }
+
+    overrides::check_dynamic_class(context, dynamic_class);
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
@@ -1,5 +1,6 @@
 use crate::types::class::{
-    ClassLiteral, DynamicClassAnchor, DynamicClassLiteral, DynamicMetaclassConflict,
+    ClassLiteral, DynamicClassAnchor, DynamicClassLiteral, DynamicClassMember,
+    DynamicMetaclassConflict,
 };
 use crate::types::diagnostic::{
     INVALID_ARGUMENT_TYPE, NO_MATCHING_OVERLOAD, report_conflicting_metaclass_from_bases,
@@ -9,12 +10,172 @@ use crate::types::infer::builder::{
     TypeInferenceBuilder,
     dynamic_class::{DynamicClassKind, report_dynamic_mro_errors},
 };
-use crate::types::{KnownClass, SubclassOfType, Type, TypeContext, definition_expression_type};
+use crate::types::{
+    KnownClass, SubclassOfType, Type, TypeContext, definition_expression_type, overrides,
+    typed_dict::extract_unpacked_typed_dict_keys,
+};
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, HasNodeIndex, NodeIndex};
+use ruff_text_size::Ranged;
+use rustc_hash::FxHashMap;
 use ty_python_core::definition::Definition;
 
+#[derive(Default)]
+struct GuaranteedDynamicClassMembers<'db> {
+    members: Vec<DynamicClassMember<'db>>,
+    member_indices: FxHashMap<Name, usize>,
+}
+
+impl<'db> GuaranteedDynamicClassMembers<'db> {
+    fn insert(&mut self, member: DynamicClassMember<'db>) {
+        if let Some(index) = self.member_indices.get(&member.name) {
+            self.members[*index] = member;
+        } else {
+            self.member_indices
+                .insert(member.name.clone(), self.members.len());
+            self.members.push(member);
+        }
+    }
+
+    fn clear(&mut self) {
+        self.members.clear();
+        self.member_indices.clear();
+    }
+
+    fn into_vec(self) -> Vec<DynamicClassMember<'db>> {
+        self.members
+    }
+}
+
+struct ExtractedDynamicNamespace<'db> {
+    members: Vec<DynamicClassMember<'db>>,
+    has_dynamic_namespace: bool,
+    has_uncertain_writes: bool,
+}
+
 impl<'db> TypeInferenceBuilder<'db, '_> {
+    fn extract_dynamic_override_members(
+        &self,
+        namespace_arg: &ast::Expr,
+        namespace_type: Type<'db>,
+    ) -> (Box<[DynamicClassMember<'db>]>, bool) {
+        if let ast::Expr::Dict(dict) = namespace_arg {
+            let extracted = self.extract_dynamic_override_members_from_dict(dict);
+            return (
+                extracted.members.into_boxed_slice(),
+                extracted.has_dynamic_namespace,
+            );
+        }
+
+        if let Type::TypedDict(typed_dict) = namespace_type {
+            // `namespace` is a TypedDict instance. Only required keys are guaranteed to be
+            // present at runtime; optional keys may be omitted.
+            let members: Box<[DynamicClassMember<'db>]> = typed_dict
+                .items(self.db())
+                .iter()
+                .filter_map(|(name, field)| {
+                    field.is_required().then_some(DynamicClassMember {
+                        name: name.clone(),
+                        ty: field.declared_ty,
+                        range: namespace_arg.range(),
+                    })
+                })
+                .collect();
+
+            // TypedDicts are "open" (can have additional string keys), so this is still a
+            // dynamic namespace for unknown attributes.
+            return (members, true);
+        }
+
+        // `namespace` is not a dict literal, so it's dynamic.
+        (Box::new([]), true)
+    }
+
+    fn extract_dynamic_override_members_from_dict(
+        &self,
+        dict: &ast::ExprDict,
+    ) -> ExtractedDynamicNamespace<'db> {
+        let mut guaranteed_members = GuaranteedDynamicClassMembers::default();
+        let mut has_dynamic_namespace = false;
+        let mut has_uncertain_writes = false;
+
+        for item in &dict.items {
+            if let Some(key_expr) = item.key.as_ref() {
+                let key_ty = self.expression_type(key_expr);
+                let Some(key_name) = key_ty.as_string_literal() else {
+                    has_dynamic_namespace = true;
+
+                    // Keys that cannot be strings still make the namespace dynamic, but they
+                    // cannot shadow string-named members and therefore should not erase
+                    // guaranteed override diagnostics for earlier entries.
+                    if !key_ty.is_disjoint_from(self.db(), KnownClass::Str.to_instance(self.db())) {
+                        guaranteed_members.clear();
+                        has_uncertain_writes = true;
+                    }
+                    continue;
+                };
+
+                guaranteed_members.insert(DynamicClassMember {
+                    name: ast::name::Name::new(key_name.value(self.db())),
+                    ty: self.expression_type(&item.value),
+                    range: item.value.range(),
+                });
+                continue;
+            }
+
+            let unpacked = self.extract_unpacked_dynamic_override_members(&item.value);
+            if unpacked.has_uncertain_writes {
+                guaranteed_members.clear();
+            }
+            for member in unpacked.members {
+                guaranteed_members.insert(member);
+            }
+            has_dynamic_namespace |= unpacked.has_dynamic_namespace;
+            has_uncertain_writes |= unpacked.has_uncertain_writes;
+        }
+
+        ExtractedDynamicNamespace {
+            members: guaranteed_members.into_vec(),
+            has_dynamic_namespace,
+            has_uncertain_writes,
+        }
+    }
+
+    fn extract_unpacked_dynamic_override_members(
+        &self,
+        unpacked: &ast::Expr,
+    ) -> ExtractedDynamicNamespace<'db> {
+        if let ast::Expr::Dict(dict) = unpacked {
+            return self.extract_dynamic_override_members_from_dict(dict);
+        }
+
+        let unpacked_type = self.expression_type(unpacked);
+        if let Some(unpacked_keys) = extract_unpacked_typed_dict_keys(self.db(), unpacked_type) {
+            let members = unpacked_keys
+                .into_iter()
+                .filter_map(|(name, unpacked_key)| {
+                    unpacked_key.is_required.then_some(DynamicClassMember {
+                        name,
+                        ty: unpacked_key.value_ty,
+                        range: unpacked.range(),
+                    })
+                })
+                .collect();
+
+            return ExtractedDynamicNamespace {
+                members,
+                has_dynamic_namespace: true,
+                has_uncertain_writes: true,
+            };
+        }
+
+        ExtractedDynamicNamespace {
+            members: Vec::new(),
+            has_dynamic_namespace: true,
+            has_uncertain_writes: true,
+        }
+    }
+
     /// Infer a call to `builtins.type()`.
     ///
     /// `builtins.type` has two overloads: a single-argument overload (e.g. `type("foo")`,
@@ -133,7 +294,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
 
         // Extract members from the namespace dict (third argument).
-        let (members, has_dynamic_namespace): (Box<[(ast::name::Name, Type<'db>)]>, bool) =
+        let (members, has_dynamic_namespace): (Box<[DynamicClassMember<'db>]>, bool) =
             if let ast::Expr::Dict(dict) = namespace_arg {
                 // Check if all keys are string literal types. If any key is not a string literal
                 // type or is missing (spread), the namespace is considered dynamic.
@@ -152,7 +313,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         let key_name = ast::name::Name::new(key_name.value(db));
                         // Get the already-inferred type from when we inferred the dict above.
                         let value_ty = self.expression_type(&item.value);
-                        Some((key_name, value_ty))
+                        Some(DynamicClassMember {
+                            name: key_name,
+                            ty: value_ty,
+                            range: item.value.range(),
+                        })
                     })
                     .collect();
                 (members, !all_keys_are_string_literals)
@@ -160,16 +325,23 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 // `namespace` is a TypedDict instance. Extract known keys as members.
                 // TypedDicts are "open" (can have additional string keys), so this
                 // is still a dynamic namespace for unknown attributes.
-                let members: Box<[(ast::name::Name, Type<'db>)]> = typed_dict
+                let members: Box<[DynamicClassMember<'db>]> = typed_dict
                     .items(db)
                     .iter()
-                    .map(|(name, field)| (name.clone(), field.declared_ty))
+                    .map(|(name, field)| DynamicClassMember {
+                        name: name.clone(),
+                        ty: field.declared_ty,
+                        range: namespace_arg.range(),
+                    })
                     .collect();
                 (members, true)
             } else {
                 // `namespace` is not a dict literal, so it's dynamic.
                 (Box::new([]), true)
             };
+
+        let (override_members, _has_dynamic_override_namespace) =
+            self.extract_dynamic_override_members(namespace_arg, namespace_type);
 
         if !matches!(namespace_type, Type::TypedDict(_))
             && !namespace_type.is_assignable_to(
@@ -256,6 +428,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             name.clone(),
             anchor,
             members,
+            override_members,
             has_dynamic_namespace,
             None,
         );
@@ -303,6 +476,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     base2.display(db),
                 );
             }
+
+            overrides::check_dynamic_class(&self.context, dynamic_class);
         }
 
         Type::ClassLiteral(ClassLiteral::Dynamic(dynamic_class))

--- a/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
@@ -1,5 +1,6 @@
 use crate::types::class::{
-    ClassLiteral, DynamicClassAnchor, DynamicClassLiteral, DynamicMetaclassConflict,
+    ClassLiteral, DynamicClassAnchor, DynamicClassLiteral, DynamicClassMember,
+    DynamicMetaclassConflict,
 };
 use crate::types::diagnostic::{
     INVALID_ARGUMENT_TYPE, NO_MATCHING_OVERLOAD, report_conflicting_metaclass_from_bases,
@@ -9,12 +10,235 @@ use crate::types::infer::builder::{
     TypeInferenceBuilder,
     dynamic_class::{DynamicClassKind, report_dynamic_mro_errors},
 };
-use crate::types::{KnownClass, SubclassOfType, Type, TypeContext, definition_expression_type};
+use crate::types::{
+    KnownClass, SubclassOfType, Type, TypeContext, definition_expression_type, overrides,
+    typed_dict::extract_unpacked_typed_dict_keys_from_value_type,
+};
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, HasNodeIndex, NodeIndex};
+use ruff_text_size::Ranged;
+use rustc_hash::FxHashMap;
 use ty_python_core::definition::Definition;
 
+/// Tracks namespace members that are guaranteed to survive until class creation.
+///
+/// The order matches the dictionary's insertion order, but later writes to the same string key
+/// replace earlier writes. That matches Python's dictionary semantics:
+///
+/// ```python
+/// C = type("C", (), {"method": first, "method": second})
+/// ```
+///
+/// In this example, override diagnostics must consider only `second`.
+#[derive(Default)]
+struct GuaranteedDynamicClassMembers<'db> {
+    members: Vec<DynamicClassMember<'db>>,
+    member_indices: FxHashMap<Name, usize>,
+}
+
+impl<'db> GuaranteedDynamicClassMembers<'db> {
+    /// Inserts a guaranteed member, replacing an earlier member with the same name.
+    fn insert(&mut self, member: DynamicClassMember<'db>) {
+        if let Some(index) = self.member_indices.get(&member.name) {
+            self.members[*index] = member;
+        } else {
+            self.member_indices
+                .insert(member.name.clone(), self.members.len());
+            self.members.push(member);
+        }
+    }
+
+    /// Removes all currently guaranteed members after an uncertain namespace write.
+    ///
+    /// For example, a dynamic key could overwrite any previous string-named member:
+    ///
+    /// ```python
+    /// C = type("C", (), {"method": good, maybe_name: bad})
+    /// ```
+    fn clear(&mut self) {
+        self.members.clear();
+        self.member_indices.clear();
+    }
+
+    /// Returns the surviving members in dictionary insertion order.
+    fn into_vec(self) -> Vec<DynamicClassMember<'db>> {
+        self.members
+    }
+}
+
+/// Members extracted from a dynamic class namespace, plus uncertainty metadata.
+///
+/// `has_dynamic_namespace` controls normal attribute lookup for unknown members, while
+/// `has_uncertain_writes` controls whether earlier guaranteed override members must be discarded.
+struct ExtractedDynamicNamespace<'db> {
+    members: Vec<DynamicClassMember<'db>>,
+    has_dynamic_namespace: bool,
+    has_uncertain_writes: bool,
+}
+
 impl<'db> TypeInferenceBuilder<'db, '_> {
+    /// Extracts namespace members that are safe to use for dynamic override diagnostics.
+    ///
+    /// This is more conservative than normal dynamic member extraction: only entries that are
+    /// guaranteed to be present at class creation are returned.
+    ///
+    /// ```python
+    /// class Base:
+    ///     def method(self, x: int) -> None: ...
+    ///
+    /// def bad(self, x: str) -> None: ...
+    ///
+    /// C = type("C", (Base,), {"method": bad})
+    /// ```
+    ///
+    /// The `method` entry is guaranteed, so it can produce an `invalid-method-override`
+    /// diagnostic.
+    fn extract_dynamic_override_members(
+        &self,
+        namespace_arg: &ast::Expr,
+        namespace_type: Type<'db>,
+    ) -> (Box<[DynamicClassMember<'db>]>, bool) {
+        if let ast::Expr::Dict(dict) = namespace_arg {
+            let extracted = self.extract_dynamic_override_members_from_dict(dict);
+            return (
+                extracted.members.into_boxed_slice(),
+                extracted.has_dynamic_namespace,
+            );
+        }
+
+        if let Type::TypedDict(typed_dict) = namespace_type {
+            // `namespace` is a TypedDict instance. Only required keys are guaranteed to be
+            // present at runtime; optional keys may be omitted.
+            let members: Box<[DynamicClassMember<'db>]> = typed_dict
+                .items(self.db())
+                .iter()
+                .filter_map(|(name, field)| {
+                    field.is_required().then_some(DynamicClassMember {
+                        name: name.clone(),
+                        ty: field.declared_ty,
+                        range: namespace_arg.range(),
+                    })
+                })
+                .collect();
+
+            // TypedDicts are "open" (can have additional string keys), so this is still a
+            // dynamic namespace for unknown attributes.
+            return (members, true);
+        }
+
+        // `namespace` is not a dict literal, so it's dynamic.
+        (Box::new([]), true)
+    }
+
+    /// Extracts guaranteed override members from a literal dictionary namespace.
+    ///
+    /// Spread entries and non-literal keys are treated conservatively because they can overwrite
+    /// earlier values:
+    ///
+    /// ```python
+    /// C = type("C", (), {"method": first, **namespace, "other": value})
+    /// ```
+    ///
+    /// After `**namespace`, only later entries with known string keys are guaranteed.
+    fn extract_dynamic_override_members_from_dict(
+        &self,
+        dict: &ast::ExprDict,
+    ) -> ExtractedDynamicNamespace<'db> {
+        let mut guaranteed_members = GuaranteedDynamicClassMembers::default();
+        let mut has_dynamic_namespace = false;
+        let mut has_uncertain_writes = false;
+
+        for item in &dict.items {
+            if let Some(key_expr) = item.key.as_ref() {
+                let key_ty = self.expression_type(key_expr);
+                let Some(key_name) = key_ty.as_string_literal() else {
+                    has_dynamic_namespace = true;
+
+                    // Keys that cannot be strings still make the namespace dynamic, but they
+                    // cannot shadow string-named members and therefore should not erase
+                    // guaranteed override diagnostics for earlier entries.
+                    if !key_ty.is_disjoint_from(self.db(), KnownClass::Str.to_instance(self.db())) {
+                        guaranteed_members.clear();
+                        has_uncertain_writes = true;
+                    }
+                    continue;
+                };
+
+                guaranteed_members.insert(DynamicClassMember {
+                    name: ast::name::Name::new(key_name.value(self.db())),
+                    ty: self.expression_type(&item.value),
+                    range: item.value.range(),
+                });
+                continue;
+            }
+
+            let unpacked = self.extract_unpacked_dynamic_override_members(&item.value);
+            if unpacked.has_uncertain_writes {
+                guaranteed_members.clear();
+            }
+            for member in unpacked.members {
+                guaranteed_members.insert(member);
+            }
+            has_dynamic_namespace |= unpacked.has_dynamic_namespace;
+            has_uncertain_writes |= unpacked.has_uncertain_writes;
+        }
+
+        ExtractedDynamicNamespace {
+            members: guaranteed_members.into_vec(),
+            has_dynamic_namespace,
+            has_uncertain_writes,
+        }
+    }
+
+    /// Extracts guaranteed override members from a dictionary unpack in a namespace literal.
+    ///
+    /// Literal unpacked dictionaries preserve their own guaranteed keys, while a typed-dict unpack
+    /// only guarantees required keys:
+    ///
+    /// ```python
+    /// namespace = {"method": bad}
+    /// C = type("C", (Base,), {**namespace})
+    /// ```
+    ///
+    /// If the unpacked value is not statically understood, the namespace is treated as dynamic and
+    /// as an uncertain write.
+    fn extract_unpacked_dynamic_override_members(
+        &self,
+        unpacked: &ast::Expr,
+    ) -> ExtractedDynamicNamespace<'db> {
+        if let ast::Expr::Dict(dict) = unpacked {
+            return self.extract_dynamic_override_members_from_dict(dict);
+        }
+
+        let unpacked_type = self.expression_type(unpacked);
+        if let Some(unpacked_keys) =
+            extract_unpacked_typed_dict_keys_from_value_type(self.db(), unpacked_type)
+        {
+            let members = unpacked_keys
+                .into_iter()
+                .filter_map(|(name, unpacked_key)| {
+                    unpacked_key.is_required.then_some(DynamicClassMember {
+                        name,
+                        ty: unpacked_key.value_ty,
+                        range: unpacked.range(),
+                    })
+                })
+                .collect();
+
+            return ExtractedDynamicNamespace {
+                members,
+                has_dynamic_namespace: true,
+                has_uncertain_writes: true,
+            };
+        }
+
+        ExtractedDynamicNamespace {
+            members: Vec::new(),
+            has_dynamic_namespace: true,
+            has_uncertain_writes: true,
+        }
+    }
+
     /// Infer a call to `builtins.type()`.
     ///
     /// `builtins.type` has two overloads: a single-argument overload (e.g. `type("foo")`,
@@ -133,7 +357,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
 
         // Extract members from the namespace dict (third argument).
-        let (members, has_dynamic_namespace): (Box<[(ast::name::Name, Type<'db>)]>, bool) =
+        let (members, has_dynamic_namespace): (Box<[DynamicClassMember<'db>]>, bool) =
             if let ast::Expr::Dict(dict) = namespace_arg {
                 // Check if all keys are string literal types. If any key is not a string literal
                 // type or is missing (spread), the namespace is considered dynamic.
@@ -152,7 +376,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         let key_name = ast::name::Name::new(key_name.value(db));
                         // Get the already-inferred type from when we inferred the dict above.
                         let value_ty = self.expression_type(&item.value);
-                        Some((key_name, value_ty))
+                        Some(DynamicClassMember {
+                            name: key_name,
+                            ty: value_ty,
+                            range: item.value.range(),
+                        })
                     })
                     .collect();
                 (members, !all_keys_are_string_literals)
@@ -160,16 +388,23 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 // `namespace` is a TypedDict instance. Extract known keys as members.
                 // TypedDicts are "open" (can have additional string keys), so this
                 // is still a dynamic namespace for unknown attributes.
-                let members: Box<[(ast::name::Name, Type<'db>)]> = typed_dict
+                let members: Box<[DynamicClassMember<'db>]> = typed_dict
                     .items(db)
                     .iter()
-                    .map(|(name, field)| (name.clone(), field.declared_ty))
+                    .map(|(name, field)| DynamicClassMember {
+                        name: name.clone(),
+                        ty: field.declared_ty,
+                        range: namespace_arg.range(),
+                    })
                     .collect();
                 (members, true)
             } else {
                 // `namespace` is not a dict literal, so it's dynamic.
                 (Box::new([]), true)
             };
+
+        let (override_members, _has_dynamic_override_namespace) =
+            self.extract_dynamic_override_members(namespace_arg, namespace_type);
 
         if !matches!(namespace_type, Type::TypedDict(_))
             && !namespace_type.is_assignable_to(
@@ -256,6 +491,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             name.clone(),
             anchor,
             members,
+            override_members,
             has_dynamic_namespace,
             None,
         );
@@ -303,6 +539,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     base2.display(db),
                 );
             }
+
+            overrides::check_dynamic_class(&self.context, dynamic_class);
         }
 
         Type::ClassLiteral(ClassLiteral::Dynamic(dynamic_class))

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -7,7 +7,8 @@ use bitflags::bitflags;
 use ruff_db::diagnostic::Annotation;
 use ruff_python_ast::name::Name;
 use ruff_python_stdlib::identifiers::is_mangled_private;
-use rustc_hash::FxHashSet;
+use ruff_text_size::{Ranged, TextRange};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     Db,
@@ -17,14 +18,16 @@ use crate::{
         CallableType, ClassBase, ClassLiteral, ClassType, KnownClass, Parameter, Parameters,
         Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
         call::CallArguments,
-        class::{CodeGeneratorKind, FieldKind},
+        class::{CodeGeneratorKind, DynamicClassLiteral, FieldKind},
         constraints::ConstraintSetBuilder,
         context::InferContext,
         diagnostic::{
             INVALID_ASSIGNMENT, INVALID_DATACLASS, INVALID_EXPLICIT_OVERRIDE,
             INVALID_METHOD_OVERRIDE, INVALID_NAMED_TUPLE, INVALID_NAMED_TUPLE_OVERRIDE,
             OVERRIDE_OF_FINAL_METHOD, OVERRIDE_OF_FINAL_VARIABLE, report_invalid_method_override,
-            report_overridden_final_method, report_overridden_final_variable,
+            report_invalid_method_override_at_range, report_overridden_final_method,
+            report_overridden_final_method_at_range, report_overridden_final_variable,
+            report_overridden_final_variable_at_range,
         },
         enums::{EnumMetadata, enum_metadata},
         function::{FunctionDecorators, FunctionType, KnownFunction},
@@ -57,9 +60,6 @@ const PROHIBITED_NAMEDTUPLE_ATTRS: &[&str] = &[
     "_source",
 ];
 
-// TODO: Support dynamic class literals. If we allow dynamic classes to define attributes in their
-// namespace dictionary, we should also check whether those attributes are valid overrides of
-// attributes in their superclasses.
 pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticClassLiteral<'db>) {
     let db = context.db();
     let configuration = OverrideRulesConfig::from(context);
@@ -84,13 +84,69 @@ pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticCla
     }
 }
 
+pub(super) fn check_dynamic_class<'db>(
+    context: &InferContext<'db, '_>,
+    class: DynamicClassLiteral<'db>,
+) {
+    let db = context.db();
+    let configuration = OverrideRulesConfig::from(context);
+    if configuration.no_rules_enabled() {
+        return;
+    }
+
+    let class_specialized = ClassLiteral::Dynamic(class).identity_specialization(db);
+    let class_kind = CodeGeneratorKind::from_class(db, class.into(), None);
+    let mut final_members_by_name = FxHashMap::default();
+    let mut seen_names = FxHashSet::default();
+
+    for dynamic_member in class.override_members(db) {
+        final_members_by_name.insert(dynamic_member.name.clone(), dynamic_member);
+    }
+
+    for dynamic_member in class.override_members(db) {
+        // Dict literals keep the original insertion order for duplicate keys, but the last
+        // assignment provides the surviving value.
+        if !seen_names.insert(dynamic_member.name.clone()) {
+            continue;
+        }
+
+        let Some(dynamic_member) = final_members_by_name.get(&dynamic_member.name).copied() else {
+            continue;
+        };
+
+        let member = Member {
+            name: dynamic_member.name.clone(),
+            ty: dynamic_member.ty,
+        };
+        check_named_tuple_field_override(
+            context,
+            configuration,
+            class_specialized,
+            &member.name,
+            MemberOrigin::Dynamic {
+                range: dynamic_member.range,
+            },
+        );
+        check_member_override_rules(
+            context,
+            configuration,
+            class_kind,
+            class_specialized,
+            &member,
+            MemberOrigin::Dynamic {
+                range: dynamic_member.range,
+            },
+        );
+    }
+}
+
 /// Returns the first inherited `NamedTuple` field in the MRO for `field_name`.
 fn conflicting_named_tuple_field_in_mro<'db>(
     db: &'db dyn Db,
-    class: StaticClassLiteral<'db>,
+    class: ClassType<'db>,
     field_name: &Name,
 ) -> Option<(ClassType<'db>, Option<Definition<'db>>)> {
-    for class_base in class.iter_mro(db, None).skip(1) {
+    for class_base in class.iter_mro(db).skip(1) {
         let Some(superclass) = class_base.into_class() else {
             continue;
         };
@@ -124,6 +180,59 @@ fn conflicting_named_tuple_field_in_mro<'db>(
     None
 }
 
+fn check_named_tuple_field_override<'db>(
+    context: &InferContext<'db, '_>,
+    configuration: OverrideRulesConfig,
+    class: ClassType<'db>,
+    member_name: &Name,
+    origin: MemberOrigin<'db>,
+) {
+    if !configuration.check_invalid_named_tuple_field_overrides() {
+        return;
+    }
+
+    let db = context.db();
+
+    let Some((superclass, overridden_field_declaration)) =
+        conflicting_named_tuple_field_in_mro(db, class, member_name)
+    else {
+        return;
+    };
+
+    let primary_range = match origin {
+        MemberOrigin::Static {
+            first_reachable_definition,
+        } => first_reachable_definition
+            .focus_range(db, context.module())
+            .range(),
+        MemberOrigin::Dynamic { range } => range,
+    };
+
+    let Some(builder) = context.report_lint(&INVALID_NAMED_TUPLE_OVERRIDE, primary_range) else {
+        return;
+    };
+
+    let mut diagnostic = builder.into_diagnostic(format_args!(
+        "Cannot override NamedTuple field `{}` inherited from `{}`",
+        member_name,
+        superclass.name(db)
+    ));
+    diagnostic.info("Subclass members are not allowed to reuse inherited NamedTuple field names");
+    if let Some(first_declaration) = overridden_field_declaration
+        && first_declaration.file(db) == context.file()
+    {
+        diagnostic.annotate(
+            Annotation::secondary(
+                context.span(first_declaration.kind(db).full_range(context.module())),
+            )
+            .message(format_args!(
+                "Inherited NamedTuple field `{}` declared here",
+                member_name
+            )),
+        );
+    }
+}
+
 fn check_class_declaration<'db>(
     context: &InferContext<'db, '_>,
     configuration: OverrideRulesConfig,
@@ -132,41 +241,6 @@ fn check_class_declaration<'db>(
     class_scope: ScopeId<'db>,
     member: &MemberWithDefinition<'db>,
 ) {
-    /// Salsa-tracked query to check whether any of the definitions of a symbol
-    /// in a superclass scope are function definitions.
-    ///
-    /// We need to know this for compatibility with pyright and mypy, neither of which emit an error
-    /// on `C.f` here:
-    ///
-    /// ```python
-    /// from typing import final
-    ///
-    /// class A:
-    ///     @final
-    ///     def f(self) -> None: ...
-    ///
-    /// class B:
-    ///     f = A.f
-    ///
-    /// class C(B):
-    ///     def f(self) -> None: ...  # no error here
-    /// ```
-    ///
-    /// This is a Salsa-tracked query because it has to look at the AST node for the definition,
-    /// which might be in a different Python module. If this weren't a tracked query, we could
-    /// introduce cross-module dependencies and over-invalidation.
-    #[salsa::tracked(heap_size=ruff_memory_usage::heap_size)]
-    fn is_function_definition<'db>(
-        db: &'db dyn Db,
-        scope: ScopeId<'db>,
-        symbol: ScopedSymbolId,
-    ) -> bool {
-        use_def_map(db, scope)
-            .end_of_scope_symbol_bindings(symbol)
-            .filter_map(|binding| binding.binding.definition())
-            .any(|definition| definition.kind(db).is_function_def())
-    }
-
     let db = context.db();
 
     let MemberWithDefinition {
@@ -175,14 +249,6 @@ fn check_class_declaration<'db>(
     } = member;
 
     let instance_of_class = Type::instance(db, class);
-
-    let Place::Defined(DefinedPlace {
-        ty: type_on_subclass_instance,
-        ..
-    }) = instance_of_class.member(db, &member.name).place
-    else {
-        return;
-    };
 
     let Some((literal, specialization)) = class.static_class_literal(db) else {
         return;
@@ -226,35 +292,15 @@ fn check_class_declaration<'db>(
         Some(CodeGeneratorKind::TypedDict) | None => {}
     }
 
-    if configuration.check_invalid_named_tuple_field_overrides()
-        && let Some((superclass, overridden_field_declaration)) =
-            conflicting_named_tuple_field_in_mro(db, literal, &member.name)
-        && let Some(builder) = context.report_lint(
-            &INVALID_NAMED_TUPLE_OVERRIDE,
-            first_reachable_definition.focus_range(db, context.module()),
-        )
-    {
-        let mut diagnostic = builder.into_diagnostic(format_args!(
-            "Cannot override NamedTuple field `{}` inherited from `{}`",
-            member.name,
-            superclass.name(db)
-        ));
-        diagnostic
-            .info("Subclass members are not allowed to reuse inherited NamedTuple field names");
-        if let Some(first_declaration) = overridden_field_declaration
-            && first_declaration.file(db) == context.file()
-        {
-            diagnostic.annotate(
-                Annotation::secondary(
-                    context.span(first_declaration.kind(db).full_range(context.module())),
-                )
-                .message(format_args!(
-                    "Inherited NamedTuple field `{}` declared here",
-                    member.name
-                )),
-            );
-        }
-    }
+    check_named_tuple_field_override(
+        context,
+        configuration,
+        class,
+        &member.name,
+        MemberOrigin::Static {
+            first_reachable_definition: *first_reachable_definition,
+        },
+    );
 
     // Check for invalid Enum member values.
     if let Some(enum_info) = enum_info {
@@ -316,6 +362,189 @@ fn check_class_declaration<'db>(
             }
         }
     }
+
+    check_member_override_rules(
+        context,
+        configuration,
+        class_kind,
+        class,
+        member,
+        MemberOrigin::Static {
+            first_reachable_definition: *first_reachable_definition,
+        },
+    );
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(super) enum MethodKind<'db> {
+    Synthesized(CodeGeneratorKind<'db>),
+    #[default]
+    NotSynthesized,
+}
+
+bitflags! {
+    /// Bitflags representing which override-related rules have been enabled.
+    #[derive(Default, Debug, Copy, Clone)]
+    struct OverrideRulesConfig: u8 {
+        const LISKOV_METHODS = 1 << 0;
+        const EXPLICIT_OVERRIDE = 1 << 1;
+        const FINAL_METHOD_OVERRIDDEN = 1 << 2;
+        const INVALID_NAMED_TUPLE = 1 << 3;
+        const NAMED_TUPLE_FIELD_OVERRIDE = 1 << 4;
+        const INVALID_DATACLASS = 1 << 5;
+        const FINAL_VARIABLE_OVERRIDDEN = 1 << 6;
+        const INVALID_ENUM_VALUE = 1 << 7;
+    }
+}
+
+impl From<&InferContext<'_, '_>> for OverrideRulesConfig {
+    fn from(value: &InferContext<'_, '_>) -> Self {
+        let db = value.db();
+        let rule_selection = db.rule_selection(value.file());
+
+        let mut config = OverrideRulesConfig::empty();
+
+        if rule_selection.is_enabled(LintId::of(&INVALID_METHOD_OVERRIDE)) {
+            config |= OverrideRulesConfig::LISKOV_METHODS;
+        }
+        if rule_selection.is_enabled(LintId::of(&INVALID_EXPLICIT_OVERRIDE)) {
+            config |= OverrideRulesConfig::EXPLICIT_OVERRIDE;
+        }
+        if rule_selection.is_enabled(LintId::of(&OVERRIDE_OF_FINAL_METHOD)) {
+            config |= OverrideRulesConfig::FINAL_METHOD_OVERRIDDEN;
+        }
+        if rule_selection.is_enabled(LintId::of(&INVALID_NAMED_TUPLE)) {
+            config |= OverrideRulesConfig::INVALID_NAMED_TUPLE;
+        }
+        if rule_selection.is_enabled(LintId::of(&INVALID_NAMED_TUPLE_OVERRIDE)) {
+            config |= OverrideRulesConfig::NAMED_TUPLE_FIELD_OVERRIDE;
+        }
+        if rule_selection.is_enabled(LintId::of(&INVALID_DATACLASS)) {
+            config |= OverrideRulesConfig::INVALID_DATACLASS;
+        }
+        if rule_selection.is_enabled(LintId::of(&OVERRIDE_OF_FINAL_VARIABLE)) {
+            config |= OverrideRulesConfig::FINAL_VARIABLE_OVERRIDDEN;
+        }
+        if rule_selection.is_enabled(LintId::of(&INVALID_ASSIGNMENT)) {
+            config |= OverrideRulesConfig::INVALID_ENUM_VALUE;
+        }
+
+        config
+    }
+}
+
+impl OverrideRulesConfig {
+    const fn no_rules_enabled(self) -> bool {
+        self.is_empty()
+    }
+
+    const fn check_method_liskov_violations(self) -> bool {
+        self.contains(OverrideRulesConfig::LISKOV_METHODS)
+    }
+
+    const fn check_final_method_overridden(self) -> bool {
+        self.contains(OverrideRulesConfig::FINAL_METHOD_OVERRIDDEN)
+    }
+
+    const fn check_invalid_named_tuple_definitions(self) -> bool {
+        self.contains(OverrideRulesConfig::INVALID_NAMED_TUPLE)
+    }
+
+    const fn check_invalid_named_tuple_field_overrides(self) -> bool {
+        self.contains(OverrideRulesConfig::NAMED_TUPLE_FIELD_OVERRIDE)
+    }
+
+    const fn check_invalid_dataclasses(self) -> bool {
+        self.contains(OverrideRulesConfig::INVALID_DATACLASS)
+    }
+
+    const fn check_final_variable_overridden(self) -> bool {
+        self.contains(OverrideRulesConfig::FINAL_VARIABLE_OVERRIDDEN)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum MemberOrigin<'db> {
+    Static {
+        first_reachable_definition: Definition<'db>,
+    },
+    Dynamic {
+        range: TextRange,
+    },
+}
+
+impl MemberOrigin<'_> {
+    fn is_function_definition(self, db: &dyn Db) -> bool {
+        match self {
+            Self::Static {
+                first_reachable_definition,
+            } => first_reachable_definition.kind(db).is_function_def(),
+            Self::Dynamic { .. } => false,
+        }
+    }
+}
+
+fn check_member_override_rules<'db>(
+    context: &InferContext<'db, '_>,
+    configuration: OverrideRulesConfig,
+    class_kind: Option<CodeGeneratorKind<'db>>,
+    class: ClassType<'db>,
+    member: &Member<'db>,
+    origin: MemberOrigin<'db>,
+) {
+    /// Salsa-tracked query to check whether any of the definitions of a symbol
+    /// in a superclass scope are function definitions.
+    ///
+    /// We need to know this for compatibility with pyright and mypy, neither of which emit an error
+    /// on `C.f` here:
+    ///
+    /// ```python
+    /// from typing import final
+    ///
+    /// class A:
+    ///     @final
+    ///     def f(self) -> None: ...
+    ///
+    /// class B:
+    ///     f = A.f
+    ///
+    /// class C(B):
+    ///     def f(self) -> None: ...  # no error here
+    /// ```
+    ///
+    /// This is a Salsa-tracked query because it has to look at the AST node for the definition,
+    /// which might be in a different Python module. If this weren't a tracked query, we could
+    /// introduce cross-module dependencies and over-invalidation.
+    #[salsa::tracked(heap_size=ruff_memory_usage::heap_size)]
+    fn is_function_definition<'db>(
+        db: &'db dyn Db,
+        scope: ScopeId<'db>,
+        symbol: ScopedSymbolId,
+    ) -> bool {
+        use_def_map(db, scope)
+            .end_of_scope_symbol_bindings(symbol)
+            .filter_map(|binding| binding.binding.definition())
+            .any(|definition| definition.kind(db).is_function_def())
+    }
+
+    let db = context.db();
+
+    let instance_of_class = Type::instance(db, class);
+    let type_on_subclass_instance = match (class.class_literal(db), member.ty) {
+        (ClassLiteral::Dynamic(_), Type::FunctionLiteral(function)) => {
+            Type::BoundMethod(function.into_bound_method_type(db, instance_of_class))
+        }
+        _ => {
+            let Place::Defined(DefinedPlace {
+                ty: type_on_subclass_instance,
+                ..
+            }) = instance_of_class.member(db, &member.name).place
+            else {
+                return;
+            };
+            type_on_subclass_instance
+        }
+    };
 
     let mut subclass_overrides_superclass_declaration = false;
     let mut has_dynamic_superclass = false;
@@ -503,29 +732,38 @@ fn check_class_declaration<'db>(
             // If so, don't report the same violation for the child class -- it would be a false positive
             // since the child cannot fix the violation without contradicting its immediate parent's contract.
             // See: https://github.com/astral-sh/ty/issues/2000
-            if let Some((immediate_parent, immediate_parent_type)) = immediate_parent_method {
-                if immediate_parent != superclass {
-                    // The immediate parent already defines this method and is different from the
-                    // current ancestor we're checking. Check if the immediate parent's method
-                    // is also incompatible with this ancestor.
-                    if !immediate_parent_type.is_assignable_to(db, superclass_type_as_type) {
-                        // The immediate parent already has an LSP violation with this ancestor.
-                        // Don't report the same violation for the child.
-                        continue;
-                    }
-                }
+            if let Some((immediate_parent, immediate_parent_type)) = immediate_parent_method
+                && immediate_parent != superclass
+                && !immediate_parent_type.is_assignable_to(db, superclass_type_as_type)
+            {
+                // The immediate parent already has an LSP violation with this ancestor.
+                // Don't report the same violation for the child.
+                continue;
             }
 
-            report_invalid_method_override(
-                context,
-                &member.name,
-                class,
-                *first_reachable_definition,
-                subclass_function,
-                superclass,
-                superclass_type,
-                method_kind,
-            );
+            match origin {
+                MemberOrigin::Static {
+                    first_reachable_definition,
+                } => report_invalid_method_override(
+                    context,
+                    &member.name,
+                    class,
+                    first_reachable_definition,
+                    subclass_function,
+                    superclass,
+                    superclass_type,
+                    method_kind,
+                ),
+                MemberOrigin::Dynamic { range } => report_invalid_method_override_at_range(
+                    context,
+                    &member.name,
+                    class,
+                    range,
+                    superclass,
+                    superclass_type,
+                    method_kind,
+                ),
+            }
 
             liskov_diagnostic_emitted = true;
         }
@@ -555,122 +793,56 @@ fn check_class_declaration<'db>(
 
     if !subclass_overrides_superclass_declaration
         && !has_dynamic_superclass
-        // accessing `.kind()` here is fine as `definition`
-        // will always be a definition in the file currently being checked
-        && first_reachable_definition.kind(db).is_function_def()
+        && origin.is_function_definition(db)
     {
         check_explicit_overrides(context, member, class);
     }
 
     if let Some((superclass, superclass_method)) = overridden_final_method {
-        report_overridden_final_method(
-            context,
-            &member.name,
-            *first_reachable_definition,
-            member.ty,
-            superclass,
-            class,
-            &superclass_method,
-        );
+        match origin {
+            MemberOrigin::Static {
+                first_reachable_definition,
+            } => report_overridden_final_method(
+                context,
+                &member.name,
+                first_reachable_definition,
+                member.ty,
+                superclass,
+                class,
+                &superclass_method,
+            ),
+            MemberOrigin::Dynamic { range } => report_overridden_final_method_at_range(
+                context,
+                &member.name,
+                range,
+                superclass,
+                class,
+                &superclass_method,
+            ),
+        }
     }
 
     if let Some((superclass, superclass_definition)) = overridden_final_variable {
-        report_overridden_final_variable(
-            context,
-            &member.name,
-            *first_reachable_definition,
-            superclass,
-            class,
-            superclass_definition,
-        );
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub(super) enum MethodKind<'db> {
-    Synthesized(CodeGeneratorKind<'db>),
-    #[default]
-    NotSynthesized,
-}
-
-bitflags! {
-    /// Bitflags representing which override-related rules have been enabled.
-    #[derive(Default, Debug, Copy, Clone)]
-    struct OverrideRulesConfig: u8 {
-        const LISKOV_METHODS = 1 << 0;
-        const EXPLICIT_OVERRIDE = 1 << 1;
-        const FINAL_METHOD_OVERRIDDEN = 1 << 2;
-        const INVALID_NAMED_TUPLE = 1 << 3;
-        const NAMED_TUPLE_FIELD_OVERRIDE = 1 << 4;
-        const INVALID_DATACLASS = 1 << 5;
-        const FINAL_VARIABLE_OVERRIDDEN = 1 << 6;
-        const INVALID_ENUM_VALUE = 1 << 7;
-    }
-}
-
-impl From<&InferContext<'_, '_>> for OverrideRulesConfig {
-    fn from(value: &InferContext<'_, '_>) -> Self {
-        let db = value.db();
-        let rule_selection = db.rule_selection(value.file());
-
-        let mut config = OverrideRulesConfig::empty();
-
-        if rule_selection.is_enabled(LintId::of(&INVALID_METHOD_OVERRIDE)) {
-            config |= OverrideRulesConfig::LISKOV_METHODS;
+        match origin {
+            MemberOrigin::Static {
+                first_reachable_definition,
+            } => report_overridden_final_variable(
+                context,
+                &member.name,
+                first_reachable_definition,
+                superclass,
+                class,
+                superclass_definition,
+            ),
+            MemberOrigin::Dynamic { range } => report_overridden_final_variable_at_range(
+                context,
+                &member.name,
+                range,
+                superclass,
+                class,
+                superclass_definition,
+            ),
         }
-        if rule_selection.is_enabled(LintId::of(&INVALID_EXPLICIT_OVERRIDE)) {
-            config |= OverrideRulesConfig::EXPLICIT_OVERRIDE;
-        }
-        if rule_selection.is_enabled(LintId::of(&OVERRIDE_OF_FINAL_METHOD)) {
-            config |= OverrideRulesConfig::FINAL_METHOD_OVERRIDDEN;
-        }
-        if rule_selection.is_enabled(LintId::of(&INVALID_NAMED_TUPLE)) {
-            config |= OverrideRulesConfig::INVALID_NAMED_TUPLE;
-        }
-        if rule_selection.is_enabled(LintId::of(&INVALID_NAMED_TUPLE_OVERRIDE)) {
-            config |= OverrideRulesConfig::NAMED_TUPLE_FIELD_OVERRIDE;
-        }
-        if rule_selection.is_enabled(LintId::of(&INVALID_DATACLASS)) {
-            config |= OverrideRulesConfig::INVALID_DATACLASS;
-        }
-        if rule_selection.is_enabled(LintId::of(&OVERRIDE_OF_FINAL_VARIABLE)) {
-            config |= OverrideRulesConfig::FINAL_VARIABLE_OVERRIDDEN;
-        }
-        if rule_selection.is_enabled(LintId::of(&INVALID_ASSIGNMENT)) {
-            config |= OverrideRulesConfig::INVALID_ENUM_VALUE;
-        }
-
-        config
-    }
-}
-
-impl OverrideRulesConfig {
-    const fn no_rules_enabled(self) -> bool {
-        self.is_empty()
-    }
-
-    const fn check_method_liskov_violations(self) -> bool {
-        self.contains(OverrideRulesConfig::LISKOV_METHODS)
-    }
-
-    const fn check_final_method_overridden(self) -> bool {
-        self.contains(OverrideRulesConfig::FINAL_METHOD_OVERRIDDEN)
-    }
-
-    const fn check_invalid_named_tuple_definitions(self) -> bool {
-        self.contains(OverrideRulesConfig::INVALID_NAMED_TUPLE)
-    }
-
-    const fn check_invalid_named_tuple_field_overrides(self) -> bool {
-        self.contains(OverrideRulesConfig::NAMED_TUPLE_FIELD_OVERRIDE)
-    }
-
-    const fn check_invalid_dataclasses(self) -> bool {
-        self.contains(OverrideRulesConfig::INVALID_DATACLASS)
-    }
-
-    const fn check_final_variable_overridden(self) -> bool {
-        self.contains(OverrideRulesConfig::FINAL_VARIABLE_OVERRIDDEN)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -7,7 +7,8 @@ use bitflags::bitflags;
 use ruff_db::diagnostic::Annotation;
 use ruff_python_ast::name::Name;
 use ruff_python_stdlib::identifiers::is_mangled_private;
-use rustc_hash::FxHashSet;
+use ruff_text_size::{Ranged, TextRange};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     Db,
@@ -17,14 +18,15 @@ use crate::{
         CallableType, ClassBase, ClassLiteral, ClassType, KnownClass, Parameter, Parameters,
         Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
         call::CallArguments,
-        class::{CodeGeneratorKind, FieldKind},
+        class::{CodeGeneratorKind, DynamicClassLiteral, FieldKind},
         constraints::ConstraintSetBuilder,
         context::InferContext,
         diagnostic::{
             INVALID_ASSIGNMENT, INVALID_ATTRIBUTE_OVERRIDE, INVALID_DATACLASS,
             INVALID_EXPLICIT_OVERRIDE, INVALID_METHOD_OVERRIDE, INVALID_NAMED_TUPLE,
             INVALID_NAMED_TUPLE_OVERRIDE, OVERRIDE_OF_FINAL_METHOD, OVERRIDE_OF_FINAL_VARIABLE,
-            report_invalid_method_override, report_overridden_final_method,
+            report_invalid_method_override, report_invalid_method_override_at_range,
+            report_overridden_final_method, report_overridden_final_method_at_range,
             report_overridden_final_variable,
         },
         enums::{EnumMetadata, enum_metadata},
@@ -58,9 +60,6 @@ const PROHIBITED_NAMEDTUPLE_ATTRS: &[&str] = &[
     "_source",
 ];
 
-// TODO: Support dynamic class literals. If we allow dynamic classes to define attributes in their
-// namespace dictionary, we should also check whether those attributes are valid overrides of
-// attributes in their superclasses.
 pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticClassLiteral<'db>) {
     let db = context.db();
     let configuration = OverrideRulesConfig::from(context);
@@ -85,13 +84,101 @@ pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticCla
     }
 }
 
+/// Checks override rules for guaranteed members of a dynamic class.
+///
+/// Dynamic classes do not have a class body, so diagnostics use the source ranges recovered from
+/// the namespace argument:
+///
+/// ```python
+/// from typing import Final, final
+///
+/// class Base:
+///     value: Final[int] = 1
+///
+///     @final
+///     def final_method(self) -> None: ...
+///
+///     def method(self, x: int) -> None: ...
+///
+/// def bad(self, x: str) -> None: ...
+/// def replacement(self) -> None: ...
+///
+/// C = type("C", (Base,), {
+///     "method": bad,
+///     "final_method": replacement,
+///     "value": 2,
+/// })
+/// ```
+///
+/// Classes with invalid MROs are skipped to avoid cascading override diagnostics for classes that
+/// cannot be created at runtime.
+pub(super) fn check_dynamic_class<'db>(
+    context: &InferContext<'db, '_>,
+    class: DynamicClassLiteral<'db>,
+) {
+    let db = context.db();
+    let configuration = OverrideRulesConfig::from(context);
+    if configuration.no_rules_enabled() {
+        return;
+    }
+
+    if class.try_mro(db).is_err() {
+        return;
+    }
+
+    let class_specialized = ClassLiteral::Dynamic(class).identity_specialization(db);
+    let class_kind = CodeGeneratorKind::from_class(db, class.into(), None);
+    let mut final_members_by_name = FxHashMap::default();
+    let mut seen_names = FxHashSet::default();
+
+    for dynamic_member in class.override_members(db) {
+        final_members_by_name.insert(dynamic_member.name.clone(), dynamic_member);
+    }
+
+    for dynamic_member in class.override_members(db) {
+        // Dict literals keep the original insertion order for duplicate keys, but the last
+        // assignment provides the surviving value.
+        if !seen_names.insert(dynamic_member.name.clone()) {
+            continue;
+        }
+
+        let Some(dynamic_member) = final_members_by_name.get(&dynamic_member.name).copied() else {
+            continue;
+        };
+
+        let member = Member {
+            name: dynamic_member.name.clone(),
+            ty: dynamic_member.ty,
+        };
+        check_named_tuple_field_override(
+            context,
+            configuration,
+            class_specialized,
+            &member.name,
+            MemberOrigin::Dynamic {
+                range: dynamic_member.range,
+            },
+        );
+        check_member_override_rules(
+            context,
+            configuration,
+            class_kind,
+            class_specialized,
+            &member,
+            MemberOrigin::Dynamic {
+                range: dynamic_member.range,
+            },
+        );
+    }
+}
+
 /// Returns the first inherited `NamedTuple` field in the MRO for `field_name`.
 fn conflicting_named_tuple_field_in_mro<'db>(
     db: &'db dyn Db,
-    class: StaticClassLiteral<'db>,
+    class: ClassType<'db>,
     field_name: &Name,
 ) -> Option<(ClassType<'db>, Option<Definition<'db>>)> {
-    for class_base in class.iter_mro(db, None).skip(1) {
+    for class_base in class.iter_mro(db).skip(1) {
         let Some(superclass) = class_base.into_class() else {
             continue;
         };
@@ -125,6 +212,73 @@ fn conflicting_named_tuple_field_in_mro<'db>(
     None
 }
 
+/// Reports an invalid override of an inherited `NamedTuple` field.
+///
+/// This helper is shared by static and dynamic classes so both of these forms are handled:
+///
+/// ```python
+/// from typing import NamedTuple
+///
+/// class Base(NamedTuple):
+///     field: int
+///
+/// class StaticChild(Base):
+///     field = 1
+///
+/// DynamicChild = type("DynamicChild", (Base,), {"field": 1})
+/// ```
+fn check_named_tuple_field_override<'db>(
+    context: &InferContext<'db, '_>,
+    configuration: OverrideRulesConfig,
+    class: ClassType<'db>,
+    member_name: &Name,
+    origin: MemberOrigin<'db>,
+) {
+    if !configuration.check_invalid_named_tuple_field_overrides() {
+        return;
+    }
+
+    let db = context.db();
+
+    let Some((superclass, overridden_field_declaration)) =
+        conflicting_named_tuple_field_in_mro(db, class, member_name)
+    else {
+        return;
+    };
+
+    let primary_range = match origin {
+        MemberOrigin::Static {
+            first_reachable_definition,
+        } => first_reachable_definition
+            .focus_range(db, context.module())
+            .range(),
+        MemberOrigin::Dynamic { range } => range,
+    };
+
+    let Some(builder) = context.report_lint(&INVALID_NAMED_TUPLE_OVERRIDE, primary_range) else {
+        return;
+    };
+
+    let mut diagnostic = builder.into_diagnostic(format_args!(
+        "Cannot override NamedTuple field `{}` inherited from `{}`",
+        member_name,
+        superclass.name(db)
+    ));
+    diagnostic.info("Subclass members are not allowed to reuse inherited NamedTuple field names");
+    if let Some(first_declaration) = overridden_field_declaration
+        && first_declaration.file(db) == context.file()
+    {
+        diagnostic.annotate(
+            Annotation::secondary(
+                context.span(first_declaration.kind(db).full_range(context.module())),
+            )
+            .message(format_args!(
+                "Inherited NamedTuple field `{member_name}` declared here"
+            )),
+        );
+    }
+}
+
 fn check_class_declaration<'db>(
     context: &InferContext<'db, '_>,
     configuration: OverrideRulesConfig,
@@ -141,15 +295,6 @@ fn check_class_declaration<'db>(
     } = member;
 
     let instance_of_class = Type::instance(db, class);
-
-    let subclass_instance_member = instance_of_class.member(db, &member.name);
-    let Place::Defined(DefinedPlace {
-        ty: type_on_subclass_instance,
-        ..
-    }) = subclass_instance_member.place
-    else {
-        return;
-    };
 
     let Some((literal, specialization)) = class.static_class_literal(db) else {
         return;
@@ -193,35 +338,15 @@ fn check_class_declaration<'db>(
         Some(CodeGeneratorKind::TypedDict) | None => {}
     }
 
-    if configuration.check_invalid_named_tuple_field_overrides()
-        && let Some((superclass, overridden_field_declaration)) =
-            conflicting_named_tuple_field_in_mro(db, literal, &member.name)
-        && let Some(builder) = context.report_lint(
-            &INVALID_NAMED_TUPLE_OVERRIDE,
-            first_reachable_definition.focus_range(db, context.module()),
-        )
-    {
-        let mut diagnostic = builder.into_diagnostic(format_args!(
-            "Cannot override NamedTuple field `{}` inherited from `{}`",
-            member.name,
-            superclass.name(db)
-        ));
-        diagnostic
-            .info("Subclass members are not allowed to reuse inherited NamedTuple field names");
-        if let Some(first_declaration) = overridden_field_declaration
-            && first_declaration.file(db) == context.file()
-        {
-            diagnostic.annotate(
-                Annotation::secondary(
-                    context.span(first_declaration.kind(db).full_range(context.module())),
-                )
-                .message(format_args!(
-                    "Inherited NamedTuple field `{}` declared here",
-                    member.name
-                )),
-            );
-        }
-    }
+    check_named_tuple_field_override(
+        context,
+        configuration,
+        class,
+        &member.name,
+        MemberOrigin::Static {
+            first_reachable_definition: *first_reachable_definition,
+        },
+    );
 
     // Check for invalid Enum member values.
     if let Some(enum_info) = enum_info {
@@ -283,6 +408,138 @@ fn check_class_declaration<'db>(
             }
         }
     }
+
+    check_member_override_rules(
+        context,
+        configuration,
+        class_kind,
+        class,
+        member,
+        MemberOrigin::Static {
+            first_reachable_definition: *first_reachable_definition,
+        },
+    );
+}
+
+/// The syntactic origin for a subclass member considered by override checks.
+#[derive(Clone, Copy)]
+enum MemberOrigin<'db> {
+    /// A member declared in a normal class body.
+    Static {
+        first_reachable_definition: Definition<'db>,
+    },
+    /// A member recovered from a dynamic class namespace value.
+    Dynamic { range: TextRange },
+}
+
+impl MemberOrigin<'_> {
+    /// Returns whether this origin is a function definition in the current semantic model.
+    fn is_function_definition(self, db: &dyn Db) -> bool {
+        match self {
+            Self::Static {
+                first_reachable_definition,
+            } => first_reachable_definition.kind(db).is_function_def(),
+            Self::Dynamic { .. } => false,
+        }
+    }
+}
+
+/// Checks all override rules that apply to a single subclass member.
+///
+/// The member can come from either a static class body or from a guaranteed dynamic namespace
+/// entry:
+///
+/// ```python
+/// class Base:
+///     def method(self, x: int) -> None: ...
+///
+/// class StaticChild(Base):
+///     def method(self, x: str) -> None: ...
+///
+/// def bad(self, x: str) -> None: ...
+/// DynamicChild = type("DynamicChild", (Base,), {"method": bad})
+/// ```
+///
+/// For dynamic namespace values, descriptor binding is applied before Liskov checks so
+/// `staticmethod(...)` and `classmethod(...)` values are compared like their static-class
+/// equivalents.
+fn check_member_override_rules<'db>(
+    context: &InferContext<'db, '_>,
+    configuration: OverrideRulesConfig,
+    class_kind: Option<CodeGeneratorKind<'db>>,
+    class: ClassType<'db>,
+    member: &Member<'db>,
+    origin: MemberOrigin<'db>,
+) {
+    /// Salsa-tracked query to check whether any of the definitions of a symbol
+    /// in a superclass scope are function definitions.
+    ///
+    /// We need to know this for compatibility with pyright and mypy, neither of which emit an error
+    /// on `C.f` here:
+    ///
+    /// ```python
+    /// from typing import final
+    ///
+    /// class A:
+    ///     @final
+    ///     def f(self) -> None: ...
+    ///
+    /// class B:
+    ///     f = A.f
+    ///
+    /// class C(B):
+    ///     def f(self) -> None: ...  # no error here
+    /// ```
+    ///
+    /// This is a Salsa-tracked query because it has to look at the AST node for the definition,
+    /// which might be in a different Python module. If this weren't a tracked query, we could
+    /// introduce cross-module dependencies and over-invalidation.
+    #[salsa::tracked(heap_size=ruff_memory_usage::heap_size)]
+    fn is_function_definition<'db>(
+        db: &'db dyn Db,
+        scope: ScopeId<'db>,
+        symbol: ScopedSymbolId,
+    ) -> bool {
+        use_def_map(db, scope)
+            .end_of_scope_symbol_bindings(symbol)
+            .filter_map(|binding| binding.binding.definition())
+            .any(|definition| definition.kind(db).is_function_def())
+    }
+
+    let db = context.db();
+
+    let instance_of_class = Type::instance(db, class);
+    let subclass_instance_member = instance_of_class.member(db, &member.name);
+    let (type_on_subclass_instance, dynamic_descriptor_member) = match class.class_literal(db) {
+        ClassLiteral::Dynamic(_) => {
+            if let Some((ty, _)) =
+                member
+                    .ty
+                    .try_call_dunder_get(db, Some(instance_of_class), Type::from(class))
+            {
+                (ty, true)
+            } else {
+                let Place::Defined(DefinedPlace {
+                    ty: type_on_subclass_instance,
+                    ..
+                }) = subclass_instance_member.place
+                else {
+                    return;
+                };
+                (type_on_subclass_instance, false)
+            }
+        }
+        _ => {
+            let Place::Defined(DefinedPlace {
+                ty: type_on_subclass_instance,
+                ..
+            }) = subclass_instance_member.place
+            else {
+                return;
+            };
+            (type_on_subclass_instance, false)
+        }
+    };
 
     let mut subclass_overrides_superclass_declaration = false;
     let mut has_dynamic_superclass = false;
@@ -436,7 +693,11 @@ fn check_class_declaration<'db>(
                 continue;
             }
 
-            if configuration.check_attribute_liskov_violations() {
+            if configuration.check_attribute_liskov_violations()
+                && let MemberOrigin::Static {
+                    first_reachable_definition,
+                } = origin
+            {
                 if let Some(superclass_variable_kind) =
                     effective_superclass_variable_kind(db, superclass, member.name.clone())
                 {
@@ -485,7 +746,7 @@ fn check_class_declaration<'db>(
                         report_invalid_attribute_override(
                             context,
                             &member.name,
-                            *first_reachable_definition,
+                            first_reachable_definition,
                             superclass,
                             superclass_definition,
                             subclass_kind,
@@ -501,9 +762,13 @@ fn check_class_declaration<'db>(
                 continue;
             }
 
-            let Type::FunctionLiteral(subclass_function) = member.ty else {
-                continue;
+            let subclass_function = match member.ty {
+                Type::FunctionLiteral(function) => Some(function),
+                _ => None,
             };
+            if subclass_function.is_none() && !dynamic_descriptor_member {
+                continue;
+            }
 
             // Constructor methods are not checked for Liskov compliance
             if matches!(
@@ -536,33 +801,50 @@ fn check_class_declaration<'db>(
             // If so, don't report the same violation for the child class -- it would be a false positive
             // since the child cannot fix the violation without contradicting its immediate parent's contract.
             // See: https://github.com/astral-sh/ty/issues/2000
-            if let Some((immediate_parent, immediate_parent_type)) = immediate_parent_method {
-                if immediate_parent != superclass {
-                    // The immediate parent already defines this method and is different from the
-                    // current ancestor we're checking. Check if the immediate parent's method
-                    // is also incompatible with this ancestor.
-                    if !immediate_parent_type.is_assignable_to(db, superclass_type_as_type) {
-                        // The immediate parent already has an LSP violation with this ancestor.
-                        // Don't report the same violation for the child.
-                        continue;
-                    }
-                }
+            if let Some((immediate_parent, immediate_parent_type)) = immediate_parent_method
+                && immediate_parent != superclass
+                && !immediate_parent_type.is_assignable_to(db, superclass_type_as_type)
+            {
+                // The immediate parent already has an LSP violation with this ancestor.
+                // Don't report the same violation for the child.
+                continue;
             }
 
-            report_invalid_method_override(
-                context,
-                &member.name,
-                class,
-                *first_reachable_definition,
-                subclass_function,
-                superclass,
-                superclass_type,
-                method_kind,
-                || {
-                    type_on_subclass_instance
-                        .assignability_error_context(db, superclass_type_as_type)
-                },
-            );
+            match (origin, subclass_function) {
+                (
+                    MemberOrigin::Static {
+                        first_reachable_definition,
+                    },
+                    Some(subclass_function),
+                ) => report_invalid_method_override(
+                    context,
+                    &member.name,
+                    class,
+                    first_reachable_definition,
+                    subclass_function,
+                    superclass,
+                    superclass_type,
+                    method_kind,
+                    || {
+                        type_on_subclass_instance
+                            .assignability_error_context(db, superclass_type_as_type)
+                    },
+                ),
+                (MemberOrigin::Static { .. }, None) => continue,
+                (MemberOrigin::Dynamic { range }, _) => report_invalid_method_override_at_range(
+                    context,
+                    &member.name,
+                    class,
+                    range,
+                    superclass,
+                    superclass_type,
+                    method_kind,
+                    || {
+                        type_on_subclass_instance
+                            .assignability_error_context(db, superclass_type_as_type)
+                    },
+                ),
+            }
 
             liskov_diagnostic_emitted = true;
         }
@@ -592,30 +874,49 @@ fn check_class_declaration<'db>(
 
     if !subclass_overrides_superclass_declaration
         && !has_dynamic_superclass
-        // accessing `.kind()` here is fine as `definition`
-        // will always be a definition in the file currently being checked
-        && first_reachable_definition.kind(db).is_function_def()
+        && origin.is_function_definition(db)
     {
         check_explicit_overrides(context, member, class);
     }
 
     if let Some((superclass, superclass_method)) = overridden_final_method {
-        report_overridden_final_method(
-            context,
-            &member.name,
-            *first_reachable_definition,
-            member.ty,
-            superclass,
-            class,
-            &superclass_method,
-        );
+        match origin {
+            MemberOrigin::Static {
+                first_reachable_definition,
+            } => report_overridden_final_method(
+                context,
+                &member.name,
+                first_reachable_definition,
+                member.ty,
+                superclass,
+                class,
+                &superclass_method,
+            ),
+            MemberOrigin::Dynamic { range } => report_overridden_final_method_at_range(
+                context,
+                &member.name,
+                range,
+                superclass,
+                class,
+                &superclass_method,
+            ),
+        }
     }
 
     if let Some((superclass, superclass_definition)) = overridden_final_variable {
+        let range = match origin {
+            MemberOrigin::Static {
+                first_reachable_definition,
+            } => first_reachable_definition
+                .focus_range(context.db(), context.module())
+                .range(),
+            MemberOrigin::Dynamic { range } => range,
+        };
+
         report_overridden_final_variable(
             context,
             &member.name,
-            *first_reachable_definition,
+            range,
             superclass,
             class,
             superclass_definition,

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -817,9 +817,9 @@ pub(super) fn validate_typed_dict_required_keys<'db, 'ast>(
 }
 
 #[derive(Debug, Clone, Copy)]
-struct UnpackedTypedDictKey<'db> {
-    value_ty: Type<'db>,
-    is_required: bool,
+pub(super) struct UnpackedTypedDictKey<'db> {
+    pub(super) value_ty: Type<'db>,
+    pub(super) is_required: bool,
 }
 
 /// Extracts `TypedDict` keys, their value types, and whether they are required when unpacked as
@@ -831,7 +831,7 @@ struct UnpackedTypedDictKey<'db> {
 /// intersected, and the key is considered required if any constituent `TypedDict` requires it.
 /// For unions, returns all keys that may appear in any arm, unioning value types for shared keys,
 /// and a key is only considered required if every arm requires it.
-fn extract_unpacked_typed_dict_keys<'db>(
+pub(super) fn extract_unpacked_typed_dict_keys<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
 ) -> Option<BTreeMap<Name, UnpackedTypedDictKey<'db>>> {


### PR DESCRIPTION
## Summary

This PR resolves a TODO by adding override validation for members defined through dynamic class namespaces, as in:

```python
from typing import Final, final

class Base:
    value: Final[int] = 1

    @final
    def final_method(self) -> None: ...

    def method(self, x: int) -> None: ...

def bad(self, x: str) -> None: ...
def replacement(self) -> None: ...

Dyn1 = type("Dyn1", (Base,), {"method": bad})  # invalid-method-override
Dyn2 = type("Dyn2", (Base,), {"final_method": replacement})  # override-of-final-method
Dyn3 = type("Dyn3", (Base,), {"value": 2})  # override-of-final-variable
```

The implementation only reports diagnostics for entries that are guaranteed to be present.
