### PR TITLE
Optimize parser comparison handling

### DIFF
--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -270,9 +270,12 @@ impl<'src> Parser<'src> {
                 break;
             }
 
-            let Some(operator) = BinaryLikeOperator::try_from_tokens(current_token, self.peek())
-            else {
-                // Not an operator.
+            let operator = if let Some(operator) = BinaryLikeOperator::try_from_token(current_token)
+            {
+                operator
+            } else if let Some(cmp_op) = self.cmp_op_from_current_token(current_token) {
+                BinaryLikeOperator::Comparison(cmp_op)
+            } else {
                 break;
             };
 
@@ -1156,24 +1159,38 @@ impl<'src> Parser<'src> {
     }
 
     /// Bump the appropriate token(s) for the given comparison operator.
+    #[inline]
     fn bump_cmp_op(&mut self, op: CmpOp) {
-        let (first, second) = match op {
-            CmpOp::Eq => (TokenKind::EqEqual, None),
-            CmpOp::NotEq => (TokenKind::NotEqual, None),
-            CmpOp::Lt => (TokenKind::Less, None),
-            CmpOp::LtE => (TokenKind::LessEqual, None),
-            CmpOp::Gt => (TokenKind::Greater, None),
-            CmpOp::GtE => (TokenKind::GreaterEqual, None),
-            CmpOp::Is => (TokenKind::Is, None),
-            CmpOp::IsNot => (TokenKind::Is, Some(TokenKind::Not)),
-            CmpOp::In => (TokenKind::In, None),
-            CmpOp::NotIn => (TokenKind::Not, Some(TokenKind::In)),
-        };
-
-        self.bump(first);
-        if let Some(second) = second {
-            self.bump(second);
+        match op {
+            CmpOp::Eq => self.bump(TokenKind::EqEqual),
+            CmpOp::NotEq => self.bump(TokenKind::NotEqual),
+            CmpOp::Lt => self.bump(TokenKind::Less),
+            CmpOp::LtE => self.bump(TokenKind::LessEqual),
+            CmpOp::Gt => self.bump(TokenKind::Greater),
+            CmpOp::GtE => self.bump(TokenKind::GreaterEqual),
+            CmpOp::Is => self.bump(TokenKind::Is),
+            CmpOp::In => self.bump(TokenKind::In),
+            CmpOp::IsNot => {
+                self.bump(TokenKind::Is);
+                self.bump(TokenKind::Not);
+            }
+            CmpOp::NotIn => {
+                self.bump(TokenKind::Not);
+                self.bump(TokenKind::In);
+            }
         }
+    }
+
+    /// Returns the comparison operator starting at the current token.
+    #[inline]
+    fn cmp_op_from_current_token(&mut self, token: TokenKind) -> Option<CmpOp> {
+        helpers::token_kind_to_single_cmp_op(token).or_else(|| {
+            if matches!(token, TokenKind::Is | TokenKind::Not) {
+                helpers::token_kind_to_lookahead_cmp_op(token, self.peek())
+            } else {
+                None
+            }
+        })
     }
 
     /// Parse a comparison expression.
@@ -1197,8 +1214,9 @@ impl<'src> Parser<'src> {
     ) -> ast::ExprCompare {
         self.bump_cmp_op(op);
 
-        let mut comparators = vec![];
-        let mut operators = vec![op];
+        let mut comparators = Vec::with_capacity(1);
+        let mut operators = Vec::with_capacity(1);
+        operators.push(op);
 
         let mut progress = ParserProgress::default();
 
@@ -1218,7 +1236,7 @@ impl<'src> Parser<'src> {
                 break;
             }
 
-            let Some(next_op) = helpers::token_kind_to_cmp_op([next_token, self.peek()]) else {
+            let Some(next_op) = self.cmp_op_from_current_token(next_token) else {
                 break;
             };
 
@@ -2958,15 +2976,16 @@ enum BinaryLikeOperator {
 }
 
 impl BinaryLikeOperator {
-    /// Attempts to convert the two tokens into the corresponding binary-like operator. Returns
+    /// Attempts to convert the current token into the corresponding binary-like operator. Returns
     /// [None] if it's not a binary-like operator.
-    fn try_from_tokens(current: TokenKind, next: TokenKind) -> Option<BinaryLikeOperator> {
+    #[inline]
+    fn try_from_token(current: TokenKind) -> Option<BinaryLikeOperator> {
         if let Some(bool_op) = current.as_bool_operator() {
             Some(BinaryLikeOperator::Boolean(bool_op))
         } else if let Some(bin_op) = current.as_binary_operator() {
             Some(BinaryLikeOperator::Binary(bin_op))
         } else {
-            helpers::token_kind_to_cmp_op([current, next]).map(BinaryLikeOperator::Comparison)
+            None
         }
     }
 

--- a/crates/ruff_python_parser/src/parser/helpers.rs
+++ b/crates/ruff_python_parser/src/parser/helpers.rs
@@ -30,19 +30,33 @@ pub(super) fn set_expr_ctx(expr: &mut Expr, new_ctx: ExprContext) {
     }
 }
 
-/// Converts a [`TokenKind`] array of size 2 to its correspondent [`CmpOp`].
-pub(super) const fn token_kind_to_cmp_op(tokens: [TokenKind; 2]) -> Option<CmpOp> {
-    Some(match tokens {
-        [TokenKind::Is, TokenKind::Not] => CmpOp::IsNot,
-        [TokenKind::Is, _] => CmpOp::Is,
-        [TokenKind::Not, TokenKind::In] => CmpOp::NotIn,
-        [TokenKind::In, _] => CmpOp::In,
-        [TokenKind::EqEqual, _] => CmpOp::Eq,
-        [TokenKind::NotEqual, _] => CmpOp::NotEq,
-        [TokenKind::Less, _] => CmpOp::Lt,
-        [TokenKind::LessEqual, _] => CmpOp::LtE,
-        [TokenKind::Greater, _] => CmpOp::Gt,
-        [TokenKind::GreaterEqual, _] => CmpOp::GtE,
+/// Converts a single-token comparison operator to its corresponding [`CmpOp`].
+#[inline]
+pub(super) fn token_kind_to_single_cmp_op(token: TokenKind) -> Option<CmpOp> {
+    Some(match token {
+        TokenKind::In => CmpOp::In,
+        TokenKind::EqEqual => CmpOp::Eq,
+        TokenKind::NotEqual => CmpOp::NotEq,
+        TokenKind::Less => CmpOp::Lt,
+        TokenKind::LessEqual => CmpOp::LtE,
+        TokenKind::Greater => CmpOp::Gt,
+        TokenKind::GreaterEqual => CmpOp::GtE,
+        _ => return None,
+    })
+}
+
+/// Converts comparison operators that require lookahead to their corresponding [`CmpOp`].
+#[inline]
+pub(super) fn token_kind_to_lookahead_cmp_op(current: TokenKind, next: TokenKind) -> Option<CmpOp> {
+    Some(match current {
+        TokenKind::Is => {
+            if matches!(next, TokenKind::Not) {
+                CmpOp::IsNot
+            } else {
+                CmpOp::Is
+            }
+        }
+        TokenKind::Not if matches!(next, TokenKind::In) => CmpOp::NotIn,
         _ => return None,
     })
 }


### PR DESCRIPTION
This PR applies runtime-autotune recovered candidate candidate-campaign-ruff-mixed-ruff-1776087351760-77c52409-1776105804046-481ba464.

Candidate evidence:
- public delta: 2.4041098009914164%
- recovered shadow delta: 0.804377261067335%
- recovery id: shadow-recovery-proof-20260414b
- recovered decision: accepted

Local validation on current upstream main:
- git apply --check --exclude=.codex
- git diff --check
- cargo fmt --check

The generated patch included an empty .codex artifact file; it was excluded from this PR branch.