### PR TITLE
[ty] Show a diagnostic for unsupported inferred Python version

### DIFF
--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -1050,6 +1050,9 @@ pub enum DiagnosticId {
     /// Use of a deprecated setting.
     DeprecatedSetting,
 
+    /// Use of a Python version that ty doesn't support.
+    UnsupportedPythonVersion,
+
     /// The code needs to be formatted.
     Unformatted,
 
@@ -1109,6 +1112,7 @@ impl DiagnosticId {
             DiagnosticId::UnnecessaryOverridesSection => "unnecessary-overrides-section",
             DiagnosticId::UselessOverridesSection => "useless-overrides-section",
             DiagnosticId::DeprecatedSetting => "deprecated-setting",
+            DiagnosticId::UnsupportedPythonVersion => "unsupported-python-version",
             DiagnosticId::Unformatted => "unformatted",
             DiagnosticId::InvalidCliOption => "invalid-cli-option",
             DiagnosticId::PreviewFeature => "preview-feature",

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -1051,6 +1051,9 @@ pub enum DiagnosticId {
     /// Use of a deprecated setting.
     DeprecatedSetting,
 
+    /// Use of a Python version that ty doesn't support.
+    UnsupportedPythonVersion,
+
     /// The code needs to be formatted.
     Unformatted,
 
@@ -1110,6 +1113,7 @@ impl DiagnosticId {
             DiagnosticId::UnnecessaryOverridesSection => "unnecessary-overrides-section",
             DiagnosticId::UselessOverridesSection => "useless-overrides-section",
             DiagnosticId::DeprecatedSetting => "deprecated-setting",
+            DiagnosticId::UnsupportedPythonVersion => "unsupported-python-version",
             DiagnosticId::Unformatted => "unformatted",
             DiagnosticId::InvalidCliOption => "invalid-cli-option",
             DiagnosticId::PreviewFeature => "preview-feature",

--- a/crates/ty/tests/cli/python_environment.rs
+++ b/crates/ty/tests/cli/python_environment.rs
@@ -1218,10 +1218,20 @@ fn config_file_python_setting_directory_with_unsupported_python_version() -> any
     success: true
     exit_code: 0
     ----- stdout -----
-    All checks passed!
+    warning[unsupported-python-version]: Ignoring unsupported inferred Python version `3.16`; ty will use Python 3.14 instead.
+     --> venv/pyvenv.cfg:2:16
+      |
+    2 | version_info = 3.16.0
+      |                ^^^^^^
+    3 | home = base/bin
+      |
+    info: Expected one of `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, `3.15`.
+    info: Set `python-version` explicitly to override the inferred version.
+    info: The version was inferred from your virtual environment metadata.
+    
+    Found 1 diagnostic
 
     ----- stderr -----
-    WARN Ignoring unsupported inferred Python version: 3.16
     ");
 
     Ok(())

--- a/crates/ty/tests/cli/python_environment.rs
+++ b/crates/ty/tests/cli/python_environment.rs
@@ -1197,8 +1197,8 @@ fn config_file_python_setting_directory_with_unsupported_python_version() -> any
         (
             "venv/pyvenv.cfg",
             r#"
-            home = base/bin
             version_info = 3.16.0
+            home = base/bin
             "#,
         ),
         if cfg!(target_os = "windows") {
@@ -1219,13 +1219,13 @@ fn config_file_python_setting_directory_with_unsupported_python_version() -> any
     exit_code: 0
     ----- stdout -----
     warning[unsupported-python-version]: Ignoring unsupported inferred Python version `3.16`; ty will use Python 3.14 instead.
-     --> venv/pyvenv.cfg:3:16
+     --> venv/pyvenv.cfg:2:16
       |
-    3 | version_info = 3.16.0
+    2 | version_info = 3.16.0
       |                ^^^^^^
       |
     info: Expected one of `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, `3.15`.
-    info: Set `python-version` explicitly to override the inferred version.
+    info: Set `environment.python-version` explicitly to override the inferred version.
     info: The version was inferred from your virtual environment metadata.
     
     Found 1 diagnostic

--- a/crates/ty/tests/cli/python_environment.rs
+++ b/crates/ty/tests/cli/python_environment.rs
@@ -1248,10 +1248,20 @@ fn config_file_python_setting_directory_with_unsupported_python_version() -> any
     success: true
     exit_code: 0
     ----- stdout -----
-    All checks passed!
+    warning[unsupported-python-version]: Ignoring unsupported inferred Python version `3.16`; ty will use Python 3.14 instead.
+     --> venv/pyvenv.cfg:2:16
+      |
+    2 | version_info = 3.16.0
+      |                ^^^^^^
+    3 | home = base/bin
+      |
+    info: Expected one of `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, `3.15`.
+    info: Set `python-version` explicitly to override the inferred version.
+    info: The version was inferred from your virtual environment metadata.
+    
+    Found 1 diagnostic
 
     ----- stderr -----
-    WARN Ignoring unsupported inferred Python version: 3.16
     ");
 
     Ok(())

--- a/crates/ty/tests/cli/python_environment.rs
+++ b/crates/ty/tests/cli/python_environment.rs
@@ -1197,8 +1197,8 @@ fn config_file_python_setting_directory_with_unsupported_python_version() -> any
         (
             "venv/pyvenv.cfg",
             r#"
-            version_info = 3.16.0
             home = base/bin
+            version_info = 3.16.0
             "#,
         ),
         if cfg!(target_os = "windows") {
@@ -1219,11 +1219,10 @@ fn config_file_python_setting_directory_with_unsupported_python_version() -> any
     exit_code: 0
     ----- stdout -----
     warning[unsupported-python-version]: Ignoring unsupported inferred Python version `3.16`; ty will use Python 3.14 instead.
-     --> venv/pyvenv.cfg:2:16
+     --> venv/pyvenv.cfg:3:16
       |
-    2 | version_info = 3.16.0
+    3 | version_info = 3.16.0
       |                ^^^^^^
-    3 | home = base/bin
       |
     info: Expected one of `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, `3.15`.
     info: Set `python-version` explicitly to override the inferred version.

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -1176,7 +1176,7 @@ print(sys.last_exc, os.getegid())
 
 #[cfg_attr(windows, ignore = "site-packages layout inference is Unix-only")]
 #[test]
-fn touching_pyproject_updates_inferred_python_version_diagnostics_when_metadata_is_unchanged()
+fn reloading_options_updates_inferred_python_version_diagnostics_when_metadata_is_unchanged()
 -> anyhow::Result<()> {
     let latest_supported_minor = PythonVersion::iter().last().unwrap().minor;
     let unsupported_minor = latest_supported_minor + 1;
@@ -1218,6 +1218,8 @@ fn touching_pyproject_updates_inferred_python_version_diagnostics_when_metadata_
         case.project_path(&supported_python_directory).as_std_path(),
     )?;
 
+    // TODO: Invalidate program settings when a `site-packages` directory is renamed. This
+    // manually reloads the options instead of exercising the file-watching path for that rename.
     case.update_options(Options::default())?;
 
     let diagnostics = case.db.check();

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -9,6 +9,7 @@ use ruff_db::source::source_text;
 use ruff_db::system::{
     OsSystem, System, SystemPath, SystemPathBuf, UserConfigDirectoryOverrideGuard, file_time_now,
 };
+use ruff_python_ast::PythonVersion;
 use ty_module_resolver::{Module, ModuleName, resolve_module_confident};
 use ty_project::metadata::options::{EnvironmentOptions, Options, ProjectOptionsOverrides};
 use ty_project::metadata::pyproject::{PyProject, Tool};
@@ -1169,6 +1170,61 @@ print(sys.last_exc, os.getegid())
 
     let diagnostics = case.db.check();
     assert!(diagnostics.is_empty());
+
+    Ok(())
+}
+
+#[cfg_attr(windows, ignore = "site-packages layout inference is Unix-only")]
+#[test]
+fn touching_pyproject_updates_inferred_python_version_diagnostics_when_metadata_is_unchanged()
+-> anyhow::Result<()> {
+    let latest_supported_minor = PythonVersion::iter().last().unwrap().minor;
+    let unsupported_minor = latest_supported_minor + 1;
+    let unsupported_site_packages = SystemPathBuf::from(format!(
+        ".venv/lib/python3.{unsupported_minor}/site-packages/foo.py"
+    ));
+    let unsupported_python_directory =
+        SystemPathBuf::from(format!(".venv/lib/python3.{unsupported_minor}"));
+    let supported_python_directory =
+        SystemPathBuf::from(format!(".venv/lib/python3.{latest_supported_minor}"));
+
+    let mut case = setup(|context: &mut SetupContext| {
+        let python_home = context.join_root_path("base/bin");
+
+        context.write_project_file("main.py", "x = 1\n")?;
+        context.write_file("base/bin/python", "")?;
+        context.write_project_file(".venv/bin/python", "")?;
+        context.write_project_file(".venv/pyvenv.cfg", &format!("home = {python_home}\n"))?;
+        context.write_project_file(&unsupported_site_packages, "")?;
+        context.set_options(Options::default());
+
+        Ok(())
+    })?;
+
+    let diagnostics = case.db.check();
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].primary_message(),
+        format!(
+            "Ignoring unsupported inferred Python version `3.{unsupported_minor}`; ty will use Python {} instead.",
+            PythonVersion::latest_ty()
+        )
+    );
+
+    std::fs::rename(
+        case.project_path(&unsupported_python_directory)
+            .as_std_path(),
+        case.project_path(&supported_python_directory).as_std_path(),
+    )?;
+
+    case.update_options(Options::default())?;
+
+    let diagnostics = case.db.check();
+    assert!(
+        diagnostics.is_empty(),
+        "Expected no diagnostics but got: {diagnostics:#?}"
+    );
 
     Ok(())
 }

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -106,15 +106,18 @@ impl ProjectDatabase {
         //   we may want to have a dedicated method for this?
 
         // Initialize the `Program` singleton
-        let program_settings = strategy.to_anyhow(project_metadata.to_program_settings(
-            db.system(),
-            db.vendored(),
-            strategy,
-        ))?;
+        let (program_settings, program_settings_diagnostics) = strategy.to_anyhow(
+            project_metadata.to_program_settings(&db, db.system(), db.vendored(), strategy),
+        )?;
         Program::from_settings(&db, program_settings);
 
         db.project = Some(strategy.map_err(
-            Project::from_metadata(&db, project_metadata, strategy),
+            Project::from_metadata(
+                &db,
+                project_metadata,
+                program_settings_diagnostics,
+                strategy,
+            ),
             |error| anyhow::anyhow!("{}", error.pretty(&db)),
         )?);
 
@@ -631,7 +634,8 @@ pub(crate) mod tests {
                 project: None,
             };
 
-            let project = Project::from_metadata(&db, project, &FallibleStrategy).unwrap();
+            let project =
+                Project::from_metadata(&db, project, Vec::new(), &FallibleStrategy).unwrap();
             db.project = Some(project);
             db
         }

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -111,15 +111,20 @@ impl ProjectDatabase {
         )?;
         Program::from_settings(&db, program_settings);
 
-        db.project = Some(strategy.map_err(
-            Project::from_metadata(
-                &db,
-                project_metadata,
-                program_settings_diagnostics,
-                strategy,
-            ),
+        let (settings, mut settings_diagnostics) = strategy.map_err(
+            project_metadata
+                .options()
+                .to_settings(&db, project_metadata.root(), strategy),
             |error| anyhow::anyhow!("{}", error.pretty(&db)),
-        )?);
+        )?;
+        settings_diagnostics.extend(program_settings_diagnostics);
+
+        db.project = Some(Project::from_metadata(
+            &db,
+            project_metadata,
+            settings,
+            settings_diagnostics,
+        ));
 
         Ok(db)
     }
@@ -634,8 +639,11 @@ pub(crate) mod tests {
                 project: None,
             };
 
-            let project =
-                Project::from_metadata(&db, project, Vec::new(), &FallibleStrategy).unwrap();
+            let (settings, settings_diagnostics) = project
+                .options()
+                .to_settings(&db, project.root(), &FallibleStrategy)
+                .unwrap();
+            let project = Project::from_metadata(&db, project, settings, settings_diagnostics);
             db.project = Some(project);
             db
         }

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -106,15 +106,18 @@ impl ProjectDatabase {
         //   we may want to have a dedicated method for this?
 
         // Initialize the `Program` singleton
-        let program_settings = strategy.to_anyhow(project_metadata.to_program_settings(
-            db.system(),
-            db.vendored(),
-            strategy,
-        ))?;
+        let (program_settings, program_settings_diagnostics) = strategy.to_anyhow(
+            project_metadata.to_program_settings(&db, db.system(), db.vendored(), strategy),
+        )?;
         Program::from_settings(&db, program_settings);
 
         db.project = Some(strategy.map_err(
-            Project::from_metadata(&db, project_metadata, strategy),
+            Project::from_metadata(
+                &db,
+                project_metadata,
+                program_settings_diagnostics,
+                strategy,
+            ),
             |error| anyhow::anyhow!("{}", error.pretty(&db)),
         )?);
 
@@ -622,7 +625,8 @@ pub(crate) mod tests {
                 project: None,
             };
 
-            let project = Project::from_metadata(&db, project, &FallibleStrategy).unwrap();
+            let project =
+                Project::from_metadata(&db, project, Vec::new(), &FallibleStrategy).unwrap();
             db.project = Some(project);
             db
         }

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -111,15 +111,20 @@ impl ProjectDatabase {
         )?;
         Program::from_settings(&db, program_settings);
 
-        db.project = Some(strategy.map_err(
-            Project::from_metadata(
-                &db,
-                project_metadata,
-                program_settings_diagnostics,
-                strategy,
-            ),
+        let (settings, mut settings_diagnostics) = strategy.map_err(
+            project_metadata
+                .options()
+                .to_settings(&db, project_metadata.root(), strategy),
             |error| anyhow::anyhow!("{}", error.pretty(&db)),
-        )?);
+        )?;
+        settings_diagnostics.extend(program_settings_diagnostics);
+
+        db.project = Some(Project::from_metadata(
+            &db,
+            project_metadata,
+            settings,
+            settings_diagnostics,
+        ));
 
         Ok(db)
     }
@@ -625,8 +630,11 @@ pub(crate) mod tests {
                 project: None,
             };
 
-            let project =
-                Project::from_metadata(&db, project, Vec::new(), &FallibleStrategy).unwrap();
+            let (settings, settings_diagnostics) = project
+                .options()
+                .to_settings(&db, project.root(), &FallibleStrategy)
+                .unwrap();
+            let project = Project::from_metadata(&db, project, settings, settings_diagnostics);
             db.project = Some(project);
             db
         }

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -107,23 +107,23 @@ impl ProjectDatabase {
 
         // Initialize the `Program` singleton
         let (program_settings, program_settings_diagnostics) = strategy.to_anyhow(
-            project_metadata.to_program_settings(&db, db.system(), db.vendored(), strategy),
+            project_metadata.to_program_settings(db.system(), db.vendored(), strategy),
         )?;
         Program::from_settings(&db, program_settings);
 
-        let (settings, mut settings_diagnostics) = strategy.map_err(
+        let (settings, settings_diagnostics) = strategy.map_err(
             project_metadata
                 .options()
                 .to_settings(&db, project_metadata.root(), strategy),
             |error| anyhow::anyhow!("{}", error.pretty(&db)),
         )?;
-        settings_diagnostics.extend(program_settings_diagnostics);
 
         db.project = Some(Project::from_metadata(
             &db,
             project_metadata,
             settings,
             settings_diagnostics,
+            program_settings_diagnostics,
         ));
 
         Ok(db)
@@ -643,7 +643,8 @@ pub(crate) mod tests {
                 .options()
                 .to_settings(&db, project.root(), &FallibleStrategy)
                 .unwrap();
-            let project = Project::from_metadata(&db, project, settings, settings_diagnostics);
+            let project =
+                Project::from_metadata(&db, project, settings, settings_diagnostics, Vec::new());
             db.project = Some(project);
             db
         }

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -265,24 +265,27 @@ impl ProjectDatabase {
                         metadata.apply_overrides(overrides);
                     }
 
-                    match metadata.to_program_settings(
+                    let program_settings_diagnostics = match metadata.to_program_settings(
+                        self,
                         self.system(),
                         self.vendored(),
                         &FallibleStrategy,
                     ) {
-                        Ok(program_settings) => {
+                        Ok((program_settings, diagnostics)) => {
                             let program = Program::get(self);
                             program.update_from_settings(self, program_settings);
+                            diagnostics
                         }
                         Err(error) => {
                             tracing::error!(
                                 "Failed to convert metadata to program settings, continuing without applying them: {error}"
                             );
+                            Vec::new()
                         }
-                    }
+                    };
 
                     tracing::debug!("Reloading project after structural change");
-                    project.reload(self, metadata);
+                    project.reload(self, metadata, program_settings_diagnostics);
                 }
                 Err(error) => {
                     tracing::error!(
@@ -294,11 +297,12 @@ impl ProjectDatabase {
             return result;
         } else if result.custom_stdlib_changed {
             match project.metadata(self).to_program_settings(
+                self,
                 self.system(),
                 self.vendored(),
                 &FallibleStrategy,
             ) {
-                Ok(program_settings) => {
+                Ok((program_settings, _diagnostics)) => {
                     program.update_from_settings(self, program_settings);
                 }
                 Err(error) => {

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -284,8 +284,23 @@ impl ProjectDatabase {
                         }
                     };
 
+                    let (settings, mut settings_diagnostics) = match metadata.options().to_settings(
+                        self,
+                        metadata.root(),
+                        &FallibleStrategy,
+                    ) {
+                        Ok((settings, diagnostics)) => (Some(settings), diagnostics),
+                        Err(error) => {
+                            tracing::warn!(
+                                "Keeping old project configuration because loading the new settings failed with: {error}"
+                            );
+                            (None, vec![error.into_diagnostic()])
+                        }
+                    };
+                    settings_diagnostics.extend(program_settings_diagnostics);
+
                     tracing::debug!("Reloading project after structural change");
-                    project.reload(self, metadata, program_settings_diagnostics);
+                    project.reload(self, metadata, settings, settings_diagnostics);
                 }
                 Err(error) => {
                     tracing::error!(

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -266,7 +266,6 @@ impl ProjectDatabase {
                     }
 
                     let program_settings_diagnostics = match metadata.to_program_settings(
-                        self,
                         self.system(),
                         self.vendored(),
                         &FallibleStrategy,
@@ -284,7 +283,7 @@ impl ProjectDatabase {
                         }
                     };
 
-                    let (settings, mut settings_diagnostics) = match metadata.options().to_settings(
+                    let (settings, settings_diagnostics) = match metadata.options().to_settings(
                         self,
                         metadata.root(),
                         &FallibleStrategy,
@@ -297,10 +296,15 @@ impl ProjectDatabase {
                             (None, vec![error.into_diagnostic()])
                         }
                     };
-                    settings_diagnostics.extend(program_settings_diagnostics);
 
                     tracing::debug!("Reloading project after structural change");
-                    project.reload(self, metadata, settings, settings_diagnostics);
+                    project.reload(
+                        self,
+                        metadata,
+                        settings,
+                        settings_diagnostics,
+                        program_settings_diagnostics,
+                    );
                 }
                 Err(error) => {
                     tracing::error!(
@@ -312,13 +316,25 @@ impl ProjectDatabase {
             return result;
         } else if result.custom_stdlib_changed {
             match project.metadata(self).to_program_settings(
-                self,
                 self.system(),
                 self.vendored(),
                 &FallibleStrategy,
             ) {
-                Ok((program_settings, _diagnostics)) => {
+                Ok((program_settings, program_settings_diagnostics)) => {
                     program.update_from_settings(self, program_settings);
+                    let settings_diagnostics = match project.metadata(self).options().to_settings(
+                        self,
+                        project.metadata(self).root(),
+                        &FallibleStrategy,
+                    ) {
+                        Ok((_, diagnostics)) => diagnostics,
+                        Err(error) => vec![error.into_diagnostic()],
+                    };
+                    project.update_settings_diagnostics(
+                        self,
+                        settings_diagnostics,
+                        program_settings_diagnostics,
+                    );
                 }
                 Err(error) => {
                     tracing::error!("Failed to resolve program settings: {error}");

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -165,14 +165,6 @@ impl ProgressReporter for CollectReporter {
     }
 }
 
-fn merge_settings_diagnostics(
-    mut diagnostics: Vec<OptionDiagnostic>,
-    program_settings_diagnostics: Vec<OptionDiagnostic>,
-) -> Vec<OptionDiagnostic> {
-    diagnostics.extend(program_settings_diagnostics);
-    diagnostics
-}
-
 #[salsa::tracked]
 impl Project {
     pub fn from_metadata<Strategy: MisconfigurationStrategy>(
@@ -181,11 +173,11 @@ impl Project {
         program_settings_diagnostics: Vec<OptionDiagnostic>,
         strategy: &Strategy,
     ) -> Result<Self, Strategy::Error<ToSettingsError>> {
-        let (settings, diagnostics) =
+        let (settings, mut diagnostics) =
             metadata
                 .options()
                 .to_settings(db, metadata.root(), strategy)?;
-        let diagnostics = merge_settings_diagnostics(diagnostics, program_settings_diagnostics);
+        diagnostics.extend(program_settings_diagnostics);
 
         let project = Project::builder(Box::new(metadata), Box::new(settings), diagnostics)
             .durability(Durability::MEDIUM)
@@ -254,20 +246,16 @@ impl Project {
         program_settings_diagnostics: Vec<OptionDiagnostic>,
     ) {
         tracing::debug!("Reloading project");
+        let metadata_changed = &metadata != self.metadata(db);
 
         self.reload_files(db);
-
-        if &metadata == self.metadata(db) {
-            return;
-        }
 
         match metadata
             .options()
             .to_settings(db, metadata.root(), &FallibleStrategy)
         {
-            Ok((settings, settings_diagnostics)) => {
-                let settings_diagnostics =
-                    merge_settings_diagnostics(settings_diagnostics, program_settings_diagnostics);
+            Ok((settings, mut settings_diagnostics)) => {
+                settings_diagnostics.extend(program_settings_diagnostics);
 
                 if self.settings(db) != &settings {
                     self.set_settings(db).to(Box::new(settings));
@@ -281,12 +269,14 @@ impl Project {
                 tracing::warn!(
                     "Keeping old project configuration because loading the new settings failed with: {error}"
                 );
-                self.set_settings_diagnostics(db)
-                    .to(merge_settings_diagnostics(
-                        vec![error.into_diagnostic()],
-                        program_settings_diagnostics,
-                    ));
+                let mut settings_diagnostics = vec![error.into_diagnostic()];
+                settings_diagnostics.extend(program_settings_diagnostics);
+                self.set_settings_diagnostics(db).to(settings_diagnostics);
             }
+        }
+
+        if !metadata_changed {
+            return;
         }
 
         self.set_metadata(db).to(Box::new(metadata));
@@ -768,7 +758,10 @@ where
 mod tests {
     use crate::ProjectMetadata;
     use crate::check_file_impl;
+    use crate::db::Db;
     use crate::db::tests::TestDb;
+    use crate::metadata::options::OptionDiagnostic;
+    use ruff_db::diagnostic::{DiagnosticId, Severity};
     use ruff_db::files::system_path_to_file;
     use ruff_db::source::source_text;
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemPathBuf};
@@ -819,5 +812,51 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn reload_updates_settings_diagnostics_when_metadata_is_unchanged() {
+        let project_metadata =
+            ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/"));
+        let mut db = TestDb::new(project_metadata);
+        let project = db.project();
+
+        project.reload(
+            &mut db,
+            ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/")),
+            vec![OptionDiagnostic::new(
+                DiagnosticId::UnsupportedPythonVersion,
+                "first diagnostic".to_string(),
+                Severity::Warning,
+            )],
+        );
+
+        assert_eq!(
+            project
+                .check_settings(&db)
+                .iter()
+                .map(|diagnostic| diagnostic.primary_message().to_string())
+                .collect::<Vec<_>>(),
+            vec!["first diagnostic".to_string()]
+        );
+
+        project.reload(
+            &mut db,
+            ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/")),
+            vec![OptionDiagnostic::new(
+                DiagnosticId::UnsupportedPythonVersion,
+                "second diagnostic".to_string(),
+                Severity::Warning,
+            )],
+        );
+
+        assert_eq!(
+            project
+                .check_settings(&db)
+                .iter()
+                .map(|diagnostic| diagnostic.primary_message().to_string())
+                .collect::<Vec<_>>(),
+            vec!["second diagnostic".to_string()]
+        );
     }
 }

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -25,7 +25,6 @@ use std::collections::hash_set;
 use std::iter::FusedIterator;
 use std::panic::{AssertUnwindSafe, UnwindSafe};
 use std::sync::Arc;
-use ty_python_core::program::{FallibleStrategy, MisconfigurationStrategy};
 use ty_python_semantic::lint::RuleSelection;
 
 mod db;

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -165,17 +165,27 @@ impl ProgressReporter for CollectReporter {
     }
 }
 
+fn merge_settings_diagnostics(
+    mut diagnostics: Vec<OptionDiagnostic>,
+    program_settings_diagnostics: Vec<OptionDiagnostic>,
+) -> Vec<OptionDiagnostic> {
+    diagnostics.extend(program_settings_diagnostics);
+    diagnostics
+}
+
 #[salsa::tracked]
 impl Project {
     pub fn from_metadata<Strategy: MisconfigurationStrategy>(
         db: &dyn Db,
         metadata: ProjectMetadata,
+        program_settings_diagnostics: Vec<OptionDiagnostic>,
         strategy: &Strategy,
     ) -> Result<Self, Strategy::Error<ToSettingsError>> {
         let (settings, diagnostics) =
             metadata
                 .options()
                 .to_settings(db, metadata.root(), strategy)?;
+        let diagnostics = merge_settings_diagnostics(diagnostics, program_settings_diagnostics);
 
         let project = Project::builder(Box::new(metadata), Box::new(settings), diagnostics)
             .durability(Durability::MEDIUM)
@@ -237,7 +247,12 @@ impl Project {
         )
     }
 
-    pub fn reload(self, db: &mut dyn Db, metadata: ProjectMetadata) {
+    pub fn reload(
+        self,
+        db: &mut dyn Db,
+        metadata: ProjectMetadata,
+        program_settings_diagnostics: Vec<OptionDiagnostic>,
+    ) {
         tracing::debug!("Reloading project");
 
         self.reload_files(db);
@@ -251,6 +266,9 @@ impl Project {
             .to_settings(db, metadata.root(), &FallibleStrategy)
         {
             Ok((settings, settings_diagnostics)) => {
+                let settings_diagnostics =
+                    merge_settings_diagnostics(settings_diagnostics, program_settings_diagnostics);
+
                 if self.settings(db) != &settings {
                     self.set_settings(db).to(Box::new(settings));
                 }
@@ -264,7 +282,10 @@ impl Project {
                     "Keeping old project configuration because loading the new settings failed with: {error}"
                 );
                 self.set_settings_diagnostics(db)
-                    .to(vec![error.into_diagnostic()]);
+                    .to(merge_settings_diagnostics(
+                        vec![error.into_diagnostic()],
+                        program_settings_diagnostics,
+                    ));
             }
         }
 

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -3,7 +3,7 @@
     reason = "Prefer System trait methods over std methods in ty crates"
 )]
 use crate::glob::{GlobFilterCheckMode, IncludeResult};
-use crate::metadata::options::{OptionDiagnostic, ToSettingsError};
+use crate::metadata::options::OptionDiagnostic;
 use crate::walk::{ProjectFilesFilter, ProjectFilesWalker};
 #[cfg(feature = "testing")]
 pub use db::tests::TestDb;
@@ -167,18 +167,12 @@ impl ProgressReporter for CollectReporter {
 
 #[salsa::tracked]
 impl Project {
-    pub fn from_metadata<Strategy: MisconfigurationStrategy>(
+    pub fn from_metadata(
         db: &dyn Db,
         metadata: ProjectMetadata,
-        program_settings_diagnostics: Vec<OptionDiagnostic>,
-        strategy: &Strategy,
-    ) -> Result<Self, Strategy::Error<ToSettingsError>> {
-        let (settings, mut diagnostics) =
-            metadata
-                .options()
-                .to_settings(db, metadata.root(), strategy)?;
-        diagnostics.extend(program_settings_diagnostics);
-
+        settings: Settings,
+        diagnostics: Vec<OptionDiagnostic>,
+    ) -> Self {
         let project = Project::builder(Box::new(metadata), Box::new(settings), diagnostics)
             .durability(Durability::MEDIUM)
             .open_fileset_durability(Durability::LOW)
@@ -187,7 +181,7 @@ impl Project {
 
         project.try_add_file_root(db);
 
-        Ok(project)
+        project
     }
 
     fn try_add_file_root(self, db: &dyn Db) {
@@ -243,36 +237,22 @@ impl Project {
         self,
         db: &mut dyn Db,
         metadata: ProjectMetadata,
-        program_settings_diagnostics: Vec<OptionDiagnostic>,
+        settings: Option<Settings>,
+        settings_diagnostics: Vec<OptionDiagnostic>,
     ) {
         tracing::debug!("Reloading project");
         let metadata_changed = &metadata != self.metadata(db);
 
         self.reload_files(db);
 
-        match metadata
-            .options()
-            .to_settings(db, metadata.root(), &FallibleStrategy)
+        if let Some(settings) = settings
+            && self.settings(db) != &settings
         {
-            Ok((settings, mut settings_diagnostics)) => {
-                settings_diagnostics.extend(program_settings_diagnostics);
+            self.set_settings(db).to(Box::new(settings));
+        }
 
-                if self.settings(db) != &settings {
-                    self.set_settings(db).to(Box::new(settings));
-                }
-
-                if self.settings_diagnostics(db) != settings_diagnostics {
-                    self.set_settings_diagnostics(db).to(settings_diagnostics);
-                }
-            }
-            Err(error) => {
-                tracing::warn!(
-                    "Keeping old project configuration because loading the new settings failed with: {error}"
-                );
-                let mut settings_diagnostics = vec![error.into_diagnostic()];
-                settings_diagnostics.extend(program_settings_diagnostics);
-                self.set_settings_diagnostics(db).to(settings_diagnostics);
-            }
+        if self.settings_diagnostics(db) != settings_diagnostics {
+            self.set_settings_diagnostics(db).to(settings_diagnostics);
         }
 
         if !metadata_changed {
@@ -767,11 +747,24 @@ mod tests {
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemPathBuf};
     use ruff_db::testing::assert_function_query_was_not_run;
     use ruff_python_ast::name::Name;
+    use ty_python_core::program::FallibleStrategy;
     use ty_python_semantic::types::check_types;
+
+    fn test_project_metadata() -> ProjectMetadata {
+        ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/"))
+    }
+
+    fn settings_diagnostic_messages(project: crate::Project, db: &dyn Db) -> Vec<String> {
+        project
+            .check_settings(db)
+            .iter()
+            .map(|diagnostic| diagnostic.primary_message().to_string())
+            .collect()
+    }
 
     #[test]
     fn check_file_skips_type_checking_when_file_cant_be_read() -> ruff_db::system::Result<()> {
-        let project = ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/"));
+        let project = test_project_metadata();
         let mut db = TestDb::new(project);
         db.init_program().unwrap();
         let path = SystemPath::new("test.py");
@@ -816,14 +809,18 @@ mod tests {
 
     #[test]
     fn reload_updates_settings_diagnostics_when_metadata_is_unchanged() {
-        let project_metadata =
-            ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/"));
-        let mut db = TestDb::new(project_metadata);
+        let mut db = TestDb::new(test_project_metadata());
         let project = db.project();
+        let first_metadata = test_project_metadata();
+        let first_settings = first_metadata
+            .to_settings(&db, &FallibleStrategy)
+            .unwrap()
+            .0;
 
         project.reload(
             &mut db,
-            ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/")),
+            first_metadata,
+            Some(first_settings),
             vec![OptionDiagnostic::new(
                 DiagnosticId::UnsupportedPythonVersion,
                 "first diagnostic".to_string(),
@@ -832,17 +829,20 @@ mod tests {
         );
 
         assert_eq!(
-            project
-                .check_settings(&db)
-                .iter()
-                .map(|diagnostic| diagnostic.primary_message().to_string())
-                .collect::<Vec<_>>(),
+            settings_diagnostic_messages(project, &db),
             vec!["first diagnostic".to_string()]
         );
 
+        let second_metadata = test_project_metadata();
+        let second_settings = second_metadata
+            .to_settings(&db, &FallibleStrategy)
+            .unwrap()
+            .0;
+
         project.reload(
             &mut db,
-            ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/")),
+            second_metadata,
+            Some(second_settings),
             vec![OptionDiagnostic::new(
                 DiagnosticId::UnsupportedPythonVersion,
                 "second diagnostic".to_string(),
@@ -851,11 +851,7 @@ mod tests {
         );
 
         assert_eq!(
-            project
-                .check_settings(&db)
-                .iter()
-                .map(|diagnostic| diagnostic.primary_message().to_string())
-                .collect::<Vec<_>>(),
+            settings_diagnostic_messages(project, &db),
             vec!["second diagnostic".to_string()]
         );
     }

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -170,14 +170,6 @@ impl ProgressReporter for CollectReporter {
     }
 }
 
-fn merge_settings_diagnostics(
-    mut diagnostics: Vec<OptionDiagnostic>,
-    program_settings_diagnostics: Vec<OptionDiagnostic>,
-) -> Vec<OptionDiagnostic> {
-    diagnostics.extend(program_settings_diagnostics);
-    diagnostics
-}
-
 #[salsa::tracked]
 impl Project {
     pub fn from_metadata<Strategy: MisconfigurationStrategy>(
@@ -186,11 +178,11 @@ impl Project {
         program_settings_diagnostics: Vec<OptionDiagnostic>,
         strategy: &Strategy,
     ) -> Result<Self, Strategy::Error<ToSettingsError>> {
-        let (settings, diagnostics) =
+        let (settings, mut diagnostics) =
             metadata
                 .options()
                 .to_settings(db, metadata.root(), strategy)?;
-        let diagnostics = merge_settings_diagnostics(diagnostics, program_settings_diagnostics);
+        diagnostics.extend(program_settings_diagnostics);
 
         let project = Project::builder(Box::new(metadata), Box::new(settings), diagnostics)
             .durability(Durability::MEDIUM)
@@ -259,20 +251,16 @@ impl Project {
         program_settings_diagnostics: Vec<OptionDiagnostic>,
     ) {
         tracing::debug!("Reloading project");
+        let metadata_changed = &metadata != self.metadata(db);
 
         self.reload_files(db);
-
-        if &metadata == self.metadata(db) {
-            return;
-        }
 
         match metadata
             .options()
             .to_settings(db, metadata.root(), &FallibleStrategy)
         {
-            Ok((settings, settings_diagnostics)) => {
-                let settings_diagnostics =
-                    merge_settings_diagnostics(settings_diagnostics, program_settings_diagnostics);
+            Ok((settings, mut settings_diagnostics)) => {
+                settings_diagnostics.extend(program_settings_diagnostics);
 
                 if self.settings(db) != &settings {
                     self.set_settings(db).to(Box::new(settings));
@@ -286,12 +274,14 @@ impl Project {
                 tracing::warn!(
                     "Keeping old project configuration because loading the new settings failed with: {error}"
                 );
-                self.set_settings_diagnostics(db)
-                    .to(merge_settings_diagnostics(
-                        vec![error.into_diagnostic()],
-                        program_settings_diagnostics,
-                    ));
+                let mut settings_diagnostics = vec![error.into_diagnostic()];
+                settings_diagnostics.extend(program_settings_diagnostics);
+                self.set_settings_diagnostics(db).to(settings_diagnostics);
             }
+        }
+
+        if !metadata_changed {
+            return;
         }
 
         self.set_metadata(db).to(Box::new(metadata));
@@ -845,7 +835,10 @@ where
 mod tests {
     use crate::ProjectMetadata;
     use crate::check_file_impl;
+    use crate::db::Db;
     use crate::db::tests::TestDb;
+    use crate::metadata::options::OptionDiagnostic;
+    use ruff_db::diagnostic::{DiagnosticId, Severity};
     use ruff_db::files::system_path_to_file;
     use ruff_db::source::source_text;
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemPathBuf};
@@ -896,5 +889,51 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn reload_updates_settings_diagnostics_when_metadata_is_unchanged() {
+        let project_metadata =
+            ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/"));
+        let mut db = TestDb::new(project_metadata);
+        let project = db.project();
+
+        project.reload(
+            &mut db,
+            ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/")),
+            vec![OptionDiagnostic::new(
+                DiagnosticId::UnsupportedPythonVersion,
+                "first diagnostic".to_string(),
+                Severity::Warning,
+            )],
+        );
+
+        assert_eq!(
+            project
+                .check_settings(&db)
+                .iter()
+                .map(|diagnostic| diagnostic.primary_message().to_string())
+                .collect::<Vec<_>>(),
+            vec!["first diagnostic".to_string()]
+        );
+
+        project.reload(
+            &mut db,
+            ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/")),
+            vec![OptionDiagnostic::new(
+                DiagnosticId::UnsupportedPythonVersion,
+                "second diagnostic".to_string(),
+                Severity::Warning,
+            )],
+        );
+
+        assert_eq!(
+            project
+                .check_settings(&db)
+                .iter()
+                .map(|diagnostic| diagnostic.primary_message().to_string())
+                .collect::<Vec<_>>(),
+            vec!["second diagnostic".to_string()]
+        );
     }
 }

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -737,33 +737,17 @@ where
 mod tests {
     use crate::ProjectMetadata;
     use crate::check_file_impl;
-    use crate::db::Db;
     use crate::db::tests::TestDb;
-    use crate::metadata::options::OptionDiagnostic;
-    use ruff_db::diagnostic::{DiagnosticId, Severity};
     use ruff_db::files::system_path_to_file;
     use ruff_db::source::source_text;
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemPathBuf};
     use ruff_db::testing::assert_function_query_was_not_run;
     use ruff_python_ast::name::Name;
-    use ty_python_core::program::FallibleStrategy;
     use ty_python_semantic::types::check_types;
-
-    fn test_project_metadata() -> ProjectMetadata {
-        ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/"))
-    }
-
-    fn settings_diagnostic_messages(project: crate::Project, db: &dyn Db) -> Vec<String> {
-        project
-            .check_settings(db)
-            .iter()
-            .map(|diagnostic| diagnostic.primary_message().to_string())
-            .collect()
-    }
 
     #[test]
     fn check_file_skips_type_checking_when_file_cant_be_read() -> ruff_db::system::Result<()> {
-        let project = test_project_metadata();
+        let project = ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/"));
         let mut db = TestDb::new(project);
         db.init_program().unwrap();
         let path = SystemPath::new("test.py");
@@ -804,54 +788,5 @@ mod tests {
         );
 
         Ok(())
-    }
-
-    #[test]
-    fn reload_updates_settings_diagnostics_when_metadata_is_unchanged() {
-        let mut db = TestDb::new(test_project_metadata());
-        let project = db.project();
-        let first_metadata = test_project_metadata();
-        let first_settings = first_metadata
-            .to_settings(&db, &FallibleStrategy)
-            .unwrap()
-            .0;
-
-        project.reload(
-            &mut db,
-            first_metadata,
-            Some(first_settings),
-            vec![OptionDiagnostic::new(
-                DiagnosticId::UnsupportedPythonVersion,
-                "first diagnostic".to_string(),
-                Severity::Warning,
-            )],
-        );
-
-        assert_eq!(
-            settings_diagnostic_messages(project, &db),
-            vec!["first diagnostic".to_string()]
-        );
-
-        let second_metadata = test_project_metadata();
-        let second_settings = second_metadata
-            .to_settings(&db, &FallibleStrategy)
-            .unwrap()
-            .0;
-
-        project.reload(
-            &mut db,
-            second_metadata,
-            Some(second_settings),
-            vec![OptionDiagnostic::new(
-                DiagnosticId::UnsupportedPythonVersion,
-                "second diagnostic".to_string(),
-                Severity::Warning,
-            )],
-        );
-
-        assert_eq!(
-            settings_diagnostic_messages(project, &db),
-            vec!["second diagnostic".to_string()]
-        );
     }
 }

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -3,7 +3,7 @@
     reason = "Prefer System trait methods over std methods in ty crates"
 )]
 use crate::glob::{GlobFilterCheckMode, IncludeResult};
-use crate::metadata::options::OptionDiagnostic;
+use crate::metadata::options::{OptionDiagnostic, ProgramSettingsDiagnostic};
 use crate::walk::{ProjectFilesFilter, ProjectFilesWalker};
 #[cfg(feature = "testing")]
 pub use db::tests::TestDb;
@@ -166,12 +166,22 @@ impl ProgressReporter for CollectReporter {
 
 #[salsa::tracked]
 impl Project {
-    pub fn from_metadata(
+    /// Create a project from resolved metadata and settings.
+    ///
+    /// Program-settings diagnostics are accepted separately so callers do not need to know how to
+    /// convert and merge them into the stored project settings diagnostics.
+    pub(crate) fn from_metadata(
         db: &dyn Db,
         metadata: ProjectMetadata,
         settings: Settings,
-        diagnostics: Vec<OptionDiagnostic>,
+        settings_diagnostics: Vec<OptionDiagnostic>,
+        program_settings_diagnostics: Vec<ProgramSettingsDiagnostic>,
     ) -> Self {
+        let diagnostics = Self::settings_diagnostics_with_program_diagnostics(
+            db,
+            settings_diagnostics,
+            program_settings_diagnostics,
+        );
         let project = Project::builder(Box::new(metadata), Box::new(settings), diagnostics)
             .durability(Durability::MEDIUM)
             .open_fileset_durability(Durability::LOW)
@@ -232,15 +242,25 @@ impl Project {
         )
     }
 
+    /// Reload the project after its metadata or settings have changed.
+    ///
+    /// Program-settings diagnostics are converted and merged here to keep reload behavior
+    /// consistent with initial project creation.
     pub fn reload(
         self,
         db: &mut dyn Db,
         metadata: ProjectMetadata,
         settings: Option<Settings>,
         settings_diagnostics: Vec<OptionDiagnostic>,
+        program_settings_diagnostics: Vec<ProgramSettingsDiagnostic>,
     ) {
         tracing::debug!("Reloading project");
         let metadata_changed = &metadata != self.metadata(db);
+        let settings_diagnostics = Self::settings_diagnostics_with_program_diagnostics(
+            db,
+            settings_diagnostics,
+            program_settings_diagnostics,
+        );
 
         self.reload_files(db);
 
@@ -260,6 +280,40 @@ impl Project {
 
         self.set_metadata(db).to(Box::new(metadata));
         self.try_add_file_root(db);
+    }
+
+    /// Replace stored settings diagnostics after recomputing program settings.
+    ///
+    /// This is used when a change affects [`ty_python_core::program::ProgramSettings`] without
+    /// reloading the full project.
+    pub(crate) fn update_settings_diagnostics(
+        self,
+        db: &mut dyn Db,
+        settings_diagnostics: Vec<OptionDiagnostic>,
+        program_settings_diagnostics: Vec<ProgramSettingsDiagnostic>,
+    ) {
+        let settings_diagnostics = Self::settings_diagnostics_with_program_diagnostics(
+            db,
+            settings_diagnostics,
+            program_settings_diagnostics,
+        );
+
+        if self.settings_diagnostics(db) != settings_diagnostics {
+            self.set_settings_diagnostics(db).to(settings_diagnostics);
+        }
+    }
+
+    fn settings_diagnostics_with_program_diagnostics(
+        db: &dyn Db,
+        mut settings_diagnostics: Vec<OptionDiagnostic>,
+        program_settings_diagnostics: Vec<ProgramSettingsDiagnostic>,
+    ) -> Vec<OptionDiagnostic> {
+        settings_diagnostics.extend(
+            program_settings_diagnostics
+                .into_iter()
+                .map(|diagnostic| diagnostic.into_diagnostic(db)),
+        );
+        settings_diagnostics
     }
 
     /// Checks the project and its dependencies according to the project's check mode.

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -27,7 +27,6 @@ use std::iter::FusedIterator;
 use std::panic::{AssertUnwindSafe, UnwindSafe};
 use std::sync::Arc;
 use thiserror::Error;
-use ty_python_core::program::{FallibleStrategy, MisconfigurationStrategy};
 use ty_python_semantic::add_inferred_python_version_hint_to_diagnostic;
 use ty_python_semantic::lint::RuleSelection;
 use ty_python_semantic::types::check_types;

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -170,17 +170,27 @@ impl ProgressReporter for CollectReporter {
     }
 }
 
+fn merge_settings_diagnostics(
+    mut diagnostics: Vec<OptionDiagnostic>,
+    program_settings_diagnostics: Vec<OptionDiagnostic>,
+) -> Vec<OptionDiagnostic> {
+    diagnostics.extend(program_settings_diagnostics);
+    diagnostics
+}
+
 #[salsa::tracked]
 impl Project {
     pub fn from_metadata<Strategy: MisconfigurationStrategy>(
         db: &dyn Db,
         metadata: ProjectMetadata,
+        program_settings_diagnostics: Vec<OptionDiagnostic>,
         strategy: &Strategy,
     ) -> Result<Self, Strategy::Error<ToSettingsError>> {
         let (settings, diagnostics) =
             metadata
                 .options()
                 .to_settings(db, metadata.root(), strategy)?;
+        let diagnostics = merge_settings_diagnostics(diagnostics, program_settings_diagnostics);
 
         let project = Project::builder(Box::new(metadata), Box::new(settings), diagnostics)
             .durability(Durability::MEDIUM)
@@ -242,7 +252,12 @@ impl Project {
         )
     }
 
-    pub fn reload(self, db: &mut dyn Db, metadata: ProjectMetadata) {
+    pub fn reload(
+        self,
+        db: &mut dyn Db,
+        metadata: ProjectMetadata,
+        program_settings_diagnostics: Vec<OptionDiagnostic>,
+    ) {
         tracing::debug!("Reloading project");
 
         self.reload_files(db);
@@ -256,6 +271,9 @@ impl Project {
             .to_settings(db, metadata.root(), &FallibleStrategy)
         {
             Ok((settings, settings_diagnostics)) => {
+                let settings_diagnostics =
+                    merge_settings_diagnostics(settings_diagnostics, program_settings_diagnostics);
+
                 if self.settings(db) != &settings {
                     self.set_settings(db).to(Box::new(settings));
                 }
@@ -269,7 +287,10 @@ impl Project {
                     "Keeping old project configuration because loading the new settings failed with: {error}"
                 );
                 self.set_settings_diagnostics(db)
-                    .to(vec![error.into_diagnostic()]);
+                    .to(merge_settings_diagnostics(
+                        vec![error.into_diagnostic()],
+                        program_settings_diagnostics,
+                    ));
             }
         }
 

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -3,7 +3,7 @@
     reason = "Prefer System trait methods over std methods in ty crates"
 )]
 use crate::glob::{GlobFilterCheckMode, IncludeResult};
-use crate::metadata::options::{OptionDiagnostic, ToSettingsError};
+use crate::metadata::options::OptionDiagnostic;
 use crate::walk::{ProjectFilesFilter, ProjectFilesWalker};
 #[cfg(feature = "testing")]
 pub use db::tests::TestDb;
@@ -172,18 +172,12 @@ impl ProgressReporter for CollectReporter {
 
 #[salsa::tracked]
 impl Project {
-    pub fn from_metadata<Strategy: MisconfigurationStrategy>(
+    pub fn from_metadata(
         db: &dyn Db,
         metadata: ProjectMetadata,
-        program_settings_diagnostics: Vec<OptionDiagnostic>,
-        strategy: &Strategy,
-    ) -> Result<Self, Strategy::Error<ToSettingsError>> {
-        let (settings, mut diagnostics) =
-            metadata
-                .options()
-                .to_settings(db, metadata.root(), strategy)?;
-        diagnostics.extend(program_settings_diagnostics);
-
+        settings: Settings,
+        diagnostics: Vec<OptionDiagnostic>,
+    ) -> Self {
         let project = Project::builder(Box::new(metadata), Box::new(settings), diagnostics)
             .durability(Durability::MEDIUM)
             .open_fileset_durability(Durability::LOW)
@@ -192,7 +186,7 @@ impl Project {
 
         project.try_add_file_root(db);
 
-        Ok(project)
+        project
     }
 
     fn try_add_file_root(self, db: &dyn Db) {
@@ -248,36 +242,22 @@ impl Project {
         self,
         db: &mut dyn Db,
         metadata: ProjectMetadata,
-        program_settings_diagnostics: Vec<OptionDiagnostic>,
+        settings: Option<Settings>,
+        settings_diagnostics: Vec<OptionDiagnostic>,
     ) {
         tracing::debug!("Reloading project");
         let metadata_changed = &metadata != self.metadata(db);
 
         self.reload_files(db);
 
-        match metadata
-            .options()
-            .to_settings(db, metadata.root(), &FallibleStrategy)
+        if let Some(settings) = settings
+            && self.settings(db) != &settings
         {
-            Ok((settings, mut settings_diagnostics)) => {
-                settings_diagnostics.extend(program_settings_diagnostics);
+            self.set_settings(db).to(Box::new(settings));
+        }
 
-                if self.settings(db) != &settings {
-                    self.set_settings(db).to(Box::new(settings));
-                }
-
-                if self.settings_diagnostics(db) != settings_diagnostics {
-                    self.set_settings_diagnostics(db).to(settings_diagnostics);
-                }
-            }
-            Err(error) => {
-                tracing::warn!(
-                    "Keeping old project configuration because loading the new settings failed with: {error}"
-                );
-                let mut settings_diagnostics = vec![error.into_diagnostic()];
-                settings_diagnostics.extend(program_settings_diagnostics);
-                self.set_settings_diagnostics(db).to(settings_diagnostics);
-            }
+        if self.settings_diagnostics(db) != settings_diagnostics {
+            self.set_settings_diagnostics(db).to(settings_diagnostics);
         }
 
         if !metadata_changed {
@@ -844,11 +824,24 @@ mod tests {
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemPathBuf};
     use ruff_db::testing::assert_function_query_was_not_run;
     use ruff_python_ast::name::Name;
+    use ty_python_core::program::FallibleStrategy;
     use ty_python_semantic::types::check_types;
+
+    fn test_project_metadata() -> ProjectMetadata {
+        ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/"))
+    }
+
+    fn settings_diagnostic_messages(project: crate::Project, db: &dyn Db) -> Vec<String> {
+        project
+            .check_settings(db)
+            .iter()
+            .map(|diagnostic| diagnostic.primary_message().to_string())
+            .collect()
+    }
 
     #[test]
     fn check_file_skips_type_checking_when_file_cant_be_read() -> ruff_db::system::Result<()> {
-        let project = ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/"));
+        let project = test_project_metadata();
         let mut db = TestDb::new(project);
         db.init_program().unwrap();
         let path = SystemPath::new("test.py");
@@ -893,14 +886,18 @@ mod tests {
 
     #[test]
     fn reload_updates_settings_diagnostics_when_metadata_is_unchanged() {
-        let project_metadata =
-            ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/"));
-        let mut db = TestDb::new(project_metadata);
+        let mut db = TestDb::new(test_project_metadata());
         let project = db.project();
+        let first_metadata = test_project_metadata();
+        let first_settings = first_metadata
+            .to_settings(&db, &FallibleStrategy)
+            .unwrap()
+            .0;
 
         project.reload(
             &mut db,
-            ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/")),
+            first_metadata,
+            Some(first_settings),
             vec![OptionDiagnostic::new(
                 DiagnosticId::UnsupportedPythonVersion,
                 "first diagnostic".to_string(),
@@ -909,17 +906,20 @@ mod tests {
         );
 
         assert_eq!(
-            project
-                .check_settings(&db)
-                .iter()
-                .map(|diagnostic| diagnostic.primary_message().to_string())
-                .collect::<Vec<_>>(),
+            settings_diagnostic_messages(project, &db),
             vec!["first diagnostic".to_string()]
         );
 
+        let second_metadata = test_project_metadata();
+        let second_settings = second_metadata
+            .to_settings(&db, &FallibleStrategy)
+            .unwrap()
+            .0;
+
         project.reload(
             &mut db,
-            ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/")),
+            second_metadata,
+            Some(second_settings),
             vec![OptionDiagnostic::new(
                 DiagnosticId::UnsupportedPythonVersion,
                 "second diagnostic".to_string(),
@@ -928,11 +928,7 @@ mod tests {
         );
 
         assert_eq!(
-            project
-                .check_settings(&db)
-                .iter()
-                .map(|diagnostic| diagnostic.primary_message().to_string())
-                .collect::<Vec<_>>(),
+            settings_diagnostic_messages(project, &db),
             vec!["second diagnostic".to_string()]
         );
     }

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -7,6 +7,8 @@ use thiserror::Error;
 use ty_combine::Combine;
 use ty_python_core::program::{FallibleStrategy, MisconfigurationStrategy, ProgramSettings};
 
+use crate::Db;
+use crate::metadata::options::OptionDiagnostic;
 use crate::metadata::options::ProjectOptionsOverrides;
 use crate::metadata::pyproject::{Project, PyProject, PyProjectError, ResolveRequiresPythonError};
 use crate::metadata::value::ValueSource;
@@ -281,12 +283,13 @@ impl ProjectMetadata {
 
     pub fn to_program_settings<Strategy: MisconfigurationStrategy>(
         &self,
+        db: &dyn Db,
         system: &dyn System,
         vendored: &VendoredFileSystem,
         strategy: &Strategy,
-    ) -> Result<ProgramSettings, Strategy::Error<anyhow::Error>> {
+    ) -> Result<(ProgramSettings, Vec<OptionDiagnostic>), Strategy::Error<anyhow::Error>> {
         self.options
-            .to_program_settings(self.root(), self.name(), system, vendored, strategy)
+            .to_program_settings(db, self.root(), self.name(), system, vendored, strategy)
     }
 
     pub fn apply_overrides(&mut self, overrides: &ProjectOptionsOverrides) {

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -8,9 +8,10 @@ use ty_combine::Combine;
 use ty_python_core::program::{FallibleStrategy, MisconfigurationStrategy, ProgramSettings};
 
 use crate::Db;
-use crate::metadata::options::OptionDiagnostic;
 use crate::metadata::options::ProjectOptionsOverrides;
+use crate::metadata::options::{OptionDiagnostic, ToSettingsError};
 use crate::metadata::pyproject::{Project, PyProject, PyProjectError, ResolveRequiresPythonError};
+use crate::metadata::settings::Settings;
 use crate::metadata::value::ValueSource;
 pub use options::Options;
 use options::TyTomlError;
@@ -290,6 +291,14 @@ impl ProjectMetadata {
     ) -> Result<(ProgramSettings, Vec<OptionDiagnostic>), Strategy::Error<anyhow::Error>> {
         self.options
             .to_program_settings(db, self.root(), self.name(), system, vendored, strategy)
+    }
+
+    pub fn to_settings<Strategy: MisconfigurationStrategy>(
+        &self,
+        db: &dyn Db,
+        strategy: &Strategy,
+    ) -> Result<(Settings, Vec<OptionDiagnostic>), Strategy::Error<ToSettingsError>> {
+        self.options.to_settings(db, self.root(), strategy)
     }
 
     pub fn apply_overrides(&mut self, overrides: &ProjectOptionsOverrides) {

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -9,7 +9,7 @@ use ty_python_core::program::{FallibleStrategy, MisconfigurationStrategy, Progra
 
 use crate::Db;
 use crate::metadata::options::ProjectOptionsOverrides;
-use crate::metadata::options::{OptionDiagnostic, ToSettingsError};
+use crate::metadata::options::{OptionDiagnostic, ProgramSettingsDiagnostic, ToSettingsError};
 use crate::metadata::pyproject::{Project, PyProject, PyProjectError, ResolveRequiresPythonError};
 use crate::metadata::settings::Settings;
 use crate::metadata::value::ValueSource;
@@ -284,13 +284,13 @@ impl ProjectMetadata {
 
     pub fn to_program_settings<Strategy: MisconfigurationStrategy>(
         &self,
-        db: &dyn Db,
         system: &dyn System,
         vendored: &VendoredFileSystem,
         strategy: &Strategy,
-    ) -> Result<(ProgramSettings, Vec<OptionDiagnostic>), Strategy::Error<anyhow::Error>> {
+    ) -> Result<(ProgramSettings, Vec<ProgramSettingsDiagnostic>), Strategy::Error<anyhow::Error>>
+    {
         self.options
-            .to_program_settings(db, self.root(), self.name(), system, vendored, strategy)
+            .to_program_settings(self.root(), self.name(), system, vendored, strategy)
     }
 
     pub fn to_settings<Strategy: MisconfigurationStrategy>(

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -265,13 +265,10 @@ impl Options {
                     return true;
                 }
 
-                diagnostics.push(unsupported_inferred_python_version_diagnostic(db, python_version));
-
-                tracing::warn!(
-                    "Ignoring unsupported inferred Python version `{}`; ty will use Python {} instead.",
-                    python_version.version,
-                    PythonVersion::latest_ty()
-                );
+                diagnostics.push(unsupported_inferred_python_version_diagnostic(
+                    db,
+                    python_version,
+                ));
 
                 false
             })

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -252,10 +252,6 @@ impl Options {
                 tracing::info!("No real stdlib found, stdlib goto-definition may have degraded quality: {err}");
             }).ok()
         });
-        let layout_inference_source = python_environment
-            .as_ref()
-            .and_then(ty_python_semantic::PythonEnvironment::pyvenv_cfg_path);
-
         let python_version = options_python_version
             .or_else(|| {
                 python_environment
@@ -263,17 +259,13 @@ impl Options {
                     .python_version_from_metadata()
                     .cloned()
             })
-            .or_else(|| site_packages_paths.python_version_from_layout())
+            .or_else(|| site_packages_paths.python_version_from_layout(system))
             .filter(|python_version| {
                 if SupportedPythonVersion::try_from(python_version.version).is_ok() {
                     return true;
                 }
 
-                diagnostics.push(unsupported_inferred_python_version_diagnostic(
-                    db,
-                    python_version,
-                    layout_inference_source.as_deref(),
-                ));
+                diagnostics.push(unsupported_inferred_python_version_diagnostic(db, python_version));
 
                 tracing::warn!(
                     "Ignoring unsupported inferred Python version `{}`; ty will use Python {} instead.",
@@ -574,7 +566,6 @@ impl Options {
 fn unsupported_inferred_python_version_diagnostic(
     db: &dyn Db,
     python_version: &PythonVersionWithSource,
-    layout_inference_source: Option<&SystemPath>,
 ) -> OptionDiagnostic {
     let expected = SupportedPythonVersion::iter()
         .map(|version| format!("`{version}`"))
@@ -614,12 +605,9 @@ fn unsupported_inferred_python_version_diagnostic(
             )),
         PythonVersionSource::InstallationDirectoryLayout {
             site_packages_parent_dir,
+            source,
         } => diagnostic
-            .with_annotation(
-                layout_inference_source
-                    .and_then(|path| system_path_to_file(db, path).ok())
-                    .map(|file| Annotation::primary(Span::from(file))),
-            )
+            .with_annotation(source.as_ref().and_then(|source| source.span(db)).map(Annotation::primary))
             .sub(SubDiagnostic::new(
                 SubDiagnosticSeverity::Info,
                 format!(

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -40,6 +40,7 @@ use ty_python_semantic::lint::{Level, LintSource, RuleSelection};
 use ty_python_semantic::{
     AnalysisSettings, PythonEnvironment, PythonVersionFileSource, PythonVersionSource,
     PythonVersionWithSource, SitePackagesPaths, SysPrefixPathOrigin,
+    inferred_python_version_source_annotation,
 };
 use ty_static::EnvVars;
 
@@ -590,14 +591,14 @@ fn unsupported_inferred_python_version_diagnostic(
     ));
 
     diagnostic = match &python_version.source {
-        PythonVersionSource::ConfigFile(source) => diagnostic
-            .with_annotation(source.span(db).map(Annotation::primary))
+        source @ PythonVersionSource::ConfigFile(_) => diagnostic
+            .with_annotation(inferred_python_version_source_annotation(db, source))
             .sub(SubDiagnostic::new(
                 SubDiagnosticSeverity::Info,
                 "The version was inferred from a configuration file.",
             )),
-        PythonVersionSource::PyvenvCfgFile(source) => diagnostic
-            .with_annotation(source.span(db).map(Annotation::primary))
+        source @ PythonVersionSource::PyvenvCfgFile(_) => diagnostic
+            .with_annotation(inferred_python_version_source_annotation(db, source))
             .sub(SubDiagnostic::new(
                 SubDiagnosticSeverity::Info,
                 "The version was inferred from your virtual environment metadata.",
@@ -606,7 +607,13 @@ fn unsupported_inferred_python_version_diagnostic(
             site_packages_parent_dir,
             source,
         } => diagnostic
-            .with_annotation(source.as_ref().and_then(|source| source.span(db)).map(Annotation::primary))
+            .with_annotation(inferred_python_version_source_annotation(
+                db,
+                &PythonVersionSource::InstallationDirectoryLayout {
+                    site_packages_parent_dir: site_packages_parent_dir.clone(),
+                    source: source.clone(),
+                },
+            ))
             .sub(SubDiagnostic::new(
                 SubDiagnosticSeverity::Info,
                 format!(

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -28,6 +28,7 @@ use std::fmt::{self, Debug, Display};
 use std::hash::BuildHasherDefault;
 use std::ops::Deref;
 use std::sync::Arc;
+use strum::IntoEnumIterator;
 use thiserror::Error;
 use ty_combine::Combine;
 use ty_module_resolver::{
@@ -156,12 +157,14 @@ impl Options {
 
     pub(crate) fn to_program_settings<Strategy: MisconfigurationStrategy>(
         &self,
+        db: &dyn Db,
         project_root: &SystemPath,
         project_name: &str,
         system: &dyn System,
         vendored: &VendoredFileSystem,
         strategy: &Strategy,
-    ) -> Result<ProgramSettings, Strategy::Error<anyhow::Error>> {
+    ) -> Result<(ProgramSettings, Vec<OptionDiagnostic>), Strategy::Error<anyhow::Error>> {
+        let mut diagnostics = Vec::new();
         let environment = self.environment.or_default();
 
         let options_python_version =
@@ -249,6 +252,9 @@ impl Options {
                 tracing::info!("No real stdlib found, stdlib goto-definition may have degraded quality: {err}");
             }).ok()
         });
+        let layout_inference_source = python_environment
+            .as_ref()
+            .and_then(ty_python_semantic::PythonEnvironment::pyvenv_cfg_path);
 
         let python_version = options_python_version
             .or_else(|| {
@@ -259,14 +265,23 @@ impl Options {
             })
             .or_else(|| site_packages_paths.python_version_from_layout())
             .filter(|python_version| {
-                let is_supported = SupportedPythonVersion::try_from(python_version.version).is_ok();
-                if !is_supported {
-                    tracing::warn!(
-                        "Ignoring unsupported inferred Python version: {}",
-                        python_version.version
-                    );
+                if SupportedPythonVersion::try_from(python_version.version).is_ok() {
+                    return true;
                 }
-                is_supported
+
+                diagnostics.push(unsupported_inferred_python_version_diagnostic(
+                    db,
+                    python_version,
+                    layout_inference_source.as_deref(),
+                ));
+
+                tracing::warn!(
+                    "Ignoring unsupported inferred Python version `{}`; ty will use Python {} instead.",
+                    python_version.version,
+                    PythonVersion::latest_ty()
+                );
+
+                false
             })
             .unwrap_or_default();
 
@@ -286,11 +301,14 @@ impl Options {
             python_version = python_version.version
         );
 
-        Ok(ProgramSettings {
-            python_version,
-            python_platform,
-            search_paths,
-        })
+        Ok((
+            ProgramSettings {
+                python_version,
+                python_platform,
+                search_paths,
+            },
+            diagnostics,
+        ))
     }
 
     #[expect(clippy::too_many_arguments)]
@@ -551,6 +569,78 @@ impl Options {
 
         Ok(overrides)
     }
+}
+
+fn unsupported_inferred_python_version_diagnostic(
+    db: &dyn Db,
+    python_version: &PythonVersionWithSource,
+    layout_inference_source: Option<&SystemPath>,
+) -> OptionDiagnostic {
+    let expected = SupportedPythonVersion::iter()
+        .map(|version| format!("`{version}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let fallback = PythonVersion::latest_ty();
+
+    let mut diagnostic = OptionDiagnostic::new(
+        DiagnosticId::UnsupportedPythonVersion,
+        format!(
+            "Ignoring unsupported inferred Python version `{}`; ty will use Python {fallback} instead.",
+            python_version.version
+        ),
+        Severity::Warning,
+    )
+    .sub(SubDiagnostic::new(
+        SubDiagnosticSeverity::Info,
+        format!("Expected one of {expected}."),
+    ))
+    .sub(SubDiagnostic::new(
+        SubDiagnosticSeverity::Info,
+        "Set `python-version` explicitly to override the inferred version.",
+    ));
+
+    diagnostic = match &python_version.source {
+        PythonVersionSource::ConfigFile(source) => diagnostic
+            .with_annotation(source.span(db).map(Annotation::primary))
+            .sub(SubDiagnostic::new(
+                SubDiagnosticSeverity::Info,
+                "The version was inferred from a configuration file.",
+            )),
+        PythonVersionSource::PyvenvCfgFile(source) => diagnostic
+            .with_annotation(source.span(db).map(Annotation::primary))
+            .sub(SubDiagnostic::new(
+                SubDiagnosticSeverity::Info,
+                "The version was inferred from your virtual environment metadata.",
+            )),
+        PythonVersionSource::InstallationDirectoryLayout {
+            site_packages_parent_dir,
+        } => diagnostic
+            .with_annotation(
+                layout_inference_source
+                    .and_then(|path| system_path_to_file(db, path).ok())
+                    .map(|file| Annotation::primary(Span::from(file))),
+            )
+            .sub(SubDiagnostic::new(
+                SubDiagnosticSeverity::Info,
+                format!(
+                    "The version was inferred from the `lib/{site_packages_parent_dir}/site-packages` directory layout.",
+                ),
+            )),
+        PythonVersionSource::Cli => diagnostic.sub(SubDiagnostic::new(
+            SubDiagnosticSeverity::Info,
+            "The version was inferred from the command line.",
+        )),
+        PythonVersionSource::Editor => diagnostic.sub(SubDiagnostic::new(
+            SubDiagnosticSeverity::Info,
+            "The version was inferred from your editor.",
+        )),
+        PythonVersionSource::Default => diagnostic.sub(SubDiagnostic::new(
+            SubDiagnosticSeverity::Info,
+            "ty fell back to its default Python version.",
+        )),
+    };
+
+    diagnostic
 }
 
 /// Return the site-packages from the environment ty is installed in, as derived from ty's

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -252,6 +252,7 @@ impl Options {
                 tracing::info!("No real stdlib found, stdlib goto-definition may have degraded quality: {err}");
             }).ok()
         });
+
         let python_version = options_python_version
             .or_else(|| {
                 python_environment
@@ -560,6 +561,7 @@ impl Options {
     }
 }
 
+/// Construct an [`OptionDiagnostic`] to indicate that the inferred Python version is unsupported.
 fn unsupported_inferred_python_version_diagnostic(
     db: &dyn Db,
     python_version: &PythonVersionWithSource,

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -158,13 +158,13 @@ impl Options {
 
     pub(crate) fn to_program_settings<Strategy: MisconfigurationStrategy>(
         &self,
-        db: &dyn Db,
         project_root: &SystemPath,
         project_name: &str,
         system: &dyn System,
         vendored: &VendoredFileSystem,
         strategy: &Strategy,
-    ) -> Result<(ProgramSettings, Vec<OptionDiagnostic>), Strategy::Error<anyhow::Error>> {
+    ) -> Result<(ProgramSettings, Vec<ProgramSettingsDiagnostic>), Strategy::Error<anyhow::Error>>
+    {
         let mut diagnostics = Vec::new();
         let environment = self.environment.or_default();
 
@@ -257,7 +257,7 @@ impl Options {
 
                 inferred_python_version.map(PythonVersionResolution::Inferred)
             })
-            .and_then(|resolution| resolution.into_program_version(db, &mut diagnostics))
+            .and_then(|resolution| resolution.into_program_version(&mut diagnostics))
             .unwrap_or_default();
 
         // Safe mode is handled inside this function, so we just assume this can't fail
@@ -573,8 +573,7 @@ enum PythonVersionResolution {
 impl PythonVersionResolution {
     fn into_program_version(
         self,
-        db: &dyn Db,
-        diagnostics: &mut Vec<OptionDiagnostic>,
+        diagnostics: &mut Vec<ProgramSettingsDiagnostic>,
     ) -> Option<PythonVersionWithSource> {
         match self {
             Self::Configured(python_version) => Some(python_version),
@@ -582,12 +581,32 @@ impl PythonVersionResolution {
                 if SupportedPythonVersion::try_from(python_version.version).is_ok() {
                     Some(python_version)
                 } else {
-                    diagnostics.push(unsupported_inferred_python_version_diagnostic(
-                        db,
-                        &python_version,
+                    diagnostics.push(ProgramSettingsDiagnostic::UnsupportedInferredPythonVersion(
+                        python_version,
                     ));
                     None
                 }
+            }
+        }
+    }
+}
+
+/// A diagnostic produced while resolving [`ProgramSettings`].
+///
+/// These diagnostics are kept separate from [`OptionDiagnostic`] while program settings are
+/// resolved so that this step does not need access to the database.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ProgramSettingsDiagnostic {
+    /// The Python version inferred from the environment is newer than ty supports.
+    UnsupportedInferredPythonVersion(PythonVersionWithSource),
+}
+
+impl ProgramSettingsDiagnostic {
+    /// Convert this program-settings diagnostic into a diagnostic that can be stored on a project.
+    pub(crate) fn into_diagnostic(self, db: &dyn Db) -> OptionDiagnostic {
+        match self {
+            Self::UnsupportedInferredPythonVersion(python_version) => {
+                unsupported_inferred_python_version_diagnostic(db, &python_version)
             }
         }
     }

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -253,7 +253,7 @@ impl Options {
                         python_environment.python_version_from_metadata()
                     })
                     .cloned()
-                    .or_else(|| site_packages_paths.python_version_from_layout(system));
+                    .or_else(|| site_packages_paths.python_version_from_layout());
 
                 inferred_python_version.map(PythonVersionResolution::Inferred)
             })

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -168,20 +168,10 @@ impl Options {
         let mut diagnostics = Vec::new();
         let environment = self.environment.or_default();
 
-        let options_python_version =
-            environment
-                .python_version
-                .as_ref()
-                .map(|ranged_version| PythonVersionWithSource {
-                    version: PythonVersion::from(**ranged_version),
-                    source: match ranged_version.source() {
-                        ValueSource::Cli => PythonVersionSource::Cli,
-                        ValueSource::File(path) => PythonVersionSource::ConfigFile(
-                            PythonVersionFileSource::new(path.clone(), ranged_version.range()),
-                        ),
-                        ValueSource::Editor => PythonVersionSource::Editor,
-                    },
-                });
+        let configured_python_version = environment
+            .python_version
+            .as_ref()
+            .map(python_version_from_config);
         let python_platform = environment
             .python_platform
             .as_deref()
@@ -254,26 +244,20 @@ impl Options {
             }).ok()
         });
 
-        let python_version = options_python_version
+        let python_version = configured_python_version
+            .map(PythonVersionResolution::Configured)
             .or_else(|| {
-                python_environment
-                    .as_ref()?
-                    .python_version_from_metadata()
+                let inferred_python_version = python_environment
+                    .as_ref()
+                    .and_then(|python_environment| {
+                        python_environment.python_version_from_metadata()
+                    })
                     .cloned()
-            })
-            .or_else(|| site_packages_paths.python_version_from_layout(system))
-            .filter(|python_version| {
-                if SupportedPythonVersion::try_from(python_version.version).is_ok() {
-                    return true;
-                }
+                    .or_else(|| site_packages_paths.python_version_from_layout(system));
 
-                diagnostics.push(unsupported_inferred_python_version_diagnostic(
-                    db,
-                    python_version,
-                ));
-
-                false
+                inferred_python_version.map(PythonVersionResolution::Inferred)
             })
+            .and_then(|resolution| resolution.into_program_version(db, &mut diagnostics))
             .unwrap_or_default();
 
         // Safe mode is handled inside this function, so we just assume this can't fail
@@ -562,6 +546,53 @@ impl Options {
     }
 }
 
+fn python_version_from_config(
+    ranged_version: &RangedValue<SupportedPythonVersion>,
+) -> PythonVersionWithSource {
+    PythonVersionWithSource {
+        version: PythonVersion::from(**ranged_version),
+        source: match ranged_version.source() {
+            ValueSource::Cli => PythonVersionSource::Cli,
+            ValueSource::File(path) => PythonVersionSource::ConfigFile(
+                PythonVersionFileSource::new(path.clone(), ranged_version.range()),
+            ),
+            ValueSource::Editor => PythonVersionSource::Editor,
+        },
+    }
+}
+
+/// A Python version before unsupported inferred versions are filtered.
+#[derive(Eq, PartialEq, Debug, Clone)]
+enum PythonVersionResolution {
+    /// The Python version was configured directly by the user.
+    Configured(PythonVersionWithSource),
+    /// The Python version was inferred from the environment.
+    Inferred(PythonVersionWithSource),
+}
+
+impl PythonVersionResolution {
+    fn into_program_version(
+        self,
+        db: &dyn Db,
+        diagnostics: &mut Vec<OptionDiagnostic>,
+    ) -> Option<PythonVersionWithSource> {
+        match self {
+            Self::Configured(python_version) => Some(python_version),
+            Self::Inferred(python_version) => {
+                if SupportedPythonVersion::try_from(python_version.version).is_ok() {
+                    Some(python_version)
+                } else {
+                    diagnostics.push(unsupported_inferred_python_version_diagnostic(
+                        db,
+                        &python_version,
+                    ));
+                    None
+                }
+            }
+        }
+    }
+}
+
 /// Construct an [`OptionDiagnostic`] to indicate that the inferred Python version is unsupported.
 fn unsupported_inferred_python_version_diagnostic(
     db: &dyn Db,
@@ -587,7 +618,7 @@ fn unsupported_inferred_python_version_diagnostic(
     ))
     .sub(SubDiagnostic::new(
         SubDiagnosticSeverity::Info,
-        "Set `python-version` explicitly to override the inferred version.",
+        "Set `environment.python-version` explicitly to override the inferred version.",
     ));
 
     diagnostic = match &python_version.source {

--- a/crates/ty_python_semantic/src/diagnostic/mod.rs
+++ b/crates/ty_python_semantic/src/diagnostic/mod.rs
@@ -85,6 +85,7 @@ pub fn add_inferred_python_version_hint_to_diagnostic(
         }
         crate::PythonVersionSource::InstallationDirectoryLayout {
             site_packages_parent_dir,
+            source: _,
         } => {
             // TODO: it would also be nice to tell them how we resolved this Python installation...
             diagnostic.info(format_args!(

--- a/crates/ty_python_semantic/src/diagnostic/mod.rs
+++ b/crates/ty_python_semantic/src/diagnostic/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Db, Program, PythonVersionWithSource, lint::lint_documentation_url, types::TypeCheckDiagnostics,
+    Db, Program, PythonVersionSource, PythonVersionWithSource, lint::lint_documentation_url,
+    types::TypeCheckDiagnostics,
 };
 use levenshtein::{HideUnderscoredSuggestions, find_best_suggestion};
 use ruff_db::{
@@ -20,6 +21,24 @@ where
     find_best_suggestion(options, typo, HideUnderscoredSuggestions::Yes)
 }
 
+/// Return an annotation for the source from which ty inferred the Python version, when one exists.
+pub fn inferred_python_version_source_annotation(
+    db: &dyn Db,
+    source: &PythonVersionSource,
+) -> Option<Annotation> {
+    match source {
+        PythonVersionSource::ConfigFile(source) => source.span(db).map(Annotation::primary),
+        PythonVersionSource::PyvenvCfgFile(source) => source.span(db).map(Annotation::primary),
+        PythonVersionSource::InstallationDirectoryLayout { source, .. } => source
+            .as_ref()
+            .and_then(|source| source.span(db))
+            .map(Annotation::primary),
+        PythonVersionSource::Cli | PythonVersionSource::Editor | PythonVersionSource::Default => {
+            None
+        }
+    }
+}
+
 /// Add a subdiagnostic to `diagnostic` that explains why a certain Python version was inferred.
 ///
 /// ty can infer the Python version from various sources, such as command-line arguments,
@@ -38,14 +57,13 @@ pub fn add_inferred_python_version_hint_to_diagnostic(
                 "Python {version} was assumed when {action} because it was specified on the command line",
             ));
         }
-        crate::PythonVersionSource::ConfigFile(source) => {
-            if let Some(span) = source.span(db) {
+        source @ crate::PythonVersionSource::ConfigFile(_) => {
+            if let Some(annotation) = inferred_python_version_source_annotation(db, source) {
                 let mut sub_diagnostic = SubDiagnostic::new(
                     SubDiagnosticSeverity::Info,
                     format_args!("Python {version} was assumed when {action}"),
                 );
-                sub_diagnostic
-                    .annotate(Annotation::primary(span).message("Python version configuration"));
+                sub_diagnostic.annotate(annotation.message("Python version configuration"));
                 diagnostic.sub(sub_diagnostic);
             } else {
                 diagnostic.info(format_args!(
@@ -53,16 +71,15 @@ pub fn add_inferred_python_version_hint_to_diagnostic(
                 ));
             }
         }
-        crate::PythonVersionSource::PyvenvCfgFile(source) => {
-            if let Some(span) = source.span(db) {
+        source @ crate::PythonVersionSource::PyvenvCfgFile(_) => {
+            if let Some(annotation) = inferred_python_version_source_annotation(db, source) {
                 let mut sub_diagnostic = SubDiagnostic::new(
                     SubDiagnosticSeverity::Info,
                     format_args!(
                         "Python {version} was assumed when {action} because of your virtual environment"
                     ),
                 );
-                sub_diagnostic
-                    .annotate(Annotation::primary(span).message("Virtual environment metadata"));
+                sub_diagnostic.annotate(annotation.message("Virtual environment metadata"));
                 // TODO: it would also be nice to tell them how we resolved their virtual environment...
                 diagnostic.sub(sub_diagnostic);
             } else {

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -8,7 +8,9 @@ use crate::suppression::{
 };
 use crate::types::check_types;
 pub use db::Db;
-pub use diagnostic::add_inferred_python_version_hint_to_diagnostic;
+pub use diagnostic::{
+    add_inferred_python_version_hint_to_diagnostic, inferred_python_version_source_annotation,
+};
 pub use fixes::{fix_all_diagnostics, suppress_all_diagnostics};
 use ruff_db::diagnostic::{Annotation, Diagnostic, DiagnosticId, Severity, Span};
 use ruff_db::files::File;

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -9,7 +9,9 @@ use crate::suppression::{
     IGNORE_COMMENT_UNKNOWN_RULE, INVALID_IGNORE_COMMENT, UNUSED_TYPE_IGNORE_COMMENT,
 };
 pub use db::Db;
-pub use diagnostic::add_inferred_python_version_hint_to_diagnostic;
+pub use diagnostic::{
+    add_inferred_python_version_hint_to_diagnostic, inferred_python_version_source_annotation,
+};
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;

--- a/crates/ty_server/tests/e2e/configuration.rs
+++ b/crates/ty_server/tests/e2e/configuration.rs
@@ -246,6 +246,7 @@ reveal_type(sys.version_info[:2])
     Ok(())
 }
 
+#[cfg_attr(windows, ignore = "site-packages layout inference is Unix-only")]
 #[test]
 fn unsupported_inferred_python_version_setting_diagnostic() -> Result<()> {
     let workspace_root = SystemPath::new("project");
@@ -286,6 +287,65 @@ fn unsupported_inferred_python_version_setting_diagnostic() -> Result<()> {
     let diagnostics = server.collect_publish_diagnostic_notifications(1);
 
     assert_json_snapshot!(diagnostics);
+
+    Ok(())
+}
+
+#[cfg_attr(windows, ignore = "site-packages layout inference is Unix-only")]
+#[test]
+fn unsupported_inferred_python_version_setting_diagnostic_for_system_interpreter() -> Result<()> {
+    let workspace_root = SystemPath::new("project");
+    let main = SystemPath::new("project/main.py");
+    let python = "python/bin/python3.16";
+    let site_packages = "python/lib/python3.16/site-packages/foo.py";
+
+    let builder = TestServerBuilder::new()?;
+    let sys_prefix = builder.file_path("python");
+    let python_uri = builder.file_uri(python);
+
+    let workspace_options: ClientOptions = serde_json::from_value(json!({
+        "pythonExtension": {
+            "activeEnvironment": {
+                "executable": {
+                    "uri": python_uri,
+                    "sysPrefix": sys_prefix,
+                }
+            }
+        }
+    }))?;
+
+    let mut server = builder
+        .with_workspace(workspace_root, Some(workspace_options))?
+        .with_file(main, "x = 1\n")?
+        .with_file(python, "")?
+        .with_file(site_packages, "")?
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    let diagnostics = server.collect_publish_diagnostic_notifications(1);
+
+    assert_json_snapshot!(diagnostics, @r#"
+    {
+      "file://<temp_dir>/python/bin/python3.16": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "severity": 2,
+          "code": "unsupported-python-version",
+          "source": "ty",
+          "message": "Ignoring unsupported inferred Python version `3.16`; ty will use Python 3.14 instead.\n\ninfo: Expected one of `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, `3.15`.\ninfo: Set `python-version` explicitly to override the inferred version.\ninfo: The version was inferred from the `lib/python3.16/site-packages` directory layout."
+        }
+      ]
+    }
+    "#);
 
     Ok(())
 }

--- a/crates/ty_server/tests/e2e/configuration.rs
+++ b/crates/ty_server/tests/e2e/configuration.rs
@@ -211,6 +211,10 @@ reveal_type(sys.version_info[:2])
         .build()
         .wait_until_workspaces_are_initialized();
 
+    // The unsupported version inferred from the selected environment now surfaces as a
+    // settings diagnostic on the environment's `pyvenv.cfg`.
+    server.collect_publish_diagnostic_notifications(1);
+
     server.open_text_document(main, foo_content, 1);
     let diagnostics = server.document_diagnostic_request(main, None);
 
@@ -238,6 +242,50 @@ reveal_type(sys.version_info[:2])
       ]
     }
     "#);
+
+    Ok(())
+}
+
+#[test]
+fn unsupported_inferred_python_version_setting_diagnostic() -> Result<()> {
+    let workspace_root = SystemPath::new("project");
+    let main = SystemPath::new("project/main.py");
+    let python_home = "base/bin";
+    let base_python = if cfg!(target_os = "windows") {
+        "base/bin/python.exe"
+    } else {
+        "base/bin/python"
+    };
+    let python = if cfg!(target_os = "windows") {
+        "project/.venv/Scripts/python.exe"
+    } else {
+        "project/.venv/bin/python"
+    };
+    let site_packages = if cfg!(target_os = "windows") {
+        "project/.venv/Lib/site-packages/foo.py"
+    } else {
+        "project/.venv/lib/python3.16/site-packages/foo.py"
+    };
+
+    let builder = TestServerBuilder::new()?;
+    let python_home = builder.file_path(python_home);
+
+    let mut server = builder
+        .with_workspace(workspace_root, None)?
+        .with_file(main, "x = 1\n")?
+        .with_file(base_python, "")?
+        .with_file(python, "")?
+        .with_file(
+            "project/.venv/pyvenv.cfg",
+            format!("home = {python_home}\n"),
+        )?
+        .with_file(site_packages, "")?
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    let diagnostics = server.collect_publish_diagnostic_notifications(1);
+
+    assert_json_snapshot!(diagnostics);
 
     Ok(())
 }

--- a/crates/ty_server/tests/e2e/configuration.rs
+++ b/crates/ty_server/tests/e2e/configuration.rs
@@ -211,7 +211,7 @@ reveal_type(sys.version_info[:2])
         .build()
         .wait_until_workspaces_are_initialized();
 
-    // The unsupported version inferred from the selected environment now surfaces as a
+    // The unsupported version inferred from the selected environment surfaces as a
     // settings diagnostic on the environment's `pyvenv.cfg`.
     server.collect_publish_diagnostic_notifications(1);
 

--- a/crates/ty_server/tests/e2e/configuration.rs
+++ b/crates/ty_server/tests/e2e/configuration.rs
@@ -213,7 +213,29 @@ reveal_type(sys.version_info[:2])
 
     // The unsupported version inferred from the selected environment surfaces as a
     // settings diagnostic on the environment's `pyvenv.cfg`.
-    server.collect_publish_diagnostic_notifications(1);
+    let diagnostics = server.collect_publish_diagnostic_notifications(1);
+    assert_json_snapshot!(diagnostics, @r#"
+    {
+      "file://<temp_dir>/venv/pyvenv.cfg": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 15
+            },
+            "end": {
+              "line": 0,
+              "character": 21
+            }
+          },
+          "severity": 2,
+          "code": "unsupported-python-version",
+          "source": "ty",
+          "message": "Ignoring unsupported inferred Python version `3.16`; ty will use Python 3.14 instead.\n\ninfo: Expected one of `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, `3.15`.\ninfo: Set `environment.python-version` explicitly to override the inferred version.\ninfo: The version was inferred from the `pyvenv.cfg` file."
+        }
+      ]
+    }
+    "#);
 
     server.open_text_document(main, foo_content, 1);
     let diagnostics = server.document_diagnostic_request(main, None);

--- a/crates/ty_server/tests/e2e/configuration.rs
+++ b/crates/ty_server/tests/e2e/configuration.rs
@@ -341,7 +341,7 @@ fn unsupported_inferred_python_version_setting_diagnostic_for_system_interpreter
           "severity": 2,
           "code": "unsupported-python-version",
           "source": "ty",
-          "message": "Ignoring unsupported inferred Python version `3.16`; ty will use Python 3.14 instead.\n\ninfo: Expected one of `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, `3.15`.\ninfo: Set `python-version` explicitly to override the inferred version.\ninfo: The version was inferred from the `lib/python3.16/site-packages` directory layout."
+          "message": "Ignoring unsupported inferred Python version `3.16`; ty will use Python 3.14 instead.\n\ninfo: Expected one of `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, `3.15`.\ninfo: Set `environment.python-version` explicitly to override the inferred version.\ninfo: The version was inferred from the `lib/python3.16/site-packages` directory layout."
         }
       ]
     }

--- a/crates/ty_server/tests/e2e/configuration.rs
+++ b/crates/ty_server/tests/e2e/configuration.rs
@@ -231,7 +231,7 @@ reveal_type(sys.version_info[:2])
           "severity": 2,
           "code": "unsupported-python-version",
           "source": "ty",
-          "message": "Ignoring unsupported inferred Python version `3.16`; ty will use Python 3.14 instead.\n\ninfo: Expected one of `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, `3.15`.\ninfo: Set `environment.python-version` explicitly to override the inferred version.\ninfo: The version was inferred from the `pyvenv.cfg` file."
+          "message": "Ignoring unsupported inferred Python version `3.16`; ty will use Python 3.14 instead.\n\ninfo: Expected one of `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, `3.15`.\ninfo: Set `environment.python-version` explicitly to override the inferred version.\ninfo: The version was inferred from your virtual environment metadata."
         }
       ]
     }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__configuration__unsupported_inferred_python_version_setting_diagnostic.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__configuration__unsupported_inferred_python_version_setting_diagnostic.snap
@@ -1,0 +1,24 @@
+---
+source: crates/ty_server/tests/e2e/configuration.rs
+expression: diagnostics
+---
+{
+  "file://<temp_dir>/project/.venv/pyvenv.cfg": [
+    {
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 0,
+          "character": 0
+        }
+      },
+      "severity": 2,
+      "code": "unsupported-python-version",
+      "source": "ty",
+      "message": "Ignoring unsupported inferred Python version `3.16`; ty will use Python 3.14 instead.\n\ninfo: Expected one of `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, `3.15`.\ninfo: Set `python-version` explicitly to override the inferred version.\ninfo: The version was inferred from the `lib/python3.16/site-packages` directory layout."
+    }
+  ]
+}

--- a/crates/ty_server/tests/e2e/snapshots/e2e__configuration__unsupported_inferred_python_version_setting_diagnostic.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__configuration__unsupported_inferred_python_version_setting_diagnostic.snap
@@ -18,7 +18,7 @@ expression: diagnostics
       "severity": 2,
       "code": "unsupported-python-version",
       "source": "ty",
-      "message": "Ignoring unsupported inferred Python version `3.16`; ty will use Python 3.14 instead.\n\ninfo: Expected one of `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, `3.15`.\ninfo: Set `python-version` explicitly to override the inferred version.\ninfo: The version was inferred from the `lib/python3.16/site-packages` directory layout."
+      "message": "Ignoring unsupported inferred Python version `3.16`; ty will use Python 3.14 instead.\n\ninfo: Expected one of `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, `3.15`.\ninfo: Set `environment.python-version` explicitly to override the inferred version.\ninfo: The version was inferred from the `lib/python3.16/site-packages` directory layout."
     }
   ]
 }

--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -74,7 +74,10 @@ impl SitePackagesPaths {
     }
 
     /// Tries to detect the version from the layout of the `site-packages` directory.
-    pub fn python_version_from_layout(&self) -> Option<PythonVersionWithSource> {
+    pub fn python_version_from_layout(
+        &self,
+        system: &dyn System,
+    ) -> Option<PythonVersionWithSource> {
         if cfg!(windows) {
             // The path to `site-packages` on Unix is
             // `<sys.prefix>/lib/pythonX.Y/site-packages`,
@@ -112,6 +115,8 @@ impl SitePackagesPaths {
         let version = PythonVersion::from_str(version).ok()?;
         let source = PythonVersionSource::InstallationDirectoryLayout {
             site_packages_parent_dir: Box::from(parent_component),
+            source: settings_diagnostic_path_from_site_packages_path(primary_site_packages, system)
+                .map(|path| PythonVersionFileSource::new(Arc::new(path), None)),
         };
 
         Some(PythonVersionWithSource { version, source })
@@ -126,6 +131,57 @@ impl fmt::Display for SitePackagesPaths {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.0.iter()).finish()
     }
+}
+
+fn settings_diagnostic_path_from_site_packages_path(
+    site_packages_path: &SystemPath,
+    system: &dyn System,
+) -> Option<SystemPathBuf> {
+    let sys_prefix = site_packages_path.ancestors().nth(3)?;
+    settings_diagnostic_path_from_sys_prefix(sys_prefix, system)
+}
+
+fn settings_diagnostic_path_from_sys_prefix(
+    sys_prefix: &SystemPath,
+    system: &dyn System,
+) -> Option<SystemPathBuf> {
+    let pyvenv_cfg = sys_prefix.join("pyvenv.cfg");
+    if system.is_file(&pyvenv_cfg) {
+        return Some(pyvenv_cfg);
+    }
+
+    let bin_dir = if cfg!(windows) {
+        sys_prefix.to_path_buf()
+    } else {
+        sys_prefix.join("bin")
+    };
+
+    for candidate in [
+        bin_dir.join("python3"),
+        bin_dir.join("python"),
+        bin_dir.join("pypy3"),
+        bin_dir.join("pypy"),
+    ] {
+        if system.is_file(&candidate) {
+            return Some(candidate);
+        }
+    }
+
+    let entries = system.read_directory(&bin_dir).ok()?;
+    for entry in entries.flatten() {
+        if entry.file_type().is_directory() {
+            continue;
+        }
+
+        let path = entry.into_path();
+        if let Some(file_name) = path.file_name()
+            && (file_name.starts_with("python") || file_name.starts_with("pypy"))
+        {
+            return Some(path);
+        }
+    }
+
+    None
 }
 
 impl<const N: usize> From<[SystemPathBuf; N]> for SitePackagesPaths {
@@ -2659,6 +2715,46 @@ mod tests {
         paths.insert(SystemPathBuf::from("/path/to/site/packages"));
 
         assert_eq!(paths.to_string(), r#"["/path/to/site/packages"]"#);
+    }
+
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn layout_inference_uses_the_primary_site_packages_source() {
+        let system = TestSystem::default();
+        let memory_fs = system.memory_file_system();
+
+        let self_site_packages = SystemPathBuf::from("/self/.venv/lib/python3.16/site-packages");
+        let project_site_packages =
+            SystemPathBuf::from("/project/.venv/lib/python3.12/site-packages");
+        let self_pyvenv_cfg = SystemPathBuf::from("/self/.venv/pyvenv.cfg");
+        let project_pyvenv_cfg = SystemPathBuf::from("/project/.venv/pyvenv.cfg");
+
+        memory_fs.create_directory_all(&self_site_packages).unwrap();
+        memory_fs
+            .create_directory_all(&project_site_packages)
+            .unwrap();
+        memory_fs
+            .write_file_all(&self_pyvenv_cfg, "home = /python/bin")
+            .unwrap();
+        memory_fs
+            .write_file_all(&project_pyvenv_cfg, "home = /python/bin")
+            .unwrap();
+
+        let paths = SitePackagesPaths::from([self_site_packages, project_site_packages]);
+        let PythonVersionWithSource { version, source } =
+            paths.python_version_from_layout(&system).unwrap();
+
+        assert_eq!(version, PythonVersion::from((3, 16)));
+        assert_eq!(
+            source,
+            PythonVersionSource::InstallationDirectoryLayout {
+                site_packages_parent_dir: Box::from("python3.16"),
+                source: Some(PythonVersionFileSource::new(
+                    Arc::new(self_pyvenv_cfg),
+                    None
+                )),
+            }
+        );
     }
 
     /// Test that dist-packages directories (Debian/Ubuntu) are discovered alongside site-packages

--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -175,13 +175,24 @@ fn settings_diagnostic_path_from_sys_prefix(
 
         let path = entry.into_path();
         if let Some(file_name) = path.file_name()
-            && (file_name.starts_with("python") || file_name.starts_with("pypy"))
+            && is_versioned_interpreter_path(file_name)
         {
             return Some(path);
         }
     }
 
     None
+}
+
+fn is_versioned_interpreter_path(file_name: &str) -> bool {
+    let Some(version) = file_name
+        .strip_prefix("python")
+        .or_else(|| file_name.strip_prefix("pypy"))
+    else {
+        return false;
+    };
+
+    !version.is_empty() && PythonVersion::from_str(version.trim_end_matches('t')).is_ok()
 }
 
 impl<const N: usize> From<[SystemPathBuf; N]> for SitePackagesPaths {
@@ -2754,6 +2765,31 @@ mod tests {
                     None
                 )),
             }
+        );
+    }
+
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn settings_diagnostic_path_ignores_python_helper_scripts() {
+        let system = TestSystem::default();
+        let memory_fs = system.memory_file_system();
+
+        let sys_prefix = SystemPathBuf::from("/python");
+        let bin_dir = sys_prefix.join("bin");
+        let interpreter = bin_dir.join("python3.16");
+
+        memory_fs.create_directory_all(&bin_dir).unwrap();
+        memory_fs
+            .write_file_all(bin_dir.join("python3.16-config"), "")
+            .unwrap();
+        memory_fs
+            .write_file_all(bin_dir.join("pythonw"), "")
+            .unwrap();
+        memory_fs.write_file_all(&interpreter, "").unwrap();
+
+        assert_eq!(
+            settings_diagnostic_path_from_sys_prefix(&sys_prefix, &system),
+            Some(interpreter)
         );
     }
 

--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -277,6 +277,14 @@ impl PythonEnvironment {
         }
     }
 
+    /// Returns the `pyvenv.cfg` path for virtual environments.
+    pub fn pyvenv_cfg_path(&self) -> Option<SystemPathBuf> {
+        match self {
+            Self::Virtual(env) => Some(env.root_path.join("pyvenv.cfg")),
+            Self::System(_) => None,
+        }
+    }
+
     /// Returns `true` if this is a virtual environment (has a `pyvenv.cfg` file).
     pub fn is_virtual(&self) -> bool {
         matches!(self, Self::Virtual(_))

--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -133,6 +133,8 @@ impl fmt::Display for SitePackagesPaths {
     }
 }
 
+/// Return a [`SystemPathBuf`] to use for anchoring settings diagnostics surfaced while analyzing
+/// the interpreter at the given `site-packages` directly.
 fn settings_diagnostic_path_from_site_packages_path(
     site_packages_path: &SystemPath,
     system: &dyn System,
@@ -141,6 +143,8 @@ fn settings_diagnostic_path_from_site_packages_path(
     settings_diagnostic_path_from_sys_prefix(sys_prefix, system)
 }
 
+/// Return a [`SystemPathBuf`] to use for anchoring settings diagnostics surfaced while analyzing
+/// the interpreter at the given `sys.prefix`.
 fn settings_diagnostic_path_from_sys_prefix(
     sys_prefix: &SystemPath,
     system: &dyn System,
@@ -184,6 +188,8 @@ fn settings_diagnostic_path_from_sys_prefix(
     None
 }
 
+/// Returns `true` if the file name appears to be that of a versioned interpreter
+/// (e.g., `python3.15`).
 fn is_versioned_interpreter_path(file_name: &str) -> bool {
     let Some(version) = file_name
         .strip_prefix("python")
@@ -2776,16 +2782,14 @@ mod tests {
 
         let sys_prefix = SystemPathBuf::from("/python");
         let bin_dir = sys_prefix.join("bin");
+        let config_helper = bin_dir.join("python3.16-config");
         let interpreter = bin_dir.join("python3.16");
+        let windowed_interpreter = bin_dir.join("pythonw");
 
         memory_fs.create_directory_all(&bin_dir).unwrap();
-        memory_fs
-            .write_file_all(bin_dir.join("python3.16-config"), "")
-            .unwrap();
-        memory_fs
-            .write_file_all(bin_dir.join("pythonw"), "")
-            .unwrap();
+        memory_fs.write_file_all(&config_helper, "").unwrap();
         memory_fs.write_file_all(&interpreter, "").unwrap();
+        memory_fs.write_file_all(&windowed_interpreter, "").unwrap();
 
         assert_eq!(
             settings_diagnostic_path_from_sys_prefix(&sys_prefix, &system),

--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -10,6 +10,7 @@
 
 mod version;
 
+use std::hash::{Hash, Hasher};
 use std::io;
 use std::num::NonZeroUsize;
 use std::ops::Deref;
@@ -49,15 +50,56 @@ type StdlibDiscoveryResult<T> = Result<T, StdlibDiscoveryError>;
 /// *might* be added to the `SitePackagesPaths` twice, but we wouldn't
 /// want duplicates to appear in this set.
 #[derive(Debug, PartialEq, Eq, Default)]
-pub struct SitePackagesPaths(IndexSet<SystemPathBuf>);
+pub struct SitePackagesPaths(IndexSet<SitePackagesPath>);
+
+#[derive(Debug, Clone)]
+struct SitePackagesPath {
+    /// The resolved `site-packages` or `dist-packages` directory.
+    path: SystemPathBuf,
+    /// A file to use when anchoring diagnostics for settings inferred from this path.
+    settings_diagnostic_path: Option<SystemPathBuf>,
+}
+
+impl SitePackagesPath {
+    fn new(path: SystemPathBuf, settings_diagnostic_path: Option<SystemPathBuf>) -> Self {
+        Self {
+            path,
+            settings_diagnostic_path,
+        }
+    }
+
+    fn into_path(self) -> SystemPathBuf {
+        self.path
+    }
+}
+
+impl PartialEq for SitePackagesPath {
+    fn eq(&self, other: &Self) -> bool {
+        // The diagnostic anchor is metadata for this path, not part of the path's set identity.
+        self.path == other.path
+    }
+}
+
+impl Eq for SitePackagesPath {}
+
+impl Hash for SitePackagesPath {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.path.hash(state);
+    }
+}
 
 impl SitePackagesPaths {
     fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
-    fn insert(&mut self, path: SystemPathBuf) {
-        self.0.insert(path);
+    fn insert_with_settings_diagnostic_path(
+        &mut self,
+        path: SystemPathBuf,
+        settings_diagnostic_path: Option<SystemPathBuf>,
+    ) {
+        self.0
+            .insert(SitePackagesPath::new(path, settings_diagnostic_path));
     }
 
     fn extend(&mut self, other: Self) {
@@ -67,17 +109,14 @@ impl SitePackagesPaths {
     /// Concatenate two instances of [`SitePackagesPaths`].
     #[must_use]
     pub fn concatenate(mut self, other: Self) -> Self {
-        for path in other {
+        for path in other.0 {
             self.0.insert(path);
         }
         self
     }
 
     /// Tries to detect the version from the layout of the `site-packages` directory.
-    pub fn python_version_from_layout(
-        &self,
-        system: &dyn System,
-    ) -> Option<PythonVersionWithSource> {
+    pub fn python_version_from_layout(&self) -> Option<PythonVersionWithSource> {
         if cfg!(windows) {
             // The path to `site-packages` on Unix is
             // `<sys.prefix>/lib/pythonX.Y/site-packages`,
@@ -87,8 +126,12 @@ impl SitePackagesPaths {
 
         let primary_site_packages = self.0.first()?;
 
-        let mut site_packages_ancestor_components =
-            primary_site_packages.components().rev().skip(1).map(|c| {
+        let mut site_packages_ancestor_components = primary_site_packages
+            .path
+            .components()
+            .rev()
+            .skip(1)
+            .map(|c| {
                 // This should have all been validated in `site_packages.rs`
                 // when we resolved the search paths for the project.
                 debug_assert!(
@@ -115,7 +158,9 @@ impl SitePackagesPaths {
         let version = PythonVersion::from_str(version).ok()?;
         let source = PythonVersionSource::InstallationDirectoryLayout {
             site_packages_parent_dir: Box::from(parent_component),
-            source: settings_diagnostic_path_from_site_packages_path(primary_site_packages, system)
+            source: primary_site_packages
+                .settings_diagnostic_path
+                .clone()
                 .map(|path| PythonVersionFileSource::new(Arc::new(path), None)),
         };
 
@@ -123,24 +168,16 @@ impl SitePackagesPaths {
     }
 
     pub fn into_vec(self) -> Vec<SystemPathBuf> {
-        self.0.into_iter().collect()
+        self.into_iter().collect()
     }
 }
 
 impl fmt::Display for SitePackagesPaths {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_list().entries(self.0.iter()).finish()
+        f.debug_list()
+            .entries(self.0.iter().map(|path| &path.path))
+            .finish()
     }
-}
-
-/// Return a [`SystemPathBuf`] to use for anchoring settings diagnostics surfaced while analyzing
-/// the interpreter at the given `site-packages` directly.
-fn settings_diagnostic_path_from_site_packages_path(
-    site_packages_path: &SystemPath,
-    system: &dyn System,
-) -> Option<SystemPathBuf> {
-    let sys_prefix = site_packages_path.ancestors().nth(3)?;
-    settings_diagnostic_path_from_sys_prefix(sys_prefix, system)
 }
 
 /// Return a [`SystemPathBuf`] to use for anchoring settings diagnostics surfaced while analyzing
@@ -203,22 +240,31 @@ fn is_versioned_interpreter_path(file_name: &str) -> bool {
 
 impl<const N: usize> From<[SystemPathBuf; N]> for SitePackagesPaths {
     fn from(paths: [SystemPathBuf; N]) -> Self {
-        Self(IndexSet::from(paths))
+        Self(
+            paths
+                .into_iter()
+                .map(|path| SitePackagesPath::new(path, None))
+                .collect(),
+        )
     }
 }
 
 impl IntoIterator for SitePackagesPaths {
     type Item = SystemPathBuf;
-    type IntoIter = indexmap::set::IntoIter<SystemPathBuf>;
+    type IntoIter = std::vec::IntoIter<SystemPathBuf>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+        self.0
+            .into_iter()
+            .map(SitePackagesPath::into_path)
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 }
 
 impl PartialEq<&[SystemPathBuf]> for SitePackagesPaths {
     fn eq(&self, other: &&[SystemPathBuf]) -> bool {
-        self.0.as_slice() == *other
+        self.0.iter().map(|path| &path.path).eq(other.iter())
     }
 }
 
@@ -1275,21 +1321,24 @@ fn probe_package_dirs(
     python_version: PythonVersion,
     implementation: PythonImplementation,
     system: &dyn System,
+    settings_diagnostic_path: Option<&SystemPath>,
     directories: &mut SitePackagesPaths,
 ) {
+    let settings_diagnostic_path = || settings_diagnostic_path.map(SystemPath::to_path_buf);
+
     // Try to insert the CPython-style package path into `directories`.
     // Returns `true` if a matching directory was found, so the caller can
     // decide whether to fall back to probing other implementations.
     let probe_cpython_path = |directories: &mut SitePackagesPaths| {
         let path = prefix_dir.join(format!("python{python_version}/{suffix}"));
         if system.is_directory(&path) {
-            directories.insert(path);
+            directories.insert_with_settings_diagnostic_path(path, settings_diagnostic_path());
             true
         } else if python_version.free_threaded_build_available() {
             // CPython free-threaded (3.13+) variant: pythonX.Yt
             let alt = prefix_dir.join(format!("python{python_version}t/{suffix}"));
             if system.is_directory(&alt) {
-                directories.insert(alt);
+                directories.insert_with_settings_diagnostic_path(alt, settings_diagnostic_path());
                 true
             } else {
                 false
@@ -1304,7 +1353,7 @@ fn probe_package_dirs(
     let probe_pypy_path = |directories: &mut SitePackagesPaths| {
         let path = prefix_dir.join(format!("pypy{python_version}/{suffix}"));
         if system.is_directory(&path) {
-            directories.insert(path);
+            directories.insert_with_settings_diagnostic_path(path, settings_diagnostic_path());
             true
         } else {
             false
@@ -1335,6 +1384,7 @@ fn discover_package_dirs(
     suffixes: &(impl IntoIterator<Item = InstallationDir> + Clone),
     implementation: PythonImplementation,
     system: &dyn System,
+    settings_diagnostic_path: Option<&SystemPath>,
     directories: &mut SitePackagesPaths,
 ) {
     let Ok(dir_iter) = system.read_directory(prefix_dir) else {
@@ -1365,7 +1415,10 @@ fn discover_package_dirs(
             for suffix in suffixes.clone() {
                 let candidate = path.join(suffix.as_str());
                 if system.is_directory(&candidate) {
-                    directories.insert(candidate);
+                    directories.insert_with_settings_diagnostic_path(
+                        candidate,
+                        settings_diagnostic_path.map(SystemPath::to_path_buf),
+                    );
                 }
             }
         }
@@ -1430,6 +1483,8 @@ fn site_packages_directories_from_sys_prefix(
 
     let mut directories = SitePackagesPaths::default();
     let is_debian_system_prefix = sys_prefix_path.as_str() == "/usr";
+    let settings_diagnostic_path =
+        settings_diagnostic_path_from_sys_prefix(sys_prefix_path, system);
 
     // On Debian/Ubuntu with sys.prefix=/usr, pip-installed packages go to
     // /usr/local/lib/pythonX.Y/dist-packages and take priority over system
@@ -1445,6 +1500,7 @@ fn site_packages_directories_from_sys_prefix(
                 python_version,
                 implementation,
                 system,
+                settings_diagnostic_path.as_deref(),
                 &mut directories,
             );
         }
@@ -1458,6 +1514,7 @@ fn site_packages_directories_from_sys_prefix(
                     python_version,
                     implementation,
                     system,
+                    settings_diagnostic_path.as_deref(),
                     &mut directories,
                 );
             }
@@ -1469,6 +1526,7 @@ fn site_packages_directories_from_sys_prefix(
                 &[InstallationDir::DistPackages],
                 implementation,
                 system,
+                settings_diagnostic_path.as_deref(),
                 &mut directories,
             );
         }
@@ -1480,6 +1538,7 @@ fn site_packages_directories_from_sys_prefix(
                 &InstallationDir::iter(),
                 implementation,
                 system,
+                settings_diagnostic_path.as_deref(),
                 &mut directories,
             );
         }
@@ -1494,7 +1553,10 @@ fn site_packages_directories_from_sys_prefix(
     ) {
         let debian_dist_packages = sys_prefix_path.join("lib/python3/dist-packages");
         if system.is_directory(&debian_dist_packages) {
-            directories.insert(debian_dist_packages);
+            directories.insert_with_settings_diagnostic_path(
+                debian_dist_packages,
+                settings_diagnostic_path,
+            );
         }
     }
 
@@ -2729,7 +2791,10 @@ mod tests {
         assert_eq!(paths.to_string(), "[]");
 
         let mut paths = SitePackagesPaths::default();
-        paths.insert(SystemPathBuf::from("/path/to/site/packages"));
+        paths.insert_with_settings_diagnostic_path(
+            SystemPathBuf::from("/path/to/site/packages"),
+            None,
+        );
 
         assert_eq!(paths.to_string(), r#"["/path/to/site/packages"]"#);
     }
@@ -2757,9 +2822,14 @@ mod tests {
             .write_file_all(&project_pyvenv_cfg, "home = /python/bin")
             .unwrap();
 
-        let paths = SitePackagesPaths::from([self_site_packages, project_site_packages]);
+        let mut paths = SitePackagesPaths::default();
+        paths.insert_with_settings_diagnostic_path(
+            self_site_packages,
+            Some(self_pyvenv_cfg.clone()),
+        );
+        paths.insert_with_settings_diagnostic_path(project_site_packages, Some(project_pyvenv_cfg));
         let PythonVersionWithSource { version, source } =
-            paths.python_version_from_layout(&system).unwrap();
+            paths.python_version_from_layout().unwrap();
 
         assert_eq!(version, PythonVersion::from((3, 16)));
         assert_eq!(

--- a/crates/ty_site_packages/src/version.rs
+++ b/crates/ty_site_packages/src/version.rs
@@ -24,7 +24,10 @@ pub enum PythonVersionSource {
     /// This only ever applies on Unix. On Unix, the `site-packages` directory
     /// will always be at `sys.prefix/lib/pythonX.Y/site-packages`,
     /// so we can infer the Python version from the parent directory of `site-packages`.
-    InstallationDirectoryLayout { site_packages_parent_dir: Box<str> },
+    InstallationDirectoryLayout {
+        site_packages_parent_dir: Box<str>,
+        source: Option<PythonVersionFileSource>,
+    },
 
     /// The value comes from a CLI argument, while it's left open if specified using a short argument,
     /// long argument (`--extra-paths`) or `--config key=value`.

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -164,12 +164,19 @@ impl Workspace {
         )
         .map_err(into_error)?;
 
-        let program_settings = project
-            .to_program_settings(&self.system, self.db.vendored(), &FallibleStrategy)
+        let (program_settings, program_settings_diagnostics) = project
+            .to_program_settings(
+                &self.db,
+                &self.system,
+                self.db.vendored(),
+                &FallibleStrategy,
+            )
             .map_err(into_error)?;
         Program::get(&self.db).update_from_settings(&mut self.db, program_settings);
 
-        self.db.project().reload(&mut self.db, project);
+        self.db
+            .project()
+            .reload(&mut self.db, project, program_settings_diagnostics);
 
         Ok(())
     }

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -174,9 +174,14 @@ impl Workspace {
             .map_err(into_error)?;
         Program::get(&self.db).update_from_settings(&mut self.db, program_settings);
 
+        let (settings, mut settings_diagnostics) = project
+            .to_settings(&self.db, &FallibleStrategy)
+            .map_err(into_error)?;
+        settings_diagnostics.extend(program_settings_diagnostics);
+
         self.db
             .project()
-            .reload(&mut self.db, project, program_settings_diagnostics);
+            .reload(&mut self.db, project, Some(settings), settings_diagnostics);
 
         Ok(())
     }

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -166,23 +166,21 @@ impl Workspace {
         .map_err(into_error)?;
 
         let (program_settings, program_settings_diagnostics) = project
-            .to_program_settings(
-                &self.db,
-                &self.system,
-                self.db.vendored(),
-                &FallibleStrategy,
-            )
+            .to_program_settings(&self.system, self.db.vendored(), &FallibleStrategy)
             .map_err(into_error)?;
         Program::get(&self.db).update_from_settings(&mut self.db, program_settings);
 
-        let (settings, mut settings_diagnostics) = project
+        let (settings, settings_diagnostics) = project
             .to_settings(&self.db, &FallibleStrategy)
             .map_err(into_error)?;
-        settings_diagnostics.extend(program_settings_diagnostics);
 
-        self.db
-            .project()
-            .reload(&mut self.db, project, Some(settings), settings_diagnostics);
+        self.db.project().reload(
+            &mut self.db,
+            project,
+            Some(settings),
+            settings_diagnostics,
+            program_settings_diagnostics,
+        );
 
         Ok(())
     }

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -165,12 +165,19 @@ impl Workspace {
         )
         .map_err(into_error)?;
 
-        let program_settings = project
-            .to_program_settings(&self.system, self.db.vendored(), &FallibleStrategy)
+        let (program_settings, program_settings_diagnostics) = project
+            .to_program_settings(
+                &self.db,
+                &self.system,
+                self.db.vendored(),
+                &FallibleStrategy,
+            )
             .map_err(into_error)?;
         Program::get(&self.db).update_from_settings(&mut self.db, program_settings);
 
-        self.db.project().reload(&mut self.db, project);
+        self.db
+            .project()
+            .reload(&mut self.db, project, program_settings_diagnostics);
 
         Ok(())
     }

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -175,9 +175,14 @@ impl Workspace {
             .map_err(into_error)?;
         Program::get(&self.db).update_from_settings(&mut self.db, program_settings);
 
+        let (settings, mut settings_diagnostics) = project
+            .to_settings(&self.db, &FallibleStrategy)
+            .map_err(into_error)?;
+        settings_diagnostics.extend(program_settings_diagnostics);
+
         self.db
             .project()
-            .reload(&mut self.db, project, program_settings_diagnostics);
+            .reload(&mut self.db, project, Some(settings), settings_diagnostics);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

This PR adds the infrastructure to surface diagnostics during project and program settings resolution. The motivating use-case is: when we see an unsupported Python version in an editor, we want to surface a diagnostic rather than limiting to a `tracing` warning, as in:

```
warning[unsupported-python-version]: Ignoring unsupported inferred Python version `3.16`; ty will use Python 3.14 instead.
 --> venv/pyvenv.cfg:2:16
  |
2 | version_info = 3.16.0
  |                ^^^^^^
3 | home = base/bin
  |
info: Expected one of `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, `3.15`.
info: Set `python-version` explicitly to override the inferred version.
info: The version was inferred from your virtual environment metadata.
```
