### PR TITLE
Return stabilized `std::io::ErrorKind`s in ruff_db

### DIFF
--- a/crates/ruff_db/src/system/memory_fs.rs
+++ b/crates/ruff_db/src/system/memory_fs.rs
@@ -459,19 +459,15 @@ fn not_found() -> std::io::Error {
 }
 
 fn is_a_directory() -> std::io::Error {
-    // Note: Rust returns `ErrorKind::IsADirectory` for this error but this is a nightly only variant :(.
-    //   So we have to use other for now.
-    std::io::Error::other("Is a directory")
+    std::io::Error::from(std::io::ErrorKind::IsADirectory)
 }
 
 fn not_a_directory() -> std::io::Error {
-    // Note: Rust returns `ErrorKind::NotADirectory` for this error but this is a nightly only variant :(.
-    //   So we have to use `Other` for now.
-    std::io::Error::other("Not a directory")
+    std::io::Error::from(std::io::ErrorKind::NotADirectory)
 }
 
 fn directory_not_empty() -> std::io::Error {
-    std::io::Error::other("directory not empty")
+    std::io::Error::from(std::io::ErrorKind::DirectoryNotEmpty)
 }
 
 fn invalid_utf8() -> std::io::Error {
@@ -820,7 +816,7 @@ mod tests {
         let error = fs
             .create_directory_all(SystemPath::new("a/b.py/c"))
             .unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::Other);
+        assert_eq!(error.kind(), ErrorKind::NotADirectory);
     }
 
     #[test]
@@ -842,7 +838,7 @@ mod tests {
             .write_file_all(SystemPath::new("a/b.py/c"), "content")
             .unwrap_err();
 
-        assert_eq!(error.kind(), ErrorKind::Other);
+        assert_eq!(error.kind(), ErrorKind::NotADirectory);
     }
 
     #[test]
@@ -877,7 +873,7 @@ mod tests {
 
         let error = fs.read_to_string(SystemPath::new("a")).unwrap_err();
 
-        assert_eq!(error.kind(), ErrorKind::Other);
+        assert_eq!(error.kind(), ErrorKind::IsADirectory);
 
         Ok(())
     }
@@ -901,7 +897,7 @@ mod tests {
 
         let error = fs.write_file(SystemPath::new("a"), "content").unwrap_err();
 
-        assert_eq!(error.kind(), ErrorKind::Other);
+        assert_eq!(error.kind(), ErrorKind::IsADirectory);
 
         Ok(())
     }
@@ -959,7 +955,7 @@ mod tests {
         fs.create_directory_all("a")?;
 
         let error = fs.remove_file("a").unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::Other);
+        assert_eq!(error.kind(), ErrorKind::IsADirectory);
 
         Ok(())
     }
@@ -984,7 +980,7 @@ mod tests {
         let fs = with_files(["a/a.py"]);
 
         let error = fs.remove_directory("a").unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::Other);
+        assert_eq!(error.kind(), ErrorKind::DirectoryNotEmpty);
     }
 
     #[test]
@@ -1014,7 +1010,7 @@ mod tests {
         let fs = with_files(["a"]);
 
         let error = fs.remove_directory("a").unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::Other);
+        assert_eq!(error.kind(), ErrorKind::NotADirectory);
     }
 
     #[test]
@@ -1048,8 +1044,7 @@ mod tests {
         let Err(error) = fs.read_directory("a.py") else {
             panic!("Expected this to fail");
         };
-        assert_eq!(error.kind(), std::io::ErrorKind::Other);
-        assert!(error.to_string().contains("Not a directory"));
+        assert_eq!(error.kind(), std::io::ErrorKind::NotADirectory);
     }
 
     #[test]

--- a/crates/ruff_db/src/system/memory_fs.rs
+++ b/crates/ruff_db/src/system/memory_fs.rs
@@ -131,7 +131,7 @@ impl MemoryFileSystem {
                 Entry::File(file) => {
                     String::from_utf8(file.content.to_vec()).map_err(|_| invalid_utf8())
                 }
-                Entry::Directory(_) => Err(is_a_directory()),
+                Entry::Directory(_) => Err(io::Error::from(io::ErrorKind::IsADirectory)),
             }
         }
 
@@ -281,7 +281,7 @@ impl MemoryFileSystem {
                         entry.remove();
                         Ok(())
                     }
-                    Entry::Directory(_) => Err(is_a_directory()),
+                    Entry::Directory(_) => Err(io::Error::from(io::ErrorKind::IsADirectory)),
                 },
                 btree_map::Entry::Vacant(_) => Err(not_found()),
             }
@@ -336,7 +336,7 @@ impl MemoryFileSystem {
             // Skip the directory path itself
             for (maybe_child, _) in by_path.range(normalized.clone()..).skip(1) {
                 if maybe_child.starts_with(&normalized) {
-                    return Err(directory_not_empty());
+                    return Err(io::Error::from(io::ErrorKind::DirectoryNotEmpty));
                 } else if !maybe_child.as_str().starts_with(normalized.as_str()) {
                     break;
                 }
@@ -348,7 +348,7 @@ impl MemoryFileSystem {
                         entry.remove();
                         Ok(())
                     }
-                    Entry::File(_) => Err(not_a_directory()),
+                    Entry::File(_) => Err(io::Error::from(io::ErrorKind::NotADirectory)),
                 },
                 btree_map::Entry::Vacant(_) => Err(not_found()),
             }
@@ -367,7 +367,7 @@ impl MemoryFileSystem {
         let normalized = self.normalize_path(path.as_ref());
         let entry = by_path.get(&normalized).ok_or_else(not_found)?;
         if entry.is_file() {
-            return Err(not_a_directory());
+            return Err(io::Error::from(io::ErrorKind::NotADirectory));
         };
 
         // Collect the entries into a vector to avoid deadlocks when the
@@ -458,18 +458,6 @@ fn not_found() -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::NotFound, "No such file or directory")
 }
 
-fn is_a_directory() -> std::io::Error {
-    std::io::Error::from(std::io::ErrorKind::IsADirectory)
-}
-
-fn not_a_directory() -> std::io::Error {
-    std::io::Error::from(std::io::ErrorKind::NotADirectory)
-}
-
-fn directory_not_empty() -> std::io::Error {
-    std::io::Error::from(std::io::ErrorKind::DirectoryNotEmpty)
-}
-
 fn invalid_utf8() -> std::io::Error {
     std::io::Error::new(
         std::io::ErrorKind::InvalidData,
@@ -492,7 +480,7 @@ fn create_dir_all(
         });
 
         if entry.is_file() {
-            return Err(not_a_directory());
+            return Err(io::Error::from(io::ErrorKind::NotADirectory));
         }
     }
 
@@ -507,7 +495,7 @@ fn get_or_create_file<'a>(
         let parent_entry = paths.get(parent).ok_or_else(not_found)?;
 
         if parent_entry.is_file() {
-            return Err(not_a_directory());
+            return Err(io::Error::from(io::ErrorKind::NotADirectory));
         }
     }
 
@@ -520,7 +508,7 @@ fn get_or_create_file<'a>(
 
     match entry {
         Entry::File(file) => Ok(file),
-        Entry::Directory(_) => Err(is_a_directory()),
+        Entry::Directory(_) => Err(io::Error::from(io::ErrorKind::IsADirectory)),
     }
 }
 


### PR DESCRIPTION
Summary
--

Fixes #24614 by using the standard error variants stabilized in 1.83.

Test Plan
--

Existing tests updated to show the new variants

References
--

- https://blog.rust-lang.org/2024/11/28/Rust-1.83.0/#stabilized-apis
- https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.NotADirectory
