### PR TITLE
[ty] Split reachability analysis into two files

### DIFF
--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -44,6 +44,7 @@ pub(crate) mod place;
 mod program;
 mod python_platform;
 mod rank;
+mod reachability_constraints;
 pub mod semantic_index;
 mod semantic_model;
 mod subscript;

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -13,8 +13,8 @@ use crate::semantic_index::place::{PlaceExprRef, ScopedPlaceId};
 use crate::semantic_index::predicate::{Predicate, ScopedPredicateId};
 use crate::semantic_index::scope::ScopeId;
 use crate::semantic_index::{
-    BindingWithConstraints, BindingWithConstraintsIterator, DeclarationsIterator,
-    ReachabilityConstraints, get_loop_header, place_table,
+    BindingWithConstraints, BindingWithConstraintsIterator, DeclarationsIterator, get_loop_header,
+    place_table, reachability_constraints_datastructures::ReachabilityConstraints,
 };
 use crate::semantic_index::{DeclarationWithConstraint, global_scope, use_def_map};
 use crate::types::{

--- a/crates/ty_python_semantic/src/reachability_constraints.rs
+++ b/crates/ty_python_semantic/src/reachability_constraints.rs
@@ -1,4 +1,4 @@
-//! # Reachability constraints
+//! # Reachability evaluation
 //!
 //! During semantic index building, we record so-called reachability constraints that keep track
 //! of a set of conditions that need to apply in order for a certain statement or expression to
@@ -193,132 +193,26 @@
 //! [Kleene]: <https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Priest_logics>
 //! [bdd]: https://en.wikipedia.org/wiki/Binary_decision_diagram
 
-use std::cmp::Ordering;
-
-use ruff_index::{Idx, IndexVec};
-use rustc_hash::FxHashMap;
-
-use crate::Db;
-use crate::dunder_all::dunder_all_names;
-use crate::place::{RequiresExplicitReExport, imported_symbol};
-use crate::rank::RankBitBox;
-use crate::semantic_index::place::ScopedPlaceId;
-use crate::semantic_index::place_table;
-use crate::semantic_index::predicate::{
-    CallableAndCallExpr, PatternPredicate, PatternPredicateKind, Predicate, PredicateNode,
-    Predicates, ScopedPredicateId,
+use crate::{
+    Db,
+    dunder_all::dunder_all_names,
+    place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
+    semantic_index::{
+        place::ScopedPlaceId,
+        place_table,
+        predicate::{
+            CallableAndCallExpr, PatternPredicate, PatternPredicateKind, Predicate, PredicateNode,
+            Predicates,
+        },
+        reachability_constraints_datastructures::{
+            ReachabilityConstraints, ScopedReachabilityConstraintId,
+        },
+    },
+    types::{
+        CallableTypes, IntersectionBuilder, KnownClass, NarrowingConstraint, Truthiness, Type,
+        TypeContext, UnionBuilder, UnionType, infer_expression_type, infer_narrowing_constraint,
+    },
 };
-use crate::types::{
-    CallableTypes, IntersectionBuilder, KnownClass, NarrowingConstraint, Truthiness, Type,
-    TypeContext, UnionBuilder, UnionType, infer_expression_type, infer_narrowing_constraint,
-};
-
-/// A ternary formula that defines under what conditions a binding is visible. (A ternary formula
-/// is just like a boolean formula, but with `Ambiguous` as a third potential result. See the
-/// module documentation for more details.)
-///
-/// The primitive atoms of the formula are [`Predicate`]s, which express some property of the
-/// runtime state of the code that we are analyzing.
-///
-/// We assume that each atom has a stable value each time that the formula is evaluated. An atom
-/// that resolves to `Ambiguous` might be true or false, and we can't tell which — but within that
-/// evaluation, we assume that the atom has the _same_ unknown value each time it appears. That
-/// allows us to perform simplifications like `A ∨ !A → true` and `A ∧ !A → false`.
-///
-/// That means that when you are constructing a formula, you might need to create distinct atoms
-/// for a particular [`Predicate`], if your formula needs to consider how a particular runtime
-/// property might be different at different points in the execution of the program.
-///
-/// reachability constraints are normalized, so equivalent constraints are guaranteed to have equal
-/// IDs.
-#[derive(Clone, Copy, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
-pub(crate) struct ScopedReachabilityConstraintId(u32);
-
-impl std::fmt::Debug for ScopedReachabilityConstraintId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut f = f.debug_tuple("ScopedReachabilityConstraintId");
-        match *self {
-            // We use format_args instead of rendering the strings directly so that we don't get
-            // any quotes in the output: ScopedReachabilityConstraintId(AlwaysTrue) instead of
-            // ScopedReachabilityConstraintId("AlwaysTrue").
-            ALWAYS_TRUE => f.field(&format_args!("AlwaysTrue")),
-            AMBIGUOUS => f.field(&format_args!("Ambiguous")),
-            ALWAYS_FALSE => f.field(&format_args!("AlwaysFalse")),
-            _ => f.field(&self.0),
-        };
-        f.finish()
-    }
-}
-
-// Internal details:
-//
-// There are 3 terminals, with hard-coded constraint IDs: true, ambiguous, and false.
-//
-// _Atoms_ are the underlying Predicates, which are the variables that are evaluated by the
-// ternary function.
-//
-// _Interior nodes_ provide the TDD structure for the formula. Interior nodes are stored in an
-// arena Vec, with the constraint ID providing an index into the arena.
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize)]
-struct InteriorNode {
-    /// A "variable" that is evaluated as part of a TDD ternary function. For reachability
-    /// constraints, this is a `Predicate` that represents some runtime property of the Python
-    /// code that we are evaluating.
-    atom: ScopedPredicateId,
-    if_true: ScopedReachabilityConstraintId,
-    if_ambiguous: ScopedReachabilityConstraintId,
-    if_false: ScopedReachabilityConstraintId,
-}
-
-impl ScopedReachabilityConstraintId {
-    /// A special ID that is used for an "always true" / "always visible" constraint.
-    pub(crate) const ALWAYS_TRUE: ScopedReachabilityConstraintId =
-        ScopedReachabilityConstraintId(0xffff_ffff);
-
-    /// A special ID that is used for an ambiguous constraint.
-    pub(crate) const AMBIGUOUS: ScopedReachabilityConstraintId =
-        ScopedReachabilityConstraintId(0xffff_fffe);
-
-    /// A special ID that is used for an "always false" / "never visible" constraint.
-    pub(crate) const ALWAYS_FALSE: ScopedReachabilityConstraintId =
-        ScopedReachabilityConstraintId(0xffff_fffd);
-
-    fn is_terminal(self) -> bool {
-        self.0 >= SMALLEST_TERMINAL.0
-    }
-
-    fn as_u32(self) -> u32 {
-        self.0
-    }
-}
-
-impl Idx for ScopedReachabilityConstraintId {
-    #[inline]
-    fn new(value: usize) -> Self {
-        assert!(value <= (SMALLEST_TERMINAL.0 as usize));
-        #[expect(clippy::cast_possible_truncation)]
-        Self(value as u32)
-    }
-
-    #[inline]
-    fn index(self) -> usize {
-        debug_assert!(!self.is_terminal());
-        self.0 as usize
-    }
-}
-
-// Rebind some constants locally so that we don't need as many qualifiers below.
-const ALWAYS_TRUE: ScopedReachabilityConstraintId = ScopedReachabilityConstraintId::ALWAYS_TRUE;
-const AMBIGUOUS: ScopedReachabilityConstraintId = ScopedReachabilityConstraintId::AMBIGUOUS;
-const ALWAYS_FALSE: ScopedReachabilityConstraintId = ScopedReachabilityConstraintId::ALWAYS_FALSE;
-const SMALLEST_TERMINAL: ScopedReachabilityConstraintId = ALWAYS_FALSE;
-
-/// Maximum number of interior TDD nodes per scope. When exceeded, new constraint
-/// operations return `AMBIGUOUS` to prevent exponential blowup on pathological inputs
-/// (e.g., a 5000-line while loop with hundreds of if-branches). This can lead to less precise
-/// reachability analysis and type narrowing.
-const MAX_INTERIOR_NODES: usize = 512 * 1024;
 
 fn singleton_to_type(db: &dyn Db, singleton: ruff_python_ast::Singleton) -> Type<'_> {
     let ty = match singleton {
@@ -445,326 +339,6 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
     }
 }
 
-/// A collection of reachability constraints for a given scope.
-#[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
-pub(crate) struct ReachabilityConstraints {
-    /// The interior TDD nodes that were marked as used when being built.
-    used_interiors: Box<[InteriorNode]>,
-    /// A bit vector indicating which interior TDD nodes were marked as used. This is indexed by
-    /// the node's [`ScopedReachabilityConstraintId`]. The rank of the corresponding bit gives the
-    /// index of that node in the `used_interiors` vector.
-    used_indices: RankBitBox,
-}
-
-#[derive(Debug, Default, PartialEq, Eq)]
-pub(crate) struct ReachabilityConstraintsBuilder {
-    interiors: IndexVec<ScopedReachabilityConstraintId, InteriorNode>,
-    interior_used: IndexVec<ScopedReachabilityConstraintId, bool>,
-    interior_cache: FxHashMap<InteriorNode, ScopedReachabilityConstraintId>,
-    not_cache: FxHashMap<ScopedReachabilityConstraintId, ScopedReachabilityConstraintId>,
-    and_cache: FxHashMap<
-        (
-            ScopedReachabilityConstraintId,
-            ScopedReachabilityConstraintId,
-        ),
-        ScopedReachabilityConstraintId,
-    >,
-    or_cache: FxHashMap<
-        (
-            ScopedReachabilityConstraintId,
-            ScopedReachabilityConstraintId,
-        ),
-        ScopedReachabilityConstraintId,
-    >,
-}
-
-impl ReachabilityConstraintsBuilder {
-    pub(crate) fn build(self) -> ReachabilityConstraints {
-        let used_indices = RankBitBox::from_bits(self.interior_used.iter().copied());
-        let used_interiors = (self.interiors.into_iter())
-            .zip(self.interior_used)
-            .filter_map(|(interior, used)| used.then_some(interior))
-            .collect();
-        ReachabilityConstraints {
-            used_interiors,
-            used_indices,
-        }
-    }
-
-    /// Marks that a particular TDD node is used. This lets us throw away interior nodes that were
-    /// only calculated for intermediate values, and which don't need to be included in the final
-    /// built result.
-    pub(crate) fn mark_used(&mut self, node: ScopedReachabilityConstraintId) {
-        if !node.is_terminal() && !self.interior_used[node] {
-            self.interior_used[node] = true;
-            let node = self.interiors[node];
-            self.mark_used(node.if_true);
-            self.mark_used(node.if_ambiguous);
-            self.mark_used(node.if_false);
-        }
-    }
-
-    /// Implements the ordering that determines which level a TDD node appears at.
-    ///
-    /// Each interior node checks the value of a single variable (for us, a `Predicate`).
-    /// TDDs are ordered such that every path from the root of the graph to the leaves must
-    /// check each variable at most once, and must check each variable in the same order.
-    ///
-    /// We can choose any ordering that we want, as long as it's consistent — with the
-    /// caveat that terminal nodes must always be last in the ordering, since they are the
-    /// leaf nodes of the graph.
-    ///
-    /// We currently compare interior nodes by looking at the Salsa IDs of each variable's
-    /// `Predicate`, since this is already available and easy to compare. We also _reverse_
-    /// the comparison of those Salsa IDs. The Salsa IDs are assigned roughly sequentially
-    /// while traversing the source code. Reversing the comparison means `Predicate`s that
-    /// appear later in the source will tend to be placed "higher" (closer to the root) in
-    /// the TDD graph. We have found empirically that this leads to smaller TDD graphs [1],
-    /// since there are often repeated combinations of `Predicate`s from earlier in the
-    /// file.
-    ///
-    /// [1]: https://github.com/astral-sh/ruff/pull/20098
-    fn cmp_atoms(
-        &self,
-        a: ScopedReachabilityConstraintId,
-        b: ScopedReachabilityConstraintId,
-    ) -> Ordering {
-        if a == b || (a.is_terminal() && b.is_terminal()) {
-            Ordering::Equal
-        } else if a.is_terminal() {
-            Ordering::Greater
-        } else if b.is_terminal() {
-            Ordering::Less
-        } else {
-            // See https://github.com/astral-sh/ruff/pull/20098 for an explanation of why this
-            // ordering is reversed.
-            self.interiors[a]
-                .atom
-                .cmp(&self.interiors[b].atom)
-                .reverse()
-        }
-    }
-
-    /// Adds an interior node, ensuring that we always use the same reachability constraint ID for
-    /// equal nodes.
-    fn add_interior(&mut self, node: InteriorNode) -> ScopedReachabilityConstraintId {
-        // If the true and false branches lead to the same node, we can override the ambiguous
-        // branch to go there too. And this node is then redundant and can be reduced.
-        if node.if_true == node.if_false {
-            return node.if_true;
-        }
-
-        *self.interior_cache.entry(node).or_insert_with(|| {
-            self.interior_used.push(false);
-            self.interiors.push(node)
-        })
-    }
-
-    /// Adds a new reachability constraint that checks a single [`Predicate`].
-    ///
-    /// [`ScopedPredicateId`]s are the “variables” that are evaluated by a TDD. A TDD variable has
-    /// the same value no matter how many times it appears in the ternary formula that the TDD
-    /// represents.
-    ///
-    /// However, we sometimes have to model how a `Predicate` can have a different runtime
-    /// value at different points in the execution of the program. To handle this, you can take
-    /// advantage of the fact that the [`Predicates`] arena does not deduplicate `Predicate`s.
-    /// You can add a `Predicate` multiple times, yielding different `ScopedPredicateId`s, which
-    /// you can then create separate TDD atoms for.
-    pub(crate) fn add_atom(
-        &mut self,
-        predicate: ScopedPredicateId,
-    ) -> ScopedReachabilityConstraintId {
-        if predicate == ScopedPredicateId::ALWAYS_FALSE {
-            ScopedReachabilityConstraintId::ALWAYS_FALSE
-        } else if predicate == ScopedPredicateId::ALWAYS_TRUE {
-            ScopedReachabilityConstraintId::ALWAYS_TRUE
-        } else {
-            self.add_interior(InteriorNode {
-                atom: predicate,
-                if_true: ALWAYS_TRUE,
-                if_ambiguous: AMBIGUOUS,
-                if_false: ALWAYS_FALSE,
-            })
-        }
-    }
-
-    /// Adds a new reachability constraint that is the ternary NOT of an existing one.
-    pub(crate) fn add_not_constraint(
-        &mut self,
-        a: ScopedReachabilityConstraintId,
-    ) -> ScopedReachabilityConstraintId {
-        if a == ALWAYS_TRUE {
-            return ALWAYS_FALSE;
-        } else if a == AMBIGUOUS {
-            return AMBIGUOUS;
-        } else if a == ALWAYS_FALSE {
-            return ALWAYS_TRUE;
-        }
-
-        if let Some(cached) = self.not_cache.get(&a) {
-            return *cached;
-        }
-
-        if self.interiors.len() >= MAX_INTERIOR_NODES {
-            return AMBIGUOUS;
-        }
-
-        let a_node = self.interiors[a];
-        let if_true = self.add_not_constraint(a_node.if_true);
-        let if_ambiguous = self.add_not_constraint(a_node.if_ambiguous);
-        let if_false = self.add_not_constraint(a_node.if_false);
-        let result = self.add_interior(InteriorNode {
-            atom: a_node.atom,
-            if_true,
-            if_ambiguous,
-            if_false,
-        });
-        self.not_cache.insert(a, result);
-        result
-    }
-
-    /// Adds a new reachability constraint that is the ternary OR of two existing ones.
-    pub(crate) fn add_or_constraint(
-        &mut self,
-        a: ScopedReachabilityConstraintId,
-        b: ScopedReachabilityConstraintId,
-    ) -> ScopedReachabilityConstraintId {
-        match (a, b) {
-            (ALWAYS_TRUE, _) | (_, ALWAYS_TRUE) => return ALWAYS_TRUE,
-            (ALWAYS_FALSE, other) | (other, ALWAYS_FALSE) => return other,
-            (AMBIGUOUS, AMBIGUOUS) => return AMBIGUOUS,
-            _ => {}
-        }
-
-        // OR is commutative, which lets us halve the cache requirements
-        let (a, b) = if b.0 < a.0 { (b, a) } else { (a, b) };
-        if let Some(cached) = self.or_cache.get(&(a, b)) {
-            return *cached;
-        }
-
-        if self.interiors.len() >= MAX_INTERIOR_NODES {
-            return AMBIGUOUS;
-        }
-
-        let (atom, if_true, if_ambiguous, if_false) = match self.cmp_atoms(a, b) {
-            Ordering::Equal => {
-                let a_node = self.interiors[a];
-                let b_node = self.interiors[b];
-                let if_true = self.add_or_constraint(a_node.if_true, b_node.if_true);
-                let if_false = self.add_or_constraint(a_node.if_false, b_node.if_false);
-                let if_ambiguous = if if_true == if_false {
-                    if_true
-                } else {
-                    self.add_or_constraint(a_node.if_ambiguous, b_node.if_ambiguous)
-                };
-                (a_node.atom, if_true, if_ambiguous, if_false)
-            }
-            Ordering::Less => {
-                let a_node = self.interiors[a];
-                let if_true = self.add_or_constraint(a_node.if_true, b);
-                let if_false = self.add_or_constraint(a_node.if_false, b);
-                let if_ambiguous = if if_true == if_false {
-                    if_true
-                } else {
-                    self.add_or_constraint(a_node.if_ambiguous, b)
-                };
-                (a_node.atom, if_true, if_ambiguous, if_false)
-            }
-            Ordering::Greater => {
-                let b_node = self.interiors[b];
-                let if_true = self.add_or_constraint(a, b_node.if_true);
-                let if_false = self.add_or_constraint(a, b_node.if_false);
-                let if_ambiguous = if if_true == if_false {
-                    if_true
-                } else {
-                    self.add_or_constraint(a, b_node.if_ambiguous)
-                };
-                (b_node.atom, if_true, if_ambiguous, if_false)
-            }
-        };
-
-        let result = self.add_interior(InteriorNode {
-            atom,
-            if_true,
-            if_ambiguous,
-            if_false,
-        });
-        self.or_cache.insert((a, b), result);
-        result
-    }
-
-    /// Adds a new reachability constraint that is the ternary AND of two existing ones.
-    pub(crate) fn add_and_constraint(
-        &mut self,
-        a: ScopedReachabilityConstraintId,
-        b: ScopedReachabilityConstraintId,
-    ) -> ScopedReachabilityConstraintId {
-        match (a, b) {
-            (ALWAYS_FALSE, _) | (_, ALWAYS_FALSE) => return ALWAYS_FALSE,
-            (ALWAYS_TRUE, other) | (other, ALWAYS_TRUE) => return other,
-            (AMBIGUOUS, AMBIGUOUS) => return AMBIGUOUS,
-            _ => {}
-        }
-
-        // AND is commutative, which lets us halve the cache requirements
-        let (a, b) = if b.0 < a.0 { (b, a) } else { (a, b) };
-        if let Some(cached) = self.and_cache.get(&(a, b)) {
-            return *cached;
-        }
-
-        if self.interiors.len() >= MAX_INTERIOR_NODES {
-            return AMBIGUOUS;
-        }
-
-        let (atom, if_true, if_ambiguous, if_false) = match self.cmp_atoms(a, b) {
-            Ordering::Equal => {
-                let a_node = self.interiors[a];
-                let b_node = self.interiors[b];
-                let if_true = self.add_and_constraint(a_node.if_true, b_node.if_true);
-                let if_false = self.add_and_constraint(a_node.if_false, b_node.if_false);
-                let if_ambiguous = if if_true == if_false {
-                    if_true
-                } else {
-                    self.add_and_constraint(a_node.if_ambiguous, b_node.if_ambiguous)
-                };
-                (a_node.atom, if_true, if_ambiguous, if_false)
-            }
-            Ordering::Less => {
-                let a_node = self.interiors[a];
-                let if_true = self.add_and_constraint(a_node.if_true, b);
-                let if_false = self.add_and_constraint(a_node.if_false, b);
-                let if_ambiguous = if if_true == if_false {
-                    if_true
-                } else {
-                    self.add_and_constraint(a_node.if_ambiguous, b)
-                };
-                (a_node.atom, if_true, if_ambiguous, if_false)
-            }
-            Ordering::Greater => {
-                let b_node = self.interiors[b];
-                let if_true = self.add_and_constraint(a, b_node.if_true);
-                let if_false = self.add_and_constraint(a, b_node.if_false);
-                let if_ambiguous = if if_true == if_false {
-                    if_true
-                } else {
-                    self.add_and_constraint(a, b_node.if_ambiguous)
-                };
-                (b_node.atom, if_true, if_ambiguous, if_false)
-            }
-        };
-
-        let result = self.add_interior(InteriorNode {
-            atom,
-            if_true,
-            if_ambiguous,
-            if_false,
-        });
-        self.and_cache.insert((a, b), result);
-        result
-    }
-}
-
 /// AND a new optional narrowing constraint with an accumulated one.
 fn accumulate_constraint<'db>(
     accumulated: Option<NarrowingConstraint<'db>>,
@@ -779,18 +353,6 @@ fn accumulate_constraint<'db>(
 }
 
 impl ReachabilityConstraints {
-    /// Look up an interior node by its constraint ID.
-    fn get_interior_node(&self, id: ScopedReachabilityConstraintId) -> InteriorNode {
-        debug_assert!(!id.is_terminal());
-        let raw_index = id.as_u32() as usize;
-        debug_assert!(
-            self.used_indices.get_bit(raw_index).unwrap_or(false),
-            "all used reachability constraints should have been marked as used",
-        );
-        let index = self.used_indices.rank(raw_index) as usize;
-        self.used_interiors[index]
-    }
-
     /// Narrow a type by walking a TDD narrowing constraint.
     ///
     /// The TDD represents a ternary formula over predicates that encodes which predicates
@@ -833,8 +395,10 @@ impl ReachabilityConstraints {
         place: ScopedPlaceId,
         accumulated: Option<NarrowingConstraint<'db>>,
     ) -> Type<'db> {
+        type Id = ScopedReachabilityConstraintId;
+
         match id {
-            ALWAYS_TRUE | AMBIGUOUS => {
+            Id::ALWAYS_TRUE | Id::AMBIGUOUS => {
                 // Apply all accumulated narrowing constraints to the base type
                 match accumulated {
                     Some(constraint) => NarrowingConstraint::intersection(base_ty)
@@ -843,10 +407,10 @@ impl ReachabilityConstraints {
                     None => base_ty,
                 }
             }
-            ALWAYS_FALSE => Type::Never,
+            Id::ALWAYS_FALSE => Type::Never,
             _ => {
                 let node = self.get_interior_node(id);
-                let predicate = predicates[node.atom];
+                let predicate = predicates[node.atom()];
 
                 // `IsNonTerminalCall` predicates don't narrow any variable; they only
                 // affect reachability. Evaluate the predicate to determine which
@@ -858,7 +422,7 @@ impl ReachabilityConstraints {
                         Truthiness::AlwaysTrue => self.narrow_by_constraint_inner(
                             db,
                             predicates,
-                            node.if_true,
+                            node.if_true(),
                             base_ty,
                             place,
                             accumulated,
@@ -866,7 +430,7 @@ impl ReachabilityConstraints {
                         Truthiness::AlwaysFalse => self.narrow_by_constraint_inner(
                             db,
                             predicates,
-                            node.if_false,
+                            node.if_false(),
                             base_ty,
                             place,
                             accumulated,
@@ -881,7 +445,7 @@ impl ReachabilityConstraints {
                 let pos_constraint = infer_narrowing_constraint(db, predicate, place);
 
                 // If the true branch is statically unreachable, skip it entirely.
-                if node.if_true == ALWAYS_FALSE {
+                if node.if_true() == Id::ALWAYS_FALSE {
                     let neg_predicate = Predicate {
                         node: predicate.node,
                         is_positive: !predicate.is_positive,
@@ -891,7 +455,7 @@ impl ReachabilityConstraints {
                     return self.narrow_by_constraint_inner(
                         db,
                         predicates,
-                        node.if_false,
+                        node.if_false(),
                         base_ty,
                         place,
                         false_accumulated,
@@ -899,12 +463,12 @@ impl ReachabilityConstraints {
                 }
 
                 // If the false branch is statically unreachable, skip it entirely.
-                if node.if_false == ALWAYS_FALSE {
+                if node.if_false() == Id::ALWAYS_FALSE {
                     let true_accumulated = accumulate_constraint(accumulated, pos_constraint);
                     return self.narrow_by_constraint_inner(
                         db,
                         predicates,
-                        node.if_true,
+                        node.if_true(),
                         base_ty,
                         place,
                         true_accumulated,
@@ -916,7 +480,7 @@ impl ReachabilityConstraints {
                 let true_ty = self.narrow_by_constraint_inner(
                     db,
                     predicates,
-                    node.if_true,
+                    node.if_true(),
                     base_ty,
                     place,
                     true_accumulated,
@@ -932,7 +496,7 @@ impl ReachabilityConstraints {
                 let false_ty = self.narrow_by_constraint_inner(
                     db,
                     predicates,
-                    node.if_false,
+                    node.if_false(),
                     base_ty,
                     place,
                     false_accumulated,
@@ -950,11 +514,13 @@ impl ReachabilityConstraints {
         predicates: &Predicates<'db>,
         mut id: ScopedReachabilityConstraintId,
     ) -> Truthiness {
+        type Id = ScopedReachabilityConstraintId;
+
         loop {
             let node = match id {
-                ALWAYS_TRUE => return Truthiness::AlwaysTrue,
-                AMBIGUOUS => return Truthiness::Ambiguous,
-                ALWAYS_FALSE => return Truthiness::AlwaysFalse,
+                Id::ALWAYS_TRUE => return Truthiness::AlwaysTrue,
+                Id::AMBIGUOUS => return Truthiness::Ambiguous,
+                Id::ALWAYS_FALSE => return Truthiness::AlwaysFalse,
                 _ => {
                     // `id` gives us the index of this node in the IndexVec that we used when
                     // constructing this BDD. When finalizing the builder, we threw away any
@@ -964,18 +530,18 @@ impl ReachabilityConstraints {
                     // `used_interiors` vector.
                     let raw_index = id.as_u32() as usize;
                     debug_assert!(
-                        self.used_indices.get_bit(raw_index).unwrap_or(false),
+                        self.used_indices().get_bit(raw_index).unwrap_or(false),
                         "all used reachability constraints should have been marked as used",
                     );
-                    let index = self.used_indices.rank(raw_index) as usize;
-                    self.used_interiors[index]
+                    let index = self.used_indices().rank(raw_index) as usize;
+                    self.used_interiors()[index]
                 }
             };
-            let predicate = &predicates[node.atom];
+            let predicate = &predicates[node.atom()];
             match Self::analyze_single(db, predicate) {
-                Truthiness::AlwaysTrue => id = node.if_true,
-                Truthiness::Ambiguous => id = node.if_ambiguous,
-                Truthiness::AlwaysFalse => id = node.if_false,
+                Truthiness::AlwaysTrue => id = node.if_true(),
+                Truthiness::Ambiguous => id = node.if_ambiguous(),
+                Truthiness::AlwaysFalse => id = node.if_false(),
             }
         }
     }
@@ -1023,7 +589,8 @@ impl ReachabilityConstraints {
 
                             Self::analyze_single_pattern_predicate_kind(db, p, narrowed_subject_ty)
                         })
-                        // this is just a "max", but with a slight optimization: `AlwaysTrue` is the "greatest" possible element, so we short-circuit if we get there
+                        // this is just a "max", but with a slight optimization:
+                        // `AlwaysTrue` is the "greatest" possible element, so we short-circuit if we get there
                         .try_fold(Truthiness::AlwaysFalse, |acc, next| match (acc, next) {
                             (Truthiness::AlwaysTrue, _) | (_, Truthiness::AlwaysTrue) => {
                                 ControlFlow::Break(Truthiness::AlwaysTrue)
@@ -1179,15 +746,15 @@ impl ReachabilityConstraints {
                 )
                 .place
                 {
-                    crate::place::Place::Defined(crate::place::DefinedPlace {
-                        definedness: crate::place::Definedness::AlwaysDefined,
+                    Place::Defined(DefinedPlace {
+                        definedness: Definedness::AlwaysDefined,
                         ..
                     }) => Truthiness::AlwaysTrue,
-                    crate::place::Place::Defined(crate::place::DefinedPlace {
-                        definedness: crate::place::Definedness::PossiblyUndefined,
+                    Place::Defined(DefinedPlace {
+                        definedness: Definedness::PossiblyUndefined,
                         ..
                     }) => Truthiness::Ambiguous,
-                    crate::place::Place::Undefined => Truthiness::AlwaysFalse,
+                    Place::Undefined => Truthiness::AlwaysFalse,
                 }
             }
         }

--- a/crates/ty_python_semantic/src/semantic_index.rs
+++ b/crates/ty_python_semantic/src/semantic_index.rs
@@ -30,7 +30,6 @@ use crate::semantic_index::scope::{
 use crate::semantic_index::symbol::ScopedSymbolId;
 use crate::semantic_index::use_def::{EnclosingSnapshotKey, ScopedEnclosingSnapshotId, UseDefMap};
 use crate::semantic_model::HasTrackedScope;
-pub(crate) use reachability_constraints::ReachabilityConstraints;
 
 pub mod ast_ids;
 mod builder;
@@ -41,7 +40,7 @@ pub(crate) mod narrowing_constraints;
 pub mod place;
 pub(crate) mod predicate;
 mod re_exports;
-mod reachability_constraints;
+pub(crate) mod reachability_constraints_datastructures;
 pub(crate) mod scope;
 pub(crate) mod symbol;
 mod use_def;

--- a/crates/ty_python_semantic/src/semantic_index/builder.rs
+++ b/crates/ty_python_semantic/src/semantic_index/builder.rs
@@ -39,7 +39,7 @@ use crate::semantic_index::predicate::{
     PredicateNode, PredicateOrLiteral, ScopedPredicateId, StarImportPlaceholderPredicate,
 };
 use crate::semantic_index::re_exports::exported_names;
-use crate::semantic_index::reachability_constraints::{
+use crate::semantic_index::reachability_constraints_datastructures::{
     ReachabilityConstraintsBuilder, ScopedReachabilityConstraintId,
 };
 use crate::semantic_index::scope::{

--- a/crates/ty_python_semantic/src/semantic_index/narrowing_constraints.rs
+++ b/crates/ty_python_semantic/src/semantic_index/narrowing_constraints.rs
@@ -13,7 +13,7 @@
 //! [`Predicate`]: crate::semantic_index::predicate::Predicate
 
 use crate::semantic_index::ast_ids::ScopedUseId;
-use crate::semantic_index::reachability_constraints::ScopedReachabilityConstraintId;
+use crate::semantic_index::reachability_constraints_datastructures::ScopedReachabilityConstraintId;
 use crate::semantic_index::scope::FileScopeId;
 
 /// A narrowing constraint associated with a live binding.

--- a/crates/ty_python_semantic/src/semantic_index/predicate.rs
+++ b/crates/ty_python_semantic/src/semantic_index/predicate.rs
@@ -4,7 +4,7 @@
 //!
 //! - [_Narrowing constraints_][crate::semantic_index::narrowing_constraints] constrain the type of
 //!   a binding that is visible at a particular use.
-//! - [_Reachability constraints_][crate::semantic_index::reachability_constraints] determine the
+//! - [_Reachability constraints_][crate::reachability_constraints] determine the
 //!   static reachability of a binding, and the reachability of a statement or expression.
 
 use ruff_db::files::File;

--- a/crates/ty_python_semantic/src/semantic_index/reachability_constraints_datastructures.rs
+++ b/crates/ty_python_semantic/src/semantic_index/reachability_constraints_datastructures.rs
@@ -1,0 +1,479 @@
+//! # Core data structures for recording reachability constraints.
+//!
+//! See [`crate::reachability_constraints`] for more details.
+
+use std::cmp::Ordering;
+
+use ruff_index::{Idx, IndexVec};
+use rustc_hash::FxHashMap;
+
+use crate::rank::RankBitBox;
+use crate::semantic_index::predicate::ScopedPredicateId;
+
+/// A ternary formula that defines under what conditions a binding is visible. (A ternary formula
+/// is just like a boolean formula, but with `Ambiguous` as a third potential result. See the
+/// module documentation for more details.)
+///
+/// The primitive atoms of the formula are [`super::predicate::Predicate`]s, which express some
+/// property of the runtime state of the code that we are analyzing.
+///
+/// We assume that each atom has a stable value each time that the formula is evaluated. An atom
+/// that resolves to `Ambiguous` might be true or false, and we can't tell which — but within that
+/// evaluation, we assume that the atom has the _same_ unknown value each time it appears. That
+/// allows us to perform simplifications like `A ∨ !A → true` and `A ∧ !A → false`.
+///
+/// That means that when you are constructing a formula, you might need to create distinct atoms
+/// for a particular [`super::predicate::Predicate`], if your formula needs to consider how a
+/// particular runtime property might be different at different points in the execution of the
+/// program.
+///
+/// reachability constraints are normalized, so equivalent constraints are guaranteed to have equal
+/// IDs.
+#[derive(Clone, Copy, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) struct ScopedReachabilityConstraintId(u32);
+
+impl std::fmt::Debug for ScopedReachabilityConstraintId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut f = f.debug_tuple("ScopedReachabilityConstraintId");
+        match *self {
+            // We use format_args instead of rendering the strings directly so that we don't get
+            // any quotes in the output: ScopedReachabilityConstraintId(AlwaysTrue) instead of
+            // ScopedReachabilityConstraintId("AlwaysTrue").
+            ALWAYS_TRUE => f.field(&format_args!("AlwaysTrue")),
+            AMBIGUOUS => f.field(&format_args!("Ambiguous")),
+            ALWAYS_FALSE => f.field(&format_args!("AlwaysFalse")),
+            _ => f.field(&self.0),
+        };
+        f.finish()
+    }
+}
+
+// Internal details:
+//
+// There are 3 terminals, with hard-coded constraint IDs: true, ambiguous, and false.
+//
+// _Atoms_ are the underlying Predicates, which are the variables that are evaluated by the
+// ternary function.
+//
+// _Interior nodes_ provide the TDD structure for the formula. Interior nodes are stored in an
+// arena Vec, with the constraint ID providing an index into the arena.
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize)]
+pub(crate) struct InteriorNode {
+    /// A "variable" that is evaluated as part of a TDD ternary function. For reachability
+    /// constraints, this is a `Predicate` that represents some runtime property of the Python
+    /// code that we are evaluating.
+    atom: ScopedPredicateId,
+    if_true: ScopedReachabilityConstraintId,
+    if_ambiguous: ScopedReachabilityConstraintId,
+    if_false: ScopedReachabilityConstraintId,
+}
+
+impl InteriorNode {
+    pub(crate) const fn atom(self) -> ScopedPredicateId {
+        self.atom
+    }
+
+    pub(crate) const fn if_true(self) -> ScopedReachabilityConstraintId {
+        self.if_true
+    }
+
+    pub(crate) const fn if_ambiguous(self) -> ScopedReachabilityConstraintId {
+        self.if_ambiguous
+    }
+
+    pub(crate) const fn if_false(self) -> ScopedReachabilityConstraintId {
+        self.if_false
+    }
+}
+
+impl ScopedReachabilityConstraintId {
+    /// A special ID that is used for an "always true" / "always visible" constraint.
+    pub(crate) const ALWAYS_TRUE: ScopedReachabilityConstraintId =
+        ScopedReachabilityConstraintId(0xffff_ffff);
+
+    /// A special ID that is used for an ambiguous constraint.
+    pub(crate) const AMBIGUOUS: ScopedReachabilityConstraintId =
+        ScopedReachabilityConstraintId(0xffff_fffe);
+
+    /// A special ID that is used for an "always false" / "never visible" constraint.
+    pub(crate) const ALWAYS_FALSE: ScopedReachabilityConstraintId =
+        ScopedReachabilityConstraintId(0xffff_fffd);
+
+    pub(crate) fn is_terminal(self) -> bool {
+        self.0 >= SMALLEST_TERMINAL.0
+    }
+
+    pub(crate) fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+impl Idx for ScopedReachabilityConstraintId {
+    #[inline]
+    fn new(value: usize) -> Self {
+        assert!(value <= (SMALLEST_TERMINAL.0 as usize));
+        #[expect(clippy::cast_possible_truncation)]
+        Self(value as u32)
+    }
+
+    #[inline]
+    fn index(self) -> usize {
+        debug_assert!(!self.is_terminal());
+        self.0 as usize
+    }
+}
+
+// Rebind some constants locally so that we don't need as many qualifiers below.
+const ALWAYS_TRUE: ScopedReachabilityConstraintId = ScopedReachabilityConstraintId::ALWAYS_TRUE;
+const AMBIGUOUS: ScopedReachabilityConstraintId = ScopedReachabilityConstraintId::AMBIGUOUS;
+const ALWAYS_FALSE: ScopedReachabilityConstraintId = ScopedReachabilityConstraintId::ALWAYS_FALSE;
+const SMALLEST_TERMINAL: ScopedReachabilityConstraintId = ALWAYS_FALSE;
+
+/// Maximum number of interior TDD nodes per scope. When exceeded, new constraint
+/// operations return `AMBIGUOUS` to prevent exponential blowup on pathological inputs
+/// (e.g., a 5000-line while loop with hundreds of if-branches). This can lead to less precise
+/// reachability analysis and type narrowing.
+const MAX_INTERIOR_NODES: usize = 512 * 1024;
+
+/// A collection of reachability constraints for a given scope.
+#[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+pub(crate) struct ReachabilityConstraints {
+    /// The interior TDD nodes that were marked as used when being built.
+    used_interiors: Box<[InteriorNode]>,
+    /// A bit vector indicating which interior TDD nodes were marked as used. This is indexed by
+    /// the node's [`ScopedReachabilityConstraintId`]. The rank of the corresponding bit gives the
+    /// index of that node in the `used_interiors` vector.
+    used_indices: RankBitBox,
+}
+
+impl ReachabilityConstraints {
+    /// Look up an interior node by its constraint ID.
+    pub(crate) fn get_interior_node(&self, id: ScopedReachabilityConstraintId) -> InteriorNode {
+        debug_assert!(!id.is_terminal());
+        let raw_index = id.as_u32() as usize;
+        debug_assert!(
+            self.used_indices().get_bit(raw_index).unwrap_or(false),
+            "all used reachability constraints should have been marked as used",
+        );
+        let index = self.used_indices().rank(raw_index) as usize;
+        self.used_interiors()[index]
+    }
+
+    pub(crate) fn used_interiors(&self) -> &[InteriorNode] {
+        &self.used_interiors
+    }
+
+    pub(crate) fn used_indices(&self) -> &RankBitBox {
+        &self.used_indices
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct ReachabilityConstraintsBuilder {
+    interiors: IndexVec<ScopedReachabilityConstraintId, InteriorNode>,
+    interior_used: IndexVec<ScopedReachabilityConstraintId, bool>,
+    interior_cache: FxHashMap<InteriorNode, ScopedReachabilityConstraintId>,
+    not_cache: FxHashMap<ScopedReachabilityConstraintId, ScopedReachabilityConstraintId>,
+    and_cache: FxHashMap<
+        (
+            ScopedReachabilityConstraintId,
+            ScopedReachabilityConstraintId,
+        ),
+        ScopedReachabilityConstraintId,
+    >,
+    or_cache: FxHashMap<
+        (
+            ScopedReachabilityConstraintId,
+            ScopedReachabilityConstraintId,
+        ),
+        ScopedReachabilityConstraintId,
+    >,
+}
+
+impl ReachabilityConstraintsBuilder {
+    pub(crate) fn build(self) -> ReachabilityConstraints {
+        let used_indices = RankBitBox::from_bits(self.interior_used.iter().copied());
+        let used_interiors = (self.interiors.into_iter())
+            .zip(self.interior_used)
+            .filter_map(|(interior, used)| used.then_some(interior))
+            .collect();
+        ReachabilityConstraints {
+            used_interiors,
+            used_indices,
+        }
+    }
+
+    /// Marks that a particular TDD node is used. This lets us throw away interior nodes that were
+    /// only calculated for intermediate values, and which don't need to be included in the final
+    /// built result.
+    pub(crate) fn mark_used(&mut self, node: ScopedReachabilityConstraintId) {
+        if !node.is_terminal() && !self.interior_used[node] {
+            self.interior_used[node] = true;
+            let node = self.interiors[node];
+            self.mark_used(node.if_true);
+            self.mark_used(node.if_ambiguous);
+            self.mark_used(node.if_false);
+        }
+    }
+
+    /// Implements the ordering that determines which level a TDD node appears at.
+    ///
+    /// Each interior node checks the value of a single variable (for us, a `Predicate`).
+    /// TDDs are ordered such that every path from the root of the graph to the leaves must
+    /// check each variable at most once, and must check each variable in the same order.
+    ///
+    /// We can choose any ordering that we want, as long as it's consistent — with the
+    /// caveat that terminal nodes must always be last in the ordering, since they are the
+    /// leaf nodes of the graph.
+    ///
+    /// We currently compare interior nodes by looking at the Salsa IDs of each variable's
+    /// `Predicate`, since this is already available and easy to compare. We also _reverse_
+    /// the comparison of those Salsa IDs. The Salsa IDs are assigned roughly sequentially
+    /// while traversing the source code. Reversing the comparison means `Predicate`s that
+    /// appear later in the source will tend to be placed "higher" (closer to the root) in
+    /// the TDD graph. We have found empirically that this leads to smaller TDD graphs [1],
+    /// since there are often repeated combinations of `Predicate`s from earlier in the
+    /// file.
+    ///
+    /// [1]: https://github.com/astral-sh/ruff/pull/20098
+    fn cmp_atoms(
+        &self,
+        a: ScopedReachabilityConstraintId,
+        b: ScopedReachabilityConstraintId,
+    ) -> Ordering {
+        if a == b || (a.is_terminal() && b.is_terminal()) {
+            Ordering::Equal
+        } else if a.is_terminal() {
+            Ordering::Greater
+        } else if b.is_terminal() {
+            Ordering::Less
+        } else {
+            // See https://github.com/astral-sh/ruff/pull/20098 for an explanation of why this
+            // ordering is reversed.
+            self.interiors[a]
+                .atom
+                .cmp(&self.interiors[b].atom)
+                .reverse()
+        }
+    }
+
+    /// Adds an interior node, ensuring that we always use the same reachability constraint ID for
+    /// equal nodes.
+    fn add_interior(&mut self, node: InteriorNode) -> ScopedReachabilityConstraintId {
+        // If the true and false branches lead to the same node, we can override the ambiguous
+        // branch to go there too. And this node is then redundant and can be reduced.
+        if node.if_true == node.if_false {
+            return node.if_true;
+        }
+
+        *self.interior_cache.entry(node).or_insert_with(|| {
+            self.interior_used.push(false);
+            self.interiors.push(node)
+        })
+    }
+
+    /// Adds a new reachability constraint that checks a single [`super::predicate::Predicate`].
+    ///
+    /// [`ScopedPredicateId`]s are the “variables” that are evaluated by a TDD. A TDD variable has
+    /// the same value no matter how many times it appears in the ternary formula that the TDD
+    /// represents.
+    ///
+    /// However, we sometimes have to model how a `Predicate` can have a different runtime
+    /// value at different points in the execution of the program. To handle this, you can take
+    /// advantage of the fact that the [`super::predicate::Predicates`] arena does not deduplicate
+    /// `Predicate`s. You can add a `Predicate` multiple times, yielding different
+    /// `ScopedPredicateId`s, which you can then create separate TDD atoms for.
+    pub(crate) fn add_atom(
+        &mut self,
+        predicate: ScopedPredicateId,
+    ) -> ScopedReachabilityConstraintId {
+        if predicate == ScopedPredicateId::ALWAYS_FALSE {
+            ALWAYS_FALSE
+        } else if predicate == ScopedPredicateId::ALWAYS_TRUE {
+            ALWAYS_TRUE
+        } else {
+            self.add_interior(InteriorNode {
+                atom: predicate,
+                if_true: ALWAYS_TRUE,
+                if_ambiguous: AMBIGUOUS,
+                if_false: ALWAYS_FALSE,
+            })
+        }
+    }
+
+    /// Adds a new reachability constraint that is the ternary NOT of an existing one.
+    pub(crate) fn add_not_constraint(
+        &mut self,
+        a: ScopedReachabilityConstraintId,
+    ) -> ScopedReachabilityConstraintId {
+        if a == ALWAYS_TRUE {
+            return ALWAYS_FALSE;
+        } else if a == AMBIGUOUS {
+            return AMBIGUOUS;
+        } else if a == ALWAYS_FALSE {
+            return ALWAYS_TRUE;
+        }
+
+        if let Some(cached) = self.not_cache.get(&a) {
+            return *cached;
+        }
+
+        if self.interiors.len() >= MAX_INTERIOR_NODES {
+            return AMBIGUOUS;
+        }
+
+        let a_node = self.interiors[a];
+        let if_true = self.add_not_constraint(a_node.if_true);
+        let if_ambiguous = self.add_not_constraint(a_node.if_ambiguous);
+        let if_false = self.add_not_constraint(a_node.if_false);
+        let result = self.add_interior(InteriorNode {
+            atom: a_node.atom,
+            if_true,
+            if_ambiguous,
+            if_false,
+        });
+        self.not_cache.insert(a, result);
+        result
+    }
+
+    /// Adds a new reachability constraint that is the ternary OR of two existing ones.
+    pub(crate) fn add_or_constraint(
+        &mut self,
+        a: ScopedReachabilityConstraintId,
+        b: ScopedReachabilityConstraintId,
+    ) -> ScopedReachabilityConstraintId {
+        match (a, b) {
+            (ALWAYS_TRUE, _) | (_, ALWAYS_TRUE) => return ALWAYS_TRUE,
+            (ALWAYS_FALSE, other) | (other, ALWAYS_FALSE) => return other,
+            (AMBIGUOUS, AMBIGUOUS) => return AMBIGUOUS,
+            _ => {}
+        }
+
+        // OR is commutative, which lets us halve the cache requirements
+        let (a, b) = if b.0 < a.0 { (b, a) } else { (a, b) };
+        if let Some(cached) = self.or_cache.get(&(a, b)) {
+            return *cached;
+        }
+
+        if self.interiors.len() >= MAX_INTERIOR_NODES {
+            return AMBIGUOUS;
+        }
+
+        let (atom, if_true, if_ambiguous, if_false) = match self.cmp_atoms(a, b) {
+            Ordering::Equal => {
+                let a_node = self.interiors[a];
+                let b_node = self.interiors[b];
+                let if_true = self.add_or_constraint(a_node.if_true, b_node.if_true);
+                let if_false = self.add_or_constraint(a_node.if_false, b_node.if_false);
+                let if_ambiguous = if if_true == if_false {
+                    if_true
+                } else {
+                    self.add_or_constraint(a_node.if_ambiguous, b_node.if_ambiguous)
+                };
+                (a_node.atom, if_true, if_ambiguous, if_false)
+            }
+            Ordering::Less => {
+                let a_node = self.interiors[a];
+                let if_true = self.add_or_constraint(a_node.if_true, b);
+                let if_false = self.add_or_constraint(a_node.if_false, b);
+                let if_ambiguous = if if_true == if_false {
+                    if_true
+                } else {
+                    self.add_or_constraint(a_node.if_ambiguous, b)
+                };
+                (a_node.atom, if_true, if_ambiguous, if_false)
+            }
+            Ordering::Greater => {
+                let b_node = self.interiors[b];
+                let if_true = self.add_or_constraint(a, b_node.if_true);
+                let if_false = self.add_or_constraint(a, b_node.if_false);
+                let if_ambiguous = if if_true == if_false {
+                    if_true
+                } else {
+                    self.add_or_constraint(a, b_node.if_ambiguous)
+                };
+                (b_node.atom, if_true, if_ambiguous, if_false)
+            }
+        };
+
+        let result = self.add_interior(InteriorNode {
+            atom,
+            if_true,
+            if_ambiguous,
+            if_false,
+        });
+        self.or_cache.insert((a, b), result);
+        result
+    }
+
+    /// Adds a new reachability constraint that is the ternary AND of two existing ones.
+    pub(crate) fn add_and_constraint(
+        &mut self,
+        a: ScopedReachabilityConstraintId,
+        b: ScopedReachabilityConstraintId,
+    ) -> ScopedReachabilityConstraintId {
+        match (a, b) {
+            (ALWAYS_FALSE, _) | (_, ALWAYS_FALSE) => return ALWAYS_FALSE,
+            (ALWAYS_TRUE, other) | (other, ALWAYS_TRUE) => return other,
+            (AMBIGUOUS, AMBIGUOUS) => return AMBIGUOUS,
+            _ => {}
+        }
+
+        // AND is commutative, which lets us halve the cache requirements
+        let (a, b) = if b.0 < a.0 { (b, a) } else { (a, b) };
+        if let Some(cached) = self.and_cache.get(&(a, b)) {
+            return *cached;
+        }
+
+        if self.interiors.len() >= MAX_INTERIOR_NODES {
+            return AMBIGUOUS;
+        }
+
+        let (atom, if_true, if_ambiguous, if_false) = match self.cmp_atoms(a, b) {
+            Ordering::Equal => {
+                let a_node = self.interiors[a];
+                let b_node = self.interiors[b];
+                let if_true = self.add_and_constraint(a_node.if_true, b_node.if_true);
+                let if_false = self.add_and_constraint(a_node.if_false, b_node.if_false);
+                let if_ambiguous = if if_true == if_false {
+                    if_true
+                } else {
+                    self.add_and_constraint(a_node.if_ambiguous, b_node.if_ambiguous)
+                };
+                (a_node.atom, if_true, if_ambiguous, if_false)
+            }
+            Ordering::Less => {
+                let a_node = self.interiors[a];
+                let if_true = self.add_and_constraint(a_node.if_true, b);
+                let if_false = self.add_and_constraint(a_node.if_false, b);
+                let if_ambiguous = if if_true == if_false {
+                    if_true
+                } else {
+                    self.add_and_constraint(a_node.if_ambiguous, b)
+                };
+                (a_node.atom, if_true, if_ambiguous, if_false)
+            }
+            Ordering::Greater => {
+                let b_node = self.interiors[b];
+                let if_true = self.add_and_constraint(a, b_node.if_true);
+                let if_false = self.add_and_constraint(a, b_node.if_false);
+                let if_ambiguous = if if_true == if_false {
+                    if_true
+                } else {
+                    self.add_and_constraint(a, b_node.if_ambiguous)
+                };
+                (b_node.atom, if_true, if_ambiguous, if_false)
+            }
+        };
+
+        let result = self.add_interior(InteriorNode {
+            atom,
+            if_true,
+            if_ambiguous,
+            if_false,
+        });
+        self.and_cache.insert((a, b), result);
+        result
+    }
+}

--- a/crates/ty_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/ty_python_semantic/src/semantic_index/use_def.rs
@@ -254,7 +254,7 @@ use crate::semantic_index::place::{PlaceExprRef, ScopedPlaceId};
 use crate::semantic_index::predicate::{
     PredicateOrLiteral, Predicates, PredicatesBuilder, ScopedPredicateId,
 };
-use crate::semantic_index::reachability_constraints::{
+use crate::semantic_index::reachability_constraints_datastructures::{
     ReachabilityConstraints, ReachabilityConstraintsBuilder, ScopedReachabilityConstraintId,
 };
 use crate::semantic_index::scope::{FileScopeId, ScopeKind, ScopeLaziness};

--- a/crates/ty_python_semantic/src/semantic_index/use_def/place_state.rs
+++ b/crates/ty_python_semantic/src/semantic_index/use_def/place_state.rs
@@ -47,7 +47,7 @@ use ruff_index::newtype_index;
 use smallvec::{SmallVec, smallvec};
 
 use crate::semantic_index::narrowing_constraints::ScopedNarrowingConstraint;
-use crate::semantic_index::reachability_constraints::{
+use crate::semantic_index::reachability_constraints_datastructures::{
     ReachabilityConstraintsBuilder, ScopedReachabilityConstraintId,
 };
 


### PR DESCRIPTION
## Summary

In order to accomplish #24471, `semantic_index/reachability_constraints.rs` needs to be split into two files. Most of the logic in that file must remain in the `ty_python_semantic` crate, because evaluation of reachability constraints requires awareness of `Type`s. The core datastructures that are used for _recording_ reachability constraints during semantic indexing, however, must be moved with the rest of the semantic-index submodule into the lower-level `ty_python_core` crate.

Because the file must be split in two rather than simply moved, git is not recognising preserving the blame for either "new file" in #24471, which is regrettable. This PR is therefore a simple split of the two files, keeping the name "`reachability_constraints.rs`" for the file that is most similar to the file currently known as "`reachability_constraints.rs`" in order to preserve as much `git blame` as possible. By splitting it into a standlone PR, git is successfully able to recognize the file as simply having been moved.

## Test Plan

existing tests
