### PR TITLE
fix(linter): suppress FURB122 fix when walrus operator rebinds loop variable

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB122.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB122.py
@@ -214,3 +214,27 @@ def _():
     with open("file", "w") as f:
         for line in ((1,) if True else (2,)):
             f.write(f"{line}")
+
+
+# Suppress fix when walrus operator rebinds comprehension variable
+# https://github.com/astral-sh/ruff/issues/21107
+def _():
+    with open("file", "w", encoding="utf-8") as src:
+        with open("file.txt", "w", encoding="utf-8") as dst:
+            for line in src:
+                dst.write(line := line.upper())  # walrus target `line` is the loop variable
+
+
+def _():
+    with open("file", "w", encoding="utf-8") as src:
+        with open("file.txt", "w", encoding="utf-8") as dst:
+            for first, *rest in src:
+                dst.write(rest := "".join(rest))  # walrus target `rest` is a loop variable
+
+
+def _():
+    with open("file", "w") as f:
+        for x in items:  # type: ignore
+            f.write(y := process(x))  # OK: walrus target `y` is NOT a loop variable, should still trigger FURB122
+
+

--- a/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs
@@ -1,5 +1,5 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::{Expr, ExprList, ExprName, ExprTuple, Stmt, StmtFor};
+use ruff_python_ast::{Expr, ExprList, ExprName, ExprNamed, ExprTuple, Stmt, StmtFor};
 use ruff_python_semantic::analyze::typing;
 use ruff_python_semantic::{Binding, ScopeId, SemanticModel, TypingOnlyBindingsStatus};
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -185,6 +185,15 @@ fn for_loop_writes(
         return;
     }
 
+    // Suppress the fix if the write argument contains a walrus operator (`:=`)
+    // that binds one of the for-loop targets. For example:
+    //     for f in files: f.write(data := get_data(f))
+    // The generated comprehension `f.writelines(data for f in files)` would
+    // reference `data` which is only bound inside the comprehension itself.
+    if write_arg_contains_walrus_binding(write_arg, binding_names) {
+        return;
+    }
+
     let locator = checker.locator();
     let content = match (for_stmt.target.as_ref(), write_arg) {
         (Expr::Name(for_target), Expr::Name(write_arg)) if for_target.id == write_arg.id => {
@@ -269,4 +278,43 @@ fn loop_variables_are_used_outside_loop(
     binding_names
         .iter()
         .any(|name| name_overwrites_outer(name) || name_is_used_later(name))
+}
+
+/// Check if `expr` contains a named expression (walrus operator `:=`) whose
+/// target is one of the given `binding_names` from the for-loop.
+fn write_arg_contains_walrus_binding(expr: &Expr, binding_names: &[&ExprName]) -> bool {
+    use ruff_python_ast::visitor::Visitor;
+
+    struct WalrusChecker<'a> {
+        loop_name_ids: Vec<&'a str>,
+        found: bool,
+    }
+
+    impl<'a> Visitor<'a> for WalrusChecker<'a> {
+        fn visit_expr(&mut self, expr: &'a Expr) {
+            if self.found {
+                return;
+            }
+            if let Expr::Named(ExprNamed { target, .. }) = expr {
+                if let Expr::Name(name) = target.as_ref() {
+                    if self
+                        .loop_name_ids
+                        .iter()
+                        .any(|id| *id == name.id.as_str())
+                    {
+                        self.found = true;
+                        return;
+                    }
+                }
+            }
+            ruff_python_ast::visitor::walk_expr(self, expr);
+        }
+    }
+
+    let mut checker = WalrusChecker {
+        loop_name_ids: binding_names.iter().map(|n| n.id.as_str()).collect(),
+        found: false,
+    };
+    checker.visit_expr(expr);
+    checker.found
 }

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB122_FURB122.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB122_FURB122.py.snap
@@ -412,3 +412,21 @@ help: Replace with `f.writelines`
     -         for line in ((1,) if True else (2,)):
     -             f.write(f"{line}")
 215 +         f.writelines(f"{line}" for line in ((1,) if True else (2,)))
+
+FURB122 [*] Use of `f.write` in a for loop
+  --> FURB122.py:235:9
+   |
+235 | def _():
+236 |     with open("file", "w") as f:
+237 | /         for x in items:  # type: ignore
+238 | |             f.write(y := process(x))  # OK: walrus target `y` is NOT a loop variable, should still trigger FURB122
+   | |______________________________^
+   |
+help: Replace with `f.writelines`
+232 |
+233 |
+234 | def _():
+235 |     with open("file", "w") as f:
+   -         for x in items:  # type: ignore
+   -             f.write(y := process(x))  # OK: walrus target `y` is NOT a loop variable, should still trigger FURB122
+236 +         f.writelines(y := process(x) for x in items)  # type: ignore


### PR DESCRIPTION
## Summary

Suppresses the FURB122 (`for-loop-writes`) fix when the `.write()` argument contains a walrus operator (`:=`) whose target is one of the for-loop's iteration variables.

The fix would otherwise generate an invalid comprehension. For example:

```python
for line in src:
    dst.write(line := line.upper())
```

would be transformed to:

```python
dst.writelines(line := line.upper() for line in src)
```

which produces `SyntaxError: assignment expression cannot rebind comprehension iteration variable 'line'`.

Similarly for tuple unpacking:

```python
for first, *rest in src:
    dst.write(rest := "".join(rest))
```

## Test Plan

Added test cases to `FURB122.py` fixture:

1. **Suppressed**: `dst.write(line := line.upper())` where `line` is the loop variable
2. **Suppressed**: `dst.write(rest := "".join(rest))` where `rest` is a loop variable from tuple unpacking  
3. **Still triggers**: `f.write(y := process(x))` where `y` is NOT a loop variable — the fix is still valid here

Closes: #21107
