### PR TITLE
mdtest.py: set `CARGO_PROFILE_DEV_OPT_LEVEL=1` unless filters were specified

### DIFF
--- a/crates/ty_python_semantic/mdtest.py
+++ b/crates/ty_python_semantic/mdtest.py
@@ -70,7 +70,11 @@ class MDTestRunner:
                 message_format,
             ],
             cwd=CRATE_ROOT,
-            env=dict(os.environ, CLI_COLOR="1"),
+            env=dict(
+                os.environ,
+                CLI_COLOR="1",
+                CARGO_PROFILE_DEV_OPT_LEVEL="0" if self.filters else "1",
+            ),
             stderr=subprocess.STDOUT,
             text=True,
         )


### PR DESCRIPTION
## Summary

Setting `CARGO_DEV_OPT_LEVEL=1` makes compile times much slower but mdtest runtime much faster. Overall, for a full run of ty's mdtest suite, it's faster to run mdtests (including compilation time) if you set this environment variable.

This PR sets the environment variable in mdtest.py, but only if filters weren't specified. If you specified a filter, only a (probably small) subset of mdtests will be run, so the compile time is going to dominate and setting this environment variable will be counterproductive. For a full mdtest run, though, it'll be helpful.

## Test Plan

I ran mdtest.py locally and observed that the whole mdtest suite finished in <3s, compared to 13.77s on `main`
