### PR TITLE
Fix PLC2701 for type parameter scopes

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/import_private_name/submodule/__main__.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/import_private_name/submodule/__main__.py
@@ -45,4 +45,8 @@ class Class:
     def __init__(self, arg: vv) -> "zz":
         pass
 
+
+def generic[T: _nn](arg: T) -> T:
+    return arg
+
 from foo.    _bar import baz

--- a/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
@@ -166,10 +166,7 @@ pub(crate) fn import_private_name(checker: &Checker, scope: &Scope) {
 
 /// Returns `true` if the [`ResolvedReference`] is in a typing context.
 fn is_typing(reference: &ResolvedReference) -> bool {
-    reference.in_type_checking_block()
-        || reference.in_typing_only_annotation()
-        || reference.in_string_type_definition()
-        || reference.in_runtime_evaluated_annotation()
+    reference.in_typing_context() || reference.in_runtime_evaluated_annotation()
 }
 
 #[expect(clippy::struct_field_names)]

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC2701_import_private_name__submodule____main__.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC2701_import_private_name__submodule____main__.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
+assertion_line: 256
 ---
 PLC2701 Private name import `_a`
  --> __main__.py:2:6
@@ -77,10 +78,10 @@ PLC2701 Private name import `_ddd` from external module `bbb.ccc`
    |
 
 PLC2701 Private name import `_bar` from external module `foo`
-  --> __main__.py:48:14
+  --> __main__.py:52:14
    |
-46 |         pass
-47 |
-48 | from foo.    _bar import baz
+50 |     return arg
+51 |
+52 | from foo.    _bar import baz
    |              ^^^^
    |


### PR DESCRIPTION
Fixes #24563.

Ruff was treating private-name usage in PEP 695 type parameter lists as runtime code, which triggered PLC2701 false positives. This patch extends the typing-context check so private imports used only in type parameter scopes are exempt, and adds a regression case for a generic function with a private type parameter bound.
