### PR TITLE
Add `ty_python_core` to the pr-assignee-pools.toml config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,5 +23,6 @@
 /crates/ty/ @carljm @MichaReiser @sharkdp @dcreager @ibraheemdev
 /crates/ty_wasm/ @carljm @MichaReiser @sharkdp @dcreager @Gankra
 /scripts/ty_benchmark/ @carljm @MichaReiser @AlexWaygood @sharkdp @dcreager @ibraheemdev
+/crates/ty_python_core/ @carljm @sharkdp @dcreager @ibraheemdev
 /crates/ty_python_semantic/ @carljm @AlexWaygood @sharkdp @dcreager @ibraheemdev
 /crates/ty_module_resolver/ @carljm @MichaReiser @AlexWaygood @Gankra @BurntSushi

--- a/.github/pr-assignee-pools.toml
+++ b/.github/pr-assignee-pools.toml
@@ -8,7 +8,7 @@ reviewers = ["amyreese", "ntBre"]
 
 [[pools]]
 name = "ty-semantic"
-paths = ["/crates/ty_python_semantic/**"]
+paths = ["/crates/ty_python_core/**", "/crates/ty_python_semantic/**"]
 reviewers = ["carljm", "charliermarsh", "sharkdp", "dcreager", "ibraheemdev", "oconnor663"]
 
 [[pools]]


### PR DESCRIPTION
Missed in https://github.com/astral-sh/ruff/pull/24471