### PR TITLE
Update Neovim config examples to use `vim.lsp.config`

### DIFF
--- a/docs/editors/settings.md
+++ b/docs/editors/settings.md
@@ -64,13 +64,13 @@ _Using configuration file path:_
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           configuration = "~/path/to/ruff.toml"
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -117,7 +117,7 @@ _Using inline configuration:_
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           configuration = {
@@ -138,7 +138,7 @@ _Using inline configuration:_
           }
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -199,13 +199,13 @@ configuration is prioritized over `ruff.toml` and `pyproject.toml` files.
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           configurationPreference = "filesystemFirst"
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -246,13 +246,13 @@ documentation](https://docs.astral.sh/ruff/settings/#exclude) for more details.
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           exclude = ["**/tests/**"]
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -292,13 +292,13 @@ The line length to use for the linter and formatter.
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           lineLength = 100
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -338,13 +338,13 @@ Whether to register the server as capable of handling `source.fixAll` code actio
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           fixAll = false
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -384,13 +384,13 @@ Whether to register the server as capable of handling `source.organizeImports` c
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           organizeImports = false
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -432,13 +432,13 @@ Whether to show syntax error diagnostics.
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           showSyntaxErrors = false
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -478,13 +478,13 @@ The log level to use for the server.
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           logLevel = "debug"
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -526,13 +526,13 @@ If not set, logs will be written to stderr.
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           logFile = "~/path/to/ruff.log"
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -576,7 +576,7 @@ Whether to display Quick Fix actions to disable rules via `noqa` suppression com
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           codeAction = {
@@ -586,7 +586,7 @@ Whether to display Quick Fix actions to disable rules via `noqa` suppression com
           }
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -630,7 +630,7 @@ Whether to display Quick Fix actions to autofix violations.
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           codeAction = {
@@ -640,7 +640,7 @@ Whether to display Quick Fix actions to autofix violations.
           }
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -688,7 +688,7 @@ Whether to enable linting. Set to `false` to use Ruff exclusively as a formatter
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           lint = {
@@ -696,7 +696,7 @@ Whether to enable linting. Set to `false` to use Ruff exclusively as a formatter
           }
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -738,7 +738,7 @@ Whether to enable Ruff's preview mode when linting.
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           lint = {
@@ -746,7 +746,7 @@ Whether to enable Ruff's preview mode when linting.
           }
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -788,7 +788,7 @@ Rules to enable by default. See [the documentation](https://docs.astral.sh/ruff/
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           lint = {
@@ -796,7 +796,7 @@ Rules to enable by default. See [the documentation](https://docs.astral.sh/ruff/
           }
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -838,7 +838,7 @@ Rules to enable in addition to those in [`lint.select`](#select).
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           lint = {
@@ -846,7 +846,7 @@ Rules to enable in addition to those in [`lint.select`](#select).
           }
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -888,7 +888,7 @@ Rules to disable by default. See [the documentation](https://docs.astral.sh/ruff
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           lint = {
@@ -896,7 +896,7 @@ Rules to disable by default. See [the documentation](https://docs.astral.sh/ruff
           }
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -942,7 +942,7 @@ Whether to enable Ruff's preview mode when formatting.
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           format = {
@@ -950,7 +950,7 @@ Whether to enable Ruff's preview mode when formatting.
           }
         }
       }
-    }
+    })
     ```
 
 === "Zed"
@@ -998,7 +998,7 @@ formatter version may differ.
 === "Neovim"
 
     ```lua
-    require('lspconfig').ruff.setup {
+    vim.lsp.config('ruff', {
       init_options = {
         settings = {
           format = {
@@ -1006,7 +1006,7 @@ formatter version may differ.
           }
         }
       }
-    }
+    })
     ```
 
 === "Zed"

--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -31,10 +31,10 @@ For more documentation on the Ruff extension, refer to the
 ## Neovim
 
 The Ruff language server can be setup in Neovim using the built-in LSP client either via
-[`vim.lsp.config`](https://neovim.io/doc/user/lsp.html#vim.lsp.config()) (Neovim 0.11+) or the
+[`vim.lsp.config`](<https://neovim.io/doc/user/lsp.html#vim.lsp.config()>) (Neovim 0.11+) or the
 [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) plugin (Neovim 0.10 and earlier).
 
-To setup using [`vim.lsp.config`](https://neovim.io/doc/user/lsp.html#vim.lsp.config()), you can
+To setup using [`vim.lsp.config`](<https://neovim.io/doc/user/lsp.html#vim.lsp.config()>), you can
 either use the [default configuration provided in
 `nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/blob/master/lsp/ruff.lua) or configure
 the server without any external dependencies.
@@ -84,7 +84,7 @@ the server without any external dependencies.
         [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) has
         [deprecated](https://github.com/neovim/nvim-lspconfig/issues/3693) support for Neovim 0.10
         and earlier in favor of using
-        [`vim.lsp.config`](https://neovim.io/doc/user/lsp.html#vim.lsp.config()) instead.
+        [`vim.lsp.config`](<https://neovim.io/doc/user/lsp.html#vim.lsp.config()>) instead.
 
     ```lua
     require('lspconfig').ruff.setup({

--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -30,23 +30,15 @@ For more documentation on the Ruff extension, refer to the
 
 ## Neovim
 
-The [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) plugin can be used to configure the
-Ruff Language Server in Neovim. To set it up, install
-[`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) plugin, set it up as per the
-[configuration](https://github.com/neovim/nvim-lspconfig#configuration) documentation, and add the
-following to your `init.lua`:
+Neovim 0.11+ requires no external dependencies to
+configure the Ruff Language Server. The [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig)
+plugin can still be used to provide a [default configuration](https://github.com/neovim/nvim-lspconfig/blob/master/lsp/ruff.lua).
 
-=== "Neovim 0.10 (with [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig))"
+If using Neovim < 0.11, the [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) plugin
+can be used to configure the Ruff Language Server.
 
-    ```lua
-    require('lspconfig').ruff.setup({
-      init_options = {
-        settings = {
-          -- Ruff language server settings go here
-        }
-      }
-    })
-    ```
+To set it up, install the [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) plugin
+and add the following to your `init.lua`:
 
 === "Neovim 0.11+ (with [`vim.lsp.config`](https://neovim.io/doc/user/lsp.html#vim.lsp.config()))"
 
@@ -60,6 +52,18 @@ following to your `init.lua`:
     })
 
     vim.lsp.enable('ruff')
+    ```
+
+=== "Neovim 0.10 (with [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig))"
+
+    ```lua
+    require('lspconfig').ruff.setup({
+      init_options = {
+        settings = {
+          -- Ruff language server settings go here
+        }
+      }
+    })
     ```
 
 !!! note
@@ -92,7 +96,7 @@ If you'd like to use Ruff exclusively for linting, formatting, and organizing im
 capabilities for Pyright:
 
 ```lua
-require('lspconfig').pyright.setup {
+vim.lsp.config('pyright', {
   settings = {
     pyright = {
       -- Using Ruff's import organizer
@@ -105,20 +109,20 @@ require('lspconfig').pyright.setup {
       },
     },
   },
-}
+})
 ```
 
 By default, the log level for Ruff is set to `info`. To change the log level, you can set the
 [`logLevel`](./settings.md#loglevel) setting:
 
 ```lua
-require('lspconfig').ruff.setup {
+vim.lsp.config('ruff', {
   init_options = {
     settings = {
       logLevel = 'debug',
     }
   }
-}
+})
 ```
 
 By default, Ruff will write logs to stderr which will be available in Neovim's LSP client log file

--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -44,17 +44,22 @@ the server without any external dependencies.
     The following configuration needs to be stored in `nvim/lsp/ruff.lua` or `nvim/after/lsp/ruff.lua`:
 
     ```lua
-    vim.lsp.config('ruff', {
+    ---@type vim.lsp.Config  
+    return {
       cmd = { 'ruff', 'server' },
       filetypes = { 'python' },
-      root_dir = vim.fs.dirname(vim.fs.find({ 'pyproject.toml', '.git' }, { upward = true })[1]),
+      root_markers = { 'pyproject.toml', 'ruff.toml', '.ruff.toml', '.git' },
       init_options = {
         settings = {
           -- Ruff language server settings go here
         }
       }
-    })
+    }
+    ```
 
+    And, then enable the server by including the following in your `init.lua`:
+
+    ```lua
     vim.lsp.enable('ruff')
     ```
 

--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -30,17 +30,35 @@ For more documentation on the Ruff extension, refer to the
 
 ## Neovim
 
-Neovim 0.11+ requires no external dependencies to
-configure the Ruff Language Server. The [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig)
-plugin can still be used to provide a [default configuration](https://github.com/neovim/nvim-lspconfig/blob/master/lsp/ruff.lua).
+The Ruff language server can be setup in Neovim using the built-in LSP client either via
+[`vim.lsp.config`](https://neovim.io/doc/user/lsp.html#vim.lsp.config()) (Neovim 0.11+) or the
+[`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) plugin (Neovim 0.10 and earlier).
 
-If using Neovim < 0.11, the [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) plugin
-can be used to configure the Ruff Language Server.
+To setup using [`vim.lsp.config`](https://neovim.io/doc/user/lsp.html#vim.lsp.config()), you can
+either use the [default configuration provided in
+`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/blob/master/lsp/ruff.lua) or configure
+the server without any external dependencies.
 
-To set it up, install the [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) plugin
-and add the following to your `init.lua`:
+=== "Neovim 0.11+ (without external dependencies)"
 
-=== "Neovim 0.11+ (with [`vim.lsp.config`](https://neovim.io/doc/user/lsp.html#vim.lsp.config()))"
+    The following configuration needs to be stored in `nvim/lsp/ruff.lua` or `nvim/after/lsp/ruff.lua`:
+
+    ```lua
+    vim.lsp.config('ruff', {
+      cmd = { 'ruff', 'server' },
+      filetypes = { 'python' },
+      root_dir = vim.fs.dirname(vim.fs.find({ 'pyproject.toml', '.git' }, { upward = true })[1]),
+      init_options = {
+        settings = {
+          -- Ruff language server settings go here
+        }
+      }
+    })
+
+    vim.lsp.enable('ruff')
+    ```
+
+=== "Neovim 0.11+ (with [`vim.lsp.config`](https://neovim.io/doc/user/lsp.html#vim.lsp.config()) and [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig))"
 
     ```lua
     vim.lsp.config('ruff', {
@@ -55,6 +73,13 @@ and add the following to your `init.lua`:
     ```
 
 === "Neovim 0.10 (with [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig))"
+
+    !!! note
+
+        [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) has
+        [deprecated](https://github.com/neovim/nvim-lspconfig/issues/3693) support for Neovim 0.10
+        and earlier in favor of using
+        [`vim.lsp.config`](https://neovim.io/doc/user/lsp.html#vim.lsp.config()) instead.
 
     ```lua
     require('lspconfig').ruff.setup({


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Neovim 0.11 (in March 2025) added [vim.lsp.config()](https://neovim.io/doc/user/lsp/#vim.lsp.config()) which is now the recommended way to set up language servers. This was added to the Ruff docs in #18108 in addition to the legacy method using `nvim-lspconfig`.

Calling `nvim-lspconfig` to configure a language server is deprecated - see [their documentation](https://github.com/neovim/nvim-lspconfig?tab=readme-ov-file#important-%EF%B8%8F).

This PR:
- updates the documentation which describes both methods to now prefer `vim.lsp.config`
- updates all other examples which only show the legacy method to now use `vim.lsp.config`.

## Test Plan

<!-- How was it tested? -->
I have tested a subset of the examples locally using Neovim 0.12.1.

---

I considered just removing the legacy method but was unsure. I'll follow others' guidance on when that should be kept until.

https://github.com/user-attachments/assets/93984c45-a2f1-48dd-9fec-ed291b0a144e

