### PR TITLE
[ty] Allow empty names in functional `Enum(...)` semantics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -1648,6 +1648,36 @@ Color = Enum("Color", 123)
 reveal_type(enum_members(Color))  # revealed: Unknown
 ```
 
+Empty functional enums are valid, even though they have no members:
+
+```py
+from enum import Enum
+
+EmptyFromString = Enum("EmptyFromString", "")
+EmptyFromList = Enum("EmptyFromList", [])
+EmptyFromDict = Enum("EmptyFromDict", {})
+```
+
+Literal list/tuple/dict inputs that use unpacking should degrade to unknown members rather than
+being rejected outright:
+
+```py
+from enum import Enum
+from ty_extensions import enum_members
+
+names: list[str] = ["B"]
+pairs: list[tuple[str, int]] = [("B", 2)]
+more: dict[str, int] = {"B": 2}
+
+FromNames = Enum("FromNames", ["A", *names])
+FromPairs = Enum("FromPairs", [("A", 1), *pairs])
+FromMapping = Enum("FromMapping", {"A": 1, **more})
+
+reveal_type(enum_members(FromNames))  # revealed: Unknown
+reveal_type(enum_members(FromPairs))  # revealed: Unknown
+reveal_type(enum_members(FromMapping))  # revealed: Unknown
+```
+
 ### Keyword argument type validation
 
 Functional enum construction should still preserve overload-based argument validation:

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -1545,15 +1545,37 @@ enum base class should still resolve through the MRO.
 
 ```py
 from enum import Enum
+from ty_extensions import enum_members
 
-names: list[str] = ["A", "B"]
-E = Enum("E", names)
+def f(
+    names: list[str],
+    labels: str,
+    pairs: tuple[tuple[str, int], ...],
+    mapping: dict[str, int],
+    name: str,
+    key: str,
+) -> None:
+    E1 = Enum("E1", names)
+    E2 = Enum("E2", labels)
+    E3 = Enum("E3", pairs)
+    E4 = Enum("E4", mapping)
+    E5 = Enum("E5", ["A", name])
+    E6 = Enum("E6", [(name, 1)])
+    E7 = Enum("E7", {key: 1})
 
-# Inherited class attributes resolve from Enum base.
-reveal_type(E.__members__)  # revealed: MappingProxyType[str, E]
+    reveal_type(enum_members(E1))  # revealed: Unknown
+    reveal_type(enum_members(E2))  # revealed: Unknown
+    reveal_type(enum_members(E3))  # revealed: Unknown
+    reveal_type(enum_members(E4))  # revealed: Unknown
+    reveal_type(enum_members(E5))  # revealed: Unknown
+    reveal_type(enum_members(E6))  # revealed: Unknown
+    reveal_type(enum_members(E7))  # revealed: Unknown
 
-# But own member access is unknown.
-reveal_type(E.FOO)  # revealed: Unknown
+    # Inherited class attributes resolve from Enum base.
+    reveal_type(E1.__members__)  # revealed: MappingProxyType[str, E1]
+
+    # But own member access is unknown.
+    reveal_type(E1.FOO)  # revealed: Unknown
 ```
 
 ### Too many positional args
@@ -1603,8 +1625,8 @@ Non-literal names should still be recognized as creating an enum class.
 ```py
 from enum import Enum
 
-def make_enum(name: str, labels: tuple[str, ...]) -> type[Enum]:
-    result = Enum(name.title(), labels, module=__name__)
+def make_enum(name: str) -> type[Enum]:
+    result = Enum(name.title(), "RED BLUE", module=__name__)
     reveal_type(result)  # revealed: type[Enum]
     return result
 
@@ -1636,7 +1658,7 @@ Color = Enum("Color", "RED GREEN BLUE", bad_kwarg=True)
 
 ### Definitely invalid `names` arguments
 
-Functional enums should still reject `names` values that are definitely not `_EnumNames`:
+Functional enums should still reject obviously invalid `names` values:
 
 ```py
 from enum import Enum
@@ -1652,30 +1674,44 @@ Empty functional enums are valid, even though they have no members:
 
 ```py
 from enum import Enum
+from ty_extensions import enum_members
 
 EmptyFromString = Enum("EmptyFromString", "")
 EmptyFromList = Enum("EmptyFromList", [])
 EmptyFromDict = Enum("EmptyFromDict", {})
+
+reveal_type(enum_members(EmptyFromString))  # revealed: tuple[()]
+reveal_type(enum_members(EmptyFromList))  # revealed: tuple[()]
+reveal_type(enum_members(EmptyFromDict))  # revealed: tuple[()]
+
+class ExtendedEmpty(EmptyFromString):
+    A = 1
+
+# revealed: tuple[Literal["A"]]
+reveal_type(enum_members(ExtendedEmpty))
 ```
 
-Literal list/tuple/dict inputs that use unpacking should degrade to unknown members rather than
-being rejected outright:
+Literal list/tuple/dict inputs that use unpacking are rejected:
 
 ```py
 from enum import Enum
-from ty_extensions import enum_members
 
 names: list[str] = ["B"]
 pairs: list[tuple[str, int]] = [("B", 2)]
 more: dict[str, int] = {"B": 2}
+bad_keys: dict[int, int] = {1: 2}
 
-FromNames = Enum("FromNames", ["A", *names])
-FromPairs = Enum("FromPairs", [("A", 1), *pairs])
-FromMapping = Enum("FromMapping", {"A": 1, **more})
+# error: [invalid-argument-type]
+Enum("FromNames", ["A", *names])
 
-reveal_type(enum_members(FromNames))  # revealed: Unknown
-reveal_type(enum_members(FromPairs))  # revealed: Unknown
-reveal_type(enum_members(FromMapping))  # revealed: Unknown
+# error: [invalid-argument-type]
+Enum("FromPairs", [("A", 1), *pairs])
+
+# error: [invalid-argument-type]
+Enum("FromMapping", {"A": 1, **more})
+
+# error: [invalid-argument-type]
+Enum("BadDoubleStar", {**bad_keys})
 ```
 
 ### Keyword argument type validation

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -548,7 +548,8 @@ impl<'db> ClassLiteral<'db> {
         match self {
             Self::Static(class) => class.is_final(db),
             Self::DynamicEnum(enum_lit) => {
-                crate::types::enums::enum_metadata(db, Self::DynamicEnum(enum_lit)).is_some()
+                crate::types::enums::enum_metadata(db, Self::DynamicEnum(enum_lit))
+                    .is_some_and(|metadata| !metadata.members.is_empty())
             }
             // Dynamic classes created via `type()`, `collections.namedtuple()`, etc. cannot be
             // marked as final.

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -214,9 +214,6 @@ pub(crate) fn enum_metadata<'db>(
                 }
                 members.insert(name.clone(), *ty);
             }
-            if members.is_empty() {
-                return None;
-            }
             return Some(EnumMetadata {
                 members,
                 aliases,

--- a/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
@@ -81,11 +81,6 @@ fn enum_functional_call_keyword_is_valid(name: &str, python_version: PythonVersi
     ) || (name == "boundary" && python_version >= PythonVersion::PY311)
 }
 
-fn has_duplicate_enum_member_names(members: &[(Name, Type<'_>)]) -> bool {
-    let mut seen = FxHashSet::default();
-    members.iter().any(|(name, _)| !seen.insert(name.clone()))
-}
-
 /// Returns the effective `_EnumNames` type accepted by the functional enum APIs.
 ///
 /// This includes the string form, iterables of strings, iterables of
@@ -404,7 +399,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         } else {
             match self.parse_enum_members_arg(names_arg, start, base_class) {
                 EnumMembersArgParseResult::Known(members) => {
-                    if has_duplicate_enum_member_names(&members) {
+                    let mut seen = FxHashSet::default();
+                    if members.iter().any(|(name, _)| !seen.insert(name.clone())) {
                         // Duplicate member names raise at runtime, so degrade to an unknown
                         // member set and let normal call binding surface the rest.
                         (vec![], false)
@@ -466,7 +462,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     ) -> EnumMembersArgParseResult<'db> {
         let db = self.db();
         let ty = self.expression_type(names_arg);
-
         if let Some(string_lit) = ty.as_string_literal() {
             let s = string_lit.value(db);
             let names: Vec<Name> = s
@@ -513,7 +508,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         for elt in elts {
             if matches!(elt, ast::Expr::Starred(_)) {
-                return EnumMembersArgParseResult::Unknown;
+                return EnumMembersArgParseResult::Invalid;
             }
             match self.classify_sequence_enum_member(elt) {
                 SequenceEnumMember::NameKnown(name) => {
@@ -593,7 +588,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let mut has_opaque_keys = false;
         for item in &dict.items {
             let Some(key) = &item.key else {
-                return EnumMembersArgParseResult::Unknown;
+                return EnumMembersArgParseResult::Invalid;
             };
             let key_ty = self.expression_type(key);
             let Some(string_lit) = key_ty.as_string_literal() else {

--- a/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
@@ -475,9 +475,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .filter(|s| !s.is_empty())
                 .map(Name::new)
                 .collect();
-            if names.is_empty() {
-                return EnumMembersArgParseResult::Invalid;
-            }
             let members = enum_members_from_names(db, names, start, base_class);
             return EnumMembersArgParseResult::Known(members);
         }
@@ -515,6 +512,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let mut has_opaque_members = false;
 
         for elt in elts {
+            if matches!(elt, ast::Expr::Starred(_)) {
+                return EnumMembersArgParseResult::Unknown;
+            }
             match self.classify_sequence_enum_member(elt) {
                 SequenceEnumMember::NameKnown(name) => {
                     if matches!(form, Some(SequenceEnumMemberForm::Pairs)) {
@@ -558,7 +558,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ));
         }
         if form.is_none() {
-            return EnumMembersArgParseResult::Invalid;
+            return EnumMembersArgParseResult::Known(vec![]);
         }
 
         let mut members = Vec::with_capacity(elts.len());
@@ -593,7 +593,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let mut has_opaque_keys = false;
         for item in &dict.items {
             let Some(key) = &item.key else {
-                return EnumMembersArgParseResult::Invalid;
+                return EnumMembersArgParseResult::Unknown;
             };
             let key_ty = self.expression_type(key);
             let Some(string_lit) = key_ty.as_string_literal() else {
@@ -617,8 +617,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
         if has_opaque_keys {
             EnumMembersArgParseResult::Unknown
-        } else if members.is_empty() {
-            EnumMembersArgParseResult::Invalid
         } else {
             EnumMembersArgParseResult::Known(members)
         }


### PR DESCRIPTION
## Summary

We now accept empty names, like `Enum("E", ""), Enum("E", []), Enum("E", {})`. These are valid at runtime; we return `tuple[()]` for its members.

I've also added some more tests to make a few behaviors explicit (without changing them): we reject literals with star unpacking (for simplicity), but accept non-literal arguments, and non-literal keys and values within literal arguments.
