### PR TITLE
[ty] Model `functools.partial` call results

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -1,0 +1,1446 @@
+# `functools.partial`
+
+## Basic reduction and invocation
+
+### Basic positional binding
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(b: str) -> bool]
+```
+
+### Keyword binding
+
+Keyword-bound parameters are kept with a default, but they become keyword-only in the resulting
+callable. `partial` allows overriding them at call time, but only by keyword.
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, b="hello")
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello") -> bool]
+```
+
+### Mixed positional and keyword binding
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+p = partial(f, 1, c=3.14)
+reveal_type(p)  # revealed: partial[(b: str, *, c: int | float = ...) -> bool]
+```
+
+### All args bound
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1, "hello")
+reveal_type(p)  # revealed: partial[() -> bool]
+```
+
+### No args bound
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f)
+reveal_type(p)  # revealed: partial[(a: int, b: str) -> bool]
+```
+
+### Positional-only params
+
+```py
+from functools import partial
+
+def f(a: int, b: str, /) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(b: str, /) -> bool]
+```
+
+### Keyword-only params
+
+```py
+from functools import partial
+
+def f(a: int, *, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(*, b: str) -> bool]
+```
+
+### Keyword-only params bound by keyword
+
+```py
+from functools import partial
+
+def f(a: int, *, b: str) -> bool:
+    return True
+
+p = partial(f, b="hello")
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello") -> bool]
+```
+
+### Variadic preserved
+
+```py
+from functools import partial
+
+def f(a: int, *args: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(*args: str) -> bool]
+```
+
+### Keyword variadic preserved
+
+```py
+from functools import partial
+
+def f(a: int, **kwargs: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(**kwargs: str) -> bool]
+```
+
+### Defaults preserved
+
+```py
+from functools import partial
+
+def f(a: int, b: str = "default") -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(b: str = "default") -> bool]
+```
+
+### Lambda
+
+```py
+from functools import partial
+
+p = partial(lambda x, y: x + y, 1)
+reveal_type(p)  # revealed: partial[(y: Any) -> Unknown]
+```
+
+### Bound method
+
+```py
+from functools import partial
+
+class Greeter:
+    def greet(self, name: str, greeting: str = "Hello") -> str:
+        return f"{greeting}, {name}"
+
+g = Greeter()
+p = partial(g.greet, "world")
+reveal_type(p)  # revealed: partial[(greeting: str = "Hello") -> str]
+reveal_type(p())  # revealed: str
+```
+
+### Calling the partial result
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p("hello", 3.14))  # revealed: bool
+reveal_type(p(b="hello", c=3.14))  # revealed: bool
+```
+
+## Construction-time diagnostics
+
+### Wrong positional arg type
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, "not_an_int")  # error: [invalid-argument-type]
+reveal_type(p)  # revealed: partial[(b: str) -> bool]
+```
+
+### Wrong keyword arg type
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, b=42)  # error: [invalid-argument-type]
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = 42) -> bool]
+```
+
+### Unknown keyword argument
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, c=1)  # error: [unknown-argument]
+```
+
+### Parameter already assigned
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1, a=2)  # error: [parameter-already-assigned]
+```
+
+### Too-many-positional is reported at partial construction
+
+```py
+from functools import partial
+
+def f(a: int, b: int) -> int:
+    return a + b
+
+p = partial(f, 1, 2, 3)  # error: [too-many-positional-arguments]
+reveal_type(p)  # revealed: partial[() -> int]
+p()
+p(1)  # error: [too-many-positional-arguments]
+```
+
+### Non-callable first argument
+
+`partial(42)` is an error caught by the constructor call; we fall back to the default `partial[T]`
+type.
+
+```py
+from functools import partial
+
+p = partial(42)  # error: [invalid-argument-type]
+reveal_type(p)  # revealed: partial[Unknown]
+```
+
+### Keyword binding to positional-only param
+
+Positional-only parameters cannot be bound by keyword in `partial()`. The parameter should be
+preserved in the resulting callable, while still reporting a construction-time error:
+
+```py
+from functools import partial
+
+def f(x: int, /, y: str) -> bool:
+    return True
+
+# `x` is positional-only, so `x=1` does not bind it.
+p = partial(f, x=1)  # error: [positional-only-parameter-as-kwarg]
+reveal_type(p)  # revealed: partial[(x: int, /, y: str) -> bool]
+```
+
+## Generics, overloads, and signature inference
+
+### Generic functions
+
+Type variables are inferred from the bound arguments:
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def identity(x: T) -> T:
+    return x
+
+p = partial(identity, 1)
+reveal_type(p)  # revealed: partial[() -> Literal[1]]
+```
+
+### Generic functions with remaining params
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def pair(a: T, b: T) -> tuple[T, T]:
+    return (a, b)
+
+p = partial(pair, 1)
+reveal_type(p)  # revealed: partial[(b: int) -> tuple[int, int]]
+reveal_type(p(2))  # revealed: tuple[int, int]
+reveal_type(p(2)[1])  # revealed: int
+```
+
+### Generic functions preserve defaults for no-longer-inferable type params
+
+```py
+from functools import partial
+from typing import cast
+from typing_extensions import TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U", default=T)
+
+def with_default(x: T) -> tuple[T, U]:
+    return (x, cast(U, x))
+
+reveal_type(with_default(1))  # revealed: tuple[Literal[1], Literal[1]]
+
+p = partial(with_default, 1)
+reveal_type(p)  # revealed: partial[() -> tuple[Literal[1], Literal[1]]]
+reveal_type(p())  # revealed: tuple[Literal[1], Literal[1]]
+```
+
+### Generic constructors
+
+```py
+from functools import partial
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Box(Generic[T]):
+    def __init__(self, value: T) -> None:
+        self.value = value
+
+list_factory = partial(list, [1])
+# TODO: should reveal `partial[() -> list[int]]` once constructor partials are modeled.
+reveal_type(list_factory)  # revealed: partial[Unknown]
+# TODO: should reveal `list[int]` once constructor partials are modeled.
+reveal_type(list_factory())  # revealed: Unknown
+
+box_factory = partial(Box, "hi")
+# TODO: should reveal `partial[() -> Box[str]]` once constructor partials are modeled.
+reveal_type(box_factory)  # revealed: partial[Unknown]
+# TODO: should reveal `Box[str]` once constructor partials are modeled.
+reveal_type(box_factory())  # revealed: Unknown
+```
+
+### Stored partials specialize through generic instances
+
+```py
+from functools import partial
+from typing import Callable, Generic, TypeVar
+
+T = TypeVar("T")
+
+def identity(x: T) -> T:
+    return x
+
+class Box(Generic[T]):
+    def __init__(self, value: T) -> None:
+        self.callback = partial(identity, value)
+
+box = Box[int](1)
+reveal_type(box.callback)  # revealed: partial[() -> int]
+
+target: Callable[[], int] = box.callback
+```
+
+### Overloaded functions
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def f(a: int) -> int: ...
+@overload
+def f(a: str) -> str: ...
+def f(a: int | str) -> int | str:
+    return a
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[() -> int]
+```
+
+### Union of callables preserves union of partials
+
+```py
+from functools import partial
+from typing import Callable
+
+def zero_arg(x: int) -> int:
+    return x
+
+def one_arg(x: int, y: str) -> int:
+    return x + len(y)
+
+def test_union_partial(
+    f: Callable[[int], int] | Callable[[int, str], int],
+) -> None:
+    p = partial(f, 1)
+    reveal_type(p)  # revealed: partial[() -> int] | partial[(str, /) -> int]
+
+    bad: Callable[[bytes, bytes], int] = p  # error: [invalid-assignment]
+```
+
+### Keyword-bound overload filtering
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def g(path: bytes, start: bytes | None = b".") -> bytes: ...
+@overload
+def g(path: str, start: str | None = ".") -> str: ...
+def g(path: bytes | str, start: bytes | str | None = None) -> bytes | str:
+    return path
+
+p = partial(g, start=".")
+paths: list[str] = ["x"]
+reveal_type(p)  # revealed: partial[(path: str, *, start: str | None = ".") -> str]
+reveal_type(list(map(p, paths)))  # revealed: list[str]
+```
+
+### ParamSpec callable bound with `partial`
+
+```py
+from functools import partial
+from typing import Any, Callable, TypeVar
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def invoke(func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+    return func(*args, **kwargs)
+
+def pre(cfg: Any) -> Any:
+    return cfg
+
+bound = partial(invoke, pre)
+reveal_type(bound)  # revealed: partial[(cfg: Any) -> Any]
+reveal_type(bound({}))  # revealed: Any
+```
+
+### ParamSpec callable with keyword-bound wrapper parameters
+
+```py
+from functools import partial
+from typing import Callable, TypeVar
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def invoke(flag: int, func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+    return func(*args, **kwargs)
+
+def pre(*, cfg: str) -> int:
+    return 1
+
+bound = partial(invoke, flag=1, func=pre)
+reveal_type(bound(cfg="x"))  # revealed: int
+```
+
+### Partial assignability with a keyword-bound middle parameter
+
+```py
+from functools import partial
+from typing import Any, Protocol
+
+class Conv(Protocol):
+    def __call__(self, __x: Any, *, _target_: str = "set", CBuildsFn: type[Any]) -> Any: ...
+
+class ConfigFromTuple:
+    def __init__(self, _args_: tuple[Any, ...], _target_: str, CBuildsFn: type[Any]) -> None: ...
+
+p = partial(ConfigFromTuple, _target_="set")
+# TODO: should preserve the keyword-bound middle parameter in the reduced signature.
+reveal_type(p)  # revealed: partial[Unknown]
+
+conversion: dict[type, Conv] = {}
+conversion[set] = p
+```
+
+### Overloaded stdlib callable narrowed by bound args
+
+`partial(reduce, operator.mul)` should keep the narrowed return type from the bound reducer:
+
+```py
+from functools import partial, reduce
+import operator
+
+prod = partial(reduce, operator.mul)
+shape: list[int] = [1, 2, 3]
+
+reveal_type(prod(shape))  # revealed: Any
+```
+
+### Overloaded stdlib callable with keyword-only binding
+
+`partial(zip, strict=True)` should accept the keyword-only argument and preserve the element types
+of the resulting iterator:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from functools import partial
+import builtins
+
+zips = partial(builtins.zip, strict=True)
+
+xs = [1]
+ys = ["a"]
+pairs = list(zips(xs, ys))
+
+# TODO: should reveal `list[tuple[int, str]]` once keyword-only constructor bindings are preserved.
+reveal_type(pairs)  # revealed: list[Unknown]
+```
+
+### Keyword argument with literal sequence annotation
+
+`partial(...)` should accept keyword arguments whose literal container types are inferred without
+context at the call site:
+
+```py
+from functools import partial
+from typing import Literal, Sequence
+
+Distribution = Literal["sdist", "wheel", "editable"]
+
+def build(distributions: Sequence[Distribution]) -> None:
+    pass
+
+p = partial(build, distributions=["wheel"])  # error: [invalid-argument-type]
+# TODO: should accept this keyword literal without a construction-time error.
+reveal_type(p)  # revealed: partial[(*, distributions: Sequence[Literal["sdist", "wheel", "editable"]] = ...) -> None]
+reveal_type(p())  # revealed: None
+```
+
+### Keyword argument with empty literal sequence annotation
+
+`partial(...)` should still re-run argument refinement even when the initial constructor binding
+already succeeds, so empty literals keep the parameter's contextual element type:
+
+```py
+from functools import partial
+from typing import Literal, Sequence
+
+Distribution = Literal["sdist", "wheel", "editable"]
+
+def build(distributions: Sequence[Distribution]) -> None:
+    pass
+
+p = partial(build, distributions=[])
+reveal_type(p)  # revealed: partial[(*, distributions: Sequence[Literal["sdist", "wheel", "editable"]] = ...) -> None]
+reveal_type(p())  # revealed: None
+```
+
+### Overloaded functions with remaining params
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def g(a: int, b: str) -> int: ...
+@overload
+def g(a: str, b: str) -> str: ...
+def g(a: int | str, b: str) -> int | str:
+    return a
+
+p = partial(g, 1)
+reveal_type(p)  # revealed: partial[(b: str) -> int]
+```
+
+## Argument unpacking and nested partials
+
+### Starred args with fixed-length tuple
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+args: tuple[int] = (1,)
+p = partial(f, *args)
+reveal_type(p)  # revealed: partial[(b: str) -> bool]
+```
+
+### Starred args with multiple elements
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+args: tuple[int, str] = (1, "hello")
+p = partial(f, *args)
+reveal_type(p)  # revealed: partial[(c: int | float) -> bool]
+```
+
+### Mixed positional and starred args
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+args: tuple[str] = ("hello",)
+p = partial(f, 1, *args)
+reveal_type(p)  # revealed: partial[(c: int | float) -> bool]
+```
+
+### Fallback for starred args with variable-length tuple
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+def get_args() -> tuple[int, ...]:
+    return (1,)
+
+p = partial(f, *get_args())
+reveal_type(p)  # revealed: partial[bool]
+```
+
+### Kwargs splat with TypedDict
+
+```py
+from functools import partial
+from typing import TypedDict
+
+class MyKwargs(TypedDict):
+    b: str
+
+def f(a: int, b: str) -> bool:
+    return True
+
+kwargs: MyKwargs = {"b": "hello"}
+p = partial(f, **kwargs)
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = ...) -> bool]
+```
+
+### Mixed keywords and kwargs splat
+
+```py
+from functools import partial
+from typing import TypedDict
+
+class MyKwargs(TypedDict):
+    c: float
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+kwargs: MyKwargs = {"c": 3.14}
+p = partial(f, b="hello", **kwargs)
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello", c: int | float = ...) -> bool]
+```
+
+### Fallback for kwargs splat with dict
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+kwargs = {"a": 1}
+p = partial(f, **kwargs)
+reveal_type(p)  # revealed: partial[bool]
+```
+
+### Fallback for kwargs splat with optional TypedDict keys
+
+```py
+from functools import partial
+from typing import TypedDict
+
+class MaybeKwargs(TypedDict, total=False):
+    b: str
+
+def f(a: int, *, b: str) -> None:
+    pass
+
+def make(kwargs: MaybeKwargs) -> None:
+    p = partial(f, **kwargs)
+    reveal_type(p)  # revealed: partial[None]
+```
+
+### Nested partial
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+p1 = partial(f, 1)
+reveal_type(p1)  # revealed: partial[(b: str, c: int | float) -> bool]
+
+p2 = partial(p1, "hello")
+reveal_type(p2)  # revealed: partial[(c: int | float) -> bool]
+```
+
+## Constructors and advanced signatures
+
+### Class constructor
+
+```py
+from functools import partial
+
+class MyClass:
+    def __init__(self, x: int, y: str) -> None:
+        pass
+
+p = partial(MyClass, 1)
+# TODO: should reveal `partial[(y: str) -> MyClass]` once constructor partials are modeled.
+reveal_type(p)  # revealed: partial[Unknown]
+```
+
+### Class constructor with both `__new__` and `__init__`
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: int) -> None: ...
+
+p = partial(MyClass, 1)
+reveal_type(p)  # revealed: partial[Unknown]
+p()
+# TODO: should reveal `partial[() -> MyClass]` once constructor signatures are merged.
+# TODO: should error: [too-many-positional-arguments] once constructor signatures are merged.
+p("extra")
+```
+
+### Class constructor partial preserves one-sided bound `__new__` positional params
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self) -> None: ...
+
+p = partial(MyClass, 1)
+# TODO: should reveal `partial[(x: Never) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should error: [missing-argument] once constructor signatures are merged.
+p()
+# TODO: should error: [invalid-argument-type] once constructor signatures are merged.
+p(1)
+```
+
+### Class constructor partial preserves one-sided bound `__new__` keyword params
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self) -> None: ...
+
+p = partial(MyClass, x=1)
+# TODO: should reveal `partial[(*, x: Never) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should error: [missing-argument] once constructor signatures are merged.
+p()
+# TODO: should error: [invalid-argument-type] once constructor signatures are merged.
+p(x=1)
+```
+
+### Class constructor preserves downstream params after partial binding
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: int, y: str) -> None: ...
+
+p = partial(MyClass, 1)
+# TODO: should reveal `partial[(y: Never) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should error: [missing-argument] once constructor signatures are merged.
+p()
+# TODO: should error: [invalid-argument-type] once constructor signatures are merged.
+p("extra")
+```
+
+### Class constructor partial preserves one-sided `__init__` params
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: int) -> None: ...
+
+p = partial(MyClass)
+# TODO: should reveal `partial[(x: Never) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should error: [missing-argument] once constructor signatures are merged.
+p()
+# TODO: should error: [invalid-argument-type] once constructor signatures are merged.
+p(1)
+```
+
+### Class constructor partial preserves downstream keyword-only params
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, *, y: str) -> None: ...
+
+p = partial(MyClass, 1)
+# TODO: should reveal `partial[(x: Never, *, y: Never) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should error: [missing-argument] once constructor signatures are merged.
+p()
+# TODO: should error: [missing-argument] and [invalid-argument-type] once constructor signatures are merged.
+p(y="extra")
+```
+
+### Class constructor partial keeps the narrower subtype-compatible signature
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: object) -> None: ...
+
+p = partial(MyClass)
+# TODO: should reveal `partial[(x: int) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should reveal `MyClass` once constructor signatures are merged.
+reveal_type(p(1))  # revealed: Unknown
+# TODO: should error: [invalid-argument-type] once constructor signatures are merged.
+p("s")
+```
+
+### Class constructor partial matches reordered params by name
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int, *, y: str) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, *, y: str, x: int) -> None: ...
+
+p = partial(MyClass)
+# TODO: should reveal `partial[(*, x: int, y: str) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should reveal `MyClass` once constructor signatures are merged.
+reveal_type(p(x=1, y="s"))  # revealed: Unknown
+# TODO: should error: [missing-argument] once constructor signatures are merged.
+p(y="s")
+```
+
+### Class constructor partial keeps reordered positional params keyword-only
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int, y: str) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, y: str, x: int) -> None: ...
+
+p = partial(MyClass)
+# TODO: should reveal `partial[(*, x: int, y: str) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should reveal `MyClass` once constructor signatures are merged.
+reveal_type(p(x=1, y="s"))  # revealed: Unknown
+# TODO: should error: [missing-argument] and [too-many-positional-arguments] once constructor signatures are merged.
+p(1, "s")
+```
+
+### Class constructor partial preserves both `__new__` and `__init__`
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int | str) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: int) -> None: ...
+
+p = partial(MyClass)
+# TODO: should reveal `partial[(x: int) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+p(1)
+# TODO: should error: [invalid-argument-type] once constructor signatures are merged.
+p("s")
+```
+
+### Class constructor partial preserves per-overload correlations
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+
+class MyClass:
+    def __new__(cls, x: T, y: T) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: int, y: str) -> None: ...
+
+p = partial(MyClass)
+# TODO: should error twice with [invalid-argument-type] once constructor signatures are merged.
+p(1, "s")
+```
+
+### Class constructor partial keeps non-instance `__new__` overloads
+
+```py
+from __future__ import annotations
+
+from functools import partial
+from typing import overload
+
+class MyClass:
+    @overload
+    def __new__(cls, x: int) -> "MyClass": ...
+    @overload
+    def __new__(cls, x: str) -> str: ...
+    def __new__(cls, x: int | str) -> "MyClass" | str:
+        if isinstance(x, str):
+            return x
+        return super().__new__(cls)
+
+    def __init__(self, x: int) -> None: ...
+
+p = partial(MyClass)
+# TODO: should preserve the non-instance `__new__` overload in the reduced partial signature.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should reveal `MyClass` once constructor signatures are merged.
+reveal_type(p(1))  # revealed: Unknown
+# TODO: should reveal `str` once constructor signatures are merged.
+reveal_type(p("s"))  # revealed: Unknown
+```
+
+## Additional signature-shaping cases
+
+### Binding a default parameter
+
+Binding a parameter that has a default value removes it from the signature.
+
+```py
+from functools import partial
+
+def f(a: int, b: str = "default", c: float = 0.0) -> bool:
+    return True
+
+p = partial(f, 1, "hello")
+reveal_type(p)  # revealed: partial[(c: int | float = ...) -> bool]
+```
+
+### Multiple keyword bindings
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float, d: bool) -> int:
+    return 0
+
+p = partial(f, b="hello", d=True)
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello", c: int | float, d: bool = True) -> int]
+```
+
+### Mixed positional-only, regular, and keyword-only
+
+```py
+from functools import partial
+
+def f(a: int, /, b: str, *, c: float) -> bool:
+    return True
+
+# Bind the positional-only param
+p1 = partial(f, 1)
+reveal_type(p1)  # revealed: partial[(b: str, *, c: int | float) -> bool]
+
+# Bind a keyword-only param by keyword
+p2 = partial(f, c=3.14)
+reveal_type(p2)  # revealed: partial[(a: int, /, b: str, *, c: int | float = ...) -> bool]
+
+# Bind both positional-only and keyword-only
+p3 = partial(f, 1, c=3.14)
+reveal_type(p3)  # revealed: partial[(b: str, *, c: int | float = ...) -> bool]
+```
+
+### Starred args combined with keyword args
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+args: tuple[int] = (1,)
+p = partial(f, *args, c=3.14)
+reveal_type(p)  # revealed: partial[(b: str, *, c: int | float = ...) -> bool]
+```
+
+### Starred args with empty tuple
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+args: tuple[()] = ()
+p = partial(f, *args)
+reveal_type(p)  # revealed: partial[(a: int, b: str) -> bool]
+```
+
+### Generic function with multiple type variables
+
+TODO: preserve uninferred type variables in the resulting partial signature.
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+def combine(a: T, b: U) -> tuple[T, U]:
+    return (a, b)
+
+p = partial(combine, 1)
+reveal_type(p)  # revealed: partial[(b: Unknown) -> tuple[Literal[1], Unknown]]
+```
+
+### Callable object (class with `__call__`)
+
+```py
+from functools import partial
+
+class Adder:
+    def __call__(self, a: int, b: int) -> int:
+        return a + b
+
+adder = Adder()
+p = partial(adder, 1)
+reveal_type(p)  # revealed: partial[(b: int) -> int]
+```
+
+### Staticmethod
+
+```py
+from functools import partial
+
+class MyClass:
+    @staticmethod
+    def f(a: int, b: str) -> bool:
+        return True
+
+p = partial(MyClass.f, 1)
+reveal_type(p)  # revealed: partial[(b: str) -> bool]
+```
+
+### Overloaded function with later matching overload
+
+When the bound argument matches a later overload but not the first, no error should be emitted:
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def f(a: int) -> int: ...
+@overload
+def f(a: str) -> str: ...
+def f(a: int | str) -> int | str:
+    return a
+
+# "hello" matches the second overload (str -> str), so no error.
+p = partial(f, "hello")
+reveal_type(p)  # revealed: partial[() -> str]
+```
+
+### Overriding keyword-bound args at call time
+
+`partial` allows keyword arguments to be overridden when calling the result:
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+p = partial(f, b="hello")
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello", c: int | float) -> bool]
+
+# Override b at call time
+reveal_type(p(1, b="world", c=3.14))  # revealed: bool
+```
+
+### Overriding keyword-bound generic args at call time
+
+TODO: preserve the override branch when a keyword-bound generic is rebound at call time.
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def pair(a: T, b: T) -> tuple[T, T]:
+    return (a, b)
+
+p = partial(pair, b=1)
+reveal_type(p)  # revealed: partial[(a: int, *, b: int = 1) -> tuple[int, int]]
+p("x")  # error: [invalid-argument-type]
+# error: [invalid-argument-type]
+# error: [invalid-argument-type]
+p("x", b="y")
+```
+
+## Assignability and partial object behavior
+
+### Assignability to callable
+
+A `partial` result is assignable to a `Callable` with the matching signature:
+
+```py
+from functools import partial
+from typing import Callable
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(b: str) -> bool]
+
+def takes_callable(fn: Callable[[str], bool]) -> None:
+    pass
+
+takes_callable(p)  # OK -- partial[(b: str) -> bool] is callable with (str) -> bool
+
+def takes_wrong_callable(fn: Callable[[int], bool]) -> None:
+    pass
+
+takes_wrong_callable(p)  # error: [invalid-argument-type]
+
+def returns_partial() -> partial[bool]:
+    return p  # OK -- partial[(b: str) -> bool] is assignable to partial[bool]
+```
+
+### Assignability to a stub-style function alias
+
+```py
+from functools import partial
+from typing import TYPE_CHECKING
+
+def f(a: int, b: str | None, c: dict[str, int]) -> dict[str, int]:
+    return c
+
+if TYPE_CHECKING:
+    def g(a: int, b: str | None) -> dict[str, int]: ...
+
+g = partial(f, c={})
+```
+
+### Ambiguous binding preserves overload
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def f(a: int) -> int: ...
+@overload
+def f(a: str) -> str: ...
+def f(a: int | str) -> int | str:
+    return a
+
+def make_partial(x):
+    p = partial(f, x)
+    reveal_type(p)  # revealed: partial[Overload[() -> int, () -> str]]
+    return p
+
+p = make_partial(1)
+```
+
+### Invalid overloaded binding falls back to default partial type
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def f(a: int) -> int: ...
+@overload
+def f(a: str) -> str: ...
+def f(a):
+    return a
+
+p = partial(f, 1.0)  # error: [invalid-argument-type]
+reveal_type(p)  # revealed: partial[Unknown]
+```
+
+### Partial of bound classmethod is assignable to zero-arg callable
+
+```py
+from functools import partial
+from typing import Callable
+from typing_extensions import Self
+
+class C:
+    @classmethod
+    def make(cls, *, x: int = 0) -> Self:
+        raise RuntimeError
+
+factory: Callable[[], C] = partial(C.make, x=0)
+```
+
+### Partials of nested local functions with same signature
+
+Two `partial(...)` values from distinct nested local functions should still be assignable when their
+remaining callable signatures match:
+
+```py
+from functools import partial
+
+def outer(x, y):
+    def left(a, b):
+        return a, x
+
+    def right(a, b):
+        return a, y
+
+    branches = [partial(left, 1)]
+    branches.append(partial(right, 2))
+```
+
+### Keyword-bound predicate remains unary for filter
+
+Binding a predicate parameter via keyword should still produce a unary predicate acceptable to
+`filter(...)`:
+
+```py
+from functools import partial
+
+def has_same_ip_version(addr_or_net: str, is_ipv6: bool) -> bool:
+    return is_ipv6
+
+values = ["127.0.0.1", "::1"]
+predicate = partial(has_same_ip_version, is_ipv6=False)
+reveal_type(predicate)  # revealed: partial[(addr_or_net: str, *, is_ipv6: bool = False) -> bool]
+reveal_type(list(filter(predicate, values)))  # revealed: list[str]
+```
+
+### Overloaded partial reports type mismatch, not unknown keyword
+
+```py
+from functools import partial
+from typing import Callable, Literal, Optional, cast, overload
+
+@overload
+def task(__fn: Callable[[], int]) -> int: ...
+@overload
+def task(
+    __fn: Literal[None] = None,
+    *,
+    retries: int = 0,
+) -> Callable[[Callable[[], int]], int]: ...
+@overload
+def task(
+    *,
+    retries: int = 0,
+) -> Callable[[Callable[[], int]], int]: ...
+def task(
+    __fn: Optional[Callable[[], int]] = None,
+    *,
+    retries: Optional[int] = None,
+):
+    if __fn:
+        return 1
+    return cast(
+        Callable[[Callable[[], int]], int],
+        partial(task, retries=retries),  # error: [invalid-argument-type]
+    )
+```
+
+### Bound classmethod callback with weakref
+
+Binding the first explicit parameter of a bound classmethod callback should preserve assignability
+for `ReferenceType[Self]` arguments:
+
+```py
+from functools import partial
+from typing import Any, Generic, TypeVar
+from weakref import ReferenceType, ref
+
+T = TypeVar("T")
+
+class CallbackHost(Generic[T]):
+    @classmethod
+    def callback(cls, wself: ReferenceType["CallbackHost[Any]"], x: int) -> None: ...
+    def __init__(self) -> None:
+        p = partial(self.callback, ref(self))  # error: [invalid-argument-type]
+        # TODO: should accept `ReferenceType[Self]` here and preserve the reduced signature.
+        reveal_type(p)  # revealed: partial[(x: int) -> None]
+```
+
+### Assignability to protocol
+
+A `partial` result is assignable to a `Protocol` with a matching `__call__` signature. Required
+keyword-only parameters can be bound away, and extra keyword-only parameters with defaults in the
+resulting `partial` are allowed, since they don't need to be provided by the caller:
+
+```py
+from functools import partial
+from typing import Protocol
+
+class Request: ...
+class Response: ...
+class Context: ...
+
+class Handler(Protocol):
+    def __call__(
+        self,
+        request: Request,
+        *,
+        header: str | None = None,
+    ) -> Response: ...
+
+def handle(
+    request: Request,
+    *,
+    header: str | None = None,
+    verbose: bool = False,
+    context: Context,
+) -> Response:
+    return Response()
+
+handler: Handler = partial(handle, context=Context())
+```
+
+### Accessing `__call__` directly
+
+`__call__` on a `partial` result should reflect the refined callable signature, not the broad
+`(*args: Any, **kwargs: Any) -> T` from the `partial` class stub.
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p.__call__)  # revealed: (b: str) -> bool
+
+reveal_type(p.__call__("hello"))  # revealed: bool
+```
+
+### Attribute access on partial results
+
+Standard `partial` attributes like `.func`, `.args`, and `.keywords` should be accessible:
+
+```py
+from functools import partial
+from typing import Callable
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p.func)  # revealed: def f(a: int, b: str) -> bool
+reveal_type(p.func(2, "hello"))  # revealed: bool
+reveal_type(p.args)  # revealed: tuple[Any, ...]
+reveal_type(p.keywords)  # revealed: dict[str, Any]
+```
+
+### `partial.func` keeps the original callable type
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+def combine(a: T, b: U) -> tuple[T, U]:
+    return (a, b)
+
+p = partial(combine, 1)
+reveal_type(p.func(2, "x"))  # revealed: tuple[Literal[2], Literal["x"]]
+```
+
+### Attribute assignment on partial results
+
+Attribute assignment should go through the standard nominal instance path:
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+p.func = f  # error: [invalid-assignment]
+```
+
+### Unknown attribute assignment on partial results
+
+We intentionally reject ad-hoc attributes on `functools.partial` results. This matches `pyright` and
+`mypy`, even though these assignments work at runtime.
+
+```py
+from functools import partial
+
+def f() -> None:
+    pass
+
+p = partial(f)
+# error: [unresolved-attribute]
+p.__name__ = "renamed"
+```

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -29,6 +29,25 @@ p = partial(f, b="hello")
 reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello") -> bool]
 ```
 
+### Leading parameter bound by keyword
+
+Binding a positional-or-keyword parameter by keyword makes it defaulted and keyword-only in the
+reduced signature, and later positional-or-keyword parameters become keyword-only too:
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, a=1)
+reveal_type(p)  # revealed: partial[(*, a: int = 1, b: str) -> bool]
+reveal_type(p(b="hello"))  # revealed: bool
+# error: [missing-argument]
+# error: [too-many-positional-arguments]
+p("hello")
+```
+
 ### Mixed positional and keyword binding
 
 ```py
@@ -110,6 +129,18 @@ def f(a: int, *args: str) -> bool:
     return True
 
 p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(*args: str) -> bool]
+```
+
+### Variadic partially bound
+
+```py
+from functools import partial
+
+def f(a: int, *args: str) -> bool:
+    return True
+
+p = partial(f, 1, "hello")
 reveal_type(p)  # revealed: partial[(*args: str) -> bool]
 ```
 
@@ -220,6 +251,20 @@ def f(a: int, b: str) -> bool:
     return True
 
 p = partial(f, 1, a=2)  # error: [parameter-already-assigned]
+```
+
+### Parameter already assigned with keyword variadic fallback
+
+```py
+from functools import partial
+
+def f(a: int, **kwargs: str) -> bool:
+    return True
+
+# error: [invalid-argument-type]
+# error: [parameter-already-assigned]
+p = partial(f, 1, a="hello")
+reveal_type(p)  # revealed: partial[(**kwargs: str) -> bool]
 ```
 
 ### Too-many-positional is reported at partial construction
@@ -366,6 +411,30 @@ reveal_type(box.callback)  # revealed: partial[() -> int]
 target: Callable[[], int] = box.callback
 ```
 
+### Bound method returning `Self`
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from functools import partial
+from typing import Self
+
+class Builder:
+    def clone_with(self, value: int) -> Self:
+        return self
+
+class Fancy(Builder):
+    pass
+
+fancy = Fancy()
+p = partial(fancy.clone_with, 1)
+reveal_type(p)  # revealed: partial[() -> Fancy]
+reveal_type(p())  # revealed: Fancy
+```
+
 ### Overloaded functions
 
 ```py
@@ -395,11 +464,10 @@ def zero_arg(x: int) -> int:
 def one_arg(x: int, y: str) -> int:
     return x + len(y)
 
-def test_union_partial(
-    f: Callable[[int], int] | Callable[[int, str], int],
-) -> None:
+def test_union_partial(flag: bool) -> None:
+    f = zero_arg if flag else one_arg
     p = partial(f, 1)
-    reveal_type(p)  # revealed: partial[() -> int] | partial[(str, /) -> int]
+    reveal_type(p)  # revealed: partial[() -> int] | partial[(y: str) -> int]
 
     bad: Callable[[bytes, bytes], int] = p  # error: [invalid-assignment]
 ```
@@ -464,38 +532,22 @@ bound = partial(invoke, flag=1, func=pre)
 reveal_type(bound(cfg="x"))  # revealed: int
 ```
 
-### Partial assignability with a keyword-bound middle parameter
-
-```py
-from functools import partial
-from typing import Any, Protocol
-
-class Conv(Protocol):
-    def __call__(self, __x: Any, *, _target_: str = "set", CBuildsFn: type[Any]) -> Any: ...
-
-class ConfigFromTuple:
-    def __init__(self, _args_: tuple[Any, ...], _target_: str, CBuildsFn: type[Any]) -> None: ...
-
-p = partial(ConfigFromTuple, _target_="set")
-# TODO: should preserve the keyword-bound middle parameter in the reduced signature.
-reveal_type(p)  # revealed: partial[Unknown]
-
-conversion: dict[type, Conv] = {}
-conversion[set] = p
-```
-
 ### Overloaded stdlib callable narrowed by bound args
 
-`partial(reduce, operator.mul)` should keep the narrowed return type from the bound reducer:
+`partial(reduce, mul)` should keep the narrowed return type from the bound reducer:
 
 ```py
 from functools import partial, reduce
-import operator
 
-prod = partial(reduce, operator.mul)
+def mul(x: int, y: int, /) -> int:
+    return x * y
+
+prod = partial(reduce, mul)
 shape: list[int] = [1, 2, 3]
 
-reveal_type(prod(shape))  # revealed: Any
+# revealed: partial[Overload[(iterable: Iterable[int], initial: int, /) -> int, (iterable: Iterable[int], /) -> int]]
+reveal_type(prod)
+reveal_type(prod(shape))  # revealed: int
 ```
 
 ### Overloaded stdlib callable with keyword-only binding
@@ -621,6 +673,9 @@ reveal_type(p)  # revealed: partial[(c: int | float) -> bool]
 
 ### Fallback for starred args with variable-length tuple
 
+We intentionally fall back here instead of enumerating possible tuple lengths; this matches the
+existing treatment of variable-length tuple splats in ordinary calls.
+
 ```py
 from functools import partial
 
@@ -670,6 +725,12 @@ reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello", c: int | float
 
 ### Fallback for kwargs splat with dict
 
+We intentionally fall back for a plain `dict`, even if a literal key is visible at the call site,
+because we don't track the key set precisely the way we do for direct keyword arguments or
+`TypedDict`. In particular, we don't know whether a required parameter like `b` will be supplied by
+the mapping, so we can't safely choose between a reduced signature where `b` remains required and
+one where `b` becomes a defaulted keyword-only parameter.
+
 ```py
 from functools import partial
 
@@ -682,6 +743,10 @@ reveal_type(p)  # revealed: partial[bool]
 ```
 
 ### Fallback for kwargs splat with optional TypedDict keys
+
+Optional `TypedDict` keys have the same ambiguity: a key like `b` may or may not be present at
+runtime, so we can't safely decide whether the reduced signature should keep `b` required or mark it
+as already bound with a default.
 
 ```py
 from functools import partial
@@ -1173,6 +1238,29 @@ def returns_partial() -> partial[bool]:
     return p  # OK -- partial[(b: str) -> bool] is assignable to partial[bool]
 ```
 
+### Assignability with a keyword-bound middle parameter
+
+```py
+from functools import partial
+from typing import Any, Protocol
+
+class Conv(Protocol):
+    def __call__(self, __x: Any, *, _target_: str = "set", CBuildsFn: type[Any]) -> Any: ...
+
+def build(
+    _args_: tuple[Any, ...],
+    _target_: str,
+    CBuildsFn: type[Any],
+) -> None:
+    pass
+
+p = partial(build, _target_="set")
+reveal_type(p)  # revealed: partial[(_args_: tuple[Any, ...], *, _target_: str = "set", CBuildsFn: type[Any]) -> None]
+
+conversion: dict[type, Conv] = {}
+conversion[set] = p
+```
+
 ### Assignability to a stub-style function alias
 
 ```py
@@ -1201,7 +1289,7 @@ def f(a: str) -> str: ...
 def f(a: int | str) -> int | str:
     return a
 
-def make_partial(x):
+def make_partial(x: int | str):
     p = partial(f, x)
     reveal_type(p)  # revealed: partial[Overload[() -> int, () -> str]]
     return p

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -1,0 +1,1534 @@
+# `functools.partial`
+
+## Basic reduction and invocation
+
+### Basic positional binding
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(b: str) -> bool]
+```
+
+### Keyword binding
+
+Keyword-bound parameters are kept with a default, but they become keyword-only in the resulting
+callable. `partial` allows overriding them at call time, but only by keyword.
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, b="hello")
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello") -> bool]
+```
+
+### Leading parameter bound by keyword
+
+Binding a positional-or-keyword parameter by keyword makes it defaulted and keyword-only in the
+reduced signature, and later positional-or-keyword parameters become keyword-only too:
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, a=1)
+reveal_type(p)  # revealed: partial[(*, a: int = 1, b: str) -> bool]
+reveal_type(p(b="hello"))  # revealed: bool
+# error: [missing-argument]
+# error: [too-many-positional-arguments]
+p("hello")
+```
+
+### Mixed positional and keyword binding
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+p = partial(f, 1, c=3.14)
+reveal_type(p)  # revealed: partial[(b: str, *, c: int | float = ...) -> bool]
+```
+
+### All args bound
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1, "hello")
+reveal_type(p)  # revealed: partial[() -> bool]
+```
+
+### No args bound
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f)
+reveal_type(p)  # revealed: partial[(a: int, b: str) -> bool]
+```
+
+### Positional-only params
+
+```py
+from functools import partial
+
+def f(a: int, b: str, /) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(b: str, /) -> bool]
+```
+
+### Keyword-only params
+
+```py
+from functools import partial
+
+def f(a: int, *, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(*, b: str) -> bool]
+```
+
+### Keyword-only params bound by keyword
+
+```py
+from functools import partial
+
+def f(a: int, *, b: str) -> bool:
+    return True
+
+p = partial(f, b="hello")
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello") -> bool]
+```
+
+### Variadic preserved
+
+```py
+from functools import partial
+
+def f(a: int, *args: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(*args: str) -> bool]
+```
+
+### Variadic partially bound
+
+```py
+from functools import partial
+
+def f(a: int, *args: str) -> bool:
+    return True
+
+p = partial(f, 1, "hello")
+reveal_type(p)  # revealed: partial[(*args: str) -> bool]
+```
+
+### Keyword variadic preserved
+
+```py
+from functools import partial
+
+def f(a: int, **kwargs: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(**kwargs: str) -> bool]
+```
+
+### Defaults preserved
+
+```py
+from functools import partial
+
+def f(a: int, b: str = "default") -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(b: str = "default") -> bool]
+```
+
+### Lambda
+
+```py
+from functools import partial
+
+p = partial(lambda x, y: x + y, 1)
+reveal_type(p)  # revealed: partial[(y: Any) -> Any]
+```
+
+### Bound method
+
+```py
+from functools import partial
+
+class Greeter:
+    def greet(self, name: str, greeting: str = "Hello") -> str:
+        return f"{greeting}, {name}"
+
+g = Greeter()
+p = partial(g.greet, "world")
+reveal_type(p)  # revealed: partial[(greeting: str = "Hello") -> str]
+reveal_type(p())  # revealed: str
+```
+
+### Calling the partial result
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p("hello", 3.14))  # revealed: bool
+reveal_type(p(b="hello", c=3.14))  # revealed: bool
+```
+
+## Construction-time diagnostics
+
+### Wrong positional arg type
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, "not_an_int")  # error: [invalid-argument-type]
+reveal_type(p)  # revealed: partial[(b: str) -> bool]
+```
+
+### Wrong keyword arg type
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, b=42)  # error: [invalid-argument-type]
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = 42) -> bool]
+```
+
+### Unknown keyword argument
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, c=1)  # error: [unknown-argument]
+```
+
+### Parameter already assigned
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1, a=2)  # error: [parameter-already-assigned]
+```
+
+### Parameter already assigned with keyword variadic fallback
+
+```py
+from functools import partial
+
+def f(a: int, **kwargs: str) -> bool:
+    return True
+
+# error: [invalid-argument-type]
+# error: [parameter-already-assigned]
+p = partial(f, 1, a="hello")
+reveal_type(p)  # revealed: partial[(**kwargs: str) -> bool]
+```
+
+### Too-many-positional is reported at partial construction
+
+```py
+from functools import partial
+
+def f(a: int, b: int) -> int:
+    return a + b
+
+p = partial(f, 1, 2, 3)  # error: [too-many-positional-arguments]
+reveal_type(p)  # revealed: partial[() -> int]
+p()
+p(1)  # error: [too-many-positional-arguments]
+```
+
+### Non-callable first argument
+
+`partial(42)` is an error caught by the constructor call; we fall back to the default `partial[T]`
+type.
+
+```py
+from functools import partial
+
+p = partial(42)  # error: [invalid-argument-type]
+reveal_type(p)  # revealed: partial[Unknown]
+```
+
+### Keyword binding to positional-only param
+
+Positional-only parameters cannot be bound by keyword in `partial()`. The parameter should be
+preserved in the resulting callable, while still reporting a construction-time error:
+
+```py
+from functools import partial
+
+def f(x: int, /, y: str) -> bool:
+    return True
+
+# `x` is positional-only, so `x=1` does not bind it.
+p = partial(f, x=1)  # error: [positional-only-parameter-as-kwarg]
+reveal_type(p)  # revealed: partial[(x: int, /, y: str) -> bool]
+```
+
+## Generics, overloads, and signature inference
+
+### Generic functions
+
+Type variables are inferred from the bound arguments:
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def identity(x: T) -> T:
+    return x
+
+p = partial(identity, 1)
+reveal_type(p)  # revealed: partial[() -> Literal[1]]
+```
+
+### Generic functions with remaining params
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def pair(a: T, b: T) -> tuple[T, T]:
+    return (a, b)
+
+p = partial(pair, 1)
+reveal_type(p)  # revealed: partial[(b: int) -> tuple[int, int]]
+reveal_type(p(2))  # revealed: tuple[int, int]
+reveal_type(p(2)[1])  # revealed: int
+```
+
+### Generic functions preserve defaults for no-longer-inferable type params
+
+```py
+from functools import partial
+from typing import cast
+from typing_extensions import TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U", default=T)
+
+def with_default(x: T) -> tuple[T, U]:
+    return (x, cast(U, x))
+
+reveal_type(with_default(1))  # revealed: tuple[Literal[1], Literal[1]]
+
+p = partial(with_default, 1)
+reveal_type(p)  # revealed: partial[() -> tuple[Literal[1], Literal[1]]]
+reveal_type(p())  # revealed: tuple[Literal[1], Literal[1]]
+```
+
+### Generic constructors
+
+```py
+from functools import partial
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Box(Generic[T]):
+    def __init__(self, value: T) -> None:
+        self.value = value
+
+list_factory = partial(list, [1])
+# TODO: should reveal `partial[() -> list[int]]` once constructor partials are modeled.
+reveal_type(list_factory)  # revealed: partial[Unknown]
+# TODO: should reveal `list[int]` once constructor partials are modeled.
+reveal_type(list_factory())  # revealed: Unknown
+
+box_factory = partial(Box, "hi")
+# TODO: should reveal `partial[() -> Box[str]]` once constructor partials are modeled.
+reveal_type(box_factory)  # revealed: partial[Unknown]
+# TODO: should reveal `Box[str]` once constructor partials are modeled.
+reveal_type(box_factory())  # revealed: Unknown
+```
+
+### Stored partials specialize through generic instances
+
+```py
+from functools import partial
+from typing import Callable, Generic, TypeVar
+
+T = TypeVar("T")
+
+def identity(x: T) -> T:
+    return x
+
+class Box(Generic[T]):
+    def __init__(self, value: T) -> None:
+        self.callback = partial(identity, value)
+
+box = Box[int](1)
+reveal_type(box.callback)  # revealed: partial[() -> int]
+
+target: Callable[[], int] = box.callback
+```
+
+### Bound method returning `Self`
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from functools import partial
+from typing import Self
+
+class Builder:
+    def clone_with(self, value: int) -> Self:
+        return self
+
+class Fancy(Builder):
+    pass
+
+fancy = Fancy()
+p = partial(fancy.clone_with, 1)
+reveal_type(p)  # revealed: partial[() -> Fancy]
+reveal_type(p())  # revealed: Fancy
+```
+
+### Overloaded functions
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def f(a: int) -> int: ...
+@overload
+def f(a: str) -> str: ...
+def f(a: int | str) -> int | str:
+    return a
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[() -> int]
+```
+
+### Union of callables preserves union of partials
+
+```py
+from functools import partial
+from typing import Callable
+
+def zero_arg(x: int) -> int:
+    return x
+
+def one_arg(x: int, y: str) -> int:
+    return x + len(y)
+
+def test_union_partial(flag: bool) -> None:
+    f = zero_arg if flag else one_arg
+    p = partial(f, 1)
+    reveal_type(p)  # revealed: partial[() -> int] | partial[(y: str) -> int]
+
+    bad: Callable[[bytes, bytes], int] = p  # error: [invalid-assignment]
+```
+
+### Keyword-bound overload filtering
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def g(path: bytes, start: bytes | None = b".") -> bytes: ...
+@overload
+def g(path: str, start: str | None = ".") -> str: ...
+def g(path: bytes | str, start: bytes | str | None = None) -> bytes | str:
+    return path
+
+p = partial(g, start=".")
+paths: list[str] = ["x"]
+reveal_type(p)  # revealed: partial[(path: str, *, start: str | None = ".") -> str]
+reveal_type(list(map(p, paths)))  # revealed: list[str]
+```
+
+### ParamSpec callable bound with `partial`
+
+```py
+from functools import partial
+from typing import Any, Callable, TypeVar
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def invoke(func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+    return func(*args, **kwargs)
+
+def pre(cfg: Any) -> Any:
+    return cfg
+
+bound = partial(invoke, pre)
+reveal_type(bound)  # revealed: partial[(cfg: Any) -> Any]
+reveal_type(bound({}))  # revealed: Any
+```
+
+### ParamSpec callable with keyword-bound wrapper parameters
+
+```py
+from functools import partial
+from typing import Callable, TypeVar
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def invoke(flag: int, func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+    return func(*args, **kwargs)
+
+def pre(*, cfg: str) -> int:
+    return 1
+
+bound = partial(invoke, flag=1, func=pre)
+reveal_type(bound(cfg="x"))  # revealed: int
+```
+
+### Overloaded stdlib callable narrowed by bound args
+
+`partial(reduce, mul)` should keep the narrowed return type from the bound reducer:
+
+```py
+from functools import partial, reduce
+
+def mul(x: int, y: int, /) -> int:
+    return x * y
+
+prod = partial(reduce, mul)
+shape: list[int] = [1, 2, 3]
+
+# revealed: partial[Overload[(iterable: Iterable[int], initial: int, /) -> int, (iterable: Iterable[int], /) -> int]]
+reveal_type(prod)
+reveal_type(prod(shape))  # revealed: int
+```
+
+### Overloaded stdlib callable with keyword-only binding
+
+`partial(zip, strict=True)` should accept the keyword-only argument and preserve the element types
+of the resulting iterator:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from functools import partial
+import builtins
+
+zips = partial(builtins.zip, strict=True)
+
+xs = [1]
+ys = ["a"]
+pairs = list(zips(xs, ys))
+
+# TODO: should reveal `list[tuple[int, str]]` once keyword-only constructor bindings are preserved.
+reveal_type(pairs)  # revealed: list[Unknown]
+```
+
+### Keyword argument with literal sequence annotation
+
+`partial(...)` should accept keyword arguments whose literal container types are inferred without
+context at the call site:
+
+```py
+from functools import partial
+from typing import Literal, Sequence
+
+Distribution = Literal["sdist", "wheel", "editable"]
+
+def build(distributions: Sequence[Distribution]) -> None:
+    pass
+
+p = partial(build, distributions=["wheel"])  # error: [invalid-argument-type]
+# TODO: should accept this keyword literal without a construction-time error.
+reveal_type(p)  # revealed: partial[(*, distributions: Sequence[Literal["sdist", "wheel", "editable"]] = ...) -> None]
+reveal_type(p())  # revealed: None
+```
+
+### Keyword argument with empty literal sequence annotation
+
+`partial(...)` should still re-run argument refinement even when the initial constructor binding
+already succeeds, so empty literals keep the parameter's contextual element type:
+
+```py
+from functools import partial
+from typing import Literal, Sequence
+
+Distribution = Literal["sdist", "wheel", "editable"]
+
+def build(distributions: Sequence[Distribution]) -> None:
+    pass
+
+p = partial(build, distributions=[])
+reveal_type(p)  # revealed: partial[(*, distributions: Sequence[Literal["sdist", "wheel", "editable"]] = ...) -> None]
+reveal_type(p())  # revealed: None
+```
+
+### Overloaded functions with remaining params
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def g(a: int, b: str) -> int: ...
+@overload
+def g(a: str, b: str) -> str: ...
+def g(a: int | str, b: str) -> int | str:
+    return a
+
+p = partial(g, 1)
+reveal_type(p)  # revealed: partial[(b: str) -> int]
+```
+
+## Argument unpacking and nested partials
+
+### Starred args with fixed-length tuple
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+args: tuple[int] = (1,)
+p = partial(f, *args)
+reveal_type(p)  # revealed: partial[(b: str) -> bool]
+```
+
+### Starred args with multiple elements
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+args: tuple[int, str] = (1, "hello")
+p = partial(f, *args)
+reveal_type(p)  # revealed: partial[(c: int | float) -> bool]
+```
+
+### Mixed positional and starred args
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+args: tuple[str] = ("hello",)
+p = partial(f, 1, *args)
+reveal_type(p)  # revealed: partial[(c: int | float) -> bool]
+```
+
+### Fallback for starred args with variable-length tuple
+
+We intentionally fall back here instead of enumerating possible tuple lengths; this matches the
+existing treatment of variable-length tuple splats in ordinary calls.
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+def get_args() -> tuple[int, ...]:
+    return (1,)
+
+p = partial(f, *get_args())
+reveal_type(p)  # revealed: partial[bool]
+```
+
+### Kwargs splat with TypedDict
+
+```py
+from functools import partial
+from typing import TypedDict
+
+class MyKwargs(TypedDict):
+    b: str
+
+def f(a: int, b: str) -> bool:
+    return True
+
+kwargs: MyKwargs = {"b": "hello"}
+p = partial(f, **kwargs)
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = ...) -> bool]
+```
+
+### Mixed keywords and kwargs splat
+
+```py
+from functools import partial
+from typing import TypedDict
+
+class MyKwargs(TypedDict):
+    c: float
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+kwargs: MyKwargs = {"c": 3.14}
+p = partial(f, b="hello", **kwargs)
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello", c: int | float = ...) -> bool]
+```
+
+### Fallback for kwargs splat with dict
+
+We intentionally fall back for a plain `dict`, even if a literal key is visible at the call site,
+because we don't track the key set precisely the way we do for direct keyword arguments or
+`TypedDict`. In particular, we don't know whether a required parameter like `b` will be supplied by
+the mapping, so we can't safely choose between a reduced signature where `b` remains required and
+one where `b` becomes a defaulted keyword-only parameter.
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+kwargs = {"a": 1}
+p = partial(f, **kwargs)
+reveal_type(p)  # revealed: partial[bool]
+```
+
+### Fallback for kwargs splat with optional TypedDict keys
+
+Optional `TypedDict` keys have the same ambiguity: a key like `b` may or may not be present at
+runtime, so we can't safely decide whether the reduced signature should keep `b` required or mark it
+as already bound with a default.
+
+```py
+from functools import partial
+from typing import TypedDict
+
+class MaybeKwargs(TypedDict, total=False):
+    b: str
+
+def f(a: int, *, b: str) -> None:
+    pass
+
+def make(kwargs: MaybeKwargs) -> None:
+    p = partial(f, **kwargs)
+    reveal_type(p)  # revealed: partial[None]
+```
+
+### Nested partial
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+p1 = partial(f, 1)
+reveal_type(p1)  # revealed: partial[(b: str, c: int | float) -> bool]
+
+p2 = partial(p1, "hello")
+reveal_type(p2)  # revealed: partial[(c: int | float) -> bool]
+```
+
+## Constructors and advanced signatures
+
+### Class constructor
+
+```py
+from functools import partial
+
+class MyClass:
+    def __init__(self, x: int, y: str) -> None:
+        pass
+
+p = partial(MyClass, 1)
+# TODO: should reveal `partial[(y: str) -> MyClass]` once constructor partials are modeled.
+reveal_type(p)  # revealed: partial[Unknown]
+```
+
+### Class constructor with both `__new__` and `__init__`
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: int) -> None: ...
+
+p = partial(MyClass, 1)
+reveal_type(p)  # revealed: partial[Unknown]
+p()
+# TODO: should reveal `partial[() -> MyClass]` once constructor signatures are merged.
+# TODO: should error: [too-many-positional-arguments] once constructor signatures are merged.
+p("extra")
+```
+
+### Class constructor partial preserves one-sided bound `__new__` positional params
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self) -> None: ...
+
+p = partial(MyClass, 1)
+# TODO: should reveal `partial[(x: Never) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should error: [missing-argument] once constructor signatures are merged.
+p()
+# TODO: should error: [invalid-argument-type] once constructor signatures are merged.
+p(1)
+```
+
+### Class constructor partial preserves one-sided bound `__new__` keyword params
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self) -> None: ...
+
+p = partial(MyClass, x=1)
+# TODO: should reveal `partial[(*, x: Never) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should error: [missing-argument] once constructor signatures are merged.
+p()
+# TODO: should error: [invalid-argument-type] once constructor signatures are merged.
+p(x=1)
+```
+
+### Class constructor preserves downstream params after partial binding
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: int, y: str) -> None: ...
+
+p = partial(MyClass, 1)
+# TODO: should reveal `partial[(y: Never) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should error: [missing-argument] once constructor signatures are merged.
+p()
+# TODO: should error: [invalid-argument-type] once constructor signatures are merged.
+p("extra")
+```
+
+### Class constructor partial preserves one-sided `__init__` params
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: int) -> None: ...
+
+p = partial(MyClass)
+# TODO: should reveal `partial[(x: Never) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should error: [missing-argument] once constructor signatures are merged.
+p()
+# TODO: should error: [invalid-argument-type] once constructor signatures are merged.
+p(1)
+```
+
+### Class constructor partial preserves downstream keyword-only params
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, *, y: str) -> None: ...
+
+p = partial(MyClass, 1)
+# TODO: should reveal `partial[(x: Never, *, y: Never) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should error: [missing-argument] once constructor signatures are merged.
+p()
+# TODO: should error: [missing-argument] and [invalid-argument-type] once constructor signatures are merged.
+p(y="extra")
+```
+
+### Class constructor partial keeps the narrower subtype-compatible signature
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: object) -> None: ...
+
+p = partial(MyClass)
+# TODO: should reveal `partial[(x: int) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should reveal `MyClass` once constructor signatures are merged.
+reveal_type(p(1))  # revealed: Unknown
+# TODO: should error: [invalid-argument-type] once constructor signatures are merged.
+p("s")
+```
+
+### Class constructor partial matches reordered params by name
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int, *, y: str) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, *, y: str, x: int) -> None: ...
+
+p = partial(MyClass)
+# TODO: should reveal `partial[(*, x: int, y: str) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should reveal `MyClass` once constructor signatures are merged.
+reveal_type(p(x=1, y="s"))  # revealed: Unknown
+# TODO: should error: [missing-argument] once constructor signatures are merged.
+p(y="s")
+```
+
+### Class constructor partial keeps reordered positional params keyword-only
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int, y: str) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, y: str, x: int) -> None: ...
+
+p = partial(MyClass)
+# TODO: should reveal `partial[(*, x: int, y: str) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should reveal `MyClass` once constructor signatures are merged.
+reveal_type(p(x=1, y="s"))  # revealed: Unknown
+# TODO: should error: [missing-argument] and [too-many-positional-arguments] once constructor signatures are merged.
+p(1, "s")
+```
+
+### Class constructor partial preserves both `__new__` and `__init__`
+
+```py
+from functools import partial
+
+class MyClass:
+    def __new__(cls, x: int | str) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: int) -> None: ...
+
+p = partial(MyClass)
+# TODO: should reveal `partial[(x: int) -> MyClass]` once constructor signatures are merged.
+reveal_type(p)  # revealed: partial[Unknown]
+p(1)
+# TODO: should error: [invalid-argument-type] once constructor signatures are merged.
+p("s")
+```
+
+### Class constructor partial preserves per-overload correlations
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+
+class MyClass:
+    def __new__(cls, x: T, y: T) -> "MyClass":
+        return super().__new__(cls)
+    def __init__(self, x: int, y: str) -> None: ...
+
+p = partial(MyClass)
+# TODO: should error twice with [invalid-argument-type] once constructor signatures are merged.
+p(1, "s")
+```
+
+### Class constructor partial keeps non-instance `__new__` overloads
+
+```py
+from __future__ import annotations
+
+from functools import partial
+from typing import overload
+
+class MyClass:
+    @overload
+    def __new__(cls, x: int) -> "MyClass": ...
+    @overload
+    def __new__(cls, x: str) -> str: ...
+    def __new__(cls, x: int | str) -> "MyClass" | str:
+        if isinstance(x, str):
+            return x
+        return super().__new__(cls)
+
+    def __init__(self, x: int) -> None: ...
+
+p = partial(MyClass)
+# TODO: should preserve the non-instance `__new__` overload in the reduced partial signature.
+reveal_type(p)  # revealed: partial[Unknown]
+# TODO: should reveal `MyClass` once constructor signatures are merged.
+reveal_type(p(1))  # revealed: Unknown
+# TODO: should reveal `str` once constructor signatures are merged.
+reveal_type(p("s"))  # revealed: Unknown
+```
+
+## Additional signature-shaping cases
+
+### Binding a default parameter
+
+Binding a parameter that has a default value removes it from the signature.
+
+```py
+from functools import partial
+
+def f(a: int, b: str = "default", c: float = 0.0) -> bool:
+    return True
+
+p = partial(f, 1, "hello")
+reveal_type(p)  # revealed: partial[(c: int | float = ...) -> bool]
+```
+
+### Multiple keyword bindings
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float, d: bool) -> int:
+    return 0
+
+p = partial(f, b="hello", d=True)
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello", c: int | float, d: bool = True) -> int]
+```
+
+### Mixed positional-only, regular, and keyword-only
+
+```py
+from functools import partial
+
+def f(a: int, /, b: str, *, c: float) -> bool:
+    return True
+
+# Bind the positional-only param
+p1 = partial(f, 1)
+reveal_type(p1)  # revealed: partial[(b: str, *, c: int | float) -> bool]
+
+# Bind a keyword-only param by keyword
+p2 = partial(f, c=3.14)
+reveal_type(p2)  # revealed: partial[(a: int, /, b: str, *, c: int | float = ...) -> bool]
+
+# Bind both positional-only and keyword-only
+p3 = partial(f, 1, c=3.14)
+reveal_type(p3)  # revealed: partial[(b: str, *, c: int | float = ...) -> bool]
+```
+
+### Starred args combined with keyword args
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+args: tuple[int] = (1,)
+p = partial(f, *args, c=3.14)
+reveal_type(p)  # revealed: partial[(b: str, *, c: int | float = ...) -> bool]
+```
+
+### Starred args with empty tuple
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+args: tuple[()] = ()
+p = partial(f, *args)
+reveal_type(p)  # revealed: partial[(a: int, b: str) -> bool]
+```
+
+### Generic function with multiple type variables
+
+TODO: preserve uninferred type variables in the resulting partial signature.
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+def combine(a: T, b: U) -> tuple[T, U]:
+    return (a, b)
+
+p = partial(combine, 1)
+reveal_type(p)  # revealed: partial[(b: Unknown) -> tuple[Literal[1], Unknown]]
+```
+
+### Callable object (class with `__call__`)
+
+```py
+from functools import partial
+
+class Adder:
+    def __call__(self, a: int, b: int) -> int:
+        return a + b
+
+adder = Adder()
+p = partial(adder, 1)
+reveal_type(p)  # revealed: partial[(b: int) -> int]
+```
+
+### Staticmethod
+
+```py
+from functools import partial
+
+class MyClass:
+    @staticmethod
+    def f(a: int, b: str) -> bool:
+        return True
+
+p = partial(MyClass.f, 1)
+reveal_type(p)  # revealed: partial[(b: str) -> bool]
+```
+
+### Overloaded function with later matching overload
+
+When the bound argument matches a later overload but not the first, no error should be emitted:
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def f(a: int) -> int: ...
+@overload
+def f(a: str) -> str: ...
+def f(a: int | str) -> int | str:
+    return a
+
+# "hello" matches the second overload (str -> str), so no error.
+p = partial(f, "hello")
+reveal_type(p)  # revealed: partial[() -> str]
+```
+
+### Overriding keyword-bound args at call time
+
+`partial` allows keyword arguments to be overridden when calling the result:
+
+```py
+from functools import partial
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+p = partial(f, b="hello")
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello", c: int | float) -> bool]
+
+# Override b at call time
+reveal_type(p(1, b="world", c=3.14))  # revealed: bool
+```
+
+### Overriding keyword-bound generic args at call time
+
+TODO: preserve the override branch when a keyword-bound generic is rebound at call time.
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def pair(a: T, b: T) -> tuple[T, T]:
+    return (a, b)
+
+p = partial(pair, b=1)
+reveal_type(p)  # revealed: partial[(a: int, *, b: int = 1) -> tuple[int, int]]
+p("x")  # error: [invalid-argument-type]
+# error: [invalid-argument-type]
+# error: [invalid-argument-type]
+p("x", b="y")
+```
+
+## Assignability and partial object behavior
+
+### Assignability to callable
+
+A `partial` result is assignable to a `Callable` with the matching signature:
+
+```py
+from functools import partial
+from typing import Callable
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p)  # revealed: partial[(b: str) -> bool]
+
+def takes_callable(fn: Callable[[str], bool]) -> None:
+    pass
+
+takes_callable(p)  # OK -- partial[(b: str) -> bool] is callable with (str) -> bool
+
+def takes_wrong_callable(fn: Callable[[int], bool]) -> None:
+    pass
+
+takes_wrong_callable(p)  # error: [invalid-argument-type]
+
+def returns_partial() -> partial[bool]:
+    return p  # OK -- partial[(b: str) -> bool] is assignable to partial[bool]
+```
+
+### Assignability with a keyword-bound middle parameter
+
+```py
+from functools import partial
+from typing import Any, Protocol
+
+class Conv(Protocol):
+    def __call__(self, __x: Any, *, _target_: str = "set", CBuildsFn: type[Any]) -> Any: ...
+
+def build(
+    _args_: tuple[Any, ...],
+    _target_: str,
+    CBuildsFn: type[Any],
+) -> None:
+    pass
+
+p = partial(build, _target_="set")
+reveal_type(p)  # revealed: partial[(_args_: tuple[Any, ...], *, _target_: str = "set", CBuildsFn: type[Any]) -> None]
+
+conversion: dict[type, Conv] = {}
+conversion[set] = p
+```
+
+### Assignability to a stub-style function alias
+
+```py
+from functools import partial
+from typing import TYPE_CHECKING
+
+def f(a: int, b: str | None, c: dict[str, int]) -> dict[str, int]:
+    return c
+
+if TYPE_CHECKING:
+    def g(a: int, b: str | None) -> dict[str, int]: ...
+
+g = partial(f, c={})
+```
+
+### Ambiguous binding preserves overload
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def f(a: int) -> int: ...
+@overload
+def f(a: str) -> str: ...
+def f(a: int | str) -> int | str:
+    return a
+
+def make_partial(x: int | str):
+    p = partial(f, x)
+    reveal_type(p)  # revealed: partial[Overload[() -> int, () -> str]]
+    return p
+
+p = make_partial(1)
+```
+
+### Invalid overloaded binding falls back to default partial type
+
+```py
+from functools import partial
+from typing import overload
+
+@overload
+def f(a: int) -> int: ...
+@overload
+def f(a: str) -> str: ...
+def f(a):
+    return a
+
+p = partial(f, 1.0)  # error: [invalid-argument-type]
+reveal_type(p)  # revealed: partial[Unknown]
+```
+
+### Partial of bound classmethod is assignable to zero-arg callable
+
+```py
+from functools import partial
+from typing import Callable
+from typing_extensions import Self
+
+class C:
+    @classmethod
+    def make(cls, *, x: int = 0) -> Self:
+        raise RuntimeError
+
+factory: Callable[[], C] = partial(C.make, x=0)
+```
+
+### Partials of nested local functions with same signature
+
+Two `partial(...)` values from distinct nested local functions should still be assignable when their
+remaining callable signatures match:
+
+```py
+from functools import partial
+
+def outer(x, y):
+    def left(a, b):
+        return a, x
+
+    def right(a, b):
+        return a, y
+
+    branches = [partial(left, 1)]
+    branches.append(partial(right, 2))
+```
+
+### Keyword-bound predicate remains unary for filter
+
+Binding a predicate parameter via keyword should still produce a unary predicate acceptable to
+`filter(...)`:
+
+```py
+from functools import partial
+
+def has_same_ip_version(addr_or_net: str, is_ipv6: bool) -> bool:
+    return is_ipv6
+
+values = ["127.0.0.1", "::1"]
+predicate = partial(has_same_ip_version, is_ipv6=False)
+reveal_type(predicate)  # revealed: partial[(addr_or_net: str, *, is_ipv6: bool = False) -> bool]
+reveal_type(list(filter(predicate, values)))  # revealed: list[str]
+```
+
+### Overloaded partial reports type mismatch, not unknown keyword
+
+```py
+from functools import partial
+from typing import Callable, Literal, Optional, cast, overload
+
+@overload
+def task(__fn: Callable[[], int]) -> int: ...
+@overload
+def task(
+    __fn: Literal[None] = None,
+    *,
+    retries: int = 0,
+) -> Callable[[Callable[[], int]], int]: ...
+@overload
+def task(
+    *,
+    retries: int = 0,
+) -> Callable[[Callable[[], int]], int]: ...
+def task(
+    __fn: Optional[Callable[[], int]] = None,
+    *,
+    retries: Optional[int] = None,
+):
+    if __fn:
+        return 1
+    return cast(
+        Callable[[Callable[[], int]], int],
+        partial(task, retries=retries),  # error: [invalid-argument-type]
+    )
+```
+
+### Bound classmethod callback with weakref
+
+Binding the first explicit parameter of a bound classmethod callback should preserve assignability
+for `ReferenceType[Self]` arguments:
+
+```py
+from functools import partial
+from typing import Any, Generic, TypeVar
+from weakref import ReferenceType, ref
+
+T = TypeVar("T")
+
+class CallbackHost(Generic[T]):
+    @classmethod
+    def callback(cls, wself: ReferenceType["CallbackHost[Any]"], x: int) -> None: ...
+    def __init__(self) -> None:
+        p = partial(self.callback, ref(self))  # error: [invalid-argument-type]
+        # TODO: should accept `ReferenceType[Self]` here and preserve the reduced signature.
+        reveal_type(p)  # revealed: partial[(x: int) -> None]
+```
+
+### Assignability to protocol
+
+A `partial` result is assignable to a `Protocol` with a matching `__call__` signature. Required
+keyword-only parameters can be bound away, and extra keyword-only parameters with defaults in the
+resulting `partial` are allowed, since they don't need to be provided by the caller:
+
+```py
+from functools import partial
+from typing import Protocol
+
+class Request: ...
+class Response: ...
+class Context: ...
+
+class Handler(Protocol):
+    def __call__(
+        self,
+        request: Request,
+        *,
+        header: str | None = None,
+    ) -> Response: ...
+
+def handle(
+    request: Request,
+    *,
+    header: str | None = None,
+    verbose: bool = False,
+    context: Context,
+) -> Response:
+    return Response()
+
+handler: Handler = partial(handle, context=Context())
+```
+
+### Accessing `__call__` directly
+
+`__call__` on a `partial` result should reflect the refined callable signature, not the broad
+`(*args: Any, **kwargs: Any) -> T` from the `partial` class stub.
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p.__call__)  # revealed: (b: str) -> bool
+
+reveal_type(p.__call__("hello"))  # revealed: bool
+```
+
+### Attribute access on partial results
+
+Standard `partial` attributes like `.func`, `.args`, and `.keywords` should be accessible:
+
+```py
+from functools import partial
+from typing import Callable
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+reveal_type(p.func)  # revealed: def f(a: int, b: str) -> bool
+reveal_type(p.func(2, "hello"))  # revealed: bool
+reveal_type(p.args)  # revealed: tuple[Any, ...]
+reveal_type(p.keywords)  # revealed: dict[str, Any]
+```
+
+### `partial.func` keeps the original callable type
+
+```py
+from functools import partial
+from typing import TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+def combine(a: T, b: U) -> tuple[T, U]:
+    return (a, b)
+
+p = partial(combine, 1)
+reveal_type(p.func(2, "x"))  # revealed: tuple[Literal[2], Literal["x"]]
+```
+
+### Attribute assignment on partial results
+
+Attribute assignment should go through the standard nominal instance path:
+
+```py
+from functools import partial
+
+def f(a: int, b: str) -> bool:
+    return True
+
+p = partial(f, 1)
+p.func = f  # error: [invalid-assignment]
+```
+
+### Unknown attribute assignment on partial results
+
+We intentionally reject ad-hoc attributes on `functools.partial` results. This matches `pyright` and
+`mypy`, even though these assignments work at runtime.
+
+```py
+from functools import partial
+
+def f() -> None:
+    pass
+
+p = partial(f)
+# error: [unresolved-attribute]
+p.__name__ = "renamed"
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2286,6 +2286,9 @@ impl<'db> Type<'db> {
     /// Return true if this type is non-empty and all inhabitants of this type compare equal.
     pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
         match self {
+            // Each `partial()` call creates a distinct object at runtime.
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_)) => false,
+
             Type::FunctionLiteral(..)
             | Type::WrapperDescriptor(_)
             | Type::KnownBoundMethod(_)
@@ -3473,6 +3476,39 @@ impl<'db> Type<'db> {
                     .into()
             }
 
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial))
+                if name_str == "__call__" =>
+            {
+                Place::bound(Type::Callable(partial.partial(db))).into()
+            }
+
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
+                let wrapped = partial.wrapped(db).inner(db);
+                let nominal_lookup = partial
+                    .partial(db)
+                    .into_functools_partial_instance(db)
+                    .member_lookup_with_policy(db, name.clone(), policy);
+                if name_str == "func" {
+                    match nominal_lookup.place {
+                        Place::Defined(DefinedPlace {
+                            origin,
+                            definedness,
+                            public_type_policy,
+                            ..
+                        }) => Place::Defined(DefinedPlace {
+                            ty: wrapped,
+                            origin,
+                            definedness,
+                            public_type_policy,
+                        })
+                        .into(),
+                        Place::Undefined => Place::bound(wrapped).into(),
+                    }
+                } else {
+                    nominal_lookup
+                }
+            }
+
             Type::NominalInstance(..)
             | Type::ProtocolInstance(..)
             | Type::NewTypeInstance(..)
@@ -4142,6 +4178,10 @@ impl<'db> Type<'db> {
             )
             .into(),
 
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
+                Type::Callable(partial.partial(db)).bindings(db)
+            }
+
             Type::KnownInstance(known_instance) => {
                 known_instance.instance_fallback(db).bindings(db)
             }
@@ -4398,6 +4438,47 @@ impl<'db> Type<'db> {
                 )
             }
 
+            KnownClass::FunctoolsPartial => {
+                // ```py
+                // class partial(Generic[_T]):
+                //     def __new__(cls, func: Callable[..., _T], /, *args: Any, **kwargs: Any) -> Self: ...
+                // ```
+                let return_ty = BoundTypeVarInstance::synthetic(
+                    db,
+                    Name::new_static("_T"),
+                    TypeVarVariance::Covariant,
+                );
+
+                Some(
+                    Binding::single(
+                        self,
+                        Signature::new_generic(
+                            Some(GenericContext::from_typevar_instances(db, [return_ty])),
+                            Parameters::new(
+                                db,
+                                [
+                                    Parameter::positional_only(Some(Name::new_static("func")))
+                                        .with_annotated_type(Type::single_callable(
+                                            db,
+                                            Signature::new(
+                                                Parameters::gradual_form(),
+                                                Type::TypeVar(return_ty),
+                                            ),
+                                        )),
+                                    Parameter::variadic(Name::new_static("args"))
+                                        .with_annotated_type(Type::any()),
+                                    Parameter::keyword_variadic(Name::new_static("kwargs"))
+                                        .with_annotated_type(Type::any()),
+                                ],
+                            ),
+                            KnownClass::FunctoolsPartial
+                                .to_specialized_instance(db, &[Type::TypeVar(return_ty)]),
+                        ),
+                    )
+                    .into(),
+                )
+            }
+
             KnownClass::Tuple => {
                 let element_ty = BoundTypeVarInstance::synthetic(
                     db,
@@ -4527,6 +4608,7 @@ impl<'db> Type<'db> {
                 KnownClass::Bool
                     | KnownClass::Type
                     | KnownClass::Object
+                    | KnownClass::FunctoolsPartial
                     | KnownClass::Property
                     | KnownClass::Super
                     | KnownClass::TypeAliasType
@@ -5342,6 +5424,12 @@ impl<'db> Type<'db> {
                 }
                 KnownInstanceType::Callable(callable) => Ok(Type::Callable(*callable)),
                 KnownInstanceType::LiteralStringAlias(ty) => Ok(ty.inner(db)),
+                KnownInstanceType::FunctoolsPartial(_) => Err(InvalidTypeExpressionError {
+                    invalid_expressions: smallvec_inline![InvalidTypeExpression::InvalidType(
+                        *self, scope_id
+                    )],
+                    fallback_type: Type::unknown(),
+                }),
             },
 
             Type::SpecialForm(special_form) => special_form
@@ -6051,7 +6139,8 @@ impl<'db> Type<'db> {
                 | KnownInstanceType::Literal(_)
                 | KnownInstanceType::LiteralStringAlias(_)
                 | KnownInstanceType::NamedTupleSpec(_)
-                | KnownInstanceType::NewType(_) => {
+                | KnownInstanceType::NewType(_)
+                | KnownInstanceType::FunctoolsPartial(_) => {
                     // TODO: For some of these, we may need to try to find legacy typevars in inner types.
                 }
             },

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2290,6 +2290,9 @@ impl<'db> Type<'db> {
     /// Return true if this type is non-empty and all inhabitants of this type compare equal.
     pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
         match self {
+            // Each `partial()` call creates a distinct object at runtime.
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_)) => false,
+
             Type::FunctionLiteral(..)
             | Type::WrapperDescriptor(_)
             | Type::KnownBoundMethod(_)
@@ -3477,6 +3480,39 @@ impl<'db> Type<'db> {
                     .into()
             }
 
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial))
+                if name_str == "__call__" =>
+            {
+                Place::bound(Type::Callable(partial.partial(db))).into()
+            }
+
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
+                let wrapped = partial.wrapped(db).inner(db);
+                let nominal_lookup = partial
+                    .partial(db)
+                    .into_functools_partial_instance(db)
+                    .member_lookup_with_policy(db, name.clone(), policy);
+                if name_str == "func" {
+                    match nominal_lookup.place {
+                        Place::Defined(DefinedPlace {
+                            origin,
+                            definedness,
+                            public_type_policy,
+                            ..
+                        }) => Place::Defined(DefinedPlace {
+                            ty: wrapped,
+                            origin,
+                            definedness,
+                            public_type_policy,
+                        })
+                        .into(),
+                        Place::Undefined => Place::bound(wrapped).into(),
+                    }
+                } else {
+                    nominal_lookup
+                }
+            }
+
             Type::NominalInstance(..)
             | Type::ProtocolInstance(..)
             | Type::NewTypeInstance(..)
@@ -4146,6 +4182,10 @@ impl<'db> Type<'db> {
             )
             .into(),
 
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
+                Type::Callable(partial.partial(db)).bindings(db)
+            }
+
             Type::KnownInstance(known_instance) => {
                 known_instance.instance_fallback(db).bindings(db)
             }
@@ -4402,6 +4442,47 @@ impl<'db> Type<'db> {
                 )
             }
 
+            KnownClass::FunctoolsPartial => {
+                // ```py
+                // class partial(Generic[_T]):
+                //     def __new__(cls, func: Callable[..., _T], /, *args: Any, **kwargs: Any) -> Self: ...
+                // ```
+                let return_ty = BoundTypeVarInstance::synthetic(
+                    db,
+                    Name::new_static("_T"),
+                    TypeVarVariance::Covariant,
+                );
+
+                Some(
+                    Binding::single(
+                        self,
+                        Signature::new_generic(
+                            Some(GenericContext::from_typevar_instances(db, [return_ty])),
+                            Parameters::new(
+                                db,
+                                [
+                                    Parameter::positional_only(Some(Name::new_static("func")))
+                                        .with_annotated_type(Type::single_callable(
+                                            db,
+                                            Signature::new(
+                                                Parameters::gradual_form(),
+                                                Type::TypeVar(return_ty),
+                                            ),
+                                        )),
+                                    Parameter::variadic(Name::new_static("args"))
+                                        .with_annotated_type(Type::any()),
+                                    Parameter::keyword_variadic(Name::new_static("kwargs"))
+                                        .with_annotated_type(Type::any()),
+                                ],
+                            ),
+                            KnownClass::FunctoolsPartial
+                                .to_specialized_instance(db, &[Type::TypeVar(return_ty)]),
+                        ),
+                    )
+                    .into(),
+                )
+            }
+
             KnownClass::Tuple => {
                 let element_ty = BoundTypeVarInstance::synthetic(
                     db,
@@ -4531,6 +4612,7 @@ impl<'db> Type<'db> {
                 KnownClass::Bool
                     | KnownClass::Type
                     | KnownClass::Object
+                    | KnownClass::FunctoolsPartial
                     | KnownClass::Property
                     | KnownClass::Super
                     | KnownClass::TypeAliasType
@@ -5328,6 +5410,12 @@ impl<'db> Type<'db> {
                 }
                 KnownInstanceType::Callable(callable) => Ok(Type::Callable(*callable)),
                 KnownInstanceType::LiteralStringAlias(ty) => Ok(ty.inner(db)),
+                KnownInstanceType::FunctoolsPartial(_) => Err(InvalidTypeExpressionError {
+                    invalid_expressions: smallvec_inline![InvalidTypeExpression::InvalidType(
+                        *self, scope_id
+                    )],
+                    fallback_type: Type::unknown(),
+                }),
             },
 
             Type::SpecialForm(special_form) => special_form
@@ -6036,7 +6124,8 @@ impl<'db> Type<'db> {
                 | KnownInstanceType::Literal(_)
                 | KnownInstanceType::LiteralStringAlias(_)
                 | KnownInstanceType::NamedTupleSpec(_)
-                | KnownInstanceType::NewType(_) => {
+                | KnownInstanceType::NewType(_)
+                | KnownInstanceType::FunctoolsPartial(_) => {
                     // TODO: For some of these, we may need to try to find legacy typevars in inner types.
                 }
             },

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -230,11 +230,44 @@ impl<'a, 'db> CallArguments<'a, 'db> {
     }
 
     /// Create a new [`CallArguments`] starting from the specified index.
-    pub(super) fn start_from(&self, index: usize) -> Self {
+    pub(crate) fn start_from(&self, index: usize) -> Self {
         Self {
             arguments: self.arguments[index..].to_vec(),
             types: self.types[index..].to_vec(),
         }
+    }
+
+    /// Returns the `functools.partial(...)` bound-argument slice when argument expansion is
+    /// concrete enough for partial-application analysis.
+    pub(crate) fn functools_partial_bound_arguments(&self, db: &'db dyn Db) -> Option<Self> {
+        let bound_call_arguments = self.start_from(1);
+
+        // We only handle variadics and keyword-maps that can be normalized to concrete argument
+        // positions for overload matching.
+        if bound_call_arguments.iter().any(|(argument, argument_ty)| {
+            let argument_ty = argument_ty.get_default().unwrap_or_else(Type::unknown);
+            match argument {
+                Argument::Variadic => !matches!(
+                    argument_ty
+                        .as_nominal_instance()
+                        .and_then(|nominal| nominal.tuple_spec(db)),
+                    Some(spec) if spec.as_fixed_length().is_some()
+                ),
+                // Optional TypedDict keys may be absent at runtime, so we can only refine
+                // `partial(...)` when every expanded key is guaranteed to be present.
+                Argument::Keywords => argument_ty.as_typed_dict().is_none_or(|typed_dict| {
+                    typed_dict
+                        .items(db)
+                        .values()
+                        .any(|field| !field.is_required())
+                }),
+                Argument::Positional | Argument::Synthetic | Argument::Keyword(_) => false,
+            }
+        }) {
+            return None;
+        }
+
+        Some(bound_call_arguments)
     }
 
     /// Returns an iterator on performing [argument type expansion].

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -242,10 +242,43 @@ impl<'a, 'db> CallArguments<'a, 'db> {
     }
 
     /// Create a new [`CallArguments`] starting from the specified index.
-    pub(super) fn start_from(&self, index: usize) -> Self {
+    pub(crate) fn start_from(&self, index: usize) -> Self {
         Self {
             items: self.items[index..].to_vec(),
         }
+    }
+
+    /// Returns the `functools.partial(...)` bound-argument slice when argument expansion is
+    /// concrete enough for partial-application analysis.
+    pub(crate) fn functools_partial_bound_arguments(&self, db: &'db dyn Db) -> Option<Self> {
+        let bound_call_arguments = self.start_from(1);
+
+        // We only handle variadics and keyword-maps that can be normalized to concrete argument
+        // positions for overload matching.
+        if bound_call_arguments.iter().any(|(argument, argument_ty)| {
+            let argument_ty = argument_ty.get_default().unwrap_or_else(Type::unknown);
+            match argument {
+                Argument::Variadic => !matches!(
+                    argument_ty
+                        .as_nominal_instance()
+                        .and_then(|nominal| nominal.tuple_spec(db)),
+                    Some(spec) if spec.as_fixed_length().is_some()
+                ),
+                // Optional TypedDict keys may be absent at runtime, so we can only refine
+                // `partial(...)` when every expanded key is guaranteed to be present.
+                Argument::Keywords => argument_ty.as_typed_dict().is_none_or(|typed_dict| {
+                    typed_dict
+                        .items(db)
+                        .values()
+                        .any(|field| !field.is_required())
+                }),
+                Argument::Positional | Argument::Synthetic | Argument::Keyword(_) => false,
+            }
+        }) {
+            return None;
+        }
+
+        Some(bound_call_arguments)
     }
 
     /// Returns an iterator on performing [argument type expansion].

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -44,7 +44,7 @@ use crate::types::function::{
 use crate::types::generics::{
     GenericContext, InferableTypeVars, Specialization, SpecializationBuilder, SpecializationError,
 };
-use crate::types::known_instance::FieldInstance;
+use crate::types::known_instance::{FieldInstance, FunctoolsPartialInstance};
 use crate::types::signatures::{
     CallableSignature, Parameter, ParameterForm, ParameterKind, Parameters,
 };
@@ -52,10 +52,11 @@ use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
 use crate::types::typevar::BoundTypeVarIdentity;
 use crate::types::{
     BoundMethodType, BoundTypeVarInstance, CallableType, ClassLiteral, DATACLASS_FLAGS,
-    DataclassFlags, DataclassParams, GenericAlias, InternedConstraintSet, IntersectionType,
-    KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind, NominalInstanceType,
-    PropertyInstanceType, SpecialFormType, TypeAliasType, TypeContext, TypeVarBoundOrConstraints,
-    TypeVarVariance, UnionBuilder, UnionType, WrapperDescriptorKind, enums, list_members,
+    DataclassFlags, DataclassParams, GenericAlias, InternedConstraintSet, InternedType,
+    IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
+    NominalInstanceType, PropertyInstanceType, SpecialFormType, TypeAliasType, TypeContext,
+    TypeVarBoundOrConstraints, TypeVarVariance, UnionBuilder, UnionType, WrapperDescriptorKind,
+    enums, list_members,
 };
 use crate::{DisplaySettings, FxOrderSet, Program};
 use ruff_db::diagnostic::{Annotation, Diagnostic, SubDiagnostic, SubDiagnosticSeverity};
@@ -83,6 +84,17 @@ enum CallErrorPriority {
 enum CallableItem<'db> {
     Regular(CallableBinding<'db>),
     Constructor(ConstructorBinding<'db>),
+}
+
+/// Wraps a reduced callable as a synthetic `functools.partial(...)` instance type.
+fn functools_partial_instance<'db>(
+    db: &'db dyn Db,
+    wrapped: Type<'db>,
+    partial: CallableType<'db>,
+) -> Type<'db> {
+    Type::KnownInstance(KnownInstanceType::FunctoolsPartial(
+        FunctoolsPartialInstance::new(db, InternedType::new(db, wrapped), partial),
+    ))
 }
 
 impl<'db> CallableItem<'db> {
@@ -187,6 +199,22 @@ impl<'db> CallableItem<'db> {
 
     fn callable_type(&self) -> Type<'db> {
         self.callable().callable_type
+    }
+
+    /// Returns the `functools.partial(...)` result synthesized from this callable item.
+    fn functools_partial_type<'a>(
+        &self,
+        db: &'db dyn Db,
+        wrapped_callable_ty: Type<'db>,
+        partial_overload: &mut Binding<'db>,
+        bound_call_arguments: &CallArguments<'a, 'db>,
+    ) -> Option<Type<'db>> {
+        match self {
+            CallableItem::Regular(binding) => binding
+                .functools_partial_callable(db, partial_overload, bound_call_arguments)
+                .map(|callable| functools_partial_instance(db, wrapped_callable_ty, callable)),
+            CallableItem::Constructor(_) => None,
+        }
     }
 
     fn map<F>(self, f: &F) -> CallableItem<'db>
@@ -650,6 +678,18 @@ impl<'db> Bindings<'db> {
             .filter_map(CallableItem::as_constructor_mut)
     }
 
+    fn clear_deferred_constructor_errors_for_partial_application(&mut self) {
+        for binding in self.iter_flat_mut() {
+            binding.clear_deferred_constructor_errors_for_partial_application();
+        }
+
+        for constructor in self.iter_constructor_items_mut() {
+            if let Some(downstream) = constructor.downstream_constructor_mut() {
+                downstream.clear_deferred_constructor_errors_for_partial_application();
+            }
+        }
+    }
+
     fn collect_type_context_callables<'a>(&'a self, out: &mut Vec<&'a CallableBinding<'db>>) {
         for item in self.iter_callable_items() {
             out.push(item.callable());
@@ -708,6 +748,61 @@ impl<'db> Bindings<'db> {
         }
 
         UnionType::from_elements(db, element_types)
+    }
+
+    /// Maps each `CallableItem` to a type and combines results while preserving
+    /// the union-of-intersections structure:
+    ///
+    /// - callable items inside an element are intersected
+    /// - elements are unioned
+    fn map_item_types(
+        &self,
+        db: &'db dyn Db,
+        mut map: impl FnMut(&CallableItem<'db>) -> Option<Type<'db>>,
+    ) -> Type<'db> {
+        let mut element_types = Vec::with_capacity(self.elements.len());
+        for element in &self.elements {
+            let mut item_types = Vec::new();
+            for item in element.items() {
+                if let Some(ty) = map(item) {
+                    item_types.push(ty);
+                }
+            }
+
+            if !item_types.is_empty() {
+                element_types.push(IntersectionType::from_elements(db, item_types));
+            }
+        }
+
+        UnionType::from_elements(db, element_types)
+    }
+
+    /// Builds matched bindings for the callable wrapped by `functools.partial(...)`.
+    ///
+    /// This handles the shared partial-specific preprocessing (callable validation and argument
+    /// normalization) used by both inference and known-call evaluation.
+    pub(crate) fn functools_partial_matched_bindings<'a>(
+        db: &'db dyn Db,
+        wrapped_callable_ty: Type<'db>,
+        call_arguments: &CallArguments<'a, 'db>,
+    ) -> Option<(CallArguments<'a, 'db>, Bindings<'db>)> {
+        // We can only infer bound-argument context from an actual callable.
+        wrapped_callable_ty.try_upcast_to_callable(db)?;
+
+        let bound_call_arguments = call_arguments.functools_partial_bound_arguments(db)?;
+
+        let mut partial_bindings = wrapped_callable_ty
+            .bindings(db)
+            .match_parameters(db, &bound_call_arguments);
+        for binding in partial_bindings.iter_flat_mut() {
+            binding.clear_missing_argument_errors_for_partial_application();
+        }
+        for constructor in partial_bindings.iter_constructor_items_mut() {
+            if let Some(downstream) = constructor.downstream_constructor_mut() {
+                downstream.clear_deferred_constructor_errors_for_partial_application();
+            }
+        }
+        Some((bound_call_arguments, partial_bindings))
     }
 
     fn map_with<F>(self, f: &F) -> Self
@@ -2377,6 +2472,115 @@ impl<'db> Bindings<'db> {
                             }
                         }
 
+                        Some(KnownClass::FunctoolsPartial) => {
+                            // `partial(...)` receives the wrapped callable as its first explicit
+                            // argument (after constructor receiver handling).
+                            let func_ty = match overload.parameter_types() {
+                                [Some(func_ty), ..] => *func_ty,
+                                _ => continue,
+                            };
+                            let fallback_return_type = KnownClass::FunctoolsPartial
+                                .to_specialized_instance(db, &[Type::unknown()]);
+
+                            let Some((bound_call_arguments, partial_bindings)) =
+                                Self::functools_partial_matched_bindings(
+                                    db,
+                                    func_ty,
+                                    call_arguments,
+                                )
+                            else {
+                                continue;
+                            };
+
+                            // Reuse call-binding machinery to resolve which wrapped overloads are
+                            // compatible with bound arguments and to surface binding diagnostics.
+                            let partial_bindings = match partial_bindings.check_types(
+                                db,
+                                &ConstraintSetBuilder::new(),
+                                &bound_call_arguments,
+                                TypeContext::default(),
+                                &[],
+                            ) {
+                                Ok(bindings) => bindings,
+                                Err(CallError(_, bindings)) => *bindings,
+                            };
+                            let new_return_type = if func_ty.is_union() || func_ty.is_intersection()
+                            {
+                                partial_bindings.map_item_types(db, |partial_item| {
+                                    partial_item.functools_partial_type(
+                                        db,
+                                        func_ty,
+                                        overload,
+                                        &bound_call_arguments,
+                                    )
+                                })
+                            } else {
+                                let mut partial_types = Vec::new();
+                                let mut new_overloads = Vec::new();
+                                let mut seen_overloads = FxHashSet::default();
+                                for partial_item in partial_bindings.iter_callable_items() {
+                                    let Some(partial_type) = partial_item.functools_partial_type(
+                                        db,
+                                        func_ty,
+                                        overload,
+                                        &bound_call_arguments,
+                                    ) else {
+                                        continue;
+                                    };
+
+                                    if let Type::KnownInstance(
+                                        KnownInstanceType::FunctoolsPartial(partial_instance),
+                                    ) = partial_type
+                                    {
+                                        for signature in partial_instance.partial(db).signatures(db)
+                                        {
+                                            let signature = signature.clone();
+                                            let dedup_key = signature.clone().with_definition(None);
+                                            if seen_overloads.insert(dedup_key) {
+                                                new_overloads.push(signature);
+                                            }
+                                        }
+                                    } else {
+                                        partial_types.push(partial_type);
+                                    }
+                                }
+
+                                if partial_types.is_empty() {
+                                    if new_overloads.is_empty() {
+                                        Type::Never
+                                    } else {
+                                        let new_callable_sig =
+                                            CallableSignature::from_overloads(new_overloads);
+                                        let callable = CallableType::new(
+                                            db,
+                                            new_callable_sig,
+                                            CallableTypeKind::Regular,
+                                        );
+                                        functools_partial_instance(db, func_ty, callable)
+                                    }
+                                } else {
+                                    if !new_overloads.is_empty() {
+                                        let new_callable_sig =
+                                            CallableSignature::from_overloads(new_overloads);
+                                        let callable = CallableType::new(
+                                            db,
+                                            new_callable_sig,
+                                            CallableTypeKind::Regular,
+                                        );
+                                        partial_types.push(functools_partial_instance(
+                                            db, func_ty, callable,
+                                        ));
+                                    }
+                                    IntersectionType::from_elements(db, partial_types)
+                                }
+                            };
+                            if new_return_type.is_never() {
+                                overload.set_return_type(fallback_return_type);
+                                continue;
+                            }
+                            overload.set_return_type(new_return_type);
+                        }
+
                         Some(KnownClass::Tuple) if overload_index == 1 => {
                             // `tuple(range(42))` => `tuple[int, ...]`
                             // BUT `tuple((1, 2))` => `tuple[Literal[1], Literal[2]]` rather than `tuple[Literal[1, 2], ...]`
@@ -2509,6 +2713,24 @@ pub(crate) struct CallableBinding<'db> {
     overloads: SmallVec<[Binding<'db>; 1]>,
 }
 
+#[derive(Copy, Clone)]
+enum FailingOverloadSelection {
+    /// Consider all errors that participate in overload filtering.
+    AffectsOverloadResolution,
+    /// Consider only errors that are reported during `functools.partial(...)` construction.
+    ReportableForPartial,
+}
+
+impl FailingOverloadSelection {
+    /// Returns whether this selection mode should count the given error.
+    fn includes(self, error: &BindingError<'_>) -> bool {
+        match self {
+            Self::AffectsOverloadResolution => error.affects_overload_resolution(),
+            Self::ReportableForPartial => error.is_relevant_for_partial_application(),
+        }
+    }
+}
+
 impl<'db> CallableBinding<'db> {
     pub(crate) fn from_overloads(
         signature_type: Type<'db>,
@@ -2541,6 +2763,8 @@ impl<'db> CallableBinding<'db> {
         }
     }
 
+    /// Rewrites overload signatures as if an implicit bound receiver argument had already been
+    /// consumed.
     pub(crate) fn bake_bound_type_into_overloads(&mut self, db: &'db dyn Db) {
         let Some(bound_self) = self.bound_type.take() else {
             return;
@@ -2548,6 +2772,154 @@ impl<'db> CallableBinding<'db> {
         for overload in &mut self.overloads {
             overload.signature = overload.signature.bind_self(db, Some(bound_self));
         }
+    }
+
+    /// Ignore missing-argument errors when constructing `functools.partial(...)`.
+    ///
+    /// Partial application intentionally leaves some parameters unbound, so we still want to
+    /// type-check all explicitly bound arguments against each overload.
+    fn clear_missing_argument_errors_for_partial_application(&mut self) {
+        for overload in &mut self.overloads {
+            overload.clear_missing_argument_errors_for_partial_application();
+        }
+    }
+
+    /// Ignore downstream constructor call-shape errors when constructing
+    /// `functools.partial(...)`.
+    ///
+    /// The merged partial signature decides which parameters remain callable, so downstream
+    /// arity/name mismatches caused by as-yet-unbound constructor parameters should not reject
+    /// partial construction. Explicit bound-argument type errors are still preserved.
+    fn clear_deferred_constructor_errors_for_partial_application(&mut self) {
+        for overload in &mut self.overloads {
+            overload.clear_deferred_constructor_errors_for_partial_application();
+        }
+    }
+
+    /// Chooses which overload to use as the source for diagnostics when no overload fully matches.
+    ///
+    /// If step 1 of overload resolution identified a single arity match, we keep using that
+    /// overload as the diagnostic source. Otherwise, we rank failing overloads by error quality:
+    /// fewer unknown-argument errors and fewer relevant errors are preferred.
+    fn best_failing_overload_index(&self, selection: FailingOverloadSelection) -> Option<usize> {
+        self.matching_overload_before_type_checking.or_else(|| {
+            self.overloads
+                .iter()
+                .enumerate()
+                .filter_map(|(index, overload)| {
+                    let mut relevant_count = 0;
+                    let mut unknown_argument_count = 0;
+
+                    for error in &overload.errors {
+                        if !selection.includes(error) {
+                            continue;
+                        }
+                        relevant_count += 1;
+                        if matches!(error, BindingError::UnknownArgument { .. }) {
+                            unknown_argument_count += 1;
+                        }
+                    }
+
+                    (relevant_count > 0).then_some((index, unknown_argument_count, relevant_count))
+                })
+                .min_by_key(|(_, unknown_argument_count, relevant_count)| {
+                    (*unknown_argument_count, *relevant_count)
+                })
+                .map(|(index, _, _)| index)
+        })
+    }
+
+    /// Returns the matching overload indexes when `functools.partial(...)` ignores errors that are
+    /// only relevant at invocation time.
+    fn matching_partial_overload_index(&self) -> MatchingOverloadIndex {
+        let mut matching_overloads = self.overloads.iter().enumerate().filter(|(_, overload)| {
+            !overload
+                .errors
+                .iter()
+                .any(BindingError::is_relevant_for_partial_application)
+        });
+        match matching_overloads.next() {
+            None => MatchingOverloadIndex::None,
+            Some((first, _)) => {
+                if let Some((second, _)) = matching_overloads.next() {
+                    let mut indexes = vec![first, second];
+                    for (index, _) in matching_overloads {
+                        indexes.push(index);
+                    }
+                    MatchingOverloadIndex::Multiple(indexes)
+                } else {
+                    MatchingOverloadIndex::Single(first)
+                }
+            }
+        }
+    }
+
+    /// Builds the reduced callable for this `functools.partial(...)` binding.
+    ///
+    /// The synthesized callable preserves the reduced callable signature for this binding and reports
+    /// any partial-construction diagnostics back to the outer `partial(...)` overload.
+    fn functools_partial_callable<'a>(
+        &self,
+        db: &'db dyn Db,
+        partial_overload: &mut Binding<'db>,
+        bound_call_arguments: &CallArguments<'a, 'db>,
+    ) -> Option<CallableType<'db>> {
+        if self.overloads().is_empty() {
+            return None;
+        }
+
+        let selected_overload_indexes = match self.matching_partial_overload_index() {
+            MatchingOverloadIndex::Single(index) => vec![index],
+            MatchingOverloadIndex::Multiple(indexes) => indexes,
+            MatchingOverloadIndex::None => {
+                let source_overload_index = self
+                    .best_failing_overload_index(FailingOverloadSelection::ReportableForPartial)
+                    .unwrap_or(0);
+                let source_errors = &self.overloads()[source_overload_index].errors;
+                for error in source_errors {
+                    if error.is_relevant_for_partial_application() {
+                        let error = error.clone().maybe_apply_argument_index_offset(Some(1));
+                        if !partial_overload.errors.contains(&error) {
+                            partial_overload.errors.push(error);
+                        }
+                    }
+                }
+
+                // When no overload is compatible with the bound arguments, don't manufacture a
+                // precise reduced signature from an arbitrary overloaded callable shape.
+                if self.overloads().len() > 1 {
+                    return None;
+                }
+
+                vec![source_overload_index]
+            }
+        };
+
+        let signature_arguments = bound_call_arguments.with_self(self.bound_type);
+        let mut new_overloads = Vec::new();
+        let mut seen_overloads = FxHashSet::default();
+        for index in selected_overload_indexes {
+            let Some(bound_overload) = self.overloads().get(index) else {
+                continue;
+            };
+            let signature =
+                bound_overload.partially_applied_signature(db, signature_arguments.as_ref());
+            let dedup_key = signature.clone().with_definition(None);
+            if seen_overloads.insert(dedup_key) {
+                new_overloads.push(signature);
+            }
+        }
+
+        if new_overloads.is_empty() {
+            return None;
+        }
+
+        let new_callable_sig = CallableSignature::from_overloads(new_overloads);
+        Some(CallableType::new(
+            db,
+            new_callable_sig,
+            CallableTypeKind::Regular,
+        ))
     }
 
     pub(crate) fn with_bound_type(mut self, bound_type: Type<'db>) -> Self {
@@ -4160,6 +4532,7 @@ struct ArgumentTypeChecker<'a, 'db> {
 
     inferable_typevars: InferableTypeVars<'db>,
     specialization: Option<Specialization<'db>>,
+    partial_specialization: Option<Specialization<'db>>,
 
     /// Argument indices for which specialization inference has already produced a sufficiently
     /// precise argument mismatch. We can then silence `check_argument_type` for those arguments to
@@ -4195,6 +4568,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             errors,
             inferable_typevars: InferableTypeVars::None,
             specialization: None,
+            partial_specialization: None,
             constraint_set_errors: vec![false; arguments.len()],
         }
     }
@@ -4445,9 +4819,11 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             };
 
         let specialization = builder.build_with(generic_context, maybe_promote);
+        let partial_specialization = specialization;
 
         self.return_ty = self.return_ty.apply_specialization(self.db, specialization);
         self.specialization = Some(specialization);
+        self.partial_specialization = Some(partial_specialization);
     }
 
     fn infer_argument_constraints<'c>(
@@ -4762,7 +5138,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     );
                 } else {
                     let index = callable_binding
-                        .matching_overload_before_type_checking
+                        .best_failing_overload_index(
+                            FailingOverloadSelection::AffectsOverloadResolution,
+                        )
                         .unwrap_or(0);
                     // TODO: We should also update the specialization for the `ParamSpec` to reflect
                     // the matching overload here.
@@ -4912,9 +5290,15 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     ) -> (
         InferableTypeVars<'db>,
         Option<Specialization<'db>>,
+        Option<Specialization<'db>>,
         Type<'db>,
     ) {
-        (self.inferable_typevars, self.specialization, self.return_ty)
+        (
+            self.inferable_typevars,
+            self.specialization,
+            self.partial_specialization,
+            self.return_ty,
+        )
     }
 }
 
@@ -4988,6 +5372,10 @@ pub(crate) struct Binding<'db> {
     /// The specialization that was inferred from the argument types, if the callable is generic.
     specialization: Option<Specialization<'db>>,
 
+    /// A partial-application view of the inferred specialization which preserves uninferred
+    /// type variables as generic.
+    partial_specialization: Option<Specialization<'db>>,
+
     /// Information about which parameter(s) each argument was matched with, in argument source
     /// order.
     argument_matches: Box<[MatchedArgument<'db>]>,
@@ -5015,6 +5403,7 @@ impl<'db> Binding<'db> {
             constructor_context: None,
             inferable_typevars: InferableTypeVars::None,
             specialization: None,
+            partial_specialization: None,
             argument_matches: Box::from([]),
             variadic_argument_matched_to_variadic_parameter: false,
             parameter_tys: Box::from([]),
@@ -5103,7 +5492,12 @@ impl<'db> Binding<'db> {
         checker.infer_specialization(constraints);
         checker.check_argument_types(constraints);
 
-        (self.inferable_typevars, self.specialization, self.return_ty) = checker.finish();
+        (
+            self.inferable_typevars,
+            self.specialization,
+            self.partial_specialization,
+            self.return_ty,
+        ) = checker.finish();
     }
 
     pub(crate) fn set_return_type(&mut self, return_ty: Type<'db>) {
@@ -5118,6 +5512,208 @@ impl<'db> Binding<'db> {
     /// argument was matched to that parameter.
     pub(crate) fn parameter_types(&self) -> &[Option<Type<'db>>] {
         &self.parameter_tys
+    }
+
+    /// `functools.partial(...)` is allowed to leave required parameters unbound.
+    fn clear_missing_argument_errors_for_partial_application(&mut self) {
+        self.errors
+            .retain(|error| !matches!(error, BindingError::MissingArguments { .. }));
+    }
+
+    /// Downstream constructor validation is deferred until after partial signatures are merged.
+    fn clear_deferred_constructor_errors_for_partial_application(&mut self) {
+        self.errors.retain(|error| {
+            !matches!(
+                error,
+                BindingError::MissingArguments { .. }
+                    | BindingError::UnknownArgument { .. }
+                    | BindingError::PositionalOnlyParameterAsKwarg { .. }
+                    | BindingError::TooManyPositionalArguments { .. }
+                    | BindingError::ParameterAlreadyAssigned { .. }
+            )
+        });
+    }
+
+    /// Returns the callable signature produced by partially applying this bound overload.
+    ///
+    /// For example, starting from `(a: int, b: str, c: bool) -> bytes`,
+    /// `partial(f, 1, c=True)` should expose `(b: str, *, c: bool = True) -> bytes`:
+    /// the positionally bound `a` is removed, the keyword-bound `c` stays as a defaulted
+    /// parameter, and `c` becomes keyword-only in the reduced signature.
+    fn partially_applied_signature(
+        &self,
+        db: &'db dyn Db,
+        arguments: &CallArguments<'_, 'db>,
+    ) -> Signature<'db> {
+        let parameters = self.signature.parameters().as_slice();
+        let mut remove_positionally_bound = vec![false; parameters.len()];
+        let mut keyword_defaults = vec![None; parameters.len()];
+        let mut keyword_bound = vec![false; parameters.len()];
+
+        for ((argument, argument_ty), argument_matches) in
+            arguments.iter().zip(&self.argument_matches)
+        {
+            match argument {
+                Argument::Positional | Argument::Synthetic | Argument::Variadic => {
+                    for (parameter_index, _) in argument_matches.iter() {
+                        let parameter = &parameters[parameter_index];
+                        if parameter.is_positional()
+                            && parameter.annotated_type() != Type::Never
+                            && !parameter.is_variadic()
+                            && !parameter.is_keyword_variadic()
+                        {
+                            remove_positionally_bound[parameter_index] = true;
+                        }
+                    }
+                }
+                Argument::Keyword(_) | Argument::Keywords => {
+                    for (parameter_index, matched_ty) in argument_matches.iter() {
+                        if remove_positionally_bound[parameter_index] {
+                            continue;
+                        }
+
+                        let parameter = &parameters[parameter_index];
+                        if parameter.is_positional_only()
+                            || parameter.is_variadic()
+                            || parameter.is_keyword_variadic()
+                        {
+                            continue;
+                        }
+
+                        keyword_bound[parameter_index] = true;
+                        if parameter.annotated_type() != Type::Never {
+                            keyword_defaults[parameter_index] =
+                                Some(matched_ty.unwrap_or_else(|| {
+                                    argument_ty.get_default().unwrap_or_else(Type::unknown)
+                                }));
+                        }
+                    }
+                }
+            }
+        }
+
+        let signature_specialization =
+            self.partial_signature_specialization(db, &remove_positionally_bound);
+        let signature = signature_specialization.map_or_else(
+            || self.signature.clone(),
+            |specialization| self.signature.apply_specialization(db, specialization),
+        );
+
+        let parameters = signature.parameters().as_slice();
+        let return_ty = self.partial_specialization.map_or_else(
+            || self.unspecialized_return_type(db),
+            |specialization| {
+                self.unspecialized_return_type(db)
+                    .apply_specialization(db, signature_specialization.unwrap_or(specialization))
+            },
+        );
+
+        let mut remaining = Vec::with_capacity(parameters.len());
+        let mut first_keyword_bound_positional_or_keyword = None;
+        for (index, parameter) in parameters.iter().enumerate() {
+            if remove_positionally_bound[index] {
+                continue;
+            }
+
+            let parameter = keyword_defaults[index].map_or_else(
+                || parameter.clone(),
+                |default_ty| parameter.clone().with_default_type(default_ty),
+            );
+
+            if first_keyword_bound_positional_or_keyword.is_none()
+                && keyword_bound[index]
+                && matches!(parameter.kind(), ParameterKind::PositionalOrKeyword { .. })
+            {
+                first_keyword_bound_positional_or_keyword = Some(remaining.len());
+            }
+
+            remaining.push(parameter);
+        }
+
+        // Expand `P.args`/`P.kwargs` while the pair is still adjacent. The keyword-only reshuffle
+        // below can separate them, which would otherwise prevent expansion.
+        let remaining = expand_paramspec_variadics(db, remaining);
+
+        let mut reordered = Vec::with_capacity(remaining.len());
+        let mut keyword_only = Vec::new();
+        let mut keyword_variadic = Vec::new();
+        for (index, parameter) in remaining.into_iter().enumerate() {
+            let mut parameter = parameter;
+            // Keyword-bound positional-or-keyword parameters can only be overridden by keyword at
+            // call time. Once one appears, later positional-or-keyword parameters also become
+            // keyword-only to match `inspect.signature(functools.partial(...))`.
+            if first_keyword_bound_positional_or_keyword
+                .is_some_and(|first_bound_index| index >= first_bound_index)
+                && matches!(parameter.kind(), ParameterKind::PositionalOrKeyword { .. })
+            {
+                parameter = positional_or_keyword_to_keyword_only(&parameter);
+            }
+
+            if parameter.is_keyword_variadic() {
+                keyword_variadic.push(parameter);
+            } else if parameter.is_keyword_only() {
+                keyword_only.push(parameter);
+            } else {
+                reordered.push(parameter);
+            }
+        }
+
+        reordered.extend(keyword_only);
+        reordered.extend(keyword_variadic);
+
+        signature
+            .with_parameters(Parameters::new(db, reordered))
+            .with_return_type(return_ty)
+    }
+
+    /// Returns the specialization used for the callable signature exposed by a partial object.
+    ///
+    /// Surviving type variables that still appear in the reduced parameter list may need a more
+    /// specific specialization than the plain return-type view.
+    fn partial_signature_specialization(
+        &self,
+        db: &'db dyn Db,
+        remove_positionally_bound: &[bool],
+    ) -> Option<Specialization<'db>> {
+        let specialization = self.partial_specialization?;
+        let Some(generic_context) = self.signature.generic_context else {
+            return Some(specialization);
+        };
+
+        let promoted_typevars: FxHashSet<BoundTypeVarIdentity<'db>> = generic_context
+            .variables(db)
+            .filter(|typevar| {
+                self.signature
+                    .parameters()
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, _)| !remove_positionally_bound[*index])
+                    .any(|(_, parameter)| {
+                        parameter
+                            .annotated_type()
+                            .references_typevar(db, typevar.typevar(db).identity(db))
+                    })
+            })
+            .map(|typevar| typevar.identity(db))
+            .collect();
+
+        if promoted_typevars.is_empty() {
+            return Some(specialization);
+        }
+
+        Some(generic_context.specialize_recursive(
+            db,
+            generic_context.variables(db).map(|typevar| {
+                let ty = specialization
+                    .get(db, typevar)
+                    .unwrap_or(Type::TypeVar(typevar));
+                Some(if promoted_typevars.contains(&typevar.identity(db)) {
+                    ty.promote(db)
+                } else {
+                    ty
+                })
+            }),
+        ))
     }
 
     /// Returns the bound type for the specified parameter, or `None` if no argument was matched to
@@ -5204,6 +5800,7 @@ impl<'db> Binding<'db> {
             return_ty: self.return_ty,
             inferable_typevars: self.inferable_typevars,
             specialization: self.specialization,
+            partial_specialization: self.partial_specialization,
             argument_matches: self.argument_matches.clone(),
             parameter_tys: self.parameter_tys.clone(),
             errors: self.errors.clone(),
@@ -5215,6 +5812,7 @@ impl<'db> Binding<'db> {
             return_ty,
             inferable_typevars,
             specialization,
+            partial_specialization,
             argument_matches,
             parameter_tys,
             errors,
@@ -5223,6 +5821,7 @@ impl<'db> Binding<'db> {
         self.return_ty = return_ty;
         self.inferable_typevars = inferable_typevars;
         self.specialization = specialization;
+        self.partial_specialization = partial_specialization;
         self.argument_matches = argument_matches;
         self.parameter_tys = parameter_tys;
         self.errors = errors;
@@ -5247,10 +5846,89 @@ impl<'db> Binding<'db> {
         self.return_ty = self.initial_return_type(db);
         self.inferable_typevars = InferableTypeVars::None;
         self.specialization = None;
+        self.partial_specialization = None;
         self.argument_matches = Box::from([]);
         self.parameter_tys = Box::from([]);
         self.errors.clear();
     }
+}
+
+/// Rewrites a positional-or-keyword parameter as keyword-only while preserving its metadata.
+fn positional_or_keyword_to_keyword_only<'db>(parameter: &Parameter<'db>) -> Parameter<'db> {
+    let ParameterKind::PositionalOrKeyword { name, .. } = parameter.kind() else {
+        return parameter.clone();
+    };
+
+    let was_type_form = matches!(parameter.form, ParameterForm::Type);
+
+    let mut parameter = Parameter::keyword_only(name.clone())
+        .with_annotated_type(parameter.annotated_type())
+        .with_optional_default_type(parameter.default_type());
+
+    if was_type_form {
+        parameter = parameter.type_form();
+    }
+
+    parameter
+}
+
+/// Expands adjacent `P.args`/`P.kwargs` placeholders into their mapped parameters.
+fn expand_paramspec_variadics<'db>(
+    db: &'db dyn Db,
+    parameters: Vec<Parameter<'db>>,
+) -> Vec<Parameter<'db>> {
+    let mut variadic_index = None;
+    let mut paramspec_callable = None;
+
+    for (index, parameter) in parameters.iter().enumerate() {
+        if !parameter.is_variadic() {
+            continue;
+        }
+
+        let Type::Callable(callable) = parameter.annotated_type() else {
+            continue;
+        };
+        if callable.kind(db) != CallableTypeKind::ParamSpecValue {
+            continue;
+        }
+
+        variadic_index = Some(index);
+        paramspec_callable = Some(callable);
+        break;
+    }
+
+    let Some(variadic_index) = variadic_index else {
+        return parameters;
+    };
+    let Some(paramspec_callable) = paramspec_callable else {
+        return parameters;
+    };
+
+    let Some(keyword_variadic) = parameters.get(variadic_index + 1) else {
+        return parameters;
+    };
+    if !keyword_variadic.is_keyword_variadic() {
+        return parameters;
+    }
+
+    let Type::Callable(keyword_callable) = keyword_variadic.annotated_type() else {
+        return parameters;
+    };
+    if keyword_callable.kind(db) != CallableTypeKind::ParamSpecValue
+        || keyword_callable != paramspec_callable
+    {
+        return parameters;
+    }
+
+    let [mapped_signature] = paramspec_callable.signatures(db).overloads.as_slice() else {
+        return parameters;
+    };
+
+    let mut expanded = Vec::with_capacity(parameters.len());
+    expanded.extend_from_slice(&parameters[..variadic_index]);
+    expanded.extend_from_slice(mapped_signature.parameters().as_slice());
+    expanded.extend_from_slice(&parameters[variadic_index + 2..]);
+    expanded
 }
 
 #[derive(Clone, Debug)]
@@ -5258,6 +5936,7 @@ struct BindingSnapshot<'db> {
     return_ty: Type<'db>,
     inferable_typevars: InferableTypeVars<'db>,
     specialization: Option<Specialization<'db>>,
+    partial_specialization: Option<Specialization<'db>>,
     argument_matches: Box<[MatchedArgument<'db>]>,
     parameter_tys: Box<[Option<Type<'db>>]>,
     errors: Vec<BindingError<'db>>,
@@ -5299,6 +5978,7 @@ impl<'db> CallableBindingSnapshot<'db> {
                 snapshot.return_ty = binding.return_ty;
                 snapshot.inferable_typevars = binding.inferable_typevars;
                 snapshot.specialization = binding.specialization;
+                snapshot.partial_specialization = binding.partial_specialization;
                 snapshot
                     .argument_matches
                     .clone_from(&binding.argument_matches);
@@ -5536,6 +6216,27 @@ pub(crate) enum BindingError<'db> {
 }
 
 impl BindingError<'_> {
+    /// Returns whether this error is relevant to `functools.partial(...)` construction.
+    ///
+    /// These errors are used both to filter incompatible wrapped overloads and to report
+    /// statically-detectable call-shape errors at construction time. (Runtime `functools.partial`
+    /// can defer some call-shape errors until invocation.)
+    ///
+    /// For example, `partial(f, 1)` should ignore `MissingArguments` for the parameters that stay
+    /// unbound, while `partial(f, "x")` should still report `InvalidArgumentType` immediately.
+    fn is_relevant_for_partial_application(&self) -> bool {
+        matches!(
+            self,
+            Self::InvalidArgumentType { .. }
+                | Self::InvalidKeyType { .. }
+                | Self::UnknownArgument { .. }
+                | Self::PositionalOnlyParameterAsKwarg { .. }
+                | Self::TooManyPositionalArguments { .. }
+                | Self::ParameterAlreadyAssigned { .. }
+                | Self::SpecializationError { .. }
+        )
+    }
+
     pub(crate) fn maybe_apply_argument_index_offset(mut self, offset: Option<usize>) -> Self {
         if let Some(offset) = offset {
             self.apply_argument_index_offset(offset);

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -46,7 +46,7 @@ use crate::types::generics::{
 };
 use crate::types::known_instance::{FieldInstance, FunctoolsPartialInstance};
 use crate::types::signatures::{
-    CallableSignature, Parameter, ParameterForm, ParameterKind, Parameters,
+    CallableSignature, Parameter, ParameterForm, ParameterKind, Parameters, PartialApplication,
 };
 use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
 use crate::types::typevar::BoundTypeVarIdentity;
@@ -2902,8 +2902,14 @@ impl<'db> CallableBinding<'db> {
             let Some(bound_overload) = self.overloads().get(index) else {
                 continue;
             };
-            let signature =
-                bound_overload.partially_applied_signature(db, signature_arguments.as_ref());
+            let partial_application =
+                bound_overload.partial_application(signature_arguments.as_ref());
+            let signature = bound_overload.signature.partially_apply(
+                db,
+                &partial_application,
+                bound_overload.partial_specialization,
+                bound_overload.unspecialized_return_type(db),
+            );
             let dedup_key = signature.clone().with_definition(None);
             if seen_overloads.insert(dedup_key) {
                 new_overloads.push(signature);
@@ -5534,21 +5540,10 @@ impl<'db> Binding<'db> {
         });
     }
 
-    /// Returns the callable signature produced by partially applying this bound overload.
-    ///
-    /// For example, starting from `(a: int, b: str, c: bool) -> bytes`,
-    /// `partial(f, 1, c=True)` should expose `(b: str, *, c: bool = True) -> bytes`:
-    /// the positionally bound `a` is removed, the keyword-bound `c` stays as a defaulted
-    /// parameter, and `c` becomes keyword-only in the reduced signature.
-    fn partially_applied_signature(
-        &self,
-        db: &'db dyn Db,
-        arguments: &CallArguments<'_, 'db>,
-    ) -> Signature<'db> {
+    /// Collects the parameter-level effects of a `functools.partial(...)` application.
+    fn partial_application(&self, arguments: &CallArguments<'_, 'db>) -> PartialApplication<'db> {
         let parameters = self.signature.parameters().as_slice();
-        let mut remove_positionally_bound = vec![false; parameters.len()];
-        let mut keyword_defaults = vec![None; parameters.len()];
-        let mut keyword_bound = vec![false; parameters.len()];
+        let mut partial_application = PartialApplication::new(parameters.len());
 
         for ((argument, argument_ty), argument_matches) in
             arguments.iter().zip(&self.argument_matches)
@@ -5562,13 +5557,13 @@ impl<'db> Binding<'db> {
                             && !parameter.is_variadic()
                             && !parameter.is_keyword_variadic()
                         {
-                            remove_positionally_bound[parameter_index] = true;
+                            partial_application.bind_positionally(parameter_index);
                         }
                     }
                 }
                 Argument::Keyword(_) | Argument::Keywords => {
                     for (parameter_index, matched_ty) in argument_matches.iter() {
-                        if remove_positionally_bound[parameter_index] {
+                        if partial_application.is_positionally_bound(parameter_index) {
                             continue;
                         }
 
@@ -5580,140 +5575,20 @@ impl<'db> Binding<'db> {
                             continue;
                         }
 
-                        keyword_bound[parameter_index] = true;
-                        if parameter.annotated_type() != Type::Never {
-                            keyword_defaults[parameter_index] =
-                                Some(matched_ty.unwrap_or_else(|| {
+                        partial_application.bind_by_keyword(
+                            parameter_index,
+                            (parameter.annotated_type() != Type::Never).then(|| {
+                                matched_ty.unwrap_or_else(|| {
                                     argument_ty.get_default().unwrap_or_else(Type::unknown)
-                                }));
-                        }
+                                })
+                            }),
+                        );
                     }
                 }
             }
         }
 
-        let signature_specialization =
-            self.partial_signature_specialization(db, &remove_positionally_bound);
-        let signature = signature_specialization.map_or_else(
-            || self.signature.clone(),
-            |specialization| self.signature.apply_specialization(db, specialization),
-        );
-
-        let parameters = signature.parameters().as_slice();
-        let return_ty = self.partial_specialization.map_or_else(
-            || self.unspecialized_return_type(db),
-            |specialization| {
-                self.unspecialized_return_type(db)
-                    .apply_specialization(db, signature_specialization.unwrap_or(specialization))
-            },
-        );
-
-        let mut remaining = Vec::with_capacity(parameters.len());
-        let mut first_keyword_bound_positional_or_keyword = None;
-        for (index, parameter) in parameters.iter().enumerate() {
-            if remove_positionally_bound[index] {
-                continue;
-            }
-
-            let parameter = keyword_defaults[index].map_or_else(
-                || parameter.clone(),
-                |default_ty| parameter.clone().with_default_type(default_ty),
-            );
-
-            if first_keyword_bound_positional_or_keyword.is_none()
-                && keyword_bound[index]
-                && matches!(parameter.kind(), ParameterKind::PositionalOrKeyword { .. })
-            {
-                first_keyword_bound_positional_or_keyword = Some(remaining.len());
-            }
-
-            remaining.push(parameter);
-        }
-
-        // Expand `P.args`/`P.kwargs` while the pair is still adjacent. The keyword-only reshuffle
-        // below can separate them, which would otherwise prevent expansion.
-        let remaining = Parameters::new(db, remaining).expand_paramspec_variadics(db);
-
-        let mut reordered = Vec::with_capacity(remaining.len());
-        let mut keyword_only = Vec::new();
-        let mut keyword_variadic = Vec::new();
-        for (index, parameter) in remaining.iter().cloned().enumerate() {
-            let mut parameter = parameter;
-            // Keyword-bound positional-or-keyword parameters can only be overridden by keyword at
-            // call time. Once one appears, later positional-or-keyword parameters also become
-            // keyword-only to match `inspect.signature(functools.partial(...))`.
-            if first_keyword_bound_positional_or_keyword
-                .is_some_and(|first_bound_index| index >= first_bound_index)
-                && matches!(parameter.kind(), ParameterKind::PositionalOrKeyword { .. })
-            {
-                parameter = parameter.positional_or_keyword_to_keyword_only();
-            }
-
-            if parameter.is_keyword_variadic() {
-                keyword_variadic.push(parameter);
-            } else if parameter.is_keyword_only() {
-                keyword_only.push(parameter);
-            } else {
-                reordered.push(parameter);
-            }
-        }
-
-        reordered.extend(keyword_only);
-        reordered.extend(keyword_variadic);
-
-        signature
-            .with_parameters(Parameters::new(db, reordered))
-            .with_return_type(return_ty)
-    }
-
-    /// Returns the specialization used for the callable signature exposed by a partial object.
-    ///
-    /// Surviving type variables that still appear in the reduced parameter list may need a more
-    /// specific specialization than the plain return-type view.
-    fn partial_signature_specialization(
-        &self,
-        db: &'db dyn Db,
-        remove_positionally_bound: &[bool],
-    ) -> Option<Specialization<'db>> {
-        let specialization = self.partial_specialization?;
-        let Some(generic_context) = self.signature.generic_context else {
-            return Some(specialization);
-        };
-
-        let promoted_typevars: FxHashSet<BoundTypeVarIdentity<'db>> = generic_context
-            .variables(db)
-            .filter(|typevar| {
-                self.signature
-                    .parameters()
-                    .iter()
-                    .enumerate()
-                    .filter(|(index, _)| !remove_positionally_bound[*index])
-                    .any(|(_, parameter)| {
-                        parameter
-                            .annotated_type()
-                            .references_typevar(db, typevar.typevar(db).identity(db))
-                    })
-            })
-            .map(|typevar| typevar.identity(db))
-            .collect();
-
-        if promoted_typevars.is_empty() {
-            return Some(specialization);
-        }
-
-        Some(generic_context.specialize_recursive(
-            db,
-            generic_context.variables(db).map(|typevar| {
-                let ty = specialization
-                    .get(db, typevar)
-                    .unwrap_or(Type::TypeVar(typevar));
-                Some(if promoted_typevars.contains(&typevar.identity(db)) {
-                    ty.promote(db)
-                } else {
-                    ty
-                })
-            }),
-        ))
+        partial_application
     }
 
     /// Returns the bound type for the specified parameter, or `None` if no argument was matched to

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5632,12 +5632,12 @@ impl<'db> Binding<'db> {
 
         // Expand `P.args`/`P.kwargs` while the pair is still adjacent. The keyword-only reshuffle
         // below can separate them, which would otherwise prevent expansion.
-        let remaining = expand_paramspec_variadics(db, remaining);
+        let remaining = Parameters::new(db, remaining).expand_paramspec_variadics(db);
 
         let mut reordered = Vec::with_capacity(remaining.len());
         let mut keyword_only = Vec::new();
         let mut keyword_variadic = Vec::new();
-        for (index, parameter) in remaining.into_iter().enumerate() {
+        for (index, parameter) in remaining.iter().cloned().enumerate() {
             let mut parameter = parameter;
             // Keyword-bound positional-or-keyword parameters can only be overridden by keyword at
             // call time. Once one appears, later positional-or-keyword parameters also become
@@ -5851,65 +5851,6 @@ impl<'db> Binding<'db> {
         self.parameter_tys = Box::from([]);
         self.errors.clear();
     }
-}
-
-/// Expands adjacent `P.args`/`P.kwargs` placeholders into their mapped parameters.
-fn expand_paramspec_variadics<'db>(
-    db: &'db dyn Db,
-    parameters: Vec<Parameter<'db>>,
-) -> Vec<Parameter<'db>> {
-    let mut variadic_index = None;
-    let mut paramspec_callable = None;
-
-    for (index, parameter) in parameters.iter().enumerate() {
-        if !parameter.is_variadic() {
-            continue;
-        }
-
-        let Type::Callable(callable) = parameter.annotated_type() else {
-            continue;
-        };
-        if callable.kind(db) != CallableTypeKind::ParamSpecValue {
-            continue;
-        }
-
-        variadic_index = Some(index);
-        paramspec_callable = Some(callable);
-        break;
-    }
-
-    let Some(variadic_index) = variadic_index else {
-        return parameters;
-    };
-    let Some(paramspec_callable) = paramspec_callable else {
-        return parameters;
-    };
-
-    let Some(keyword_variadic) = parameters.get(variadic_index + 1) else {
-        return parameters;
-    };
-    if !keyword_variadic.is_keyword_variadic() {
-        return parameters;
-    }
-
-    let Type::Callable(keyword_callable) = keyword_variadic.annotated_type() else {
-        return parameters;
-    };
-    if keyword_callable.kind(db) != CallableTypeKind::ParamSpecValue
-        || keyword_callable != paramspec_callable
-    {
-        return parameters;
-    }
-
-    let [mapped_signature] = paramspec_callable.signatures(db).overloads.as_slice() else {
-        return parameters;
-    };
-
-    let mut expanded = Vec::with_capacity(parameters.len());
-    expanded.extend_from_slice(&parameters[..variadic_index]);
-    expanded.extend_from_slice(mapped_signature.parameters().as_slice());
-    expanded.extend_from_slice(&parameters[variadic_index + 2..]);
-    expanded
 }
 
 #[derive(Clone, Debug)]

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2907,7 +2907,7 @@ impl<'db> CallableBinding<'db> {
             let signature = bound_overload.signature.partially_apply(
                 db,
                 &partial_application,
-                bound_overload.partial_specialization,
+                bound_overload.specialization,
                 bound_overload.unspecialized_return_type(db),
             );
             let dedup_key = signature.clone().with_definition(None);
@@ -5288,7 +5288,11 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
     fn finish(
         self,
-    ) -> (InferableTypeVars<'db>, Option<Specialization<'db>>, Type<'db>) {
+    ) -> (
+        InferableTypeVars<'db>,
+        Option<Specialization<'db>>,
+        Type<'db>,
+    ) {
         (self.inferable_typevars, self.specialization, self.return_ty)
     }
 }
@@ -5363,10 +5367,6 @@ pub(crate) struct Binding<'db> {
     /// The specialization that was inferred from the argument types, if the callable is generic.
     specialization: Option<Specialization<'db>>,
 
-    /// A partial-application view of the inferred specialization which preserves uninferred
-    /// type variables as generic.
-    partial_specialization: Option<Specialization<'db>>,
-
     /// Information about which parameter(s) each argument was matched with, in argument source
     /// order.
     argument_matches: Box<[MatchedArgument<'db>]>,
@@ -5394,7 +5394,6 @@ impl<'db> Binding<'db> {
             constructor_context: None,
             inferable_typevars: InferableTypeVars::None,
             specialization: None,
-            partial_specialization: None,
             argument_matches: Box::from([]),
             variadic_argument_matched_to_variadic_parameter: false,
             parameter_tys: Box::from([]),
@@ -5484,7 +5483,6 @@ impl<'db> Binding<'db> {
         checker.check_argument_types(constraints);
 
         (self.inferable_typevars, self.specialization, self.return_ty) = checker.finish();
-        self.partial_specialization = self.specialization;
     }
 
     pub(crate) fn set_return_type(&mut self, return_ty: Type<'db>) {
@@ -5656,7 +5654,6 @@ impl<'db> Binding<'db> {
             return_ty: self.return_ty,
             inferable_typevars: self.inferable_typevars,
             specialization: self.specialization,
-            partial_specialization: self.partial_specialization,
             argument_matches: self.argument_matches.clone(),
             parameter_tys: self.parameter_tys.clone(),
             errors: self.errors.clone(),
@@ -5668,7 +5665,6 @@ impl<'db> Binding<'db> {
             return_ty,
             inferable_typevars,
             specialization,
-            partial_specialization,
             argument_matches,
             parameter_tys,
             errors,
@@ -5677,7 +5673,6 @@ impl<'db> Binding<'db> {
         self.return_ty = return_ty;
         self.inferable_typevars = inferable_typevars;
         self.specialization = specialization;
-        self.partial_specialization = partial_specialization;
         self.argument_matches = argument_matches;
         self.parameter_tys = parameter_tys;
         self.errors = errors;
@@ -5702,7 +5697,6 @@ impl<'db> Binding<'db> {
         self.return_ty = self.initial_return_type(db);
         self.inferable_typevars = InferableTypeVars::None;
         self.specialization = None;
-        self.partial_specialization = None;
         self.argument_matches = Box::from([]);
         self.parameter_tys = Box::from([]);
         self.errors.clear();
@@ -5714,7 +5708,6 @@ struct BindingSnapshot<'db> {
     return_ty: Type<'db>,
     inferable_typevars: InferableTypeVars<'db>,
     specialization: Option<Specialization<'db>>,
-    partial_specialization: Option<Specialization<'db>>,
     argument_matches: Box<[MatchedArgument<'db>]>,
     parameter_tys: Box<[Option<Type<'db>>]>,
     errors: Vec<BindingError<'db>>,
@@ -5756,7 +5749,6 @@ impl<'db> CallableBindingSnapshot<'db> {
                 snapshot.return_ty = binding.return_ty;
                 snapshot.inferable_typevars = binding.inferable_typevars;
                 snapshot.specialization = binding.specialization;
-                snapshot.partial_specialization = binding.partial_specialization;
                 snapshot
                     .argument_matches
                     .clone_from(&binding.argument_matches);

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -799,6 +799,43 @@ impl<'db> Bindings<'db> {
         Some((bound_call_arguments, partial_bindings))
     }
 
+    /// Synthesizes the precise `functools.partial(...)` type for the already-matched bindings.
+    ///
+    /// Wrapped unions and intersections keep their original callable structure by partially
+    /// applying each callable item independently. A single wrapped callable instead exposes one
+    /// reduced callable whose overload set is merged before being wrapped as `partial[...]`.
+    fn functools_partial_type<'a>(
+        &self,
+        db: &'db dyn Db,
+        wrapped_callable_ty: Type<'db>,
+        partial_overload: &mut Binding<'db>,
+        bound_call_arguments: &CallArguments<'a, 'db>,
+    ) -> Type<'db> {
+        if wrapped_callable_ty.is_union() || wrapped_callable_ty.is_intersection() {
+            return self.map_item_types(db, |partial_item| {
+                partial_item
+                    .functools_partial_callable(db, partial_overload, bound_call_arguments)
+                    .map(|callable| {
+                        callable.into_precise_functools_partial_instance(db, wrapped_callable_ty)
+                    })
+            });
+        }
+
+        let partial_callables: SmallVec<[CallableType<'db>; 1]> = self
+            .iter_callable_items()
+            .filter_map(|partial_item| {
+                partial_item.functools_partial_callable(db, partial_overload, bound_call_arguments)
+            })
+            .collect();
+
+        if partial_callables.is_empty() {
+            Type::Never
+        } else {
+            CallableTypes::from_elements(partial_callables)
+                .into_precise_functools_partial_instance(db, wrapped_callable_ty)
+        }
+    }
+
     fn map_with<F>(self, f: &F) -> Self
     where
         F: Fn(CallableBinding<'db>) -> CallableBinding<'db>,
@@ -2467,77 +2504,11 @@ impl<'db> Bindings<'db> {
                         }
 
                         Some(KnownClass::FunctoolsPartial) => {
-                            // `partial(...)` receives the wrapped callable as its first explicit
-                            // argument (after constructor receiver handling).
-                            let func_ty = match overload.parameter_types() {
-                                [Some(func_ty), ..] => *func_ty,
-                                _ => continue,
-                            };
-                            let fallback_return_type = KnownClass::FunctoolsPartial
-                                .to_specialized_instance(db, &[Type::unknown()]);
-
-                            let Some((bound_call_arguments, partial_bindings)) =
-                                Self::functools_partial_matched_bindings(
-                                    db,
-                                    func_ty,
-                                    call_arguments,
-                                )
-                            else {
-                                continue;
-                            };
-
-                            // Reuse call-binding machinery to resolve which wrapped overloads are
-                            // compatible with bound arguments and to surface binding diagnostics.
-                            let partial_bindings = match partial_bindings.check_types(
-                                db,
-                                &ConstraintSetBuilder::new(),
-                                &bound_call_arguments,
-                                TypeContext::default(),
-                                &[],
-                            ) {
-                                Ok(bindings) => bindings,
-                                Err(CallError(_, bindings)) => *bindings,
-                            };
-                            let new_return_type = if func_ty.is_union() || func_ty.is_intersection()
+                            if let Some(new_return_type) =
+                                overload.functools_partial_return_type(db, call_arguments)
                             {
-                                partial_bindings.map_item_types(db, |partial_item| {
-                                    partial_item
-                                        .functools_partial_callable(
-                                            db,
-                                            overload,
-                                            &bound_call_arguments,
-                                        )
-                                        .map(|callable| {
-                                            callable.into_precise_functools_partial_instance(
-                                                db, func_ty,
-                                            )
-                                        })
-                                })
-                            } else {
-                                let partial_callables: SmallVec<[CallableType<'db>; 1]> =
-                                    partial_bindings
-                                        .iter_callable_items()
-                                        .filter_map(|partial_item| {
-                                            partial_item.functools_partial_callable(
-                                                db,
-                                                overload,
-                                                &bound_call_arguments,
-                                            )
-                                        })
-                                        .collect();
-
-                                if partial_callables.is_empty() {
-                                    Type::Never
-                                } else {
-                                    CallableTypes::from_elements(partial_callables)
-                                        .into_precise_functools_partial_instance(db, func_ty)
-                                }
-                            };
-                            if new_return_type.is_never() {
-                                overload.set_return_type(fallback_return_type);
-                                continue;
+                                overload.set_return_type(new_return_type);
                             }
-                            overload.set_return_type(new_return_type);
                         }
 
                         Some(KnownClass::Tuple) if overload_index == 1 => {
@@ -5436,6 +5407,46 @@ impl<'db> Binding<'db> {
     /// argument was matched to that parameter.
     pub(crate) fn parameter_types(&self) -> &[Option<Type<'db>>] {
         &self.parameter_tys
+    }
+
+    /// Returns the reduced callable type exposed by this `functools.partial(...)` overload.
+    fn functools_partial_return_type<'a>(
+        &mut self,
+        db: &'db dyn Db,
+        call_arguments: &CallArguments<'a, 'db>,
+    ) -> Option<Type<'db>> {
+        // `partial(...)` receives the wrapped callable as its first explicit argument (after
+        // constructor receiver handling).
+        let func_ty = match self.parameter_types() {
+            [Some(func_ty), ..] => *func_ty,
+            _ => return None,
+        };
+        let fallback_return_type =
+            KnownClass::FunctoolsPartial.to_specialized_instance(db, &[Type::unknown()]);
+
+        let (bound_call_arguments, partial_bindings) =
+            Bindings::functools_partial_matched_bindings(db, func_ty, call_arguments)?;
+
+        // Reuse call-binding machinery to resolve which wrapped overloads are compatible with
+        // bound arguments and to surface binding diagnostics.
+        let partial_bindings = match partial_bindings.check_types(
+            db,
+            &ConstraintSetBuilder::new(),
+            &bound_call_arguments,
+            TypeContext::default(),
+            &[],
+        ) {
+            Ok(bindings) => bindings,
+            Err(CallError(_, bindings)) => *bindings,
+        };
+        let new_return_type =
+            partial_bindings.functools_partial_type(db, func_ty, self, &bound_call_arguments);
+
+        Some(if new_return_type.is_never() {
+            fallback_return_type
+        } else {
+            new_return_type
+        })
     }
 
     /// `functools.partial(...)` is allowed to leave required parameters unbound.

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -47,6 +47,7 @@ use crate::types::generics::{
 use crate::types::known_instance::{FieldInstance, FunctoolsPartialInstance};
 use crate::types::signatures::{
     CallableSignature, Parameter, ParameterForm, ParameterKind, Parameters, PartialApplication,
+    PartialSignatureApplication,
 };
 use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
 use crate::types::typevar::BoundTypeVarIdentity;
@@ -2896,31 +2897,14 @@ impl<'db> CallableBinding<'db> {
         };
 
         let signature_arguments = bound_call_arguments.with_self(self.bound_type);
-        let mut new_overloads = Vec::new();
-        let mut seen_overloads = FxHashSet::default();
-        for index in selected_overload_indexes {
-            let Some(bound_overload) = self.overloads().get(index) else {
-                continue;
-            };
-            let partial_application =
-                bound_overload.partial_application(signature_arguments.as_ref());
-            let signature = bound_overload.signature.partially_apply(
-                db,
-                &partial_application,
-                bound_overload.specialization,
-                bound_overload.unspecialized_return_type(db),
-            );
-            let dedup_key = signature.clone().with_definition(None);
-            if seen_overloads.insert(dedup_key) {
-                new_overloads.push(signature);
-            }
-        }
-
-        if new_overloads.is_empty() {
-            return None;
-        }
-
-        let new_callable_sig = CallableSignature::from_overloads(new_overloads);
+        let new_callable_sig = CallableSignature::partially_apply(
+            db,
+            selected_overload_indexes.into_iter().filter_map(|index| {
+                self.overloads().get(index).map(|overload| {
+                    overload.partial_signature_application(signature_arguments.as_ref(), db)
+                })
+            }),
+        )?;
         Some(CallableType::new(
             db,
             new_callable_sig,
@@ -5568,6 +5552,20 @@ impl<'db> Binding<'db> {
         }
 
         partial_application
+    }
+
+    /// Packages the information needed to synthesize this overload's reduced partial signature.
+    fn partial_signature_application(
+        &self,
+        arguments: &CallArguments<'_, 'db>,
+        db: &'db dyn Db,
+    ) -> PartialSignatureApplication<'db> {
+        PartialSignatureApplication::new(
+            self.signature.clone(),
+            self.partial_application(arguments),
+            self.specialization,
+            self.unspecialized_return_type(db),
+        )
     }
 
     /// Returns the bound type for the specified parameter, or `None` if no argument was matched to

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4538,7 +4538,6 @@ struct ArgumentTypeChecker<'a, 'db> {
 
     inferable_typevars: InferableTypeVars<'db>,
     specialization: Option<Specialization<'db>>,
-    partial_specialization: Option<Specialization<'db>>,
 
     /// Argument indices for which specialization inference has already produced a sufficiently
     /// precise argument mismatch. We can then silence `check_argument_type` for those arguments to
@@ -4574,7 +4573,6 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             errors,
             inferable_typevars: InferableTypeVars::None,
             specialization: None,
-            partial_specialization: None,
             constraint_set_errors: vec![false; arguments.len()],
         }
     }
@@ -4825,11 +4823,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             };
 
         let specialization = builder.build_with(generic_context, maybe_promote);
-        let partial_specialization = specialization;
-
         self.return_ty = self.return_ty.apply_specialization(self.db, specialization);
         self.specialization = Some(specialization);
-        self.partial_specialization = Some(partial_specialization);
     }
 
     fn infer_argument_constraints<'c>(
@@ -5293,18 +5288,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
     fn finish(
         self,
-    ) -> (
-        InferableTypeVars<'db>,
-        Option<Specialization<'db>>,
-        Option<Specialization<'db>>,
-        Type<'db>,
-    ) {
-        (
-            self.inferable_typevars,
-            self.specialization,
-            self.partial_specialization,
-            self.return_ty,
-        )
+    ) -> (InferableTypeVars<'db>, Option<Specialization<'db>>, Type<'db>) {
+        (self.inferable_typevars, self.specialization, self.return_ty)
     }
 }
 
@@ -5498,12 +5483,8 @@ impl<'db> Binding<'db> {
         checker.infer_specialization(constraints);
         checker.check_argument_types(constraints);
 
-        (
-            self.inferable_typevars,
-            self.specialization,
-            self.partial_specialization,
-            self.return_ty,
-        ) = checker.finish();
+        (self.inferable_typevars, self.specialization, self.return_ty) = checker.finish();
+        self.partial_specialization = self.specialization;
     }
 
     pub(crate) fn set_return_type(&mut self, return_ty: Type<'db>) {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -44,7 +44,7 @@ use crate::types::function::{
 use crate::types::generics::{
     GenericContext, InferableTypeVars, Specialization, SpecializationBuilder, SpecializationError,
 };
-use crate::types::known_instance::{FieldInstance, FunctoolsPartialInstance};
+use crate::types::known_instance::FieldInstance;
 use crate::types::signatures::{
     CallableSignature, Parameter, ParameterForm, ParameterKind, Parameters, PartialApplication,
     PartialSignatureApplication,
@@ -52,8 +52,8 @@ use crate::types::signatures::{
 use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
 use crate::types::typevar::BoundTypeVarIdentity;
 use crate::types::{
-    BoundMethodType, BoundTypeVarInstance, CallableType, ClassLiteral, DATACLASS_FLAGS,
-    DataclassFlags, DataclassParams, GenericAlias, InternedConstraintSet, InternedType,
+    BoundMethodType, BoundTypeVarInstance, CallableType, CallableTypes, ClassLiteral,
+    DATACLASS_FLAGS, DataclassFlags, DataclassParams, GenericAlias, InternedConstraintSet,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
     NominalInstanceType, PropertyInstanceType, SpecialFormType, TypeAliasType, TypeContext,
     TypeVarBoundOrConstraints, TypeVarVariance, UnionBuilder, UnionType, WrapperDescriptorKind,
@@ -85,17 +85,6 @@ enum CallErrorPriority {
 enum CallableItem<'db> {
     Regular(CallableBinding<'db>),
     Constructor(ConstructorBinding<'db>),
-}
-
-/// Wraps a reduced callable as a synthetic `functools.partial(...)` instance type.
-fn functools_partial_instance<'db>(
-    db: &'db dyn Db,
-    wrapped: Type<'db>,
-    partial: CallableType<'db>,
-) -> Type<'db> {
-    Type::KnownInstance(KnownInstanceType::FunctoolsPartial(
-        FunctoolsPartialInstance::new(db, InternedType::new(db, wrapped), partial),
-    ))
 }
 
 impl<'db> CallableItem<'db> {
@@ -202,18 +191,22 @@ impl<'db> CallableItem<'db> {
         self.callable().callable_type
     }
 
-    /// Returns the `functools.partial(...)` result synthesized from this callable item.
-    fn functools_partial_type<'a>(
+    /// Returns the reduced callable synthesized from this callable item.
+    fn functools_partial_callable<'a>(
         &self,
         db: &'db dyn Db,
-        wrapped_callable_ty: Type<'db>,
         partial_overload: &mut Binding<'db>,
         bound_call_arguments: &CallArguments<'a, 'db>,
-    ) -> Option<Type<'db>> {
+    ) -> Option<CallableType<'db>> {
         match self {
-            CallableItem::Regular(binding) => binding
-                .functools_partial_callable(db, partial_overload, bound_call_arguments)
-                .map(|callable| functools_partial_instance(db, wrapped_callable_ty, callable)),
+            CallableItem::Regular(binding) => CallableType::partially_apply(
+                db,
+                binding.partial_signature_applications(
+                    db,
+                    partial_overload,
+                    bound_call_arguments,
+                )?,
+            ),
             CallableItem::Constructor(_) => None,
         }
     }
@@ -2508,71 +2501,36 @@ impl<'db> Bindings<'db> {
                             let new_return_type = if func_ty.is_union() || func_ty.is_intersection()
                             {
                                 partial_bindings.map_item_types(db, |partial_item| {
-                                    partial_item.functools_partial_type(
-                                        db,
-                                        func_ty,
-                                        overload,
-                                        &bound_call_arguments,
-                                    )
+                                    partial_item
+                                        .functools_partial_callable(
+                                            db,
+                                            overload,
+                                            &bound_call_arguments,
+                                        )
+                                        .map(|callable| {
+                                            callable.into_precise_functools_partial_instance(
+                                                db, func_ty,
+                                            )
+                                        })
                                 })
                             } else {
-                                let mut partial_types = Vec::new();
-                                let mut new_overloads = Vec::new();
-                                let mut seen_overloads = FxHashSet::default();
-                                for partial_item in partial_bindings.iter_callable_items() {
-                                    let Some(partial_type) = partial_item.functools_partial_type(
-                                        db,
-                                        func_ty,
-                                        overload,
-                                        &bound_call_arguments,
-                                    ) else {
-                                        continue;
-                                    };
+                                let partial_callables: SmallVec<[CallableType<'db>; 1]> =
+                                    partial_bindings
+                                        .iter_callable_items()
+                                        .filter_map(|partial_item| {
+                                            partial_item.functools_partial_callable(
+                                                db,
+                                                overload,
+                                                &bound_call_arguments,
+                                            )
+                                        })
+                                        .collect();
 
-                                    if let Type::KnownInstance(
-                                        KnownInstanceType::FunctoolsPartial(partial_instance),
-                                    ) = partial_type
-                                    {
-                                        for signature in partial_instance.partial(db).signatures(db)
-                                        {
-                                            let signature = signature.clone();
-                                            let dedup_key = signature.clone().with_definition(None);
-                                            if seen_overloads.insert(dedup_key) {
-                                                new_overloads.push(signature);
-                                            }
-                                        }
-                                    } else {
-                                        partial_types.push(partial_type);
-                                    }
-                                }
-
-                                if partial_types.is_empty() {
-                                    if new_overloads.is_empty() {
-                                        Type::Never
-                                    } else {
-                                        let new_callable_sig =
-                                            CallableSignature::from_overloads(new_overloads);
-                                        let callable = CallableType::new(
-                                            db,
-                                            new_callable_sig,
-                                            CallableTypeKind::Regular,
-                                        );
-                                        functools_partial_instance(db, func_ty, callable)
-                                    }
+                                if partial_callables.is_empty() {
+                                    Type::Never
                                 } else {
-                                    if !new_overloads.is_empty() {
-                                        let new_callable_sig =
-                                            CallableSignature::from_overloads(new_overloads);
-                                        let callable = CallableType::new(
-                                            db,
-                                            new_callable_sig,
-                                            CallableTypeKind::Regular,
-                                        );
-                                        partial_types.push(functools_partial_instance(
-                                            db, func_ty, callable,
-                                        ));
-                                    }
-                                    IntersectionType::from_elements(db, partial_types)
+                                    CallableTypes::from_elements(partial_callables)
+                                        .into_precise_functools_partial_instance(db, func_ty)
                                 }
                             };
                             if new_return_type.is_never() {
@@ -2855,16 +2813,16 @@ impl<'db> CallableBinding<'db> {
         }
     }
 
-    /// Builds the reduced callable for this `functools.partial(...)` binding.
+    /// Selects the reduced signature applications for this `functools.partial(...)` binding.
     ///
-    /// The synthesized callable preserves the reduced callable signature for this binding and reports
-    /// any partial-construction diagnostics back to the outer `partial(...)` overload.
-    fn functools_partial_callable<'a>(
+    /// Diagnostics for invalid bound arguments are still reported back to the outer `partial(...)`
+    /// overload. Callable construction happens in the callable layer after this summary is built.
+    fn partial_signature_applications<'a>(
         &self,
         db: &'db dyn Db,
         partial_overload: &mut Binding<'db>,
         bound_call_arguments: &CallArguments<'a, 'db>,
-    ) -> Option<CallableType<'db>> {
+    ) -> Option<SmallVec<[PartialSignatureApplication<'db>; 1]>> {
         if self.overloads().is_empty() {
             return None;
         }
@@ -2897,19 +2855,15 @@ impl<'db> CallableBinding<'db> {
         };
 
         let signature_arguments = bound_call_arguments.with_self(self.bound_type);
-        let new_callable_sig = CallableSignature::partially_apply(
-            db,
-            selected_overload_indexes.into_iter().filter_map(|index| {
+        let applications: SmallVec<_> = selected_overload_indexes
+            .into_iter()
+            .filter_map(|index| {
                 self.overloads().get(index).map(|overload| {
                     overload.partial_signature_application(signature_arguments.as_ref(), db)
                 })
-            }),
-        )?;
-        Some(CallableType::new(
-            db,
-            new_callable_sig,
-            CallableTypeKind::Regular,
-        ))
+            })
+            .collect();
+        (!applications.is_empty()).then_some(applications)
     }
 
     pub(crate) fn with_bound_type(mut self, bound_type: Type<'db>) -> Self {
@@ -4807,6 +4761,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             };
 
         let specialization = builder.build_with(generic_context, maybe_promote);
+
         self.return_ty = self.return_ty.apply_specialization(self.db, specialization);
         self.specialization = Some(specialization);
     }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -47,16 +47,17 @@ use crate::types::generics::{
 use crate::types::known_instance::FieldInstance;
 use crate::types::signatures::{
     CallableSignature, Parameter, ParameterForm, ParameterKind, Parameters, ParametersKind,
+    PartialApplication, PartialSignatureApplication,
 };
 use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
 use crate::types::typevar::BoundTypeVarIdentity;
 use crate::types::{
-    BoundMethodType, BoundTypeVarInstance, CallableType, ClassLiteral, DATACLASS_FLAGS,
-    DataclassFlags, DataclassParams, GenericAlias, InternedConstraintSet, IntersectionType,
-    KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind, NominalInstanceType,
-    PropertyInstanceType, SpecialFormType, TypeAliasType, TypeContext, TypeVarBoundOrConstraints,
-    TypeVarVariance, UnionAccumulator, UnionBuilder, UnionType, WrapperDescriptorKind, enums,
-    list_members,
+    BoundMethodType, BoundTypeVarInstance, CallableType, CallableTypes, ClassLiteral,
+    DATACLASS_FLAGS, DataclassFlags, DataclassParams, GenericAlias, InternedConstraintSet,
+    IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
+    NominalInstanceType, PropertyInstanceType, SpecialFormType, TypeAliasType, TypeContext,
+    TypeVarBoundOrConstraints, TypeVarVariance, UnionAccumulator, UnionBuilder, UnionType,
+    WrapperDescriptorKind, enums, list_members,
 };
 use crate::{DisplaySettings, FxOrderSet, Program};
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity};
@@ -189,6 +190,26 @@ impl<'db> CallableItem<'db> {
 
     fn callable_type(&self) -> Type<'db> {
         self.callable().callable_type
+    }
+
+    /// Returns the reduced callable synthesized from this callable item.
+    fn functools_partial_callable<'a>(
+        &self,
+        db: &'db dyn Db,
+        partial_overload: &mut Binding<'db>,
+        bound_call_arguments: &CallArguments<'a, 'db>,
+    ) -> Option<CallableType<'db>> {
+        match self {
+            CallableItem::Regular(binding) => CallableType::partially_apply(
+                db,
+                binding.partial_signature_applications(
+                    db,
+                    partial_overload,
+                    bound_call_arguments,
+                )?,
+            ),
+            CallableItem::Constructor(_) => None,
+        }
     }
 
     fn map<F>(self, f: &F) -> CallableItem<'db>
@@ -652,6 +673,18 @@ impl<'db> Bindings<'db> {
             .filter_map(CallableItem::as_constructor_mut)
     }
 
+    fn clear_deferred_constructor_errors_for_partial_application(&mut self) {
+        for binding in self.iter_flat_mut() {
+            binding.clear_deferred_constructor_errors_for_partial_application();
+        }
+
+        for constructor in self.iter_constructor_items_mut() {
+            if let Some(downstream) = constructor.downstream_constructor_mut() {
+                downstream.clear_deferred_constructor_errors_for_partial_application();
+            }
+        }
+    }
+
     /// Visits the callables that should contribute argument type context, including deferred
     /// constructor callables that are relevant to the matched upstream constructor path.
     pub(crate) fn visit_type_context_callables<'a>(
@@ -705,6 +738,98 @@ impl<'db> Bindings<'db> {
         }
 
         UnionType::from_elements(db, element_types)
+    }
+
+    /// Maps each `CallableItem` to a type and combines results while preserving
+    /// the union-of-intersections structure:
+    ///
+    /// - callable items inside an element are intersected
+    /// - elements are unioned
+    fn map_item_types(
+        &self,
+        db: &'db dyn Db,
+        mut map: impl FnMut(&CallableItem<'db>) -> Option<Type<'db>>,
+    ) -> Type<'db> {
+        let mut element_types = Vec::with_capacity(self.elements.len());
+        for element in &self.elements {
+            let mut item_types = Vec::new();
+            for item in element.items() {
+                if let Some(ty) = map(item) {
+                    item_types.push(ty);
+                }
+            }
+
+            if !item_types.is_empty() {
+                element_types.push(IntersectionType::from_elements(db, item_types));
+            }
+        }
+
+        UnionType::from_elements(db, element_types)
+    }
+
+    /// Builds matched bindings for the callable wrapped by `functools.partial(...)`.
+    ///
+    /// This handles the shared partial-specific preprocessing (callable validation and argument
+    /// normalization) used by both inference and known-call evaluation.
+    pub(crate) fn functools_partial_matched_bindings<'a>(
+        db: &'db dyn Db,
+        wrapped_callable_ty: Type<'db>,
+        call_arguments: &CallArguments<'a, 'db>,
+    ) -> Option<(CallArguments<'a, 'db>, Bindings<'db>)> {
+        // We can only infer bound-argument context from an actual callable.
+        wrapped_callable_ty.try_upcast_to_callable(db)?;
+
+        let bound_call_arguments = call_arguments.functools_partial_bound_arguments(db)?;
+
+        let mut partial_bindings = wrapped_callable_ty
+            .bindings(db)
+            .match_parameters(db, &bound_call_arguments);
+        for binding in partial_bindings.iter_flat_mut() {
+            binding.clear_missing_argument_errors_for_partial_application();
+        }
+        for constructor in partial_bindings.iter_constructor_items_mut() {
+            if let Some(downstream) = constructor.downstream_constructor_mut() {
+                downstream.clear_deferred_constructor_errors_for_partial_application();
+            }
+        }
+        Some((bound_call_arguments, partial_bindings))
+    }
+
+    /// Synthesizes the precise `functools.partial(...)` type for the already-matched bindings.
+    ///
+    /// Wrapped unions and intersections keep their original callable structure by partially
+    /// applying each callable item independently. A single wrapped callable instead exposes one
+    /// reduced callable whose overload set is merged before being wrapped as `partial[...]`.
+    fn functools_partial_type<'a>(
+        &self,
+        db: &'db dyn Db,
+        wrapped_callable_ty: Type<'db>,
+        partial_overload: &mut Binding<'db>,
+        bound_call_arguments: &CallArguments<'a, 'db>,
+    ) -> Type<'db> {
+        if wrapped_callable_ty.is_union() || wrapped_callable_ty.is_intersection() {
+            return self.map_item_types(db, |partial_item| {
+                partial_item
+                    .functools_partial_callable(db, partial_overload, bound_call_arguments)
+                    .map(|callable| {
+                        callable.into_precise_functools_partial_instance(db, wrapped_callable_ty)
+                    })
+            });
+        }
+
+        let partial_callables: SmallVec<[CallableType<'db>; 1]> = self
+            .iter_callable_items()
+            .filter_map(|partial_item| {
+                partial_item.functools_partial_callable(db, partial_overload, bound_call_arguments)
+            })
+            .collect();
+
+        if partial_callables.is_empty() {
+            Type::Never
+        } else {
+            CallableTypes::from_elements(partial_callables)
+                .into_precise_functools_partial_instance(db, wrapped_callable_ty)
+        }
     }
 
     fn map_with<F>(self, f: &F) -> Self
@@ -2416,6 +2541,14 @@ impl<'db> Bindings<'db> {
                             }
                         }
 
+                        Some(KnownClass::FunctoolsPartial) => {
+                            if let Some(new_return_type) =
+                                overload.functools_partial_return_type(db, call_arguments)
+                            {
+                                overload.set_return_type(new_return_type);
+                            }
+                        }
+
                         Some(KnownClass::Tuple) if overload_index == 1 => {
                             // `tuple(range(42))` => `tuple[int, ...]`
                             // BUT `tuple((1, 2))` => `tuple[Literal[1], Literal[2]]` rather than `tuple[Literal[1, 2], ...]`
@@ -2548,6 +2681,24 @@ pub(crate) struct CallableBinding<'db> {
     overloads: SmallVec<[Binding<'db>; 1]>,
 }
 
+#[derive(Copy, Clone)]
+enum FailingOverloadSelection {
+    /// Consider all errors that participate in overload filtering.
+    AffectsOverloadResolution,
+    /// Consider only errors that are reported during `functools.partial(...)` construction.
+    ReportableForPartial,
+}
+
+impl FailingOverloadSelection {
+    /// Returns whether this selection mode should count the given error.
+    fn includes(self, error: &BindingError<'_>) -> bool {
+        match self {
+            Self::AffectsOverloadResolution => error.affects_overload_resolution(),
+            Self::ReportableForPartial => error.is_relevant_for_partial_application(),
+        }
+    }
+}
+
 impl<'db> CallableBinding<'db> {
     pub(crate) fn from_overloads(
         signature_type: Type<'db>,
@@ -2580,6 +2731,8 @@ impl<'db> CallableBinding<'db> {
         }
     }
 
+    /// Rewrites overload signatures as if an implicit bound receiver argument had already been
+    /// consumed.
     pub(crate) fn bake_bound_type_into_overloads(&mut self, db: &'db dyn Db) {
         let Some(bound_self) = self.bound_type.take() else {
             return;
@@ -2587,6 +2740,139 @@ impl<'db> CallableBinding<'db> {
         for overload in &mut self.overloads {
             overload.signature = overload.signature.bind_self(db, Some(bound_self));
         }
+    }
+
+    /// Ignore missing-argument errors when constructing `functools.partial(...)`.
+    ///
+    /// Partial application intentionally leaves some parameters unbound, so we still want to
+    /// type-check all explicitly bound arguments against each overload.
+    fn clear_missing_argument_errors_for_partial_application(&mut self) {
+        for overload in &mut self.overloads {
+            overload.clear_missing_argument_errors_for_partial_application();
+        }
+    }
+
+    /// Ignore downstream constructor call-shape errors when constructing
+    /// `functools.partial(...)`.
+    ///
+    /// The merged partial signature decides which parameters remain callable, so downstream
+    /// arity/name mismatches caused by as-yet-unbound constructor parameters should not reject
+    /// partial construction. Explicit bound-argument type errors are still preserved.
+    fn clear_deferred_constructor_errors_for_partial_application(&mut self) {
+        for overload in &mut self.overloads {
+            overload.clear_deferred_constructor_errors_for_partial_application();
+        }
+    }
+
+    /// Chooses which overload to use as the source for diagnostics when no overload fully matches.
+    ///
+    /// If step 1 of overload resolution identified a single arity match, we keep using that
+    /// overload as the diagnostic source. Otherwise, we rank failing overloads by error quality:
+    /// fewer unknown-argument errors and fewer relevant errors are preferred.
+    fn best_failing_overload_index(&self, selection: FailingOverloadSelection) -> Option<usize> {
+        self.matching_overload_before_type_checking.or_else(|| {
+            self.overloads
+                .iter()
+                .enumerate()
+                .filter_map(|(index, overload)| {
+                    let mut relevant_count = 0;
+                    let mut unknown_argument_count = 0;
+
+                    for error in &overload.errors {
+                        if !selection.includes(error) {
+                            continue;
+                        }
+                        relevant_count += 1;
+                        if matches!(error, BindingError::UnknownArgument { .. }) {
+                            unknown_argument_count += 1;
+                        }
+                    }
+
+                    (relevant_count > 0).then_some((index, unknown_argument_count, relevant_count))
+                })
+                .min_by_key(|(_, unknown_argument_count, relevant_count)| {
+                    (*unknown_argument_count, *relevant_count)
+                })
+                .map(|(index, _, _)| index)
+        })
+    }
+
+    /// Returns the matching overload indexes when `functools.partial(...)` ignores errors that are
+    /// only relevant at invocation time.
+    fn matching_partial_overload_index(&self) -> MatchingOverloadIndex {
+        let mut matching_overloads = self.overloads.iter().enumerate().filter(|(_, overload)| {
+            !overload
+                .errors
+                .iter()
+                .any(BindingError::is_relevant_for_partial_application)
+        });
+        match matching_overloads.next() {
+            None => MatchingOverloadIndex::None,
+            Some((first, _)) => {
+                if let Some((second, _)) = matching_overloads.next() {
+                    let mut indexes = vec![first, second];
+                    for (index, _) in matching_overloads {
+                        indexes.push(index);
+                    }
+                    MatchingOverloadIndex::Multiple(indexes)
+                } else {
+                    MatchingOverloadIndex::Single(first)
+                }
+            }
+        }
+    }
+
+    /// Selects the reduced signature applications for this `functools.partial(...)` binding.
+    ///
+    /// Diagnostics for invalid bound arguments are still reported back to the outer `partial(...)`
+    /// overload. Callable construction happens in the callable layer after this summary is built.
+    fn partial_signature_applications<'a>(
+        &self,
+        db: &'db dyn Db,
+        partial_overload: &mut Binding<'db>,
+        bound_call_arguments: &CallArguments<'a, 'db>,
+    ) -> Option<SmallVec<[PartialSignatureApplication<'db>; 1]>> {
+        if self.overloads().is_empty() {
+            return None;
+        }
+
+        let selected_overload_indexes = match self.matching_partial_overload_index() {
+            MatchingOverloadIndex::Single(index) => vec![index],
+            MatchingOverloadIndex::Multiple(indexes) => indexes,
+            MatchingOverloadIndex::None => {
+                let source_overload_index = self
+                    .best_failing_overload_index(FailingOverloadSelection::ReportableForPartial)
+                    .unwrap_or(0);
+                let source_errors = &self.overloads()[source_overload_index].errors;
+                for error in source_errors {
+                    if error.is_relevant_for_partial_application() {
+                        let error = error.clone().maybe_apply_argument_index_offset(Some(1));
+                        if !partial_overload.errors.contains(&error) {
+                            partial_overload.errors.push(error);
+                        }
+                    }
+                }
+
+                // When no overload is compatible with the bound arguments, don't manufacture a
+                // precise reduced signature from an arbitrary overloaded callable shape.
+                if self.overloads().len() > 1 {
+                    return None;
+                }
+
+                vec![source_overload_index]
+            }
+        };
+
+        let signature_arguments = bound_call_arguments.with_self(self.bound_type);
+        let applications: SmallVec<_> = selected_overload_indexes
+            .into_iter()
+            .filter_map(|index| {
+                self.overloads().get(index).map(|overload| {
+                    overload.partial_signature_application(signature_arguments.as_ref(), db)
+                })
+            })
+            .collect();
+        (!applications.is_empty()).then_some(applications)
     }
 
     pub(crate) fn with_bound_type(mut self, bound_type: Type<'db>) -> Self {
@@ -4842,7 +5128,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     );
                 } else {
                     let index = callable_binding
-                        .matching_overload_before_type_checking
+                        .best_failing_overload_index(
+                            FailingOverloadSelection::AffectsOverloadResolution,
+                        )
                         .unwrap_or(0);
                     // TODO: We should also update the specialization for the `ParamSpec` to reflect
                     // the matching overload here.
@@ -5255,6 +5543,131 @@ impl<'db> Binding<'db> {
     /// argument was matched to that parameter.
     pub(crate) fn parameter_types(&self) -> &[Option<Type<'db>>] {
         &self.parameter_tys
+    }
+
+    /// Returns the reduced callable type exposed by this `functools.partial(...)` overload.
+    fn functools_partial_return_type<'a>(
+        &mut self,
+        db: &'db dyn Db,
+        call_arguments: &CallArguments<'a, 'db>,
+    ) -> Option<Type<'db>> {
+        // `partial(...)` receives the wrapped callable as its first explicit argument (after
+        // constructor receiver handling).
+        let func_ty = match self.parameter_types() {
+            [Some(func_ty), ..] => *func_ty,
+            _ => return None,
+        };
+        let fallback_return_type =
+            KnownClass::FunctoolsPartial.to_specialized_instance(db, &[Type::unknown()]);
+
+        let (bound_call_arguments, partial_bindings) =
+            Bindings::functools_partial_matched_bindings(db, func_ty, call_arguments)?;
+
+        // Reuse call-binding machinery to resolve which wrapped overloads are compatible with
+        // bound arguments and to surface binding diagnostics.
+        let partial_bindings = match partial_bindings.check_types(
+            db,
+            &ConstraintSetBuilder::new(),
+            &bound_call_arguments,
+            TypeContext::default(),
+            &[],
+        ) {
+            Ok(bindings) => bindings,
+            Err(CallError(_, bindings)) => *bindings,
+        };
+        let new_return_type =
+            partial_bindings.functools_partial_type(db, func_ty, self, &bound_call_arguments);
+
+        Some(if new_return_type.is_never() {
+            fallback_return_type
+        } else {
+            new_return_type
+        })
+    }
+
+    /// `functools.partial(...)` is allowed to leave required parameters unbound.
+    fn clear_missing_argument_errors_for_partial_application(&mut self) {
+        self.errors
+            .retain(|error| !matches!(error, BindingError::MissingArguments { .. }));
+    }
+
+    /// Downstream constructor validation is deferred until after partial signatures are merged.
+    fn clear_deferred_constructor_errors_for_partial_application(&mut self) {
+        self.errors.retain(|error| {
+            !matches!(
+                error,
+                BindingError::MissingArguments { .. }
+                    | BindingError::UnknownArgument { .. }
+                    | BindingError::PositionalOnlyParameterAsKwarg { .. }
+                    | BindingError::TooManyPositionalArguments { .. }
+                    | BindingError::ParameterAlreadyAssigned { .. }
+            )
+        });
+    }
+
+    /// Collects the parameter-level effects of a `functools.partial(...)` application.
+    fn partial_application(&self, arguments: &CallArguments<'_, 'db>) -> PartialApplication<'db> {
+        let parameters = self.signature.parameters().as_slice();
+        let mut partial_application = PartialApplication::new(parameters.len());
+
+        for ((argument, argument_ty), argument_matches) in
+            arguments.iter().zip(&self.argument_matches)
+        {
+            match argument {
+                Argument::Positional | Argument::Synthetic | Argument::Variadic => {
+                    for (parameter_index, _) in argument_matches.iter() {
+                        let parameter = &parameters[parameter_index];
+                        if parameter.is_positional()
+                            && parameter.annotated_type() != Type::Never
+                            && !parameter.is_variadic()
+                            && !parameter.is_keyword_variadic()
+                        {
+                            partial_application.bind_positionally(parameter_index);
+                        }
+                    }
+                }
+                Argument::Keyword(_) | Argument::Keywords => {
+                    for (parameter_index, matched_ty) in argument_matches.iter() {
+                        if partial_application.is_positionally_bound(parameter_index) {
+                            continue;
+                        }
+
+                        let parameter = &parameters[parameter_index];
+                        if parameter.is_positional_only()
+                            || parameter.is_variadic()
+                            || parameter.is_keyword_variadic()
+                        {
+                            continue;
+                        }
+
+                        partial_application.bind_by_keyword(
+                            parameter_index,
+                            (parameter.annotated_type() != Type::Never).then(|| {
+                                matched_ty.unwrap_or_else(|| {
+                                    argument_ty.get_default().unwrap_or_else(Type::unknown)
+                                })
+                            }),
+                        );
+                    }
+                }
+            }
+        }
+
+        partial_application
+    }
+
+    /// Packages the information needed to synthesize this overload's reduced partial signature.
+    fn partial_signature_application(
+        &self,
+        arguments: &CallArguments<'_, 'db>,
+        db: &'db dyn Db,
+    ) -> PartialSignatureApplication<'db> {
+        PartialSignatureApplication::new(
+            self.signature.clone(),
+            self.partial_application(arguments),
+            self.specialization,
+            self.unspecialized_return_type(db),
+        )
     }
 
     /// Returns the bound type for the specified parameter, or `None` if no argument was matched to
@@ -5712,6 +6125,27 @@ pub(crate) enum BindingError<'db> {
 }
 
 impl BindingError<'_> {
+    /// Returns whether this error is relevant to `functools.partial(...)` construction.
+    ///
+    /// These errors are used both to filter incompatible wrapped overloads and to report
+    /// statically-detectable call-shape errors at construction time. (Runtime `functools.partial`
+    /// can defer some call-shape errors until invocation.)
+    ///
+    /// For example, `partial(f, 1)` should ignore `MissingArguments` for the parameters that stay
+    /// unbound, while `partial(f, "x")` should still report `InvalidArgumentType` immediately.
+    fn is_relevant_for_partial_application(&self) -> bool {
+        matches!(
+            self,
+            Self::InvalidArgumentType { .. }
+                | Self::InvalidKeyType { .. }
+                | Self::UnknownArgument { .. }
+                | Self::PositionalOnlyParameterAsKwarg { .. }
+                | Self::TooManyPositionalArguments { .. }
+                | Self::ParameterAlreadyAssigned { .. }
+                | Self::SpecializationError { .. }
+        )
+    }
+
     pub(crate) fn maybe_apply_argument_index_offset(mut self, offset: Option<usize>) -> Self {
         if let Some(offset) = offset {
             self.apply_argument_index_offset(offset);

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5646,7 +5646,7 @@ impl<'db> Binding<'db> {
                 .is_some_and(|first_bound_index| index >= first_bound_index)
                 && matches!(parameter.kind(), ParameterKind::PositionalOrKeyword { .. })
             {
-                parameter = positional_or_keyword_to_keyword_only(&parameter);
+                parameter = parameter.positional_or_keyword_to_keyword_only();
             }
 
             if parameter.is_keyword_variadic() {
@@ -5851,25 +5851,6 @@ impl<'db> Binding<'db> {
         self.parameter_tys = Box::from([]);
         self.errors.clear();
     }
-}
-
-/// Rewrites a positional-or-keyword parameter as keyword-only while preserving its metadata.
-fn positional_or_keyword_to_keyword_only<'db>(parameter: &Parameter<'db>) -> Parameter<'db> {
-    let ParameterKind::PositionalOrKeyword { name, .. } = parameter.kind() else {
-        return parameter.clone();
-    };
-
-    let was_type_form = matches!(parameter.form, ParameterForm::Type);
-
-    let mut parameter = Parameter::keyword_only(name.clone())
-        .with_annotated_type(parameter.annotated_type())
-        .with_optional_default_type(parameter.default_type());
-
-    if was_type_form {
-        parameter = parameter.type_form();
-    }
-
-    parameter
 }
 
 /// Expands adjacent `P.args`/`P.kwargs` placeholders into their mapped parameters.

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -1,4 +1,5 @@
 use ruff_python_ast::name::Name;
+use rustc_hash::FxHashSet;
 use smallvec::{SmallVec, smallvec_inline};
 
 use crate::{
@@ -6,12 +7,13 @@ use crate::{
     place::Place,
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarInstance, ClassType, FindLegacyTypeVarsVisitor,
-        KnownClass, KnownInstanceType, LiteralValueTypeKind, MemberLookupPolicy, Parameter,
-        Parameters, Signature, SubclassOfInner, Type, TypeContext, TypeMapping,
+        InternedType, KnownClass, KnownInstanceType, LiteralValueTypeKind, MemberLookupPolicy,
+        Parameter, Parameters, Signature, SubclassOfInner, Type, TypeContext, TypeMapping,
         TypeVarBoundOrConstraints, UnionType,
         constraints::{ConstraintSet, IteratorConstraintsExtension},
+        known_instance::FunctoolsPartialInstance,
         relation::{TypeRelation, TypeRelationChecker},
-        signatures::CallableSignature,
+        signatures::{CallableSignature, PartialSignatureApplication},
         visitor, walk_signature,
     },
 };
@@ -372,10 +374,33 @@ impl<'db> CallableType<'db> {
         CallableType::new(db, self.signatures(db), CallableTypeKind::Regular)
     }
 
+    /// Returns the reduced callable produced by partially applying selected overloads.
+    pub(crate) fn partially_apply(
+        db: &'db dyn Db,
+        overloads: impl IntoIterator<Item = PartialSignatureApplication<'db>>,
+    ) -> Option<Self> {
+        Some(Self::new(
+            db,
+            CallableSignature::partially_apply(db, overloads)?,
+            CallableTypeKind::Regular,
+        ))
+    }
+
     /// Reifies this callable as the nominal `functools.partial[T]` instance for its return type.
     pub(crate) fn into_functools_partial_instance(self, db: &'db dyn Db) -> Type<'db> {
         let return_ty = self.signatures(db).overload_return_type_or_unknown(db);
         KnownClass::FunctoolsPartial.to_specialized_instance(db, &[return_ty])
+    }
+
+    /// Wraps this reduced callable as a synthetic `functools.partial(...)` instance type.
+    pub(crate) fn into_precise_functools_partial_instance(
+        self,
+        db: &'db dyn Db,
+        wrapped: Type<'db>,
+    ) -> Type<'db> {
+        Type::KnownInstance(KnownInstanceType::FunctoolsPartial(
+            FunctoolsPartialInstance::new(db, InternedType::new(db, wrapped), self),
+        ))
     }
 
     pub(crate) fn bind_self(
@@ -503,6 +528,35 @@ impl<'db> CallableTypes<'db> {
 
     pub(crate) fn map(self, mut f: impl FnMut(CallableType<'db>) -> CallableType<'db>) -> Self {
         Self::from_elements(self.0.iter().map(|element| f(*element)))
+    }
+
+    /// Merges reduced callables into one precise `functools.partial(...)` instance type.
+    pub(crate) fn into_precise_functools_partial_instance(
+        self,
+        db: &'db dyn Db,
+        wrapped: Type<'db>,
+    ) -> Type<'db> {
+        let mut overloads = Vec::new();
+        let mut seen_overloads = FxHashSet::default();
+
+        for callable in self.0 {
+            for signature in callable.signatures(db) {
+                let signature = signature.clone();
+                let dedup_key = signature.clone().with_definition(None);
+                if seen_overloads.insert(dedup_key) {
+                    overloads.push(signature);
+                }
+            }
+        }
+
+        debug_assert!(!overloads.is_empty(), "CallableTypes should not be empty");
+
+        CallableType::new(
+            db,
+            CallableSignature::from_overloads(overloads),
+            CallableTypeKind::Regular,
+        )
+        .into_precise_functools_partial_instance(db, wrapped)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -6,9 +6,9 @@ use crate::{
     place::Place,
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarInstance, ClassType, FindLegacyTypeVarsVisitor,
-        KnownInstanceType, LiteralValueTypeKind, MemberLookupPolicy, Parameter, Parameters,
-        Signature, SubclassOfInner, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
-        UnionType,
+        KnownClass, KnownInstanceType, LiteralValueTypeKind, MemberLookupPolicy, Parameter,
+        Parameters, Signature, SubclassOfInner, Type, TypeContext, TypeMapping,
+        TypeVarBoundOrConstraints, UnionType,
         constraints::{ConstraintSet, IteratorConstraintsExtension},
         relation::{TypeRelation, TypeRelationChecker},
         signatures::CallableSignature,
@@ -213,6 +213,10 @@ impl<'db> Type<'db> {
             | Type::TypeGuard(_)
             | Type::TypedDict(_) => None,
 
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
+                Some(CallableTypes::one(partial.partial(db)))
+            }
+
             // TODO
             Type::DataclassDecorator(_)
             | Type::ModuleLiteral(_)
@@ -366,6 +370,12 @@ impl<'db> CallableType<'db> {
 
     pub(crate) fn into_regular(self, db: &'db dyn Db) -> CallableType<'db> {
         CallableType::new(db, self.signatures(db), CallableTypeKind::Regular)
+    }
+
+    /// Reifies this callable as the nominal `functools.partial[T]` instance for its return type.
+    pub(crate) fn into_functools_partial_instance(self, db: &'db dyn Db) -> Type<'db> {
+        let return_ty = self.signatures(db).overload_return_type_or_unknown(db);
+        KnownClass::FunctoolsPartial.to_specialized_instance(db, &[return_ty])
     }
 
     pub(crate) fn bind_self(

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -1,4 +1,5 @@
 use ruff_python_ast::name::Name;
+use rustc_hash::FxHashSet;
 use smallvec::{SmallVec, smallvec_inline};
 
 use crate::{
@@ -6,12 +7,13 @@ use crate::{
     place::Place,
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarInstance, ClassType, FindLegacyTypeVarsVisitor,
-        KnownInstanceType, LiteralValueTypeKind, MemberLookupPolicy, Parameter, Parameters,
-        Signature, SubclassOfInner, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
-        UnionType,
+        InternedType, KnownClass, KnownInstanceType, LiteralValueTypeKind, MemberLookupPolicy,
+        Parameter, Parameters, Signature, SubclassOfInner, Type, TypeContext, TypeMapping,
+        TypeVarBoundOrConstraints, UnionType,
         constraints::{ConstraintSet, IteratorConstraintsExtension},
+        known_instance::FunctoolsPartialInstance,
         relation::{TypeRelation, TypeRelationChecker},
-        signatures::CallableSignature,
+        signatures::{CallableSignature, PartialSignatureApplication},
         visitor, walk_signature,
     },
 };
@@ -213,6 +215,10 @@ impl<'db> Type<'db> {
             | Type::TypeGuard(_)
             | Type::TypedDict(_) => None,
 
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
+                Some(CallableTypes::one(partial.partial(db)))
+            }
+
             // TODO
             Type::DataclassDecorator(_)
             | Type::ModuleLiteral(_)
@@ -368,6 +374,35 @@ impl<'db> CallableType<'db> {
         CallableType::new(db, self.signatures(db), CallableTypeKind::Regular)
     }
 
+    /// Returns the reduced callable produced by partially applying selected overloads.
+    pub(crate) fn partially_apply(
+        db: &'db dyn Db,
+        overloads: impl IntoIterator<Item = PartialSignatureApplication<'db>>,
+    ) -> Option<Self> {
+        Some(Self::new(
+            db,
+            CallableSignature::partially_apply(db, overloads)?,
+            CallableTypeKind::Regular,
+        ))
+    }
+
+    /// Reifies this callable as the nominal `functools.partial[T]` instance for its return type.
+    pub(crate) fn into_functools_partial_instance(self, db: &'db dyn Db) -> Type<'db> {
+        let return_ty = self.signatures(db).overload_return_type_or_unknown(db);
+        KnownClass::FunctoolsPartial.to_specialized_instance(db, &[return_ty])
+    }
+
+    /// Wraps this reduced callable as a synthetic `functools.partial(...)` instance type.
+    pub(crate) fn into_precise_functools_partial_instance(
+        self,
+        db: &'db dyn Db,
+        wrapped: Type<'db>,
+    ) -> Type<'db> {
+        Type::KnownInstance(KnownInstanceType::FunctoolsPartial(
+            FunctoolsPartialInstance::new(db, InternedType::new(db, wrapped), self),
+        ))
+    }
+
     pub(crate) fn bind_self(
         self,
         db: &'db dyn Db,
@@ -493,6 +528,35 @@ impl<'db> CallableTypes<'db> {
 
     pub(crate) fn map(self, mut f: impl FnMut(CallableType<'db>) -> CallableType<'db>) -> Self {
         Self::from_elements(self.0.iter().map(|element| f(*element)))
+    }
+
+    /// Merges reduced callables into one precise `functools.partial(...)` instance type.
+    pub(crate) fn into_precise_functools_partial_instance(
+        self,
+        db: &'db dyn Db,
+        wrapped: Type<'db>,
+    ) -> Type<'db> {
+        let mut overloads = Vec::new();
+        let mut seen_overloads = FxHashSet::default();
+
+        for callable in self.0 {
+            for signature in callable.signatures(db) {
+                let signature = signature.clone();
+                let dedup_key = signature.clone().with_definition(None);
+                if seen_overloads.insert(dedup_key) {
+                    overloads.push(signature);
+                }
+            }
+        }
+
+        debug_assert!(!overloads.is_empty(), "CallableTypes should not be empty");
+
+        CallableType::new(
+            db,
+            CallableSignature::from_overloads(overloads),
+            CallableTypeKind::Regular,
+        )
+        .into_precise_functools_partial_instance(db, wrapped)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -136,6 +136,8 @@ pub enum KnownClass {
     Template,
     // pathlib
     Path,
+    // functools
+    FunctoolsPartial,
     // ty_extensions
     ConstraintSet,
     GenericContext,
@@ -254,6 +256,7 @@ impl KnownClass {
             | Self::GenericContext
             | Self::Specialization
             | Self::ProtocolMeta
+            | Self::FunctoolsPartial
             | Self::TypedDictFallback => Some(Truthiness::Ambiguous),
 
             Self::Tuple => None,
@@ -350,7 +353,8 @@ impl KnownClass {
             | KnownClass::BuiltinFunctionType
             | KnownClass::ProtocolMeta
             | KnownClass::Template
-            | KnownClass::Path => false,
+            | KnownClass::Path
+            | KnownClass::FunctoolsPartial => false,
         }
     }
 
@@ -443,7 +447,8 @@ impl KnownClass {
             | KnownClass::BuiltinFunctionType
             | KnownClass::ProtocolMeta
             | KnownClass::Template
-            | KnownClass::Path => false,
+            | KnownClass::Path
+            | KnownClass::FunctoolsPartial => false,
         }
     }
 
@@ -535,7 +540,8 @@ impl KnownClass {
             | KnownClass::BuiltinFunctionType
             | KnownClass::ProtocolMeta
             | KnownClass::Template
-            | KnownClass::Path => false,
+            | KnownClass::Path
+            | KnownClass::FunctoolsPartial => false,
         }
     }
 
@@ -639,6 +645,7 @@ impl KnownClass {
             | Self::ProtocolMeta
             | Self::Template
             | Self::Path
+            | Self::FunctoolsPartial
             | Self::Mapping
             | Self::Sequence => false,
         }
@@ -733,6 +740,7 @@ impl KnownClass {
             | KnownClass::NamedTupleLike
             | KnownClass::Template
             | KnownClass::Path
+            | KnownClass::FunctoolsPartial
             | KnownClass::ConstraintSet
             | KnownClass::GenericContext
             | KnownClass::Specialization => false,
@@ -856,6 +864,7 @@ impl KnownClass {
             Self::TypedDictFallback => "TypedDictFallback",
             Self::Template => "Template",
             Self::Path => "Path",
+            Self::FunctoolsPartial => "partial",
             Self::ProtocolMeta => "_ProtocolMeta",
         }
     }
@@ -1239,6 +1248,7 @@ impl KnownClass {
             | Self::Specialization => KnownModule::TyExtensions,
             Self::Template => KnownModule::Templatelib,
             Self::Path => KnownModule::Pathlib,
+            Self::FunctoolsPartial => KnownModule::Functools,
         }
     }
 
@@ -1333,7 +1343,8 @@ impl KnownClass {
             | Self::BuiltinFunctionType
             | Self::ProtocolMeta
             | Self::Template
-            | Self::Path => Some(false),
+            | Self::Path
+            | Self::FunctoolsPartial => Some(false),
 
             Self::Tuple => None,
         }
@@ -1431,7 +1442,8 @@ impl KnownClass {
             | Self::BuiltinFunctionType
             | Self::ProtocolMeta
             | Self::Template
-            | Self::Path => false,
+            | Self::Path
+            | Self::FunctoolsPartial => false,
         }
     }
 
@@ -1542,6 +1554,7 @@ impl KnownClass {
             "TypedDictFallback" => &[Self::TypedDictFallback],
             "Template" => &[Self::Template],
             "Path" => &[Self::Path],
+            "partial" => &[Self::FunctoolsPartial],
             "_ProtocolMeta" => &[Self::ProtocolMeta],
             _ => return None,
         };
@@ -1627,7 +1640,8 @@ impl KnownClass {
             | Self::Generator
             | Self::AsyncGenerator
             | Self::Template
-            | Self::Path => module == self.canonical_module(db),
+            | Self::Path
+            | Self::FunctoolsPartial => module == self.canonical_module(db),
             Self::NoneType => matches!(module, KnownModule::Typeshed | KnownModule::Types),
             Self::SpecialForm
             | Self::TypeAliasType

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -194,7 +194,8 @@ impl<'db> ClassBase<'db> {
                 // A class inheriting from a newtype would make intuitive sense, but newtype
                 // wrappers are just identity callables at runtime, so this sort of inheritance
                 // doesn't work and isn't allowed.
-                | KnownInstanceType::NewType(_) => None,
+                | KnownInstanceType::NewType(_)
+                | KnownInstanceType::FunctoolsPartial(_) => None,
                 KnownInstanceType::TypeGenericAlias(_) => {
                     Self::try_from_type(db, KnownClass::Type.to_class_literal(db), subclass)
                 }

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -3105,6 +3105,13 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
                 f.write_str("'>")
             }
             KnownInstanceType::NamedTupleSpec(_) => f.write_str("NamedTupleSpec"),
+            KnownInstanceType::FunctoolsPartial(partial) => {
+                f.write_str("partial[")?;
+                Type::Callable(partial.partial(self.db))
+                    .display_with(self.db, DisplaySettings::default().singleline())
+                    .fmt_detailed(f)?;
+                f.write_str("]")
+            }
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -3110,6 +3110,13 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
                 f.write_str("'>")
             }
             KnownInstanceType::NamedTupleSpec(_) => f.write_str("NamedTupleSpec"),
+            KnownInstanceType::FunctoolsPartial(partial) => {
+                f.write_str("partial[")?;
+                Type::Callable(partial.partial(self.db))
+                    .display_with(self.db, DisplaySettings::default().singleline())
+                    .fmt_detailed(f)?;
+                f.write_str("]")
+            }
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -878,46 +878,53 @@ impl<'db> GenericContext<'db> {
         I: IntoIterator<Item = Option<Type<'db>>>,
         I::IntoIter: ExactSizeIterator,
     {
-        fn specialize_recursive_impl<'db>(
-            db: &'db dyn Db,
-            context: GenericContext<'db>,
-            mut types: Box<[Type<'db>]>,
-        ) -> Specialization<'db> {
-            let len = types.len();
-            loop {
-                let mut any_changed = false;
-                for i in 0..len {
-                    let specialization = ApplySpecialization::Partial {
-                        generic_context: context,
-                        types: &types,
-                        // Don't recursively substitute type[i] in itself. Ideally, we could instead
-                        // check if the result is self-referential after we're done applying the
-                        // partial specialization. But when we apply a paramspec, we don't use the
-                        // callable that it maps to directly; we create a new callable that reuses
-                        // parts of it. That means we can't look for the previous type directly.
-                        // Instead we use this to skip specializing the type in itself in the first
-                        // place.
-                        skip: Some(i),
-                    };
-                    let updated = types[i].apply_type_mapping(
-                        db,
-                        &TypeMapping::ApplySpecialization(specialization),
-                        TypeContext::default(),
-                    );
-                    if updated != types[i] {
-                        types[i] = updated;
-                        any_changed = true;
-                    }
+        let types = self.fill_in_defaults(db, types);
+        self.specialize_from_types_recursive(db, types)
+    }
+
+    /// Builds a specialization and recursively resolves references between the chosen types.
+    fn specialize_from_types_recursive(
+        self,
+        db: &'db dyn Db,
+        mut types: Box<[Type<'db>]>,
+    ) -> Specialization<'db> {
+        let len = types.len();
+        let variables = self.variables(db).collect_vec();
+        loop {
+            let mut any_changed = false;
+            for i in 0..len {
+                // Preserve identity mappings for unresolved type variables.
+                if types[i] == Type::TypeVar(variables[i]) {
+                    continue;
                 }
 
-                if !any_changed {
-                    return Specialization::new(db, context, types, None, None);
+                let specialization = ApplySpecialization::Partial {
+                    generic_context: self,
+                    types: &types,
+                    // Don't recursively substitute type[i] in itself. Ideally, we could instead
+                    // check if the result is self-referential after we're done applying the
+                    // partial specialization. But when we apply a paramspec, we don't use the
+                    // callable that it maps to directly; we create a new callable that reuses
+                    // parts of it. That means we can't look for the previous type directly.
+                    // Instead we use this to skip specializing the type in itself in the first
+                    // place.
+                    skip: Some(i),
+                };
+                let updated = types[i].apply_type_mapping(
+                    db,
+                    &TypeMapping::ApplySpecialization(specialization),
+                    TypeContext::default(),
+                );
+                if updated != types[i] {
+                    types[i] = updated;
+                    any_changed = true;
                 }
             }
-        }
 
-        let types = self.fill_in_defaults(db, types);
-        specialize_recursive_impl(db, self, types)
+            if !any_changed {
+                return Specialization::new(db, self, types, None, None);
+            }
+        }
     }
 
     /// Creates a specialization of this generic context for the `tuple` class.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -877,46 +877,53 @@ impl<'db> GenericContext<'db> {
         I: IntoIterator<Item = Option<Type<'db>>>,
         I::IntoIter: ExactSizeIterator,
     {
-        fn specialize_recursive_impl<'db>(
-            db: &'db dyn Db,
-            context: GenericContext<'db>,
-            mut types: Box<[Type<'db>]>,
-        ) -> Specialization<'db> {
-            let len = types.len();
-            loop {
-                let mut any_changed = false;
-                for i in 0..len {
-                    let specialization = ApplySpecialization::Partial {
-                        generic_context: context,
-                        types: &types,
-                        // Don't recursively substitute type[i] in itself. Ideally, we could instead
-                        // check if the result is self-referential after we're done applying the
-                        // partial specialization. But when we apply a paramspec, we don't use the
-                        // callable that it maps to directly; we create a new callable that reuses
-                        // parts of it. That means we can't look for the previous type directly.
-                        // Instead we use this to skip specializing the type in itself in the first
-                        // place.
-                        skip: Some(i),
-                    };
-                    let updated = types[i].apply_type_mapping(
-                        db,
-                        &TypeMapping::ApplySpecialization(specialization),
-                        TypeContext::default(),
-                    );
-                    if updated != types[i] {
-                        types[i] = updated;
-                        any_changed = true;
-                    }
+        let types = self.fill_in_defaults(db, types);
+        self.specialize_from_types_recursive(db, types)
+    }
+
+    /// Builds a specialization and recursively resolves references between the chosen types.
+    fn specialize_from_types_recursive(
+        self,
+        db: &'db dyn Db,
+        mut types: Box<[Type<'db>]>,
+    ) -> Specialization<'db> {
+        let len = types.len();
+        let variables = self.variables(db).collect_vec();
+        loop {
+            let mut any_changed = false;
+            for i in 0..len {
+                // Preserve identity mappings for unresolved type variables.
+                if types[i] == Type::TypeVar(variables[i]) {
+                    continue;
                 }
 
-                if !any_changed {
-                    return Specialization::new(db, context, types, None, None);
+                let specialization = ApplySpecialization::Partial {
+                    generic_context: self,
+                    types: &types,
+                    // Don't recursively substitute type[i] in itself. Ideally, we could instead
+                    // check if the result is self-referential after we're done applying the
+                    // partial specialization. But when we apply a paramspec, we don't use the
+                    // callable that it maps to directly; we create a new callable that reuses
+                    // parts of it. That means we can't look for the previous type directly.
+                    // Instead we use this to skip specializing the type in itself in the first
+                    // place.
+                    skip: Some(i),
+                };
+                let updated = types[i].apply_type_mapping(
+                    db,
+                    &TypeMapping::ApplySpecialization(specialization),
+                    TypeContext::default(),
+                );
+                if updated != types[i] {
+                    types[i] = updated;
+                    any_changed = true;
                 }
             }
-        }
 
-        let types = self.fill_in_defaults(db, types);
-        specialize_recursive_impl(db, self, types)
+            if !any_changed {
+                return Specialization::new(db, self, types, None, None);
+            }
+        }
     }
 
     /// Creates a specialization of this generic context for the `tuple` class.

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1541,6 +1541,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                     Type::unknown()
                 }
+                KnownInstanceType::FunctoolsPartial(_) => {
+                    self.infer_type_expression(&subscript.slice);
+                    if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                        builder.into_diagnostic(format_args!(
+                            "`functools.partial` instances cannot be specialized",
+                        ));
+                    }
+                    Type::unknown()
+                }
             },
             Type::Dynamic(DynamicType::UnknownGeneric(_)) => {
                 self.infer_explicit_type_alias_specialization(subscript, value_ty, true)

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1618,6 +1618,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                     Type::unknown()
                 }
+                KnownInstanceType::FunctoolsPartial(_) => {
+                    self.infer_type_expression(&subscript.slice);
+                    if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                        builder.into_diagnostic(format_args!(
+                            "`functools.partial` instances cannot be specialized",
+                        ));
+                    }
+                    Type::unknown()
+                }
             },
             Type::Dynamic(DynamicType::UnknownGeneric(_)) => {
                 self.infer_explicit_type_alias_specialization(subscript, value_ty, true)

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -32,6 +32,16 @@ pub struct InternedConstraintSet<'db> {
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for InternedConstraintSet<'_> {}
 
+/// A salsa-interned payload for `functools.partial(...)` instances.
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+pub struct FunctoolsPartialInstance<'db> {
+    pub wrapped: InternedType<'db>,
+    pub partial: CallableType<'db>,
+}
+
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for FunctoolsPartialInstance<'_> {}
+
 /// Singleton types that are heavily special-cased by ty. Despite its name,
 /// quite a different type to [`super::NominalInstanceType`].
 ///
@@ -104,6 +114,10 @@ pub enum KnownInstanceType<'db> {
 
     /// The inferred spec for a functional `NamedTuple` class.
     NamedTupleSpec(NamedTupleSpec<'db>),
+
+    /// A `functools.partial(func, ...)` call result where we could determine
+    /// the remaining callable signature after binding some arguments.
+    FunctoolsPartial(FunctoolsPartialInstance<'db>),
 }
 
 pub(super) fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
@@ -158,6 +172,9 @@ pub(super) fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Size
             for field in spec.fields(db) {
                 visitor.visit_type(db, field.ty);
             }
+        }
+        KnownInstanceType::FunctoolsPartial(partial) => {
+            visitor.visit_callable_type(db, partial.partial(db));
         }
     }
 }
@@ -221,6 +238,9 @@ impl<'db> KnownInstanceType<'db> {
             Self::NamedTupleSpec(spec) => spec
                 .recursive_type_normalized_impl(db, div, true)
                 .map(Self::NamedTupleSpec),
+            Self::FunctoolsPartial(partial) => partial
+                .recursive_type_normalized_impl(db, div, nested)
+                .map(Self::FunctoolsPartial),
         }
     }
 
@@ -248,6 +268,7 @@ impl<'db> KnownInstanceType<'db> {
             Self::LiteralStringAlias(_) => KnownClass::Str,
             Self::NewType(_) => KnownClass::NewType,
             Self::NamedTupleSpec(_) => KnownClass::Sequence,
+            Self::FunctoolsPartial(_) => KnownClass::FunctoolsPartial,
         }
     }
 
@@ -260,7 +281,7 @@ impl<'db> KnownInstanceType<'db> {
     /// For example, an alias created using the `type` statement is an instance of
     /// `typing.TypeAliasType`, so `KnownInstanceType::TypeAliasType(_).instance_fallback(db)`
     /// returns `Type::NominalInstance(NominalInstanceType { class: <typing.TypeAliasType> })`.
-    pub(super) fn instance_fallback(self, db: &dyn Db) -> Type<'_> {
+    pub(super) fn instance_fallback(self, db: &'db dyn Db) -> Type<'db> {
         self.class(db).to_instance(db)
     }
 
@@ -311,6 +332,11 @@ impl<'db> KnownInstanceType<'db> {
             KnownInstanceType::Callable(callable_type) => {
                 Type::KnownInstance(KnownInstanceType::Callable(
                     callable_type.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                ))
+            }
+            KnownInstanceType::FunctoolsPartial(partial) => {
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(
+                    partial.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 ))
             }
             KnownInstanceType::TypeGenericAlias(ty) => {
@@ -554,6 +580,49 @@ impl<'db> UnionTypeInstance<'db> {
         };
 
         Some(Self::new(db, value_expr_types, union_type))
+    }
+}
+
+impl<'db> FunctoolsPartialInstance<'db> {
+    /// Normalizes both the wrapped callable and the exposed reduced callable recursively.
+    fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        Some(Self::new(
+            db,
+            InternedType::new(
+                db,
+                self.wrapped(db)
+                    .inner(db)
+                    .recursive_type_normalized_impl(db, div, nested)?,
+            ),
+            self.partial(db)
+                .recursive_type_normalized_impl(db, div, nested)?,
+        ))
+    }
+
+    /// Applies a type mapping to both the wrapped callable and the exposed reduced callable.
+    fn apply_type_mapping_impl(
+        self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'_, 'db>,
+        tcx: TypeContext<'db>,
+        visitor: &ApplyTypeMappingVisitor<'db>,
+    ) -> Self {
+        Self::new(
+            db,
+            InternedType::new(
+                db,
+                self.wrapped(db)
+                    .inner(db)
+                    .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            ),
+            self.partial(db)
+                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+        )
     }
 }
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -865,6 +865,26 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     })
             }
 
+            (
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(source_partial)),
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(target_partial)),
+            ) => self.with_recursion_guard(source, target, || {
+                self.check_callable_pair(db, source_partial.partial(db), target_partial.partial(db))
+            }),
+
+            // When checking `FunctoolsPartial <: functools.partial[T]`, we need to specialize
+            // the nominal instance with the partial's return type so the check is precise.
+            (
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)),
+                Type::NominalInstance(target_instance),
+            ) if target_instance
+                .class(db)
+                .is_known(db, KnownClass::FunctoolsPartial) =>
+            {
+                let specialized = partial.partial(db).into_functools_partial_instance(db);
+                self.check_type_pair(db, specialized, target)
+            }
+
             // Dynamic is only a subtype of `object` and only a supertype of `Never`; both were
             // handled above. It's always assignable, though.
             //
@@ -1227,6 +1247,22 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // only subtypes of each other if they result in the same signature.
             (Type::FunctionLiteral(source_function), Type::FunctionLiteral(target_function)) => {
                 self.check_function_pair(db, source_function, target_function)
+            }
+            (
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(source_partial)),
+                Type::FunctionLiteral(target_function),
+            ) if matches!(
+                self.relation,
+                TypeRelation::Assignability | TypeRelation::ConstraintSetAssignability
+            ) =>
+            {
+                self.with_recursion_guard(source, target, || {
+                    self.check_callable_signature_pair(
+                        db,
+                        source_partial.partial(db).signatures(db),
+                        target_function.into_callable_type(db).signatures(db),
+                    )
+                })
             }
             (Type::BoundMethod(source_method), Type::BoundMethod(target_method)) => {
                 self.check_bound_method_pair(db, source_method, target_method)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -980,6 +980,26 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     })
             }
 
+            (
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(source_partial)),
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(target_partial)),
+            ) => self.with_recursion_guard(source, target, || {
+                self.check_callable_pair(db, source_partial.partial(db), target_partial.partial(db))
+            }),
+
+            // When checking `FunctoolsPartial <: functools.partial[T]`, we need to specialize
+            // the nominal instance with the partial's return type so the check is precise.
+            (
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)),
+                Type::NominalInstance(target_instance),
+            ) if target_instance
+                .class(db)
+                .is_known(db, KnownClass::FunctoolsPartial) =>
+            {
+                let specialized = partial.partial(db).into_functools_partial_instance(db);
+                self.check_type_pair(db, specialized, target)
+            }
+
             // Dynamic is only a subtype of `object` and only a supertype of `Never`; both were
             // handled above. It's always assignable, though.
             //
@@ -1446,6 +1466,22 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // only subtypes of each other if they result in the same signature.
             (Type::FunctionLiteral(source_function), Type::FunctionLiteral(target_function)) => {
                 self.check_function_pair(db, source_function, target_function)
+            }
+            (
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(source_partial)),
+                Type::FunctionLiteral(target_function),
+            ) if matches!(
+                self.relation,
+                TypeRelation::Assignability | TypeRelation::ConstraintSetAssignability
+            ) =>
+            {
+                self.with_recursion_guard(source, target, || {
+                    self.check_callable_signature_pair(
+                        db,
+                        source_partial.partial(db).signatures(db),
+                        target_function.into_callable_type(db).signatures(db),
+                    )
+                })
             }
             (Type::BoundMethod(source_method), Type::BoundMethod(target_method)) => {
                 self.check_bound_method_pair(db, source_method, target_method)

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -74,6 +74,33 @@ pub struct CallableSignature<'db> {
     pub(crate) overloads: SmallVec<[Signature<'db>; 1]>,
 }
 
+/// The per-overload information needed to synthesize one reduced signature for
+/// `functools.partial(...)`.
+#[derive(Clone, Debug)]
+pub(crate) struct PartialSignatureApplication<'db> {
+    signature: Signature<'db>,
+    partial_application: PartialApplication<'db>,
+    specialization: Option<Specialization<'db>>,
+    unspecialized_return_ty: Type<'db>,
+}
+
+impl<'db> PartialSignatureApplication<'db> {
+    /// Creates a new per-overload partial-application summary.
+    pub(crate) fn new(
+        signature: Signature<'db>,
+        partial_application: PartialApplication<'db>,
+        specialization: Option<Specialization<'db>>,
+        unspecialized_return_ty: Type<'db>,
+    ) -> Self {
+        Self {
+            signature,
+            partial_application,
+            specialization,
+            unspecialized_return_ty,
+        }
+    }
+}
+
 impl<'db> CallableSignature<'db> {
     pub(crate) fn single(signature: Signature<'db>) -> Self {
         Self {
@@ -119,6 +146,30 @@ impl<'db> CallableSignature<'db> {
                 .clone()
                 .with_inherited_generic_context(db, inherited_generic_context)
         }))
+    }
+
+    /// Returns the reduced overloaded signature exposed by a `functools.partial(...)` object.
+    pub(crate) fn partially_apply(
+        db: &'db dyn Db,
+        overloads: impl IntoIterator<Item = PartialSignatureApplication<'db>>,
+    ) -> Option<Self> {
+        let mut new_overloads = Vec::new();
+        let mut seen_overloads = FxHashSet::default();
+
+        for overload in overloads {
+            let signature = overload.signature.partially_apply(
+                db,
+                &overload.partial_application,
+                overload.specialization,
+                overload.unspecialized_return_ty,
+            );
+            let dedup_key = signature.clone().with_definition(None);
+            if seen_overloads.insert(dedup_key) {
+                new_overloads.push(signature);
+            }
+        }
+
+        (!new_overloads.is_empty()).then(|| Self::from_overloads(new_overloads))
     }
 
     pub(crate) fn cycle_normalized(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -424,6 +424,10 @@ pub(super) fn walk_signature<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     visitor.visit_type(db, signature.return_ty);
 }
 
+/// Describes how a `functools.partial(...)` call binds one overload's parameters.
+///
+/// `call/bind.rs` computes this from argument matching. Signature rewriting then consumes this
+/// summary to synthesize the reduced callable that a partial object exposes.
 #[derive(Clone, Debug)]
 pub(crate) struct PartialApplication<'db> {
     positionally_bound: Box<[bool]>,
@@ -432,6 +436,8 @@ pub(crate) struct PartialApplication<'db> {
 }
 
 impl<'db> PartialApplication<'db> {
+    /// Creates an empty partial-application summary for a signature with `parameter_count`
+    /// parameters.
     pub(crate) fn new(parameter_count: usize) -> Self {
         Self {
             positionally_bound: vec![false; parameter_count].into_boxed_slice(),
@@ -440,10 +446,13 @@ impl<'db> PartialApplication<'db> {
         }
     }
 
+    /// Marks the parameter at `parameter_index` as consumed by a positional binding.
     pub(crate) fn bind_positionally(&mut self, parameter_index: usize) {
         self.positionally_bound[parameter_index] = true;
     }
 
+    /// Marks the parameter at `parameter_index` as bound by keyword and records the synthesized
+    /// default type that should appear in the reduced signature, if any.
     pub(crate) fn bind_by_keyword(
         &mut self,
         parameter_index: usize,
@@ -453,6 +462,8 @@ impl<'db> PartialApplication<'db> {
         self.keyword_defaults[parameter_index] = default_ty;
     }
 
+    /// Returns `true` if the parameter at `parameter_index` is removed from the reduced signature
+    /// because it was already supplied positionally to `functools.partial(...)`.
     pub(crate) fn is_positionally_bound(&self, parameter_index: usize) -> bool {
         self.positionally_bound[parameter_index]
     }

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -16,12 +16,14 @@ use itertools::{EitherOrBoth, Itertools};
 use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec_inline};
 
-use super::{DynamicType, Type, TypeVarVariance, semantic_index};
+use super::{DynamicType, Type, TypeVarVariance, UnionType, semantic_index};
 use crate::types::callable::CallableTypeKind;
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
 };
-use crate::types::generics::{GenericContext, InferableTypeVars, walk_generic_context};
+use crate::types::generics::{
+    ApplySpecialization, GenericContext, InferableTypeVars, Specialization, walk_generic_context,
+};
 use crate::types::infer::infer_deferred_types;
 use crate::types::relation::{
     HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
@@ -95,6 +97,15 @@ impl<'db> CallableSignature<'db> {
 
     pub(crate) fn iter(&self) -> std::slice::Iter<'_, Signature<'db>> {
         self.overloads.iter()
+    }
+
+    /// Returns the union of all overload return types, or `Unknown` if there are no overloads.
+    pub(crate) fn overload_return_type_or_unknown(&self, db: &'db dyn Db) -> Type<'db> {
+        match self.overloads.as_slice() {
+            [] => Type::unknown(),
+            [signature] => signature.return_ty,
+            overloads => UnionType::from_elements(db, overloads.iter().map(|sig| sig.return_ty)),
+        }
     }
 
     pub(crate) fn with_inherited_generic_context(
@@ -751,6 +762,22 @@ impl<'db> Signature<'db> {
         }
     }
 
+    /// Returns this signature with the given specialization applied to parameters and return type.
+    pub(crate) fn apply_specialization(
+        &self,
+        db: &'db dyn Db,
+        specialization: Specialization<'db>,
+    ) -> Self {
+        let type_mapping =
+            TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(specialization));
+        self.apply_type_mapping_impl(
+            db,
+            &type_mapping,
+            TypeContext::default(),
+            &ApplyTypeMappingVisitor::default(),
+        )
+    }
+
     fn inferable_typevars(&self, db: &'db dyn Db) -> InferableTypeVars<'db> {
         match self.generic_context {
             Some(generic_context) => generic_context.inferable_typevars(db),
@@ -829,6 +856,11 @@ impl<'db> Signature<'db> {
     /// Create a new signature with the given definition.
     pub(crate) fn with_definition(self, definition: Option<Definition<'db>>) -> Self {
         Self { definition, ..self }
+    }
+
+    /// Create a new signature with the given parameters.
+    pub(crate) fn with_parameters(self, parameters: Parameters<'db>) -> Self {
+        Self { parameters, ..self }
     }
 
     /// Create a new signature with the given return type.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -14,16 +14,18 @@ use std::collections::BTreeMap;
 use std::slice::Iter;
 
 use itertools::{Either, EitherOrBoth, Itertools};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::{SmallVec, smallvec_inline};
 
-use super::{DynamicType, Type, TypeVarVariance, semantic_index};
+use super::{DynamicType, Type, TypeVarVariance, UnionType, semantic_index};
 use crate::types::callable::CallableTypeKind;
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
 };
 use crate::types::cyclic::ActiveRecursionDetector;
-use crate::types::generics::{GenericContext, InferableTypeVars, walk_generic_context};
+use crate::types::generics::{
+    ApplySpecialization, GenericContext, InferableTypeVars, Specialization, walk_generic_context,
+};
 use crate::types::infer::{TypeExpressionFlags, infer_deferred_types};
 use crate::types::relation::{
     HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
@@ -32,6 +34,7 @@ use crate::types::typed_dict::{
     UnpackedTypedDictKey, extract_unpacked_typed_dict_keys_from_kwargs_annotation,
     extract_unpacked_typed_dict_keys_from_value_type,
 };
+use crate::types::typevar::BoundTypeVarIdentity;
 use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType, ErrorContext,
     FindLegacyTypeVarsVisitor, KnownClass, MaterializationKind, ParamSpecAttrKind,
@@ -95,6 +98,33 @@ pub struct CallableSignature<'db> {
     pub(crate) overloads: SmallVec<[Signature<'db>; 1]>,
 }
 
+/// The per-overload information needed to synthesize one reduced signature for
+/// `functools.partial(...)`.
+#[derive(Clone, Debug)]
+pub(crate) struct PartialSignatureApplication<'db> {
+    signature: Signature<'db>,
+    partial_application: PartialApplication<'db>,
+    specialization: Option<Specialization<'db>>,
+    unspecialized_return_ty: Type<'db>,
+}
+
+impl<'db> PartialSignatureApplication<'db> {
+    /// Creates a new per-overload partial-application summary.
+    pub(crate) fn new(
+        signature: Signature<'db>,
+        partial_application: PartialApplication<'db>,
+        specialization: Option<Specialization<'db>>,
+        unspecialized_return_ty: Type<'db>,
+    ) -> Self {
+        Self {
+            signature,
+            partial_application,
+            specialization,
+            unspecialized_return_ty,
+        }
+    }
+}
+
 impl<'db> CallableSignature<'db> {
     pub(crate) fn single(signature: Signature<'db>) -> Self {
         Self {
@@ -121,6 +151,15 @@ impl<'db> CallableSignature<'db> {
         self.overloads.iter()
     }
 
+    /// Returns the union of all overload return types, or `Unknown` if there are no overloads.
+    pub(crate) fn overload_return_type_or_unknown(&self, db: &'db dyn Db) -> Type<'db> {
+        match self.overloads.as_slice() {
+            [] => Type::unknown(),
+            [signature] => signature.return_ty,
+            overloads => UnionType::from_elements(db, overloads.iter().map(|sig| sig.return_ty)),
+        }
+    }
+
     pub(crate) fn with_inherited_generic_context(
         &self,
         db: &'db dyn Db,
@@ -131,6 +170,30 @@ impl<'db> CallableSignature<'db> {
                 .clone()
                 .with_inherited_generic_context(db, inherited_generic_context)
         }))
+    }
+
+    /// Returns the reduced overloaded signature exposed by a `functools.partial(...)` object.
+    pub(crate) fn partially_apply(
+        db: &'db dyn Db,
+        overloads: impl IntoIterator<Item = PartialSignatureApplication<'db>>,
+    ) -> Option<Self> {
+        let mut new_overloads = Vec::new();
+        let mut seen_overloads = FxHashSet::default();
+
+        for overload in overloads {
+            let signature = overload.signature.partially_apply(
+                db,
+                &overload.partial_application,
+                overload.specialization,
+                overload.unspecialized_return_ty,
+            );
+            let dedup_key = signature.clone().with_definition(None);
+            if seen_overloads.insert(dedup_key) {
+                new_overloads.push(signature);
+            }
+        }
+
+        (!new_overloads.is_empty()).then(|| Self::from_overloads(new_overloads))
     }
 
     pub(crate) fn cycle_normalized(
@@ -463,6 +526,59 @@ pub(super) fn walk_signature<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
         visitor.visit_type(db, parameter.annotated_type());
     }
     visitor.visit_type(db, signature.return_ty);
+}
+
+/// Describes how a `functools.partial(...)` call binds one overload's parameters.
+///
+/// `call/bind.rs` computes this from argument matching. Signature rewriting then consumes this
+/// summary to synthesize the reduced callable that a partial object exposes.
+#[derive(Clone, Debug)]
+pub(crate) struct PartialApplication<'db> {
+    positionally_bound: Box<[bool]>,
+    keyword_defaults: Box<[Option<Type<'db>>]>,
+    keyword_bound: Box<[bool]>,
+}
+
+impl<'db> PartialApplication<'db> {
+    /// Creates an empty partial-application summary for a signature with `parameter_count`
+    /// parameters.
+    pub(crate) fn new(parameter_count: usize) -> Self {
+        Self {
+            positionally_bound: vec![false; parameter_count].into_boxed_slice(),
+            keyword_defaults: vec![None; parameter_count].into_boxed_slice(),
+            keyword_bound: vec![false; parameter_count].into_boxed_slice(),
+        }
+    }
+
+    /// Marks the parameter at `parameter_index` as consumed by a positional binding.
+    pub(crate) fn bind_positionally(&mut self, parameter_index: usize) {
+        self.positionally_bound[parameter_index] = true;
+    }
+
+    /// Marks the parameter at `parameter_index` as bound by keyword and records the synthesized
+    /// default type that should appear in the reduced signature, if any.
+    pub(crate) fn bind_by_keyword(
+        &mut self,
+        parameter_index: usize,
+        default_ty: Option<Type<'db>>,
+    ) {
+        self.keyword_bound[parameter_index] = true;
+        self.keyword_defaults[parameter_index] = default_ty;
+    }
+
+    /// Returns `true` if the parameter at `parameter_index` is removed from the reduced signature
+    /// because it was already supplied positionally to `functools.partial(...)`.
+    pub(crate) fn is_positionally_bound(&self, parameter_index: usize) -> bool {
+        self.positionally_bound[parameter_index]
+    }
+
+    fn keyword_default(&self, parameter_index: usize) -> Option<Type<'db>> {
+        self.keyword_defaults[parameter_index]
+    }
+
+    fn is_keyword_bound(&self, parameter_index: usize) -> bool {
+        self.keyword_bound[parameter_index]
+    }
 }
 
 impl<'db> Signature<'db> {
@@ -804,6 +920,152 @@ impl<'db> Signature<'db> {
         }
     }
 
+    /// Returns this signature with the given specialization applied to parameters and return type.
+    pub(crate) fn apply_specialization(
+        &self,
+        db: &'db dyn Db,
+        specialization: Specialization<'db>,
+    ) -> Self {
+        let type_mapping =
+            TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(specialization));
+        self.apply_type_mapping_impl(
+            db,
+            &type_mapping,
+            TypeContext::default(),
+            &ApplyTypeMappingVisitor::default(),
+        )
+    }
+
+    /// Returns the callable signature produced by partially applying this signature.
+    pub(crate) fn partially_apply(
+        &self,
+        db: &'db dyn Db,
+        partial_application: &PartialApplication<'db>,
+        specialization: Option<Specialization<'db>>,
+        unspecialized_return_ty: Type<'db>,
+    ) -> Self {
+        let signature_specialization =
+            self.partial_application_specialization(db, partial_application, specialization);
+        let signature = signature_specialization.map_or_else(
+            || self.clone(),
+            |specialization| self.apply_specialization(db, specialization),
+        );
+
+        let parameters = signature.parameters().as_slice();
+        let return_ty = specialization.map_or_else(
+            || unspecialized_return_ty,
+            |specialization| {
+                unspecialized_return_ty
+                    .apply_specialization(db, signature_specialization.unwrap_or(specialization))
+            },
+        );
+
+        let mut remaining = Vec::with_capacity(parameters.len());
+        let mut first_keyword_bound_positional_or_keyword = None;
+        for (index, parameter) in parameters.iter().enumerate() {
+            if partial_application.is_positionally_bound(index) {
+                continue;
+            }
+
+            let parameter = partial_application.keyword_default(index).map_or_else(
+                || parameter.clone(),
+                |default_ty| parameter.clone().with_default_type(default_ty),
+            );
+
+            if first_keyword_bound_positional_or_keyword.is_none()
+                && partial_application.is_keyword_bound(index)
+                && matches!(parameter.kind(), ParameterKind::PositionalOrKeyword { .. })
+            {
+                first_keyword_bound_positional_or_keyword = Some(remaining.len());
+            }
+
+            remaining.push(parameter);
+        }
+
+        // Expand `P.args`/`P.kwargs` while the pair is still adjacent. The keyword-only reshuffle
+        // below can separate them, which would otherwise prevent expansion.
+        let remaining = Parameters::new(db, remaining).expand_paramspec_variadics(db);
+
+        let mut reordered = Vec::with_capacity(remaining.len());
+        let mut keyword_only = Vec::new();
+        let mut keyword_variadic = Vec::new();
+        for (index, parameter) in remaining.iter().cloned().enumerate() {
+            let parameter = if first_keyword_bound_positional_or_keyword
+                .is_some_and(|first_bound_index| index >= first_bound_index)
+                && matches!(parameter.kind(), ParameterKind::PositionalOrKeyword { .. })
+            {
+                parameter.positional_or_keyword_to_keyword_only()
+            } else {
+                parameter
+            };
+
+            if parameter.is_keyword_variadic() {
+                keyword_variadic.push(parameter);
+            } else if parameter.is_keyword_only() {
+                keyword_only.push(parameter);
+            } else {
+                reordered.push(parameter);
+            }
+        }
+
+        reordered.extend(keyword_only);
+        reordered.extend(keyword_variadic);
+
+        signature
+            .with_parameters(Parameters::new(db, reordered))
+            .with_return_type(return_ty)
+    }
+
+    /// Returns the specialization used for the callable signature exposed by a partial object.
+    ///
+    /// Surviving type variables that still appear in the reduced parameter list may need a more
+    /// specific specialization than the plain return-type view.
+    fn partial_application_specialization(
+        &self,
+        db: &'db dyn Db,
+        partial_application: &PartialApplication<'db>,
+        specialization: Option<Specialization<'db>>,
+    ) -> Option<Specialization<'db>> {
+        let specialization = specialization?;
+        let Some(generic_context) = self.generic_context else {
+            return Some(specialization);
+        };
+
+        let promoted_typevars: FxHashSet<BoundTypeVarIdentity<'db>> = generic_context
+            .variables(db)
+            .filter(|typevar| {
+                self.parameters
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, _)| !partial_application.is_positionally_bound(*index))
+                    .any(|(_, parameter)| {
+                        parameter
+                            .annotated_type()
+                            .references_typevar(db, typevar.typevar(db).identity(db))
+                    })
+            })
+            .map(|typevar| typevar.identity(db))
+            .collect();
+
+        if promoted_typevars.is_empty() {
+            return Some(specialization);
+        }
+
+        Some(generic_context.specialize_recursive(
+            db,
+            generic_context.variables(db).map(|typevar| {
+                let ty = specialization
+                    .get(db, typevar)
+                    .unwrap_or(Type::TypeVar(typevar));
+                Some(if promoted_typevars.contains(&typevar.identity(db)) {
+                    ty.promote(db)
+                } else {
+                    ty
+                })
+            }),
+        ))
+    }
+
     fn inferable_typevars(&self, db: &'db dyn Db) -> InferableTypeVars<'db> {
         match self.generic_context {
             Some(generic_context) => generic_context.inferable_typevars(db),
@@ -884,6 +1146,11 @@ impl<'db> Signature<'db> {
     /// Create a new signature with the given definition.
     pub(crate) fn with_definition(self, definition: Option<Definition<'db>>) -> Self {
         Self { definition, ..self }
+    }
+
+    /// Create a new signature with the given parameters.
+    pub(crate) fn with_parameters(self, parameters: Parameters<'db>) -> Self {
+        Self { parameters, ..self }
     }
 
     /// Create a new signature with the given return type.
@@ -3137,6 +3404,62 @@ impl<'db> Parameters<'db> {
             .enumerate()
             .rfind(|(_, parameter)| parameter.is_keyword_variadic())
     }
+
+    /// Expands adjacent `P.args`/`P.kwargs` placeholders into their mapped parameters.
+    pub(crate) fn expand_paramspec_variadics(&self, db: &'db dyn Db) -> Self {
+        let mut variadic_index = None;
+        let mut paramspec_callable = None;
+
+        for (index, parameter) in self.iter().enumerate() {
+            if !parameter.is_variadic() {
+                continue;
+            }
+
+            let Type::Callable(callable) = parameter.annotated_type() else {
+                continue;
+            };
+            if callable.kind(db) != CallableTypeKind::ParamSpecValue {
+                continue;
+            }
+
+            variadic_index = Some(index);
+            paramspec_callable = Some(callable);
+            break;
+        }
+
+        let Some(variadic_index) = variadic_index else {
+            return self.clone();
+        };
+        let Some(paramspec_callable) = paramspec_callable else {
+            return self.clone();
+        };
+
+        let Some(keyword_variadic) = self.get(variadic_index + 1) else {
+            return self.clone();
+        };
+        if !keyword_variadic.is_keyword_variadic() {
+            return self.clone();
+        }
+
+        let Type::Callable(keyword_callable) = keyword_variadic.annotated_type() else {
+            return self.clone();
+        };
+        if keyword_callable.kind(db) != CallableTypeKind::ParamSpecValue
+            || keyword_callable != paramspec_callable
+        {
+            return self.clone();
+        }
+
+        let [mapped_signature] = paramspec_callable.signatures(db).overloads.as_slice() else {
+            return self.clone();
+        };
+
+        let mut expanded = Vec::with_capacity(self.len());
+        expanded.extend_from_slice(&self.value[..variadic_index]);
+        expanded.extend_from_slice(mapped_signature.parameters().as_slice());
+        expanded.extend_from_slice(&self.value[variadic_index + 2..]);
+        Parameters::new(db, expanded)
+    }
 }
 
 impl<'db, 'a> IntoIterator for &'a Parameters<'db> {
@@ -3586,6 +3909,18 @@ impl<'db> Parameter<'db> {
             | ParameterKind::KeywordOnly { default_type, .. } => default_type,
             ParameterKind::Variadic { .. } | ParameterKind::KeywordVariadic { .. } => None,
         }
+    }
+
+    /// Rewrites a positional-or-keyword parameter as keyword-only while preserving its metadata.
+    pub(crate) fn positional_or_keyword_to_keyword_only(&self) -> Self {
+        let mut result = self.clone();
+        if let ParameterKind::PositionalOrKeyword { name, default_type } = &self.kind {
+            result.kind = ParameterKind::KeywordOnly {
+                name: name.clone(),
+                default_type: *default_type,
+            };
+        }
+        result
     }
 }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -13,7 +13,7 @@
 use std::slice::Iter;
 
 use itertools::{EitherOrBoth, Itertools};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::{SmallVec, smallvec_inline};
 
 use super::{DynamicType, Type, TypeVarVariance, UnionType, semantic_index};
@@ -28,6 +28,7 @@ use crate::types::infer::infer_deferred_types;
 use crate::types::relation::{
     HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
 };
+use crate::types::typevar::BoundTypeVarIdentity;
 use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType,
     FindLegacyTypeVarsVisitor, KnownClass, MaterializationKind, ParamSpecAttrKind, SelfBinding,
@@ -423,6 +424,48 @@ pub(super) fn walk_signature<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     visitor.visit_type(db, signature.return_ty);
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct PartialApplication<'db> {
+    positionally_bound: Box<[bool]>,
+    keyword_defaults: Box<[Option<Type<'db>>]>,
+    keyword_bound: Box<[bool]>,
+}
+
+impl<'db> PartialApplication<'db> {
+    pub(crate) fn new(parameter_count: usize) -> Self {
+        Self {
+            positionally_bound: vec![false; parameter_count].into_boxed_slice(),
+            keyword_defaults: vec![None; parameter_count].into_boxed_slice(),
+            keyword_bound: vec![false; parameter_count].into_boxed_slice(),
+        }
+    }
+
+    pub(crate) fn bind_positionally(&mut self, parameter_index: usize) {
+        self.positionally_bound[parameter_index] = true;
+    }
+
+    pub(crate) fn bind_by_keyword(
+        &mut self,
+        parameter_index: usize,
+        default_ty: Option<Type<'db>>,
+    ) {
+        self.keyword_bound[parameter_index] = true;
+        self.keyword_defaults[parameter_index] = default_ty;
+    }
+
+    pub(crate) fn is_positionally_bound(&self, parameter_index: usize) -> bool {
+        self.positionally_bound[parameter_index]
+    }
+
+    fn keyword_default(&self, parameter_index: usize) -> Option<Type<'db>> {
+        self.keyword_defaults[parameter_index]
+    }
+
+    fn is_keyword_bound(&self, parameter_index: usize) -> bool {
+        self.keyword_bound[parameter_index]
+    }
+}
+
 impl<'db> Signature<'db> {
     pub(crate) fn new(parameters: Parameters<'db>, return_ty: Type<'db>) -> Self {
         Self {
@@ -776,6 +819,136 @@ impl<'db> Signature<'db> {
             TypeContext::default(),
             &ApplyTypeMappingVisitor::default(),
         )
+    }
+
+    /// Returns the callable signature produced by partially applying this signature.
+    pub(crate) fn partially_apply(
+        &self,
+        db: &'db dyn Db,
+        partial_application: &PartialApplication<'db>,
+        specialization: Option<Specialization<'db>>,
+        unspecialized_return_ty: Type<'db>,
+    ) -> Self {
+        let signature_specialization =
+            self.partial_application_specialization(db, partial_application, specialization);
+        let signature = signature_specialization.map_or_else(
+            || self.clone(),
+            |specialization| self.apply_specialization(db, specialization),
+        );
+
+        let parameters = signature.parameters().as_slice();
+        let return_ty = specialization.map_or_else(
+            || unspecialized_return_ty,
+            |specialization| {
+                unspecialized_return_ty
+                    .apply_specialization(db, signature_specialization.unwrap_or(specialization))
+            },
+        );
+
+        let mut remaining = Vec::with_capacity(parameters.len());
+        let mut first_keyword_bound_positional_or_keyword = None;
+        for (index, parameter) in parameters.iter().enumerate() {
+            if partial_application.is_positionally_bound(index) {
+                continue;
+            }
+
+            let parameter = partial_application.keyword_default(index).map_or_else(
+                || parameter.clone(),
+                |default_ty| parameter.clone().with_default_type(default_ty),
+            );
+
+            if first_keyword_bound_positional_or_keyword.is_none()
+                && partial_application.is_keyword_bound(index)
+                && matches!(parameter.kind(), ParameterKind::PositionalOrKeyword { .. })
+            {
+                first_keyword_bound_positional_or_keyword = Some(remaining.len());
+            }
+
+            remaining.push(parameter);
+        }
+
+        // Expand `P.args`/`P.kwargs` while the pair is still adjacent. The keyword-only reshuffle
+        // below can separate them, which would otherwise prevent expansion.
+        let remaining = Parameters::new(db, remaining).expand_paramspec_variadics(db);
+
+        let mut reordered = Vec::with_capacity(remaining.len());
+        let mut keyword_only = Vec::new();
+        let mut keyword_variadic = Vec::new();
+        for (index, parameter) in remaining.iter().cloned().enumerate() {
+            let parameter = if first_keyword_bound_positional_or_keyword
+                .is_some_and(|first_bound_index| index >= first_bound_index)
+                && matches!(parameter.kind(), ParameterKind::PositionalOrKeyword { .. })
+            {
+                parameter.positional_or_keyword_to_keyword_only()
+            } else {
+                parameter
+            };
+
+            if parameter.is_keyword_variadic() {
+                keyword_variadic.push(parameter);
+            } else if parameter.is_keyword_only() {
+                keyword_only.push(parameter);
+            } else {
+                reordered.push(parameter);
+            }
+        }
+
+        reordered.extend(keyword_only);
+        reordered.extend(keyword_variadic);
+
+        signature
+            .with_parameters(Parameters::new(db, reordered))
+            .with_return_type(return_ty)
+    }
+
+    /// Returns the specialization used for the callable signature exposed by a partial object.
+    ///
+    /// Surviving type variables that still appear in the reduced parameter list may need a more
+    /// specific specialization than the plain return-type view.
+    fn partial_application_specialization(
+        &self,
+        db: &'db dyn Db,
+        partial_application: &PartialApplication<'db>,
+        specialization: Option<Specialization<'db>>,
+    ) -> Option<Specialization<'db>> {
+        let specialization = specialization?;
+        let Some(generic_context) = self.generic_context else {
+            return Some(specialization);
+        };
+
+        let promoted_typevars: FxHashSet<BoundTypeVarIdentity<'db>> = generic_context
+            .variables(db)
+            .filter(|typevar| {
+                self.parameters
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, _)| !partial_application.is_positionally_bound(*index))
+                    .any(|(_, parameter)| {
+                        parameter
+                            .annotated_type()
+                            .references_typevar(db, typevar.typevar(db).identity(db))
+                    })
+            })
+            .map(|typevar| typevar.identity(db))
+            .collect();
+
+        if promoted_typevars.is_empty() {
+            return Some(specialization);
+        }
+
+        Some(generic_context.specialize_recursive(
+            db,
+            generic_context.variables(db).map(|typevar| {
+                let ty = specialization
+                    .get(db, typevar)
+                    .unwrap_or(Type::TypeVar(typevar));
+                Some(if promoted_typevars.contains(&typevar.identity(db)) {
+                    ty.promote(db)
+                } else {
+                    ty
+                })
+            }),
+        ))
     }
 
     fn inferable_typevars(&self, db: &'db dyn Db) -> InferableTypeVars<'db> {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -3267,6 +3267,18 @@ impl<'db> Parameter<'db> {
             ParameterKind::Variadic { .. } | ParameterKind::KeywordVariadic { .. } => None,
         }
     }
+
+    /// Rewrites a positional-or-keyword parameter as keyword-only while preserving its metadata.
+    pub(crate) fn positional_or_keyword_to_keyword_only(&self) -> Self {
+        let mut result = self.clone();
+        if let ParameterKind::PositionalOrKeyword { name, default_type } = &self.kind {
+            result.kind = ParameterKind::KeywordOnly {
+                name: name.clone(),
+                default_type: *default_type,
+            };
+        }
+        result
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2891,6 +2891,62 @@ impl<'db> Parameters<'db> {
             .enumerate()
             .rfind(|(_, parameter)| parameter.is_keyword_variadic())
     }
+
+    /// Expands adjacent `P.args`/`P.kwargs` placeholders into their mapped parameters.
+    pub(crate) fn expand_paramspec_variadics(&self, db: &'db dyn Db) -> Self {
+        let mut variadic_index = None;
+        let mut paramspec_callable = None;
+
+        for (index, parameter) in self.iter().enumerate() {
+            if !parameter.is_variadic() {
+                continue;
+            }
+
+            let Type::Callable(callable) = parameter.annotated_type() else {
+                continue;
+            };
+            if callable.kind(db) != CallableTypeKind::ParamSpecValue {
+                continue;
+            }
+
+            variadic_index = Some(index);
+            paramspec_callable = Some(callable);
+            break;
+        }
+
+        let Some(variadic_index) = variadic_index else {
+            return self.clone();
+        };
+        let Some(paramspec_callable) = paramspec_callable else {
+            return self.clone();
+        };
+
+        let Some(keyword_variadic) = self.get(variadic_index + 1) else {
+            return self.clone();
+        };
+        if !keyword_variadic.is_keyword_variadic() {
+            return self.clone();
+        }
+
+        let Type::Callable(keyword_callable) = keyword_variadic.annotated_type() else {
+            return self.clone();
+        };
+        if keyword_callable.kind(db) != CallableTypeKind::ParamSpecValue
+            || keyword_callable != paramspec_callable
+        {
+            return self.clone();
+        }
+
+        let [mapped_signature] = paramspec_callable.signatures(db).overloads.as_slice() else {
+            return self.clone();
+        };
+
+        let mut expanded = Vec::with_capacity(self.len());
+        expanded.extend_from_slice(&self.value[..variadic_index]);
+        expanded.extend_from_slice(mapped_signature.parameters().as_slice());
+        expanded.extend_from_slice(&self.value[variadic_index + 2..]);
+        Parameters::new(db, expanded)
+    }
 }
 
 impl<'db, 'a> IntoIterator for &'a Parameters<'db> {


### PR DESCRIPTION
## Summary

This PR adds initial support for `functools.partial`, including:

- Constructor-time checking of bound arguments (e.g., `partial(f, "x")` should report an immediate error if `"x` is not a valid type for the parameter)
- Reduced signatures for partials (e.g., `def f(a: int, b: str, *, c: bool) -> bytes` with `partial(f, 1)` becomes `partial[(b: str, *, c: bool) -> bytes]`).
- Support for overloads, assignability checks, and more.

There are a few things that are _not_ covered and were instead cordoned off into separate commits, namely:

- Preserving unprovided generic type variables in the returned partial signature (fixed in: https://github.com/astral-sh/ruff/pull/24583). As of this commit, we get:

```python
from functools import partial
from typing import TypeVar

T = TypeVar("T")
U = TypeVar("U")

def combine(a: T, b: U) -> tuple[T, U]:
    return (a, b)

# partial[(b: Unknown) -> tuple[Literal[1], Unknown]]
p = partial(combine, 1)
```

- Keyword overrides in generics (e.g., `partial(combine, b=1)` can later be called as `p("x", b="y")`, since keyword arguments can be overridden at call time -- TIL!).
- Constructor modeling (`__new__`, etc.)

But this gets us much of the way there. After this PR, I believe our handling of `functools.partial` is generally ahead of Mypy and Pyright with the significant exception of generic modeling, where ty is behind.

(I choose to include tests for the above in `crates/ty_python_semantic/resources/mdtest/call/functools_partial.md`, with TODOs, which get resolved in subsequent PRs.)

See: https://github.com/astral-sh/ty/issues/1536.
