### PR TITLE
[ty] Automatic snapshot updates in mdtest.py

### DIFF
--- a/crates/ty_python_semantic/mdtest.py
+++ b/crates/ty_python_semantic/mdtest.py
@@ -40,12 +40,14 @@ class MDTestRunner:
     filters: list[str]
     enable_external: bool
     upgrade_lockfiles: bool
+    update_snapshots: bool
 
     def __init__(
         self,
         filters: list[str] | None,
         enable_external: bool,
         upgrade_lockfiles: bool,
+        update_snapshots: bool,
     ) -> None:
         self.mdtest_executable = None
         self.console = Console()
@@ -55,6 +57,7 @@ class MDTestRunner:
         ]
         self.enable_external = enable_external
         self.upgrade_lockfiles = upgrade_lockfiles
+        self.update_snapshots = update_snapshots
 
     def _run_cargo_test(self, *, message_format: Literal["human", "json"]) -> str:
         return subprocess.check_output(
@@ -136,6 +139,7 @@ class MDTestRunner:
                 INSTA_OUTPUT="none",
                 MDTEST_EXTERNAL="1" if self.enable_external else "0",
                 MDTEST_UPGRADE_LOCKFILES="1" if self.upgrade_lockfiles else "0",
+                MDTEST_UPDATE_SNAPSHOTS="1" if self.update_snapshots else "0",
             ),
             capture_output=capture_output,
             text=True,
@@ -321,6 +325,11 @@ def main() -> None:
         help="By default, lockfiles will be upgraded when dependency requirements in the Markdown test change."
         + " Set this flag to never upgrade any lockfiles.",
     )
+    parser.add_argument(
+        "--no-snapshot-updates",
+        action="store_true",
+        help="By default, inline snapshots will be updated automatically when they are stale. Set this flag to disable this.",
+    )
 
     args = parser.parse_args()
 
@@ -329,6 +338,7 @@ def main() -> None:
             filters=args.filters,
             enable_external=args.enable_external,
             upgrade_lockfiles=not args.no_lockfile_upgrades,
+            update_snapshots=not args.no_snapshot_updates,
         )
         runner.watch()
     except KeyboardInterrupt:

--- a/crates/ty_test/README.md
+++ b/crates/ty_test/README.md
@@ -174,7 +174,7 @@ info: Revealed type is `int`
 `# snapshot:` follows the same placement rules as other inline assertions.
 
 To insert or rewrite inline snapshots automatically, run mdtest with
-`MDTEST_UPDATE_SNAPSHOTS` set. For example:
+`MDTEST_UPDATE_SNAPSHOTS=1` set. For example:
 
 ```sh
 MDTEST_UPDATE_SNAPSHOTS=1 cargo test -p ty_python_semantic --test mdtest -- diagnostics/missing_argument.md

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -44,9 +44,10 @@ mod parser;
 /// Only tests whose names contain this filter string will be executed.
 const MDTEST_TEST_FILTER: &str = "MDTEST_TEST_FILTER";
 
-/// If set, updates the content of inline snapshots.
+/// If set to a value other than "0", updates the content of inline snapshots.
 const MDTEST_UPDATE_SNAPSHOTS: &str = "MDTEST_UPDATE_SNAPSHOTS";
 
+/// If set to a value other than "0", runs tests that include external dependencies.
 const MDTEST_EXTERNAL: &str = "MDTEST_EXTERNAL";
 
 /// Run `path` as a markdown test suite with given `title`.
@@ -795,8 +796,9 @@ fn render_diagnostics(db: &mut Db, diagnostics: &[Diagnostic]) -> String {
 }
 
 fn is_update_inline_snapshots_enabled() -> bool {
-    let is_enabled: std::sync::LazyLock<_> =
-        std::sync::LazyLock::new(|| std::env::var_os(MDTEST_UPDATE_SNAPSHOTS).is_some());
+    let is_enabled: std::sync::LazyLock<_> = std::sync::LazyLock::new(|| {
+        std::env::var_os(MDTEST_UPDATE_SNAPSHOTS).is_some_and(|v| v != "0")
+    });
     *is_enabled
 }
 
@@ -883,7 +885,7 @@ fn validate_inline_snapshot(
                 failures.push(
                     line,
                     vec![Failure::new(format!(
-                        "Add a `snapshot` block for this `# snapshot` assertion, or set `{MDTEST_UPDATE_SNAPSHOTS}` to insert one automatically",
+                        "Add a `snapshot` block for this `# snapshot` assertion, or set `{MDTEST_UPDATE_SNAPSHOTS}=1` to insert one automatically",
                     ))],
                 );
             }
@@ -903,7 +905,7 @@ fn validate_inline_snapshot(
             failures.push(
                 failure_line,
                 vec![Failure::new(format_args!(
-                        "inline diagnostics snapshot are out of date; set `{MDTEST_UPDATE_SNAPSHOTS}` to update the `snapshot` block",
+                        "inline diagnostics snapshot are out of date; set `{MDTEST_UPDATE_SNAPSHOTS}=1` to update the `snapshot` block",
                     )).with_diff(snapshot_code_block.expected.to_string(), actual)],
                 );
         }


### PR DESCRIPTION
## Summary

Update "the mdtest Python thing" to do snapshot edits by default, unless `--no-snapshot-updates` is set.

## Test Plan

Tested both variants.