### PR TITLE
fix typo: accomodate -> accommodate

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -9052,7 +9052,7 @@ raise <CURSOR>
                 // N.B. We very much want to use the default settings
                 // here, so that our test environment matches the
                 // production environment. If a default changes, the
-                // tests should be fixed to accomodate that change
+                // tests should be fixed to accommodate that change
                 // as well. ---AG
                 settings: CompletionSettings::default(),
                 skip_builtins: false,


### PR DESCRIPTION
Good day,

Found a typo in a comment in completion.rs. Fixed the typo 'accomodate' to 'accommodate'.

感谢你们的奉献，希望能提供帮助。如果我解决得有问题或有待商妥的地方，请在下面留言，我会来处理。

Warmly,