### PR TITLE
[ty] Improve consistency of pedantic lints complaining about badly named types

### DIFF
--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -8,7 +8,7 @@
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22abstract-method-in-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2372" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2404" target="_blank">View source</a>
 </small>
 
 
@@ -49,7 +49,7 @@ class Derived(Base):  # Error: `Derived` does not implement `method`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-protocol-member%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L654" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L655" target="_blank">View source</a>
 </small>
 
 
@@ -90,7 +90,7 @@ class SubProto(BaseProto, Protocol):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22assert-type-unspellable-subtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2508" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2540" target="_blank">View source</a>
 </small>
 
 
@@ -126,7 +126,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Preview (since <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a>) ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-abstract-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2407" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2439" target="_blank">View source</a>
 </small>
 
 
@@ -175,7 +175,7 @@ Foo.method()  # Error: cannot call abstract classmethod
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-non-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L170" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L171" target="_blank">View source</a>
 </small>
 
 
@@ -199,7 +199,7 @@ Calling a non-callable object will raise a `TypeError` at runtime.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.7">0.0.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-top-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L188" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L189" target="_blank">View source</a>
 </small>
 
 
@@ -230,7 +230,7 @@ def f(x: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-argument-forms%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L239" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L240" target="_blank">View source</a>
 </small>
 
 
@@ -262,7 +262,7 @@ f(int)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-declarations%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L265" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L266" target="_blank">View source</a>
 </small>
 
 
@@ -293,7 +293,7 @@ a = 1
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L290" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L291" target="_blank">View source</a>
 </small>
 
 
@@ -325,7 +325,7 @@ class C(A, B): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-class-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L316" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L317" target="_blank">View source</a>
 </small>
 
 
@@ -357,7 +357,7 @@ class B(A): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-type-alias-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L342" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L343" target="_blank">View source</a>
 </small>
 
 
@@ -385,7 +385,7 @@ type B = A
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22dataclass-field-order%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L460" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L461" target="_blank">View source</a>
 </small>
 
 
@@ -417,7 +417,7 @@ class Example:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.16">0.0.1-alpha.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22deprecated%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L386" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L387" target="_blank">View source</a>
 </small>
 
 
@@ -444,7 +444,7 @@ old_func()  # emits [deprecated] diagnostic
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22division-by-zero%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L364" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L365" target="_blank">View source</a>
 </small>
 
 
@@ -473,7 +473,7 @@ false positives it can produce.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L407" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L408" target="_blank">View source</a>
 </small>
 
 
@@ -500,7 +500,7 @@ class B(A, A): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-kw-only%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L428" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L429" target="_blank">View source</a>
 </small>
 
 
@@ -538,7 +538,7 @@ class A:  # Crash at runtime
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22empty-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L968" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L969" target="_blank">View source</a>
 </small>
 
 
@@ -609,7 +609,7 @@ def foo() -> "intt\b": ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-on-non-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2319" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2351" target="_blank">View source</a>
 </small>
 
 
@@ -641,7 +641,7 @@ def my_function() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-without-value%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2345" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2377" target="_blank">View source</a>
 </small>
 
 
@@ -736,7 +736,7 @@ def test(): -> "Literal[5]":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22inconsistent-mro%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L737" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L738" target="_blank">View source</a>
 </small>
 
 
@@ -766,7 +766,7 @@ class C(A, B): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22index-out-of-bounds%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L761" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L762" target="_blank">View source</a>
 </small>
 
 
@@ -792,7 +792,7 @@ t[3]  # IndexError: tuple index out of range
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.33">0.0.1-alpha.33</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ineffective-final%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2291" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2323" target="_blank">View source</a>
 </small>
 
 
@@ -826,7 +826,7 @@ class MyClass: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22instance-layout-conflict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L543" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L544" target="_blank">View source</a>
 </small>
 
 
@@ -915,7 +915,7 @@ an atypical memory layout.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-argument-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L899" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L900" target="_blank">View source</a>
 </small>
 
 
@@ -942,7 +942,7 @@ func("foo")  # error: [invalid-argument-type]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-assignment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1008" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1009" target="_blank">View source</a>
 </small>
 
 
@@ -970,7 +970,7 @@ a: int = ''
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-attribute-access%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2837" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2869" target="_blank">View source</a>
 </small>
 
 
@@ -1004,7 +1004,7 @@ C.instance_var = 3  # error: Cannot assign to instance variable
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-await%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1030" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1031" target="_blank">View source</a>
 </small>
 
 
@@ -1040,7 +1040,7 @@ asyncio.run(main())
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1060" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1061" target="_blank">View source</a>
 </small>
 
 
@@ -1064,7 +1064,7 @@ class A(42): ...  # error: [invalid-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-context-manager%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1144" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1145" target="_blank">View source</a>
 </small>
 
 
@@ -1091,7 +1091,7 @@ with 1:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L512" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L513" target="_blank">View source</a>
 </small>
 
 
@@ -1128,7 +1128,7 @@ class Foo(NamedTuple):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L486" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L487" target="_blank">View source</a>
 </small>
 
 
@@ -1160,7 +1160,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-declaration%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1165" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1166" target="_blank">View source</a>
 </small>
 
 
@@ -1189,7 +1189,7 @@ a: str
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-enum-member-annotation%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1224" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1225" target="_blank">View source</a>
 </small>
 
 
@@ -1238,7 +1238,7 @@ class Pet(Enum):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-exception-caught%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1188" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1189" target="_blank">View source</a>
 </small>
 
 
@@ -1282,7 +1282,7 @@ except ZeroDivisionError:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.28">0.0.1-alpha.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-explicit-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2450" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2482" target="_blank">View source</a>
 </small>
 
 
@@ -1324,7 +1324,7 @@ class D(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.35">0.0.1-alpha.35</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-frozen-dataclass-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3195" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3227" target="_blank">View source</a>
 </small>
 
 
@@ -1368,7 +1368,7 @@ class NonFrozenChild(FrozenBase):  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1308" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1309" target="_blank">View source</a>
 </small>
 
 
@@ -1406,7 +1406,7 @@ class D(Generic[U, T]): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-enum%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1266" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1267" target="_blank">View source</a>
 </small>
 
 
@@ -1485,7 +1485,7 @@ a = 20 / 0  # type: ignore
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.17">0.0.1-alpha.17</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L782" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L783" target="_blank">View source</a>
 </small>
 
 
@@ -1524,7 +1524,7 @@ carol = Person(name="Carol", aeg=25)  # typo!
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-positional-parameter%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3273" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3305" target="_blank">View source</a>
 </small>
 
 
@@ -1585,7 +1585,7 @@ def f(x, y, /):  # Python 3.8+ syntax
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1365" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1366" target="_blank">View source</a>
 </small>
 
 
@@ -1620,7 +1620,7 @@ def f(t: TypeVar("U")): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-match-pattern%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1738" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1770" target="_blank">View source</a>
 </small>
 
 
@@ -1648,7 +1648,7 @@ match x:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1462" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1494" target="_blank">View source</a>
 </small>
 
 
@@ -1682,7 +1682,7 @@ class B(metaclass=f): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-method-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3097" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3129" target="_blank">View source</a>
 </small>
 
 
@@ -1789,7 +1789,7 @@ Correct use of `@override` is enforced by ty's [`invalid-explicit-override`](#in
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-named-tuple%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L689" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L690" target="_blank">View source</a>
 </small>
 
 
@@ -1843,7 +1843,7 @@ AttributeError: Cannot overwrite NamedTuple attribute _asdict
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.27">0.0.1-alpha.27</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-newtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1438" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1439" target="_blank">View source</a>
 </small>
 
 
@@ -1873,7 +1873,7 @@ Baz = NewType("Baz", int | str)  # error: invalid base for `typing.NewType`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1489" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1521" target="_blank">View source</a>
 </small>
 
 
@@ -1923,7 +1923,7 @@ def foo(x: int) -> int: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-parameter-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1588" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1620" target="_blank">View source</a>
 </small>
 
 
@@ -1949,7 +1949,7 @@ def f(a: int = ''): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-paramspec%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1393" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1394" target="_blank">View source</a>
 </small>
 
 
@@ -1980,7 +1980,7 @@ P2 = ParamSpec("S2")  # error: ParamSpec name must match the variable it's assig
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L625" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L626" target="_blank">View source</a>
 </small>
 
 
@@ -2014,7 +2014,7 @@ TypeError: Protocols can only inherit from other protocols, got <class 'int'>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-raise%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1608" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1640" target="_blank">View source</a>
 </small>
 
 
@@ -2063,7 +2063,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-return-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L920" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L921" target="_blank">View source</a>
 </small>
 
 
@@ -2092,7 +2092,7 @@ def func() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-super-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1651" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1683" target="_blank">View source</a>
 </small>
 
 
@@ -2188,7 +2188,7 @@ class C: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.10">0.0.10</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-total-ordering%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3233" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3265" target="_blank">View source</a>
 </small>
 
 
@@ -2234,7 +2234,7 @@ class MyClass:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.6">0.0.1-alpha.6</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-alias-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1417" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1418" target="_blank">View source</a>
 </small>
 
 
@@ -2261,7 +2261,7 @@ NewAlias = TypeAliasType(get_name(), int)        # error: TypeAliasType name mus
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1998" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2030" target="_blank">View source</a>
 </small>
 
 
@@ -2308,7 +2308,7 @@ Bar[int]  # error: too few arguments
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-checking-constant%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1690" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1722" target="_blank">View source</a>
 </small>
 
 
@@ -2338,7 +2338,7 @@ TYPE_CHECKING = ''
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-form%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1714" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1746" target="_blank">View source</a>
 </small>
 
 
@@ -2368,7 +2368,7 @@ b: Annotated[int]  # `Annotated` expects at least two arguments
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-guard-call%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1788" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1820" target="_blank">View source</a>
 </small>
 
 
@@ -2402,7 +2402,7 @@ f(10)  # Error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-guard-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1760" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1792" target="_blank">View source</a>
 </small>
 
 
@@ -2436,7 +2436,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-bound%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1857" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1889" target="_blank">View source</a>
 </small>
 
 
@@ -2467,7 +2467,7 @@ def g[U, T: U](): ...  # error: [invalid-type-variable-bound]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-constraints%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1816" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1848" target="_blank">View source</a>
 </small>
 
 
@@ -2514,7 +2514,7 @@ U = TypeVar('U', list[int], int)  # valid constrained Type
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1882" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1914" target="_blank">View source</a>
 </small>
 
 
@@ -2546,7 +2546,7 @@ U = TypeVar("U", int, str, default=bytes)  # error: [invalid-type-variable-defau
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.28">0.0.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-field%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3043" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3075" target="_blank">View source</a>
 </small>
 
 
@@ -2577,7 +2577,7 @@ class Child(Base):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-header%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3068" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3100" target="_blank">View source</a>
 </small>
 
 
@@ -2612,7 +2612,7 @@ def f(x: dict):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.9">0.0.9</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-statement%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3018" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3050" target="_blank">View source</a>
 </small>
 
 
@@ -2643,7 +2643,7 @@ class Foo(TypedDict):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.25">0.0.25</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-yield%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L943" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L944" target="_blank">View source</a>
 </small>
 
 
@@ -2674,7 +2674,7 @@ def gen() -> Iterator[int]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L815" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L816" target="_blank">View source</a>
 </small>
 
 
@@ -2729,7 +2729,7 @@ def h(arg2: type):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-typed-dict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L863" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L864" target="_blank">View source</a>
 </small>
 
 
@@ -2766,13 +2766,51 @@ def g(arg: object):
 
 - [Typing specification: `TypedDict`](https://typing.python.org/en/latest/spec/typeddict.html)
 
+## `mismatched-type-name`
+
+<small>
+Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
+Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
+<a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22mismatched-type-name%22" target="_blank">Related issues</a> ·
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1463" target="_blank">View source</a>
+</small>
+
+
+**What it does**
+
+Checks for functional typing definitions whose declared name does not match
+the variable they are assigned to.
+
+**Why is this bad?**
+
+Constructors like `TypeVar`, `ParamSpec`, `NewType`, `NamedTuple`,
+`TypedDict`, and `TypeAliasType` all take a name argument that is
+normally expected to match the assigned variable. A mismatch is usually a
+typo and makes later diagnostics harder to understand.
+
+**Default level**
+
+This rule is a warning by default because ty can usually recover and
+continue understanding the resulting type.
+
+**Examples**
+
+```python
+from typing import NewType, TypeVar
+from typing_extensions import TypedDict
+
+T = TypeVar("U")  # error: [mismatched-type-name]
+UserId = NewType("Id", int)  # error: [mismatched-type-name]
+Movie = TypedDict("Film", {"title": str})  # error: [mismatched-type-name]
+```
+
 ## `missing-argument`
 
 <small>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1938" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1970" target="_blank">View source</a>
 </small>
 
 
@@ -2797,7 +2835,7 @@ func()  # TypeError: func() missing 1 required positional argument: 'x'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-typed-dict-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2991" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3023" target="_blank">View source</a>
 </small>
 
 
@@ -2830,7 +2868,7 @@ alice["age"]  # KeyError
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22no-matching-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1957" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1989" target="_blank">View source</a>
 </small>
 
 
@@ -2859,7 +2897,7 @@ func("string")  # error: [no-matching-overload]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22non-callable-init-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1339" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1340" target="_blank">View source</a>
 </small>
 
 
@@ -2892,7 +2930,7 @@ class Sub(Super): ...  # error: [non-callable-init-subclass]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-iterable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2039" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2071" target="_blank">View source</a>
 </small>
 
 
@@ -2918,7 +2956,7 @@ for i in 34:  # TypeError: 'int' object is not iterable
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-subscriptable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1980" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2012" target="_blank">View source</a>
 </small>
 
 
@@ -2942,7 +2980,7 @@ Subscripting an object that does not support it will raise a `TypeError` at runt
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2237" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2269" target="_blank">View source</a>
 </small>
 
 
@@ -2975,7 +3013,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2264" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2296" target="_blank">View source</a>
 </small>
 
 
@@ -3008,7 +3046,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22parameter-already-assigned%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2090" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2122" target="_blank">View source</a>
 </small>
 
 
@@ -3035,7 +3073,7 @@ f(1, x=2)  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22positional-only-parameter-as-kwarg%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2664" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2696" target="_blank">View source</a>
 </small>
 
 
@@ -3062,7 +3100,7 @@ f(x=1)  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2111" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2143" target="_blank">View source</a>
 </small>
 
 
@@ -3095,7 +3133,7 @@ A.c  # AttributeError: type object 'A' has no attribute 'c'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-implicit-call%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L213" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L214" target="_blank">View source</a>
 </small>
 
 
@@ -3127,7 +3165,7 @@ A()[0]  # TypeError: 'A' object is not subscriptable
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2158" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2190" target="_blank">View source</a>
 </small>
 
 
@@ -3164,7 +3202,7 @@ from module import a  # ImportError: cannot import name 'a' from 'module'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.23">0.0.23</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-submodule%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2137" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2169" target="_blank">View source</a>
 </small>
 
 
@@ -3191,7 +3229,7 @@ html.parser  # AttributeError: module 'html' has no attribute 'parser'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2188" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2220" target="_blank">View source</a>
 </small>
 
 
@@ -3255,7 +3293,7 @@ def test(): -> "int":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-cast%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2865" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2897" target="_blank">View source</a>
 </small>
 
 
@@ -3282,7 +3320,7 @@ cast(int, f())  # Redundant
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-final-classvar%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2886" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2918" target="_blank">View source</a>
 </small>
 
 
@@ -3314,7 +3352,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22shadowed-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2912" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2944" target="_blank">View source</a>
 </small>
 
 
@@ -3348,7 +3386,7 @@ class Outer[T]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22static-assert-error%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2813" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2845" target="_blank">View source</a>
 </small>
 
 
@@ -3378,7 +3416,7 @@ static_assert(int(2.0 * 3.0) == 6)  # error: does not have a statically known tr
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2214" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2246" target="_blank">View source</a>
 </small>
 
 
@@ -3407,7 +3445,7 @@ class B(A): ...  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.30">0.0.1-alpha.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22super-call-in-named-tuple-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2598" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2630" target="_blank">View source</a>
 </small>
 
 
@@ -3441,7 +3479,7 @@ class F(NamedTuple):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22too-many-positional-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2538" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2570" target="_blank">View source</a>
 </small>
 
 
@@ -3468,7 +3506,7 @@ f("foo")  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22type-assertion-failure%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2486" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2518" target="_blank">View source</a>
 </small>
 
 
@@ -3496,7 +3534,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unavailable-implicit-super-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2559" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2591" target="_blank">View source</a>
 </small>
 
 
@@ -3542,7 +3580,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unbound-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1908" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1940" target="_blank">View source</a>
 </small>
 
 
@@ -3579,7 +3617,7 @@ class C(Generic[T]):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22undefined-reveal%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2625" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2657" target="_blank">View source</a>
 </small>
 
 
@@ -3603,7 +3641,7 @@ reveal_type(1)  # NameError: name 'reveal_type' is not defined
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unknown-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2643" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2675" target="_blank">View source</a>
 </small>
 
 
@@ -3630,7 +3668,7 @@ f(x=1, y=2)  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2685" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2717" target="_blank">View source</a>
 </small>
 
 
@@ -3658,7 +3696,7 @@ A().foo  # AttributeError: 'A' object has no attribute 'foo'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.15">0.0.1-alpha.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-global%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2939" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2971" target="_blank">View source</a>
 </small>
 
 
@@ -3716,7 +3754,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2707" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2739" target="_blank">View source</a>
 </small>
 
 
@@ -3741,7 +3779,7 @@ import foo  # ModuleNotFoundError: No module named 'foo'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2726" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2758" target="_blank">View source</a>
 </small>
 
 
@@ -3766,7 +3804,7 @@ print(x)  # NameError: name 'x' is not defined
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.7">0.0.1-alpha.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1078" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1079" target="_blank">View source</a>
 </small>
 
 
@@ -3805,7 +3843,7 @@ class D(C): ...  # error: [unsupported-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-bool-conversion%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2059" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2091" target="_blank">View source</a>
 </small>
 
 
@@ -3842,7 +3880,7 @@ b1 < b2 < b1  # exception raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-dynamic-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1111" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1112" target="_blank">View source</a>
 </small>
 
 
@@ -3882,7 +3920,7 @@ def factory(base: type[Base]) -> type:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-operator%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2745" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2777" target="_blank">View source</a>
 </small>
 
 
@@ -3910,7 +3948,7 @@ A() + A()  # TypeError: unsupported operand type(s) for +: 'A' and 'A'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Preview (since <a href="https://github.com/astral-sh/ty/releases/tag/0.0.21">0.0.21</a>) ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-awaitable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2767" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2799" target="_blank">View source</a>
 </small>
 
 
@@ -4016,7 +4054,7 @@ to `false`.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22useless-overload-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1532" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1564" target="_blank">View source</a>
 </small>
 
 
@@ -4079,7 +4117,7 @@ def foo(x: int | str) -> int | str:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22zero-stepsize-in-slice%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2794" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2826" target="_blank">View source</a>
 </small>
 
 

--- a/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
@@ -171,6 +171,25 @@ Foo = NewType(name, int)
 reveal_type(Foo)  # revealed: <NewType pseudo-class 'Foo'>
 ```
 
+## The assigned name should match the constructor name
+
+<!-- snapshot-diagnostics -->
+
+```py
+from typing_extensions import NewType
+from ty_extensions import is_subtype_of
+
+# error: [mismatched-type-name]
+UserId = NewType("Id", int)
+reveal_type(UserId)  # revealed: <NewType pseudo-class 'Id'>
+reveal_type(is_subtype_of(UserId, int))  # revealed: ConstraintSet[Literal[True]]
+
+Id = int
+# error: [mismatched-type-name]
+UsesExistingId = NewType("Id", "Id")
+UsesExistingId(1)
+```
+
 ## The base must be a class type or another newtype
 
 Other typing constructs like `Union` are not _generally_ allowed. (However, see the next section for

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typevars.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typevars.md
@@ -45,7 +45,7 @@ tuple_with_typevar = ("foo", TypeVar("W"))
 ```py
 from typing import TypeVar
 
-# error: [invalid-legacy-type-variable]
+# error: [mismatched-type-name]
 T = TypeVar("Q")
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -1390,6 +1390,24 @@ Color = Enum("Color", names="RED GREEN BLUE")
 reveal_type(enum_members(Color))
 ```
 
+### Name mismatch diagnostics
+
+<!-- snapshot-diagnostics -->
+
+```py
+from enum import Enum
+
+# error: [mismatched-type-name]
+Mismatch = Enum("WrongName", "A B")
+
+def f(name: str) -> None:
+    # error: [mismatched-type-name]
+    DynamicMismatch = Enum(name, "A B")
+
+name = "GoodMatch"
+GoodMatch = Enum(name, "A B")
+```
+
 ### List/tuple of tuples
 
 ```py
@@ -1626,6 +1644,7 @@ Non-literal names should still be recognized as creating an enum class.
 from enum import Enum
 
 def make_enum(name: str) -> type[Enum]:
+    # error: [mismatched-type-name]
     result = Enum(name.title(), "RED BLUE", module=__name__)
     reveal_type(result)  # revealed: type[Enum]
     return result

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -51,12 +51,17 @@ reveal_type(tuple_with_typevar[1])  # revealed: ParamSpec
 ### `ParamSpec` parameter must match variable name
 
 ```py
-from typing import ParamSpec
+from typing import Callable, Generic, ParamSpec
 
 P1 = ParamSpec("P1")
 
-# error: [invalid-paramspec]
+# error: [mismatched-type-name]
 P2 = ParamSpec("P3")
+
+class Wrapper(Generic[P2]): ...
+
+def decorator(f: Callable[P2, int]) -> Callable[P2, int]:
+    return f
 ```
 
 ### Accepts only a single `name` argument

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
@@ -69,10 +69,35 @@ reveal_type(tuple_with_typevar[1])  # revealed: TypeVar
 > The argument to `TypeVar()` must be a string equal to the variable name to which it is assigned.
 
 ```py
-from typing import TypeVar
+from typing import Generic, TypeVar
 
-# error: [invalid-legacy-type-variable]
+# error: [mismatched-type-name]
 T = TypeVar("Q")
+
+class Box(Generic[T]): ...
+
+reveal_type(Box[int]())  # revealed: Box[int]
+```
+
+### Shadowing checks use the binding name
+
+<!-- snapshot-diagnostics -->
+
+```py
+from typing import Generic, TypeVar
+
+S = TypeVar("S")
+T = TypeVar("T")
+
+# This recovers as the `Q` binding for source-level name resolution.
+# error: [mismatched-type-name]
+Q = TypeVar("T")
+
+class Outer(Generic[Q]):
+    class Ok(Generic[S]): ...
+    # error: [shadowed-type-variable]
+    # error: [shadowed-type-variable]
+    class Bad(Generic[Q]): ...
 ```
 
 ### No redefinition

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -91,6 +91,7 @@ del alice.id
 Alternative functional syntax with a list of tuples:
 
 ```py
+# error: [mismatched-type-name]
 Person2 = NamedTuple("Person", [("id", int), ("name", str)])
 alice2 = Person2(1, "Alice")
 
@@ -104,6 +105,7 @@ reveal_type(alice2.name)  # revealed: str
 Functional syntax with a tuple of tuples:
 
 ```py
+# error: [mismatched-type-name]
 Person3 = NamedTuple("Person", (("id", int), ("name", str)))
 alice3 = Person3(1, "Alice")
 
@@ -114,6 +116,7 @@ reveal_type(alice3.name)  # revealed: str
 Functional syntax with a tuple of lists:
 
 ```py
+# error: [mismatched-type-name]
 Person4 = NamedTuple("Person", (["id", int], ["name", str]))
 alice4 = Person4(1, "Alice")
 
@@ -124,11 +127,28 @@ reveal_type(alice4.name)  # revealed: str
 Functional syntax with a list of lists:
 
 ```py
+# error: [mismatched-type-name]
 Person5 = NamedTuple("Person", [["id", int], ["name", str]])
 alice5 = Person5(1, "Alice")
 
 reveal_type(alice5.id)  # revealed: int
 reveal_type(alice5.name)  # revealed: str
+```
+
+### Name mismatch diagnostics
+
+<!-- snapshot-diagnostics -->
+
+The assigned variable name should match the `typename` argument:
+
+```py
+from typing import NamedTuple
+from ty_extensions import is_subtype_of
+
+# error: [mismatched-type-name]
+Mismatch = NamedTuple("WrongName", [("x", int)])
+reveal_type(Mismatch)  # revealed: <class 'WrongName'>
+reveal_type(is_subtype_of(Mismatch, tuple[int]))  # revealed: ConstraintSet[Literal[True]]
 ```
 
 ### Functional syntax with string annotations
@@ -268,6 +288,15 @@ Person = NamedTuple(name, [("id", int), ("name", str)])
 p = Person(1, "Alice")
 reveal_type(p.id)  # revealed: int
 reveal_type(p.name)  # revealed: str
+```
+
+Non-literal `str` names should not be treated as proven mismatches:
+
+```py
+from typing import NamedTuple
+
+def f(name: str) -> None:
+    Match = NamedTuple(name, [("value", int)])
 ```
 
 ### Functional syntax with tuple variable fields
@@ -526,30 +555,35 @@ import collections
 from ty_extensions import reveal_mro
 
 # String field names (space-separated)
+# error: [mismatched-type-name]
 Point1 = collections.namedtuple("Point", "x y")
 reveal_type(Point1)  # revealed: <class 'Point'>
 # revealed: (<class 'Point'>, <class 'tuple[Any, Any]'>, <class 'Sequence[Any]'>, <class 'Reversible[Any]'>, <class 'Collection[Any]'>, <class 'Iterable[Any]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(Point1)
 
 # String field names with multiple spaces
+# error: [mismatched-type-name]
 Point1a = collections.namedtuple("Point", "x       y")
 reveal_type(Point1a)  # revealed: <class 'Point'>
 # revealed: (<class 'Point'>, <class 'tuple[Any, Any]'>, <class 'Sequence[Any]'>, <class 'Reversible[Any]'>, <class 'Collection[Any]'>, <class 'Iterable[Any]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(Point1a)
 
 # String field names (comma-separated also works at runtime)
+# error: [mismatched-type-name]
 Point2 = collections.namedtuple("Point", "x, y")
 reveal_type(Point2)  # revealed: <class 'Point'>
 # revealed: (<class 'Point'>, <class 'tuple[Any, Any]'>, <class 'Sequence[Any]'>, <class 'Reversible[Any]'>, <class 'Collection[Any]'>, <class 'Iterable[Any]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(Point2)
 
 # List of strings
+# error: [mismatched-type-name]
 Point3 = collections.namedtuple("Point", ["x", "y"])
 reveal_type(Point3)  # revealed: <class 'Point'>
 # revealed: (<class 'Point'>, <class 'tuple[Any, Any]'>, <class 'Sequence[Any]'>, <class 'Reversible[Any]'>, <class 'Collection[Any]'>, <class 'Iterable[Any]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(Point3)
 
 # Tuple of strings
+# error: [mismatched-type-name]
 Point4 = collections.namedtuple("Point", ("x", "y"))
 reveal_type(Point4)  # revealed: <class 'Point'>
 # revealed: (<class 'Point'>, <class 'tuple[Any, Any]'>, <class 'Sequence[Any]'>, <class 'Reversible[Any]'>, <class 'Collection[Any]'>, <class 'Iterable[Any]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
@@ -573,10 +607,12 @@ The `typing.NamedTuple` function accepts `Iterable[tuple[str, Any]]` for `fields
 from typing import NamedTuple
 
 # List of tuples
+# error: [mismatched-type-name]
 Person1 = NamedTuple("Person", [("name", str), ("age", int)])
 reveal_type(Person1)  # revealed: <class 'Person'>
 
 # Tuple of tuples
+# error: [mismatched-type-name]
 Person2 = NamedTuple("Person", (("name", str), ("age", int)))
 reveal_type(Person2)  # revealed: <class 'Person'>
 

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -91,8 +91,7 @@ del alice.id
 Alternative functional syntax with a list of tuples:
 
 ```py
-# error: [mismatched-type-name]
-Person2 = NamedTuple("Person", [("id", int), ("name", str)])
+Person2 = NamedTuple("Person2", [("id", int), ("name", str)])
 alice2 = Person2(1, "Alice")
 
 # error: [missing-argument]
@@ -105,8 +104,7 @@ reveal_type(alice2.name)  # revealed: str
 Functional syntax with a tuple of tuples:
 
 ```py
-# error: [mismatched-type-name]
-Person3 = NamedTuple("Person", (("id", int), ("name", str)))
+Person3 = NamedTuple("Person3", (("id", int), ("name", str)))
 alice3 = Person3(1, "Alice")
 
 reveal_type(alice3.id)  # revealed: int
@@ -116,8 +114,7 @@ reveal_type(alice3.name)  # revealed: str
 Functional syntax with a tuple of lists:
 
 ```py
-# error: [mismatched-type-name]
-Person4 = NamedTuple("Person", (["id", int], ["name", str]))
+Person4 = NamedTuple("Person4", (["id", int], ["name", str]))
 alice4 = Person4(1, "Alice")
 
 reveal_type(alice4.id)  # revealed: int
@@ -127,8 +124,7 @@ reveal_type(alice4.name)  # revealed: str
 Functional syntax with a list of lists:
 
 ```py
-# error: [mismatched-type-name]
-Person5 = NamedTuple("Person", [["id", int], ["name", str]])
+Person5 = NamedTuple("Person5", [["id", int], ["name", str]])
 alice5 = Person5(1, "Alice")
 
 reveal_type(alice5.id)  # revealed: int
@@ -555,38 +551,33 @@ import collections
 from ty_extensions import reveal_mro
 
 # String field names (space-separated)
-# error: [mismatched-type-name]
-Point1 = collections.namedtuple("Point", "x y")
-reveal_type(Point1)  # revealed: <class 'Point'>
-# revealed: (<class 'Point'>, <class 'tuple[Any, Any]'>, <class 'Sequence[Any]'>, <class 'Reversible[Any]'>, <class 'Collection[Any]'>, <class 'Iterable[Any]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+Point1 = collections.namedtuple("Point1", "x y")
+reveal_type(Point1)  # revealed: <class 'Point1'>
+# revealed: (<class 'Point1'>, <class 'tuple[Any, Any]'>, <class 'Sequence[Any]'>, <class 'Reversible[Any]'>, <class 'Collection[Any]'>, <class 'Iterable[Any]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(Point1)
 
 # String field names with multiple spaces
-# error: [mismatched-type-name]
-Point1a = collections.namedtuple("Point", "x       y")
-reveal_type(Point1a)  # revealed: <class 'Point'>
-# revealed: (<class 'Point'>, <class 'tuple[Any, Any]'>, <class 'Sequence[Any]'>, <class 'Reversible[Any]'>, <class 'Collection[Any]'>, <class 'Iterable[Any]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+Point1a = collections.namedtuple("Point1a", "x       y")
+reveal_type(Point1a)  # revealed: <class 'Point1a'>
+# revealed: (<class 'Point1a'>, <class 'tuple[Any, Any]'>, <class 'Sequence[Any]'>, <class 'Reversible[Any]'>, <class 'Collection[Any]'>, <class 'Iterable[Any]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(Point1a)
 
 # String field names (comma-separated also works at runtime)
-# error: [mismatched-type-name]
-Point2 = collections.namedtuple("Point", "x, y")
-reveal_type(Point2)  # revealed: <class 'Point'>
-# revealed: (<class 'Point'>, <class 'tuple[Any, Any]'>, <class 'Sequence[Any]'>, <class 'Reversible[Any]'>, <class 'Collection[Any]'>, <class 'Iterable[Any]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+Point2 = collections.namedtuple("Point2", "x, y")
+reveal_type(Point2)  # revealed: <class 'Point2'>
+# revealed: (<class 'Point2'>, <class 'tuple[Any, Any]'>, <class 'Sequence[Any]'>, <class 'Reversible[Any]'>, <class 'Collection[Any]'>, <class 'Iterable[Any]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(Point2)
 
 # List of strings
-# error: [mismatched-type-name]
-Point3 = collections.namedtuple("Point", ["x", "y"])
-reveal_type(Point3)  # revealed: <class 'Point'>
-# revealed: (<class 'Point'>, <class 'tuple[Any, Any]'>, <class 'Sequence[Any]'>, <class 'Reversible[Any]'>, <class 'Collection[Any]'>, <class 'Iterable[Any]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+Point3 = collections.namedtuple("Point3", ["x", "y"])
+reveal_type(Point3)  # revealed: <class 'Point3'>
+# revealed: (<class 'Point3'>, <class 'tuple[Any, Any]'>, <class 'Sequence[Any]'>, <class 'Reversible[Any]'>, <class 'Collection[Any]'>, <class 'Iterable[Any]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(Point3)
 
 # Tuple of strings
-# error: [mismatched-type-name]
-Point4 = collections.namedtuple("Point", ("x", "y"))
-reveal_type(Point4)  # revealed: <class 'Point'>
-# revealed: (<class 'Point'>, <class 'tuple[Any, Any]'>, <class 'Sequence[Any]'>, <class 'Reversible[Any]'>, <class 'Collection[Any]'>, <class 'Iterable[Any]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+Point4 = collections.namedtuple("Point4", ("x", "y"))
+reveal_type(Point4)  # revealed: <class 'Point4'>
+# revealed: (<class 'Point4'>, <class 'tuple[Any, Any]'>, <class 'Sequence[Any]'>, <class 'Reversible[Any]'>, <class 'Collection[Any]'>, <class 'Iterable[Any]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(Point4)
 # Invalid: integer is not a valid typename
 # error: [invalid-argument-type]
@@ -607,14 +598,12 @@ The `typing.NamedTuple` function accepts `Iterable[tuple[str, Any]]` for `fields
 from typing import NamedTuple
 
 # List of tuples
-# error: [mismatched-type-name]
-Person1 = NamedTuple("Person", [("name", str), ("age", int)])
-reveal_type(Person1)  # revealed: <class 'Person'>
+Person1 = NamedTuple("Person1", [("name", str), ("age", int)])
+reveal_type(Person1)  # revealed: <class 'Person1'>
 
 # Tuple of tuples
-# error: [mismatched-type-name]
-Person2 = NamedTuple("Person", (("name", str), ("age", int)))
-reveal_type(Person2)  # revealed: <class 'Person'>
+Person2 = NamedTuple("Person2", (("name", str), ("age", int)))
+reveal_type(Person2)  # revealed: <class 'Person2'>
 
 # Invalid: integer is not a valid typename
 # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -316,10 +316,12 @@ IntOrStr = TypeAliasType(get_name(), int | str)
 #### Name does not match variable
 
 ```py
+from typing import Union
 from typing_extensions import TypeAliasType
 
-# error: [invalid-type-alias-type] "The name of a `TypeAliasType` (`WrongName`) must match the name of the variable it is assigned to (`IntOrStr`)"
-IntOrStr = TypeAliasType("WrongName", int | str)
+# error: [mismatched-type-name] "The name passed to `TypeAliasType` must match the variable it is assigned to: Expected "IntOrStr", got "WrongName""
+IntOrStr = TypeAliasType("WrongName", Union[int, str])
+reveal_type(IntOrStr)  # revealed: TypeAliasType
 ```
 
 #### Not a simple variable assignment

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/enums.md_-_Enums_-_Function_syntax_-_Name_mismatch_diagno…_(9f5bdb1f7c5ad96a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/enums.md_-_Enums_-_Function_syntax_-_Name_mismatch_diagno…_(9f5bdb1f7c5ad96a).snap
@@ -1,0 +1,56 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: enums.md - Enums - Function syntax - Name mismatch diagnostics
+mdtest path: crates/ty_python_semantic/resources/mdtest/enums.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | from enum import Enum
+ 2 | 
+ 3 | # error: [mismatched-type-name]
+ 4 | Mismatch = Enum("WrongName", "A B")
+ 5 | 
+ 6 | def f(name: str) -> None:
+ 7 |     # error: [mismatched-type-name]
+ 8 |     DynamicMismatch = Enum(name, "A B")
+ 9 | 
+10 | name = "GoodMatch"
+11 | GoodMatch = Enum(name, "A B")
+```
+
+# Diagnostics
+
+```
+warning[mismatched-type-name]: The name passed to `Enum` must match the variable it is assigned to
+ --> src/mdtest_snippet.py:4:17
+  |
+3 | # error: [mismatched-type-name]
+4 | Mismatch = Enum("WrongName", "A B")
+  |                 ^^^^^^^^^^^ Expected "Mismatch", got "WrongName"
+5 |
+6 | def f(name: str) -> None:
+  |
+
+```
+
+```
+warning[mismatched-type-name]: The name passed to `Enum` must match the variable it is assigned to
+  --> src/mdtest_snippet.py:8:28
+   |
+ 6 | def f(name: str) -> None:
+ 7 |     # error: [mismatched-type-name]
+ 8 |     DynamicMismatch = Enum(name, "A B")
+   |                            ^^^^ Expected "DynamicMismatch", got variable of type `str`
+ 9 |
+10 | name = "GoodMatch"
+   |
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_`TypeVar`_parameter_…_(8424f2b8bc4351f9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_`TypeVar`_parameter_…_(8424f2b8bc4351f9).snap
@@ -15,19 +15,19 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typev
 ```
 1 | from typing import TypeVar
 2 | 
-3 | # error: [invalid-legacy-type-variable]
+3 | # error: [mismatched-type-name]
 4 | T = TypeVar("Q")
 ```
 
 # Diagnostics
 
 ```
-error[invalid-legacy-type-variable]: The name of a `TypeVar` (`Q`) must match the name of the variable it is assigned to (`T`)
- --> src/mdtest_snippet.py:4:1
+warning[mismatched-type-name]: The name passed to `TypeVar` must match the variable it is assigned to
+ --> src/mdtest_snippet.py:4:13
   |
-3 | # error: [invalid-legacy-type-variable]
+3 | # error: [mismatched-type-name]
 4 | T = TypeVar("Q")
-  | ^
+  |             ^^^ Expected "T", got "Q"
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_`typing.NamedTuple`_-_Name_mismatch_diagno…_(8ca723b970e370d0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_`typing.NamedTuple`_-_Name_mismatch_diagno…_(8ca723b970e370d0).snap
@@ -1,0 +1,38 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: named_tuple.md - `NamedTuple` - `typing.NamedTuple` - Name mismatch diagnostics
+mdtest path: crates/ty_python_semantic/resources/mdtest/named_tuple.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | from typing import NamedTuple
+2 | from ty_extensions import is_subtype_of
+3 | 
+4 | # error: [mismatched-type-name]
+5 | Mismatch = NamedTuple("WrongName", [("x", int)])
+6 | reveal_type(Mismatch)  # revealed: <class 'WrongName'>
+7 | reveal_type(is_subtype_of(Mismatch, tuple[int]))  # revealed: ConstraintSet[Literal[True]]
+```
+
+# Diagnostics
+
+```
+warning[mismatched-type-name]: The name passed to `NamedTuple` must match the variable it is assigned to
+ --> src/mdtest_snippet.py:5:23
+  |
+4 | # error: [mismatched-type-name]
+5 | Mismatch = NamedTuple("WrongName", [("x", int)])
+  |                       ^^^^^^^^^^^ Expected "Mismatch", got "WrongName"
+6 | reveal_type(Mismatch)  # revealed: <class 'WrongName'>
+7 | reveal_type(is_subtype_of(Mismatch, tuple[int]))  # revealed: ConstraintSet[Literal[True]]
+  |
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/new_types.md_-_NewType_-_The_assigned_name_sh…_(124f70124aebd214).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/new_types.md_-_NewType_-_The_assigned_name_sh…_(124f70124aebd214).snap
@@ -1,0 +1,56 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: new_types.md - NewType - The assigned name should match the constructor name
+mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | from typing_extensions import NewType
+ 2 | from ty_extensions import is_subtype_of
+ 3 | 
+ 4 | # error: [mismatched-type-name]
+ 5 | UserId = NewType("Id", int)
+ 6 | reveal_type(UserId)  # revealed: <NewType pseudo-class 'Id'>
+ 7 | reveal_type(is_subtype_of(UserId, int))  # revealed: ConstraintSet[Literal[True]]
+ 8 | 
+ 9 | Id = int
+10 | # error: [mismatched-type-name]
+11 | UsesExistingId = NewType("Id", "Id")
+12 | UsesExistingId(1)
+```
+
+# Diagnostics
+
+```
+warning[mismatched-type-name]: The name passed to `NewType` must match the variable it is assigned to
+ --> src/mdtest_snippet.py:5:18
+  |
+4 | # error: [mismatched-type-name]
+5 | UserId = NewType("Id", int)
+  |                  ^^^^ Expected "UserId", got "Id"
+6 | reveal_type(UserId)  # revealed: <NewType pseudo-class 'Id'>
+7 | reveal_type(is_subtype_of(UserId, int))  # revealed: ConstraintSet[Literal[True]]
+  |
+
+```
+
+```
+warning[mismatched-type-name]: The name passed to `NewType` must match the variable it is assigned to
+  --> src/mdtest_snippet.py:11:26
+   |
+ 9 | Id = int
+10 | # error: [mismatched-type-name]
+11 | UsesExistingId = NewType("Id", "Id")
+   |                          ^^^^ Expected "UsesExistingId", got "Id"
+12 | UsesExistingId(1)
+   |
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Function_syntax_with…_(4b18755412dfaff1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Function_syntax_with…_(4b18755412dfaff1).snap
@@ -22,92 +22,93 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/typed_dict.md
  7 | # error: [missing-argument] "No argument provided for required parameter `fields` of function `TypedDict`"
  8 | TypedDict("Foo")
  9 | 
-10 | # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "Bad1", got variable of type `Literal[123]`"
+10 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
 11 | Bad1 = TypedDict(123, {"name": str})
 12 | 
-13 | # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "BadTypedDict3", got "WrongName""
+13 | # error: [mismatched-type-name] "The name passed to `TypedDict` must match the variable it is assigned to: Expected "BadTypedDict3", got "WrongName""
 14 | BadTypedDict3 = TypedDict("WrongName", {"name": str})
-15 | 
-16 | def f(x: str) -> None:
-17 |     # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "Y", got variable of type `str`"
-18 |     Y = TypedDict(x, {})
-19 | 
-20 | def g(x: str) -> None:
-21 |     TypedDict(x, {})  # fine
-22 | 
-23 | name = "GoodTypedDict"
-24 | GoodTypedDict = TypedDict(name, {"name": str})
-25 | 
-26 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
-27 | Bad2 = TypedDict("Bad2", "not a dict")
-28 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
-29 | TypedDict("Bad2", "not a dict")
-30 | 
-31 | def get_fields() -> dict[str, object]:
-32 |     return {"name": str}
-33 | 
-34 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
-35 | Bad2b = TypedDict("Bad2b", get_fields())
-36 | 
-37 | # error: [invalid-argument-type] "Invalid argument to parameter `total` of `TypedDict()`"
-38 | Bad3 = TypedDict("Bad3", {"name": str}, total="not a bool")
-39 | 
-40 | # error: [invalid-argument-type] "Invalid argument to parameter `closed` of `TypedDict()`"
-41 | Bad4 = TypedDict("Bad4", {"name": str}, closed=123)
-42 | 
-43 | tup = ("foo", "bar")
-44 | kw = {"name": str}
-45 | 
-46 | # error: [invalid-argument-type] "Variadic positional arguments are not supported in `TypedDict()` calls"
-47 | Bad5 = TypedDict(*tup)
-48 | 
-49 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
-50 | Bad6 = TypedDict("Bad6", {"name": str}, **kw)
-51 | 
-52 | # error: [invalid-argument-type] "Variadic positional and keyword arguments are not supported in `TypedDict()` calls"
-53 | Bad7 = TypedDict(*tup, "foo", "bar", **kw)
-54 | 
-55 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
-56 | # error: [unknown-argument] "Argument `random_other_arg` does not match any known parameter of function `TypedDict`"
-57 | Bad7b = TypedDict("Bad7b", **kw, random_other_arg=56)
-58 | 
-59 | kwargs = {"x": int}
-60 | 
-61 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-62 | Bad8 = TypedDict("Bad8", {**kwargs})
-63 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-64 | TypedDict("Bad8", {**kwargs})
-65 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+15 | reveal_type(BadTypedDict3)  # revealed: <class 'WrongName'>
+16 | 
+17 | def f(x: str) -> None:
+18 |     # error: [mismatched-type-name] "The name passed to `TypedDict` must match the variable it is assigned to: Expected "Y", got variable of type `str`"
+19 |     Y = TypedDict(x, {})
+20 | 
+21 | def g(x: str) -> None:
+22 |     TypedDict(x, {})  # fine
+23 | 
+24 | name = "GoodTypedDict"
+25 | GoodTypedDict = TypedDict(name, {"name": str})
+26 | 
+27 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
+28 | Bad2 = TypedDict("Bad2", "not a dict")
+29 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
+30 | TypedDict("Bad2", "not a dict")
+31 | 
+32 | def get_fields() -> dict[str, object]:
+33 |     return {"name": str}
+34 | 
+35 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
+36 | Bad2b = TypedDict("Bad2b", get_fields())
+37 | 
+38 | # error: [invalid-argument-type] "Invalid argument to parameter `total` of `TypedDict()`"
+39 | Bad3 = TypedDict("Bad3", {"name": str}, total="not a bool")
+40 | 
+41 | # error: [invalid-argument-type] "Invalid argument to parameter `closed` of `TypedDict()`"
+42 | Bad4 = TypedDict("Bad4", {"name": str}, closed=123)
+43 | 
+44 | tup = ("foo", "bar")
+45 | kw = {"name": str}
+46 | 
+47 | # error: [invalid-argument-type] "Variadic positional arguments are not supported in `TypedDict()` calls"
+48 | Bad5 = TypedDict(*tup)
+49 | 
+50 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
+51 | Bad6 = TypedDict("Bad6", {"name": str}, **kw)
+52 | 
+53 | # error: [invalid-argument-type] "Variadic positional and keyword arguments are not supported in `TypedDict()` calls"
+54 | Bad7 = TypedDict(*tup, "foo", "bar", **kw)
+55 | 
+56 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
+57 | # error: [unknown-argument] "Argument `random_other_arg` does not match any known parameter of function `TypedDict`"
+58 | Bad7b = TypedDict("Bad7b", **kw, random_other_arg=56)
+59 | 
+60 | kwargs = {"x": int}
+61 | 
+62 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+63 | Bad8 = TypedDict("Bad8", {**kwargs})
+64 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+65 | TypedDict("Bad8", {**kwargs})
 66 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-67 | Bad81 = TypedDict("Bad81", {**kwargs, **kwargs})
-68 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+67 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+68 | Bad81 = TypedDict("Bad81", {**kwargs, **kwargs})
 69 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-70 | TypedDict("Bad81", {**kwargs, **kwargs})
-71 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-72 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-73 | Bad82 = TypedDict("Bad82", {**kwargs, "foo": []})
-74 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-75 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-76 | TypedDict("Bad82", {**kwargs, "foo": []})
-77 | 
-78 | def get_name() -> str:
-79 |     return "x"
-80 | 
-81 | name = get_name()
-82 | 
-83 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
-84 | Bad9 = TypedDict("Bad9", {name: int})
-85 | 
-86 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
-87 | # error: [invalid-type-form]
-88 | Bad10 = TypedDict("Bad10", {name: 42})
-89 | 
-90 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
-91 | # error: [invalid-type-form] "Int literals are not allowed in this context in a type expression"
-92 | class Bad11(TypedDict("Bad11", {name: 42})): ...
-93 | 
-94 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
-95 | class Bad12(TypedDict(123, {"field": int})): ...
+70 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+71 | TypedDict("Bad81", {**kwargs, **kwargs})
+72 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+73 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+74 | Bad82 = TypedDict("Bad82", {**kwargs, "foo": []})
+75 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+76 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+77 | TypedDict("Bad82", {**kwargs, "foo": []})
+78 | 
+79 | def get_name() -> str:
+80 |     return "x"
+81 | 
+82 | name = get_name()
+83 | 
+84 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+85 | Bad9 = TypedDict("Bad9", {name: int})
+86 | 
+87 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+88 | # error: [invalid-type-form]
+89 | Bad10 = TypedDict("Bad10", {name: 42})
+90 | 
+91 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+92 | # error: [invalid-type-form] "Int literals are not allowed in this context in a type expression"
+93 | class Bad11(TypedDict("Bad11", {name: 42})): ...
+94 | 
+95 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
+96 | class Bad12(TypedDict(123, {"field": int})): ...
 ```
 
 # Diagnostics
@@ -148,291 +149,290 @@ error[missing-argument]: No argument provided for required parameter `fields` of
  8 | TypedDict("Foo")
    | ^^^^^^^^^^^^^^^^
  9 |
-10 | # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "Bad1", got variable of type `Lit…
+10 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
    |
 
 ```
 
 ```
-error[invalid-argument-type]: TypedDict name must match the variable it is assigned to
+error[invalid-argument-type]: Invalid argument to parameter `typename` of `TypedDict()`
   --> src/mdtest_snippet.py:11:18
    |
-10 | # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "Bad1", got variable of type `Lit…
+10 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
 11 | Bad1 = TypedDict(123, {"name": str})
-   |                  ^^^ Expected "Bad1", got variable of type `Literal[123]`
+   |                  ^^^ Expected `str`, found `Literal[123]`
 12 |
-13 | # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "BadTypedDict3", got "WrongName""
+13 | # error: [mismatched-type-name] "The name passed to `TypedDict` must match the variable it is assigned to: Expected "BadTypedDict3", g…
    |
 
 ```
 
 ```
-error[invalid-argument-type]: TypedDict name must match the variable it is assigned to
+warning[mismatched-type-name]: The name passed to `TypedDict` must match the variable it is assigned to
   --> src/mdtest_snippet.py:14:27
    |
-13 | # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "BadTypedDict3", got "WrongName""
+13 | # error: [mismatched-type-name] "The name passed to `TypedDict` must match the variable it is assigned to: Expected "BadTypedDict3", g…
 14 | BadTypedDict3 = TypedDict("WrongName", {"name": str})
    |                           ^^^^^^^^^^^ Expected "BadTypedDict3", got "WrongName"
-15 |
-16 | def f(x: str) -> None:
+15 | reveal_type(BadTypedDict3)  # revealed: <class 'WrongName'>
    |
 
 ```
 
 ```
-error[invalid-argument-type]: TypedDict name must match the variable it is assigned to
-  --> src/mdtest_snippet.py:18:19
+warning[mismatched-type-name]: The name passed to `TypedDict` must match the variable it is assigned to
+  --> src/mdtest_snippet.py:19:19
    |
-16 | def f(x: str) -> None:
-17 |     # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "Y", got variable of type `st…
-18 |     Y = TypedDict(x, {})
+17 | def f(x: str) -> None:
+18 |     # error: [mismatched-type-name] "The name passed to `TypedDict` must match the variable it is assigned to: Expected "Y", got varia…
+19 |     Y = TypedDict(x, {})
    |                   ^ Expected "Y", got variable of type `str`
-19 |
-20 | def g(x: str) -> None:
+20 |
+21 | def g(x: str) -> None:
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Expected a dict literal for parameter `fields` of `TypedDict()`
-  --> src/mdtest_snippet.py:27:26
+  --> src/mdtest_snippet.py:28:26
    |
-26 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
-27 | Bad2 = TypedDict("Bad2", "not a dict")
+27 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
+28 | Bad2 = TypedDict("Bad2", "not a dict")
    |                          ^^^^^^^^^^^^
-28 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
-29 | TypedDict("Bad2", "not a dict")
+29 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
+30 | TypedDict("Bad2", "not a dict")
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Expected a dict literal for parameter `fields` of `TypedDict()`
-  --> src/mdtest_snippet.py:29:19
+  --> src/mdtest_snippet.py:30:19
    |
-27 | Bad2 = TypedDict("Bad2", "not a dict")
-28 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
-29 | TypedDict("Bad2", "not a dict")
+28 | Bad2 = TypedDict("Bad2", "not a dict")
+29 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
+30 | TypedDict("Bad2", "not a dict")
    |                   ^^^^^^^^^^^^
-30 |
-31 | def get_fields() -> dict[str, object]:
+31 |
+32 | def get_fields() -> dict[str, object]:
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Expected a dict literal for parameter `fields` of `TypedDict()`
-  --> src/mdtest_snippet.py:35:28
+  --> src/mdtest_snippet.py:36:28
    |
-34 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
-35 | Bad2b = TypedDict("Bad2b", get_fields())
+35 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
+36 | Bad2b = TypedDict("Bad2b", get_fields())
    |                            ^^^^^^^^^^^^
-36 |
-37 | # error: [invalid-argument-type] "Invalid argument to parameter `total` of `TypedDict()`"
+37 |
+38 | # error: [invalid-argument-type] "Invalid argument to parameter `total` of `TypedDict()`"
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Invalid argument to parameter `total` of `TypedDict()`
-  --> src/mdtest_snippet.py:38:47
+  --> src/mdtest_snippet.py:39:47
    |
-37 | # error: [invalid-argument-type] "Invalid argument to parameter `total` of `TypedDict()`"
-38 | Bad3 = TypedDict("Bad3", {"name": str}, total="not a bool")
+38 | # error: [invalid-argument-type] "Invalid argument to parameter `total` of `TypedDict()`"
+39 | Bad3 = TypedDict("Bad3", {"name": str}, total="not a bool")
    |                                               ^^^^^^^^^^^^ Expected either `True` or `False`, got object of type `Literal["not a bool"]`
-39 |
-40 | # error: [invalid-argument-type] "Invalid argument to parameter `closed` of `TypedDict()`"
+40 |
+41 | # error: [invalid-argument-type] "Invalid argument to parameter `closed` of `TypedDict()`"
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Invalid argument to parameter `closed` of `TypedDict()`
-  --> src/mdtest_snippet.py:41:48
+  --> src/mdtest_snippet.py:42:48
    |
-40 | # error: [invalid-argument-type] "Invalid argument to parameter `closed` of `TypedDict()`"
-41 | Bad4 = TypedDict("Bad4", {"name": str}, closed=123)
+41 | # error: [invalid-argument-type] "Invalid argument to parameter `closed` of `TypedDict()`"
+42 | Bad4 = TypedDict("Bad4", {"name": str}, closed=123)
    |                                                ^^^ Expected either `True` or `False`, got object of type `Literal[123]`
-42 |
-43 | tup = ("foo", "bar")
+43 |
+44 | tup = ("foo", "bar")
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Variadic positional arguments are not supported in `TypedDict()` calls
-  --> src/mdtest_snippet.py:47:18
+  --> src/mdtest_snippet.py:48:18
    |
-46 | # error: [invalid-argument-type] "Variadic positional arguments are not supported in `TypedDict()` calls"
-47 | Bad5 = TypedDict(*tup)
+47 | # error: [invalid-argument-type] "Variadic positional arguments are not supported in `TypedDict()` calls"
+48 | Bad5 = TypedDict(*tup)
    |                  ^^^^
-48 |
-49 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
+49 |
+50 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Variadic keyword arguments are not supported in `TypedDict()` calls
-  --> src/mdtest_snippet.py:50:41
+  --> src/mdtest_snippet.py:51:41
    |
-49 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
-50 | Bad6 = TypedDict("Bad6", {"name": str}, **kw)
+50 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
+51 | Bad6 = TypedDict("Bad6", {"name": str}, **kw)
    |                                         ^^^^
-51 |
-52 | # error: [invalid-argument-type] "Variadic positional and keyword arguments are not supported in `TypedDict()` calls"
+52 |
+53 | # error: [invalid-argument-type] "Variadic positional and keyword arguments are not supported in `TypedDict()` calls"
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Variadic positional and keyword arguments are not supported in `TypedDict()` calls
-  --> src/mdtest_snippet.py:53:18
+  --> src/mdtest_snippet.py:54:18
    |
-52 | # error: [invalid-argument-type] "Variadic positional and keyword arguments are not supported in `TypedDict()` calls"
-53 | Bad7 = TypedDict(*tup, "foo", "bar", **kw)
+53 | # error: [invalid-argument-type] "Variadic positional and keyword arguments are not supported in `TypedDict()` calls"
+54 | Bad7 = TypedDict(*tup, "foo", "bar", **kw)
    |                  ^^^^                ----
-54 |
-55 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
+55 |
+56 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Variadic keyword arguments are not supported in `TypedDict()` calls
-  --> src/mdtest_snippet.py:57:28
+  --> src/mdtest_snippet.py:58:28
    |
-55 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
-56 | # error: [unknown-argument] "Argument `random_other_arg` does not match any known parameter of function `TypedDict`"
-57 | Bad7b = TypedDict("Bad7b", **kw, random_other_arg=56)
+56 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
+57 | # error: [unknown-argument] "Argument `random_other_arg` does not match any known parameter of function `TypedDict`"
+58 | Bad7b = TypedDict("Bad7b", **kw, random_other_arg=56)
    |                            ^^^^
-58 |
-59 | kwargs = {"x": int}
+59 |
+60 | kwargs = {"x": int}
    |
 
 ```
 
 ```
 error[unknown-argument]: Argument `random_other_arg` does not match any known parameter of function `TypedDict`
-  --> src/mdtest_snippet.py:57:34
+  --> src/mdtest_snippet.py:58:34
    |
-55 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
-56 | # error: [unknown-argument] "Argument `random_other_arg` does not match any known parameter of function `TypedDict`"
-57 | Bad7b = TypedDict("Bad7b", **kw, random_other_arg=56)
+56 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
+57 | # error: [unknown-argument] "Argument `random_other_arg` does not match any known parameter of function `TypedDict`"
+58 | Bad7b = TypedDict("Bad7b", **kw, random_other_arg=56)
    |                                  ^^^^^^^^^^^^^^^^^^^
-58 |
-59 | kwargs = {"x": int}
+59 |
+60 | kwargs = {"x": int}
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
-  --> src/mdtest_snippet.py:62:29
+  --> src/mdtest_snippet.py:63:29
    |
-61 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-62 | Bad8 = TypedDict("Bad8", {**kwargs})
+62 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+63 | Bad8 = TypedDict("Bad8", {**kwargs})
    |                             ^^^^^^
-63 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-64 | TypedDict("Bad8", {**kwargs})
+64 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+65 | TypedDict("Bad8", {**kwargs})
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
-  --> src/mdtest_snippet.py:64:22
+  --> src/mdtest_snippet.py:65:22
    |
-62 | Bad8 = TypedDict("Bad8", {**kwargs})
-63 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-64 | TypedDict("Bad8", {**kwargs})
+63 | Bad8 = TypedDict("Bad8", {**kwargs})
+64 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+65 | TypedDict("Bad8", {**kwargs})
    |                      ^^^^^^
-65 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
 66 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+67 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
-  --> src/mdtest_snippet.py:67:31
+  --> src/mdtest_snippet.py:68:31
    |
-65 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
 66 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-67 | Bad81 = TypedDict("Bad81", {**kwargs, **kwargs})
+67 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+68 | Bad81 = TypedDict("Bad81", {**kwargs, **kwargs})
    |                               ^^^^^^
-68 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
 69 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+70 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
-  --> src/mdtest_snippet.py:67:41
+  --> src/mdtest_snippet.py:68:41
    |
-65 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
 66 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-67 | Bad81 = TypedDict("Bad81", {**kwargs, **kwargs})
+67 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+68 | Bad81 = TypedDict("Bad81", {**kwargs, **kwargs})
    |                                         ^^^^^^
-68 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
 69 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+70 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
-  --> src/mdtest_snippet.py:70:23
+  --> src/mdtest_snippet.py:71:23
    |
-68 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
 69 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-70 | TypedDict("Bad81", {**kwargs, **kwargs})
+70 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+71 | TypedDict("Bad81", {**kwargs, **kwargs})
    |                       ^^^^^^
-71 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-72 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+72 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+73 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
-  --> src/mdtest_snippet.py:70:33
+  --> src/mdtest_snippet.py:71:33
    |
-68 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
 69 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-70 | TypedDict("Bad81", {**kwargs, **kwargs})
+70 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+71 | TypedDict("Bad81", {**kwargs, **kwargs})
    |                                 ^^^^^^
-71 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-72 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+72 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+73 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
-  --> src/mdtest_snippet.py:73:31
+  --> src/mdtest_snippet.py:74:31
    |
-71 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-72 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-73 | Bad82 = TypedDict("Bad82", {**kwargs, "foo": []})
+72 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+73 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+74 | Bad82 = TypedDict("Bad82", {**kwargs, "foo": []})
    |                               ^^^^^^
-74 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-75 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+75 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+76 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
    |
 
 ```
 
 ```
 error[invalid-type-form]: List literals are not allowed in this context in a type expression
-  --> src/mdtest_snippet.py:73:46
+  --> src/mdtest_snippet.py:74:46
    |
-71 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-72 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-73 | Bad82 = TypedDict("Bad82", {**kwargs, "foo": []})
+72 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+73 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+74 | Bad82 = TypedDict("Bad82", {**kwargs, "foo": []})
    |                                              ^^
-74 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-75 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+75 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+76 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
    |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -441,28 +441,28 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 
 ```
 error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
-  --> src/mdtest_snippet.py:76:23
+  --> src/mdtest_snippet.py:77:23
    |
-74 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-75 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-76 | TypedDict("Bad82", {**kwargs, "foo": []})
+75 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+76 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+77 | TypedDict("Bad82", {**kwargs, "foo": []})
    |                       ^^^^^^
-77 |
-78 | def get_name() -> str:
+78 |
+79 | def get_name() -> str:
    |
 
 ```
 
 ```
 error[invalid-type-form]: List literals are not allowed in this context in a type expression
-  --> src/mdtest_snippet.py:76:38
+  --> src/mdtest_snippet.py:77:38
    |
-74 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-75 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-76 | TypedDict("Bad82", {**kwargs, "foo": []})
+75 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
+76 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+77 | TypedDict("Bad82", {**kwargs, "foo": []})
    |                                      ^^
-77 |
-78 | def get_name() -> str:
+78 |
+79 | def get_name() -> str:
    |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -471,41 +471,41 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 
 ```
 error[invalid-argument-type]: Expected a string-literal key in the `fields` dict of `TypedDict()`
-  --> src/mdtest_snippet.py:84:27
+  --> src/mdtest_snippet.py:85:27
    |
-83 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
-84 | Bad9 = TypedDict("Bad9", {name: int})
+84 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+85 | Bad9 = TypedDict("Bad9", {name: int})
    |                           ^^^^ Found `str`
-85 |
-86 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+86 |
+87 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
    |
 
 ```
 
 ```
 error[invalid-argument-type]: Expected a string-literal key in the `fields` dict of `TypedDict()`
-  --> src/mdtest_snippet.py:88:29
+  --> src/mdtest_snippet.py:89:29
    |
-86 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
-87 | # error: [invalid-type-form]
-88 | Bad10 = TypedDict("Bad10", {name: 42})
+87 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+88 | # error: [invalid-type-form]
+89 | Bad10 = TypedDict("Bad10", {name: 42})
    |                             ^^^^ Found `str`
-89 |
-90 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+90 |
+91 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
    |
 
 ```
 
 ```
 error[invalid-type-form]: Int literals are not allowed in this context in a type expression
-  --> src/mdtest_snippet.py:88:35
+  --> src/mdtest_snippet.py:89:35
    |
-86 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
-87 | # error: [invalid-type-form]
-88 | Bad10 = TypedDict("Bad10", {name: 42})
+87 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+88 | # error: [invalid-type-form]
+89 | Bad10 = TypedDict("Bad10", {name: 42})
    |                                   ^^ Did you mean `typing.Literal[42]`?
-89 |
-90 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+90 |
+91 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
    |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -514,28 +514,28 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 
 ```
 error[invalid-argument-type]: Expected a string-literal key in the `fields` dict of `TypedDict()`
-  --> src/mdtest_snippet.py:92:33
+  --> src/mdtest_snippet.py:93:33
    |
-90 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
-91 | # error: [invalid-type-form] "Int literals are not allowed in this context in a type expression"
-92 | class Bad11(TypedDict("Bad11", {name: 42})): ...
+91 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+92 | # error: [invalid-type-form] "Int literals are not allowed in this context in a type expression"
+93 | class Bad11(TypedDict("Bad11", {name: 42})): ...
    |                                 ^^^^ Found `str`
-93 |
-94 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
+94 |
+95 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
    |
 
 ```
 
 ```
 error[invalid-type-form]: Int literals are not allowed in this context in a type expression
-  --> src/mdtest_snippet.py:92:39
+  --> src/mdtest_snippet.py:93:39
    |
-90 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
-91 | # error: [invalid-type-form] "Int literals are not allowed in this context in a type expression"
-92 | class Bad11(TypedDict("Bad11", {name: 42})): ...
+91 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
+92 | # error: [invalid-type-form] "Int literals are not allowed in this context in a type expression"
+93 | class Bad11(TypedDict("Bad11", {name: 42})): ...
    |                                       ^^ Did you mean `typing.Literal[42]`?
-93 |
-94 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
+94 |
+95 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
    |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -544,10 +544,10 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 
 ```
 error[invalid-argument-type]: Invalid argument to parameter `typename` of `TypedDict()`
-  --> src/mdtest_snippet.py:95:23
+  --> src/mdtest_snippet.py:96:23
    |
-94 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
-95 | class Bad12(TypedDict(123, {"field": int})): ...
+95 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
+96 | class Bad12(TypedDict(123, {"field": int})): ...
    |                       ^^^ Expected `str`, found `Literal[123]`
    |
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Shadowing_checks_use…_(7e6bb178099059fe).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Shadowing_checks_use…_(7e6bb178099059fe).snap
@@ -1,0 +1,80 @@
+---
+source: crates/ty_test/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: variables.md - Legacy type variables - Type variables - Shadowing checks use the binding name
+mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+ 1 | from typing import Generic, TypeVar
+ 2 | 
+ 3 | S = TypeVar("S")
+ 4 | T = TypeVar("T")
+ 5 | 
+ 6 | # This recovers as the `Q` binding for source-level name resolution.
+ 7 | # error: [mismatched-type-name]
+ 8 | Q = TypeVar("T")
+ 9 | 
+10 | class Outer(Generic[Q]):
+11 |     class Ok(Generic[S]): ...
+12 |     # error: [shadowed-type-variable]
+13 |     # error: [shadowed-type-variable]
+14 |     class Bad(Generic[Q]): ...
+```
+
+# Diagnostics
+
+```
+warning[mismatched-type-name]: The name passed to `TypeVar` must match the variable it is assigned to
+  --> src/mdtest_snippet.py:8:13
+   |
+ 6 | # This recovers as the `Q` binding for source-level name resolution.
+ 7 | # error: [mismatched-type-name]
+ 8 | Q = TypeVar("T")
+   |             ^^^ Expected "Q", got "T"
+ 9 |
+10 | class Outer(Generic[Q]):
+   |
+
+```
+
+```
+error[shadowed-type-variable]: Generic class `Bad` uses type variable `Q` already bound by an enclosing scope
+  --> src/mdtest_snippet.py:10:7
+   |
+ 8 | Q = TypeVar("T")
+ 9 |
+10 | class Outer(Generic[Q]):
+   |       ----------------- Type variable `Q` is bound in this enclosing scope
+11 |     class Ok(Generic[S]): ...
+12 |     # error: [shadowed-type-variable]
+13 |     # error: [shadowed-type-variable]
+14 |     class Bad(Generic[Q]): ...
+   |           ^^^^^^^^^^^^^^^ `Q` used in class definition here
+   |
+
+```
+
+```
+error[shadowed-type-variable]: Generic class `Bad` uses type variable `Q` already bound by an enclosing scope
+  --> src/mdtest_snippet.py:10:7
+   |
+ 8 | Q = TypeVar("T")
+ 9 |
+10 | class Outer(Generic[Q]):
+   |       ----------------- Type variable `Q` is bound in this enclosing scope
+11 |     class Ok(Generic[S]): ...
+12 |     # error: [shadowed-type-variable]
+13 |     # error: [shadowed-type-variable]
+14 |     class Bad(Generic[Q]): ...
+   |           ^^^^^^^^^^^^^^^ `Q` used in class definition here
+   |
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2848,14 +2848,15 @@ TypedDict()
 # error: [missing-argument] "No argument provided for required parameter `fields` of function `TypedDict`"
 TypedDict("Foo")
 
-# error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "Bad1", got variable of type `Literal[123]`"
+# error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
 Bad1 = TypedDict(123, {"name": str})
 
-# error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "BadTypedDict3", got "WrongName""
+# error: [mismatched-type-name] "The name passed to `TypedDict` must match the variable it is assigned to: Expected "BadTypedDict3", got "WrongName""
 BadTypedDict3 = TypedDict("WrongName", {"name": str})
+reveal_type(BadTypedDict3)  # revealed: <class 'WrongName'>
 
 def f(x: str) -> None:
-    # error: [invalid-argument-type] "TypedDict name must match the variable it is assigned to: Expected "Y", got variable of type `str`"
+    # error: [mismatched-type-name] "The name passed to `TypedDict` must match the variable it is assigned to: Expected "Y", got variable of type `str`"
     Y = TypedDict(x, {})
 
 def g(x: str) -> None:

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -91,6 +91,7 @@ pub(crate) fn register_lints(registry: &mut LintRegistryBuilder) {
     registry.register_lint(&INVALID_PARAMSPEC);
     registry.register_lint(&INVALID_TYPE_ALIAS_TYPE);
     registry.register_lint(&INVALID_NEWTYPE);
+    registry.register_lint(&MISMATCHED_TYPE_NAME);
     registry.register_lint(&INVALID_METACLASS);
     registry.register_lint(&INVALID_OVERLOAD);
     registry.register_lint(&USELESS_OVERLOAD_BODY);
@@ -1456,6 +1457,37 @@ declare_lint! {
         summary: "detects invalid NewType definitions",
         status: LintStatus::stable("0.0.1-alpha.27"),
         default_level: Level::Error,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Checks for functional typing definitions whose declared name does not match
+    /// the variable they are assigned to.
+    ///
+    /// ## Why is this bad?
+    /// Constructors like `TypeVar`, `ParamSpec`, `NewType`, `NamedTuple`,
+    /// `TypedDict`, and `TypeAliasType` all take a name argument that is
+    /// normally expected to match the assigned variable. A mismatch is usually a
+    /// typo and makes later diagnostics harder to understand.
+    ///
+    /// ## Default level
+    /// This rule is a warning by default because ty can usually recover and
+    /// continue understanding the resulting type.
+    ///
+    /// ## Examples
+    /// ```python
+    /// from typing import NewType, TypeVar
+    /// from typing_extensions import TypedDict
+    ///
+    /// T = TypeVar("U")  # error: [mismatched-type-name]
+    /// UserId = NewType("Id", int)  # error: [mismatched-type-name]
+    /// Movie = TypedDict("Film", {"title": str})  # error: [mismatched-type-name]
+    /// ```
+    pub(crate) static MISMATCHED_TYPE_NAME = {
+        summary: "detects functional typing definitions whose declared name does not match the assigned variable",
+        status: LintStatus::stable("0.0.30"),
+        default_level: Level::Warn,
     }
 }
 
@@ -3329,6 +3361,31 @@ declare_lint! {
 pub struct TypeCheckDiagnostics {
     diagnostics: Vec<Diagnostic>,
     used_suppressions: FxHashSet<FileSuppressionId>,
+}
+
+pub(crate) fn report_mismatched_type_name<'db>(
+    context: &InferContext<'db, '_>,
+    node: impl Ranged,
+    constructor: &str,
+    expected_name: &str,
+    actual_name: Option<&str>,
+    actual_name_ty: Type<'db>,
+) {
+    if let Some(builder) = context.report_lint(&MISMATCHED_TYPE_NAME, node) {
+        let mut diagnostic = builder.into_diagnostic(format_args!(
+            "The name passed to `{constructor}` must match the variable it is assigned to"
+        ));
+        if let Some(actual_name) = actual_name {
+            diagnostic.set_primary_message(format_args!(
+                "Expected \"{expected_name}\", got \"{actual_name}\""
+            ));
+        } else {
+            diagnostic.set_primary_message(format_args!(
+                "Expected \"{expected_name}\", got variable of type `{}`",
+                actual_name_ty.display(context.db())
+            ));
+        }
+    }
 }
 
 impl TypeCheckDiagnostics {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -78,9 +78,9 @@ use crate::types::diagnostic::{
     report_invalid_generator_yield_type, report_invalid_key_on_typed_dict,
     report_invalid_type_checking_constant,
     report_match_pattern_against_non_runtime_checkable_protocol,
-    report_match_pattern_against_typed_dict, report_possibly_missing_attribute,
-    report_possibly_unresolved_reference, report_unsupported_augmented_assignment,
-    report_unsupported_comparison,
+    report_match_pattern_against_typed_dict, report_mismatched_type_name,
+    report_possibly_missing_attribute, report_possibly_unresolved_reference,
+    report_unsupported_augmented_assignment, report_unsupported_comparison,
 };
 use crate::types::enums::{enum_ignored_names, is_enum_class_by_inheritance};
 use crate::types::function::{
@@ -3268,13 +3268,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         if name != target_name {
-            return error(
+            report_mismatched_type_name(
                 &self.context,
-                format_args!(
-                    "The name of a `NewType` (`{name}`) must match \
-                    the name of the variable it is assigned to (`{target_name}`)"
-                ),
-                target,
+                &arguments.args[0],
+                "NewType",
+                target_name,
+                Some(name),
+                name_param_ty,
             );
         }
 
@@ -3516,13 +3516,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         if name != target_name {
-            return error(
+            report_mismatched_type_name(
                 &self.context,
-                format_args!(
-                    "The name of a `TypeAliasType` (`{name}`) must match \
-                    the name of the variable it is assigned to (`{target_name}`)"
-                ),
-                target,
+                &arguments.args[0],
+                "TypeAliasType",
+                target_name,
+                Some(name),
+                name_param_ty,
             );
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
@@ -11,7 +11,7 @@ use crate::{
         constraints::ConstraintSetBuilder,
         diagnostic::{
             INVALID_ARGUMENT_TYPE, INVALID_BASE, PARAMETER_ALREADY_ASSIGNED,
-            TOO_MANY_POSITIONAL_ARGUMENTS, UNKNOWN_ARGUMENT,
+            TOO_MANY_POSITIONAL_ARGUMENTS, UNKNOWN_ARGUMENT, report_mismatched_type_name,
         },
         infer::TypeInferenceBuilder,
         infer::builder::dynamic_class::report_mro_error_kind,
@@ -393,6 +393,26 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         // Without `names`, this is a value-lookup call, not functional enum creation.
         let names_arg = names_arg?;
+        let name_ty = self.expression_type(name_arg);
+        let name = name_ty
+            .as_string_literal()
+            .map(|name_literal| Name::new(name_literal.value(db)));
+
+        if (name.is_some() || name_ty.is_assignable_to(db, KnownClass::Str.to_instance(db)))
+            && let Some(definition) = definition
+            && let Some(assigned_name) = definition.name(db)
+            && Some(assigned_name.as_str()) != name.as_deref()
+        {
+            report_mismatched_type_name(
+                &self.context,
+                name_arg,
+                base_name,
+                &assigned_name,
+                name.as_deref(),
+                name_ty,
+            );
+        }
+
         let spec = self.infer_enum_spec(
             names_arg,
             start,

--- a/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
@@ -10,6 +10,7 @@ use crate::{
         diagnostic::{
             INVALID_ARGUMENT_TYPE, INVALID_NAMED_TUPLE, MISSING_ARGUMENT,
             PARAMETER_ALREADY_ASSIGNED, TOO_MANY_POSITIONAL_ARGUMENTS, UNKNOWN_ARGUMENT,
+            report_mismatched_type_name,
         },
         extract_fixed_length_iterable_element_types,
         function::KnownFunction,
@@ -312,23 +313,37 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
 
         // Extract name.
-        let name = if let Some(literal) = name_type.as_string_literal() {
-            Name::new(literal.value(db))
-        } else {
-            // Name is not a string literal; use <unknown> like we do for type() calls.
-            if !name_type.is_assignable_to(db, KnownClass::Str.to_instance(db))
-                && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, name_arg)
-            {
-                let mut diagnostic = builder.into_diagnostic(format_args!(
-                    "Invalid argument to parameter `typename` of `{kind}()`"
-                ));
-                diagnostic.set_primary_message(format_args!(
-                    "Expected `str`, found `{}`",
-                    name_type.display(db)
-                ));
-            }
-            Name::new_static("<unknown>")
-        };
+        let name = name_type
+            .as_string_literal()
+            .map(|literal| Name::new(literal.value(db)));
+
+        if name.is_none()
+            && !name_type.is_assignable_to(db, KnownClass::Str.to_instance(db))
+            && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, name_arg)
+        {
+            let mut diagnostic = builder.into_diagnostic(format_args!(
+                "Invalid argument to parameter `typename` of `{kind}()`"
+            ));
+            diagnostic.set_primary_message(format_args!(
+                "Expected `str`, found `{}`",
+                name_type.display(db)
+            ));
+        } else if let Some(actual_name) = name.as_deref()
+            && let Some(definition) = definition
+            && let Some(assigned_name) = definition.name(db)
+            && assigned_name.as_str() != actual_name
+        {
+            report_mismatched_type_name(
+                &self.context,
+                name_arg,
+                &kind.to_string(),
+                &assigned_name,
+                Some(actual_name),
+                name_type,
+            );
+        }
+
+        let name = name.unwrap_or_else(|| Name::new_static("<unknown>"));
 
         // Handle fields based on which namedtuple variant.
         let anchor = match definition {

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -10,7 +10,7 @@ use crate::semantic_index::definition::Definition;
 use crate::types::class::{ClassLiteral, DynamicTypedDictAnchor, DynamicTypedDictLiteral};
 use crate::types::diagnostic::{
     INVALID_ARGUMENT_TYPE, INVALID_TYPE_FORM, MISSING_ARGUMENT, TOO_MANY_POSITIONAL_ARGUMENTS,
-    UNKNOWN_ARGUMENT,
+    UNKNOWN_ARGUMENT, report_mismatched_type_name,
 };
 use crate::types::infer::builder::DeferredExpressionState;
 use crate::types::special_form::TypeQualifier;
@@ -197,24 +197,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .as_string_literal()
             .map(|literal| Name::new(literal.value(db)));
 
-        if let Some(definition) = definition
-            && let Some(assigned_name) = definition.name(db)
-            && Some(assigned_name.as_str()) != name.as_deref()
-            && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, name_arg)
-        {
-            let mut diagnostic =
-                builder.into_diagnostic("TypedDict name must match the variable it is assigned to");
-            if let Some(name) = name.as_deref() {
-                diagnostic.set_primary_message(format_args!(
-                    "Expected \"{assigned_name}\", got \"{name}\""
-                ));
-            } else {
-                diagnostic.set_primary_message(format_args!(
-                    "Expected \"{assigned_name}\", got variable of type `{}`",
-                    name_type.display(db)
-                ));
-            }
-        } else if name.is_none()
+        if name.is_none()
             && !name_type.is_assignable_to(db, KnownClass::Str.to_instance(db))
             && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, name_arg)
         {
@@ -225,6 +208,18 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 "Expected `str`, found `{}`",
                 name_type.display(db)
             ));
+        } else if let Some(definition) = definition
+            && let Some(assigned_name) = definition.name(db)
+            && Some(assigned_name.as_str()) != name.as_deref()
+        {
+            report_mismatched_type_name(
+                &self.context,
+                name_arg,
+                "TypedDict",
+                &assigned_name,
+                name.as_deref(),
+                name_type,
+            );
         }
 
         let name = name.unwrap_or_else(|| Name::new_static("<unknown>"));

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -807,25 +807,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         if name_param != target_name {
-            if let Some(name_param_node) = name_param_node {
-                report_mismatched_type_name(
-                    &self.context,
-                    name_param_node,
-                    "ParamSpec",
-                    target_name,
-                    Some(name_param),
-                    name_param_ty,
-                );
-            } else {
-                report_mismatched_type_name(
-                    &self.context,
-                    call_expr,
-                    "ParamSpec",
-                    target_name,
-                    Some(name_param),
-                    name_param_ty,
-                );
-            }
+            report_mismatched_type_name(
+                &self.context,
+                name_param_node
+                    .map(Ranged::range)
+                    .unwrap_or_else(|| call_expr.range()),
+                "ParamSpec",
+                target_name,
+                Some(name_param),
+                name_param_ty,
+            );
         }
 
         if default.is_some() {
@@ -1042,25 +1033,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         if name_param != target_name {
-            if let Some(name_param_node) = name_param_node {
-                report_mismatched_type_name(
-                    &self.context,
-                    name_param_node,
-                    "TypeVar",
-                    target_name,
-                    Some(name_param),
-                    name_param_ty,
-                );
-            } else {
-                report_mismatched_type_name(
-                    &self.context,
-                    call_expr,
-                    "TypeVar",
-                    target_name,
-                    Some(name_param),
-                    name_param_ty,
-                );
-            }
+            report_mismatched_type_name(
+                &self.context,
+                name_param_node
+                    .map(Ranged::range)
+                    .unwrap_or_else(|| call_expr.range()),
+                "TypeVar",
+                target_name,
+                Some(name_param),
+                name_param_ty,
+            );
         }
 
         // Inference of bounds, constraints, and defaults must be deferred, to avoid cycles. So we

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -8,6 +8,7 @@ use crate::{
         diagnostic::{
             INVALID_LEGACY_TYPE_VARIABLE, INVALID_PARAMSPEC, INVALID_TYPE_VARIABLE_BOUND,
             INVALID_TYPE_VARIABLE_CONSTRAINTS, INVALID_TYPE_VARIABLE_DEFAULT,
+            report_mismatched_type_name,
         },
         infer::{
             InferenceFlags, TypeInferenceBuilder,
@@ -698,6 +699,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let mut default = None;
         let mut name_param_ty = None;
+        let mut name_param_node = None;
 
         if arguments.args.len() > 1 {
             return error(
@@ -734,6 +736,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             kwarg,
                         );
                     }
+                    name_param_node = Some(&kwarg.value);
                     name_param_ty =
                         Some(self.infer_expression(&kwarg.value, TypeContext::default()));
                 }
@@ -790,6 +793,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 call_expr,
             );
         };
+        let name_param_node = name_param_node.or_else(|| arguments.find_positional(0));
 
         let ast::Expr::Name(ast::ExprName {
             id: target_name, ..
@@ -803,22 +807,37 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         if name_param != target_name {
-            return error(
-                &self.context,
-                format_args!(
-                    "The name of a `ParamSpec` (`{name_param}`) must match \
-                    the name of the variable it is assigned to (`{target_name}`)"
-                ),
-                target,
-            );
+            if let Some(name_param_node) = name_param_node {
+                report_mismatched_type_name(
+                    &self.context,
+                    name_param_node,
+                    "ParamSpec",
+                    target_name,
+                    Some(name_param),
+                    name_param_ty,
+                );
+            } else {
+                report_mismatched_type_name(
+                    &self.context,
+                    call_expr,
+                    "ParamSpec",
+                    target_name,
+                    Some(name_param),
+                    name_param_ty,
+                );
+            }
         }
 
         if default.is_some() {
             self.deferred.insert(definition);
         }
 
-        let identity =
-            TypeVarIdentity::new(db, target_name, Some(definition), TypeVarKind::ParamSpec);
+        let identity = TypeVarIdentity::new(
+            db,
+            target_name.clone(),
+            Some(definition),
+            TypeVarKind::ParamSpec,
+        );
         Type::KnownInstance(KnownInstanceType::TypeVar(TypeVarInstance::new(
             db, identity, None, None, default,
         )))
@@ -857,6 +876,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut covariant = false;
         let mut contravariant = false;
         let mut name_param_ty = None;
+        let mut name_param_node = None;
 
         if let Some(starred) = arguments.args.iter().find(|arg| arg.is_starred_expr()) {
             return error(
@@ -885,6 +905,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             kwarg,
                         );
                     }
+                    name_param_node = Some(&kwarg.value);
                     name_param_ty =
                         Some(self.infer_expression(&kwarg.value, TypeContext::default()));
                 }
@@ -1007,6 +1028,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 call_expr,
             );
         };
+        let name_param_node = name_param_node.or_else(|| arguments.find_positional(0));
 
         let ast::Expr::Name(ast::ExprName {
             id: target_name, ..
@@ -1020,14 +1042,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         if name_param != target_name {
-            return error(
-                &self.context,
-                format_args!(
-                    "The name of a `TypeVar` (`{name_param}`) must match \
-                    the name of the variable it is assigned to (`{target_name}`)"
-                ),
-                target,
-            );
+            if let Some(name_param_node) = name_param_node {
+                report_mismatched_type_name(
+                    &self.context,
+                    name_param_node,
+                    "TypeVar",
+                    target_name,
+                    Some(name_param),
+                    name_param_ty,
+                );
+            } else {
+                report_mismatched_type_name(
+                    &self.context,
+                    call_expr,
+                    "TypeVar",
+                    target_name,
+                    Some(name_param),
+                    name_param_ty,
+                );
+            }
         }
 
         // Inference of bounds, constraints, and defaults must be deferred, to avoid cycles. So we
@@ -1059,7 +1092,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.deferred.insert(definition);
         }
 
-        let identity = TypeVarIdentity::new(db, target_name, Some(definition), TypeVarKind::Legacy);
+        let identity = TypeVarIdentity::new(
+            db,
+            target_name.clone(),
+            Some(definition),
+            TypeVarKind::Legacy,
+        );
         Type::KnownInstance(KnownInstanceType::TypeVar(TypeVarInstance::new(
             db,
             identity,

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -499,6 +499,7 @@ def collect_ty_diagnostics(
             "--ignore=assert-type-unspellable-subtype",
             "--error=invalid-enum-member-annotation",
             "--error=invalid-legacy-positional-parameter",
+            "--error=mismatched-type-name",
             "--error=deprecated",
             "--error=redundant-final-classvar",
             "--exit-zero",

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -1070,6 +1070,16 @@
             }
           ]
         },
+        "mismatched-type-name": {
+          "title": "detects functional typing definitions whose declared name does not match the assigned variable",
+          "description": "## What it does\nChecks for functional typing definitions whose declared name does not match\nthe variable they are assigned to.\n\n## Why is this bad?\nConstructors like `TypeVar`, `ParamSpec`, `NewType`, `NamedTuple`,\n`TypedDict`, and `TypeAliasType` all take a name argument that is\nnormally expected to match the assigned variable. A mismatch is usually a\ntypo and makes later diagnostics harder to understand.\n\n## Default level\nThis rule is a warning by default because ty can usually recover and\ncontinue understanding the resulting type.\n\n## Examples\n```python\nfrom typing import NewType, TypeVar\nfrom typing_extensions import TypedDict\n\nT = TypeVar(\"U\")  # error: [mismatched-type-name]\nUserId = NewType(\"Id\", int)  # error: [mismatched-type-name]\nMovie = TypedDict(\"Film\", {\"title\": str})  # error: [mismatched-type-name]\n```",
+          "default": "warn",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Level"
+            }
+          ]
+        },
         "missing-argument": {
           "title": "detects missing required arguments in a call",
           "description": "## What it does\nChecks for missing required arguments in a call.\n\n## Why is this bad?\nFailing to provide a required argument will raise a `TypeError` at runtime.\n\n## Examples\n```python\ndef func(x: int): ...\nfunc()  # TypeError: func() missing 1 required positional argument: 'x'\n```",


### PR DESCRIPTION
## Summary

We now use the same error code for all of these, with the same range, and it's a warning by default:
```python
N = NamedTuple("O", [])
TD = TypedDict("TE", {})
T = TypeVar("U")
P = ParamSpec("Q")
NT = NewType("N", int)
```

It also implements more graceful recovery for `TypeVar`, `TypeAliasType`, `ParamSpec`, and `NewType`.

Closes https://github.com/astral-sh/ty/issues/3255.
