### PR TITLE
[ty] Inherit `dataclass_transform` metadata from metaclass bases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
@@ -1033,6 +1033,36 @@ Person("Alice", 30, [], "some notes", email="alice@example.com")
 Person("Bob", email="bob@example.com", notes="other notes")
 ```
 
+#### Inherited metaclass-based transformer
+
+```py
+from typing import Any, dataclass_transform
+
+def field(*, default: Any = ...) -> Any: ...
+
+@dataclass_transform(field_specifiers=(field,))
+class ModelMeta(type): ...
+
+class RegistryMeta(ModelMeta): ...
+class ModelBase(metaclass=RegistryMeta): ...
+
+class Person(ModelBase):
+    name: str
+    age: int = field(default=0)
+
+reveal_type(Person.__init__)  # revealed: (self: Person, name: str, age: int = ...) -> None
+
+Person("Alice")
+Person("Alice", 30)
+Person(name="Alice", age=30)
+
+# error: [missing-argument]
+Person(age=30)
+
+# error: [unknown-argument]
+Person(name="Alice", extra=1)
+```
+
 #### Base-class-based transformer
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -47,6 +47,33 @@ reveal_type(product.name)  # revealed: str
 reveal_type(product.internal_price_cent)  # revealed: int
 ```
 
+## Inherited `ModelMetaclass`
+
+Pydantic's metaclass-based `@dataclass_transform` metadata should continue to apply when a custom
+metaclass inherits from `ModelMetaclass`.
+
+```py
+from pydantic import BaseModel
+from pydantic._internal._model_construction import ModelMetaclass
+
+class RegistryMeta(ModelMetaclass): ...
+
+class User(BaseModel, metaclass=RegistryMeta):
+    name: str
+    age: int = 0
+
+reveal_type(User.__init__)  # revealed: (self: User, *, name: str, age: int = 0) -> None
+
+User(name="alice")
+User(name="alice", age=1)
+
+# error: [missing-argument]
+User()
+
+# error: [unknown-argument]
+User(name="alice", extra=1)
+```
+
 ## Validator and serializer decorators with explicit `@classmethod`
 
 Pydantic [recommends](https://docs.pydantic.dev/latest/concepts/validators/#class-validators) using

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -785,6 +785,27 @@ impl<'db> StaticClassLiteral<'db> {
             || transformer_params.is_some_and(|params| params.flags(db).contains(param))
     }
 
+    /// Returns the nearest `@dataclass_transform` parameters for this class or its MRO.
+    ///
+    /// This is used for metaclass-based transforms because `__dataclass_transform__` is inherited,
+    /// so a metaclass subclass should preserve the transform metadata of its decorated base class
+    /// unless it provides its own.
+    fn inherited_dataclass_transformer_params(
+        self,
+        db: &'db dyn Db,
+        specialization: Option<Specialization<'db>>,
+    ) -> Option<DataclassTransformerParams<'db>> {
+        self.dataclass_transformer_params(db).or_else(|| {
+            self.iter_mro(db, specialization).skip(1).find_map(|base| {
+                base.into_class().and_then(|class| {
+                    class
+                        .static_class_literal(db)
+                        .and_then(|(lit, _)| lit.dataclass_transformer_params(db))
+                })
+            })
+        })
+    }
+
     /// Return the explicit `metaclass` of this class, if one is defined.
     ///
     /// ## Note
@@ -945,7 +966,9 @@ impl<'db> StaticClassLiteral<'db> {
         let transform_info = candidate
             .metaclass
             .static_class_literal(db)
-            .and_then(|(metaclass_literal, _)| metaclass_literal.dataclass_transformer_params(db))
+            .and_then(|(metaclass_literal, specialization)| {
+                metaclass_literal.inherited_dataclass_transformer_params(db, specialization)
+            })
             .map(|params| MetaclassTransformInfo {
                 params,
                 from_explicit_metaclass: candidate.explicit_metaclass_of == self,


### PR DESCRIPTION
## Summary

This PR modifies our `dataclass_transform` handling to respect `@dataclass_transform` on inherited metaclasses. See https://github.com/astral-sh/ty/issues/3269 for an extensive write-up of the underlying issue.

Closes https://github.com/astral-sh/ty/issues/3269.
