### PR TITLE
[ty] Correct the instructions in the `ty_test` README for running markdown tests.

### DIFF
--- a/crates/ty_test/README.md
+++ b/crates/ty_test/README.md
@@ -423,11 +423,11 @@ x: int = "foo"  # error: [invalid-assignment]
 
 ## Running the tests
 
-All Markdown-based tests are executed in a normal `cargo test` / `cargo run nextest` run. If you want to run the Markdown tests
-*only*, you can filter the tests using `mdtest__`:
+All Markdown-based tests are executed in a normal `cargo test` / `cargo nextest run` invocation. If you want to run the Markdown tests
+*only*, you can filter the tests using `mdtest`:
 
 ```bash
-cargo test -p ty_python_semantic -- mdtest__
+cargo test -p ty_python_semantic -- mdtest
 ```
 
 Alternatively, you can use the `mdtest.py` runner which has a watch mode that will re-run corresponding tests when Markdown files change, and recompile automatically when Rust code changes:


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

This corrects/updates the documentation for running markdown tests:

1. It corrects the spelling of the `nextest` invocation.
2. It corrects the filter that can be applied to select just the markdown tests.

## Test Plan

No tests necessary.
<!-- How was it tested? -->
