### PR TITLE
[ty] Make dataclass `own_fields` a `salsa::tracked` method

### DIFF
--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1605,12 +1605,27 @@ impl<'db> StaticClassLiteral<'db> {
     /// Returns a list of all annotated attributes defined in this class, or any of its superclasses.
     ///
     /// See [`StaticClassLiteral::own_fields`] for more details.
+    pub(crate) fn fields(
+        self,
+        db: &'db dyn Db,
+        specialization: Option<Specialization<'db>>,
+        field_policy: CodeGeneratorKind<'db>,
+    ) -> &'db FxIndexMap<Name, Field<'db>> {
+        if field_policy == CodeGeneratorKind::NamedTuple {
+            // NamedTuples do not allow multiple inheritance, so it is sufficient to enumerate the
+            // fields of this class only.
+            return self.own_fields(db, specialization, field_policy);
+        }
+
+        self.fields_inner(db, specialization, field_policy)
+    }
+
     #[salsa::tracked(
         returns(ref),
         cycle_initial=|_, _, _, _, _| FxIndexMap::default(),
         heap_size=get_size2::GetSize::get_heap_size
     )]
-    pub(crate) fn fields(
+    fn fields_inner(
         self,
         db: &'db dyn Db,
         specialization: Option<Specialization<'db>>,
@@ -1621,11 +1636,11 @@ impl<'db> StaticClassLiteral<'db> {
             DynamicTypedDict(DynamicTypedDictLiteral<'db>),
         }
 
-        if field_policy == CodeGeneratorKind::NamedTuple {
-            // NamedTuples do not allow multiple inheritance, so it is sufficient to enumerate the
-            // fields of this class only.
-            return self.own_fields(db, specialization, field_policy);
-        }
+        debug_assert_ne!(
+            field_policy,
+            CodeGeneratorKind::NamedTuple,
+            "Collecting `fields` for NamedTuples should short-circuit in `fields()`"
+        );
 
         self.iter_mro(db, specialization)
             .rev()
@@ -1650,7 +1665,8 @@ impl<'db> StaticClassLiteral<'db> {
                 FieldSource::Static(class, specialization) => Either::Left(
                     class
                         .own_fields(db, specialization, field_policy)
-                        .into_iter(),
+                        .iter()
+                        .map(|(name, field)| (name.clone(), field.clone())),
                 ),
                 FieldSource::DynamicTypedDict(typeddict) => {
                     Either::Right(typeddict.items(db).iter().map(|(name, td_field)| {
@@ -1753,11 +1769,16 @@ impl<'db> StaticClassLiteral<'db> {
     /// including properties inherited from class-level dataclass parameters (like `kw_only=True`)
     /// and dataclass-transform parameters (like `kw_only_default=True`). They do not represent
     /// only what is explicitly specified in each field definition.
+    #[salsa::tracked(
+        returns(ref),
+        cycle_initial=|_, _, _, _, _| FxIndexMap::default(),
+        heap_size=get_size2::GetSize::get_heap_size
+    )]
     pub(crate) fn own_fields(
         self,
         db: &'db dyn Db,
         specialization: Option<Specialization<'db>>,
-        field_policy: CodeGeneratorKind,
+        field_policy: CodeGeneratorKind<'db>,
     ) -> FxIndexMap<Name, Field<'db>> {
         let mut attributes = FxIndexMap::default();
 
@@ -1767,6 +1788,8 @@ impl<'db> StaticClassLiteral<'db> {
         let use_def = use_def_map(db, class_body_scope);
 
         let typed_dict_params = self.typed_dict_params(db);
+        let dataclass_kw_only_default = matches!(field_policy, CodeGeneratorKind::DataclassLike(_))
+            .then(|| self.has_dataclass_param(db, field_policy, DataclassFlags::KW_ONLY));
         let mut kw_only_sentinel_field_seen = false;
 
         for (symbol_id, declarations) in use_def.all_end_of_scope_symbol_declarations() {
@@ -1878,7 +1901,7 @@ impl<'db> StaticClassLiteral<'db> {
                     ..
                 } = field.kind
                 {
-                    *kw = Some(self.has_dataclass_param(db, field_policy, DataclassFlags::KW_ONLY));
+                    *kw = dataclass_kw_only_default;
                 }
 
                 attributes.insert(symbol.name().clone(), field);

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -117,7 +117,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                 report_named_tuple_field_with_leading_underscore(
                     context,
                     class,
-                    &field_name,
+                    field_name,
                     field.first_declaration,
                 );
             }
@@ -127,12 +127,13 @@ pub(crate) fn check_static_class_definitions<'db>(
                     default_ty: Some(_)
                 }
             ) {
-                field_with_default_encountered = Some((field_name, field.first_declaration));
+                field_with_default_encountered =
+                    Some((field_name.clone(), field.first_declaration));
             } else if let Some(field_with_default) = field_with_default_encountered.as_ref() {
                 report_namedtuple_field_without_default_after_field_with_default(
                     context,
                     class,
-                    (&field_name, field.first_declaration),
+                    (field_name, field.first_declaration),
                     field_with_default,
                 );
             }


### PR DESCRIPTION
## Summary

The lack of memoization here is leading to O(N^2) in at least one dataclass operation. If you trace `check_class`, we iterate over each member; then for dataclasses, for each member, we call `is_own_dataclass_instance_field`, which in turn calls `self.own_fields`. So for every member, we're re-creating the entire member map.

I asked Codex to do some benchmarking -- here, with 1,000 fields:

  | Metric | Before | After |
  |---|---:|---:|
  | Wall time | 5.65s | 0.545s |
  | Max RSS | 113.45 MB | 87.52 MB |
  | Salsa memory report | 51.30 MB | 27.65 MB |

If you increase to multiple thousands of fields, it generally doesn't finish on main (but takes ~1 second on this branch).

As an alternative, we could rewrite the `check_class` pipeline to avoid the O(N^2) behavior, though we may end up just chasing down other usage sites (e.g., Codex suggests that `list_member.srs` also suffers from this as-is).

Closes https://github.com/astral-sh/ty/issues/3190.
