### PR TITLE
[ty] Revert addition of unnecessary complexity to `module_docstring` API

### DIFF
--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -133,17 +133,14 @@ impl<'db> Definition<'db> {
 }
 
 /// Extract a docstring from a function, module, or class body.
-fn docstring_from_body(body: &[ast::Stmt]) -> Option<&ast::ExprStringLiteral> {
+pub fn docstring_from_body(body: &[ast::Stmt]) -> Option<&ast::ExprStringLiteral> {
     let stmt = body.first()?;
     // Require the docstring to be a standalone expression.
-    let ast::Stmt::Expr(ast::StmtExpr {
+    let ast::StmtExpr {
         value,
         range: _,
         node_index: _,
-    }) = stmt
-    else {
-        return None;
-    };
+    } = stmt.as_expr_stmt()?;
     // Only match string literals.
     value.as_string_literal_expr()
 }

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -12,7 +12,6 @@ pub use db::Db;
 pub use diagnostic::add_inferred_python_version_hint_to_diagnostic;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
-use ruff_python_ast as ast;
 use rustc_hash::FxHasher;
 pub use semantic_model::{
     Completion, HasDefinition, HasOptionalDefinition, HasType, MemberDefinition, NameKind,
@@ -22,6 +21,7 @@ pub use suppression::{
     UNUSED_IGNORE_COMMENT, is_unused_ignore_comment_lint, suppress_all, suppress_single,
 };
 use ty_module_resolver::ModuleGlobSet;
+use ty_python_core::definition::docstring_from_body;
 use ty_python_core::platform::PythonPlatform;
 use ty_python_core::program::Program;
 use ty_python_core::scope::ScopeId;
@@ -154,10 +154,6 @@ pub(crate) fn attribute_declarations<'db, 's>(
 /// Get the module-level docstring for the given file.
 pub(crate) fn module_docstring(db: &dyn Db, file: File) -> Option<String> {
     let module = parsed_module(db, file).load(db);
-    let stmt = module.suite().first()?;
-    let ast::Stmt::Expr(ast::StmtExpr { value, .. }) = stmt else {
-        return None;
-    };
-    let docstring_expr = value.as_string_literal_expr()?;
-    Some(docstring_expr.value.to_str().to_owned())
+    docstring_from_body(module.suite())
+        .map(|docstring_expr| docstring_expr.value.to_str().to_owned())
 }


### PR DESCRIPTION
## Summary

Claude screwed this up in https://github.com/astral-sh/ruff/pull/24604 and I didn't notice until after merging (sorry)

## Test Plan

existing tests
