### PR TITLE
[ty] Attach explanatory subdiagnostics when emitting diagnostics for implicit calls to `__init_subclass__` or a metaclass constructor

### DIFF
--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -8,7 +8,7 @@
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22abstract-method-in-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2372" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2373" target="_blank">View source</a>
 </small>
 
 
@@ -49,7 +49,7 @@ class Derived(Base):  # Error: `Derived` does not implement `method`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-protocol-member%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L654" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L655" target="_blank">View source</a>
 </small>
 
 
@@ -90,7 +90,7 @@ class SubProto(BaseProto, Protocol):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22assert-type-unspellable-subtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2508" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2509" target="_blank">View source</a>
 </small>
 
 
@@ -126,7 +126,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Preview (since <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a>) ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-abstract-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2407" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2408" target="_blank">View source</a>
 </small>
 
 
@@ -175,7 +175,7 @@ Foo.method()  # Error: cannot call abstract classmethod
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-non-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L170" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L171" target="_blank">View source</a>
 </small>
 
 
@@ -199,7 +199,7 @@ Calling a non-callable object will raise a `TypeError` at runtime.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.7">0.0.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-top-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L188" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L189" target="_blank">View source</a>
 </small>
 
 
@@ -230,7 +230,7 @@ def f(x: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-argument-forms%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L239" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L240" target="_blank">View source</a>
 </small>
 
 
@@ -262,7 +262,7 @@ f(int)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-declarations%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L265" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L266" target="_blank">View source</a>
 </small>
 
 
@@ -293,7 +293,7 @@ a = 1
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L290" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L291" target="_blank">View source</a>
 </small>
 
 
@@ -325,7 +325,7 @@ class C(A, B): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-class-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L316" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L317" target="_blank">View source</a>
 </small>
 
 
@@ -357,7 +357,7 @@ class B(A): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-type-alias-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L342" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L343" target="_blank">View source</a>
 </small>
 
 
@@ -385,7 +385,7 @@ type B = A
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22dataclass-field-order%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L460" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L461" target="_blank">View source</a>
 </small>
 
 
@@ -417,7 +417,7 @@ class Example:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.16">0.0.1-alpha.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22deprecated%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L386" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L387" target="_blank">View source</a>
 </small>
 
 
@@ -444,7 +444,7 @@ old_func()  # emits [deprecated] diagnostic
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22division-by-zero%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L364" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L365" target="_blank">View source</a>
 </small>
 
 
@@ -473,7 +473,7 @@ false positives it can produce.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L407" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L408" target="_blank">View source</a>
 </small>
 
 
@@ -500,7 +500,7 @@ class B(A, A): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-kw-only%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L428" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L429" target="_blank">View source</a>
 </small>
 
 
@@ -538,7 +538,7 @@ class A:  # Crash at runtime
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22empty-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L968" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L969" target="_blank">View source</a>
 </small>
 
 
@@ -609,7 +609,7 @@ def foo() -> "intt\b": ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-on-non-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2319" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2320" target="_blank">View source</a>
 </small>
 
 
@@ -641,7 +641,7 @@ def my_function() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-without-value%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2345" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2346" target="_blank">View source</a>
 </small>
 
 
@@ -736,7 +736,7 @@ def test(): -> "Literal[5]":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22inconsistent-mro%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L737" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L738" target="_blank">View source</a>
 </small>
 
 
@@ -766,7 +766,7 @@ class C(A, B): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22index-out-of-bounds%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L761" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L762" target="_blank">View source</a>
 </small>
 
 
@@ -792,7 +792,7 @@ t[3]  # IndexError: tuple index out of range
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.33">0.0.1-alpha.33</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ineffective-final%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2291" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2292" target="_blank">View source</a>
 </small>
 
 
@@ -826,7 +826,7 @@ class MyClass: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22instance-layout-conflict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L543" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L544" target="_blank">View source</a>
 </small>
 
 
@@ -915,7 +915,7 @@ an atypical memory layout.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-argument-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L899" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L900" target="_blank">View source</a>
 </small>
 
 
@@ -942,7 +942,7 @@ func("foo")  # error: [invalid-argument-type]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-assignment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1008" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1009" target="_blank">View source</a>
 </small>
 
 
@@ -970,7 +970,7 @@ a: int = ''
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-attribute-access%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2837" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2838" target="_blank">View source</a>
 </small>
 
 
@@ -1004,7 +1004,7 @@ C.instance_var = 3  # error: Cannot assign to instance variable
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-await%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1030" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1031" target="_blank">View source</a>
 </small>
 
 
@@ -1040,7 +1040,7 @@ asyncio.run(main())
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1060" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1061" target="_blank">View source</a>
 </small>
 
 
@@ -1064,7 +1064,7 @@ class A(42): ...  # error: [invalid-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-context-manager%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1144" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1145" target="_blank">View source</a>
 </small>
 
 
@@ -1091,7 +1091,7 @@ with 1:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L512" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L513" target="_blank">View source</a>
 </small>
 
 
@@ -1128,7 +1128,7 @@ class Foo(NamedTuple):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L486" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L487" target="_blank">View source</a>
 </small>
 
 
@@ -1160,7 +1160,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-declaration%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1165" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1166" target="_blank">View source</a>
 </small>
 
 
@@ -1189,7 +1189,7 @@ a: str
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-enum-member-annotation%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1224" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1225" target="_blank">View source</a>
 </small>
 
 
@@ -1238,7 +1238,7 @@ class Pet(Enum):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-exception-caught%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1188" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1189" target="_blank">View source</a>
 </small>
 
 
@@ -1282,7 +1282,7 @@ except ZeroDivisionError:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.28">0.0.1-alpha.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-explicit-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2450" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2451" target="_blank">View source</a>
 </small>
 
 
@@ -1324,7 +1324,7 @@ class D(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.35">0.0.1-alpha.35</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-frozen-dataclass-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3195" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3196" target="_blank">View source</a>
 </small>
 
 
@@ -1368,7 +1368,7 @@ class NonFrozenChild(FrozenBase):  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1308" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1309" target="_blank">View source</a>
 </small>
 
 
@@ -1406,7 +1406,7 @@ class D(Generic[U, T]): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-enum%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1266" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1267" target="_blank">View source</a>
 </small>
 
 
@@ -1485,7 +1485,7 @@ a = 20 / 0  # type: ignore
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.17">0.0.1-alpha.17</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L782" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L783" target="_blank">View source</a>
 </small>
 
 
@@ -1524,7 +1524,7 @@ carol = Person(name="Carol", aeg=25)  # typo!
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-positional-parameter%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3273" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3274" target="_blank">View source</a>
 </small>
 
 
@@ -1585,7 +1585,7 @@ def f(x, y, /):  # Python 3.8+ syntax
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1365" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1366" target="_blank">View source</a>
 </small>
 
 
@@ -1620,7 +1620,7 @@ def f(t: TypeVar("U")): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-match-pattern%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1738" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1739" target="_blank">View source</a>
 </small>
 
 
@@ -1648,7 +1648,7 @@ match x:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1462" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1463" target="_blank">View source</a>
 </small>
 
 
@@ -1682,7 +1682,7 @@ class B(metaclass=f): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-method-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3097" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3098" target="_blank">View source</a>
 </small>
 
 
@@ -1789,7 +1789,7 @@ Correct use of `@override` is enforced by ty's [`invalid-explicit-override`](#in
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-named-tuple%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L689" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L690" target="_blank">View source</a>
 </small>
 
 
@@ -1843,7 +1843,7 @@ AttributeError: Cannot overwrite NamedTuple attribute _asdict
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.27">0.0.1-alpha.27</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-newtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1438" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1439" target="_blank">View source</a>
 </small>
 
 
@@ -1873,7 +1873,7 @@ Baz = NewType("Baz", int | str)  # error: invalid base for `typing.NewType`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1489" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1490" target="_blank">View source</a>
 </small>
 
 
@@ -1923,7 +1923,7 @@ def foo(x: int) -> int: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-parameter-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1588" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1589" target="_blank">View source</a>
 </small>
 
 
@@ -1949,7 +1949,7 @@ def f(a: int = ''): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-paramspec%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1393" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1394" target="_blank">View source</a>
 </small>
 
 
@@ -1980,7 +1980,7 @@ P2 = ParamSpec("S2")  # error: ParamSpec name must match the variable it's assig
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L625" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L626" target="_blank">View source</a>
 </small>
 
 
@@ -2014,7 +2014,7 @@ TypeError: Protocols can only inherit from other protocols, got <class 'int'>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-raise%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1608" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1609" target="_blank">View source</a>
 </small>
 
 
@@ -2063,7 +2063,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-return-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L920" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L921" target="_blank">View source</a>
 </small>
 
 
@@ -2092,7 +2092,7 @@ def func() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-super-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1651" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1652" target="_blank">View source</a>
 </small>
 
 
@@ -2188,7 +2188,7 @@ class C: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.10">0.0.10</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-total-ordering%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3233" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3234" target="_blank">View source</a>
 </small>
 
 
@@ -2234,7 +2234,7 @@ class MyClass:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.6">0.0.1-alpha.6</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-alias-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1417" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1418" target="_blank">View source</a>
 </small>
 
 
@@ -2261,7 +2261,7 @@ NewAlias = TypeAliasType(get_name(), int)        # error: TypeAliasType name mus
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1998" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1999" target="_blank">View source</a>
 </small>
 
 
@@ -2308,7 +2308,7 @@ Bar[int]  # error: too few arguments
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-checking-constant%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1690" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1691" target="_blank">View source</a>
 </small>
 
 
@@ -2338,7 +2338,7 @@ TYPE_CHECKING = ''
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-form%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1714" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1715" target="_blank">View source</a>
 </small>
 
 
@@ -2368,7 +2368,7 @@ b: Annotated[int]  # `Annotated` expects at least two arguments
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-guard-call%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1788" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1789" target="_blank">View source</a>
 </small>
 
 
@@ -2402,7 +2402,7 @@ f(10)  # Error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-guard-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1760" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1761" target="_blank">View source</a>
 </small>
 
 
@@ -2436,7 +2436,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-bound%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1857" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1858" target="_blank">View source</a>
 </small>
 
 
@@ -2467,7 +2467,7 @@ def g[U, T: U](): ...  # error: [invalid-type-variable-bound]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-constraints%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1816" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1817" target="_blank">View source</a>
 </small>
 
 
@@ -2514,7 +2514,7 @@ U = TypeVar('U', list[int], int)  # valid constrained Type
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1882" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1883" target="_blank">View source</a>
 </small>
 
 
@@ -2546,7 +2546,7 @@ U = TypeVar("U", int, str, default=bytes)  # error: [invalid-type-variable-defau
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.28">0.0.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-field%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3043" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3044" target="_blank">View source</a>
 </small>
 
 
@@ -2577,7 +2577,7 @@ class Child(Base):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-header%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3068" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3069" target="_blank">View source</a>
 </small>
 
 
@@ -2612,7 +2612,7 @@ def f(x: dict):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.9">0.0.9</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-statement%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3018" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3019" target="_blank">View source</a>
 </small>
 
 
@@ -2643,7 +2643,7 @@ class Foo(TypedDict):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.25">0.0.25</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-yield%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L943" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L944" target="_blank">View source</a>
 </small>
 
 
@@ -2674,7 +2674,7 @@ def gen() -> Iterator[int]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L815" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L816" target="_blank">View source</a>
 </small>
 
 
@@ -2729,7 +2729,7 @@ def h(arg2: type):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-typed-dict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L863" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L864" target="_blank">View source</a>
 </small>
 
 
@@ -2772,7 +2772,7 @@ def g(arg: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1938" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1939" target="_blank">View source</a>
 </small>
 
 
@@ -2797,7 +2797,7 @@ func()  # TypeError: func() missing 1 required positional argument: 'x'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-typed-dict-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2991" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2992" target="_blank">View source</a>
 </small>
 
 
@@ -2830,7 +2830,7 @@ alice["age"]  # KeyError
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22no-matching-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1957" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1958" target="_blank">View source</a>
 </small>
 
 
@@ -2859,7 +2859,7 @@ func("string")  # error: [no-matching-overload]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22non-callable-init-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1339" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1340" target="_blank">View source</a>
 </small>
 
 
@@ -2892,7 +2892,7 @@ class Sub(Super): ...  # error: [non-callable-init-subclass]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-iterable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2039" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2040" target="_blank">View source</a>
 </small>
 
 
@@ -2918,7 +2918,7 @@ for i in 34:  # TypeError: 'int' object is not iterable
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-subscriptable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1980" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1981" target="_blank">View source</a>
 </small>
 
 
@@ -2942,7 +2942,7 @@ Subscripting an object that does not support it will raise a `TypeError` at runt
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2237" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2238" target="_blank">View source</a>
 </small>
 
 
@@ -2975,7 +2975,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2264" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2265" target="_blank">View source</a>
 </small>
 
 
@@ -3008,7 +3008,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22parameter-already-assigned%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2090" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2091" target="_blank">View source</a>
 </small>
 
 
@@ -3035,7 +3035,7 @@ f(1, x=2)  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22positional-only-parameter-as-kwarg%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2664" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2665" target="_blank">View source</a>
 </small>
 
 
@@ -3062,7 +3062,7 @@ f(x=1)  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2111" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2112" target="_blank">View source</a>
 </small>
 
 
@@ -3095,7 +3095,7 @@ A.c  # AttributeError: type object 'A' has no attribute 'c'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-implicit-call%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L213" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L214" target="_blank">View source</a>
 </small>
 
 
@@ -3127,7 +3127,7 @@ A()[0]  # TypeError: 'A' object is not subscriptable
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2158" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2159" target="_blank">View source</a>
 </small>
 
 
@@ -3164,7 +3164,7 @@ from module import a  # ImportError: cannot import name 'a' from 'module'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.23">0.0.23</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-submodule%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2137" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2138" target="_blank">View source</a>
 </small>
 
 
@@ -3191,7 +3191,7 @@ html.parser  # AttributeError: module 'html' has no attribute 'parser'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2188" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2189" target="_blank">View source</a>
 </small>
 
 
@@ -3255,7 +3255,7 @@ def test(): -> "int":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-cast%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2865" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2866" target="_blank">View source</a>
 </small>
 
 
@@ -3282,7 +3282,7 @@ cast(int, f())  # Redundant
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-final-classvar%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2886" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2887" target="_blank">View source</a>
 </small>
 
 
@@ -3314,7 +3314,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22shadowed-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2912" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2913" target="_blank">View source</a>
 </small>
 
 
@@ -3348,7 +3348,7 @@ class Outer[T]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22static-assert-error%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2813" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2814" target="_blank">View source</a>
 </small>
 
 
@@ -3378,7 +3378,7 @@ static_assert(int(2.0 * 3.0) == 6)  # error: does not have a statically known tr
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2214" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2215" target="_blank">View source</a>
 </small>
 
 
@@ -3407,7 +3407,7 @@ class B(A): ...  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.30">0.0.1-alpha.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22super-call-in-named-tuple-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2598" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2599" target="_blank">View source</a>
 </small>
 
 
@@ -3441,7 +3441,7 @@ class F(NamedTuple):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22too-many-positional-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2538" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2539" target="_blank">View source</a>
 </small>
 
 
@@ -3468,7 +3468,7 @@ f("foo")  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22type-assertion-failure%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2486" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2487" target="_blank">View source</a>
 </small>
 
 
@@ -3496,7 +3496,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unavailable-implicit-super-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2559" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2560" target="_blank">View source</a>
 </small>
 
 
@@ -3542,7 +3542,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unbound-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1908" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1909" target="_blank">View source</a>
 </small>
 
 
@@ -3579,7 +3579,7 @@ class C(Generic[T]):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22undefined-reveal%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2625" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2626" target="_blank">View source</a>
 </small>
 
 
@@ -3603,7 +3603,7 @@ reveal_type(1)  # NameError: name 'reveal_type' is not defined
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unknown-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2643" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2644" target="_blank">View source</a>
 </small>
 
 
@@ -3630,7 +3630,7 @@ f(x=1, y=2)  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2685" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2686" target="_blank">View source</a>
 </small>
 
 
@@ -3658,7 +3658,7 @@ A().foo  # AttributeError: 'A' object has no attribute 'foo'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.15">0.0.1-alpha.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-global%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2939" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2940" target="_blank">View source</a>
 </small>
 
 
@@ -3716,7 +3716,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2707" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2708" target="_blank">View source</a>
 </small>
 
 
@@ -3741,7 +3741,7 @@ import foo  # ModuleNotFoundError: No module named 'foo'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2726" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2727" target="_blank">View source</a>
 </small>
 
 
@@ -3766,7 +3766,7 @@ print(x)  # NameError: name 'x' is not defined
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.7">0.0.1-alpha.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1078" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1079" target="_blank">View source</a>
 </small>
 
 
@@ -3805,7 +3805,7 @@ class D(C): ...  # error: [unsupported-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-bool-conversion%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2059" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2060" target="_blank">View source</a>
 </small>
 
 
@@ -3842,7 +3842,7 @@ b1 < b2 < b1  # exception raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-dynamic-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1111" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1112" target="_blank">View source</a>
 </small>
 
 
@@ -3882,7 +3882,7 @@ def factory(base: type[Base]) -> type:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-operator%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2745" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2746" target="_blank">View source</a>
 </small>
 
 
@@ -3910,7 +3910,7 @@ A() + A()  # TypeError: unsupported operand type(s) for +: 'A' and 'A'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Preview (since <a href="https://github.com/astral-sh/ty/releases/tag/0.0.21">0.0.21</a>) ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-awaitable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2767" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2768" target="_blank">View source</a>
 </small>
 
 
@@ -4016,7 +4016,7 @@ to `false`.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22useless-overload-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1532" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1533" target="_blank">View source</a>
 </small>
 
 
@@ -4079,7 +4079,7 @@ def foo(x: int | str) -> int | str:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22zero-stepsize-in-slice%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2794" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2795" target="_blank">View source</a>
 </small>
 
 

--- a/crates/ty_python_semantic/resources/mdtest/annotations/any.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/any.md
@@ -175,7 +175,8 @@ Any()  # error: [call-non-callable] "Object of type `<special-form 'typing.Any'>
 `Any` also cannot be used as a metaclass (under the hood, this leads to an implicit call to `Any`):
 
 ```py
-class F(metaclass=Any): ...  # error: [invalid-metaclass] "Metaclass type `<special-form 'typing.Any'>` is not callable"
+# TODO: ideally, we would emit an error here
+class F(metaclass=Any): ...
 ```
 
 And `Any` cannot be used in `isinstance()` checks:

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1008,7 +1008,7 @@ object first, i.e. on the metaclass:
 ```py
 from typing import Literal
 
-class Meta1:
+class Meta1(type):
     attr: Literal["metaclass value"] = "metaclass value"
 
 class C1(metaclass=Meta1): ...
@@ -1021,7 +1021,7 @@ descriptor. If it is a non-data descriptor or a normal attribute, the class-leve
 instead (see the [descriptor protocol tests] for data/non-data descriptor attributes):
 
 ```py
-class Meta2:
+class Meta2(type):
     attr: str = "metaclass value"
 
 class C2(metaclass=Meta2):
@@ -1035,7 +1035,7 @@ class-level attribute:
 
 ```py
 def _(flag: bool):
-    class Meta3:
+    class Meta3(type):
         attr1 = "metaclass value"
         attr2: Literal["metaclass value"] = "metaclass value"
 
@@ -1054,7 +1054,7 @@ diagnostic:
 
 ```py
 def _(flag: bool):
-    class Meta4:
+    class Meta4(type):
         if flag:
             attr1: str = "metaclass value"
 
@@ -1068,7 +1068,7 @@ we union them and emit a `possibly-missing-attribute` diagnostic:
 
 ```py
 def _(flag1: bool, flag2: bool):
-    class Meta5:
+    class Meta5(type):
         if flag1:
             attr1 = "metaclass value"
 
@@ -1269,6 +1269,7 @@ def _(flag: bool):
             y: int | str = "f"
 
     class C3(metaclass=Meta3): ...
+    reveal_type(C3.__class__)  # revealed: <class 'Meta3'> | <class 'Meta3'>
     reveal_type(C3.x)  # revealed: int | str
     reveal_type(C3.y)  # revealed: int | str
 

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -584,6 +584,13 @@ class Base:
 
 class Valid(Base, arg=5, metaclass=object): ...
 
+# Despite the explicit `metaclass=object` call,
+# the metaclass of this class is `type`, because that is
+# the metaclass of its superclass `object`, and `type`
+# (metaclass of superclass) is a subclass of `object`
+# (explicit `metaclass=` argument in this class statement).
+reveal_type(Valid.__class__)  # revealed: <class 'type'>
+
 # error: [invalid-argument-type]
 class Invalid(Base, metaclass=type, arg="foo"): ...
 ```
@@ -694,6 +701,357 @@ class Base(Generic[T]):
 
 class Valid(Base[int], arg=1): ...
 class InvalidType(Base[int], arg="x"): ...  # error: [invalid-argument-type]
+```
+
+### Metaclass `__new__` keyword arguments
+
+<!-- snapshot-diagnostics -->
+
+When a custom metaclass overrides `__new__` with keyword-only parameters, class keyword arguments
+are validated against the metaclass's `__new__` signature instead of `__init_subclass__`.
+
+```py
+from typing import Any
+
+class Meta(type):
+    def __new__(mcs, name: str, bases: tuple[type, ...], namespace: dict[str, Any], *, required_arg: int):
+        return super().__new__(mcs, name, bases, namespace)
+
+class Valid(metaclass=Meta, required_arg=5): ...
+class MissingArg(metaclass=Meta): ...  # error: [missing-argument]
+class InvalidType(metaclass=Meta, required_arg="foo"): ...  # error: [invalid-argument-type]
+```
+
+### Metaclass `__new__` takes priority over `__init_subclass__`
+
+<!-- snapshot-diagnostics -->
+
+If a metaclass defines `__new__`, we do no checking of a superclass `__init_subclass__` method even
+if one exists on a base. `__new__` on the metaclass could consume or add arbitrary keyword arguments
+before passing them onto `__init_subclass__`, so there is no way for us to check that
+`__init_subclass__` has been called correctly in this scenario:
+
+```py
+from typing import Any
+
+class Meta(type):
+    def __new__(mcs, name: str, bases: tuple[type, ...], namespace: dict[str, Any], *, meta_arg: int):
+        return super().__new__(mcs, name, bases, namespace, sub_arg="ooh, fancy")
+
+class Base:
+    def __init_subclass__(cls, sub_arg: str): ...
+
+# `meta_arg` is checked against `Meta.__new__`, not `Base.__init_subclass__`
+class Valid(Base, meta_arg=5, metaclass=Meta): ...
+class MissingArg(Base, metaclass=Meta): ...  # error: [missing-argument]
+class InvalidType(Base, meta_arg="foo", metaclass=Meta): ...  # error: [invalid-argument-type]
+
+# error: [missing-argument]
+class Invalid2(metaclass=Meta):
+    def __init_subclass__(cls, sub_arg: str): ...
+```
+
+### Metaclass `__prepare__` keyword arguments
+
+<!-- snapshot-diagnostics -->
+
+When a metaclass defines `__prepare__`, class keyword arguments are also validated against its
+signature.
+
+```py
+from typing import Any
+
+class Meta(type):
+    @classmethod
+    def __prepare__(mcs, name: str, bases: tuple[type, ...], *, prep_arg: int = 0, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    def __new__(mcs, name: str, bases: tuple[type, ...], namespace: dict[str, Any], **kwargs: Any):
+        return super().__new__(mcs, name, bases, namespace)
+
+class Valid(metaclass=Meta, prep_arg=5): ...
+class InvalidType(metaclass=Meta, prep_arg="foo"): ...  # error: [invalid-argument-type]
+```
+
+### Metaclass `__new__` with incompatible namespace type from `__prepare__`
+
+<!-- snapshot-diagnostics -->
+
+When `__new__` expects a custom `dict` subclass as the namespace parameter, and `__prepare__`
+returns a plain `dict[str, Any]`, this should produce a type error on the namespace argument.
+
+```py
+from typing import Any
+
+class MyNamespace(dict[str, Any]):
+    pass
+
+class Meta(type):
+    @classmethod
+    def __prepare__(mcs, name: str, bases: tuple[type, ...], **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    def __new__(mcs, name: str, bases: tuple[type, ...], namespace: MyNamespace, **kwargs: Any):
+        return super().__new__(mcs, name, bases, namespace)
+
+class Foo(metaclass=Meta): ...  # error: [invalid-argument-type]
+```
+
+### Metaclass `__new__` with compatible namespace type from `__prepare__`
+
+When `__prepare__` returns the expected custom namespace type, no error should be emitted.
+
+```py
+from typing import Any
+
+class MyNamespace(dict[str, Any]):
+    pass
+
+class Meta(type):
+    @classmethod
+    def __prepare__(mcs, name: str, bases: tuple[type, ...], **kwargs: Any) -> MyNamespace:
+        return MyNamespace()
+
+    def __new__(mcs, name: str, bases: tuple[type, ...], namespace: MyNamespace, **kwargs: Any):
+        return super().__new__(mcs, name, bases, namespace)
+
+class Foo(metaclass=Meta): ...
+```
+
+### Metaclass `__new__`, `__init__` and `__prepare__` all defined
+
+<!-- snapshot-diagnostics -->
+
+```py
+from typing import Any
+
+class Meta(type):
+    @classmethod
+    def __prepare__(  # error: [invalid-method-override]
+        mcs, name: str, bases: tuple[type, ...], prepare_arg: int, **kwargs: Any
+    ) -> dict[str, Any]:
+        return {}
+
+    def __new__(mcs, name: str, bases: tuple[type, ...], namespace: dict[str, Any], dunder_new_arg: int, **kwargs: Any):
+        return super().__new__(mcs, name, bases, namespace)
+
+    # TODO: we could complain here that `__init__` has an incompatible signature with `__new__`
+    def __init__(cls, *args, init_arg: int): ...
+
+# Implicit calls to metaclass constructors work the same way as explicit "regular" constructor calls.
+# We do not complain about the missing argument to the metaclass `__init__` method here:
+# it'll never get called because of the missing argument to the metaclass `__new__` method
+#
+# error: [missing-argument] "No argument provided for required parameter `prepare_arg` of bound method `__prepare__`"
+# error: [missing-argument] "No argument provided for required parameter `dunder_new_arg` of function `__new__`"
+class Foo(metaclass=Meta): ...
+```
+
+### `__prepare__ = None`
+
+<!-- snapshot-diagnostics -->
+
+```py
+class Meta(type):
+    __prepare__ = None
+
+# error: [invalid-metaclass] "Creation of class `Foo` will fail due to a metaclass with an invalid `__prepare__` definition"
+class Foo(metaclass=Meta): ...
+class MetaSub(Meta): ...
+
+# error: [invalid-metaclass]
+class Bar(Foo, metaclass=MetaSub): ...
+```
+
+### Metaclass `__new__` expects a fixed-length tuple of bases
+
+<!-- snapshot-diagnostics -->
+
+```py
+from typing import Any
+
+class Meta(type):
+    def __new__(metacls, name: str, bases: tuple[type, type], ns: dict[str, Any]): ...
+
+class A: ...
+class B: ...
+
+# This errors because a `bases` tuple of length 0 was passed to metaclass `__new__`
+#
+# error: [invalid-argument-type]
+class Bad1(metaclass=Meta): ...
+
+# This errors because a `bases` tuple of length 1 was passed to metaclass `__new__`
+#
+# error: [invalid-argument-type]
+class Bad2(A, metaclass=Meta): ...
+
+# This succeeds
+class Good(A, B, metaclass=Meta): ...
+```
+
+### Metaclass `__new__` expects a string-literal type
+
+```py
+from typing import Literal, Any
+
+class Meta(type):
+    def __new__(metacls, name: Literal["Foo"], bases: tuple[type, ...], namespace: dict[str, Any]): ...
+
+# this errors because `Literal["Bad"]` was passed as the `name` argument to `Meta.__new__`,
+# instead of `Literal["Foo"]`
+#
+# error: [invalid-argument-type]
+class Bad(metaclass=Meta): ...
+class Foo(metaclass=Meta): ...
+```
+
+### If a metaclass does not override `__new__`, we still check `__init_subclass__`
+
+<!-- snapshot-diagnostics -->
+
+The mere presence of a custom metaclass does not prevent us from checking `__init_subclass__`: if
+the metaclass is a `type` subclass that does not override `__new__`, we will still do so:
+
+```py
+class Meta(type):
+    pass
+
+class Base(metaclass=Meta):
+    def __init_subclass__(cls, arg: int): ...
+
+class Valid(Base, arg=5): ...
+class MissingArg(Base): ...  # error: [missing-argument]
+class InvalidType(Base, arg="foo"): ...  # error: [invalid-argument-type]
+```
+
+This includes if the metaclass defines `__init__`: `__init_subclass__` is called before the
+metaclass's `__init__` method, so it is not possible for a metaclass's `__init__` method to consume
+or inject arguments before `__init_subclass__` is called in the same way that it is possible for a
+metaclass's `__new__` method:
+
+```py
+class Meta2(type):
+    def __init__(cls, *args, **kwargs): ...
+
+class Base(metaclass=Meta2):
+    def __init_subclass__(cls, arg: int): ...
+
+class Valid(Base, arg=5): ...
+class MissingArg(Base): ...  # error: [missing-argument]
+class InvalidType(Base, arg="foo"): ...  # error: [invalid-argument-type]
+
+class MetaclassWithFancyInit(type):
+    def __init__(cls, *args, metaclass_arg: int, **kwargs): ...
+
+# `object.__init_subclass__` is called before `MetaclassWithFancyInit.__init__` here, so this is an...
+#
+# error: [unknown-argument] "Argument `metaclass_arg` does not match any known parameter of function `__init_subclass__`"
+class Base2(metaclass=MetaclassWithFancyInit, metaclass_arg=42):
+    def __init_subclass__(cls, init_subclass_arg: int): ...
+
+class Base3:
+    def __init_subclass__(cls, *args, **kwargs): ...
+
+# In this situation, the permissive signature of `Base3.__init_subclass__` allows
+# the `metaclass_arg` argument to be passed unhindered to the metaclass `__init__` method
+class Fine(Base3, metaclass=MetaclassWithFancyInit, metaclass_arg=42): ...
+
+# error: [missing-argument] "No argument provided for required parameter `metaclass_arg` of bound method `__init__`"
+class NotGood(Base3, metaclass=MetaclassWithFancyInit): ...
+```
+
+### Metaclass with a custom metaclass
+
+<!-- snapshot-diagnostics -->
+
+If the metaclass itself has a custom metaclass and the meta-metaclass defines `__call__`, we do call
+checking against `__call__` on the meta-metaclass:
+
+```py
+class MetaMeta(type):
+    def __call__(metacls, *args, meta_meta_arg: int, **kwargs) -> str:
+        return "foo"
+
+class Meta(type, metaclass=MetaMeta): ...
+
+# error: [missing-argument] "No argument provided for required parameter `meta_meta_arg` of bound method `__call__`"
+class Bad(metaclass=Meta): ...
+
+# TODO: should be `str` because of the return type of `MetaMeta.__call__`
+reveal_type(Bad)  # revealed: <class 'Bad'>
+
+class Good(metaclass=Meta, meta_meta_arg=42): ...
+```
+
+Similar to the case where a metaclass defines `__new__`, this also prevents us from checking the
+call signature of `__init_subclass__`, since the `__call__` method of a meta-metaclass is called
+prior to `__init_subclass__` on the class and could therefore consume or inject arbitrary arguments
+when the `__init_subclass__` method is called:
+
+```py
+class InitSubclassBase(metaclass=Meta, meta_meta_arg=42):
+    def __init_subclass__(cls, required_arg: int): ...
+
+class InitSubclassNotCheckedHere(InitSubclassBase, metaclass=Meta, meta_meta_arg=42): ...
+```
+
+But if the meta-metaclass does not override `__call__`, `__init_subclass__` is still checked:
+
+```py
+class LessFancyMetaMeta(type): ...
+class LessFancyMeta(type, metaclass=LessFancyMetaMeta): ...
+
+class WithInitSubclass(metaclass=LessFancyMeta):
+    def __init_subclass__(cls, arg: int): ...
+
+# error: [missing-argument] "No argument provided for required parameter `arg` of function `__init_subclass__`"
+class Bad(WithInitSubclass): ...
+class Good(WithInitSubclass, arg=42): ...
+```
+
+### Metaclass with a custom `__new__` method and a custom meta-metaclass
+
+<!-- snapshot-diagnostics -->
+
+Same as the way that we do not check `__new__` if a regular class's metaclass defines `__call__` and
+`__call__` does not return an instance of the class, we also do not check `__new__` on a metaclass
+if the meta-metaclass has a `__call__` method that does not return an instance of the metaclass:
+
+```py
+class MetaMeta(type):
+    def __call__(metacls, *args, meta_meta_arg: int, **kwargs) -> str:
+        return "foo"
+
+class Meta(type, metaclass=MetaMeta):
+    def __new__(metacls, *args, meta_arg: int, **kwargs): ...
+
+# error: [missing-argument] "No argument provided for required parameter `meta_meta_arg` of bound method `__call__`"
+class Bad(metaclass=Meta): ...
+
+# `Meta.__new__` is not checked because `MetaMeta.__call__` returns `str`,
+# so no diagnostic is emitted here
+class Fine(metaclass=Meta, meta_meta_arg=42): ...
+
+class MetaMeta2(type):
+    def __call__(metacls, *args, **kwargs) -> "Meta2":
+        return type.__call__(metacls, *args, **kwargs)
+
+class Meta2(type, metaclass=MetaMeta2):
+    def __new__(metacls, *args, meta_arg: int, **kwargs): ...
+
+# error: [missing-argument] "No argument provided for required parameter `meta_arg` of function `__new__`"
+class AlsoBad(metaclass=Meta2): ...
+
+class MetaMeta3(type):
+    def __call__(metacls, *args, **kwargs) -> "Meta3":
+        return type.__call__(metacls, *args, **kwargs)
+
+class Meta3(type, metaclass=MetaMeta3):
+    def __init__(cls, *args, init_arg: int, **kwargs): ...
+
+# error: [missing-argument] "No argument provided for required parameter `init_arg` of bound method `__init__`"
+class AlsoFine(metaclass=Meta3): ...
 ```
 
 ## `@staticmethod`

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -557,9 +557,10 @@ arguments as `type.__new__`) isn't a valid metaclass.
 
 ```py
 class M: ...
+
+# error: [too-many-positional-arguments] "Too many positional arguments to bound method `__init__`: expected 1, got 4"
 class A(metaclass=M): ...
 
-# TODO: emit a diagnostic for the invalid metaclass
 reveal_type(A.__class__)  # revealed: <class 'M'>
 ```
 
@@ -715,14 +716,14 @@ class A(metaclass=f): ...
 
 # TODO: Should be `int`
 reveal_type(A)  # revealed: <class 'A'>
-reveal_type(A.__class__)  # revealed: type[int]
+reveal_type(A.__class__)  # revealed: Unknown
 
 def _(n: int):
     # error: [invalid-metaclass]
     class B(metaclass=n): ...
     # TODO: Should be `Unknown`
     reveal_type(B)  # revealed: <class 'B'>
-    reveal_type(B.__class__)  # revealed: type[Unknown]
+    reveal_type(B.__class__)  # revealed: Unknown
 
 def _(flag: bool):
     m = f if flag else 42
@@ -731,17 +732,23 @@ def _(flag: bool):
     class C(metaclass=m): ...
     # TODO: Should be `int | Unknown`
     reveal_type(C)  # revealed: <class 'C'>
-    reveal_type(C.__class__)  # revealed: type[Unknown]
+    reveal_type(C.__class__)  # revealed: Unknown
 
 class SignatureMismatch: ...
 
-# TODO: Emit a diagnostic
+# error: [too-many-positional-arguments] "Too many positional arguments to bound method `__init__`: expected 1, got 4"
 class D(metaclass=SignatureMismatch): ...
 
 # TODO: Should be `Unknown`
 reveal_type(D)  # revealed: <class 'D'>
 # TODO: Should be `type[Unknown]`
 reveal_type(D.__class__)  # revealed: <class 'SignatureMismatch'>
+
+# This is fine
+class E(metaclass=print): ...
+
+# TODO: should be `None`
+reveal_type(E)  # revealed: <class 'E'>
 ```
 
 ## Diagnostic range

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/metaclass.md_-_Diagnostic_range_(4940b37ce546ecbf).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/metaclass.md_-_Diagnostic_range_(4940b37ce546ecbf).snap
@@ -23,7 +23,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/metaclass.md
 # Diagnostics
 
 ```
-error[invalid-metaclass]: Metaclass type `int` is not callable
+error[invalid-metaclass]: Metaclass of type `int` is not callable
  --> src/mdtest_snippet.py:3:13
   |
 1 | def _(n: int):
@@ -33,5 +33,7 @@ error[invalid-metaclass]: Metaclass type `int` is not callable
 4 |         x = 1
 5 |         y = 2
   |
+info: A `class` statement leads to an implicit call to the class's metaclass
+info: See https://docs.python.org/3/reference/datamodel.html#metaclasses
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_If_a_metaclass_does_…_(6fc0713b0448174d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_If_a_metaclass_does_…_(6fc0713b0448174d).snap
@@ -1,0 +1,186 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: methods.md - Methods - `@classmethod` - If a metaclass does not override `__new__`, we still check `__init_subclass__`
+mdtest path: crates/ty_python_semantic/resources/mdtest/call/methods.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | class Meta(type):
+ 2 |     pass
+ 3 | 
+ 4 | class Base(metaclass=Meta):
+ 5 |     def __init_subclass__(cls, arg: int): ...
+ 6 | 
+ 7 | class Valid(Base, arg=5): ...
+ 8 | class MissingArg(Base): ...  # error: [missing-argument]
+ 9 | class InvalidType(Base, arg="foo"): ...  # error: [invalid-argument-type]
+10 | class Meta2(type):
+11 |     def __init__(cls, *args, **kwargs): ...
+12 | 
+13 | class Base(metaclass=Meta2):
+14 |     def __init_subclass__(cls, arg: int): ...
+15 | 
+16 | class Valid(Base, arg=5): ...
+17 | class MissingArg(Base): ...  # error: [missing-argument]
+18 | class InvalidType(Base, arg="foo"): ...  # error: [invalid-argument-type]
+19 | 
+20 | class MetaclassWithFancyInit(type):
+21 |     def __init__(cls, *args, metaclass_arg: int, **kwargs): ...
+22 | 
+23 | # `object.__init_subclass__` is called before `MetaclassWithFancyInit.__init__` here, so this is an...
+24 | #
+25 | # error: [unknown-argument] "Argument `metaclass_arg` does not match any known parameter of function `__init_subclass__`"
+26 | class Base2(metaclass=MetaclassWithFancyInit, metaclass_arg=42):
+27 |     def __init_subclass__(cls, init_subclass_arg: int): ...
+28 | 
+29 | class Base3:
+30 |     def __init_subclass__(cls, *args, **kwargs): ...
+31 | 
+32 | # In this situation, the permissive signature of `Base3.__init_subclass__` allows
+33 | # the `metaclass_arg` argument to be passed unhindered to the metaclass `__init__` method
+34 | class Fine(Base3, metaclass=MetaclassWithFancyInit, metaclass_arg=42): ...
+35 | 
+36 | # error: [missing-argument] "No argument provided for required parameter `metaclass_arg` of bound method `__init__`"
+37 | class NotGood(Base3, metaclass=MetaclassWithFancyInit): ...
+```
+
+# Diagnostics
+
+```
+error[missing-argument]: No argument provided for required parameter `arg` of function `__init_subclass__`
+  --> src/mdtest_snippet.py:8:1
+   |
+ 7 | class Valid(Base, arg=5): ...
+ 8 | class MissingArg(Base): ...  # error: [missing-argument]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+ 9 | class InvalidType(Base, arg="foo"): ...  # error: [invalid-argument-type]
+10 | class Meta2(type):
+   |
+info: Parameter declared here
+ --> src/mdtest_snippet.py:5:32
+  |
+4 | class Base(metaclass=Meta):
+5 |     def __init_subclass__(cls, arg: int): ...
+  |                                ^^^^^^^^
+6 |
+7 | class Valid(Base, arg=5): ...
+  |
+
+```
+
+```
+error[invalid-argument-type]: Argument to function `__init_subclass__` is incorrect
+  --> src/mdtest_snippet.py:9:25
+   |
+ 7 | class Valid(Base, arg=5): ...
+ 8 | class MissingArg(Base): ...  # error: [missing-argument]
+ 9 | class InvalidType(Base, arg="foo"): ...  # error: [invalid-argument-type]
+   |                         ^^^^^^^^^ Expected `int`, found `Literal["foo"]`
+10 | class Meta2(type):
+11 |     def __init__(cls, *args, **kwargs): ...
+   |
+info: Function defined here
+ --> src/mdtest_snippet.py:5:9
+  |
+4 | class Base(metaclass=Meta):
+5 |     def __init_subclass__(cls, arg: int): ...
+  |         ^^^^^^^^^^^^^^^^^      -------- Parameter declared here
+6 |
+7 | class Valid(Base, arg=5): ...
+  |
+
+```
+
+```
+error[missing-argument]: No argument provided for required parameter `arg` of function `__init_subclass__`
+  --> src/mdtest_snippet.py:17:1
+   |
+16 | class Valid(Base, arg=5): ...
+17 | class MissingArg(Base): ...  # error: [missing-argument]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+18 | class InvalidType(Base, arg="foo"): ...  # error: [invalid-argument-type]
+   |
+info: Parameter declared here
+  --> src/mdtest_snippet.py:14:32
+   |
+13 | class Base(metaclass=Meta2):
+14 |     def __init_subclass__(cls, arg: int): ...
+   |                                ^^^^^^^^
+15 |
+16 | class Valid(Base, arg=5): ...
+   |
+
+```
+
+```
+error[invalid-argument-type]: Argument to function `__init_subclass__` is incorrect
+  --> src/mdtest_snippet.py:18:25
+   |
+16 | class Valid(Base, arg=5): ...
+17 | class MissingArg(Base): ...  # error: [missing-argument]
+18 | class InvalidType(Base, arg="foo"): ...  # error: [invalid-argument-type]
+   |                         ^^^^^^^^^ Expected `int`, found `Literal["foo"]`
+19 |
+20 | class MetaclassWithFancyInit(type):
+   |
+info: Function defined here
+  --> src/mdtest_snippet.py:14:9
+   |
+13 | class Base(metaclass=Meta2):
+14 |     def __init_subclass__(cls, arg: int): ...
+   |         ^^^^^^^^^^^^^^^^^      -------- Parameter declared here
+15 |
+16 | class Valid(Base, arg=5): ...
+   |
+
+```
+
+```
+error[unknown-argument]: Argument `metaclass_arg` does not match any known parameter of function `__init_subclass__`
+  --> src/mdtest_snippet.py:26:47
+   |
+24 | #
+25 | # error: [unknown-argument] "Argument `metaclass_arg` does not match any known parameter of function `__init_subclass__`"
+26 | class Base2(metaclass=MetaclassWithFancyInit, metaclass_arg=42):
+   |                                               ^^^^^^^^^^^^^^^^
+27 |     def __init_subclass__(cls, init_subclass_arg: int): ...
+   |
+info: Function signature here
+   --> stdlib/builtins.pyi:158:9
+    |
+157 |     def __dir__(self) -> Iterable[str]: ...
+158 |     def __init_subclass__(cls) -> None: ...
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+159 |     @classmethod
+160 |     def __subclasshook__(cls, subclass: type, /) -> bool: ...
+    |
+
+```
+
+```
+error[missing-argument]: No argument provided for required parameter `metaclass_arg` of bound method `__init__`
+  --> src/mdtest_snippet.py:37:1
+   |
+36 | # error: [missing-argument] "No argument provided for required parameter `metaclass_arg` of bound method `__init__`"
+37 | class NotGood(Base3, metaclass=MetaclassWithFancyInit): ...
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+info: Parameter declared here
+  --> src/mdtest_snippet.py:21:30
+   |
+20 | class MetaclassWithFancyInit(type):
+21 |     def __init__(cls, *args, metaclass_arg: int, **kwargs): ...
+   |                              ^^^^^^^^^^^^^^^^^^
+22 |
+23 | # `object.__init_subclass__` is called before `MetaclassWithFancyInit.__init__` here, so this is an...
+   |
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_If_a_metaclass_does_…_(6fc0713b0448174d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_If_a_metaclass_does_…_(6fc0713b0448174d).snap
@@ -73,6 +73,8 @@ info: Parameter declared here
 6 |
 7 | class Valid(Base, arg=5): ...
   |
+info: `__init_subclass__` on a superclass is implicitly called during creation of a class object
+info: See https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
 
 ```
 
@@ -96,6 +98,8 @@ info: Function defined here
 6 |
 7 | class Valid(Base, arg=5): ...
   |
+info: `__init_subclass__` on a superclass is implicitly called during creation of a class object
+info: See https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
 
 ```
 
@@ -117,6 +121,8 @@ info: Parameter declared here
 15 |
 16 | class Valid(Base, arg=5): ...
    |
+info: `__init_subclass__` on a superclass is implicitly called during creation of a class object
+info: See https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
 
 ```
 
@@ -140,6 +146,8 @@ info: Function defined here
 15 |
 16 | class Valid(Base, arg=5): ...
    |
+info: `__init_subclass__` on a superclass is implicitly called during creation of a class object
+info: See https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
 
 ```
 
@@ -162,6 +170,8 @@ info: Function signature here
 159 |     @classmethod
 160 |     def __subclasshook__(cls, subclass: type, /) -> bool: ...
     |
+info: `__init_subclass__` on a superclass is implicitly called during creation of a class object
+info: See https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
 
 ```
 
@@ -182,5 +192,7 @@ info: Parameter declared here
 22 |
 23 | # `object.__init_subclass__` is called before `MetaclassWithFancyInit.__init__` here, so this is an...
    |
+info: A `class` statement leads to an implicit call to the class's metaclass
+info: See https://docs.python.org/3/reference/datamodel.html#metaclasses
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`,…_(295e1f8113283bd1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`,…_(295e1f8113283bd1).snap
@@ -83,6 +83,8 @@ info: Parameter declared here
 7 |     ) -> dict[str, Any]:
 8 |         return {}
   |
+info: `__prepare__` on a class's metaclass is implicitly called during creation of the class object
+info: See https://docs.python.org/3/reference/datamodel.html#preparing-the-class-namespace
 
 ```
 
@@ -104,5 +106,7 @@ info: Parameter declared here
    |                                                                                     ^^^^^^^^^^^^^^^^^^^
 11 |         return super().__new__(mcs, name, bases, namespace)
    |
+info: A `class` statement leads to an implicit call to the class's metaclass
+info: See https://docs.python.org/3/reference/datamodel.html#metaclasses
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`,…_(295e1f8113283bd1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`,…_(295e1f8113283bd1).snap
@@ -1,0 +1,108 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: methods.md - Methods - `@classmethod` - Metaclass `__new__`, `__init__` and `__prepare__` all defined
+mdtest path: crates/ty_python_semantic/resources/mdtest/call/methods.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | from typing import Any
+ 2 | 
+ 3 | class Meta(type):
+ 4 |     @classmethod
+ 5 |     def __prepare__(  # error: [invalid-method-override]
+ 6 |         mcs, name: str, bases: tuple[type, ...], prepare_arg: int, **kwargs: Any
+ 7 |     ) -> dict[str, Any]:
+ 8 |         return {}
+ 9 | 
+10 |     def __new__(mcs, name: str, bases: tuple[type, ...], namespace: dict[str, Any], dunder_new_arg: int, **kwargs: Any):
+11 |         return super().__new__(mcs, name, bases, namespace)
+12 | 
+13 |     # TODO: we could complain here that `__init__` has an incompatible signature with `__new__`
+14 |     def __init__(cls, *args, init_arg: int): ...
+15 | 
+16 | # Implicit calls to metaclass constructors work the same way as explicit "regular" constructor calls.
+17 | # We do not complain about the missing argument to the metaclass `__init__` method here:
+18 | # it'll never get called because of the missing argument to the metaclass `__new__` method
+19 | #
+20 | # error: [missing-argument] "No argument provided for required parameter `prepare_arg` of bound method `__prepare__`"
+21 | # error: [missing-argument] "No argument provided for required parameter `dunder_new_arg` of function `__new__`"
+22 | class Foo(metaclass=Meta): ...
+```
+
+# Diagnostics
+
+```
+error[invalid-method-override]: Invalid override of method `__prepare__`
+   --> src/mdtest_snippet.py:5:9
+    |
+  3 |   class Meta(type):
+  4 |       @classmethod
+  5 |       def __prepare__(  # error: [invalid-method-override]
+    |  _________^
+  6 | |         mcs, name: str, bases: tuple[type, ...], prepare_arg: int, **kwargs: Any
+  7 | |     ) -> dict[str, Any]:
+    | |_______________________^ Definition is incompatible with `type.__prepare__`
+  8 |           return {}
+    |
+   ::: stdlib/builtins.pyi:303:9
+    |
+302 |       @classmethod
+303 |       def __prepare__(metacls, name: str, bases: tuple[type, ...], /, **kwds: Any) -> MutableMapping[str, object]:
+    |           ------------------------------------------------------------------------------------------------------- `type.__prepare__` defined here
+304 |           """Create the namespace for the class statement"""
+305 |       if sys.version_info >= (3, 10):
+    |
+info: This violates the Liskov Substitution Principle
+
+```
+
+```
+error[missing-argument]: No argument provided for required parameter `prepare_arg` of bound method `__prepare__`
+  --> src/mdtest_snippet.py:22:1
+   |
+20 | # error: [missing-argument] "No argument provided for required parameter `prepare_arg` of bound method `__prepare__`"
+21 | # error: [missing-argument] "No argument provided for required parameter `dunder_new_arg` of function `__new__`"
+22 | class Foo(metaclass=Meta): ...
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+info: Parameter declared here
+ --> src/mdtest_snippet.py:6:50
+  |
+4 |     @classmethod
+5 |     def __prepare__(  # error: [invalid-method-override]
+6 |         mcs, name: str, bases: tuple[type, ...], prepare_arg: int, **kwargs: Any
+  |                                                  ^^^^^^^^^^^^^^^^
+7 |     ) -> dict[str, Any]:
+8 |         return {}
+  |
+
+```
+
+```
+error[missing-argument]: No argument provided for required parameter `dunder_new_arg` of function `__new__`
+  --> src/mdtest_snippet.py:22:1
+   |
+20 | # error: [missing-argument] "No argument provided for required parameter `prepare_arg` of bound method `__prepare__`"
+21 | # error: [missing-argument] "No argument provided for required parameter `dunder_new_arg` of function `__new__`"
+22 | class Foo(metaclass=Meta): ...
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+info: Parameter declared here
+  --> src/mdtest_snippet.py:10:85
+   |
+ 8 |         return {}
+ 9 |
+10 |     def __new__(mcs, name: str, bases: tuple[type, ...], namespace: dict[str, Any], dunder_new_arg: int, **kwargs: Any):
+   |                                                                                     ^^^^^^^^^^^^^^^^^^^
+11 |         return super().__new__(mcs, name, bases, namespace)
+   |
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`_…_(3e734977f304574d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`_…_(3e734977f304574d).snap
@@ -1,0 +1,84 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: methods.md - Methods - `@classmethod` - Metaclass `__new__` expects a fixed-length tuple of bases
+mdtest path: crates/ty_python_semantic/resources/mdtest/call/methods.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | from typing import Any
+ 2 | 
+ 3 | class Meta(type):
+ 4 |     def __new__(metacls, name: str, bases: tuple[type, type], ns: dict[str, Any]): ...
+ 5 | 
+ 6 | class A: ...
+ 7 | class B: ...
+ 8 | 
+ 9 | # This errors because a `bases` tuple of length 0 was passed to metaclass `__new__`
+10 | #
+11 | # error: [invalid-argument-type]
+12 | class Bad1(metaclass=Meta): ...
+13 | 
+14 | # This errors because a `bases` tuple of length 1 was passed to metaclass `__new__`
+15 | #
+16 | # error: [invalid-argument-type]
+17 | class Bad2(A, metaclass=Meta): ...
+18 | 
+19 | # This succeeds
+20 | class Good(A, B, metaclass=Meta): ...
+```
+
+# Diagnostics
+
+```
+error[invalid-argument-type]: Argument to function `__new__` is incorrect
+  --> src/mdtest_snippet.py:12:11
+   |
+10 | #
+11 | # error: [invalid-argument-type]
+12 | class Bad1(metaclass=Meta): ...
+   |           ^^^^^^^^^^^^^^^^ Expected `tuple[type, type]`, found `tuple[()]`
+13 |
+14 | # This errors because a `bases` tuple of length 1 was passed to metaclass `__new__`
+   |
+info: Function defined here
+ --> src/mdtest_snippet.py:4:9
+  |
+3 | class Meta(type):
+4 |     def __new__(metacls, name: str, bases: tuple[type, type], ns: dict[str, Any]): ...
+  |         ^^^^^^^                     ------------------------ Parameter declared here
+5 |
+6 | class A: ...
+  |
+
+```
+
+```
+error[invalid-argument-type]: Argument to function `__new__` is incorrect
+  --> src/mdtest_snippet.py:17:11
+   |
+15 | #
+16 | # error: [invalid-argument-type]
+17 | class Bad2(A, metaclass=Meta): ...
+   |           ^^^^^^^^^^^^^^^^^^^ Expected `tuple[type, type]`, found `tuple[type]`
+18 |
+19 | # This succeeds
+   |
+info: Function defined here
+ --> src/mdtest_snippet.py:4:9
+  |
+3 | class Meta(type):
+4 |     def __new__(metacls, name: str, bases: tuple[type, type], ns: dict[str, Any]): ...
+  |         ^^^^^^^                     ------------------------ Parameter declared here
+5 |
+6 | class A: ...
+  |
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`_…_(3e734977f304574d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`_…_(3e734977f304574d).snap
@@ -57,6 +57,8 @@ info: Function defined here
 5 |
 6 | class A: ...
   |
+info: A `class` statement leads to an implicit call to the class's metaclass
+info: See https://docs.python.org/3/reference/datamodel.html#metaclasses
 
 ```
 
@@ -80,5 +82,7 @@ info: Function defined here
 5 |
 6 | class A: ...
   |
+info: A `class` statement leads to an implicit call to the class's metaclass
+info: See https://docs.python.org/3/reference/datamodel.html#metaclasses
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`_…_(443c918d926ccd4e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`_…_(443c918d926ccd4e).snap
@@ -49,5 +49,7 @@ info: Function defined here
    |         ^^^^^^^                                          ---------------------- Parameter declared here
 12 |         return super().__new__(mcs, name, bases, namespace)
    |
+info: A `class` statement leads to an implicit call to the class's metaclass
+info: See https://docs.python.org/3/reference/datamodel.html#metaclasses
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`_…_(443c918d926ccd4e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`_…_(443c918d926ccd4e).snap
@@ -1,0 +1,53 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: methods.md - Methods - `@classmethod` - Metaclass `__new__` with incompatible namespace type from `__prepare__`
+mdtest path: crates/ty_python_semantic/resources/mdtest/call/methods.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | from typing import Any
+ 2 | 
+ 3 | class MyNamespace(dict[str, Any]):
+ 4 |     pass
+ 5 | 
+ 6 | class Meta(type):
+ 7 |     @classmethod
+ 8 |     def __prepare__(mcs, name: str, bases: tuple[type, ...], **kwargs: Any) -> dict[str, Any]:
+ 9 |         return {}
+10 | 
+11 |     def __new__(mcs, name: str, bases: tuple[type, ...], namespace: MyNamespace, **kwargs: Any):
+12 |         return super().__new__(mcs, name, bases, namespace)
+13 | 
+14 | class Foo(metaclass=Meta): ...  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error[invalid-argument-type]: Argument to function `__new__` is incorrect
+  --> src/mdtest_snippet.py:14:10
+   |
+12 |         return super().__new__(mcs, name, bases, namespace)
+13 |
+14 | class Foo(metaclass=Meta): ...  # error: [invalid-argument-type]
+   |          ^^^^^^^^^^^^^^^^ Expected `MyNamespace`, found `dict[str, Any]`
+   |
+info: Function defined here
+  --> src/mdtest_snippet.py:11:9
+   |
+ 9 |         return {}
+10 |
+11 |     def __new__(mcs, name: str, bases: tuple[type, ...], namespace: MyNamespace, **kwargs: Any):
+   |         ^^^^^^^                                          ---------------------- Parameter declared here
+12 |         return super().__new__(mcs, name, bases, namespace)
+   |
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`_…_(6a5698d894880511).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`_…_(6a5698d894880511).snap
@@ -43,6 +43,8 @@ info: Parameter declared here
   |                                                                                        ^^^^^^^^^^^^^^^^^
 5 |         return super().__new__(mcs, name, bases, namespace)
   |
+info: A `class` statement leads to an implicit call to the class's metaclass
+info: See https://docs.python.org/3/reference/datamodel.html#metaclasses
 
 ```
 
@@ -63,5 +65,7 @@ info: Function defined here
   |         ^^^^^^^                                                                        ----------------- Parameter declared here
 5 |         return super().__new__(mcs, name, bases, namespace)
   |
+info: A `class` statement leads to an implicit call to the class's metaclass
+info: See https://docs.python.org/3/reference/datamodel.html#metaclasses
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`_…_(6a5698d894880511).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`_…_(6a5698d894880511).snap
@@ -1,0 +1,67 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: methods.md - Methods - `@classmethod` - Metaclass `__new__` keyword arguments
+mdtest path: crates/ty_python_semantic/resources/mdtest/call/methods.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | from typing import Any
+2 | 
+3 | class Meta(type):
+4 |     def __new__(mcs, name: str, bases: tuple[type, ...], namespace: dict[str, Any], *, required_arg: int):
+5 |         return super().__new__(mcs, name, bases, namespace)
+6 | 
+7 | class Valid(metaclass=Meta, required_arg=5): ...
+8 | class MissingArg(metaclass=Meta): ...  # error: [missing-argument]
+9 | class InvalidType(metaclass=Meta, required_arg="foo"): ...  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error[missing-argument]: No argument provided for required parameter `required_arg` of function `__new__`
+ --> src/mdtest_snippet.py:8:1
+  |
+7 | class Valid(metaclass=Meta, required_arg=5): ...
+8 | class MissingArg(metaclass=Meta): ...  # error: [missing-argument]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+9 | class InvalidType(metaclass=Meta, required_arg="foo"): ...  # error: [invalid-argument-type]
+  |
+info: Parameter declared here
+ --> src/mdtest_snippet.py:4:88
+  |
+3 | class Meta(type):
+4 |     def __new__(mcs, name: str, bases: tuple[type, ...], namespace: dict[str, Any], *, required_arg: int):
+  |                                                                                        ^^^^^^^^^^^^^^^^^
+5 |         return super().__new__(mcs, name, bases, namespace)
+  |
+
+```
+
+```
+error[invalid-argument-type]: Argument to function `__new__` is incorrect
+ --> src/mdtest_snippet.py:9:35
+  |
+7 | class Valid(metaclass=Meta, required_arg=5): ...
+8 | class MissingArg(metaclass=Meta): ...  # error: [missing-argument]
+9 | class InvalidType(metaclass=Meta, required_arg="foo"): ...  # error: [invalid-argument-type]
+  |                                   ^^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["foo"]`
+  |
+info: Function defined here
+ --> src/mdtest_snippet.py:4:9
+  |
+3 | class Meta(type):
+4 |     def __new__(mcs, name: str, bases: tuple[type, ...], namespace: dict[str, Any], *, required_arg: int):
+  |         ^^^^^^^                                                                        ----------------- Parameter declared here
+5 |         return super().__new__(mcs, name, bases, namespace)
+  |
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`_…_(f010de3da7d4075e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`_…_(f010de3da7d4075e).snap
@@ -52,6 +52,8 @@ info: Parameter declared here
   |                                                                                        ^^^^^^^^^^^^^
 5 |         return super().__new__(mcs, name, bases, namespace, sub_arg="ooh, fancy")
   |
+info: A `class` statement leads to an implicit call to the class's metaclass
+info: See https://docs.python.org/3/reference/datamodel.html#metaclasses
 
 ```
 
@@ -74,6 +76,8 @@ info: Function defined here
   |         ^^^^^^^                                                                        ------------- Parameter declared here
 5 |         return super().__new__(mcs, name, bases, namespace, sub_arg="ooh, fancy")
   |
+info: A `class` statement leads to an implicit call to the class's metaclass
+info: See https://docs.python.org/3/reference/datamodel.html#metaclasses
 
 ```
 
@@ -94,5 +98,7 @@ info: Parameter declared here
   |                                                                                        ^^^^^^^^^^^^^
 5 |         return super().__new__(mcs, name, bases, namespace, sub_arg="ooh, fancy")
   |
+info: A `class` statement leads to an implicit call to the class's metaclass
+info: See https://docs.python.org/3/reference/datamodel.html#metaclasses
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`_…_(f010de3da7d4075e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__new__`_…_(f010de3da7d4075e).snap
@@ -1,0 +1,98 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: methods.md - Methods - `@classmethod` - Metaclass `__new__` takes priority over `__init_subclass__`
+mdtest path: crates/ty_python_semantic/resources/mdtest/call/methods.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | from typing import Any
+ 2 | 
+ 3 | class Meta(type):
+ 4 |     def __new__(mcs, name: str, bases: tuple[type, ...], namespace: dict[str, Any], *, meta_arg: int):
+ 5 |         return super().__new__(mcs, name, bases, namespace, sub_arg="ooh, fancy")
+ 6 | 
+ 7 | class Base:
+ 8 |     def __init_subclass__(cls, sub_arg: str): ...
+ 9 | 
+10 | # `meta_arg` is checked against `Meta.__new__`, not `Base.__init_subclass__`
+11 | class Valid(Base, meta_arg=5, metaclass=Meta): ...
+12 | class MissingArg(Base, metaclass=Meta): ...  # error: [missing-argument]
+13 | class InvalidType(Base, meta_arg="foo", metaclass=Meta): ...  # error: [invalid-argument-type]
+14 | 
+15 | # error: [missing-argument]
+16 | class Invalid2(metaclass=Meta):
+17 |     def __init_subclass__(cls, sub_arg: str): ...
+```
+
+# Diagnostics
+
+```
+error[missing-argument]: No argument provided for required parameter `meta_arg` of function `__new__`
+  --> src/mdtest_snippet.py:12:1
+   |
+10 | # `meta_arg` is checked against `Meta.__new__`, not `Base.__init_subclass__`
+11 | class Valid(Base, meta_arg=5, metaclass=Meta): ...
+12 | class MissingArg(Base, metaclass=Meta): ...  # error: [missing-argument]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+13 | class InvalidType(Base, meta_arg="foo", metaclass=Meta): ...  # error: [invalid-argument-type]
+   |
+info: Parameter declared here
+ --> src/mdtest_snippet.py:4:88
+  |
+3 | class Meta(type):
+4 |     def __new__(mcs, name: str, bases: tuple[type, ...], namespace: dict[str, Any], *, meta_arg: int):
+  |                                                                                        ^^^^^^^^^^^^^
+5 |         return super().__new__(mcs, name, bases, namespace, sub_arg="ooh, fancy")
+  |
+
+```
+
+```
+error[invalid-argument-type]: Argument to function `__new__` is incorrect
+  --> src/mdtest_snippet.py:13:25
+   |
+11 | class Valid(Base, meta_arg=5, metaclass=Meta): ...
+12 | class MissingArg(Base, metaclass=Meta): ...  # error: [missing-argument]
+13 | class InvalidType(Base, meta_arg="foo", metaclass=Meta): ...  # error: [invalid-argument-type]
+   |                         ^^^^^^^^^^^^^^ Expected `int`, found `Literal["foo"]`
+14 |
+15 | # error: [missing-argument]
+   |
+info: Function defined here
+ --> src/mdtest_snippet.py:4:9
+  |
+3 | class Meta(type):
+4 |     def __new__(mcs, name: str, bases: tuple[type, ...], namespace: dict[str, Any], *, meta_arg: int):
+  |         ^^^^^^^                                                                        ------------- Parameter declared here
+5 |         return super().__new__(mcs, name, bases, namespace, sub_arg="ooh, fancy")
+  |
+
+```
+
+```
+error[missing-argument]: No argument provided for required parameter `meta_arg` of function `__new__`
+  --> src/mdtest_snippet.py:16:1
+   |
+15 | # error: [missing-argument]
+16 | class Invalid2(metaclass=Meta):
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+17 |     def __init_subclass__(cls, sub_arg: str): ...
+   |
+info: Parameter declared here
+ --> src/mdtest_snippet.py:4:88
+  |
+3 | class Meta(type):
+4 |     def __new__(mcs, name: str, bases: tuple[type, ...], namespace: dict[str, Any], *, meta_arg: int):
+  |                                                                                        ^^^^^^^^^^^^^
+5 |         return super().__new__(mcs, name, bases, namespace, sub_arg="ooh, fancy")
+  |
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__prepare…_(224bebe01f1c1fab).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__prepare…_(224bebe01f1c1fab).snap
@@ -46,5 +46,7 @@ info: Method defined here
   |         ^^^^^^^^^^^                                             ----------------- Parameter declared here
 6 |         return {}
   |
+info: `__prepare__` on a class's metaclass is implicitly called during creation of the class object
+info: See https://docs.python.org/3/reference/datamodel.html#preparing-the-class-namespace
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__prepare…_(224bebe01f1c1fab).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_`__prepare…_(224bebe01f1c1fab).snap
@@ -1,0 +1,50 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: methods.md - Methods - `@classmethod` - Metaclass `__prepare__` keyword arguments
+mdtest path: crates/ty_python_semantic/resources/mdtest/call/methods.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | from typing import Any
+ 2 | 
+ 3 | class Meta(type):
+ 4 |     @classmethod
+ 5 |     def __prepare__(mcs, name: str, bases: tuple[type, ...], *, prep_arg: int = 0, **kwargs: Any) -> dict[str, Any]:
+ 6 |         return {}
+ 7 | 
+ 8 |     def __new__(mcs, name: str, bases: tuple[type, ...], namespace: dict[str, Any], **kwargs: Any):
+ 9 |         return super().__new__(mcs, name, bases, namespace)
+10 | 
+11 | class Valid(metaclass=Meta, prep_arg=5): ...
+12 | class InvalidType(metaclass=Meta, prep_arg="foo"): ...  # error: [invalid-argument-type]
+```
+
+# Diagnostics
+
+```
+error[invalid-argument-type]: Argument to bound method `__prepare__` is incorrect
+  --> src/mdtest_snippet.py:12:35
+   |
+11 | class Valid(metaclass=Meta, prep_arg=5): ...
+12 | class InvalidType(metaclass=Meta, prep_arg="foo"): ...  # error: [invalid-argument-type]
+   |                                   ^^^^^^^^^^^^^^ Expected `int`, found `Literal["foo"]`
+   |
+info: Method defined here
+ --> src/mdtest_snippet.py:5:9
+  |
+3 | class Meta(type):
+4 |     @classmethod
+5 |     def __prepare__(mcs, name: str, bases: tuple[type, ...], *, prep_arg: int = 0, **kwargs: Any) -> dict[str, Any]:
+  |         ^^^^^^^^^^^                                             ----------------- Parameter declared here
+6 |         return {}
+  |
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_with_a_cus…_(2a3b72dfc7a6b324).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_with_a_cus…_(2a3b72dfc7a6b324).snap
@@ -1,0 +1,86 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: methods.md - Methods - `@classmethod` - Metaclass with a custom metaclass
+mdtest path: crates/ty_python_semantic/resources/mdtest/call/methods.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | class MetaMeta(type):
+ 2 |     def __call__(metacls, *args, meta_meta_arg: int, **kwargs) -> str:
+ 3 |         return "foo"
+ 4 | 
+ 5 | class Meta(type, metaclass=MetaMeta): ...
+ 6 | 
+ 7 | # error: [missing-argument] "No argument provided for required parameter `meta_meta_arg` of bound method `__call__`"
+ 8 | class Bad(metaclass=Meta): ...
+ 9 | 
+10 | # TODO: should be `str` because of the return type of `MetaMeta.__call__`
+11 | reveal_type(Bad)  # revealed: <class 'Bad'>
+12 | 
+13 | class Good(metaclass=Meta, meta_meta_arg=42): ...
+14 | class InitSubclassBase(metaclass=Meta, meta_meta_arg=42):
+15 |     def __init_subclass__(cls, required_arg: int): ...
+16 | 
+17 | class InitSubclassNotCheckedHere(InitSubclassBase, metaclass=Meta, meta_meta_arg=42): ...
+18 | class LessFancyMetaMeta(type): ...
+19 | class LessFancyMeta(type, metaclass=LessFancyMetaMeta): ...
+20 | 
+21 | class WithInitSubclass(metaclass=LessFancyMeta):
+22 |     def __init_subclass__(cls, arg: int): ...
+23 | 
+24 | # error: [missing-argument] "No argument provided for required parameter `arg` of function `__init_subclass__`"
+25 | class Bad(WithInitSubclass): ...
+26 | class Good(WithInitSubclass, arg=42): ...
+```
+
+# Diagnostics
+
+```
+error[missing-argument]: No argument provided for required parameter `meta_meta_arg` of bound method `__call__`
+  --> src/mdtest_snippet.py:8:1
+   |
+ 7 | # error: [missing-argument] "No argument provided for required parameter `meta_meta_arg` of bound method `__call__`"
+ 8 | class Bad(metaclass=Meta): ...
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+ 9 |
+10 | # TODO: should be `str` because of the return type of `MetaMeta.__call__`
+   |
+info: Parameter declared here
+ --> src/mdtest_snippet.py:2:34
+  |
+1 | class MetaMeta(type):
+2 |     def __call__(metacls, *args, meta_meta_arg: int, **kwargs) -> str:
+  |                                  ^^^^^^^^^^^^^^^^^^
+3 |         return "foo"
+  |
+
+```
+
+```
+error[missing-argument]: No argument provided for required parameter `arg` of function `__init_subclass__`
+  --> src/mdtest_snippet.py:25:1
+   |
+24 | # error: [missing-argument] "No argument provided for required parameter `arg` of function `__init_subclass__`"
+25 | class Bad(WithInitSubclass): ...
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+26 | class Good(WithInitSubclass, arg=42): ...
+   |
+info: Parameter declared here
+  --> src/mdtest_snippet.py:22:32
+   |
+21 | class WithInitSubclass(metaclass=LessFancyMeta):
+22 |     def __init_subclass__(cls, arg: int): ...
+   |                                ^^^^^^^^
+23 |
+24 | # error: [missing-argument] "No argument provided for required parameter `arg` of function `__init_subclass__`"
+   |
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_with_a_cus…_(2a3b72dfc7a6b324).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_with_a_cus…_(2a3b72dfc7a6b324).snap
@@ -61,6 +61,8 @@ info: Parameter declared here
   |                                  ^^^^^^^^^^^^^^^^^^
 3 |         return "foo"
   |
+info: A `class` statement leads to an implicit call to the class's metaclass
+info: See https://docs.python.org/3/reference/datamodel.html#metaclasses
 
 ```
 
@@ -82,5 +84,7 @@ info: Parameter declared here
 23 |
 24 | # error: [missing-argument] "No argument provided for required parameter `arg` of function `__init_subclass__`"
    |
+info: `__init_subclass__` on a superclass is implicitly called during creation of a class object
+info: See https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_with_a_cus…_(fe613d3dd5ab7b4c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_with_a_cus…_(fe613d3dd5ab7b4c).snap
@@ -1,0 +1,114 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: methods.md - Methods - `@classmethod` - Metaclass with a custom `__new__` method and a custom meta-metaclass
+mdtest path: crates/ty_python_semantic/resources/mdtest/call/methods.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | class MetaMeta(type):
+ 2 |     def __call__(metacls, *args, meta_meta_arg: int, **kwargs) -> str:
+ 3 |         return "foo"
+ 4 | 
+ 5 | class Meta(type, metaclass=MetaMeta):
+ 6 |     def __new__(metacls, *args, meta_arg: int, **kwargs): ...
+ 7 | 
+ 8 | # error: [missing-argument] "No argument provided for required parameter `meta_meta_arg` of bound method `__call__`"
+ 9 | class Bad(metaclass=Meta): ...
+10 | 
+11 | # `Meta.__new__` is not checked because `MetaMeta.__call__` returns `str`,
+12 | # so no diagnostic is emitted here
+13 | class Fine(metaclass=Meta, meta_meta_arg=42): ...
+14 | 
+15 | class MetaMeta2(type):
+16 |     def __call__(metacls, *args, **kwargs) -> "Meta2":
+17 |         return type.__call__(metacls, *args, **kwargs)
+18 | 
+19 | class Meta2(type, metaclass=MetaMeta2):
+20 |     def __new__(metacls, *args, meta_arg: int, **kwargs): ...
+21 | 
+22 | # error: [missing-argument] "No argument provided for required parameter `meta_arg` of function `__new__`"
+23 | class AlsoBad(metaclass=Meta2): ...
+24 | 
+25 | class MetaMeta3(type):
+26 |     def __call__(metacls, *args, **kwargs) -> "Meta3":
+27 |         return type.__call__(metacls, *args, **kwargs)
+28 | 
+29 | class Meta3(type, metaclass=MetaMeta3):
+30 |     def __init__(cls, *args, init_arg: int, **kwargs): ...
+31 | 
+32 | # error: [missing-argument] "No argument provided for required parameter `init_arg` of bound method `__init__`"
+33 | class AlsoFine(metaclass=Meta3): ...
+```
+
+# Diagnostics
+
+```
+error[missing-argument]: No argument provided for required parameter `meta_meta_arg` of bound method `__call__`
+  --> src/mdtest_snippet.py:9:1
+   |
+ 8 | # error: [missing-argument] "No argument provided for required parameter `meta_meta_arg` of bound method `__call__`"
+ 9 | class Bad(metaclass=Meta): ...
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+10 |
+11 | # `Meta.__new__` is not checked because `MetaMeta.__call__` returns `str`,
+   |
+info: Parameter declared here
+ --> src/mdtest_snippet.py:2:34
+  |
+1 | class MetaMeta(type):
+2 |     def __call__(metacls, *args, meta_meta_arg: int, **kwargs) -> str:
+  |                                  ^^^^^^^^^^^^^^^^^^
+3 |         return "foo"
+  |
+
+```
+
+```
+error[missing-argument]: No argument provided for required parameter `meta_arg` of function `__new__`
+  --> src/mdtest_snippet.py:23:1
+   |
+22 | # error: [missing-argument] "No argument provided for required parameter `meta_arg` of function `__new__`"
+23 | class AlsoBad(metaclass=Meta2): ...
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+24 |
+25 | class MetaMeta3(type):
+   |
+info: Parameter declared here
+  --> src/mdtest_snippet.py:20:33
+   |
+19 | class Meta2(type, metaclass=MetaMeta2):
+20 |     def __new__(metacls, *args, meta_arg: int, **kwargs): ...
+   |                                 ^^^^^^^^^^^^^
+21 |
+22 | # error: [missing-argument] "No argument provided for required parameter `meta_arg` of function `__new__`"
+   |
+
+```
+
+```
+error[missing-argument]: No argument provided for required parameter `init_arg` of bound method `__init__`
+  --> src/mdtest_snippet.py:33:1
+   |
+32 | # error: [missing-argument] "No argument provided for required parameter `init_arg` of bound method `__init__`"
+33 | class AlsoFine(metaclass=Meta3): ...
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+info: Parameter declared here
+  --> src/mdtest_snippet.py:30:30
+   |
+29 | class Meta3(type, metaclass=MetaMeta3):
+30 |     def __init__(cls, *args, init_arg: int, **kwargs): ...
+   |                              ^^^^^^^^^^^^^
+31 |
+32 | # error: [missing-argument] "No argument provided for required parameter `init_arg` of bound method `__init__`"
+   |
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_with_a_cus…_(fe613d3dd5ab7b4c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_Metaclass_with_a_cus…_(fe613d3dd5ab7b4c).snap
@@ -68,6 +68,8 @@ info: Parameter declared here
   |                                  ^^^^^^^^^^^^^^^^^^
 3 |         return "foo"
   |
+info: A `class` statement leads to an implicit call to the class's metaclass
+info: See https://docs.python.org/3/reference/datamodel.html#metaclasses
 
 ```
 
@@ -90,6 +92,8 @@ info: Parameter declared here
 21 |
 22 | # error: [missing-argument] "No argument provided for required parameter `meta_arg` of function `__new__`"
    |
+info: A `class` statement leads to an implicit call to the class's metaclass
+info: See https://docs.python.org/3/reference/datamodel.html#metaclasses
 
 ```
 
@@ -110,5 +114,7 @@ info: Parameter declared here
 31 |
 32 | # error: [missing-argument] "No argument provided for required parameter `init_arg` of bound method `__init__`"
    |
+info: A `class` statement leads to an implicit call to the class's metaclass
+info: See https://docs.python.org/3/reference/datamodel.html#metaclasses
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_`__init_subclass__`_-_Basics_(a1fb03132e42b69e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_`__init_subclass__`_-_Basics_(a1fb03132e42b69e).snap
@@ -113,6 +113,8 @@ info: Parameter declared here
 14 |
 15 | class NoArg:
    |
+info: `__init_subclass__` on a superclass is implicitly called during creation of a class object
+info: See https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
 
 ```
 
@@ -135,6 +137,8 @@ info: Function defined here
 14 |
 15 | class NoArg:
    |
+info: `__init_subclass__` on a superclass is implicitly called during creation of a class object
+info: See https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
 
 ```
 
@@ -158,6 +162,8 @@ info: Parameter declared here
 14 |
 15 | class NoArg:
    |
+info: `__init_subclass__` on a superclass is implicitly called during creation of a class object
+info: See https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
 
 ```
 
@@ -181,6 +187,8 @@ info: Function signature here
 14 |
 15 | class NoArg:
    |
+info: `__init_subclass__` on a superclass is implicitly called during creation of a class object
+info: See https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
 
 ```
 
@@ -222,6 +230,8 @@ info: Function defined here
 47 |
 48 | class Valid(Base, arg=5, metaclass=object): ...
    |
+info: `__init_subclass__` on a superclass is implicitly called during creation of a class object
+info: See https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
 
 ```
 
@@ -258,5 +268,7 @@ info: Overload implementation defined here
 67 |
 68 | class Valid(Base, mode="a", arg=5): ...
    |
+info: `__init_subclass__` on a superclass is implicitly called during creation of a class object
+info: See https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_`__init_subclass__`_-_Basics_(a1fb03132e42b69e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_`__init_subclass__`_-_Basics_(a1fb03132e42b69e).snap
@@ -62,27 +62,34 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/call/methods.md
 47 | 
 48 | class Valid(Base, arg=5, metaclass=object): ...
 49 | 
-50 | # error: [invalid-argument-type]
-51 | class Invalid(Base, metaclass=type, arg="foo"): ...
-52 | from typing import Literal, overload
-53 | 
-54 | class Base:
-55 |     @overload
-56 |     def __init_subclass__(cls, mode: Literal["a"], arg: int) -> None: ...
-57 |     @overload
-58 |     def __init_subclass__(cls, mode: Literal["b"], arg: str) -> None: ...
-59 |     def __init_subclass__(cls, mode: str, arg: int | str) -> None: ...
+50 | # Despite the explicit `metaclass=object` call,
+51 | # the metaclass of this class is `type`, because that is
+52 | # the metaclass of its superclass `object`, and `type`
+53 | # (metaclass of superclass) is a subclass of `object`
+54 | # (explicit `metaclass=` argument in this class statement).
+55 | reveal_type(Valid.__class__)  # revealed: <class 'type'>
+56 | 
+57 | # error: [invalid-argument-type]
+58 | class Invalid(Base, metaclass=type, arg="foo"): ...
+59 | from typing import Literal, overload
 60 | 
-61 | class Valid(Base, mode="a", arg=5): ...
-62 | class Valid(Base, mode="b", arg="foo"): ...
-63 | 
-64 | # error: [no-matching-overload]
-65 | class InvalidType(Base, mode="b", arg=5):
-66 |     a = 1
-67 |     b = 2
-68 |     c = 3
-69 |     d = 4
-70 |     e = 5
+61 | class Base:
+62 |     @overload
+63 |     def __init_subclass__(cls, mode: Literal["a"], arg: int) -> None: ...
+64 |     @overload
+65 |     def __init_subclass__(cls, mode: Literal["b"], arg: str) -> None: ...
+66 |     def __init_subclass__(cls, mode: str, arg: int | str) -> None: ...
+67 | 
+68 | class Valid(Base, mode="a", arg=5): ...
+69 | class Valid(Base, mode="b", arg="foo"): ...
+70 | 
+71 | # error: [no-matching-overload]
+72 | class InvalidType(Base, mode="b", arg=5):
+73 |     a = 1
+74 |     b = 2
+75 |     c = 3
+76 |     d = 4
+77 |     e = 5
 ```
 
 # Diagnostics
@@ -198,12 +205,12 @@ info: See https://docs.python.org/3/reference/datamodel.html#customizing-class-c
 
 ```
 error[invalid-argument-type]: Argument to function `__init_subclass__` is incorrect
-  --> src/mdtest_snippet.py:51:37
+  --> src/mdtest_snippet.py:58:37
    |
-50 | # error: [invalid-argument-type]
-51 | class Invalid(Base, metaclass=type, arg="foo"): ...
+57 | # error: [invalid-argument-type]
+58 | class Invalid(Base, metaclass=type, arg="foo"): ...
    |                                     ^^^^^^^^^ Expected `int`, found `Literal["foo"]`
-52 | from typing import Literal, overload
+59 | from typing import Literal, overload
    |
 info: Function defined here
   --> src/mdtest_snippet.py:46:9
@@ -220,36 +227,36 @@ info: Function defined here
 
 ```
 error[no-matching-overload]: No overload of function `__init_subclass__` matches arguments
-  --> src/mdtest_snippet.py:65:1
+  --> src/mdtest_snippet.py:72:1
    |
-64 | # error: [no-matching-overload]
-65 | class InvalidType(Base, mode="b", arg=5):
+71 | # error: [no-matching-overload]
+72 | class InvalidType(Base, mode="b", arg=5):
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-66 |     a = 1
-67 |     b = 2
+73 |     a = 1
+74 |     b = 2
    |
 info: First overload defined here
-  --> src/mdtest_snippet.py:56:9
+  --> src/mdtest_snippet.py:63:9
    |
-54 | class Base:
-55 |     @overload
-56 |     def __init_subclass__(cls, mode: Literal["a"], arg: int) -> None: ...
+61 | class Base:
+62 |     @overload
+63 |     def __init_subclass__(cls, mode: Literal["a"], arg: int) -> None: ...
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-57 |     @overload
-58 |     def __init_subclass__(cls, mode: Literal["b"], arg: str) -> None: ...
+64 |     @overload
+65 |     def __init_subclass__(cls, mode: Literal["b"], arg: str) -> None: ...
    |
 info: Possible overloads for function `__init_subclass__`:
 info:   (cls, mode: Literal["a"], arg: int) -> None
 info:   (cls, mode: Literal["b"], arg: str) -> None
 info: Overload implementation defined here
-  --> src/mdtest_snippet.py:59:9
+  --> src/mdtest_snippet.py:66:9
    |
-57 |     @overload
-58 |     def __init_subclass__(cls, mode: Literal["b"], arg: str) -> None: ...
-59 |     def __init_subclass__(cls, mode: str, arg: int | str) -> None: ...
+64 |     @overload
+65 |     def __init_subclass__(cls, mode: Literal["b"], arg: str) -> None: ...
+66 |     def __init_subclass__(cls, mode: str, arg: int | str) -> None: ...
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-60 |
-61 | class Valid(Base, mode="a", arg=5): ...
+67 |
+68 | class Valid(Base, mode="a", arg=5): ...
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_`__prepare___=_None`_(96abd6fe23cfeb95).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_`__prepare___=_None`_(96abd6fe23cfeb95).snap
@@ -1,0 +1,72 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: methods.md - Methods - `@classmethod` - `__prepare__ = None`
+mdtest path: crates/ty_python_semantic/resources/mdtest/call/methods.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | class Meta(type):
+2 |     __prepare__ = None
+3 | 
+4 | # error: [invalid-metaclass] "Creation of class `Foo` will fail due to a metaclass with an invalid `__prepare__` definition"
+5 | class Foo(metaclass=Meta): ...
+6 | class MetaSub(Meta): ...
+7 | 
+8 | # error: [invalid-metaclass]
+9 | class Bar(Foo, metaclass=MetaSub): ...
+```
+
+# Diagnostics
+
+```
+error[invalid-metaclass]: Invalid definition of class `Foo`
+ --> src/mdtest_snippet.py:2:5
+  |
+1 | class Meta(type):
+2 |     __prepare__ = None
+  |     ----------- Metaclass `__prepare__` defined here
+3 |
+4 | # error: [invalid-metaclass] "Creation of class `Foo` will fail due to a metaclass with an invalid `__prepare__` definition"
+5 | class Foo(metaclass=Meta): ...
+  |           ^^^^^^^^^^^^^^
+  |           |
+  |           Class creation will fail at runtime due to its metaclass
+  |           Metaclass `<class 'Meta'>` has an invalid `__prepare__` definition
+6 | class MetaSub(Meta): ...
+  |
+info: `__prepare__` on a class's metaclass is implicitly called during creation of the class object
+info: See https://docs.python.org/3/reference/datamodel.html#preparing-the-class-namespace
+
+```
+
+```
+error[invalid-metaclass]: Invalid definition of class `Bar`
+ --> src/mdtest_snippet.py:9:16
+  |
+8 | # error: [invalid-metaclass]
+9 | class Bar(Foo, metaclass=MetaSub): ...
+  |                ^^^^^^^^^^^^^^^^^
+  |                |
+  |                Class creation will fail at runtime due to its metaclass
+  |                Metaclass `<class 'MetaSub'>` has an invalid `__prepare__` definition
+  |
+ ::: src/mdtest_snippet.py:2:5
+  |
+1 | class Meta(type):
+2 |     __prepare__ = None
+  |     ----------- Metaclass `__prepare__` defined here
+3 |
+4 | # error: [invalid-metaclass] "Creation of class `Foo` will fail due to a metaclass with an invalid `__prepare__` definition"
+  |
+info: `__prepare__` on a class's metaclass is implicitly called during creation of the class object
+info: See https://docs.python.org/3/reference/datamodel.html#preparing-the-class-namespace
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3354,6 +3354,7 @@ class TypedDict:
     def __init__(self):
         pass
 
+# error: [unknown-argument] "Argument `total` does not match any known parameter of function `__init_subclass__`"
 class NotActualTypedDict(TypedDict, total=True):
     name: str
 

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -217,6 +217,19 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         }
     }
 
+    pub(crate) fn with_prepended_parameters(&self, parameters: &[Type<'db>]) -> Self {
+        let arguments = std::iter::repeat_n(Argument::Synthetic, parameters.len())
+            .chain(self.arguments.iter().copied())
+            .collect();
+        let types = parameters
+            .iter()
+            .copied()
+            .map(|ty| CallArgumentTypes::new(Some(ty)))
+            .chain(self.types.iter().cloned())
+            .collect();
+        Self { arguments, types }
+    }
+
     pub(crate) fn iter(
         &self,
     ) -> impl Iterator<Item = (Argument<'a>, &CallArgumentTypes<'db>)> + '_ {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2597,10 +2597,6 @@ pub(super) enum MetaclassErrorKind<'db> {
     },
     /// The metaclass is a parameterized generic class, which is not supported.
     GenericMetaclass,
-    /// The metaclass is not callable
-    NotCallable(Type<'db>),
-    /// The metaclass is of a union type whose some members are not callable
-    PartlyNotCallable(Type<'db>),
     /// A cycle was encountered attempting to determine the metaclass
     Cycle,
 }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -25,13 +25,12 @@ use crate::{
         use_def_map,
     },
     types::{
-        ApplyTypeMappingVisitor, BoundTypeVarInstance, CallArguments, CallableType, ClassBase,
-        ClassLiteral, ClassType, DATACLASS_FLAGS, DataclassFlags, DataclassParams, GenericAlias,
-        GenericContext, KnownClass, KnownInstanceType, MaterializationKind, MemberLookupPolicy,
-        MetaclassCandidate, MetaclassTransformInfo, Parameter, Parameters, PropertyInstanceType,
-        Signature, SpecialFormType, StaticMroError, SubclassOfType, Truthiness, Type, TypeContext,
+        ApplyTypeMappingVisitor, BoundTypeVarInstance, CallableType, ClassBase, ClassLiteral,
+        ClassType, DATACLASS_FLAGS, DataclassFlags, DataclassParams, GenericAlias, GenericContext,
+        KnownClass, KnownInstanceType, MaterializationKind, MemberLookupPolicy, MetaclassCandidate,
+        MetaclassTransformInfo, Parameter, Parameters, PropertyInstanceType, Signature,
+        SpecialFormType, StaticMroError, SubclassOfType, Truthiness, Type, TypeContext,
         TypeMapping, TypeVarVariance, UnionBuilder, UnionType,
-        call::{CallError, CallErrorKind},
         callable::CallableTypeKind,
         class::{
             ClassMemberResult, CodeGeneratorKind, DisjointBase, DynamicTypedDictLiteral, Field,
@@ -825,7 +824,9 @@ impl<'db> StaticClassLiteral<'db> {
         // Identify the class's own metaclass (or take the first base class's metaclass).
         let mut base_classes = self.fully_static_explicit_bases(db).peekable();
 
-        if base_classes.peek().is_some() && self.inheritance_cycle(db).is_some() {
+        let first_base = base_classes.peek().copied();
+
+        if first_base.is_some() && self.inheritance_cycle(db).is_some() {
             // We emit diagnostics for cyclic class definitions elsewhere.
             // Avoid attempting to infer the metaclass if the class is cyclically defined.
             return Ok((SubclassOfType::subclass_of_unknown(), None));
@@ -873,34 +874,13 @@ impl<'db> StaticClassLiteral<'db> {
                 metaclass: metaclass_ty,
                 explicit_metaclass_of: class_metaclass_was_from,
             }
+        } else if first_base.is_none()
+            && metaclass.is_subtype_of(db, KnownClass::Type.to_subclass_of(db))
+        {
+            return Ok((metaclass, None));
         } else {
-            let name = Type::string_literal(db, self.name(db));
-            let bases = Type::heterogeneous_tuple(db, self.explicit_bases(db));
-            let namespace = KnownClass::Dict
-                .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]);
-
-            // TODO: Other keyword arguments?
-            let arguments = CallArguments::positional([name, bases, namespace]);
-
-            let return_ty_result = match metaclass.try_call(db, &arguments) {
-                Ok(bindings) => Ok(bindings.return_type(db)),
-
-                Err(CallError(CallErrorKind::NotCallable, bindings)) => Err(MetaclassError {
-                    kind: MetaclassErrorKind::NotCallable(bindings.callable_type()),
-                }),
-
-                // TODO we should also check for binding errors that would indicate the metaclass
-                // does not accept the right arguments
-                Err(CallError(CallErrorKind::BindingError, bindings)) => {
-                    Ok(bindings.return_type(db))
-                }
-
-                Err(CallError(CallErrorKind::PossiblyNotCallable, _)) => Err(MetaclassError {
-                    kind: MetaclassErrorKind::PartlyNotCallable(metaclass),
-                }),
-            };
-
-            return return_ty_result.map(|ty| (ty.to_meta_type(db), None));
+            // Call validation is done elsewhere.
+            return Ok((Type::unknown(), None));
         };
 
         // Reconcile all base classes' metaclasses with the candidate metaclass.
@@ -948,6 +928,7 @@ impl<'db> StaticClassLiteral<'db> {
                 params,
                 from_explicit_metaclass: candidate.explicit_metaclass_of == self,
             });
+
         Ok((candidate.metaclass.into(), transform_info))
     }
 

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::fmt;
 
 use drop_bomb::DebugDropBomb;
@@ -15,6 +16,9 @@ use crate::diagnostic::DiagnosticGuard;
 use crate::lint::LintSource;
 use crate::semantic_index::scope::ScopeId;
 use crate::semantic_index::semantic_index;
+use crate::types::diagnostic::{
+    attach_dunder_prepare_hints, attach_init_subclass_hints, attach_metaclass_constructor_hints,
+};
 use crate::types::function::FunctionDecorators;
 use crate::{
     Db,
@@ -39,9 +43,10 @@ pub(crate) struct InferContext<'db, 'ast> {
     scope: ScopeId<'db>,
     file: File,
     module: &'ast ParsedModuleRef,
-    diagnostics: std::cell::RefCell<TypeCheckDiagnostics>,
+    diagnostics: RefCell<TypeCheckDiagnostics>,
     no_type_check: InNoTypeCheck,
     bomb: DebugDropBomb,
+    class_statement_hints: RefCell<Option<ClassStatementHint>>,
 }
 
 impl<'db, 'ast> InferContext<'db, 'ast> {
@@ -51,12 +56,27 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
             scope,
             module,
             file: scope.file(db),
-            diagnostics: std::cell::RefCell::new(TypeCheckDiagnostics::default()),
+            diagnostics: RefCell::default(),
             no_type_check: InNoTypeCheck::default(),
             bomb: DebugDropBomb::new(
                 "`InferContext` needs to be explicitly consumed by calling `::finish` to prevent accidental loss of diagnostics.",
             ),
+            class_statement_hints: RefCell::default(),
         }
+    }
+
+    /// Attach a class statement hint to the context.
+    ///
+    /// After this has been set, any diagnostics emitted will have an info-level
+    /// subdiagnostic attached that explains the implicit call behavior of certain
+    /// methods during creation of a class object.
+    pub(crate) fn attach_class_statement_hint(&self, hint: ClassStatementHint) {
+        *self.class_statement_hints.borrow_mut() = Some(hint);
+    }
+
+    /// Clear any class statement hint on the context.
+    pub(crate) fn clear_class_statement_hint(&self) {
+        self.class_statement_hints.borrow_mut().take();
     }
 
     /// The file for which the types are inferred.
@@ -136,7 +156,12 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
         lint: &'static LintMetadata,
         ranged: T,
     ) -> Option<LintDiagnosticGuardBuilder<'ctx, 'db>> {
-        LintDiagnosticGuardBuilder::new(self, lint, ranged.range())
+        LintDiagnosticGuardBuilder::new(
+            self,
+            lint,
+            ranged.range(),
+            *self.class_statement_hints.borrow(),
+        )
     }
 
     /// Optionally return a builder for a diagnostic guard.
@@ -244,6 +269,21 @@ pub(crate) enum InNoTypeCheck {
     Yes,
 }
 
+/// Certain methods, such as `__init_subclass__` on a superclass, or
+/// `__new__`/`__init__`/`__prepare__` on a metaclass, or indeed `__call__`
+/// on a meta-metaclass, are implicitly called during creation of a class
+/// object. If we emit a diagnostic due to a bad call to one of these
+/// methods, we attach an info-level subdiagnostic to the diagnostic that
+/// explains this implicit call behavior and links to relevant documentation.
+///
+/// This enum tracks which of these "class statement hints" to attach, if any.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ClassStatementHint {
+    InitSubclass,
+    MetaclassPrepare,
+    MetaclassConstructor,
+}
+
 /// An abstraction for mutating a diagnostic through the lense of a lint.
 ///
 /// Callers can build this guard by starting with `InferContext::report_lint`.
@@ -264,6 +304,8 @@ pub(super) struct LintDiagnosticGuard<'db, 'ctx> {
     diag: Option<Diagnostic>,
 
     source: LintSource,
+
+    class_statement_hints: Option<ClassStatementHint>,
 }
 
 impl LintDiagnosticGuard<'_, '_> {
@@ -353,6 +395,20 @@ impl Drop for LintDiagnosticGuard<'_, '_> {
         // once.
         let mut diag = self.diag.take().unwrap();
 
+        if let Some(hint) = self.class_statement_hints {
+            match hint {
+                ClassStatementHint::InitSubclass => {
+                    attach_init_subclass_hints(&mut diag);
+                }
+                ClassStatementHint::MetaclassConstructor => {
+                    attach_metaclass_constructor_hints(&mut diag);
+                }
+                ClassStatementHint::MetaclassPrepare => {
+                    attach_dunder_prepare_hints(&mut diag);
+                }
+            }
+        }
+
         if self.ctx.db().verbose() {
             let rule = diag.id();
 
@@ -408,6 +464,7 @@ pub(super) struct LintDiagnosticGuardBuilder<'db, 'ctx> {
     severity: Severity,
     source: LintSource,
     primary_range: TextRange,
+    class_statement_hints: Option<ClassStatementHint>,
 }
 
 impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
@@ -445,6 +502,7 @@ impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
         ctx: &'ctx InferContext<'db, 'ctx>,
         lint: &'static LintMetadata,
         range: TextRange,
+        class_statement_hints: Option<ClassStatementHint>,
     ) -> Option<LintDiagnosticGuardBuilder<'db, 'ctx>> {
         let lint_id = LintId::of(lint);
 
@@ -469,6 +527,7 @@ impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
             severity,
             source,
             primary_range: range,
+            class_statement_hints,
         })
     }
 
@@ -499,6 +558,7 @@ impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
             ctx: self.ctx,
             source: self.source,
             diag: Some(diag),
+            class_statement_hints: self.class_statement_hints,
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -6359,7 +6359,27 @@ pub(super) fn report_invalid_concatenate_last_arg<'db>(
     }
 }
 
-pub(super) fn report_subclass_of_class_with_non_callable_init_subclass<'db>(
+fn find_definition_in_mro<'db>(
+    db: &'db dyn Db,
+    member: &str,
+    mro: impl IntoIterator<Item = ClassBase<'db>>,
+) -> Option<(StaticClassLiteral<'db>, Definition<'db>)> {
+    mro.into_iter().find_map(|base| {
+        let class = base.into_class()?.class_literal(db).as_static()?;
+        let scope = class.body_scope(db);
+        let place_table = place_table(db, scope);
+        let symbol = place_table.symbol_id(member)?;
+        let use_def = use_def_map(db, scope);
+        let bindings = use_def.end_of_scope_bindings(ScopedPlaceId::Symbol(symbol));
+        let place_with_def = place_from_bindings(db, bindings);
+        if place_with_def.place.is_undefined() {
+            return None;
+        }
+        Some((class, place_with_def.first_definition?))
+    })
+}
+
+pub(super) fn report_invalid_init_subclass_call<'db>(
     context: &InferContext<'db, '_>,
     call_error: CallError<'db>,
     class: StaticClassLiteral<'db>,
@@ -6379,21 +6399,8 @@ pub(super) fn report_subclass_of_class_with_non_callable_init_subclass<'db>(
             let mut diagnostic =
                 builder.into_diagnostic(format_args!("Invalid definition of class `{class_name}`"));
 
-            let class_and_def = class
-                .iter_mro(db, None)
-                .filter_map(|base| base.into_class()?.class_literal(db).as_static())
-                .find_map(|class| {
-                    let scope = class.body_scope(db);
-                    let place_table = place_table(db, scope);
-                    let symbol = place_table.symbol_id("__init_subclass__")?;
-                    let use_def = use_def_map(db, scope);
-                    let bindings = use_def.end_of_scope_bindings(ScopedPlaceId::Symbol(symbol));
-                    let place_with_def = place_from_bindings(db, bindings);
-                    if place_with_def.place.is_undefined() {
-                        return None;
-                    }
-                    Some((class, place_with_def.first_definition?))
-                });
+            let class_and_def =
+                find_definition_in_mro(db, "__init_subclass__", class.iter_mro(db, None).skip(1));
 
             if let Some((superclass, definition)) = class_and_def {
                 let superclass_name = superclass.name(db);
@@ -6454,6 +6461,111 @@ pub(super) fn report_subclass_of_class_with_non_callable_init_subclass<'db>(
                 "See https://docs.python.org/3/reference/datamodel.html\
                 #customizing-class-creation",
             );
+        }
+        CallErrorKind::BindingError => {
+            bindings.report_diagnostics(context, class_node.into());
+        }
+    }
+}
+
+pub(super) fn report_invalid_dunder_prepare_call<'db>(
+    context: &InferContext<'db, '_>,
+    call_error: &CallError<'db>,
+    class: StaticClassLiteral<'db>,
+    metaclass: Type<'db>,
+    class_node: &ast::StmtClassDef,
+) {
+    let db = context.db();
+    let CallError(err_kind, bindings) = call_error;
+
+    match err_kind {
+        CallErrorKind::NotCallable | CallErrorKind::PossiblyNotCallable => {
+            let range = class_node
+                .arguments
+                .as_deref()
+                .and_then(|args| args.find_keyword("metaclass"))
+                .map(Ranged::range)
+                .unwrap_or_else(|| class.header_range(db));
+
+            let Some(builder) = context.report_lint(&INVALID_METACLASS, range) else {
+                return;
+            };
+            let class_name = class.name(db);
+            let mut diagnostic =
+                builder.into_diagnostic(format_args!("Invalid definition of class `{class_name}`"));
+
+            let class_and_def = metaclass.as_class_literal().and_then(|metaclass| {
+                find_definition_in_mro(db, "__prepare__", metaclass.iter_mro(db))
+            });
+
+            diagnostic
+                .set_primary_message("Class creation will fail at runtime due to its metaclass");
+            diagnostic.annotate(
+                Annotation::primary(Span::from(context.file()).with_range(range)).message(
+                    format_args!(
+                        "Metaclass `{}` has an invalid `__prepare__` definition",
+                        metaclass.display(db)
+                    ),
+                ),
+            );
+            diagnostic.set_concise_message(format_args!(
+                "Creation of class `{class_name}` will fail due \
+                to a metaclass with an invalid `__prepare__` definition"
+            ));
+
+            if let Some((_, definition)) = class_and_def {
+                let definition_module = parsed_module(db, definition.file(db));
+                let annotation = Annotation::secondary(Span::from(
+                    definition.focus_range(db, &definition_module.load(db)),
+                ))
+                .message("Metaclass `__prepare__` defined here");
+                diagnostic.annotate(annotation);
+            }
+
+            diagnostic.info(
+                "`__prepare__` on a class's metaclass is implicitly called \
+                during creation of the class object",
+            );
+            diagnostic.info(
+                "See https://docs.python.org/3/reference/datamodel.html\
+                #preparing-the-class-namespace",
+            );
+        }
+        CallErrorKind::BindingError => {
+            bindings.report_diagnostics(context, class_node.into());
+        }
+    }
+}
+
+pub(super) fn report_invalid_metaclass<'db>(
+    context: &InferContext<'db, '_>,
+    call_error: &CallError<'db>,
+    class: StaticClassLiteral<'db>,
+    metaclass: Type<'db>,
+    class_node: &ast::StmtClassDef,
+) {
+    let db = context.db();
+    let CallError(err_kind, bindings) = call_error;
+
+    match err_kind {
+        CallErrorKind::NotCallable | CallErrorKind::PossiblyNotCallable => {
+            let range = class_node
+                .arguments
+                .as_deref()
+                .and_then(|args| args.find_keyword("metaclass"))
+                .map(Ranged::range)
+                .unwrap_or_else(|| class.header_range(db));
+
+            let Some(builder) = context.report_lint(&INVALID_METACLASS, range) else {
+                return;
+            };
+            let mut diagnostic = builder.into_diagnostic(format_args!(
+                "Metaclass of type `{}` is not callable",
+                metaclass.display(db)
+            ));
+            diagnostic
+                .info("A `class` statement leads to an implicit call to the class's metaclass");
+            diagnostic.info("See https://docs.python.org/3/reference/datamodel.html#metaclasses");
         }
         CallErrorKind::BindingError => {
             bindings.report_diagnostics(context, class_node.into());

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -15,6 +15,7 @@ use crate::semantic_index::{SemanticIndex, global_scope, place_table, use_def_ma
 use crate::suppression::FileSuppressionId;
 use crate::types::call::CallError;
 use crate::types::class::{CodeGeneratorKind, DisjointBase, DisjointBaseKind, MethodDecorator};
+use crate::types::context::ClassStatementHint;
 use crate::types::function::{FunctionDecorators, FunctionType, KnownFunction, OverloadLiteral};
 use crate::types::infer::UnsupportedComparisonError;
 use crate::types::overrides::MethodKind;
@@ -6453,17 +6454,12 @@ pub(super) fn report_invalid_init_subclass_call<'db>(
                     not be callable",
                 ));
             }
-            diagnostic.info(
-                "`__init_subclass__` on a superclass is implicitly called \
-                during creation of a class object",
-            );
-            diagnostic.info(
-                "See https://docs.python.org/3/reference/datamodel.html\
-                #customizing-class-creation",
-            );
+            attach_init_subclass_hints(&mut diagnostic);
         }
         CallErrorKind::BindingError => {
+            context.attach_class_statement_hint(ClassStatementHint::InitSubclass);
             bindings.report_diagnostics(context, class_node.into());
+            context.clear_class_statement_hint();
         }
     }
 }
@@ -6522,17 +6518,12 @@ pub(super) fn report_invalid_dunder_prepare_call<'db>(
                 diagnostic.annotate(annotation);
             }
 
-            diagnostic.info(
-                "`__prepare__` on a class's metaclass is implicitly called \
-                during creation of the class object",
-            );
-            diagnostic.info(
-                "See https://docs.python.org/3/reference/datamodel.html\
-                #preparing-the-class-namespace",
-            );
+            attach_dunder_prepare_hints(&mut diagnostic);
         }
         CallErrorKind::BindingError => {
+            context.attach_class_statement_hint(ClassStatementHint::MetaclassPrepare);
             bindings.report_diagnostics(context, class_node.into());
+            context.clear_class_statement_hint();
         }
     }
 }
@@ -6563,12 +6554,36 @@ pub(super) fn report_invalid_metaclass<'db>(
                 "Metaclass of type `{}` is not callable",
                 metaclass.display(db)
             ));
-            diagnostic
-                .info("A `class` statement leads to an implicit call to the class's metaclass");
-            diagnostic.info("See https://docs.python.org/3/reference/datamodel.html#metaclasses");
+            attach_metaclass_constructor_hints(&mut diagnostic);
         }
         CallErrorKind::BindingError => {
+            context.attach_class_statement_hint(ClassStatementHint::MetaclassConstructor);
             bindings.report_diagnostics(context, class_node.into());
+            context.clear_class_statement_hint();
         }
     }
+}
+
+pub(super) fn attach_init_subclass_hints(diagnostic: &mut Diagnostic) {
+    diagnostic.info(
+        "`__init_subclass__` on a superclass is implicitly called \
+        during creation of a class object",
+    );
+    diagnostic
+        .info("See https://docs.python.org/3/reference/datamodel.html#customizing-class-creation");
+}
+
+pub(super) fn attach_dunder_prepare_hints(diagnostic: &mut Diagnostic) {
+    diagnostic.info(
+        "`__prepare__` on a class's metaclass is implicitly called \
+        during creation of the class object",
+    );
+    diagnostic.info(
+        "See https://docs.python.org/3/reference/datamodel.html#preparing-the-class-namespace",
+    );
+}
+
+pub(super) fn attach_metaclass_constructor_hints(diagnostic: &mut Diagnostic) {
+    diagnostic.info("A `class` statement leads to an implicit call to the class's metaclass");
+    diagnostic.info("See https://docs.python.org/3/reference/datamodel.html#metaclasses");
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -5,7 +5,7 @@ use ruff_db::{
     source::source_text,
 };
 use ruff_diagnostics::{Edit, Fix};
-use ruff_python_ast as ast;
+use ruff_python_ast::{self as ast, name::Name};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use rustc_hash::FxHashMap;
 
@@ -17,9 +17,9 @@ use crate::{
         SemanticIndex, attribute_assignments, definition::DefinitionKind, scope::ScopeId,
     },
     types::{
-        CallArguments, ClassBase, ClassLiteral, ClassType, GenericAlias, KnownInstanceType,
-        MemberLookupPolicy, MetaclassCandidate, Parameters, Signature, SpecialFormType,
-        StaticClassLiteral, Type,
+        CallArguments, ClassBase, ClassLiteral, ClassType, GenericAlias, KnownClass,
+        KnownInstanceType, MemberLookupPolicy, MetaclassCandidate, Parameters, Signature,
+        SpecialFormType, StaticClassLiteral, Type,
         call::Argument,
         class::{AbstractMethod, CodeGeneratorKind, FieldKind, MetaclassErrorKind},
         context::InferContext,
@@ -32,13 +32,13 @@ use crate::{
             INVALID_TYPED_DICT_HEADER, IncompatibleBases, SUBCLASS_OF_FINAL_CLASS,
             UNKNOWN_ARGUMENT, report_bad_frozen_dataclass_inheritance,
             report_conflicting_metaclass_from_bases, report_duplicate_bases,
-            report_instance_layout_conflict, report_invalid_or_unsupported_base,
-            report_invalid_total_ordering, report_invalid_type_param_order,
-            report_invalid_typevar_default_reference,
+            report_instance_layout_conflict, report_invalid_dunder_prepare_call,
+            report_invalid_init_subclass_call, report_invalid_metaclass,
+            report_invalid_or_unsupported_base, report_invalid_total_ordering,
+            report_invalid_type_param_order, report_invalid_typevar_default_reference,
             report_named_tuple_field_with_leading_underscore,
             report_namedtuple_field_without_default_after_field_with_default,
-            report_shadowed_type_variable,
-            report_subclass_of_class_with_non_callable_init_subclass, report_unsupported_base,
+            report_shadowed_type_variable, report_unsupported_base,
         },
         enums::is_enum_class_by_inheritance,
         function::KnownFunction,
@@ -598,26 +598,6 @@ pub(crate) fn check_static_class_definitions<'db>(
                     builder.into_diagnostic("Generic metaclasses are not supported");
                 }
             }
-            MetaclassErrorKind::NotCallable(ty) => {
-                if let Some(builder) =
-                    context.report_lint(&INVALID_METACLASS, invalid_metaclass_range)
-                {
-                    builder.into_diagnostic(format_args!(
-                        "Metaclass type `{}` is not callable",
-                        ty.display(db)
-                    ));
-                }
-            }
-            MetaclassErrorKind::PartlyNotCallable(ty) => {
-                if let Some(builder) =
-                    context.report_lint(&INVALID_METACLASS, invalid_metaclass_range)
-                {
-                    builder.into_diagnostic(format_args!(
-                        "Metaclass type `{}` is partly not callable",
-                        ty.display(db)
-                    ));
-                }
-            }
             MetaclassErrorKind::Conflict {
                 candidate1:
                     MetaclassCandidate {
@@ -717,41 +697,13 @@ pub(crate) fn check_static_class_definitions<'db>(
                 }
             }
         } else {
-            let call_args: CallArguments = args
-                .keywords
-                .iter()
-                .filter_map(|keyword| match keyword.arg.as_ref() {
-                    // We mimic the runtime behaviour and discard the metaclass argument
-                    Some(name) if name.id.as_str() == "metaclass" => None,
-                    Some(name) => {
-                        let ty = file_expression_type(&keyword.value);
-                        Some((Argument::Keyword(name.id.as_str()), Some(ty)))
-                    }
-                    None => {
-                        let ty = file_expression_type(&keyword.value);
-                        Some((Argument::Keywords, Some(ty)))
-                    }
-                })
-                .collect();
-
-            let init_subclass_type = class
-                .class_member_from_mro(
-                    db,
-                    "__init_subclass__",
-                    MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
-                    // skip(1) to skip the current class and only consider base classes.
-                    class.iter_mro(db, None).skip(1),
-                )
-                .ignore_possibly_undefined();
-
-            if let Some(init_subclass) = init_subclass_type {
-                let call_args = call_args.with_self(Some(Type::from(class)));
-                if let Err(call_error) = init_subclass.try_call(db, &call_args) {
-                    report_subclass_of_class_with_non_callable_init_subclass(
-                        context, call_error, class, class_node,
-                    );
-                }
-            }
+            check_non_typeddict_keyword_arguments(
+                context,
+                class,
+                class_node,
+                &args.keywords,
+                file_expression_type,
+            );
         }
     }
 
@@ -1239,4 +1191,179 @@ fn has_binding_in_init<'db>(
                 .into_iter()
                 .any(|b| b.binding.definition().is_some())
     })
+}
+
+fn check_non_typeddict_keyword_arguments<'db>(
+    context: &InferContext<'db, '_>,
+    class: StaticClassLiteral<'db>,
+    class_node: &ast::StmtClassDef,
+    keywords: &[ast::Keyword],
+    file_expression_type: &impl Fn(&ast::Expr) -> Type<'db>,
+) {
+    let db = context.db();
+
+    let mut explicit_metaclass = None;
+
+    let keyword_call_args: CallArguments = keywords
+        .iter()
+        .filter_map(|keyword| match keyword.arg.as_deref() {
+            // We mimic the runtime behaviour and discard the metaclass argument
+            Some("metaclass") => {
+                explicit_metaclass = Some(file_expression_type(&keyword.value));
+                None
+            }
+            Some(name) => {
+                let ty = file_expression_type(&keyword.value);
+                Some((Argument::Keyword(name), Some(ty)))
+            }
+            None => {
+                let ty = file_expression_type(&keyword.value);
+                Some((Argument::Keywords, Some(ty)))
+            }
+        })
+        .collect();
+
+    // If the `metaclass=` keyword argument is not passed an instance of `type`,
+    // the runtime just calls it as-is without trying to resolve the appropriate metaclass
+    // with respect to the class's base classes. So, just use the `metaclass=` argument directly
+    // in that case. If the `metaclass=` argument was passed an instance of `type`, however,
+    // the class's actual metaclass won't necessarily be the `metaclass=` argument: if you pass
+    // `metaclass=object`, the class's actual metaclass will be `type`, because all classes have
+    // `object` as a supertype and the metaclass of `object` is `type`, and `object`/`type` have
+    // a subclass relationship.
+    let metaclass = if let Some(explicit_metaclass) = explicit_metaclass
+        && !explicit_metaclass.is_subtype_of(db, KnownClass::Type.to_instance(db))
+    {
+        explicit_metaclass
+    } else {
+        class.metaclass(db)
+    };
+
+    let builtins_type = KnownClass::Type.to_class_literal(db);
+
+    let overrides_member = |typ: Type<'db>, member| {
+        !typ.member_lookup_with_policy(
+            db,
+            Name::new_static(member),
+            MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK
+                | MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+        )
+        .is_undefined()
+    };
+
+    // Any class statement is syntactic sugar at runtime for a constructor call to the class's metaclass.
+    // As an optimisation, however, we avoid desugaring the `class` statement into a call to the metaclass
+    // unless:
+    //
+    // (1) The metaclass is not `builtins.type`, and;
+    // (2) Either the metaclass is not a subclass of `builtins.type`, or one of the following conditions applies:
+    //     (a) The metaclass overrides `__new__` from `builtins.type`, or
+    //     (b) The metaclass overrides `__prepare__` from `builtins.type`, or
+    //     (c) The metaclass overrides `__init__` from `builtins.type`, or
+    //     (d) The metaclass itself has its own custom metaclass that:
+    //         (i) is not `builtins.type`, and;
+    //         (ii) either is not a subclass of `builtins.type` or overrides `__call__` from `builtins.type`.
+    let (check_call_to_metaclass, check_init_subclass) = if metaclass == builtins_type {
+        (false, true)
+    } else if !metaclass.is_subtype_of(db, KnownClass::Type.to_subclass_of(db)) {
+        // `ClassLiteral::metaclass()` doesn't give an accurate result currently if the metaclass
+        // was inherited from a superclass and is not an instance of `type` (which is anyway very rare),
+        // so we don't check either `__init_subclass__` or the call to the metaclass in that case right now.
+        (explicit_metaclass.is_some(), false)
+    } else if overrides_member(metaclass, "__new__") {
+        (true, false)
+    } else {
+        let meta_metaclass = metaclass.to_meta_type(db);
+        if meta_metaclass != builtins_type
+            && !meta_metaclass.is_subtype_of(db, KnownClass::Type.to_subclass_of(db))
+        {
+            // for now, I give up at this point
+            (false, false)
+        } else if meta_metaclass != builtins_type && overrides_member(meta_metaclass, "__call__") {
+            (true, false)
+        } else if overrides_member(metaclass, "__prepare__")
+            || overrides_member(metaclass, "__init__")
+        {
+            (true, true)
+        } else {
+            (false, true)
+        }
+    };
+
+    if check_call_to_metaclass {
+        let class_name_type = Type::string_literal(db, class.name(db));
+
+        // We pass in a tuple where all elements are `type` rather than passing in the actual bases,
+        // because `Generic[T]` is not actually an instance of `type`, but most metaclass `__new__`
+        // and `__prepare__` methods are annotated as accepting `tuple[type, ...]`, which leads to
+        // too many false-positive errors.
+        let bases_type = Type::heterogeneous_tuple(
+            db,
+            std::iter::repeat_n(
+                KnownClass::Type.to_instance(db),
+                class.explicit_bases(db).len(),
+            ),
+        );
+
+        // https://docs.python.org/3/reference/datamodel.html#preparing-the-class-namespace
+        // `__prepare__` is only called if it exists as an attribute on the metaclass;
+        // otherwise, an "empty ordered mapping" is passed in as the namespace.
+        let namespace_type = metaclass
+            .member_lookup_with_policy(
+                db,
+                Name::new_static("__prepare__"),
+                MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
+            )
+            .ignore_possibly_undefined()
+            .map(|prepare| {
+                let prepare_args =
+                    keyword_call_args.with_prepended_parameters(&[class_name_type, bases_type]);
+
+                prepare
+                    .try_call(db, &prepare_args)
+                    .unwrap_or_else(|call_error| {
+                        report_invalid_dunder_prepare_call(
+                            context,
+                            &call_error,
+                            class,
+                            metaclass,
+                            class_node,
+                        );
+                        *call_error.1
+                    })
+                    .return_type(db)
+            })
+            .unwrap_or_else(|| {
+                KnownClass::Dict
+                    .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()])
+            });
+
+        let metaclass_new_prepended_parameters = &[class_name_type, bases_type, namespace_type];
+
+        let metaclass_new_args =
+            keyword_call_args.with_prepended_parameters(metaclass_new_prepended_parameters);
+
+        if let Err(call_error) = metaclass.try_call(db, &metaclass_new_args) {
+            report_invalid_metaclass(context, &call_error, class, metaclass, class_node);
+        }
+    }
+
+    if check_init_subclass {
+        let init_subclass = class.class_member_from_mro(
+            db,
+            "__init_subclass__",
+            MemberLookupPolicy::default(),
+            // skip(1) to skip the current class and only consider base classes.
+            class.iter_mro(db, None).skip(1),
+        );
+
+        // This should generally always be `Some()`, since `object.__init_subclass__` exists...
+        // but there's always the chance that the user is employing a custom typeshed.
+        if let Some(init_subclass) = init_subclass.ignore_possibly_undefined() {
+            let args = keyword_call_args.with_self(Some(Type::from(class)));
+            if let Err(call_error) = init_subclass.try_call(db, &args) {
+                report_invalid_init_subclass_call(context, call_error, class, class_node);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/2482.

If a user fails to provide a required keyword argument when creating a subclass, we now tell them why we're complaining about an invalid call to `__init_subclass__` (it's invoked implicitly as part of the creation of a class object), and we link to the Python data model from the diagnostic.

The challenge here was to figure out how to make sure that _all_ diagnostics relating to bad `__init_subclass__` calls would have this subdiagnostic attached. The reason why this was difficult is that these diagnostics are emitted from deep inside our call-binding machinery, and there could be multiple diagnostics emitted for just a single `__init_subclass__` call. I therefore created a new `class_statement_hints` field on `InferContext` that can be used to track whether we're currently in a context where these subdiagnostics should be attached. If this field is `Some()`, all diagnostics emitted using `InferContext::report_lint()` will have appropriate subdiagnostics attached to them; if `None`, the behaviour is as normal.

## Test Plan

snapshots updated
