### PR TITLE
[ty] Use reachable first declaration in declaration-based diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -1032,6 +1032,27 @@ class D:
         # No else: y may be unbound at runtime, but there is still an assignment path
 ```
 
+### Reachable `Final` declaration wins for diagnostics
+
+If an earlier `Final` declaration is statically unreachable, diagnostics should be attached to the
+later declaration that remains visible:
+
+```py
+from typing import Final
+
+if False:
+    UNREACHABLE_MODULE_FINAL: Final[int]
+else:
+    # error: [final-without-value] "`Final` symbol `UNREACHABLE_MODULE_FINAL` is not assigned a value"
+    UNREACHABLE_MODULE_FINAL: Final[str]
+
+class C:
+    if False:
+        x: Final[int]
+    else:
+        x: Final[str]  # error: [final-without-value] "`Final` symbol `x` is not assigned a value"
+```
+
 ### Assignment in non-`__init__` method
 
 Per the typing spec, a `Final` attribute declared in a class body without a value must be

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1702,14 +1702,13 @@ fn place_from_declarations_impl<'db>(
             return None;
         }
 
-        first_declaration.get_or_insert(declaration);
-
         let static_reachability =
             reachability_constraints.evaluate(db, predicates, reachability_constraint);
 
         if static_reachability.is_always_false() {
             None
         } else {
+            first_declaration.get_or_insert(declaration);
             all_declarations_definitely_reachable =
                 all_declarations_definitely_reachable && static_reachability.is_always_true();
 


### PR DESCRIPTION
## Summary

We now use the first reachable declaration, rather than the first declaration, in certain diagnostics, e.g.:

```python
from typing import Final

if False:
    UNREACHABLE_MODULE_FINAL: Final[int]
else:
    # error: [final-without-value] "`Final` symbol `UNREACHABLE_MODULE_FINAL` is not assigned a value"
    UNREACHABLE_MODULE_FINAL: Final[str]
```