### PR TITLE
Optimize zero-prefixed numeric lexing

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1089,12 +1089,16 @@ impl<'src> Lexer<'src> {
     /// Numeric lexing. The feast can start!
     fn lex_number(&mut self, first: char) -> TokenKind {
         if first == '0' {
-            if self.cursor.eat_if(|c| matches!(c, 'x' | 'X')).is_some() {
-                self.lex_number_radix(Radix::Hex)
-            } else if self.cursor.eat_if(|c| matches!(c, 'o' | 'O')).is_some() {
-                self.lex_number_radix(Radix::Octal)
-            } else if self.cursor.eat_if(|c| matches!(c, 'b' | 'B')).is_some() {
-                self.lex_number_radix(Radix::Binary)
+            let radix = match self.cursor.rest().as_bytes() {
+                [b'x' | b'X', ..] => Some(Radix::Hex),
+                [b'o' | b'O', ..] => Some(Radix::Octal),
+                [b'b' | b'B', ..] => Some(Radix::Binary),
+                _ => None,
+            };
+
+            if let Some(radix) = radix {
+                self.cursor.skip_bytes(1);
+                self.lex_number_radix(radix)
             } else {
                 self.lex_decimal_number(first)
             }


### PR DESCRIPTION
This PR applies runtime-autotune recovered candidate candidate-campaign-ruff-mixed-ruff-1776087351760-77c52409-1776092363717-7e241b95.

Candidate evidence:
- public delta: 2.9007542376650597%
- recovered shadow delta: 0.6814710711732674%
- recovery id: shadow-recovery-ruff-active-20260414
- recovered decision: accepted

Local validation on current upstream main:
- git apply --check --exclude=.codex
- git diff --check
- cargo fmt --check

The generated patch included an empty .codex artifact file; it was excluded from this PR branch.