### PR TITLE
[ty] Set context-window to zero for mdtest snapshots

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_assignment_details.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_assignment_details.md
@@ -21,7 +21,6 @@ def _(source: str):
 error[invalid-assignment]: Object of type `str` is not assignable to `bytes`
  --> src/mdtest_snippet.py:2:13
   |
-1 | def _(source: str):
 2 |     target: bytes = source  # snapshot
   |             -----   ^^^^^^ Incompatible value of type `str`
   |             |
@@ -42,13 +41,10 @@ def _(source: str | None):
 error[invalid-assignment]: Object of type `str | None` is not assignable to `str`
  --> src/mdtest_snippet.py:2:13
   |
-1 | def _(source: str | None):
 2 |     target: str = source  # snapshot
   |             ---   ^^^^^^ Incompatible value of type `str | None`
   |             |
   |             Declared type
-3 | def _(source: int):
-4 |     target: str | None = source  # snapshot
   |
 ```
 
@@ -63,14 +59,10 @@ def _(source: int):
 error[invalid-assignment]: Object of type `int` is not assignable to `str | None`
  --> src/mdtest_snippet.py:4:13
   |
-2 |     target: str = source  # snapshot
-3 | def _(source: int):
 4 |     target: str | None = source  # snapshot
   |             ----------   ^^^^^^ Incompatible value of type `int`
   |             |
   |             Declared type
-5 | def _(source: str | None):
-6 |     target: bytes | None = source  # snapshot
   |
 ```
 
@@ -85,8 +77,6 @@ def _(source: str | None):
 error[invalid-assignment]: Object of type `str | None` is not assignable to `bytes | None`
  --> src/mdtest_snippet.py:6:13
   |
-4 |     target: str | None = source  # snapshot
-5 | def _(source: str | None):
 6 |     target: bytes | None = source  # snapshot
   |             ------------   ^^^^^^ Incompatible value of type `str | None`
   |             |
@@ -111,16 +101,13 @@ def _(source: Intersection[P, Q]):
 
 ```snapshot
 error[invalid-assignment]: Object of type `P & Q` is not assignable to `int`
-  --> src/mdtest_snippet.py:8:13
-   |
- 7 | def _(source: Intersection[P, Q]):
- 8 |     target: int = source  # snapshot
-   |             ---   ^^^^^^ Incompatible value of type `P & Q`
-   |             |
-   |             Declared type
- 9 | def _(source: P):
-10 |     target: Intersection[P, Q] = source  # snapshot
-   |
+ --> src/mdtest_snippet.py:8:13
+  |
+8 |     target: int = source  # snapshot
+  |             ---   ^^^^^^ Incompatible value of type `P & Q`
+  |             |
+  |             Declared type
+  |
 ```
 
 Assigning a non-intersection to an intersection:
@@ -134,14 +121,10 @@ def _(source: P):
 error[invalid-assignment]: Object of type `P` is not assignable to `P & Q`
   --> src/mdtest_snippet.py:10:13
    |
- 8 |     target: int = source  # snapshot
- 9 | def _(source: P):
 10 |     target: Intersection[P, Q] = source  # snapshot
    |             ------------------   ^^^^^^ Incompatible value of type `P`
    |             |
    |             Declared type
-11 | def _(source: Intersection[P, R]):
-12 |     target: Intersection[P, Q] = source  # snapshot
    |
 ```
 
@@ -156,8 +139,6 @@ def _(source: Intersection[P, R]):
 error[invalid-assignment]: Object of type `P & R` is not assignable to `P & Q`
   --> src/mdtest_snippet.py:12:13
    |
-10 |     target: Intersection[P, Q] = source  # snapshot
-11 | def _(source: Intersection[P, R]):
 12 |     target: Intersection[P, Q] = source  # snapshot
    |             ------------------   ^^^^^^ Incompatible value of type `P & R`
    |             |
@@ -178,13 +159,10 @@ def _(source: tuple[int, str, bool]):
 error[invalid-assignment]: Object of type `tuple[int, str, bool]` is not assignable to `tuple[int, bytes, bool]`
  --> src/mdtest_snippet.py:2:13
   |
-1 | def _(source: tuple[int, str, bool]):
 2 |     target: tuple[int, bytes, bool] = source  # snapshot
   |             -----------------------   ^^^^^^ Incompatible value of type `tuple[int, str, bool]`
   |             |
   |             Declared type
-3 | def _(source: tuple[int, str]):
-4 |     target: tuple[int, str, bool] = source  # snapshot
   |
 ```
 
@@ -199,8 +177,6 @@ def _(source: tuple[int, str]):
 error[invalid-assignment]: Object of type `tuple[int, str]` is not assignable to `tuple[int, str, bool]`
  --> src/mdtest_snippet.py:4:13
   |
-2 |     target: tuple[int, bytes, bool] = source  # snapshot
-3 | def _(source: tuple[int, str]):
 4 |     target: tuple[int, str, bool] = source  # snapshot
   |             ---------------------   ^^^^^^ Incompatible value of type `tuple[int, str]`
   |             |
@@ -225,14 +201,10 @@ target: Callable[[int, bytes], bool] = source  # snapshot
 error[invalid-assignment]: Object of type `def source(x: int, y: str) -> None` is not assignable to `(int, bytes, /) -> bool`
  --> src/mdtest_snippet.py:6:9
   |
-4 |     raise NotImplementedError
-5 |
 6 | target: Callable[[int, bytes], bool] = source  # snapshot
   |         ----------------------------   ^^^^^^ Incompatible value of type `def source(x: int, y: str) -> None`
   |         |
   |         Declared type
-7 | def _(source: Callable[[int, str], bool]):
-8 |     target: Callable[[int, bytes], bool] = source  # snapshot
   |
 ```
 
@@ -245,17 +217,13 @@ def _(source: Callable[[int, str], bool]):
 
 ```snapshot
 error[invalid-assignment]: Object of type `(int, str, /) -> bool` is not assignable to `(int, bytes, /) -> bool`
-  --> src/mdtest_snippet.py:8:13
-   |
- 6 | target: Callable[[int, bytes], bool] = source  # snapshot
- 7 | def _(source: Callable[[int, str], bool]):
- 8 |     target: Callable[[int, bytes], bool] = source  # snapshot
-   |             ----------------------------   ^^^^^^ Incompatible value of type `(int, str, /) -> bool`
-   |             |
-   |             Declared type
- 9 | def _(source: Callable[[int, bytes], None]):
-10 |     target: Callable[[int, bytes], bool] = source  # snapshot
-   |
+ --> src/mdtest_snippet.py:8:13
+  |
+8 |     target: Callable[[int, bytes], bool] = source  # snapshot
+  |             ----------------------------   ^^^^^^ Incompatible value of type `(int, str, /) -> bool`
+  |             |
+  |             Declared type
+  |
 ```
 
 Assigning a `Callable` to a `Callable` with wrong return type:
@@ -269,14 +237,10 @@ def _(source: Callable[[int, bytes], None]):
 error[invalid-assignment]: Object of type `(int, bytes, /) -> None` is not assignable to `(int, bytes, /) -> bool`
   --> src/mdtest_snippet.py:10:13
    |
- 8 |     target: Callable[[int, bytes], bool] = source  # snapshot
- 9 | def _(source: Callable[[int, bytes], None]):
 10 |     target: Callable[[int, bytes], bool] = source  # snapshot
    |             ----------------------------   ^^^^^^ Incompatible value of type `(int, bytes, /) -> None`
    |             |
    |             Declared type
-11 | def _(source: Callable[[int, str], bool]):
-12 |     target: Callable[[int], bool] = source  # snapshot
    |
 ```
 
@@ -291,14 +255,10 @@ def _(source: Callable[[int, str], bool]):
 error[invalid-assignment]: Object of type `(int, str, /) -> bool` is not assignable to `(int, /) -> bool`
   --> src/mdtest_snippet.py:12:13
    |
-10 |     target: Callable[[int, bytes], bool] = source  # snapshot
-11 | def _(source: Callable[[int, str], bool]):
 12 |     target: Callable[[int], bool] = source  # snapshot
    |             ---------------------   ^^^^^^ Incompatible value of type `(int, str, /) -> bool`
    |             |
    |             Declared type
-13 | class Number:
-14 |     def __init__(self, value: int): ...
    |
 ```
 
@@ -315,8 +275,6 @@ target: Callable[[str], Any] = Number  # snapshot
 error[invalid-assignment]: Object of type `<class 'Number'>` is not assignable to `(str, /) -> Any`
   --> src/mdtest_snippet.py:16:9
    |
-14 |     def __init__(self, value: int): ...
-15 |
 16 | target: Callable[[str], Any] = Number  # snapshot
    |         --------------------   ^^^^^^ Incompatible value of type `<class 'Number'>`
    |         |
@@ -345,19 +303,13 @@ class Child1(Parent):
 error[invalid-method-override]: Invalid override of method `method`
  --> src/mdtest_snippet.py:7:9
   |
-5 | class Child1(Parent):
-6 |     # snapshot
 7 |     def method(self, x: bytes) -> bool:
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.method`
-8 |         raise NotImplementedError
-9 | class Child2(Parent):
   |
  ::: src/mdtest_snippet.py:2:9
   |
-1 | class Parent:
 2 |     def method(self, x: str) -> bool:
   |         ---------------------------- `Parent.method` defined here
-3 |         raise NotImplementedError
   |
 info: This violates the Liskov Substitution Principle
 ```
@@ -375,19 +327,13 @@ class Child2(Parent):
 error[invalid-method-override]: Invalid override of method `method`
   --> src/mdtest_snippet.py:11:9
    |
- 9 | class Child2(Parent):
-10 |     # snapshot
 11 |     def method(self, x: str) -> None:
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.method`
-12 |         raise NotImplementedError
-13 | class Child3(Parent):
    |
   ::: src/mdtest_snippet.py:2:9
    |
- 1 | class Parent:
  2 |     def method(self, x: str) -> bool:
    |         ---------------------------- `Parent.method` defined here
- 3 |         raise NotImplementedError
    |
 info: This violates the Liskov Substitution Principle
 ```
@@ -405,18 +351,13 @@ class Child3(Parent):
 error[invalid-method-override]: Invalid override of method `method`
   --> src/mdtest_snippet.py:15:9
    |
-13 | class Child3(Parent):
-14 |     # snapshot
 15 |     def method(self, y: str):
    |         ^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.method`
-16 |         raise NotImplementedError
    |
   ::: src/mdtest_snippet.py:2:9
    |
- 1 | class Parent:
  2 |     def method(self, x: str) -> bool:
    |         ---------------------------- `Parent.method` defined here
- 3 |         raise NotImplementedError
    |
 info: This violates the Liskov Substitution Principle
 ```
@@ -442,13 +383,10 @@ def _(source: Person):
 error[invalid-assignment]: Object of type `Person` is not assignable to `Other`
   --> src/mdtest_snippet.py:10:13
    |
- 9 | def _(source: Person):
 10 |     target: Other = source  # snapshot
    |             -----   ^^^^^^ Incompatible value of type `Person`
    |             |
    |             Declared type
-11 | class PersonWithAge(TypedDict):
-12 |     name: str
    |
 ```
 
@@ -467,13 +405,10 @@ def _(source: Person):
 error[invalid-assignment]: Object of type `Person` is not assignable to `PersonWithAge`
   --> src/mdtest_snippet.py:16:13
    |
-15 | def _(source: Person):
 16 |     target: PersonWithAge = source  # snapshot
    |             -------------   ^^^^^^ Incompatible value of type `Person`
    |             |
    |             Declared type
-17 | class Person(TypedDict):
-18 |     name: str
    |
 ```
 
@@ -491,7 +426,6 @@ def _(source: Person):
 error[invalid-assignment]: Object of type `Person` is not assignable to `dict[str, Any]`
   --> src/mdtest_snippet.py:21:13
    |
-20 | def _(source: Person):
 21 |     target: dict[str, Any] = source  # snapshot
    |             --------------   ^^^^^^ Incompatible value of type `Person`
    |             |
@@ -517,16 +451,13 @@ def _(source: DoesNotHaveCheck):
 
 ```snapshot
 error[invalid-assignment]: Object of type `DoesNotHaveCheck` is not assignable to `SupportsCheck`
-  --> src/mdtest_snippet.py:9:13
-   |
- 8 | def _(source: DoesNotHaveCheck):
- 9 |     target: SupportsCheck = source  # snapshot
-   |             -------------   ^^^^^^ Incompatible value of type `DoesNotHaveCheck`
-   |             |
-   |             Declared type
-10 | class CheckWithWrongSignature:
-11 |     def check(self, x: int, y: bytes) -> bool:
-   |
+ --> src/mdtest_snippet.py:9:13
+  |
+9 |     target: SupportsCheck = source  # snapshot
+  |             -------------   ^^^^^^ Incompatible value of type `DoesNotHaveCheck`
+  |             |
+  |             Declared type
+  |
 ```
 
 Incompatible types for protocol members:
@@ -544,13 +475,10 @@ def _(source: CheckWithWrongSignature):
 error[invalid-assignment]: Object of type `CheckWithWrongSignature` is not assignable to `SupportsCheck`
   --> src/mdtest_snippet.py:15:13
    |
-14 | def _(source: CheckWithWrongSignature):
 15 |     target: SupportsCheck = source  # snapshot
    |             -------------   ^^^^^^ Incompatible value of type `CheckWithWrongSignature`
    |             |
    |             Declared type
-16 | class SupportsName(Protocol):
-17 |     @property
    |
 ```
 
@@ -571,7 +499,6 @@ def _(source: DoesNotHaveName):
 error[invalid-assignment]: Object of type `DoesNotHaveName` is not assignable to `SupportsName`
   --> src/mdtest_snippet.py:23:13
    |
-22 | def _(source: DoesNotHaveName):
 23 |     target: SupportsName = source  # snapshot
    |             ------------   ^^^^^^ Incompatible value of type `DoesNotHaveName`
    |             |
@@ -603,7 +530,6 @@ def _(source: HasName):
 error[invalid-assignment]: Object of type `HasName` is not assignable to `StringOrName`
   --> src/mdtest_snippet.py:13:13
    |
-12 | def _(source: HasName):
 13 |     target: StringOrName = source  # snapshot
    |             ------------   ^^^^^^ Incompatible value of type `HasName`
    |             |
@@ -626,8 +552,6 @@ target: Callable[[tuple[int, bytes]], bool] = source  # snapshot
 error[invalid-assignment]: Object of type `def source(x: tuple[int, str]) -> bool` is not assignable to `(tuple[int, bytes], /) -> bool`
  --> src/mdtest_snippet.py:6:9
   |
-4 |     return False
-5 |
 6 | target: Callable[[tuple[int, bytes]], bool] = source  # snapshot
   |         -----------------------------------   ^^^^^^ Incompatible value of type `def source(x: tuple[int, str]) -> bool`
   |         |
@@ -656,7 +580,6 @@ def _(source: Incompatible):
 error[invalid-assignment]: Object of type `Incompatible` is not assignable to `SupportsCheck`
   --> src/mdtest_snippet.py:12:13
    |
-11 | def _(source: Incompatible):
 12 |     target: SupportsCheck = source  # snapshot
    |             -------------   ^^^^^^ Incompatible value of type `Incompatible`
    |             |
@@ -685,7 +608,6 @@ def _(source: HasNeither):
 error[invalid-assignment]: Object of type `HasNeither` is not assignable to `SupportsFoo | SupportsBar`
   --> src/mdtest_snippet.py:12:13
    |
-11 | def _(source: HasNeither):
 12 |     target: SupportsFoo | SupportsBar = source  # snapshot
    |             -------------------------   ^^^^^^ Incompatible value of type `HasNeither`
    |             |
@@ -704,7 +626,6 @@ def _(source: int):
 error[invalid-assignment]: Object of type `int` is not assignable to `str | bytes | bool | None`
  --> src/mdtest_snippet.py:2:13
   |
-1 | def _(source: int):
 2 |     target: str | bytes | bool | None = source  # snapshot
   |             -------------------------   ^^^^^^ Incompatible value of type `int`
   |             |
@@ -732,7 +653,6 @@ def _(source: Intersection[DoesNotSupportFoo1, DoesNotSupportFoo2]):
 error[invalid-assignment]: Object of type `DoesNotSupportFoo1 & DoesNotSupportFoo2` is not assignable to `SupportsFoo`
   --> src/mdtest_snippet.py:11:13
    |
-10 | def _(source: Intersection[DoesNotSupportFoo1, DoesNotSupportFoo2]):
 11 |     target: SupportsFoo = source  # snapshot
    |             -----------   ^^^^^^ Incompatible value of type `DoesNotSupportFoo1 & DoesNotSupportFoo2`
    |             |
@@ -768,7 +688,6 @@ def _(source: IncompatibleFoo):
 error[invalid-assignment]: Object of type `IncompatibleFoo` is not assignable to `SupportsFooAndBar`
   --> src/mdtest_snippet.py:16:13
    |
-15 | def _(source: IncompatibleFoo):
 16 |     target: SupportsFooAndBar = source  # snapshot
    |             -----------------   ^^^^^^ Incompatible value of type `IncompatibleFoo`
    |             |
@@ -789,7 +708,6 @@ def _(source: list[str]):
 error[invalid-assignment]: Object of type `list[str]` is not assignable to `Iterable[bytes]`
  --> src/mdtest_snippet.py:4:13
   |
-3 | def _(source: list[str]):
 4 |     target: Iterable[bytes] = source  # snapshot
   |             ---------------   ^^^^^^ Incompatible value of type `list[str]`
   |             |
@@ -813,17 +731,13 @@ del c.attr  # snapshot
 error[invalid-assignment]: Cannot delete read-only property `attr` on object of type `C`
  --> src/mdtest_snippet.py:7:5
   |
-6 | c = C()
 7 | del c.attr  # snapshot
   |     ^^^^^^ Attempted deletion of `C.attr` here
   |
  ::: src/mdtest_snippet.py:3:9
   |
-1 | class C:
-2 |     @property
 3 |     def attr(self) -> int:
   |         ---- Property `C.attr` defined here with no deleter
-4 |         return 1
   |
 ```
 
@@ -841,13 +755,10 @@ def _(source: list[bool]):
 error[invalid-assignment]: Object of type `list[bool]` is not assignable to `list[int]`
  --> src/mdtest_snippet.py:2:13
   |
-1 | def _(source: list[bool]):
 2 |     target: list[int] = source  # snapshot
   |             ---------   ^^^^^^ Incompatible value of type `list[bool]`
   |             |
   |             Declared type
-3 | from collections import ChainMap, Counter, OrderedDict, defaultdict, deque
-4 | from collections.abc import MutableSequence, MutableMapping, MutableSet
   |
 info: `list` is invariant in its type parameter
 info: Consider using the covariant supertype `collections.abc.Sequence`
@@ -904,13 +815,10 @@ def _(source: MutableSequence[bool]):
 error[invalid-assignment]: Object of type `set[bool]` is not assignable to `set[int]`
  --> src/mdtest_snippet.py:7:13
   |
-6 | def _(source: set[bool]):
 7 |     target: set[int] = source  # snapshot
   |             --------   ^^^^^^ Incompatible value of type `set[bool]`
   |             |
   |             Declared type
-8 |
-9 | def _(source: dict[str, bool]):
   |
 info: `set` is invariant in its type parameter
 info: Consider using the covariant supertype `collections.abc.Set`
@@ -920,13 +828,10 @@ info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#
 error[invalid-assignment]: Object of type `dict[str, bool]` is not assignable to `dict[str, int]`
   --> src/mdtest_snippet.py:10:13
    |
- 9 | def _(source: dict[str, bool]):
 10 |     target: dict[str, int] = source  # snapshot
    |             --------------   ^^^^^^ Incompatible value of type `dict[str, bool]`
    |             |
    |             Declared type
-11 |
-12 | def _(source: dict[bool, str]):
    |
 info: `dict` is invariant in its second type parameter
 info: Consider using the supertype `collections.abc.Mapping`, which is covariant in its value type
@@ -936,13 +841,10 @@ info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#
 error[invalid-assignment]: Object of type `dict[bool, str]` is not assignable to `dict[int, str]`
   --> src/mdtest_snippet.py:13:13
    |
-12 | def _(source: dict[bool, str]):
 13 |     target: dict[int, str] = source  # snapshot
    |             --------------   ^^^^^^ Incompatible value of type `dict[bool, str]`
    |             |
    |             Declared type
-14 |
-15 | def _(source: dict[bool, bool]):
    |
 info: `dict` is invariant in its first type parameter
 info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#invariant-generics
@@ -951,13 +853,10 @@ info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#
 error[invalid-assignment]: Object of type `dict[bool, bool]` is not assignable to `dict[int, int]`
   --> src/mdtest_snippet.py:16:13
    |
-15 | def _(source: dict[bool, bool]):
 16 |     target: dict[int, int] = source  # snapshot
    |             --------------   ^^^^^^ Incompatible value of type `dict[bool, bool]`
    |             |
    |             Declared type
-17 |
-18 | def _(source: defaultdict[str, bool]):
    |
 info: `dict` is invariant in its first and second type parameters
 info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#invariant-generics
@@ -966,13 +865,10 @@ info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#
 error[invalid-assignment]: Object of type `defaultdict[str, bool]` is not assignable to `defaultdict[str, int]`
   --> src/mdtest_snippet.py:19:13
    |
-18 | def _(source: defaultdict[str, bool]):
 19 |     target: defaultdict[str, int] = source  # snapshot
    |             ---------------------   ^^^^^^ Incompatible value of type `defaultdict[str, bool]`
    |             |
    |             Declared type
-20 |
-21 | def _(source: defaultdict[bool, str]):
    |
 info: `defaultdict` is invariant in its second type parameter
 info: Consider using the supertype `collections.abc.Mapping`, which is covariant in its value type
@@ -982,13 +878,10 @@ info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#
 error[invalid-assignment]: Object of type `defaultdict[bool, str]` is not assignable to `defaultdict[int, str]`
   --> src/mdtest_snippet.py:22:13
    |
-21 | def _(source: defaultdict[bool, str]):
 22 |     target: defaultdict[int, str] = source  # snapshot
    |             ---------------------   ^^^^^^ Incompatible value of type `defaultdict[bool, str]`
    |             |
    |             Declared type
-23 |
-24 | def _(source: OrderedDict[str, bool]):
    |
 info: `defaultdict` is invariant in its first type parameter
 info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#invariant-generics
@@ -997,13 +890,10 @@ info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#
 error[invalid-assignment]: Object of type `OrderedDict[str, bool]` is not assignable to `OrderedDict[str, int]`
   --> src/mdtest_snippet.py:25:13
    |
-24 | def _(source: OrderedDict[str, bool]):
 25 |     target: OrderedDict[str, int] = source  # snapshot
    |             ---------------------   ^^^^^^ Incompatible value of type `OrderedDict[str, bool]`
    |             |
    |             Declared type
-26 |
-27 | def _(source: OrderedDict[bool, str]):
    |
 info: `OrderedDict` is invariant in its second type parameter
 info: Consider using the supertype `collections.abc.Mapping`, which is covariant in its value type
@@ -1013,13 +903,10 @@ info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#
 error[invalid-assignment]: Object of type `OrderedDict[bool, str]` is not assignable to `OrderedDict[int, str]`
   --> src/mdtest_snippet.py:28:13
    |
-27 | def _(source: OrderedDict[bool, str]):
 28 |     target: OrderedDict[int, str] = source  # snapshot
    |             ---------------------   ^^^^^^ Incompatible value of type `OrderedDict[bool, str]`
    |             |
    |             Declared type
-29 |
-30 | def _(source: ChainMap[str, bool]):
    |
 info: `OrderedDict` is invariant in its first type parameter
 info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#invariant-generics
@@ -1028,13 +915,10 @@ info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#
 error[invalid-assignment]: Object of type `ChainMap[str, bool]` is not assignable to `ChainMap[str, int]`
   --> src/mdtest_snippet.py:31:13
    |
-30 | def _(source: ChainMap[str, bool]):
 31 |     target: ChainMap[str, int] = source  # snapshot
    |             ------------------   ^^^^^^ Incompatible value of type `ChainMap[str, bool]`
    |             |
    |             Declared type
-32 |
-33 | def _(source: ChainMap[bool, str]):
    |
 info: `ChainMap` is invariant in its second type parameter
 info: Consider using the supertype `collections.abc.Mapping`, which is covariant in its value type
@@ -1044,13 +928,10 @@ info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#
 error[invalid-assignment]: Object of type `ChainMap[bool, str]` is not assignable to `ChainMap[int, str]`
   --> src/mdtest_snippet.py:34:13
    |
-33 | def _(source: ChainMap[bool, str]):
 34 |     target: ChainMap[int, str] = source  # snapshot
    |             ------------------   ^^^^^^ Incompatible value of type `ChainMap[bool, str]`
    |             |
    |             Declared type
-35 |
-36 | def _(source: deque[bool]):
    |
 info: `ChainMap` is invariant in its first type parameter
 info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#invariant-generics
@@ -1059,13 +940,10 @@ info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#
 error[invalid-assignment]: Object of type `deque[bool]` is not assignable to `deque[int]`
   --> src/mdtest_snippet.py:37:13
    |
-36 | def _(source: deque[bool]):
 37 |     target: deque[int] = source  # snapshot
    |             ----------   ^^^^^^ Incompatible value of type `deque[bool]`
    |             |
    |             Declared type
-38 |
-39 | def _(source: Counter[bool]):
    |
 info: `deque` is invariant in its type parameter
 info: Consider using the covariant supertype `collections.abc.Sequence`
@@ -1075,13 +953,10 @@ info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#
 error[invalid-assignment]: Object of type `Counter[bool]` is not assignable to `Counter[int]`
   --> src/mdtest_snippet.py:40:13
    |
-39 | def _(source: Counter[bool]):
 40 |     target: Counter[int] = source  # snapshot
    |             ------------   ^^^^^^ Incompatible value of type `Counter[bool]`
    |             |
    |             Declared type
-41 |
-42 | def _(source: MutableSequence[bool]):
    |
 info: `Counter` is invariant in its type parameter
 info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#invariant-generics
@@ -1090,12 +965,10 @@ info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#
 error[invalid-assignment]: Object of type `MutableSequence[bool]` is not assignable to `MutableSequence[int]`
   --> src/mdtest_snippet.py:43:13
    |
-42 | def _(source: MutableSequence[bool]):
 43 |     target: MutableSequence[int] = source  # snapshot
    |             --------------------   ^^^^^^ Incompatible value of type `MutableSequence[bool]`
    |             |
    |             Declared type
-44 | from typing import Generic, TypeVar
    |
 info: `MutableSequence` is invariant in its type parameter
 info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#invariant-generics
@@ -1119,13 +992,10 @@ def _(source: MyContainer[bool]):
 error[invalid-assignment]: Object of type `MyContainer[bool]` is not assignable to `MyContainer[int]`
   --> src/mdtest_snippet.py:52:13
    |
-51 | def _(source: MyContainer[bool]):
 52 |     target: MyContainer[int] = source  # snapshot
    |             ----------------   ^^^^^^ Incompatible value of type `MyContainer[bool]`
    |             |
    |             Declared type
-53 | def _(source: list[int]):
-54 |     target: list[str] = source  # snapshot
    |
 info: `MyContainer` is invariant in its type parameter
 info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#invariant-generics
@@ -1142,13 +1012,10 @@ def _(source: list[int]):
 error[invalid-assignment]: Object of type `list[int]` is not assignable to `list[str]`
   --> src/mdtest_snippet.py:54:13
    |
-52 |     target: MyContainer[int] = source  # snapshot
-53 | def _(source: list[int]):
 54 |     target: list[str] = source  # snapshot
    |             ---------   ^^^^^^ Incompatible value of type `list[int]`
    |             |
    |             Declared type
-55 | from collections.abc import Sequence
    |
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/missing_argument.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/missing_argument.md
@@ -38,31 +38,22 @@ Foo().method()  # snapshot: missing-argument
 error[missing-argument]: No argument provided for required parameter `a` of function `f`
  --> src/main.py:3:1
   |
-1 | from module import f, g, Foo
-2 |
 3 | f()  # snapshot
   | ^^^
-4 |
-5 | def coinflip() -> bool:
   |
 info: Parameter declared here
  --> src/module.py:1:7
   |
 1 | def f(a, b=42): ...
   |       ^
-2 | def g(a, b): ...
   |
 
 
 error[missing-argument]: No argument provided for required parameter `a` of function `f`
   --> src/main.py:12:1
    |
-10 | # snapshot: missing-argument
-11 | # snapshot: missing-argument
 12 | h(b=56)
    | ^^^^^^^
-13 |
-14 | Foo().method()  # snapshot: missing-argument
    |
 info: Union variant `def f(a, b=42) -> Unknown` is incompatible with this call site
 info: Attempted to call union type `(def f(a, b=42) -> Unknown) | (def g(a, b) -> Unknown)`
@@ -71,12 +62,8 @@ info: Attempted to call union type `(def f(a, b=42) -> Unknown) | (def g(a, b) -
 error[missing-argument]: No argument provided for required parameter `a` of function `g`
   --> src/main.py:12:1
    |
-10 | # snapshot: missing-argument
-11 | # snapshot: missing-argument
 12 | h(b=56)
    | ^^^^^^^
-13 |
-14 | Foo().method()  # snapshot: missing-argument
    |
 info: Union variant `def g(a, b) -> Unknown` is incompatible with this call site
 info: Attempted to call union type `(def f(a, b=42) -> Unknown) | (def g(a, b) -> Unknown)`
@@ -85,15 +72,12 @@ info: Attempted to call union type `(def f(a, b=42) -> Unknown) | (def g(a, b) -
 error[missing-argument]: No argument provided for required parameter `a` of bound method `method`
   --> src/main.py:14:1
    |
-12 | h(b=56)
-13 |
 14 | Foo().method()  # snapshot: missing-argument
    | ^^^^^^^^^^^^^^
    |
 info: Parameter declared here
  --> src/module.py:5:22
   |
-4 | class Foo:
 5 |     def method(self, a): ...
   |                      ^
   |

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/too_many_positionals.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/too_many_positionals.md
@@ -38,31 +38,22 @@ Foo().method(1, 2)  # snapshot: too-many-positional-arguments
 error[too-many-positional-arguments]: Too many positional arguments to function `f`: expected 2, got 3
  --> src/main.py:3:9
   |
-1 | from module import f, g, Foo
-2 |
 3 | f(1, 2, 3)  # snapshot: too-many-positional-arguments
   |         ^
-4 |
-5 | def coinflip() -> bool:
   |
 info: Function signature here
  --> src/module.py:1:5
   |
 1 | def f(a, b=42): ...
   |     ^^^^^^^^^^
-2 | def g(a, b): ...
   |
 
 
 error[too-many-positional-arguments]: Too many positional arguments to function `f`: expected 2, got 3
   --> src/main.py:12:9
    |
-10 | # snapshot: too-many-positional-arguments
-11 | # snapshot: too-many-positional-arguments
 12 | h(1, 2, 3)
    |         ^
-13 |
-14 | Foo().method(1, 2)  # snapshot: too-many-positional-arguments
    |
 info: Union variant `def f(a, b=42) -> Unknown` is incompatible with this call site
 info: Attempted to call union type `(def f(a, b=42) -> Unknown) | (def g(a, b) -> Unknown)`
@@ -71,12 +62,8 @@ info: Attempted to call union type `(def f(a, b=42) -> Unknown) | (def g(a, b) -
 error[too-many-positional-arguments]: Too many positional arguments to function `g`: expected 2, got 3
   --> src/main.py:12:9
    |
-10 | # snapshot: too-many-positional-arguments
-11 | # snapshot: too-many-positional-arguments
 12 | h(1, 2, 3)
    |         ^
-13 |
-14 | Foo().method(1, 2)  # snapshot: too-many-positional-arguments
    |
 info: Union variant `def g(a, b) -> Unknown` is incompatible with this call site
 info: Attempted to call union type `(def f(a, b=42) -> Unknown) | (def g(a, b) -> Unknown)`
@@ -85,15 +72,12 @@ info: Attempted to call union type `(def f(a, b=42) -> Unknown) | (def g(a, b) -
 error[too-many-positional-arguments]: Too many positional arguments to bound method `method`: expected 2, got 3
   --> src/main.py:14:17
    |
-12 | h(1, 2, 3)
-13 |
 14 | Foo().method(1, 2)  # snapshot: too-many-positional-arguments
    |                 ^
    |
 info: Method signature here
  --> src/module.py:5:9
   |
-4 | class Foo:
 5 |     def method(self, a): ...
   |         ^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -46,20 +46,13 @@ class Sub3(Super):
 error[invalid-method-override]: Invalid override of method `method`
   --> src/mdtest_snippet.pyi:10:9
    |
- 8 |     def method(self) -> bool: ...  # fine: `bool` is a subtype of `int`
- 9 | class Sub3(Super):
 10 |     def method(self) -> object: ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super.method`
-11 | class Sub4(Super):
-12 |     def method(self) -> str: ...  # snapshot: invalid-method-override
    |
   ::: src/mdtest_snippet.pyi:2:9
    |
- 1 | class Super:
  2 |     def method(self) -> int: ...
    |         ------------------- `Super.method` defined here
- 3 |
- 4 | class Sub1(Super):
    |
 info: This violates the Liskov Substitution Principle
 ```
@@ -75,29 +68,22 @@ class Sub4(Super):
 error[invalid-method-override]: Invalid override of method `method`
   --> src/mdtest_snippet.pyi:12:9
    |
-10 |     def method(self) -> object: ...  # snapshot: invalid-method-override
-11 | class Sub4(Super):
 12 |     def method(self) -> str: ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super.method`
    |
   ::: src/mdtest_snippet.pyi:2:9
    |
- 1 | class Super:
  2 |     def method(self) -> int: ...
    |         ------------------- `Super.method` defined here
- 3 |
- 4 | class Sub1(Super):
    |
 info: This violates the Liskov Substitution Principle
 ```
 
 ## Method parameters
 
-A subclass method may provide a different parameter list to the superclass method, but all
-combinations of arguments accepted by the superclass method must continue to be accepted by the
-overriding method.
+It is fine for a subclass method to accept more general parameters than the method it overrides:
 
-```pyi
+```py
 class Super:
     def method(self, x: int, /): ...
 
@@ -136,125 +122,97 @@ class Sub11(Super):
 In the following cases, some calls permitted by the superclass are no longer allowed, so we emit an
 error.
 
-This method can no longer be passed arguments:
+This method can no longer be passed any arguments:
 
-```pyi
+```py
 class Sub12(Super):
     def method(self, /): ...  # snapshot: invalid-method-override
 ```
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `method`
-  --> src/mdtest_snippet.pyi:35:9
+  --> src/mdtest_snippet.py:35:9
    |
-33 |     def method(self, x: int, *, extra_kw_only_arg=42): ...  # fine
-34 | class Sub12(Super):
 35 |     def method(self, /): ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^ Definition is incompatible with `Super.method`
-36 | class Sub13(Super):
-37 |     def method(self, x, y, /): ...  # snapshot: invalid-method-override
    |
-  ::: src/mdtest_snippet.pyi:2:9
+  ::: src/mdtest_snippet.py:2:9
    |
- 1 | class Super:
  2 |     def method(self, x: int, /): ...
    |         ----------------------- `Super.method` defined here
- 3 |
- 4 | class Sub1(Super):
    |
 info: This violates the Liskov Substitution Principle
 ```
 
 This method can no longer be passed exactly one argument:
 
-```pyi
+```py
 class Sub13(Super):
     def method(self, x, y, /): ...  # snapshot: invalid-method-override
 ```
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `method`
-  --> src/mdtest_snippet.pyi:37:9
+  --> src/mdtest_snippet.py:37:9
    |
-35 |     def method(self, /): ...  # snapshot: invalid-method-override
-36 | class Sub13(Super):
 37 |     def method(self, x, y, /): ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super.method`
-38 | class Sub14(Super):
-39 |     def method(self, /, *, x): ...  # snapshot: invalid-method-override
    |
-  ::: src/mdtest_snippet.pyi:2:9
+  ::: src/mdtest_snippet.py:2:9
    |
- 1 | class Super:
  2 |     def method(self, x: int, /): ...
    |         ----------------------- `Super.method` defined here
- 3 |
- 4 | class Sub1(Super):
    |
 info: This violates the Liskov Substitution Principle
 ```
 
 Here, `x` can no longer be passed positionally:
 
-```pyi
+```py
 class Sub14(Super):
     def method(self, /, *, x): ...  # snapshot: invalid-method-override
 ```
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `method`
-  --> src/mdtest_snippet.pyi:39:9
+  --> src/mdtest_snippet.py:39:9
    |
-37 |     def method(self, x, y, /): ...  # snapshot: invalid-method-override
-38 | class Sub14(Super):
 39 |     def method(self, /, *, x): ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super.method`
-40 | class Sub15(Super):
-41 |     def method(self, x: bool, /): ...  # snapshot: invalid-method-override
    |
-  ::: src/mdtest_snippet.pyi:2:9
+  ::: src/mdtest_snippet.py:2:9
    |
- 1 | class Super:
  2 |     def method(self, x: int, /): ...
    |         ----------------------- `Super.method` defined here
- 3 |
- 4 | class Sub1(Super):
    |
 info: This violates the Liskov Substitution Principle
 ```
 
 Here, `x` can no longer be passed any integer -- it now requires a `bool`!
 
-```pyi
+```py
 class Sub15(Super):
     def method(self, x: bool, /): ...  # snapshot: invalid-method-override
 ```
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `method`
-  --> src/mdtest_snippet.pyi:41:9
+  --> src/mdtest_snippet.py:41:9
    |
-39 |     def method(self, /, *, x): ...  # snapshot: invalid-method-override
-40 | class Sub15(Super):
 41 |     def method(self, x: bool, /): ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super.method`
-42 | class Super2:
-43 |     def method2(self, x): ...
    |
-  ::: src/mdtest_snippet.pyi:2:9
+  ::: src/mdtest_snippet.py:2:9
    |
- 1 | class Super:
  2 |     def method(self, x: int, /): ...
    |         ----------------------- `Super.method` defined here
- 3 |
- 4 | class Sub1(Super):
    |
 info: This violates the Liskov Substitution Principle
 ```
 
 In this case, `x` can no longer be passed as a keyword argument:
 
-```pyi
+```py
 class Super2:
     def method2(self, x): ...
 
@@ -264,52 +222,44 @@ class Sub16(Super2):
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `method2`
-  --> src/mdtest_snippet.pyi:43:9
+  --> src/mdtest_snippet.py:46:9
    |
-41 |     def method(self, x: bool, /): ...  # snapshot: invalid-method-override
-42 | class Super2:
-43 |     def method2(self, x): ...
-   |         ---------------- `Super2.method2` defined here
-44 |
-45 | class Sub16(Super2):
 46 |     def method2(self, x, /): ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super2.method2`
-47 | class Sub17(Super2):
-48 |     def method2(self, *, x): ...  # snapshot: invalid-method-override
+   |
+  ::: src/mdtest_snippet.py:43:9
+   |
+43 |     def method2(self, x): ...
+   |         ---------------- `Super2.method2` defined here
    |
 info: This violates the Liskov Substitution Principle
 ```
 
 In this case, `x` can no longer be passed as a positional argument:
 
-```pyi
+```py
 class Sub17(Super2):
     def method2(self, *, x): ...  # snapshot: invalid-method-override
 ```
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `method2`
-  --> src/mdtest_snippet.pyi:43:9
+  --> src/mdtest_snippet.py:48:9
    |
-41 |     def method(self, x: bool, /): ...  # snapshot: invalid-method-override
-42 | class Super2:
-43 |     def method2(self, x): ...
-   |         ---------------- `Super2.method2` defined here
-44 |
-45 | class Sub16(Super2):
-46 |     def method2(self, x, /): ...  # snapshot: invalid-method-override
-47 | class Sub17(Super2):
 48 |     def method2(self, *, x): ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super2.method2`
-49 | class Super3:
-50 |     def method3(self, *, x): ...
+   |
+  ::: src/mdtest_snippet.py:43:9
+   |
+43 |     def method2(self, x): ...
+   |         ---------------- `Super2.method2` defined here
    |
 info: This violates the Liskov Substitution Principle
 ```
 
 The reverse is fine:
 
-```pyi
+```py
 class Super3:
     def method3(self, *, x): ...
 
@@ -319,34 +269,29 @@ class Sub18(Super3):
 
 This is an error because `x` can no longer be passed as a keyword argument:
 
-```pyi
+```py
 class Sub19(Super3):
     def method3(self, x, /): ...  # snapshot: invalid-method-override
 ```
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `method3`
-  --> src/mdtest_snippet.pyi:50:9
+  --> src/mdtest_snippet.py:55:9
    |
-48 |     def method2(self, *, x): ...  # snapshot: invalid-method-override
-49 | class Super3:
-50 |     def method3(self, *, x): ...
-   |         ------------------- `Super3.method3` defined here
-51 |
-52 | class Sub18(Super3):
-53 |     def method3(self, x): ...  # fine: `x` can still be used as a keyword argument
-54 | class Sub19(Super3):
 55 |     def method3(self, x, /): ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super3.method3`
-56 | class Super4:
-57 |     def method(self, *args: int, **kwargs: str): ...
+   |
+  ::: src/mdtest_snippet.py:50:9
+   |
+50 |     def method3(self, *, x): ...
+   |         ------------------- `Super3.method3` defined here
    |
 info: This violates the Liskov Substitution Principle
 ```
 
 Accepting a wider type for `*args` and `**kwargs` is fine:
 
-```pyi
+```py
 class Super4:
     def method(self, *args: int, **kwargs: str): ...
 
@@ -356,57 +301,44 @@ class Sub20(Super4):
 
 Omitting `**kwargs` is an error:
 
-```pyi
+```py
 class Sub21(Super4):
     def method(self, *args): ...  # snapshot: invalid-method-override
 ```
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `method`
-  --> src/mdtest_snippet.pyi:57:9
+  --> src/mdtest_snippet.py:62:9
    |
-55 |     def method3(self, x, /): ...  # snapshot: invalid-method-override
-56 | class Super4:
-57 |     def method(self, *args: int, **kwargs: str): ...
-   |         --------------------------------------- `Super4.method` defined here
-58 |
-59 | class Sub20(Super4):
-60 |     def method(self, *args: object, **kwargs: object): ...  # fine
-61 | class Sub21(Super4):
 62 |     def method(self, *args): ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super4.method`
-63 | class Sub22(Super4):
-64 |     def method(self, **kwargs): ...  # snapshot: invalid-method-override
+   |
+  ::: src/mdtest_snippet.py:57:9
+   |
+57 |     def method(self, *args: int, **kwargs: str): ...
+   |         --------------------------------------- `Super4.method` defined here
    |
 info: This violates the Liskov Substitution Principle
 ```
 
 Similarly, omitting `*args` is also an error:
 
-```pyi
+```py
 class Sub22(Super4):
     def method(self, **kwargs): ...  # snapshot: invalid-method-override
 ```
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `method`
-  --> src/mdtest_snippet.pyi:64:9
+  --> src/mdtest_snippet.py:64:9
    |
-62 |     def method(self, *args): ...  # snapshot: invalid-method-override
-63 | class Sub22(Super4):
 64 |     def method(self, **kwargs): ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super4.method`
-65 | class Sub23(Super4):
-66 |     def method(self, x, *args, y, **kwargs): ...
    |
-  ::: src/mdtest_snippet.pyi:57:9
+  ::: src/mdtest_snippet.py:57:9
    |
-55 |     def method3(self, x, /): ...  # snapshot: invalid-method-override
-56 | class Super4:
 57 |     def method(self, *args: int, **kwargs: str): ...
    |         --------------------------------------- `Super4.method` defined here
-58 |
-59 | class Sub20(Super4):
    |
 info: This violates the Liskov Substitution Principle
 ```
@@ -415,7 +347,7 @@ Finally, this is not a Liskov violation because this is a gradual callable. It c
 and `**kwargs` without annotations, so it is compatible with any signature of `method` on the
 superclass.
 
-```pyi
+```py
 class Sub23(Super4):
     def method(self, x, *args, y, **kwargs): ...
 ```
@@ -481,17 +413,15 @@ class ThirdChild(GradualParent):
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `method`
- --> src/stub.pyi:4:9
+ --> src/stub.pyi:7:9
   |
-3 | class Grandparent:
-4 |     def method(self, x: int) -> None: ...
-  |         ---------------------------- `Grandparent.method` defined here
-5 |
-6 | class Parent(Grandparent):
 7 |     def method(self, x: str) -> None: ...  # snapshot: invalid-method-override
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Grandparent.method`
-8 |
-9 | class Child(Parent):
+  |
+ ::: src/stub.pyi:4:9
+  |
+4 |     def method(self, x: int) -> None: ...
+  |         ---------------------------- `Grandparent.method` defined here
   |
 info: This violates the Liskov Substitution Principle
 
@@ -499,20 +429,13 @@ info: This violates the Liskov Substitution Principle
 error[invalid-method-override]: Invalid override of method `method`
   --> src/stub.pyi:17:9
    |
-15 | class OtherChild(Parent):
-16 |     # compatible with the signature of `Grandparent.method`, but not with `Parent.method`:
 17 |     def method(self, x: int) -> None: ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.method`
-18 |
-19 | class ChildWithNewViolation(Parent):
    |
   ::: src/stub.pyi:7:9
    |
- 6 | class Parent(Grandparent):
  7 |     def method(self, x: str) -> None: ...  # snapshot: invalid-method-override
    |         ---------------------------- `Parent.method` defined here
- 8 |
- 9 | class Child(Parent):
    |
 info: This violates the Liskov Substitution Principle
 
@@ -520,36 +443,13 @@ info: This violates the Liskov Substitution Principle
 error[invalid-method-override]: Invalid override of method `method`
   --> src/stub.pyi:22:9
    |
-20 |     # incompatible with BOTH `Parent.method` (str) and `Grandparent.method` (int).
-21 |     # We report the violation against the immediate parent (`Parent`), not the grandparent.
 22 |     def method(self, x: bytes) -> None: ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.method`
-23 |
-24 | class GrandparentWithReturnType:
    |
   ::: src/stub.pyi:7:9
    |
- 6 | class Parent(Grandparent):
  7 |     def method(self, x: str) -> None: ...  # snapshot: invalid-method-override
    |         ---------------------------- `Parent.method` defined here
- 8 |
- 9 | class Child(Parent):
-   |
-info: This violates the Liskov Substitution Principle
-
-
-error[invalid-method-override]: Invalid override of method `method`
-  --> src/stub.pyi:25:9
-   |
-24 | class GrandparentWithReturnType:
-25 |     def method(self) -> int: ...
-   |         ------------------- `GrandparentWithReturnType.method` defined here
-26 |
-27 | class ParentWithReturnType(GrandparentWithReturnType):
-28 |     def method(self) -> str: ...  # snapshot: invalid-method-override
-   |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `GrandparentWithReturnType.method`
-29 |
-30 | class ChildWithReturnType(ParentWithReturnType):
    |
 info: This violates the Liskov Substitution Principle
 
@@ -557,17 +457,27 @@ info: This violates the Liskov Substitution Principle
 error[invalid-method-override]: Invalid override of method `method`
   --> src/stub.pyi:28:9
    |
-27 | class ParentWithReturnType(GrandparentWithReturnType):
 28 |     def method(self) -> str: ...  # snapshot: invalid-method-override
-   |         ------------------- `ParentWithReturnType.method` defined here
-29 |
-30 | class ChildWithReturnType(ParentWithReturnType):
-31 |     # Returns `int` again -- compatible with `GrandparentWithReturnType.method`,
-32 |     # but not with `ParentWithReturnType.method`. We report against the immediate parent.
+   |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `GrandparentWithReturnType.method`
+   |
+  ::: src/stub.pyi:25:9
+   |
+25 |     def method(self) -> int: ...
+   |         ------------------- `GrandparentWithReturnType.method` defined here
+   |
+info: This violates the Liskov Substitution Principle
+
+
+error[invalid-method-override]: Invalid override of method `method`
+  --> src/stub.pyi:33:9
+   |
 33 |     def method(self) -> int: ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `ParentWithReturnType.method`
-34 |
-35 | class GradualParent(Grandparent):
+   |
+  ::: src/stub.pyi:28:9
+   |
+28 |     def method(self) -> str: ...  # snapshot: invalid-method-override
+   |         ------------------- `ParentWithReturnType.method` defined here
    |
 info: This violates the Liskov Substitution Principle
 
@@ -575,18 +485,13 @@ info: This violates the Liskov Substitution Principle
 error[invalid-method-override]: Invalid override of method `method`
   --> src/stub.pyi:42:9
    |
-40 |     # and `ThirdChild.method` is compatible with the signature of `GradualParent.method`,
-41 |     # but `ThirdChild.method` is not compatible with the signature of `Grandparent.method`
 42 |     def method(self, x: str) -> None: ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Grandparent.method`
    |
   ::: src/stub.pyi:4:9
    |
- 3 | class Grandparent:
  4 |     def method(self, x: int) -> None: ...
    |         ---------------------------- `Grandparent.method` defined here
- 5 |
- 6 | class Parent(Grandparent):
    |
 info: This violates the Liskov Substitution Principle
 ```
@@ -615,17 +520,15 @@ class D(C):
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `get`
- --> src/other_stub.pyi:2:9
+ --> src/other_stub.pyi:5:9
   |
-1 | class A:
-2 |     def get(self, default): ...
-  |         ------------------ `A.get` defined here
-3 |
-4 | class B(A):
 5 |     def get(self, default, /): ...  # snapshot: invalid-method-override
   |         ^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `A.get`
-6 |
-7 | get = 56
+  |
+ ::: src/other_stub.pyi:2:9
+  |
+2 |     def get(self, default): ...
+  |         ------------------ `A.get` defined here
   |
 info: This violates the Liskov Substitution Principle
 ```
@@ -820,13 +723,11 @@ class A(one.A):
 error[invalid-method-override]: Invalid override of method `foo`
  --> src/two.pyi:4:9
   |
-3 | class A(one.A):
 4 |     def foo(self, y): ...  # snapshot: invalid-method-override
   |         ^^^^^^^^^^^^ Definition is incompatible with `one.A.foo`
   |
  ::: src/one.pyi:2:9
   |
-1 | class A:
 2 |     def foo(self, x): ...
   |         ------------ `one.A.foo` defined here
   |
@@ -903,17 +804,15 @@ class D(C):
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `x`
- --> src/bar.pyi:4:9
+ --> src/bar.pyi:7:5
   |
-3 | class A:
-4 |     def x(self, y: int): ...
-  |         --------------- `A.x` defined here
-5 |
-6 | class B(A):
 7 |     x = foo.x  # snapshot: invalid-method-override
   |     ^^^^^^^^^ Definition is incompatible with `A.x`
-8 |
-9 | class C:
+  |
+ ::: src/bar.pyi:4:9
+  |
+4 |     def x(self, y: int): ...
+  |         --------------- `A.x` defined here
   |
  ::: src/foo.pyi:1:5
   |
@@ -924,15 +823,15 @@ info: This violates the Liskov Substitution Principle
 
 
 error[invalid-method-override]: Invalid override of method `x`
-  --> src/bar.pyi:10:5
+  --> src/bar.pyi:13:9
    |
- 9 | class C:
-10 |     x = foo.x
-   |     --------- `C.x` defined here
-11 |
-12 | class D(C):
 13 |     def x(self, y: int): ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^ Definition is incompatible with `C.x`
+   |
+  ::: src/bar.pyi:10:5
+   |
+10 |     x = foo.x
+   |     --------- `C.x` defined here
    |
   ::: src/foo.pyi:1:5
    |
@@ -955,20 +854,13 @@ class Bad:
 error[invalid-method-override]: Invalid override of method `__eq__`
    --> src/mdtest_snippet.py:3:9
     |
-  1 | class Bad:
-  2 |     x: int
   3 |     def __eq__(self, other: "Bad") -> bool:  # snapshot: invalid-method-override
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `object.__eq__`
-  4 |         return self.x == other.x
     |
    ::: stdlib/builtins.pyi:142:9
     |
-140 |     def __setattr__(self, name: str, value: Any, /) -> None: ...
-141 |     def __delattr__(self, name: str, /) -> None: ...
 142 |     def __eq__(self, value: object, /) -> bool: ...
     |         -------------------------------------- `object.__eq__` defined here
-143 |     def __ne__(self, value: object, /) -> bool: ...
-144 |     def __str__(self) -> str: ...  # noqa: Y029
     |
 info: This violates the Liskov Substitution Principle
 help: It is recommended for `__eq__` to work with arbitrary objects, for example:
@@ -1061,29 +953,23 @@ class Spam(Baz):
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `__lt__`
-  --> src/mdtest_snippet.pyi:9:9
-   |
- 8 | class Bar(Foo):
- 9 |     def __lt__(self, other: Bar) -> bool: ...  # snapshot: invalid-method-override
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Foo.__lt__`
-10 |
-11 | # TODO: specifying `order=True` on the subclass means that a `__lt__` method is
-   |
+ --> src/mdtest_snippet.pyi:9:9
+  |
+9 |     def __lt__(self, other: Bar) -> bool: ...  # snapshot: invalid-method-override
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Foo.__lt__`
+  |
 info: This violates the Liskov Substitution Principle
 info: `Foo.__lt__` is a generated method created because `Foo` is a dataclass
  --> src/mdtest_snippet.pyi:5:7
   |
-4 | @dataclass(order=True)
 5 | class Foo:
   |       ^^^ Definition of `Foo`
-6 |     x: int
   |
 
 
 error[invalid-method-override]: Invalid override of method `_asdict`
   --> src/mdtest_snippet.pyi:54:9
    |
-53 | class Spam(Baz):
 54 |     def _asdict(self) -> tuple[int, ...]: ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Baz._asdict`
    |
@@ -1091,11 +977,8 @@ info: This violates the Liskov Substitution Principle
 info: `Baz._asdict` is a generated method created because `Baz` inherits from `typing.NamedTuple`
   --> src/mdtest_snippet.pyi:50:7
    |
-48 |     x: int
-49 |
 50 | class Baz(NamedTuple):
    |       ^^^^^^^^^^^^^^^ Definition of `Baz`
-51 |     x: int
    |
 ```
 
@@ -1137,21 +1020,13 @@ class BadTypesA(Parent):
 error[invalid-method-override]: Invalid override of method `class_method`
   --> src/mdtest_snippet.pyi:21:9
    |
-19 | class BadTypesA(Parent):
-20 |     @classmethod
 21 |     def class_method(cls, x: bool) -> object: ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.class_method`
-22 | class BadTypesB(Parent):
-23 |     @staticmethod
    |
   ::: src/mdtest_snippet.pyi:4:9
    |
- 2 |     def instance_method(self, x: int) -> int: ...
- 3 |     @classmethod
  4 |     def class_method(cls, x: int) -> int: ...
    |         -------------------------------- `Parent.class_method` defined here
- 5 |     @staticmethod
- 6 |     def static_method(x: int) -> int: ...
    |
 info: This violates the Liskov Substitution Principle
 ```
@@ -1166,21 +1041,13 @@ class BadTypesB(Parent):
 error[invalid-method-override]: Invalid override of method `static_method`
   --> src/mdtest_snippet.pyi:24:9
    |
-22 | class BadTypesB(Parent):
-23 |     @staticmethod
 24 |     def static_method(x: bool) -> object: ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.static_method`
-25 | class BadChild1A(Parent):
-26 |     @staticmethod
    |
   ::: src/mdtest_snippet.pyi:6:9
    |
- 4 |     def class_method(cls, x: int) -> int: ...
- 5 |     @staticmethod
  6 |     def static_method(x: int) -> int: ...
    |         ---------------------------- `Parent.static_method` defined here
- 7 |
- 8 | class GoodChild1(Parent):
    |
 info: This violates the Liskov Substitution Principle
 ```
@@ -1197,20 +1064,13 @@ class BadChild1A(Parent):
 error[invalid-method-override]: Invalid override of method `instance_method`
   --> src/mdtest_snippet.pyi:27:9
    |
-25 | class BadChild1A(Parent):
-26 |     @staticmethod
 27 |     def instance_method(self, x: int) -> int: ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.instance_method`
-28 | class BadChild1B(Parent):
-29 |     def static_method(x: int) -> int: ...  # snapshot: invalid-method-override
    |
   ::: src/mdtest_snippet.pyi:2:9
    |
- 1 | class Parent:
  2 |     def instance_method(self, x: int) -> int: ...
    |         ------------------------------------ `Parent.instance_method` defined here
- 3 |     @classmethod
- 4 |     def class_method(cls, x: int) -> int: ...
    |
 info: `BadChild1A.instance_method` is a staticmethod but `Parent.instance_method` is an instance method
 info: This violates the Liskov Substitution Principle
@@ -1225,21 +1085,13 @@ class BadChild1B(Parent):
 error[invalid-method-override]: Invalid override of method `static_method`
   --> src/mdtest_snippet.pyi:29:9
    |
-27 |     def instance_method(self, x: int) -> int: ...  # snapshot: invalid-method-override
-28 | class BadChild1B(Parent):
 29 |     def static_method(x: int) -> int: ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.static_method`
-30 | class BadChild2A(Parent):
-31 |     # TODO: we should emit `invalid-method-override` here.
    |
   ::: src/mdtest_snippet.pyi:6:9
    |
- 4 |     def class_method(cls, x: int) -> int: ...
- 5 |     @staticmethod
  6 |     def static_method(x: int) -> int: ...
    |         ---------------------------- `Parent.static_method` defined here
- 7 |
- 8 | class GoodChild1(Parent):
    |
 info: `BadChild1B.static_method` is an instance method but `Parent.static_method` is a staticmethod
 info: This violates the Liskov Substitution Principle
@@ -1282,21 +1134,13 @@ class BadChild3A(Parent):
 error[invalid-method-override]: Invalid override of method `class_method`
   --> src/mdtest_snippet.pyi:39:9
    |
-37 | class BadChild3A(Parent):
-38 |     @staticmethod
 39 |     def class_method(cls, x: int) -> int: ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.class_method`
-40 | class BadChild3B(Parent):
-41 |     @classmethod
    |
   ::: src/mdtest_snippet.pyi:4:9
    |
- 2 |     def instance_method(self, x: int) -> int: ...
- 3 |     @classmethod
  4 |     def class_method(cls, x: int) -> int: ...
    |         -------------------------------- `Parent.class_method` defined here
- 5 |     @staticmethod
- 6 |     def static_method(x: int) -> int: ...
    |
 info: `BadChild3A.class_method` is a staticmethod but `Parent.class_method` is a classmethod
 info: This violates the Liskov Substitution Principle
@@ -1312,19 +1156,13 @@ class BadChild3B(Parent):
 error[invalid-method-override]: Invalid override of method `static_method`
   --> src/mdtest_snippet.pyi:42:9
    |
-40 | class BadChild3B(Parent):
-41 |     @classmethod
 42 |     def static_method(x: int) -> int: ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.static_method`
    |
   ::: src/mdtest_snippet.pyi:6:9
    |
- 4 |     def class_method(cls, x: int) -> int: ...
- 5 |     @staticmethod
  6 |     def static_method(x: int) -> int: ...
    |         ---------------------------- `Parent.static_method` defined here
- 7 |
- 8 | class GoodChild1(Parent):
    |
 info: `BadChild3B.static_method` is a classmethod but `Parent.static_method` is a staticmethod
 info: This violates the Liskov Substitution Principle

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/abstract_method.md_-_Calling_abstract_met…_-_Abstract_classmethod…_(b52a273500502f2e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/abstract_method.md_-_Calling_abstract_met…_-_Abstract_classmethod…_(b52a273500502f2e).snap
@@ -30,19 +30,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/call/abstract_method.md
 error[call-abstract-method]: Cannot call `method` on class object
  --> src/mdtest_snippet.py:9:1
   |
-8 | # error: [call-abstract-method] "Cannot call `method` on class object"
 9 | Foo.method()
   | ^^^^^^^^^^^^ `method` is an abstract classmethod with a trivial body
   |
 info: Method `method` defined here
  --> src/mdtest_snippet.py:6:9
   |
-4 |     @classmethod
-5 |     @abstractmethod
 6 |     def method(cls) -> int: ...
   |         ^^^^^^
-7 |
-8 | # error: [call-abstract-method] "Cannot call `method` on class object"
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/aliases.md_-_Generic_type_aliases…_-_Default_type_paramet…_(cd50ade911a6afa4).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/aliases.md_-_Generic_type_aliases…_-_Default_type_paramet…_(cd50ade911a6afa4).snap
@@ -35,13 +35,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.
 error[invalid-type-variable-default]: Type parameters with defaults cannot follow a TypeVarTuple parameter
  --> src/mdtest_snippet.py:2:13
   |
-1 | # error: [invalid-type-variable-default] "Type parameter `T` with a default follows TypeVarTuple `Ts`"
 2 | type Alias1[*Ts, T = int] = tuple[*Ts, T]
   |             ---  ^^^^^^^ `T` has a default
   |             |
   |             `Ts` is a TypeVarTuple
-3 |
-4 | # error: [invalid-type-variable-default]
   |
 info: See https://typing.python.org/en/latest/spec/generics.html#defaults-following-typevartuple
 
@@ -51,13 +48,10 @@ info: See https://typing.python.org/en/latest/spec/generics.html#defaults-follow
 error[invalid-type-variable-default]: Type parameters with defaults cannot follow a TypeVarTuple parameter
  --> src/mdtest_snippet.py:5:17
   |
-4 | # error: [invalid-type-variable-default]
 5 | type Alias2[T1, *Ts, T2 = int] = tuple[T1, *Ts, T2]
   |                 ---  ^^^^^^^^ `T2` has a default
   |                 |
   |                 `Ts` is a TypeVarTuple
-6 |
-7 | # error: [invalid-type-variable-default]
   |
 info: See https://typing.python.org/en/latest/spec/generics.html#defaults-following-typevartuple
 
@@ -65,17 +59,14 @@ info: See https://typing.python.org/en/latest/spec/generics.html#defaults-follow
 
 ```
 error[invalid-type-variable-default]: Type parameters with defaults cannot follow a TypeVarTuple parameter
-  --> src/mdtest_snippet.py:8:13
-   |
- 7 | # error: [invalid-type-variable-default]
- 8 | type Alias3[*Ts, T1 = int, T2 = str] = tuple[*Ts, T1, T2]
-   |             ---  ^^^^^^^^  -------- `T2` also has a default
-   |             |    |
-   |             |    `T1` has a default
-   |             `Ts` is a TypeVarTuple
- 9 |
-10 | # error: [invalid-type-variable-default]
-   |
+ --> src/mdtest_snippet.py:8:13
+  |
+8 | type Alias3[*Ts, T1 = int, T2 = str] = tuple[*Ts, T1, T2]
+  |             ---  ^^^^^^^^  -------- `T2` also has a default
+  |             |    |
+  |             |    `T1` has a default
+  |             `Ts` is a TypeVarTuple
+  |
 info: See https://typing.python.org/en/latest/spec/generics.html#defaults-following-typevartuple
 
 ```
@@ -84,13 +75,10 @@ info: See https://typing.python.org/en/latest/spec/generics.html#defaults-follow
 error[invalid-type-variable-default]: Type parameters with defaults cannot follow a TypeVarTuple parameter
   --> src/mdtest_snippet.py:11:13
    |
-10 | # error: [invalid-type-variable-default]
 11 | type Alias4[*Us, *Ts = *tuple[int, str]] = tuple[*Us, *Ts]
    |             ---  ^^^^^^^^^^^^^^^^^^^^^^ `Ts` has a default
    |             |
    |             `Us` is a TypeVarTuple
-12 |
-13 | # These are fine:
    |
 info: See https://typing.python.org/en/latest/spec/generics.html#defaults-following-typevartuple
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/aliases.md_-_Generic_type_aliases…_-_Snapshots_of_verbose…_(17ec595c7d02a324).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/aliases.md_-_Generic_type_aliases…_-_Snapshots_of_verbose…_(17ec595c7d02a324).snap
@@ -35,13 +35,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.
 error[not-subscriptable]: Cannot specialize non-generic type alias `AliasA`
   --> src/mdtest_snippet.py:10:8
    |
- 9 | def f(
 10 |     a: AliasA[int],  # error: [not-subscriptable]
    |        ------^^^^^
    |        |
    |        Alias to `A`, which is not generic
-11 |     b: AliasB[int],  # error: [not-subscriptable]
-12 | ): ...
    |
 
 ```
@@ -50,13 +47,10 @@ error[not-subscriptable]: Cannot specialize non-generic type alias `AliasA`
 error[not-subscriptable]: Cannot specialize non-generic type alias `AliasB`
   --> src/mdtest_snippet.py:11:8
    |
- 9 | def f(
-10 |     a: AliasA[int],  # error: [not-subscriptable]
 11 |     b: AliasB[int],  # error: [not-subscriptable]
    |        ------^^^^^
    |        |
    |        Alias to `B[int]`, which is already specialized
-12 | ): ...
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/annotations.md_-_Assignment_with_anno…_-_Numbers_special_case_(457f31497da6a6af).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/annotations.md_-_Assignment_with_anno…_-_Numbers_special_case_(457f31497da6a6af).snap
@@ -24,8 +24,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/assignment/annotations.m
 error[invalid-assignment]: Object of type `Literal[1]` is not assignable to `Number`
  --> src/mdtest_snippet.py:3:4
   |
-1 | from numbers import Number
-2 |
 3 | a: Number = 1  # error: [invalid-assignment] "Object of type `Literal[1]` is not assignable to `Number`"
   |    ------   ^ Incompatible value of type `Literal[1]`
   |    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/annotations.md_-_Assignment_with_anno…_-_PEP-604_in_non-type-…_-_Earlier_versions_(f2859c9800f37c7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/annotations.md_-_Assignment_with_anno…_-_PEP-604_in_non-type-…_-_Earlier_versions_(f2859c9800f37c7).snap
@@ -23,7 +23,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/assignment/annotations.m
 error[unsupported-operator]: Unsupported `|` operation
  --> src/mdtest_snippet.py:2:12
   |
-1 | # error: [unsupported-operator]
 2 | IntOrStr = int | str
   |            ---^^^---
   |            |     |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assert_never.md_-_`assert_never`_-_Basic_functionality_-_Diagnostics_(be8f5d8b0718ee54).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assert_never.md_-_`assert_never`_-_Basic_functionality_-_Diagnostics_(be8f5d8b0718ee54).snap
@@ -44,13 +44,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/directives/assert_never.
 error[type-assertion-failure]: Argument does not have asserted type `Never`
  --> src/mdtest_snippet.py:5:5
   |
-4 | def _():
 5 |     assert_never(0)  # error: [type-assertion-failure]
   |     ^^^^^^^^^^^^^-^
   |                  |
   |                  Inferred type of argument is `Literal[0]`
-6 |
-7 | def _():
   |
 info: `Never` and `Literal[0]` are not equivalent types
 
@@ -58,16 +55,13 @@ info: `Never` and `Literal[0]` are not equivalent types
 
 ```
 error[type-assertion-failure]: Argument does not have asserted type `Never`
-  --> src/mdtest_snippet.py:8:5
-   |
- 7 | def _():
- 8 |     assert_never("")  # error: [type-assertion-failure]
-   |     ^^^^^^^^^^^^^--^
-   |                  |
-   |                  Inferred type of argument is `Literal[""]`
- 9 |
-10 | def _():
-   |
+ --> src/mdtest_snippet.py:8:5
+  |
+8 |     assert_never("")  # error: [type-assertion-failure]
+  |     ^^^^^^^^^^^^^--^
+  |                  |
+  |                  Inferred type of argument is `Literal[""]`
+  |
 info: `Never` and `Literal[""]` are not equivalent types
 
 ```
@@ -76,13 +70,10 @@ info: `Never` and `Literal[""]` are not equivalent types
 error[type-assertion-failure]: Argument does not have asserted type `Never`
   --> src/mdtest_snippet.py:11:5
    |
-10 | def _():
 11 |     assert_never(None)  # error: [type-assertion-failure]
    |     ^^^^^^^^^^^^^----^
    |                  |
    |                  Inferred type of argument is `None`
-12 |
-13 | def _():
    |
 info: `Never` and `None` are not equivalent types
 
@@ -92,13 +83,10 @@ info: `Never` and `None` are not equivalent types
 error[type-assertion-failure]: Argument does not have asserted type `Never`
   --> src/mdtest_snippet.py:14:5
    |
-13 | def _():
 14 |     assert_never(())  # error: [type-assertion-failure]
    |     ^^^^^^^^^^^^^--^
    |                  |
    |                  Inferred type of argument is `tuple[()]`
-15 |
-16 | def _(flag: bool, never: Never):
    |
 info: `Never` and `tuple[()]` are not equivalent types
 
@@ -108,13 +96,10 @@ info: `Never` and `tuple[()]` are not equivalent types
 error[type-assertion-failure]: Argument does not have asserted type `Never`
   --> src/mdtest_snippet.py:17:5
    |
-16 | def _(flag: bool, never: Never):
 17 |     assert_never(1 if flag else never)  # error: [type-assertion-failure]
    |     ^^^^^^^^^^^^^--------------------^
    |                  |
    |                  Inferred type of argument is `Literal[1]`
-18 |
-19 | def _(any_: Any):
    |
 info: `Never` and `Literal[1]` are not equivalent types
 
@@ -124,13 +109,10 @@ info: `Never` and `Literal[1]` are not equivalent types
 error[type-assertion-failure]: Argument does not have asserted type `Never`
   --> src/mdtest_snippet.py:20:5
    |
-19 | def _(any_: Any):
 20 |     assert_never(any_)  # error: [type-assertion-failure]
    |     ^^^^^^^^^^^^^----^
    |                  |
    |                  Inferred type of argument is `Any`
-21 |
-22 | def _(unknown: Unknown):
    |
 info: `Never` and `Any` are not equivalent types
 
@@ -140,7 +122,6 @@ info: `Never` and `Any` are not equivalent types
 error[type-assertion-failure]: Argument does not have asserted type `Never`
   --> src/mdtest_snippet.py:23:5
    |
-22 | def _(unknown: Unknown):
 23 |     assert_never(unknown)  # error: [type-assertion-failure]
    |     ^^^^^^^^^^^^^-------^
    |                  |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assert_type.md_-_`assert_type`_-_Basic_(c507788da2659ec9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assert_type.md_-_`assert_type`_-_Basic_(c507788da2659ec9).snap
@@ -28,14 +28,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/directives/assert_type.m
 error[type-assertion-failure]: Argument does not have asserted type `str`
  --> src/mdtest_snippet.py:5:5
   |
-3 | def _(x: int, y: bool):
-4 |     assert_type(x, int)  # fine
 5 |     assert_type(x, str)  # error: [type-assertion-failure]
   |     ^^^^^^^^^^^^-^^^^^^
   |                 |
   |                 Inferred type is `int`
-6 |     assert_type(assert_type(x, int), int)
-7 |     assert_type(y, int)  # error: [type-assertion-failure]
   |
 info: `str` and `int` are not equivalent types
 
@@ -45,8 +41,6 @@ info: `str` and `int` are not equivalent types
 error[type-assertion-failure]: Argument does not have asserted type `int`
  --> src/mdtest_snippet.py:7:5
   |
-5 |     assert_type(x, str)  # error: [type-assertion-failure]
-6 |     assert_type(assert_type(x, int), int)
 7 |     assert_type(y, int)  # error: [type-assertion-failure]
   |     ^^^^^^^^^^^^-^^^^^^
   |                 |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assert_type.md_-_`assert_type`_-_Unspellable_types_(385d082f9803b184).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assert_type.md_-_`assert_type`_-_Unspellable_types_(385d082f9803b184).snap
@@ -33,16 +33,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/directives/assert_type.m
 
 ```
 error[type-assertion-failure]: Argument does not have asserted type `Bar`
-  --> src/mdtest_snippet.py:8:5
-   |
- 7 | def f(x: Foo):
- 8 |     assert_type(x, Bar)  # error: [type-assertion-failure] "Type `Foo` does not match asserted type `Bar`"
-   |     ^^^^^^^^^^^^-^^^^^^
-   |                 |
-   |                 Inferred type is `Foo`
- 9 |     if isinstance(x, Bar):
-10 |         assert_type(x, Bar)  # error: [assert-type-unspellable-subtype] "Type `Foo & Bar` does not match asserted type `Bar`"
-   |
+ --> src/mdtest_snippet.py:8:5
+  |
+8 |     assert_type(x, Bar)  # error: [type-assertion-failure] "Type `Foo` does not match asserted type `Bar`"
+  |     ^^^^^^^^^^^^-^^^^^^
+  |                 |
+  |                 Inferred type is `Foo`
+  |
 info: `Bar` and `Foo` are not equivalent types
 
 ```
@@ -51,14 +48,10 @@ info: `Bar` and `Foo` are not equivalent types
 error[assert-type-unspellable-subtype]: Argument does not have asserted type `Bar`
   --> src/mdtest_snippet.py:10:9
    |
- 8 |     assert_type(x, Bar)  # error: [type-assertion-failure] "Type `Foo` does not match asserted type `Bar`"
- 9 |     if isinstance(x, Bar):
 10 |         assert_type(x, Bar)  # error: [assert-type-unspellable-subtype] "Type `Foo & Bar` does not match asserted type `Bar`"
    |         ^^^^^^^^^^^^-^^^^^^
    |                     |
    |                     Inferred type is `Foo & Bar`
-11 |
-12 |         # The actual type must be a subtype of the asserted type, as well as being unspellable,
    |
 info: `Foo & Bar` is a subtype of `Bar`, but they are not equivalent
 
@@ -68,8 +61,6 @@ info: `Foo & Bar` is a subtype of `Bar`, but they are not equivalent
 error[type-assertion-failure]: Argument does not have asserted type `Baz`
   --> src/mdtest_snippet.py:14:9
    |
-12 |         # The actual type must be a subtype of the asserted type, as well as being unspellable,
-13 |         # in order for `assert-type-unspellable-subtype` to be emitted instead of `type-assertion-failure`
 14 |         assert_type(x, Baz)  # error: [type-assertion-failure]
    |         ^^^^^^^^^^^^-^^^^^^
    |                     |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Invalid_key_type_-_For_a_`dict`_(4aa9d1d82d07fcf1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Invalid_key_type_-_For_a_`dict`_(4aa9d1d82d07fcf1).snap
@@ -23,7 +23,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/assignment_dia
 error[invalid-assignment]: Invalid subscript assignment with key of type `Literal[0]` and value of type `Literal[3]` on object of type `dict[str, int]`
  --> src/mdtest_snippet.py:2:1
   |
-1 | config: dict[str, int] = {}
 2 | config[0] = 3  # error: [invalid-assignment]
   | ^^^^^^^-^^^^^
   |        |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Invalid_key_type_-_For_a_`list`_(752cfa73fb34c1c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Invalid_key_type_-_For_a_`list`_(752cfa73fb34c1c).snap
@@ -23,7 +23,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/assignment_dia
 error[invalid-assignment]: Invalid subscript assignment with key of type `Literal["zero"]` and value of type `Literal[3]` on object of type `list[int]`
  --> src/mdtest_snippet.py:2:1
   |
-1 | numbers: list[int] = []
 2 | numbers["zero"] = 3  # error: [invalid-assignment]
   | ^^^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Invalid_key_type_for…_(815dae276e2fd2b7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Invalid_key_type_for…_(815dae276e2fd2b7).snap
@@ -28,7 +28,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/assignment_dia
 error[invalid-key]: TypedDict `Config` can only be subscripted with a string literal key, got key of type `Literal[0]`.
  --> src/mdtest_snippet.py:7:12
   |
-6 | def _(config: Config) -> None:
 7 |     config[0] = 3  # error: [invalid-key]
   |            ^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Invalid_value_type_-_For_a_`dict`_(177872afa1956fef).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Invalid_value_type_-_For_a_`dict`_(177872afa1956fef).snap
@@ -23,7 +23,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/assignment_dia
 error[invalid-assignment]: Invalid subscript assignment with key of type `Literal["retries"]` and value of type `Literal["three"]` on object of type `dict[str, int]`
  --> src/mdtest_snippet.py:2:1
   |
-1 | config: dict[str, int] = {}
 2 | config["retries"] = "three"  # error: [invalid-assignment]
   | ^^^^^^^^^^^^^^^^^^^^-------
   |                     |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Invalid_value_type_-_For_a_`list`_(e7ebbd4af387837c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Invalid_value_type_-_For_a_`list`_(e7ebbd4af387837c).snap
@@ -23,7 +23,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/assignment_dia
 error[invalid-assignment]: Invalid subscript assignment with key of type `Literal[0]` and value of type `Literal["three"]` on object of type `list[int]`
  --> src/mdtest_snippet.py:2:1
   |
-1 | numbers: list[int] = []
 2 | numbers[0] = "three"  # error: [invalid-assignment]
   | ^^^^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Invalid_value_type_f…_(155d53762388f9ad).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Invalid_value_type_f…_(155d53762388f9ad).snap
@@ -28,7 +28,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/assignment_dia
 error[invalid-assignment]: Invalid assignment to key "retries" with declared type `int` on TypedDict `Config`
  --> src/mdtest_snippet.py:7:5
   |
-6 | def _(config: Config) -> None:
 7 |     config["retries"] = "three"  # error: [invalid-assignment]
   |     ------ ---------    ^^^^^^^ value of type `Literal["three"]`
   |     |      |
@@ -38,11 +37,8 @@ error[invalid-assignment]: Invalid assignment to key "retries" with declared typ
 info: Item declaration
  --> src/mdtest_snippet.py:4:5
   |
-3 | class Config(TypedDict):
 4 |     retries: int
   |     ------------ Item declared here
-5 |
-6 | def _(config: Config) -> None:
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Misspelled_key_for_`…_(7cf0fa634e2a2d59).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Misspelled_key_for_`…_(7cf0fa634e2a2d59).snap
@@ -28,7 +28,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/assignment_dia
 error[invalid-key]: Unknown key "Retries" for TypedDict `Config`
  --> src/mdtest_snippet.py:7:5
   |
-6 | def _(config: Config) -> None:
 7 |     config["Retries"] = 30.0  # error: [invalid-key]
   |     ------ ^^^^^^^^^ Did you mean "retries"?
   |     |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_No_`__setitem__`_met…_(468f62a3bdd1d60c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_No_`__setitem__`_met…_(468f62a3bdd1d60c).snap
@@ -27,7 +27,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/assignment_dia
 error[invalid-assignment]: Cannot assign to a subscript on an object of type `ReadOnlyDict`
  --> src/mdtest_snippet.py:6:1
   |
-5 | config = ReadOnlyDict()
 6 | config["retries"] = 3  # error: [invalid-assignment]
   | ^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Possibly_missing_`__…_(efd3f0c02e9b89e9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Possibly_missing_`__…_(efd3f0c02e9b89e9).snap
@@ -23,7 +23,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/assignment_dia
 error[invalid-assignment]: Cannot assign to a subscript on an object of type `None`
  --> src/mdtest_snippet.py:2:5
   |
-1 | def _(config: dict[str, int] | None) -> None:
 2 |     config["retries"] = 3  # error: [invalid-assignment]
   |     ^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Unknown_key_for_all_…_(8a0f0e8ceccc51b2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Unknown_key_for_all_…_(8a0f0e8ceccc51b2).snap
@@ -35,8 +35,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/assignment_dia
 error[invalid-key]: Unknown key "nane" for TypedDict `Person`
   --> src/mdtest_snippet.py:14:5
    |
-12 |     # error: [invalid-key]
-13 |     # error: [invalid-key]
 14 |     being["nane"] = "unknown"
    |     ----- ^^^^^^ Did you mean "name"?
    |     |
@@ -55,8 +53,6 @@ note: This is an unsafe fix and may change runtime behavior
 error[invalid-key]: Unknown key "nane" for TypedDict `Animal`
   --> src/mdtest_snippet.py:14:5
    |
-12 |     # error: [invalid-key]
-13 |     # error: [invalid-key]
 14 |     being["nane"] = "unknown"
    |     ----- ^^^^^^ Did you mean "name"?
    |     |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Unknown_key_for_one_…_(b515711c0a451a86).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Unknown_key_for_one_…_(b515711c0a451a86).snap
@@ -33,7 +33,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/assignment_dia
 error[invalid-key]: Unknown key "legs" for TypedDict `Person`
   --> src/mdtest_snippet.py:12:5
    |
-11 | def _(being: Person | Animal) -> None:
 12 |     being["legs"] = 4  # error: [invalid-key]
    |     ----- ^^^^^^ Unknown key "legs"
    |     |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Wrong_value_type_for…_(57372b65e30392a8).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Wrong_value_type_for…_(57372b65e30392a8).snap
@@ -23,7 +23,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/assignment_dia
 error[invalid-assignment]: Invalid subscript assignment with key of type `Literal["retries"]` and value of type `Literal[3]` on object of type `dict[str, str]`
  --> src/mdtest_snippet.py:2:5
   |
-1 | def _(config: dict[str, int] | dict[str, str]) -> None:
 2 |     config["retries"] = 3  # error: [invalid-assignment]
   |     ^^^^^^^^^^^^^^^^^^^^-
   |                         |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Wrong_value_type_for…_(ffe39a3bae68cfe4).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Wrong_value_type_for…_(ffe39a3bae68cfe4).snap
@@ -25,8 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/assignment_dia
 error[invalid-assignment]: Invalid subscript assignment with key of type `Literal["retries"]` and value of type `float` on object of type `dict[str, int]`
  --> src/mdtest_snippet.py:4:5
   |
-2 |     # error: [invalid-assignment]
-3 |     # error: [invalid-assignment]
 4 |     config["retries"] = 3.0
   |     ^^^^^^^^^^^^^^^^^^^^---
   |                         |
@@ -40,8 +38,6 @@ info: The full type of the subscripted object is `dict[str, int] | dict[str, str
 error[invalid-assignment]: Invalid subscript assignment with key of type `Literal["retries"]` and value of type `float` on object of type `dict[str, str]`
  --> src/mdtest_snippet.py:4:5
   |
-2 |     # error: [invalid-assignment]
-3 |     # error: [invalid-assignment]
 4 |     config["retries"] = 3.0
   |     ^^^^^^^^^^^^^^^^^^^^---
   |                         |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/async.md_-_Async_with_statement…_-_Accidental_use_of_as…_(5b8c1b4d846bc544).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/async.md_-_Async_with_statement…_-_Accidental_use_of_as…_(5b8c1b4d846bc544).snap
@@ -29,11 +29,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/with/async.md
 error[invalid-context-manager]: Object of type `Manager` cannot be used with `async with` because it does not implement `__aenter__` and `__aexit__`
  --> src/mdtest_snippet.py:7:16
   |
-5 | async def main():
-6 |     # error: [invalid-context-manager] "Object of type `Manager` cannot be used with `async with` because it does not implement `__aent…
 7 |     async with Manager():
   |                ^^^^^^^^^
-8 |         pass
   |
 info: Objects of type `Manager` can be used as sync context managers
 info: Consider using `with` here

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/async_for.md_-_Async_-_Error_cases_-_No_`__aiter__`_metho…_(4fbd80e21774cc23).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/async_for.md_-_Async_-_Error_cases_-_No_`__aiter__`_metho…_(4fbd80e21774cc23).snap
@@ -27,11 +27,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/async_for.md
 error[not-iterable]: Object of type `NotAsyncIterable` is not async-iterable
  --> src/mdtest_snippet.py:5:20
   |
-3 | async def foo():
-4 |     # error: [not-iterable] "Object of type `NotAsyncIterable` is not async-iterable"
 5 |     async for x in NotAsyncIterable():
   |                    ^^^^^^^^^^^^^^^^^^
-6 |         reveal_type(x)  # revealed: Unknown
   |
 info: It has no `__aiter__` method
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/async_for.md_-_Async_-_Error_cases_-_No_`__anext__`_metho…_(a0b186714127abee).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/async_for.md_-_Async_-_Error_cases_-_No_`__anext__`_metho…_(a0b186714127abee).snap
@@ -29,14 +29,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/async_for.md
 
 ```
 error[not-iterable]: Object of type `AsyncIterable` is not async-iterable
-  --> src/mdtest_snippet.py:9:20
-   |
- 7 | async def foo():
- 8 |     # error: [not-iterable] "Object of type `AsyncIterable` is not async-iterable"
- 9 |     async for x in AsyncIterable():
-   |                    ^^^^^^^^^^^^^^^
-10 |         reveal_type(x)  # revealed: Unknown
-   |
+ --> src/mdtest_snippet.py:9:20
+  |
+9 |     async for x in AsyncIterable():
+  |                    ^^^^^^^^^^^^^^^
+  |
 info: Its `__aiter__` method returns an object of type `NoAnext`, which has no `__anext__` method
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/async_for.md_-_Async_-_Error_cases_-_Possibly_missing_`__…_(33924dbae5117216).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/async_for.md_-_Async_-_Error_cases_-_Possibly_missing_`__…_(33924dbae5117216).snap
@@ -34,10 +34,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/async_for.md
 error[not-iterable]: Object of type `PossiblyUnboundAiter` may not be async-iterable
   --> src/mdtest_snippet.py:12:20
    |
-11 |     # error: "Object of type `PossiblyUnboundAiter` may not be async-iterable"
 12 |     async for x in PossiblyUnboundAiter():
    |                    ^^^^^^^^^^^^^^^^^^^^^^
-13 |         reveal_type(x)  # revealed: int
    |
 info: Its `__aiter__` attribute (with type `bound method PossiblyUnboundAiter.__aiter__() -> AsyncIterable`) may not be callable
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/async_for.md_-_Async_-_Error_cases_-_Possibly_missing_`__…_(e2600ca4708d9e54).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/async_for.md_-_Async_-_Error_cases_-_Possibly_missing_`__…_(e2600ca4708d9e54).snap
@@ -34,10 +34,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/async_for.md
 error[not-iterable]: Object of type `AsyncIterable` may not be async-iterable
   --> src/mdtest_snippet.py:12:20
    |
-11 |     # error: [not-iterable] "Object of type `AsyncIterable` may not be async-iterable"
 12 |     async for x in AsyncIterable():
    |                    ^^^^^^^^^^^^^^^
-13 |         reveal_type(x)  # revealed: int
    |
 info: Its `__aiter__` method returns an object of type `PossiblyUnboundAnext`, which may not have a `__anext__` method
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/async_for.md_-_Async_-_Error_cases_-_Synchronously_iterab…_(80fa705b1c61d982).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/async_for.md_-_Async_-_Error_cases_-_Synchronously_iterab…_(80fa705b1c61d982).snap
@@ -33,10 +33,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/async_for.md
 error[not-iterable]: Object of type `Iterator` is not async-iterable
   --> src/mdtest_snippet.py:11:20
    |
-10 |     # error: [not-iterable] "Object of type `Iterator` is not async-iterable"
 11 |     async for x in Iterator():
    |                    ^^^^^^^^^^
-12 |         reveal_type(x)  # revealed: Unknown
    |
 info: It has no `__aiter__` method
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/async_for.md_-_Async_-_Error_cases_-_Wrong_signature_for_…_(b614724363eec343).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/async_for.md_-_Async_-_Error_cases_-_Wrong_signature_for_…_(b614724363eec343).snap
@@ -33,11 +33,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/async_for.md
 error[not-iterable]: Object of type `AsyncIterable` is not async-iterable
   --> src/mdtest_snippet.py:11:20
    |
- 9 | async def foo():
-10 |     # error: [not-iterable] "Object of type `AsyncIterable` is not async-iterable"
 11 |     async for x in AsyncIterable():
    |                    ^^^^^^^^^^^^^^^
-12 |         reveal_type(x)  # revealed: int
    |
 info: Its `__aiter__` method returns an object of type `AsyncIterator`, which has an invalid `__anext__` method
 info: Expected signature for `__anext__` is `def __anext__(self): ...`

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/async_for.md_-_Async_-_Error_cases_-_Wrong_signature_for_…_(e1f3e9275d0a367).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/async_for.md_-_Async_-_Error_cases_-_Wrong_signature_for_…_(e1f3e9275d0a367).snap
@@ -33,11 +33,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/async_for.md
 error[not-iterable]: Object of type `AsyncIterable` is not async-iterable
   --> src/mdtest_snippet.py:11:20
    |
- 9 | async def foo():
-10 |     # error: [not-iterable] "Object of type `AsyncIterable` is not async-iterable"
 11 |     async for x in AsyncIterable():
    |                    ^^^^^^^^^^^^^^^
-12 |         reveal_type(x)  # revealed: int
    |
 info: Its `__aiter__` method has an invalid signature
 info: Expected signature `def __aiter__(self): ...`

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Data_descriptors_-_Invalid_`__set__`_me…_(116c27bd98838df7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Data_descriptors_-_Invalid_`__set__`_me…_(116c27bd98838df7).snap
@@ -32,7 +32,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
   --> src/mdtest_snippet.py:11:1
    |
-10 | # TODO: ideally, we would mention why this is an invalid assignment (wrong number of arguments for `__set__`)
 11 | instance.attr = 1  # error: [invalid-assignment]
    | ^^^^^^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Data_descriptors_-_Invalid_argument_typ…_(a903c11fedbc5020).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Data_descriptors_-_Invalid_argument_typ…_(a903c11fedbc5020).snap
@@ -33,7 +33,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
   --> src/mdtest_snippet.py:12:1
    |
-11 | # TODO: ideally, we would mention why this is an invalid assignment (wrong argument type for `value` parameter)
 12 | instance.attr = "wrong"  # error: [invalid-assignment]
    | ^^^^^^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Instance_attributes_…_(ebfb3de6d1b96b23).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Instance_attributes_…_(ebfb3de6d1b96b23).snap
@@ -30,12 +30,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
  --> src/mdtest_snippet.py:6:1
   |
-4 | instance = C()
-5 | instance.attr = 1  # fine
 6 | instance.attr = "wrong"  # error: [invalid-assignment]
   | ^^^^^^^^^^^^^
-7 |
-8 | C.attr = 1  # fine
   |
 
 ```
@@ -44,7 +40,6 @@ error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable t
 error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
  --> src/mdtest_snippet.py:9:1
   |
-8 | C.attr = 1  # fine
 9 | C.attr = "wrong"  # error: [invalid-assignment]
   | ^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Invalid_annotated_as…_(e037abb6874b32d3).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Invalid_annotated_as…_(e037abb6874b32d3).snap
@@ -25,13 +25,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 error[invalid-assignment]: Object of type `None` is not assignable to `str`
  --> src/mdtest_snippet.py:3:20
   |
-1 | class C:
-2 |     def __init__(self):
 3 |         self.attr: str = None  # error: [invalid-assignment]
   |                    ---   ^^^^ Incompatible value of type `None`
   |                    |
   |                    Declared type
-4 |         self.attr2: int = 1  # fine
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Possibly-missing_att…_(e603e3da35f55c73).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Possibly-missing_att…_(e603e3da35f55c73).snap
@@ -30,12 +30,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 info[possibly-missing-attribute]: Attribute `attr` may be missing on class `C`
  --> src/mdtest_snippet.py:6:5
   |
-4 |             attr: int = 0
-5 |
 6 |     C.attr = 1  # error: [possibly-missing-attribute]
   |     ^^^^^^
-7 |
-8 |     instance = C()
   |
 
 ```
@@ -44,7 +40,6 @@ info[possibly-missing-attribute]: Attribute `attr` may be missing on class `C`
 info[possibly-missing-attribute]: Attribute `attr` may be missing on object of type `C`
  --> src/mdtest_snippet.py:9:5
   |
-8 |     instance = C()
 9 |     instance.attr = 1  # error: [possibly-missing-attribute]
   |     ^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Pure_instance_attrib…_(d13d57d3cc36face).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Pure_instance_attrib…_(d13d57d3cc36face).snap
@@ -30,12 +30,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
  --> src/mdtest_snippet.py:7:1
   |
-5 | instance = C()
-6 | instance.attr = 1  # fine
 7 | instance.attr = "wrong"  # error: [invalid-assignment]
   | ^^^^^^^^^^^^^
-8 |
-9 | C.attr = 1  # error: [invalid-attribute-access]
   |
 
 ```
@@ -44,8 +40,6 @@ error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable t
 error[invalid-attribute-access]: Cannot assign to instance attribute `attr` from the class object `<class 'C'>`
  --> src/mdtest_snippet.py:9:1
   |
-7 | instance.attr = "wrong"  # error: [invalid-assignment]
-8 |
 9 | C.attr = 1  # error: [invalid-attribute-access]
   | ^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Setting_attributes_o…_(467e26496f4c0c13).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Setting_attributes_o…_(467e26496f4c0c13).snap
@@ -41,11 +41,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 error[invalid-assignment]: Object of type `Literal[1]` is not assignable to attribute `attr` on type `<class 'mdtest_snippet.<locals of function '_'>.C1 @ src/mdtest_snippet.py:3:15'> | <class 'mdtest_snippet.<locals of function '_'>.C1 @ src/mdtest_snippet.py:7:15'>`
   --> src/mdtest_snippet.py:11:5
    |
-10 |     # TODO: The error message here could be improved to explain why the assignment fails.
 11 |     C1.attr = 1  # error: [invalid-assignment]
    |     ^^^^^^^
-12 |
-13 |     class C2:
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Unknown_attributes_(368ba83a71ef2120).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_Unknown_attributes_(368ba83a71ef2120).snap
@@ -27,12 +27,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 error[unresolved-attribute]: Unresolved attribute `non_existent` on type `<class 'C'>`.
  --> src/mdtest_snippet.py:3:1
   |
-1 | class C: ...
-2 |
 3 | C.non_existent = 1  # error: [unresolved-attribute]
   | ^^^^^^^^^^^^^^
-4 |
-5 | instance = C()
   |
 
 ```
@@ -41,7 +37,6 @@ error[unresolved-attribute]: Unresolved attribute `non_existent` on type `<class
 error[unresolved-attribute]: Unresolved attribute `non_existent` on type `C`
  --> src/mdtest_snippet.py:6:1
   |
-5 | instance = C()
 6 | instance.non_existent = 1  # error: [unresolved-attribute]
   | ^^^^^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_`ClassVar`s_(8d7cca27987b099d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attribute_assignment…_-_Attribute_assignment_-_`ClassVar`s_(8d7cca27987b099d).snap
@@ -31,11 +31,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_as
 error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to attribute `attr` of type `int`
  --> src/mdtest_snippet.py:7:1
   |
-6 | C.attr = 1  # fine
 7 | C.attr = "wrong"  # error: [invalid-assignment]
   | ^^^^^^
-8 |
-9 | instance = C()
   |
 
 ```
@@ -44,7 +41,6 @@ error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable t
 error[invalid-attribute-access]: Cannot assign to ClassVar `attr` from an instance of type `C`
   --> src/mdtest_snippet.py:10:1
    |
- 9 | instance = C()
 10 | instance.attr = 1  # error: [invalid-attribute-access]
    | ^^^^^^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attributes.md_-_Attributes_-_Attributes_of_standa…_(49ba2c9016d64653).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attributes.md_-_Attributes_-_Attributes_of_standa…_(49ba2c9016d64653).snap
@@ -27,11 +27,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/attributes.md
 error[unresolved-attribute]: Module `datetime` has no member `UTC`
  --> src/main.py:4:13
   |
-3 | # error: [unresolved-attribute]
 4 | reveal_type(datetime.UTC)  # revealed: Unknown
   |             ^^^^^^^^^^^^
-5 | # error: [unresolved-attribute]
-6 | reveal_type(datetime.fakenotreal)  # revealed: Unknown
   |
 info: The member may be available on other Python versions or platforms
 info: Python 3.10 was assumed when resolving the `UTC` attribute because it was specified on the command line
@@ -42,8 +39,6 @@ info: Python 3.10 was assumed when resolving the `UTC` attribute because it was 
 error[unresolved-attribute]: Module `datetime` has no member `fakenotreal`
  --> src/main.py:6:13
   |
-4 | reveal_type(datetime.UTC)  # revealed: Unknown
-5 | # error: [unresolved-attribute]
 6 | reveal_type(datetime.fakenotreal)  # revealed: Unknown
   |             ^^^^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attributes.md_-_Attributes_-_Diagnostic_for_funct…_(340818ba77052e65).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attributes.md_-_Attributes_-_Diagnostic_for_funct…_(340818ba77052e65).snap
@@ -26,10 +26,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/attributes.md
 error[unresolved-attribute]: Object of type `(...) -> Unknown` has no attribute `__name__`
  --> src/mdtest_snippet.py:4:5
   |
-3 | def f(x: Callable):
 4 |     x.__name__  # error: [unresolved-attribute]
   |     ^^^^^^^^^^
-5 |     x.__annotate__  # error: [unresolved-attribute]
   |
 help: Function objects have a `__name__` attribute, but not all callable objects are functions
 help: See this FAQ for more information: <https://docs.astral.sh/ty/reference/typing-faq/#why-does-ty-say-callable-has-no-attribute-__name__>
@@ -40,8 +38,6 @@ help: See this FAQ for more information: <https://docs.astral.sh/ty/reference/ty
 error[unresolved-attribute]: Object of type `(...) -> Unknown` has no attribute `__annotate__`
  --> src/mdtest_snippet.py:5:5
   |
-3 | def f(x: Callable):
-4 |     x.__name__  # error: [unresolved-attribute]
 5 |     x.__annotate__  # error: [unresolved-attribute]
   |     ^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attributes.md_-_Attributes_-_Invalid_access_to_at…_(5457445ffed43a87).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attributes.md_-_Attributes_-_Invalid_access_to_at…_(5457445ffed43a87).snap
@@ -102,12 +102,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/attributes.md
 error[unresolved-reference]: Name `x` used when not defined
  --> src/mdtest_snippet.py:6:13
   |
-4 |     def method(self):
-5 |         # error: [unresolved-reference] "Name `x` used when not defined"
 6 |         y = x
   |             ^
-7 | class Foo:
-8 |     x: int = 1
   |
 info: An attribute `x` is available: consider using `self.x`
 
@@ -117,12 +113,8 @@ info: An attribute `x` is available: consider using `self.x`
 error[unresolved-reference]: Name `x` used when not defined
   --> src/mdtest_snippet.py:12:13
    |
-10 |     def method(self):
-11 |         # error: [unresolved-reference] "Name `x` used when not defined"
 12 |         y = x
    |             ^
-13 | class Foo:
-14 |     def __init__(self):
    |
 info: An attribute `x` is available: consider using `self.x`
 
@@ -132,12 +124,8 @@ info: An attribute `x` is available: consider using `self.x`
 error[unresolved-reference]: Name `x` used when not defined
   --> src/mdtest_snippet.py:19:13
    |
-17 |     def method(self):
-18 |         # error: [unresolved-reference] "Name `x` used when not defined"
 19 |         y = x
    |             ^
-20 | class Foo:
-21 |     def __init__(self):
    |
 info: An attribute `x` is available: consider using `self.x`
 
@@ -147,11 +135,8 @@ info: An attribute `x` is available: consider using `self.x`
 error[unresolved-reference]: Name `x` used when not defined
   --> src/mdtest_snippet.py:27:13
    |
-25 |     def static_method():
-26 |         # error: [unresolved-reference] "Name `x` used when not defined"
 27 |         y = x
    |             ^
-28 | from typing import ClassVar
    |
 
 ```
@@ -160,12 +145,8 @@ error[unresolved-reference]: Name `x` used when not defined
 error[unresolved-reference]: Name `x` used when not defined
   --> src/mdtest_snippet.py:36:13
    |
-34 |     def class_method(cls):
-35 |         # error: [unresolved-reference] "Name `x` used when not defined"
 36 |         y = x
    |             ^
-37 | class Foo:
-38 |     def __init__(self):
    |
 info: An attribute `x` is available: consider using `cls.x`
 
@@ -175,12 +156,8 @@ info: An attribute `x` is available: consider using `cls.x`
 error[unresolved-reference]: Name `x` used when not defined
   --> src/mdtest_snippet.py:44:13
    |
-42 |     def class_method(cls):
-43 |         # error: [unresolved-reference] "Name `x` used when not defined"
 44 |         y = x
    |             ^
-45 | class Foo:
-46 |     x: ClassVar[int]
    |
 
 ```
@@ -189,12 +166,8 @@ error[unresolved-reference]: Name `x` used when not defined
 error[unresolved-reference]: Name `x` used when not defined
   --> src/mdtest_snippet.py:52:13
    |
-50 |     def class_method(cls):
-51 |         # error: [unresolved-reference] "Name `x` used when not defined"
 52 |         y = x
    |             ^
-53 | class Foo:
-54 |     def __init__(self):
    |
 
 ```
@@ -203,11 +176,8 @@ error[unresolved-reference]: Name `x` used when not defined
 error[unresolved-reference]: Name `x` used when not defined
   --> src/mdtest_snippet.py:59:13
    |
-57 |     def method(other):
-58 |         # error: [unresolved-reference] "Name `x` used when not defined"
 59 |         y = x
    |             ^
-60 | from typing import ClassVar
    |
 info: An attribute `x` is available: consider using `other.x`
 
@@ -217,11 +187,8 @@ info: An attribute `x` is available: consider using `other.x`
 error[unresolved-reference]: Name `x` used when not defined
   --> src/mdtest_snippet.py:68:13
    |
-66 |     def class_method(c_other):
-67 |         # error: [unresolved-reference] "Name `x` used when not defined"
 68 |         y = x
    |             ^
-69 | from typing import ClassVar
    |
 info: An attribute `x` is available: consider using `c_other.x`
 
@@ -231,12 +198,8 @@ info: An attribute `x` is available: consider using `c_other.x`
 error[unresolved-reference]: Name `x` used when not defined
   --> src/mdtest_snippet.py:76:15
    |
-74 |     def instance_method(*args, **kwargs):
-75 |         # error: [unresolved-reference] "Name `x` used when not defined"
 76 |         print(x)
    |               ^
-77 |
-78 |     @classmethod
    |
 
 ```
@@ -245,8 +208,6 @@ error[unresolved-reference]: Name `x` used when not defined
 error[unresolved-reference]: Name `x` used when not defined
   --> src/mdtest_snippet.py:81:13
    |
-79 |     def class_method(*, cls):
-80 |         # error: [unresolved-reference] "Name `x` used when not defined"
 81 |         y = x
    |             ^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/attributes.md_-_Attributes_-_Unimported_submodule…_(2b6da09ed380b2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/attributes.md_-_Attributes_-_Unimported_submodule…_(2b6da09ed380b2).snap
@@ -43,11 +43,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/attributes.md
 warning[possibly-missing-submodule]: Submodule `bar` might not have been imported
  --> src/main.py:5:13
   |
-4 | # error: [possibly-missing-submodule]
 5 | reveal_type(foo.bar)  # revealed: Unknown
   |             ^^^^^^^
-6 | # error: [possibly-missing-submodule]
-7 | reveal_type(baz.bar)  # revealed: Unknown
   |
 help: Consider explicitly importing `foo.bar`
 
@@ -57,8 +54,6 @@ help: Consider explicitly importing `foo.bar`
 warning[possibly-missing-submodule]: Submodule `bar` might not have been imported
  --> src/main.py:7:13
   |
-5 | reveal_type(foo.bar)  # revealed: Unknown
-6 | # error: [possibly-missing-submodule]
 7 | reveal_type(baz.bar)  # revealed: Unknown
   |             ^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/augmented.md_-_Augmented_assignment_-_Unsupported_types_(a041d9e40c83a8ac).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/augmented.md_-_Augmented_assignment_-_Unsupported_types_(a041d9e40c83a8ac).snap
@@ -30,15 +30,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/assignment/augmented.md
 error[unsupported-operator]: Unsupported `-=` operation
  --> src/mdtest_snippet.py:7:1
   |
-5 | x = C()
-6 | # error: [unsupported-operator] "Operator `-=` is not supported between objects of type `C` and `Literal[1]`"
 7 | x -= 1
   | -^^^^-
   | |    |
   | |    Has type `Literal[1]`
   | Has type `C`
-8 |
-9 | reveal_type(x)  # revealed: int
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Exception_Handling_-_Invalid_exception_ha…_(d394c561bdd35078).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Exception_Handling_-_Invalid_exception_ha…_(d394c561bdd35078).snap
@@ -55,11 +55,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/exception/basic.md
 error[invalid-exception-caught]: Invalid object caught in an exception handler
  --> src/mdtest_snippet.py:4:8
   |
-2 |     pass
-3 | # error: [invalid-exception-caught]
 4 | except 3 as e:
   |        ^ Object has type `Literal[3]`
-5 |     reveal_type(e)  # revealed: Unknown
   |
 info: Can only catch a subclass of `BaseException` or tuple of `BaseException` subclasses
 
@@ -69,14 +66,11 @@ info: Can only catch a subclass of `BaseException` or tuple of `BaseException` s
 error[invalid-exception-caught]: Invalid tuple caught in an exception handler
   --> src/mdtest_snippet.py:10:8
    |
- 8 |     pass
- 9 | # error: [invalid-exception-caught]
 10 | except (ValueError, OSError, "foo", b"bar") as e:
    |        ^^^^^^^^^^^^^^^^^^^^^^-----^^------^
    |                              |      |
    |                              |      Invalid element of type `Literal[b"bar"]`
    |                              Invalid element of type `Literal["foo"]`
-11 |     reveal_type(e)  # revealed: ValueError | OSError | Unknown
    |
 info: Can only catch a subclass of `BaseException` or tuple of `BaseException` subclasses
 
@@ -86,12 +80,8 @@ info: Can only catch a subclass of `BaseException` or tuple of `BaseException` s
 error[invalid-exception-caught]: Invalid object caught in an exception handler
   --> src/mdtest_snippet.py:21:12
    |
-19 |         help()
-20 |     # error: [invalid-exception-caught]
 21 |     except x as e:
    |            ^ Object has type `type[str]`
-22 |         reveal_type(e)  # revealed: Unknown
-23 |     # error: [invalid-exception-caught]
    |
 info: Can only catch a subclass of `BaseException` or tuple of `BaseException` subclasses
 
@@ -101,12 +91,8 @@ info: Can only catch a subclass of `BaseException` or tuple of `BaseException` s
 error[invalid-exception-caught]: Invalid tuple caught in an exception handler
   --> src/mdtest_snippet.py:24:12
    |
-22 |         reveal_type(e)  # revealed: Unknown
-23 |     # error: [invalid-exception-caught]
 24 |     except y as f:
    |            ^ Object has type `tuple[type[OSError], type[RuntimeError], int]`
-25 |         reveal_type(f)  # revealed: OSError | RuntimeError | Unknown
-26 |     # error: [invalid-exception-caught]
    |
 info: Can only catch a subclass of `BaseException` or tuple of `BaseException` subclasses
 
@@ -116,11 +102,8 @@ info: Can only catch a subclass of `BaseException` or tuple of `BaseException` s
 error[invalid-exception-caught]: Invalid tuple caught in an exception handler
   --> src/mdtest_snippet.py:27:12
    |
-25 |         reveal_type(f)  # revealed: OSError | RuntimeError | Unknown
-26 |     # error: [invalid-exception-caught]
 27 |     except z as g:
    |            ^ Object has type `tuple[type[str], ...]`
-28 |         reveal_type(g)  # revealed: Unknown
    |
 info: Can only catch a subclass of `BaseException` or tuple of `BaseException` subclasses
 
@@ -130,11 +113,8 @@ info: Can only catch a subclass of `BaseException` or tuple of `BaseException` s
 error[invalid-exception-caught]: Invalid object caught in an exception handler
   --> src/mdtest_snippet.py:33:8
    |
-31 |     {}.get("foo")
-32 | # error: [invalid-exception-caught]
 33 | except int:
    |        ^^^ Object has type `<class 'int'>`
-34 |     pass
    |
 info: Can only catch a subclass of `BaseException` or tuple of `BaseException` subclasses
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Exception_Handling_-_Special-cased_diagno…_(a97274530a7f61c1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Exception_Handling_-_Special-cased_diagno…_(a97274530a7f61c1).snap
@@ -31,12 +31,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/exception/basic.md
 error[invalid-raise]: Cannot raise `NotImplemented`
  --> src/mdtest_snippet.py:4:11
   |
-2 |     # error: [invalid-raise]
-3 |     # error: [invalid-raise]
 4 |     raise NotImplemented from NotImplemented
   |           ^^^^^^^^^^^^^^ Did you mean `NotImplementedError`?
-5 | # error: [invalid-exception-caught]
-6 | except NotImplemented:
   |
 info: Can only raise an instance or subclass of `BaseException`
 
@@ -46,12 +42,8 @@ info: Can only raise an instance or subclass of `BaseException`
 error[invalid-raise]: Cannot use `NotImplemented` as an exception cause
  --> src/mdtest_snippet.py:4:31
   |
-2 |     # error: [invalid-raise]
-3 |     # error: [invalid-raise]
 4 |     raise NotImplemented from NotImplemented
   |                               ^^^^^^^^^^^^^^ Did you mean `NotImplementedError`?
-5 | # error: [invalid-exception-caught]
-6 | except NotImplemented:
   |
 info: An exception cause must be an instance of `BaseException`, subclass of `BaseException`, or `None`
 
@@ -61,12 +53,8 @@ info: An exception cause must be an instance of `BaseException`, subclass of `Ba
 error[invalid-exception-caught]: Cannot catch `NotImplemented` in an exception handler
  --> src/mdtest_snippet.py:6:8
   |
-4 |     raise NotImplemented from NotImplemented
-5 | # error: [invalid-exception-caught]
 6 | except NotImplemented:
   |        ^^^^^^^^^^^^^^ Did you mean `NotImplementedError`?
-7 |     pass
-8 | # error: [invalid-exception-caught]
   |
 info: Can only catch a subclass of `BaseException` or tuple of `BaseException` subclasses
 
@@ -74,17 +62,14 @@ info: Can only catch a subclass of `BaseException` or tuple of `BaseException` s
 
 ```
 error[invalid-exception-caught]: Invalid tuple caught in an exception handler
-  --> src/mdtest_snippet.py:9:8
-   |
- 7 |     pass
- 8 | # error: [invalid-exception-caught]
- 9 | except (TypeError, NotImplemented):
-   |        ^^^^^^^^^^^^--------------^
-   |                    |
-   |                    Invalid element of type `NotImplementedType`
-   |                    Did you mean `NotImplementedError`?
-10 |     pass
-   |
+ --> src/mdtest_snippet.py:9:8
+  |
+9 | except (TypeError, NotImplemented):
+  |        ^^^^^^^^^^^^--------------^
+  |                    |
+  |                    Invalid element of type `NotImplementedType`
+  |                    Did you mean `NotImplementedError`?
+  |
 info: Can only catch a subclass of `BaseException` or tuple of `BaseException` subclasses
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Attempting_to_import…_(2fcfcf567587a056).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Attempting_to_import…_(2fcfcf567587a056).snap
@@ -26,8 +26,6 @@ error[unresolved-import]: Cannot resolve imported module `tomllib`
   |
 1 | import tomllib  # error: [unresolved-import]
   |        ^^^^^^^
-2 | from string.templatelib import Template  # error: [unresolved-import]
-3 | from importlib.resources import abc  # error: [unresolved-import]
   |
 info: The stdlib module `tomllib` is only available on Python 3.11+
 info: Python 3.10 was assumed when resolving modules because it was specified on the command line
@@ -38,10 +36,8 @@ info: Python 3.10 was assumed when resolving modules because it was specified on
 error[unresolved-import]: Cannot resolve imported module `string.templatelib`
  --> src/mdtest_snippet.py:2:6
   |
-1 | import tomllib  # error: [unresolved-import]
 2 | from string.templatelib import Template  # error: [unresolved-import]
   |      ^^^^^^^^^^^^^^^^^^
-3 | from importlib.resources import abc  # error: [unresolved-import]
   |
 info: The stdlib module `string.templatelib` is only available on Python 3.14+
 info: Python 3.10 was assumed when resolving modules because it was specified on the command line
@@ -52,8 +48,6 @@ info: Python 3.10 was assumed when resolving modules because it was specified on
 error[unresolved-import]: Module `importlib.resources` has no member `abc`
  --> src/mdtest_snippet.py:3:33
   |
-1 | import tomllib  # error: [unresolved-import]
-2 | from string.templatelib import Template  # error: [unresolved-import]
 3 | from importlib.resources import abc  # error: [unresolved-import]
   |                                 ^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Attempting_to_import…_(c14954eefd15211f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Attempting_to_import…_(c14954eefd15211f).snap
@@ -25,7 +25,6 @@ error[unresolved-import]: Cannot resolve imported module `aifc`
   |
 1 | import aifc  # error: [unresolved-import]
   |        ^^^^
-2 | from distutils import sysconfig  # error: [unresolved-import]
   |
 info: The stdlib module `aifc` is only available on Python <=3.12
 info: Python 3.13 was assumed when resolving modules because it was specified on the command line
@@ -36,7 +35,6 @@ info: Python 3.13 was assumed when resolving modules because it was specified on
 error[unresolved-import]: Cannot resolve imported module `distutils`
  --> src/mdtest_snippet.py:2:6
   |
-1 | import aifc  # error: [unresolved-import]
 2 | from distutils import sysconfig  # error: [unresolved-import]
   |      ^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Attempting_to_import…_(dba22bd97137ee38).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Attempting_to_import…_(dba22bd97137ee38).snap
@@ -27,8 +27,6 @@ error[unresolved-import]: Cannot resolve imported module `compression.zstd`
   |
 1 | import compression.zstd  # error: [unresolved-import]
   |        ^^^^^^^^^^^^^^^^
-2 | from compression import zstd  # error: [unresolved-import]
-3 | import compression.fakebutwhocansay  # error: [unresolved-import]
   |
 info: The stdlib module `compression` is only available on Python 3.14+
 info: Python 3.10 was assumed when resolving modules because it was specified on the command line
@@ -39,11 +37,8 @@ info: Python 3.10 was assumed when resolving modules because it was specified on
 error[unresolved-import]: Cannot resolve imported module `compression`
  --> src/mdtest_snippet.py:2:6
   |
-1 | import compression.zstd  # error: [unresolved-import]
 2 | from compression import zstd  # error: [unresolved-import]
   |      ^^^^^^^^^^^
-3 | import compression.fakebutwhocansay  # error: [unresolved-import]
-4 | from compression import fakebutwhocansay  # error: [unresolved-import]
   |
 info: The stdlib module `compression` is only available on Python 3.14+
 info: Python 3.10 was assumed when resolving modules because it was specified on the command line
@@ -54,11 +49,8 @@ info: Python 3.10 was assumed when resolving modules because it was specified on
 error[unresolved-import]: Cannot resolve imported module `compression.fakebutwhocansay`
  --> src/mdtest_snippet.py:3:8
   |
-1 | import compression.zstd  # error: [unresolved-import]
-2 | from compression import zstd  # error: [unresolved-import]
 3 | import compression.fakebutwhocansay  # error: [unresolved-import]
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-4 | from compression import fakebutwhocansay  # error: [unresolved-import]
   |
 info: The stdlib module `compression` is only available on Python 3.14+
 info: Python 3.10 was assumed when resolving modules because it was specified on the command line
@@ -69,8 +61,6 @@ info: Python 3.10 was assumed when resolving modules because it was specified on
 error[unresolved-import]: Cannot resolve imported module `compression`
  --> src/mdtest_snippet.py:4:6
   |
-2 | from compression import zstd  # error: [unresolved-import]
-3 | import compression.fakebutwhocansay  # error: [unresolved-import]
 4 | from compression import fakebutwhocansay  # error: [unresolved-import]
   |      ^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Multiple_objects_imp…_(cbfbf5ff94e6e104).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Multiple_objects_imp…_(cbfbf5ff94e6e104).snap
@@ -23,7 +23,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/import/basic.md
 error[unresolved-import]: Cannot resolve imported module `does_not_exist`
  --> src/mdtest_snippet.py:2:6
   |
-1 | # error: [unresolved-import]
 2 | from does_not_exist import foo, bar, baz
   |      ^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodu…_(4fad4be9778578b7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodu…_(4fad4be9778578b7).snap
@@ -31,11 +31,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/import/basic.md
 error[unresolved-import]: Cannot resolve imported module `a.foo`
  --> src/mdtest_snippet.py:2:8
   |
-1 | # Topmost component resolvable, submodule not resolvable:
 2 | import a.foo  # error: [unresolved-import] "Cannot resolve imported module `a.foo`"
   |        ^^^^^
-3 |
-4 | # Topmost component unresolvable:
   |
 info: Searched in the following paths during module resolution:
 info:   1. /src (first-party code)
@@ -48,7 +45,6 @@ info: make sure your Python environment is properly configured: https://docs.ast
 error[unresolved-import]: Cannot resolve imported module `b.foo`
  --> src/mdtest_snippet.py:5:8
   |
-4 | # Topmost component unresolvable:
 5 | import b.foo  # error: [unresolved-import] "Cannot resolve imported module `b.foo`"
   |        ^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/builtins.md_-_Calling_builtins_-_The_builtin_`NotImpl…_(ac366391ebdec9c0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/builtins.md_-_Calling_builtins_-_The_builtin_`NotImpl…_(ac366391ebdec9c0).snap
@@ -26,13 +26,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/call/builtins.md
 error[call-non-callable]: `NotImplemented` is not callable
  --> src/mdtest_snippet.py:2:11
   |
-1 | def _():
 2 |     raise NotImplemented()  # error: [call-non-callable]
   |           --------------^^
   |           |
   |           Did you mean `NotImplementedError`?
-3 |
-4 | def _():
   |
 
 ```
@@ -41,7 +38,6 @@ error[call-non-callable]: `NotImplemented` is not callable
 error[call-non-callable]: `NotImplemented` is not callable
  --> src/mdtest_snippet.py:5:11
   |
-4 | def _():
 5 |     raise NotImplemented("this module is not implemented yet!!!")  # error: [call-non-callable]
   |           --------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |           |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/cast.md_-_`cast`_-_Diagnostic_snapshots_(91dd3d45b6d7f2c8).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/cast.md_-_`cast`_-_Diagnostic_snapshots_(91dd3d45b6d7f2c8).snap
@@ -26,7 +26,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/directives/cast.md
 warning[redundant-cast]: Value is already of type `int`
  --> src/mdtest_snippet.py:5:1
   |
-4 | # error: [redundant-cast] "Value is already of type `int`"
 5 | cast(int, secrets.randbelow(10))
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___Leg…_-_Diagnostics_for_bad_…_(2ceba7b720e21b8b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___Leg…_-_Diagnostics_for_bad_…_(2ceba7b720e21b8b).snap
@@ -40,19 +40,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.
 error[invalid-type-arguments]: Type `int` is not assignable to upper bound `str` of type variable `T@Bounded`
  --> src/main.py:3:12
   |
-1 | from library import Bounded, Constrained
-2 |
 3 | x: Bounded[int]  # error: [invalid-type-arguments]
   |            ^^^
-4 | y: Constrained[str]  # error: [invalid-type-arguments]
   |
  ::: src/library.py:3:1
   |
-1 | from typing import TypeVar, Generic
-2 |
 3 | T = TypeVar("T", bound=str)
   | - Type variable defined here
-4 | U = TypeVar("U", int, bytes)
   |
 
 ```
@@ -61,17 +55,13 @@ error[invalid-type-arguments]: Type `int` is not assignable to upper bound `str`
 error[invalid-type-arguments]: Type `str` does not satisfy constraints `int`, `bytes` of type variable `U@Constrained`
  --> src/main.py:4:16
   |
-3 | x: Bounded[int]  # error: [invalid-type-arguments]
 4 | y: Constrained[str]  # error: [invalid-type-arguments]
   |                ^^^
   |
  ::: src/library.py:4:1
   |
-3 | T = TypeVar("T", bound=str)
 4 | U = TypeVar("U", int, bytes)
   | - Type variable defined here
-5 |
-6 | class Bounded(Generic[T]):
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___Leg…_-_Errors_for_inconsist…_(557742f3cd2464b2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___Leg…_-_Errors_for_inconsist…_(557742f3cd2464b2).snap
@@ -73,14 +73,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.
 error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` among class bases
   --> src/mdtest_snippet.py:13:7
    |
-12 | # error: [invalid-generic-class] "Inconsistent type arguments: class cannot inherit from both `Grandparent[T2@BadChild, T1@BadChild]` …
 13 | class BadChild(Parent[T1, T2], Grandparent[T2, T1]): ...
    |       ^^^^^^^^^--------------^^-------------------^
    |                |               |
    |                |               Later class base is `Grandparent[T2@BadChild, T1@BadChild]`
    |                Earlier class base inherits from `Grandparent[T1@BadChild, T2@BadChild]`
-14 |
-15 | # The same applies when the explicit base is partially specialized differently:
    |
 
 ```
@@ -89,14 +86,11 @@ error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` amon
 error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` among class bases
   --> src/mdtest_snippet.py:19:7
    |
-18 | # error: [invalid-generic-class] "Inconsistent type arguments: class cannot inherit from both `Grandparent[T2@BadChild2, int]` and `Gr…
 19 | class BadChild2(Parent2[T1, T2], Grandparent[T2, int]): ...
    |       ^^^^^^^^^^---------------^^--------------------^
    |                 |                |
    |                 |                Later class base is `Grandparent[T2@BadChild2, int]`
    |                 Earlier class base inherits from `Grandparent[T1@BadChild2, T2@BadChild2]`
-20 |
-21 | # The inconsistency can also come through two intermediate classes (diamond):
    |
 
 ```
@@ -105,14 +99,11 @@ error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` amon
 error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` among class bases
   --> src/mdtest_snippet.py:26:7
    |
-25 | # error: [invalid-generic-class] "Inconsistent type arguments: class cannot inherit from both `Grandparent[T2@BadChild3, T1@BadChild3]…
 26 | class BadChild3(Parent3[T1, T2], Parent4[T2, T1]): ...
    |       ^^^^^^^^^^---------------^^---------------^
    |                 |                |
    |                 |                Later class base inherits from `Grandparent[T2@BadChild3, T1@BadChild3]`
    |                 Earlier class base inherits from `Grandparent[T1@BadChild3, T2@BadChild3]`
-27 |
-28 | # Implicit specialization is fine:
    |
 
 ```
@@ -121,14 +112,11 @@ error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` amon
 error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` among class bases
   --> src/mdtest_snippet.py:37:7
    |
-36 | # error: [invalid-generic-class]
 37 | class BadChild4(Parent, Parent3[T1, T2], Parent4[T2, T1]): ...
    |       ^^^^^^^^^^^^^^^^^^---------------^^---------------^
    |                         |                |
    |                         |                Later class base inherits from `Grandparent[T2@BadChild4, T1@BadChild4]`
    |                         Earlier class base inherits from `Grandparent[T1@BadChild4, T2@BadChild4]`
-38 |
-39 | # error: [invalid-generic-class]
    |
 
 ```
@@ -137,14 +125,11 @@ error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` amon
 error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` among class bases
   --> src/mdtest_snippet.py:40:7
    |
-39 | # error: [invalid-generic-class]
 40 | class BadChild5(Parent[Any, Any], Parent3[T1, T2], Parent4[T2, T1]): ...
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------^^---------------^
    |                                   |                |
    |                                   |                Later class base inherits from `Grandparent[T2@BadChild5, T1@BadChild5]`
    |                                   Earlier class base inherits from `Grandparent[T1@BadChild5, T2@BadChild5]`
-41 |
-42 | # error: [invalid-generic-class]
    |
 
 ```
@@ -153,14 +138,11 @@ error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` amon
 error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` among class bases
   --> src/mdtest_snippet.py:43:7
    |
-42 | # error: [invalid-generic-class]
 43 | class BadChild6(Parent[T1, T2], Parent3, Parent4[T2, T1]): ...
    |       ^^^^^^^^^^--------------^^^^^^^^^^^---------------^
    |                 |                        |
    |                 |                        Later class base inherits from `Grandparent[T2@BadChild6, T1@BadChild6]`
    |                 Earlier class base inherits from `Grandparent[T1@BadChild6, T2@BadChild6]`
-44 |
-45 | # error: [invalid-generic-class]
    |
 
 ```
@@ -169,14 +151,11 @@ error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` amon
 error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` among class bases
   --> src/mdtest_snippet.py:46:7
    |
-45 | # error: [invalid-generic-class]
 46 | class BadChild7(Parent[T1, T2], Parent3[Any, Any], Parent4[T2, T1]): ...
    |       ^^^^^^^^^^--------------^^^^^^^^^^^^^^^^^^^^^---------------^
    |                 |                                  |
    |                 |                                  Later class base inherits from `Grandparent[T2@BadChild7, T1@BadChild7]`
    |                 Earlier class base inherits from `Grandparent[T1@BadChild7, T2@BadChild7]`
-47 |
-48 | # error: [invalid-generic-class]
    |
 
 ```
@@ -185,14 +164,11 @@ error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` amon
 error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` among class bases
   --> src/mdtest_snippet.py:49:7
    |
-48 | # error: [invalid-generic-class]
 49 | class BadChild8(Parent[T1, T2], Parent3[T2, T1], Parent4): ...
    |       ^^^^^^^^^^--------------^^---------------^^^^^^^^^^
    |                 |               |
    |                 |               Later class base inherits from `Grandparent[T2@BadChild8, T1@BadChild8]`
    |                 Earlier class base inherits from `Grandparent[T1@BadChild8, T2@BadChild8]`
-50 |
-51 | # error: [invalid-generic-class]
    |
 
 ```
@@ -201,7 +177,6 @@ error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` amon
 error[invalid-generic-class]: Inconsistent type arguments for `Grandparent` among class bases
   --> src/mdtest_snippet.py:52:7
    |
-51 | # error: [invalid-generic-class]
 52 | class BadChild9(Parent[T1, T2], Parent3[T2, T1], Parent4[Any, Any]): ...
    |       ^^^^^^^^^^--------------^^---------------^^^^^^^^^^^^^^^^^^^^
    |                 |               |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___Leg…_-_Specializing_generic…_(5a066394f338af48).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___Leg…_-_Specializing_generic…_(5a066394f338af48).snap
@@ -106,11 +106,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.
 error[invalid-type-arguments]: Too many type arguments to class `C`: expected 1, got 2
   --> src/mdtest_snippet.py:11:20
    |
- 9 | reveal_type(C[Literal[5]]())  # revealed: C[Literal[5]]
-10 | # error: [invalid-type-arguments] "Too many type arguments to class `C`: expected 1, got 2"
 11 | reveal_type(C[int, int]())  # revealed: C[Unknown]
    |                    ^^^
-12 | from typing import Union
    |
 
 ```
@@ -119,19 +116,13 @@ error[invalid-type-arguments]: Too many type arguments to class `C`: expected 1,
 error[invalid-type-arguments]: Type `str` is not assignable to upper bound `int` of type variable `BoundedT@Bounded`
   --> src/mdtest_snippet.py:25:21
    |
-24 | # error: [invalid-type-arguments] "Type `str` is not assignable to upper bound `int` of type variable `BoundedT@Bounded`"
 25 | reveal_type(Bounded[str]())  # revealed: Bounded[Unknown]
    |                     ^^^
-26 |
-27 | # error:  [invalid-type-arguments] "Type `int | str` is not assignable to upper bound `int` of type variable `BoundedT@Bounded`"
    |
   ::: src/mdtest_snippet.py:14:1
    |
-12 | from typing import Union
-13 |
 14 | BoundedT = TypeVar("BoundedT", bound=int)
    | -------- Type variable defined here
-15 | BoundedByUnionT = TypeVar("BoundedByUnionT", bound=Union[int, str])
    |
 
 ```
@@ -140,19 +131,13 @@ error[invalid-type-arguments]: Type `str` is not assignable to upper bound `int`
 error[invalid-type-arguments]: Type `int | str` is not assignable to upper bound `int` of type variable `BoundedT@Bounded`
   --> src/mdtest_snippet.py:28:21
    |
-27 | # error:  [invalid-type-arguments] "Type `int | str` is not assignable to upper bound `int` of type variable `BoundedT@Bounded`"
 28 | reveal_type(Bounded[int | str]())  # revealed: Bounded[Unknown]
    |                     ^^^^^^^^^
-29 |
-30 | reveal_type(BoundedByUnion[int]())  # revealed: BoundedByUnion[int]
    |
   ::: src/mdtest_snippet.py:14:1
    |
-12 | from typing import Union
-13 |
 14 | BoundedT = TypeVar("BoundedT", bound=int)
    | -------- Type variable defined here
-15 | BoundedByUnionT = TypeVar("BoundedByUnionT", bound=Union[int, str])
    |
 
 ```
@@ -161,19 +146,13 @@ error[invalid-type-arguments]: Type `int | str` is not assignable to upper bound
 error[invalid-type-arguments]: Type `object` does not satisfy constraints `int`, `str` of type variable `ConstrainedT@Constrained`
   --> src/mdtest_snippet.py:51:25
    |
-50 | # error: [invalid-type-arguments] "Type `object` does not satisfy constraints `int`, `str` of type variable `ConstrainedT@Constrained`"
 51 | reveal_type(Constrained[object]())  # revealed: Constrained[Unknown]
    |                         ^^^^^^
-52 | WithDefaultU = TypeVar("WithDefaultU", default=int)
    |
   ::: src/mdtest_snippet.py:34:1
    |
-32 | reveal_type(BoundedByUnion[str]())  # revealed: BoundedByUnion[str]
-33 | reveal_type(BoundedByUnion[int | str]())  # revealed: BoundedByUnion[int | str]
 34 | ConstrainedT = TypeVar("ConstrainedT", int, str)
    | ------------ Type variable defined here
-35 |
-36 | class Constrained(Generic[ConstrainedT]): ...
    |
 
 ```
@@ -182,10 +161,8 @@ error[invalid-type-arguments]: Type `object` does not satisfy constraints `int`,
 error[invalid-type-arguments]: Too many type arguments to class `WithDefault`: expected between 1 and 2, got 3
   --> src/mdtest_snippet.py:60:35
    |
-59 | # error: [invalid-type-arguments] "Too many type arguments to class `WithDefault`: expected between 1 and 2, got 3"
 60 | reveal_type(WithDefault[str, str, str]())  # revealed: WithDefault[Unknown, Unknown]
    |                                   ^^^
-61 | from typing_extensions import TypeVar, Generic
    |
 
 ```
@@ -194,22 +171,15 @@ error[invalid-type-arguments]: Too many type arguments to class `WithDefault`: e
 error[invalid-generic-class]: Default of `WithDefaultT2` cannot reference later type parameter `WithDefaultT1`
   --> src/mdtest_snippet.py:70:7
    |
-69 | # error: [invalid-generic-class] "Default of `WithDefaultT2` cannot reference later type parameter `WithDefaultT1`"
 70 | class BadOrder(Generic[WithDefaultT2, WithDefaultT1]): ...
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-71 |
-72 | WithDefaultU = TypeVar("WithDefaultU", default=int)
    |
   ::: src/mdtest_snippet.py:63:1
    |
-61 | from typing_extensions import TypeVar, Generic
-62 |
 63 | WithDefaultT1 = TypeVar("WithDefaultT1", default=int)
    | ----------------------------------------------------- `WithDefaultT1` defined here
 64 | WithDefaultT2 = TypeVar("WithDefaultT2", default=WithDefaultT1)
    | --------------------------------------------------------------- `WithDefaultT2` defined here
-65 |
-66 | # This is fine: WithDefaultT2's default references WithDefaultT1, which comes before it
    |
 
 ```
@@ -218,21 +188,15 @@ error[invalid-generic-class]: Default of `WithDefaultT2` cannot reference later 
 error[invalid-generic-class]: Default of `WithDefaultT2` cannot reference later type parameter `WithDefaultT1`
   --> src/mdtest_snippet.py:75:7
    |
-74 | # error: [invalid-generic-class]
 75 | class AlsoBadOrder(Generic[WithDefaultT2, WithDefaultT1, WithDefaultU]): ...
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-76 | from typing_extensions import TypeVar, Generic
    |
   ::: src/mdtest_snippet.py:63:1
    |
-61 | from typing_extensions import TypeVar, Generic
-62 |
 63 | WithDefaultT1 = TypeVar("WithDefaultT1", default=int)
    | ----------------------------------------------------- `WithDefaultT1` defined here
 64 | WithDefaultT2 = TypeVar("WithDefaultT2", default=WithDefaultT1)
    | --------------------------------------------------------------- `WithDefaultT2` defined here
-65 |
-66 | # This is fine: WithDefaultT2's default references WithDefaultT1, which comes before it
    |
 
 ```
@@ -241,17 +205,13 @@ error[invalid-generic-class]: Default of `WithDefaultT2` cannot reference later 
 error[invalid-generic-class]: Default of `Start2T` cannot reference out-of-scope type variable `StopT`
   --> src/mdtest_snippet.py:85:7
    |
-84 | # error: [invalid-generic-class] "Default of `Start2T` cannot reference out-of-scope type variable `StopT`"
 85 | class Bad(Generic[Start2T, Stop2T, StepT]): ...
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/mdtest_snippet.py:81:1
    |
-79 | StopT = TypeVar("StopT", default=StartT)
-80 | StepT = TypeVar("StepT", default=int | None)
 81 | Start2T = TypeVar("Start2T", default="StopT")
    | --------------------------------------------- `Start2T` defined here
-82 | Stop2T = TypeVar("Stop2T", default=int)
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___PEP…_-_Default_type_paramet…_(6bb09b09c131074).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___PEP…_-_Default_type_paramet…_(6bb09b09c131074).snap
@@ -49,13 +49,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.
 error[invalid-type-variable-default]: Type parameters with defaults cannot follow a TypeVarTuple parameter
  --> src/mdtest_snippet.py:2:11
   |
-1 | # error: [invalid-type-variable-default] "Type parameter `T` with a default follows TypeVarTuple `Ts`"
 2 | class Foo[*Ts, T = int]: ...
   |           ---  ^^^^^^^ `T` has a default
   |           |
   |           `Ts` is a TypeVarTuple
-3 |
-4 | # error: [invalid-type-variable-default]
   |
 info: See https://typing.python.org/en/latest/spec/generics.html#defaults-following-typevartuple
 
@@ -65,13 +62,10 @@ info: See https://typing.python.org/en/latest/spec/generics.html#defaults-follow
 error[invalid-type-variable-default]: Type parameters with defaults cannot follow a TypeVarTuple parameter
  --> src/mdtest_snippet.py:5:15
   |
-4 | # error: [invalid-type-variable-default]
 5 | class Bar[T1, *Ts, T2 = int]: ...
   |               ---  ^^^^^^^^ `T2` has a default
   |               |
   |               `Ts` is a TypeVarTuple
-6 |
-7 | # error: [invalid-type-variable-default]
   |
 info: See https://typing.python.org/en/latest/spec/generics.html#defaults-following-typevartuple
 
@@ -79,17 +73,14 @@ info: See https://typing.python.org/en/latest/spec/generics.html#defaults-follow
 
 ```
 error[invalid-type-variable-default]: Type parameters with defaults cannot follow a TypeVarTuple parameter
-  --> src/mdtest_snippet.py:8:11
-   |
- 7 | # error: [invalid-type-variable-default]
- 8 | class Baz[*Ts, T1 = int, T2 = str]: ...
-   |           ---  ^^^^^^^^  -------- `T2` also has a default
-   |           |    |
-   |           |    `T1` has a default
-   |           `Ts` is a TypeVarTuple
- 9 |
-10 | # Note: the spec says this is fine,
-   |
+ --> src/mdtest_snippet.py:8:11
+  |
+8 | class Baz[*Ts, T1 = int, T2 = str]: ...
+  |           ---  ^^^^^^^^  -------- `T2` also has a default
+  |           |    |
+  |           |    `T1` has a default
+  |           `Ts` is a TypeVarTuple
+  |
 info: See https://typing.python.org/en/latest/spec/generics.html#defaults-following-typevartuple
 
 ```
@@ -98,14 +89,10 @@ info: See https://typing.python.org/en/latest/spec/generics.html#defaults-follow
 error[invalid-type-variable-default]: Type parameters with defaults cannot follow a TypeVarTuple parameter
   --> src/mdtest_snippet.py:15:11
    |
-13 | #
-14 | # error: [invalid-type-variable-default]
 15 | class Qux[*Ts, **P = [int, str]]: ...
    |           ---  ^^^^^^^^^^^^^^^^ `P` has a default
    |           |
    |           `Ts` is a TypeVarTuple
-16 |
-17 | # error: [invalid-type-variable-default]
    |
 info: See https://typing.python.org/en/latest/spec/generics.html#defaults-following-typevartuple
 
@@ -115,14 +102,11 @@ info: See https://typing.python.org/en/latest/spec/generics.html#defaults-follow
 error[invalid-type-variable-default]: Type parameters with defaults cannot follow a TypeVarTuple parameter
   --> src/mdtest_snippet.py:18:12
    |
-17 | # error: [invalid-type-variable-default]
 18 | class Quux[*Ts, T1 = int, **P = [int, str]]: ...
    |            ---  ^^^^^^^^  ---------------- `P` also has a default
    |            |    |
    |            |    `T1` has a default
    |            `Ts` is a TypeVarTuple
-19 |
-20 | # error: [invalid-type-variable-default]
    |
 info: See https://typing.python.org/en/latest/spec/generics.html#defaults-following-typevartuple
 
@@ -132,15 +116,12 @@ info: See https://typing.python.org/en/latest/spec/generics.html#defaults-follow
 error[invalid-type-variable-default]: Type parameters with defaults cannot follow a TypeVarTuple parameter
   --> src/mdtest_snippet.py:21:13
    |
-20 | # error: [invalid-type-variable-default]
 21 | class Corge[*Ts, T1 = int, T2 = str, **P = [int, str]]: ...
    |             ---  ^^^^^^^^  --------  ---------------- `P` also has a default
    |             |    |         |
    |             |    |         `T2` also has a default
    |             |    `T1` has a default
    |             `Ts` is a TypeVarTuple
-22 |
-23 | # error: [invalid-type-variable-default]
    |
 info: See https://typing.python.org/en/latest/spec/generics.html#defaults-following-typevartuple
 
@@ -150,13 +131,10 @@ info: See https://typing.python.org/en/latest/spec/generics.html#defaults-follow
 error[invalid-type-variable-default]: Type parameters with defaults cannot follow a TypeVarTuple parameter
   --> src/mdtest_snippet.py:24:14
    |
-23 | # error: [invalid-type-variable-default]
 24 | class Grault[*Us, *Ts = *tuple[int, str]]: ...
    |              ---  ^^^^^^^^^^^^^^^^^^^^^^ `Ts` has a default
    |              |
    |              `Us` is a TypeVarTuple
-25 |
-26 | # These are fine:
    |
 info: See https://typing.python.org/en/latest/spec/generics.html#defaults-following-typevartuple
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___PEP…_-_Diagnostics_for_bad_…_(cf706b07cf0ec31f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___PEP…_-_Diagnostics_for_bad_…_(cf706b07cf0ec31f).snap
@@ -35,17 +35,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.
 error[invalid-type-arguments]: Type `int` is not assignable to upper bound `str` of type variable `T@Bounded`
  --> src/main.py:3:12
   |
-1 | from library import Bounded, Constrained
-2 |
 3 | x: Bounded[int]  # error: [invalid-type-arguments]
   |            ^^^
-4 | y: Constrained[str]  # error: [invalid-type-arguments]
   |
  ::: src/library.py:1:15
   |
 1 | class Bounded[T: str]:
   |               - Type variable defined here
-2 |     x: T
   |
 
 ```
@@ -54,17 +50,13 @@ error[invalid-type-arguments]: Type `int` is not assignable to upper bound `str`
 error[invalid-type-arguments]: Type `str` does not satisfy constraints `int`, `bytes` of type variable `U@Constrained`
  --> src/main.py:4:16
   |
-3 | x: Bounded[int]  # error: [invalid-type-arguments]
 4 | y: Constrained[str]  # error: [invalid-type-arguments]
   |                ^^^
   |
  ::: src/library.py:4:19
   |
-2 |     x: T
-3 |
 4 | class Constrained[U: (int, bytes)]:
   |                   - Type variable defined here
-5 |     x: U
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___PEP…_-_Scoping_of_typevars_-_No_back-references_(9051beb16a623d36).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___PEP…_-_Scoping_of_typevars_-_No_back-references_(9051beb16a623d36).snap
@@ -45,10 +45,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.
 error[invalid-type-variable-bound]: TypeVar upper bound cannot be generic
  --> src/mdtest_snippet.py:2:12
   |
-1 | # error: [invalid-type-variable-bound]
 2 | class C[S: T, T]:
   |            ^
-3 |     pass
   |
 
 ```
@@ -57,10 +55,8 @@ error[invalid-type-variable-bound]: TypeVar upper bound cannot be generic
 error[invalid-type-variable-bound]: TypeVar upper bound cannot be generic
  --> src/mdtest_snippet.py:6:15
   |
-5 | # error: [invalid-type-variable-bound]
 6 | class D[S, T: S]:
   |               ^
-7 |     pass
   |
 
 ```
@@ -69,10 +65,8 @@ error[invalid-type-variable-bound]: TypeVar upper bound cannot be generic
 error[invalid-type-variable-constraints]: TypeVar constraint cannot be generic
   --> src/mdtest_snippet.py:10:18
    |
- 9 | # error: [invalid-type-variable-constraints]
 10 | class E[S: (int, T), T]:
    |                  ^
-11 |     pass
    |
 
 ```
@@ -81,13 +75,10 @@ error[invalid-type-variable-constraints]: TypeVar constraint cannot be generic
 error[invalid-generic-class]: Default of `S` cannot reference later type parameter `T`
   --> src/mdtest_snippet.py:21:7
    |
-20 | # error: [invalid-generic-class] "Default of `S` cannot reference later type parameter `T`"
 21 | class Bad[S = T, T = int]: ...
    |       ^^^ -----  ------- `T` defined here
    |           |
    |           `S` defined here
-22 |
-23 | # error: [invalid-generic-class]
    |
 
 ```
@@ -96,7 +87,6 @@ error[invalid-generic-class]: Default of `S` cannot reference later type paramet
 error[invalid-generic-class]: Default of `S` cannot reference later type parameter `T`
   --> src/mdtest_snippet.py:24:7
    |
-23 | # error: [invalid-generic-class]
 24 | class AlsoBad[S = list[T], T = int]: ...
    |       ^^^^^^^ -----------  ------- `T` defined here
    |               |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/concatenate.md_-_`typing.Concatenate`_-_Invalid_uses_of_`Con…_-_Last_argument_must_b…_(dc429fc3e8c18eaf).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/concatenate.md_-_`typing.Concatenate`_-_Invalid_uses_of_`Con…_-_Last_argument_must_b…_(dc429fc3e8c18eaf).snap
@@ -43,11 +43,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/concaten
 error[invalid-type-arguments]: The last argument to `typing.Concatenate` must be either `...` or a `ParamSpec` type variable
  --> src/mdtest_snippet.py:7:36
   |
-6 | # error: [invalid-type-arguments] "The last argument to `typing.Concatenate` must be either `...` or a `ParamSpec` type variable: Got …
 7 | def _(c: Callable[Concatenate[int, str], bool]): ...
   |                                    ^^^ Got `str`
-8 |
-9 | # error: [invalid-type-arguments] "The last argument to `typing.Concatenate` must be either `...` or a `ParamSpec` type variable: Got …
   |
 
 ```
@@ -56,11 +53,8 @@ error[invalid-type-arguments]: The last argument to `typing.Concatenate` must be
 error[invalid-type-arguments]: The last argument to `typing.Concatenate` must be either `...` or a `ParamSpec` type variable
   --> src/mdtest_snippet.py:10:34
    |
- 9 | # error: [invalid-type-arguments] "The last argument to `typing.Concatenate` must be either `...` or a `ParamSpec` type variable: Got …
 10 | reveal_type(Foo[Concatenate[int, str]].attr)  # revealed: (...) -> None
    |                                  ^^^ Got `str`
-11 |
-12 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
    |
 
 ```
@@ -69,11 +63,8 @@ error[invalid-type-arguments]: The last argument to `typing.Concatenate` must be
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a type expression
   --> src/mdtest_snippet.py:13:34
    |
-12 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
 13 | reveal_type(Foo[Concatenate[int, Concatenate]].attr)  # revealed: (...) -> None
    |                                  ^^^^^^^^^^^
-14 |
-15 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
    |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
@@ -85,11 +76,8 @@ info:  - as a type argument for a `ParamSpec` parameter
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a type expression
   --> src/mdtest_snippet.py:16:34
    |
-15 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
 16 | reveal_type(Foo[Concatenate[int, Concatenate[()]]].attr)  # revealed: (...) -> None
    |                                  ^^^^^^^^^^^^^^^
-17 |
-18 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
    |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
@@ -101,11 +89,8 @@ info:  - as a type argument for a `ParamSpec` parameter
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a type expression
   --> src/mdtest_snippet.py:19:34
    |
-18 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
 19 | reveal_type(Foo[Concatenate[int, Concatenate[int]]].attr)  # revealed: (...) -> None
    |                                  ^^^^^^^^^^^^^^^^
-20 |
-21 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
    |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
@@ -117,7 +102,6 @@ info:  - as a type argument for a `ParamSpec` parameter
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a type expression
   --> src/mdtest_snippet.py:22:34
    |
-21 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
 22 | reveal_type(Foo[Concatenate[int, Concatenate[int, str]]].attr)  # revealed: (...) -> None
    |                                  ^^^^^^^^^^^^^^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/concatenate.md_-_`typing.Concatenate`_-_Invalid_uses_of_`Con…_-_Nested_`Concatenate`_(86093b62e6e6874c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/concatenate.md_-_`typing.Concatenate`_-_Invalid_uses_of_`Con…_-_Nested_`Concatenate`_(86093b62e6e6874c).snap
@@ -32,12 +32,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/concaten
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a parameter annotation
  --> src/mdtest_snippet.py:5:29
   |
-3 | def invalid[**P](
-4 |     # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context"
 5 |     c: Callable[Concatenate[Concatenate[int, ...], P], None],
   |                             ^^^^^^^^^^^^^^^^^^^^^
-6 |     # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a parameter annotation"
-7 |     d: Callable[Concatenate[Concatenate, P], int],
   |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
@@ -49,12 +45,8 @@ info:  - as a type argument for a `ParamSpec` parameter
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a parameter annotation
  --> src/mdtest_snippet.py:7:29
   |
-5 |     c: Callable[Concatenate[Concatenate[int, ...], P], None],
-6 |     # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a parameter annotation"
 7 |     d: Callable[Concatenate[Concatenate, P], int],
   |                             ^^^^^^^^^^^
-8 |     # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a parameter annotation"
-9 |     e: Callable[Concatenate[int, Concatenate[int, ...]], None],
   |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
@@ -64,15 +56,11 @@ info:  - as a type argument for a `ParamSpec` parameter
 
 ```
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a parameter annotation
-  --> src/mdtest_snippet.py:9:34
-   |
- 7 |     d: Callable[Concatenate[Concatenate, P], int],
- 8 |     # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a parameter annotation"
- 9 |     e: Callable[Concatenate[int, Concatenate[int, ...]], None],
-   |                                  ^^^^^^^^^^^^^^^^^^^^^
-10 | ):
-11 |     pass
-   |
+ --> src/mdtest_snippet.py:9:34
+  |
+9 |     e: Callable[Concatenate[int, Concatenate[int, ...]], None],
+  |                                  ^^^^^^^^^^^^^^^^^^^^^
+  |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
 info:  - as a type argument for a `ParamSpec` parameter

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/concatenate.md_-_`typing.Concatenate`_-_Invalid_uses_of_`Con…_-_Standalone_annotatio…_(bb5fe70ded875e4).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/concatenate.md_-_`typing.Concatenate`_-_Invalid_uses_of_`Con…_-_Standalone_annotatio…_(bb5fe70ded875e4).snap
@@ -49,11 +49,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/concaten
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a parameter annotation
  --> src/mdtest_snippet.py:6:17
   |
-5 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a parameter annotation"
 6 | def invalid0(x: Concatenate): ...
   |                 ^^^^^^^^^^^
-7 |
-8 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a parameter annotation"
   |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
@@ -63,14 +60,11 @@ info:  - as a type argument for a `ParamSpec` parameter
 
 ```
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a parameter annotation
-  --> src/mdtest_snippet.py:9:17
-   |
- 8 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a parameter annotation"
- 9 | def invalid1(x: Concatenate[int]): ...
-   |                 ^^^^^^^^^^^^^^^^
-10 |
-11 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a parameter annotation"
-   |
+ --> src/mdtest_snippet.py:9:17
+  |
+9 | def invalid1(x: Concatenate[int]): ...
+  |                 ^^^^^^^^^^^^^^^^
+  |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
 info:  - as a type argument for a `ParamSpec` parameter
@@ -81,11 +75,8 @@ info:  - as a type argument for a `ParamSpec` parameter
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a parameter annotation
   --> src/mdtest_snippet.py:12:17
    |
-11 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a parameter annotation"
 12 | def invalid2(x: Concatenate[int, ...]) -> None: ...
    |                 ^^^^^^^^^^^^^^^^^^^^^
-13 |
-14 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a return type annotation"
    |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
@@ -97,11 +88,8 @@ info:  - as a type argument for a `ParamSpec` parameter
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a return type annotation
   --> src/mdtest_snippet.py:15:19
    |
-14 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a return type annotation"
 15 | def invalid3() -> Concatenate[int, ...]: ...
    |                   ^^^^^^^^^^^^^^^^^^^^^
-16 |
-17 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a return type annotation"
    |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
@@ -113,11 +101,8 @@ info:  - as a type argument for a `ParamSpec` parameter
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a return type annotation
   --> src/mdtest_snippet.py:18:19
    |
-17 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a return type annotation"
 18 | def invalid4() -> Concatenate[()]: ...
    |                   ^^^^^^^^^^^^^^^
-19 |
-20 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
    |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
@@ -129,11 +114,8 @@ info:  - as a type argument for a `ParamSpec` parameter
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a type expression
   --> src/mdtest_snippet.py:21:4
    |
-20 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
 21 | a: Concatenate
    |    ^^^^^^^^^^^
-22 |
-23 | class Foo[**P]:
    |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
@@ -145,12 +127,8 @@ info:  - as a type argument for a `ParamSpec` parameter
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a type expression
   --> src/mdtest_snippet.py:25:8
    |
-23 | class Foo[**P]:
-24 |     # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
 25 |     b: Concatenate[int, P]
    |        ^^^^^^^^^^^^^^^^^^^
-26 |
-27 | # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
    |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
@@ -162,7 +140,6 @@ info:  - as a type argument for a `ParamSpec` parameter
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/mdtest_snippet.py:28:38
    |
-27 | # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 28 | def invalid5[**P](x: Foo[Concatenate[P, ...]]) -> None: ...
    |                                      ^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/concatenate.md_-_`typing.Concatenate`_-_Invalid_uses_of_`Con…_-_Too_few_arguments_(efcf77cdbde3ff86).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/concatenate.md_-_`typing.Concatenate`_-_Invalid_uses_of_`Con…_-_Too_few_arguments_(efcf77cdbde3ff86).snap
@@ -70,15 +70,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/concaten
 
 ```
 error[invalid-type-form]: `typing.Concatenate` requires at least 2 arguments when used in a type expression (got 0)
-  --> src/mdtest_snippet.py:8:17
-   |
- 6 | def _(
- 7 |     # error: [invalid-type-form] "`typing.Concatenate` requires at least 2 arguments when used in a type expression (got 0)"
- 8 |     a: Callable[Concatenate[()], int],
-   |                 ^^^^^^^^^^^^^^^
- 9 |     # error: [invalid-type-form] "`typing.Concatenate` requires at least 2 arguments when used in a type expression (got 1)"
-10 |     b: Callable[Concatenate[int], int],
-   |
+ --> src/mdtest_snippet.py:8:17
+  |
+8 |     a: Callable[Concatenate[()], int],
+  |                 ^^^^^^^^^^^^^^^
+  |
 
 ```
 
@@ -86,12 +82,8 @@ error[invalid-type-form]: `typing.Concatenate` requires at least 2 arguments whe
 error[invalid-type-form]: `typing.Concatenate` requires at least 2 arguments when used in a type expression (got 1)
   --> src/mdtest_snippet.py:10:17
    |
- 8 |     a: Callable[Concatenate[()], int],
- 9 |     # error: [invalid-type-form] "`typing.Concatenate` requires at least 2 arguments when used in a type expression (got 1)"
 10 |     b: Callable[Concatenate[int], int],
    |                 ^^^^^^^^^^^^^^^^
-11 |     # error: [invalid-type-form] "`typing.Concatenate` requires at least 2 arguments when used in a type expression (got 1)"
-12 |     c: Callable[Concatenate[(int,)], int],
    |
 
 ```
@@ -100,12 +92,8 @@ error[invalid-type-form]: `typing.Concatenate` requires at least 2 arguments whe
 error[invalid-type-form]: `typing.Concatenate` requires at least 2 arguments when used in a type expression (got 1)
   --> src/mdtest_snippet.py:12:17
    |
-10 |     b: Callable[Concatenate[int], int],
-11 |     # error: [invalid-type-form] "`typing.Concatenate` requires at least 2 arguments when used in a type expression (got 1)"
 12 |     c: Callable[Concatenate[(int,)], int],
    |                 ^^^^^^^^^^^^^^^^^^^
-13 |     # error: [invalid-type-form] "`typing.Concatenate` requires at least two arguments when used in a parameter annotation"
-14 |     d: Callable[Concatenate, int],
    |
 
 ```
@@ -114,12 +102,8 @@ error[invalid-type-form]: `typing.Concatenate` requires at least 2 arguments whe
 error[invalid-type-form]: `typing.Concatenate` requires at least two arguments when used in a parameter annotation
   --> src/mdtest_snippet.py:14:17
    |
-12 |     c: Callable[Concatenate[(int,)], int],
-13 |     # error: [invalid-type-form] "`typing.Concatenate` requires at least two arguments when used in a parameter annotation"
 14 |     d: Callable[Concatenate, int],
    |                 ^^^^^^^^^^^
-15 | ):
-16 |     reveal_type(a)  # revealed: (...) -> int
    |
 
 ```
@@ -128,11 +112,8 @@ error[invalid-type-form]: `typing.Concatenate` requires at least two arguments w
 error[invalid-type-form]: `typing.Concatenate` requires at least 2 arguments when used in a type expression (got 0)
   --> src/mdtest_snippet.py:21:17
    |
-20 | # error: [invalid-type-form] "`typing.Concatenate` requires at least 2 arguments when used in a type expression (got 0)"
 21 | reveal_type(Foo[Concatenate[()]].attr)  # revealed: (...) -> None
    |                 ^^^^^^^^^^^^^^^
-22 | # error: [invalid-type-form] "`typing.Concatenate` requires at least 2 arguments when used in a type expression (got 1)"
-23 | reveal_type(Foo[Concatenate[int]].attr)  # revealed: (...) -> None
    |
 
 ```
@@ -141,12 +122,8 @@ error[invalid-type-form]: `typing.Concatenate` requires at least 2 arguments whe
 error[invalid-type-form]: `typing.Concatenate` requires at least 2 arguments when used in a type expression (got 1)
   --> src/mdtest_snippet.py:23:17
    |
-21 | reveal_type(Foo[Concatenate[()]].attr)  # revealed: (...) -> None
-22 | # error: [invalid-type-form] "`typing.Concatenate` requires at least 2 arguments when used in a type expression (got 1)"
 23 | reveal_type(Foo[Concatenate[int]].attr)  # revealed: (...) -> None
    |                 ^^^^^^^^^^^^^^^^
-24 | # error: [invalid-type-form] "`typing.Concatenate` requires at least 2 arguments when used in a type expression (got 1)"
-25 | reveal_type(Foo[Concatenate[(int,)]].attr)  # revealed: (...) -> None
    |
 
 ```
@@ -155,12 +132,8 @@ error[invalid-type-form]: `typing.Concatenate` requires at least 2 arguments whe
 error[invalid-type-form]: `typing.Concatenate` requires at least 2 arguments when used in a type expression (got 1)
   --> src/mdtest_snippet.py:25:17
    |
-23 | reveal_type(Foo[Concatenate[int]].attr)  # revealed: (...) -> None
-24 | # error: [invalid-type-form] "`typing.Concatenate` requires at least 2 arguments when used in a type expression (got 1)"
 25 | reveal_type(Foo[Concatenate[(int,)]].attr)  # revealed: (...) -> None
    |                 ^^^^^^^^^^^^^^^^^^^
-26 | # error: [invalid-type-form] "`typing.Concatenate` requires at least two arguments when used in a type expression"
-27 | reveal_type(Foo[Concatenate].attr)  # revealed: (...) -> None
    |
 
 ```
@@ -169,12 +142,8 @@ error[invalid-type-form]: `typing.Concatenate` requires at least 2 arguments whe
 error[invalid-type-form]: `typing.Concatenate` requires at least two arguments when used in a type expression
   --> src/mdtest_snippet.py:27:17
    |
-25 | reveal_type(Foo[Concatenate[(int,)]].attr)  # revealed: (...) -> None
-26 | # error: [invalid-type-form] "`typing.Concatenate` requires at least two arguments when used in a type expression"
 27 | reveal_type(Foo[Concatenate].attr)  # revealed: (...) -> None
    |                 ^^^^^^^^^^^
-28 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
-29 | reveal_type(Foo[[Concatenate]].attr)  # revealed: (Unknown, /) -> None
    |
 
 ```
@@ -183,12 +152,8 @@ error[invalid-type-form]: `typing.Concatenate` requires at least two arguments w
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a type expression
   --> src/mdtest_snippet.py:29:18
    |
-27 | reveal_type(Foo[Concatenate].attr)  # revealed: (...) -> None
-28 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
 29 | reveal_type(Foo[[Concatenate]].attr)  # revealed: (Unknown, /) -> None
    |                  ^^^^^^^^^^^
-30 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
-31 | reveal_type(Foo[[Concatenate, int]].attr)  # revealed: (Unknown, int, /) -> None
    |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
@@ -200,12 +165,8 @@ info:  - as a type argument for a `ParamSpec` parameter
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a type expression
   --> src/mdtest_snippet.py:31:18
    |
-29 | reveal_type(Foo[[Concatenate]].attr)  # revealed: (Unknown, /) -> None
-30 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
 31 | reveal_type(Foo[[Concatenate, int]].attr)  # revealed: (Unknown, int, /) -> None
    |                  ^^^^^^^^^^^
-32 |
-33 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
    |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
@@ -217,11 +178,8 @@ info:  - as a type argument for a `ParamSpec` parameter
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a type expression
   --> src/mdtest_snippet.py:34:18
    |
-33 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
 34 | reveal_type(Foo[[Concatenate[int], str]].attr)  # revealed: (Unknown, str, /) -> None
    |                  ^^^^^^^^^^^^^^^^
-35 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
-36 | reveal_type(Foo[[Concatenate[int, str], str]].attr)  # revealed: (Unknown, str, /) -> None
    |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
@@ -233,12 +191,8 @@ info:  - as a type argument for a `ParamSpec` parameter
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a type expression
   --> src/mdtest_snippet.py:36:18
    |
-34 | reveal_type(Foo[[Concatenate[int], str]].attr)  # revealed: (Unknown, str, /) -> None
-35 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
 36 | reveal_type(Foo[[Concatenate[int, str], str]].attr)  # revealed: (Unknown, str, /) -> None
    |                  ^^^^^^^^^^^^^^^^^^^^^
-37 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
-38 | reveal_type(Foo[[Concatenate[()], str]].attr)  # revealed: (Unknown, str, /) -> None
    |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
@@ -250,12 +204,8 @@ info:  - as a type argument for a `ParamSpec` parameter
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a type expression
   --> src/mdtest_snippet.py:38:18
    |
-36 | reveal_type(Foo[[Concatenate[int, str], str]].attr)  # revealed: (Unknown, str, /) -> None
-37 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
 38 | reveal_type(Foo[[Concatenate[()], str]].attr)  # revealed: (Unknown, str, /) -> None
    |                  ^^^^^^^^^^^^^^^
-39 |
-40 | # Subscripting a class that does not have "exactly one paramspec" takes a different code path;
    |
 info: `typing.Concatenate` is only valid:
 info:  - as the first argument to `typing.Callable`
@@ -267,12 +217,8 @@ info:  - as a type argument for a `ParamSpec` parameter
 error[invalid-type-form]: `typing.Concatenate` requires at least two arguments when used in a type expression
   --> src/mdtest_snippet.py:48:17
    |
-46 | # error: [invalid-type-form] "`typing.Concatenate` requires at least two arguments when used in a type expression"
-47 | # error: [invalid-type-form] "`typing.Concatenate` requires at least two arguments when used in a type expression"
 48 | reveal_type(Bar[Concatenate, Concatenate].a)  # revealed: (...) -> int
    |                 ^^^^^^^^^^^
-49 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
-50 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
    |
 
 ```
@@ -281,12 +227,8 @@ error[invalid-type-form]: `typing.Concatenate` requires at least two arguments w
 error[invalid-type-form]: `typing.Concatenate` requires at least two arguments when used in a type expression
   --> src/mdtest_snippet.py:48:30
    |
-46 | # error: [invalid-type-form] "`typing.Concatenate` requires at least two arguments when used in a type expression"
-47 | # error: [invalid-type-form] "`typing.Concatenate` requires at least two arguments when used in a type expression"
 48 | reveal_type(Bar[Concatenate, Concatenate].a)  # revealed: (...) -> int
    |                              ^^^^^^^^^^^
-49 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
-50 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
    |
 
 ```
@@ -295,8 +237,6 @@ error[invalid-type-form]: `typing.Concatenate` requires at least two arguments w
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a type expression
   --> src/mdtest_snippet.py:51:18
    |
-49 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
-50 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
 51 | reveal_type(Bar[[Concatenate], [Concatenate]].a)  # revealed: (Unknown, /) -> int
    |                  ^^^^^^^^^^^
    |
@@ -310,8 +250,6 @@ info:  - as a type argument for a `ParamSpec` parameter
 error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in a type expression
   --> src/mdtest_snippet.py:51:33
    |
-49 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
-50 | # error: [invalid-type-form] "`typing.Concatenate` is not allowed in this context in a type expression"
 51 | reveal_type(Bar[[Concatenate], [Concatenate]].a)  # revealed: (Unknown, /) -> int
    |                                 ^^^^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/custom.md_-_Custom_binary_operat…_-_Classes_(93f2f1c488e06f53).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/custom.md_-_Custom_binary_operat…_-_Classes_(93f2f1c488e06f53).snap
@@ -36,13 +36,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/binary/custom.md
 error[unsupported-operator]: Unsupported `+` operation
   --> src/mdtest_snippet.py:11:13
    |
-10 | # error: [unsupported-operator] "Operator `+` is not supported between two objects of type `<class 'Yes'>`"
 11 | reveal_type(Yes + Yes)  # revealed: Unknown
    |             ---^^^---
    |             |
    |             Both operands have type `<class 'Yes'>`
-12 | # error: [unsupported-operator] "Operator `+` is not supported between two objects of type `<class 'Sub'>`"
-13 | reveal_type(Sub + Sub)  # revealed: Unknown
    |
 
 ```
@@ -51,14 +48,10 @@ error[unsupported-operator]: Unsupported `+` operation
 error[unsupported-operator]: Unsupported `+` operation
   --> src/mdtest_snippet.py:13:13
    |
-11 | reveal_type(Yes + Yes)  # revealed: Unknown
-12 | # error: [unsupported-operator] "Operator `+` is not supported between two objects of type `<class 'Sub'>`"
 13 | reveal_type(Sub + Sub)  # revealed: Unknown
    |             ---^^^---
    |             |
    |             Both operands have type `<class 'Sub'>`
-14 | # error: [unsupported-operator] "Operator `+` is not supported between two objects of type `<class 'No'>`"
-15 | reveal_type(No + No)  # revealed: Unknown
    |
 
 ```
@@ -67,8 +60,6 @@ error[unsupported-operator]: Unsupported `+` operation
 error[unsupported-operator]: Unsupported `+` operation
   --> src/mdtest_snippet.py:15:13
    |
-13 | reveal_type(Sub + Sub)  # revealed: Unknown
-14 | # error: [unsupported-operator] "Operator `+` is not supported between two objects of type `<class 'No'>`"
 15 | reveal_type(No + No)  # revealed: Unknown
    |             --^^^--
    |             |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/custom.md_-_Custom_binary_operat…_-_Classes_from_differe…_(2890e4875c9b9c1e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/custom.md_-_Custom_binary_operat…_-_Classes_from_differe…_(2890e4875c9b9c1e).snap
@@ -33,7 +33,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/binary/custom.md
 error[unsupported-operator]: Unsupported `+` operation
  --> src/mod2.py:6:1
   |
-5 | # error: [unsupported-operator] "Operator `+` is not supported between objects of type `mod2.A` and `mod1.A`"
 6 | A() + mod1.A()
   | ---^^^--------
   | |     |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/dataclasses.md_-_Dataclasses_-_Other_dataclass_para…_-_frozen__non-frozen_in…_(9af2ab07b8e829e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/dataclasses.md_-_Dataclasses_-_Other_dataclass_para…_-_frozen__non-frozen_in…_(9af2ab07b8e829e).snap
@@ -70,98 +70,83 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.
 
 ```
 error[invalid-frozen-dataclass-subclass]: Non-frozen dataclass cannot inherit from frozen dataclass
-  --> src/a.py:7:1
-   |
- 5 |     x: int
- 6 |
- 7 | @dataclass
-   | ---------- `Child` dataclass parameters
- 8 | # error: [invalid-frozen-dataclass-subclass] "Non-frozen dataclass `Child` cannot inherit from frozen dataclass `FrozenBase`"
- 9 | class Child(FrozenBase):
-   |       ^^^^^^----------^ Subclass `Child` is not frozen but base class `FrozenBase` is
-10 |     y: int
-   |
+ --> src/a.py:9:7
+  |
+9 | class Child(FrozenBase):
+  |       ^^^^^^----------^ Subclass `Child` is not frozen but base class `FrozenBase` is
+  |
+ ::: src/a.py:7:1
+  |
+7 | @dataclass
+  | ---------- `Child` dataclass parameters
+  |
 info: This causes the class creation to fail
 info: Base class definition
  --> src/a.py:3:1
   |
-1 | from dataclasses import dataclass
-2 |
 3 | @dataclass(frozen=True)
   | ----------------------- `FrozenBase` dataclass parameters
 4 | class FrozenBase:
   |       ^^^^^^^^^^ `FrozenBase` definition
-5 |     x: int
   |
 
 ```
 
 ```
 error[invalid-frozen-dataclass-subclass]: Frozen dataclass cannot inherit from non-frozen dataclass
-  --> src/b.py:7:1
-   |
- 5 |     x: int
- 6 |
- 7 | @dataclass(frozen=True)
-   | ----------------------- `FrozenChild` dataclass parameters
- 8 | # error: [invalid-frozen-dataclass-subclass] "Frozen dataclass `FrozenChild` cannot inherit from non-frozen dataclass `Base`"
- 9 | class FrozenChild(Base):
-   |       ^^^^^^^^^^^^----^ Subclass `FrozenChild` is frozen but base class `Base` is not
-10 |     y: int
-   |
+ --> src/b.py:9:7
+  |
+9 | class FrozenChild(Base):
+  |       ^^^^^^^^^^^^----^ Subclass `FrozenChild` is frozen but base class `Base` is not
+  |
+ ::: src/b.py:7:1
+  |
+7 | @dataclass(frozen=True)
+  | ----------------------- `FrozenChild` dataclass parameters
+  |
 info: This causes the class creation to fail
 info: Base class definition
  --> src/b.py:3:1
   |
-1 | from dataclasses import dataclass
-2 |
 3 | @dataclass
   | ---------- `Base` dataclass parameters
 4 | class Base:
   |       ^^^^ `Base` definition
-5 |     x: int
   |
 
 ```
 
 ```
 error[invalid-total-ordering]: Class decorated with `@total_ordering` must define at least one ordering method
-  --> src/main.py:9:1
-   |
- 7 | @final
- 8 | @dataclass(frozen=True)
- 9 | @total_ordering  # error: [invalid-total-ordering]
-   | ^^^^^^^^^^^^^^^ `FrozenChild` does not define `__lt__`, `__le__`, `__gt__`, or `__ge__`
-10 | class FrozenChild(NotFrozenBase):  # error: [invalid-frozen-dataclass-subclass]
-11 |     y: str
-   |
+ --> src/main.py:9:1
+  |
+9 | @total_ordering  # error: [invalid-total-ordering]
+  | ^^^^^^^^^^^^^^^ `FrozenChild` does not define `__lt__`, `__le__`, `__gt__`, or `__ge__`
+  |
 info: The decorator will raise `ValueError` at runtime
 
 ```
 
 ```
 error[invalid-frozen-dataclass-subclass]: Frozen dataclass cannot inherit from non-frozen dataclass
-  --> src/main.py:8:1
+  --> src/main.py:10:7
    |
- 7 | @final
- 8 | @dataclass(frozen=True)
-   | ----------------------- `FrozenChild` dataclass parameters
- 9 | @total_ordering  # error: [invalid-total-ordering]
 10 | class FrozenChild(NotFrozenBase):  # error: [invalid-frozen-dataclass-subclass]
    |       ^^^^^^^^^^^^-------------^ Subclass `FrozenChild` is frozen but base class `NotFrozenBase` is not
-11 |     y: str
+   |
+  ::: src/main.py:8:1
+   |
+ 8 | @dataclass(frozen=True)
+   | ----------------------- `FrozenChild` dataclass parameters
    |
 info: This causes the class creation to fail
 info: Base class definition
  --> src/module.py:3:1
   |
-1 | import dataclasses
-2 |
 3 | @dataclasses.dataclass(frozen=False)
   | ------------------------------------ `NotFrozenBase` dataclass parameters
 4 | class NotFrozenBase:
   |       ^^^^^^^^^^^^^ `NotFrozenBase` definition
-5 |     x: int
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/dataclasses.md_-_Dataclasses_-_`dataclasses.KW_ONLY…_(dd1b8f2f71487f16).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/dataclasses.md_-_Dataclasses_-_`dataclasses.KW_ONLY…_(dd1b8f2f71487f16).snap
@@ -73,12 +73,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.
 error[missing-argument]: No argument provided for required parameter `y`
   --> src/mdtest_snippet.py:13:1
    |
-11 | # error: [missing-argument]
-12 | # error: [too-many-positional-arguments]
 13 | C(3, "")
    | ^^^^^^^^
-14 |
-15 | C(3, y="")
    |
 
 ```
@@ -87,12 +83,8 @@ error[missing-argument]: No argument provided for required parameter `y`
 error[too-many-positional-arguments]: Too many positional arguments: expected 1, got 2
   --> src/mdtest_snippet.py:13:6
    |
-11 | # error: [missing-argument]
-12 | # error: [too-many-positional-arguments]
 13 | C(3, "")
    |      ^^
-14 |
-15 | C(3, y="")
    |
 
 ```
@@ -101,12 +93,8 @@ error[too-many-positional-arguments]: Too many positional arguments: expected 1,
 error[duplicate-kw-only]: Dataclass has more than one field annotated with `KW_ONLY`
   --> src/mdtest_snippet.py:17:7
    |
-15 | C(3, y="")
-16 | @dataclass
 17 | class Fails:  # error: [duplicate-kw-only]
    |       ^^^^^
-18 |     a: int
-19 |     b: KW_ONLY
    |
 info: `KW_ONLY` fields: `b`, `d`
 
@@ -116,11 +104,8 @@ info: `KW_ONLY` fields: `b`, `d`
 error[duplicate-kw-only]: Dataclass has more than one field annotated with `KW_ONLY`
   --> src/mdtest_snippet.py:29:7
    |
-28 | @dataclass
 29 | class D:  # error: [duplicate-kw-only]
    |       ^
-30 |     x: int
-31 |     _1: KW_ONLY
    |
 info: `KW_ONLY` fields: `_1`, `_2`
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/del.md_-_`del`_statement_-_Delete_items_-_TypedDict_deletion_(1168a65357694229).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/del.md_-_`del`_statement_-_Delete_items_-_TypedDict_deletion_(1168a65357694229).snap
@@ -56,20 +56,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/del.md
 error[invalid-argument-type]: Cannot delete required key "name" from TypedDict `Movie`
   --> src/mdtest_snippet.py:21:7
    |
-19 | # Required keys cannot be deleted.
-20 | # error: [invalid-argument-type]
 21 | del m["name"]
    |       ^^^^^^
-22 |
-23 | # In a partial TypedDict (`total=False`), all keys can be deleted.
    |
 info: Field defined here
  --> src/mdtest_snippet.py:4:5
   |
-3 | class Movie(TypedDict):
 4 |     name: str
   |     --------- `name` declared as required here; consider making it `NotRequired`
-5 |     year: int
   |
 info: Only keys marked as `NotRequired` (or in a TypedDict with `total=False`) can be deleted
 
@@ -79,20 +73,14 @@ info: Only keys marked as `NotRequired` (or in a TypedDict with `total=False`) c
 error[invalid-argument-type]: Cannot delete required key "name" from TypedDict `MixedMovie`
   --> src/mdtest_snippet.py:31:11
    |
-29 | # But required keys in mixed `TypedDict` still cannot be deleted.
-30 | # error: [invalid-argument-type]
 31 | del mixed["name"]
    |           ^^^^^^
-32 |
-33 | # And keys that don't exist cannot be deleted.
    |
 info: Field defined here
   --> src/mdtest_snippet.py:12:5
    |
-11 | class MixedMovie(TypedDict):
 12 |     name: str
    |     --------- `name` declared as required here; consider making it `NotRequired`
-13 |     year: NotRequired[int]
    |
 info: Only keys marked as `NotRequired` (or in a TypedDict with `total=False`) can be deleted
 
@@ -102,8 +90,6 @@ info: Only keys marked as `NotRequired` (or in a TypedDict with `total=False`) c
 error[invalid-argument-type]: Cannot delete unknown key "non_existent" from TypedDict `MixedMovie`
   --> src/mdtest_snippet.py:35:11
    |
-33 | # And keys that don't exist cannot be deleted.
-34 | # error: [invalid-argument-type]
 35 | del mixed["non_existent"]
    |           ^^^^^^^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/deprecated.md_-_Tests_for_the_`@depr…_-_Introduction_(cff2724f4c9d28c4).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/deprecated.md_-_Tests_for_the_`@depr…_-_Introduction_(cff2724f4c9d28c4).snap
@@ -43,11 +43,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/deprecated.md
 warning[deprecated]: The function `myfunc` is deprecated
  --> src/mdtest_snippet.py:6:1
   |
-4 | def myfunc(x: int): ...
-5 |
 6 | myfunc(1)  # error: [deprecated] "use OtherClass"
   | ^^^^^^ use OtherClass
-7 | from typing_extensions import deprecated
   |
 
 ```
@@ -56,11 +53,8 @@ warning[deprecated]: The function `myfunc` is deprecated
 warning[deprecated]: The class `MyClass` is deprecated
   --> src/mdtest_snippet.py:12:1
    |
-10 | class MyClass: ...
-11 |
 12 | MyClass()  # error: [deprecated] "use BetterClass"
    | ^^^^^^^ use BetterClass
-13 | from typing_extensions import deprecated
    |
 
 ```
@@ -69,11 +63,8 @@ warning[deprecated]: The class `MyClass` is deprecated
 warning[deprecated]: The function `afunc` is deprecated
   --> src/mdtest_snippet.py:21:9
    |
-19 |     def amethod(self): ...
-20 |
 21 | MyClass.afunc()  # error: [deprecated] "use something else"
    |         ^^^^^ use something else
-22 | MyClass().amethod()  # error: [deprecated] "don't use this!"
    |
 
 ```
@@ -82,7 +73,6 @@ warning[deprecated]: The function `afunc` is deprecated
 warning[deprecated]: The function `amethod` is deprecated
   --> src/mdtest_snippet.py:22:11
    |
-21 | MyClass.afunc()  # error: [deprecated] "use something else"
 22 | MyClass().amethod()  # error: [deprecated] "don't use this!"
    |           ^^^^^^^ don't use this!
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/deprecated.md_-_Tests_for_the_`@depr…_-_Syntax_(142fa2948c3c6cf1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/deprecated.md_-_Tests_for_the_`@depr…_-_Syntax_(142fa2948c3c6cf1).snap
@@ -71,11 +71,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/deprecated.md
 error[invalid-argument-type]: Argument to class `deprecated` is incorrect
  --> src/mdtest_snippet.py:3:1
   |
-1 | from typing_extensions import deprecated
-2 |
 3 | @deprecated  # error: [invalid-argument-type] "LiteralString"
   | ^^^^^^^^^^^ Expected `LiteralString`, found `def invalid_deco() -> Unknown`
-4 | def invalid_deco(): ...
   |
 
 ```
@@ -84,35 +81,25 @@ error[invalid-argument-type]: Argument to class `deprecated` is incorrect
 error[missing-argument]: No argument provided for required parameter `arg` of bound method `__call__`
  --> src/mdtest_snippet.py:6:1
   |
-4 | def invalid_deco(): ...
-5 |
 6 | invalid_deco()  # error: [missing-argument]
   | ^^^^^^^^^^^^^^
-7 | from typing_extensions import deprecated
   |
 info: Parameter declared here
     --> stdlib/typing_extensions.pyi:1301:28
      |
-1299 |         stacklevel: int
-1300 |         def __init__(self, message: LiteralString, /, *, category: type[Warning] | None = ..., stacklevel: int = 1) -> None: ...
 1301 |         def __call__(self, arg: _T, /) -> _T: ...
      |                            ^^^^^^^
-1302 |
-1303 |     @final
      |
 
 ```
 
 ```
 error[missing-argument]: No argument provided for required parameter `message` of class `deprecated`
-  --> src/mdtest_snippet.py:9:2
-   |
- 7 | from typing_extensions import deprecated
- 8 |
- 9 | @deprecated()  # error: [missing-argument] "message"
-   |  ^^^^^^^^^^^^
-10 | def invalid_deco(): ...
-   |
+ --> src/mdtest_snippet.py:9:2
+  |
+9 | @deprecated()  # error: [missing-argument] "message"
+  |  ^^^^^^^^^^^^
+  |
 
 ```
 
@@ -120,11 +107,8 @@ error[missing-argument]: No argument provided for required parameter `message` o
 warning[deprecated]: The function `invalid_deco` is deprecated
   --> src/mdtest_snippet.py:20:1
    |
-18 | def invalid_deco(): ...
-19 |
 20 | invalid_deco()  # error: [deprecated] "message"
    | ^^^^^^^^^^^^ message
-21 | from typing_extensions import deprecated, LiteralString
    |
 
 ```
@@ -133,11 +117,8 @@ warning[deprecated]: The function `invalid_deco` is deprecated
 warning[deprecated]: The function `valid_deco` is deprecated
   --> src/mdtest_snippet.py:29:1
    |
-27 | def valid_deco(): ...
-28 |
 29 | valid_deco()  # error: [deprecated]
    | ^^^^^^^^^^
-30 | from typing_extensions import deprecated
    |
 
 ```
@@ -146,11 +127,8 @@ warning[deprecated]: The function `valid_deco` is deprecated
 error[invalid-argument-type]: Argument to class `deprecated` is incorrect
   --> src/mdtest_snippet.py:35:13
    |
-33 |     return "message"
-34 |
 35 | @deprecated(opaque())  # error: [invalid-argument-type] "LiteralString"
    |             ^^^^^^^^ Expected `LiteralString`, found `str`
-36 | def dubious_deco(): ...
    |
 
 ```
@@ -159,11 +137,8 @@ error[invalid-argument-type]: Argument to class `deprecated` is incorrect
 error[unknown-argument]: Argument `dsfsdf` does not match any known parameter of class `deprecated`
   --> src/mdtest_snippet.py:41:29
    |
-39 | from typing_extensions import deprecated
-40 |
 41 | @deprecated("some message", dsfsdf="whatever")  # error: [unknown-argument] "dsfsdf"
    |                             ^^^^^^^^^^^^^^^^^
-42 | def invalid_deco(): ...
    |
 
 ```
@@ -172,8 +147,6 @@ error[unknown-argument]: Argument `dsfsdf` does not match any known parameter of
 warning[deprecated]: The function `valid_deco` is deprecated
   --> src/mdtest_snippet.py:50:1
    |
-48 | def valid_deco(): ...
-49 |
 50 | valid_deco()  # error: [deprecated] "some message"
    | ^^^^^^^^^^ some message
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/descriptor_protocol.…_-_Descriptor_protocol_-_Special_descriptors_-_Properties_with_no_s…_(176795bc1727dda7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/descriptor_protocol.…_-_Descriptor_protocol_-_Special_descriptors_-_Properties_with_no_s…_(176795bc1727dda7).snap
@@ -25,16 +25,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
 
 ```
 error[invalid-assignment]: Cannot assign to read-only property `immutable` on object of type `DontAssignToMe`
- --> src/mdtest_snippet.py:3:9
+ --> src/mdtest_snippet.py:6:1
   |
-1 | class DontAssignToMe:
-2 |     @property
-3 |     def immutable(self): ...
-  |         --------- Property `DontAssignToMe.immutable` defined here with no setter
-4 |
-5 | # error: [invalid-assignment]
 6 | DontAssignToMe().immutable = "the properties, they are a-changing"
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ Attempted assignment to `DontAssignToMe.immutable` here
+  |
+ ::: src/mdtest_snippet.py:3:9
+  |
+3 |     def immutable(self): ...
+  |         --------- Property `DontAssignToMe.immutable` defined here with no setter
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/enums.md_-_Enums_-_Function_syntax_-_Name_mismatch_diagno…_(9f5bdb1f7c5ad96a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/enums.md_-_Enums_-_Function_syntax_-_Name_mismatch_diagno…_(9f5bdb1f7c5ad96a).snap
@@ -32,25 +32,18 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/enums.md
 warning[mismatched-type-name]: The name passed to `Enum` must match the variable it is assigned to
  --> src/mdtest_snippet.py:4:17
   |
-3 | # error: [mismatched-type-name]
 4 | Mismatch = Enum("WrongName", "A B")
   |                 ^^^^^^^^^^^ Expected "Mismatch", got "WrongName"
-5 |
-6 | def f(name: str) -> None:
   |
 
 ```
 
 ```
 warning[mismatched-type-name]: The name passed to `Enum` must match the variable it is assigned to
-  --> src/mdtest_snippet.py:8:28
-   |
- 6 | def f(name: str) -> None:
- 7 |     # error: [mismatched-type-name]
- 8 |     DynamicMismatch = Enum(name, "A B")
-   |                            ^^^^ Expected "DynamicMismatch", got variable of type `str`
- 9 |
-10 | name = "GoodMatch"
-   |
+ --> src/mdtest_snippet.py:8:28
+  |
+8 |     DynamicMismatch = Enum(name, "A B")
+  |                            ^^^^ Expected "DynamicMismatch", got variable of type `str`
+  |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Abstract_method_in_g…_(6d8b024dda7ced11).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Abstract_method_in_g…_(6d8b024dda7ced11).snap
@@ -34,19 +34,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 error[abstract-method-in-final-class]: Final class `Child` has unimplemented abstract methods
   --> src/mdtest_snippet.py:12:7
    |
-11 | @final
 12 | class Child(Parent):  # error: [abstract-method-in-final-class]
    |       ^^^^^ `method` is unimplemented
-13 |     pass
    |
   ::: src/mdtest_snippet.py:6:9
    |
- 4 | class GrandParent(ABC):
- 5 |     @abstractmethod
  6 |     def method(self) -> int: ...
    |         ------ `method` declared as abstract on superclass `GrandParent`
- 7 |
- 8 | class Parent(GrandParent):
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Basic_case_with_ABC_(21e412599c45972a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Basic_case_with_ABC_(21e412599c45972a).snap
@@ -32,18 +32,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 error[abstract-method-in-final-class]: Final class `Derived` has unimplemented abstract methods
   --> src/mdtest_snippet.py:10:7
    |
- 9 | @final
 10 | class Derived(Base):  # error: [abstract-method-in-final-class] "Final class `Derived` has unimplemented abstract method `foo`"
    |       ^^^^^^^ `foo` is unimplemented
-11 |     pass
    |
   ::: src/mdtest_snippet.py:6:9
    |
- 4 | class Base(ABC):
- 5 |     @abstractmethod
  6 |     def foo(self) -> int:
    |         --- `foo` declared as abstract on superclass `Base`
- 7 |         raise NotImplementedError
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(ecae0f4510696c95).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(ecae0f4510696c95).snap
@@ -45,18 +45,16 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 
 ```
 error[abstract-method-in-final-class]: Final class `Abstract` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:6:7
-   |
- 4 | @final
- 5 | # error: [abstract-method-in-final-class] "Final class `Abstract` has unimplemented abstract methods `aaaaaaaaaa`, `bbbbbbbb`, `cccccc…
- 6 | class Abstract(ABC):
-   |       ^^^^^^^^ Abstract methods `aaaaaaaaaa`, `bbbbbbbb`, `cccccccc`, `ddddddddd`, `eeeeeeeee`, `ffffffff`, `ggggggg`, `hhhhhhhh`, `iiiiiiiii` and `kkkkkkkkkk` are unimplemented
- 7 |     @abstractmethod
- 8 |     def aaaaaaaaaa(self) -> int: ...
-   |         ---------- `aaaaaaaaaa` declared as abstract
- 9 |     @abstractmethod
-10 |     def bbbbbbbb(self) -> int: ...
-   |
+ --> src/mdtest_snippet.py:6:7
+  |
+6 | class Abstract(ABC):
+  |       ^^^^^^^^ Abstract methods `aaaaaaaaaa`, `bbbbbbbb`, `cccccccc`, `ddddddddd`, `eeeeeeeee`, `ffffffff`, `ggggggg`, `hhhhhhhh`, `iiiiiiiii` and `kkkkkkkkkk` are unimplemented
+  |
+ ::: src/mdtest_snippet.py:8:9
+  |
+8 |     def aaaaaaaaaa(self) -> int: ...
+  |         ---------- `aaaaaaaaaa` declared as abstract
+  |
 info: rule `abstract-method-in-final-class` is enabled by default
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(f807ff3716d8ab0d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(f807ff3716d8ab0d).snap
@@ -45,18 +45,16 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 
 ```
 error[abstract-method-in-final-class]: Final class `Abstract` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:6:7
-   |
- 4 | @final
- 5 | # error: [abstract-method-in-final-class] "Final class `Abstract` has 10 unimplemented abstract methods, including `aaaaaaaaaa`, `bbbb…
- 6 | class Abstract(ABC):
-   |       ^^^^^^^^ 10 abstract methods are unimplemented, including `aaaaaaaaaa`, `bbbbbbbb` and `cccccccc`
- 7 |     @abstractmethod
- 8 |     def aaaaaaaaaa(self) -> int: ...
-   |         ---------- `aaaaaaaaaa` declared as abstract
- 9 |     @abstractmethod
-10 |     def bbbbbbbb(self) -> int: ...
-   |
+ --> src/mdtest_snippet.py:6:7
+  |
+6 | class Abstract(ABC):
+  |       ^^^^^^^^ 10 abstract methods are unimplemented, including `aaaaaaaaaa`, `bbbbbbbb` and `cccccccc`
+  |
+ ::: src/mdtest_snippet.py:8:9
+  |
+8 |     def aaaaaaaaaa(self) -> int: ...
+  |         ---------- `aaaaaaaaaa` declared as abstract
+  |
 info: Use `--verbose` to see all 10 unimplemented abstract methods
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Multiple_abstract_me…_(feafee9a4abbe8d1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Multiple_abstract_me…_(feafee9a4abbe8d1).snap
@@ -43,19 +43,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 error[abstract-method-in-final-class]: Final class `MissingAll` has unimplemented abstract methods
   --> src/mdtest_snippet.py:13:7
    |
-12 | @final
 13 | class MissingAll(Base):  # error: [abstract-method-in-final-class]
    |       ^^^^^^^^^^ Abstract methods `foo`, `bar` and `baz` are unimplemented
-14 |     pass
    |
   ::: src/mdtest_snippet.py:6:9
    |
- 4 | class Base(ABC):
- 5 |     @abstractmethod
  6 |     def foo(self) -> int: ...
    |         --- `foo` declared as abstract on superclass `Base`
- 7 |     @abstractmethod
- 8 |     def bar(self) -> str: ...
    |
 
 ```
@@ -64,20 +58,13 @@ error[abstract-method-in-final-class]: Final class `MissingAll` has unimplemente
 error[abstract-method-in-final-class]: Final class `PartiallyImplemented` has unimplemented abstract methods
   --> src/mdtest_snippet.py:17:7
    |
-16 | @final
 17 | class PartiallyImplemented(Base):  # error: [abstract-method-in-final-class]
    |       ^^^^^^^^^^^^^^^^^^^^ `baz` is unimplemented
-18 |     def foo(self) -> int:
-19 |         return 42
    |
   ::: src/mdtest_snippet.py:10:9
    |
- 8 |     def bar(self) -> str: ...
- 9 |     @abstractmethod
 10 |     def baz(self) -> None: ...
    |         --- `baz` declared as abstract on superclass `Base`
-11 |
-12 | @final
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Protocol_with_implic…_(e373f31c7a7d88e7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Protocol_with_implic…_(e373f31c7a7d88e7).snap
@@ -169,28 +169,21 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 
 ```
 error[abstract-method-in-final-class]: Final class `Q` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:11:9
+  --> src/mdtest_snippet.py:14:7
    |
- 9 |     # would probably be subtle and surprising to many users. This also matches the
-10 |     # behaviour of all other type checkers
-11 |     def still_abstractmethod(self): ...
-   |         -------------------- `still_abstractmethod` declared as abstract on superclass `P`
-12 |
-13 | @final
 14 | class Q(P): ...  # error: [abstract-method-in-final-class]
    |       ^ `still_abstractmethod` is unimplemented
-15 |
-16 | class R(Protocol):
+   |
+  ::: src/mdtest_snippet.py:11:9
+   |
+11 |     def still_abstractmethod(self): ...
+   |         -------------------- `still_abstractmethod` declared as abstract on superclass `P`
    |
 info: `P.still_abstractmethod` is implicitly abstract because `P` is a `Protocol` class and `still_abstractmethod` lacks an implementation
  --> src/mdtest_snippet.py:3:7
   |
-1 | from typing_extensions import Protocol, final, Never, overload
-2 |
 3 | class P(Protocol):
   |       ----------- `P` declared here
-4 |     # There'd be no unsoundness here if a subclass of this
-5 |     # class were to be instantiated without the method having been overridden:
   |
 help: Change the body of `still_abstractmethod` to `return` or `return None` if it was not intended to be abstract
 
@@ -198,28 +191,21 @@ help: Change the body of `still_abstractmethod` to `return` or `return None` if 
 
 ```
 error[abstract-method-in-final-class]: Final class `S` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:18:9
+  --> src/mdtest_snippet.py:21:7
    |
-16 | class R(Protocol):
-17 |     # same here
-18 |     def also_still_abstractmethod(self) -> None: ...
-   |         ------------------------- `also_still_abstractmethod` declared as abstract on superclass `R`
-19 |
-20 | @final
 21 | class S(R): ...  # error: [abstract-method-in-final-class]
    |       ^ `also_still_abstractmethod` is unimplemented
-22 |
-23 | class Raises(Protocol):
+   |
+  ::: src/mdtest_snippet.py:18:9
+   |
+18 |     def also_still_abstractmethod(self) -> None: ...
+   |         ------------------------- `also_still_abstractmethod` declared as abstract on superclass `R`
    |
 info: `R.also_still_abstractmethod` is implicitly abstract because `R` is a `Protocol` class and `also_still_abstractmethod` lacks an implementation
   --> src/mdtest_snippet.py:16:7
    |
-14 | class Q(P): ...  # error: [abstract-method-in-final-class]
-15 |
 16 | class R(Protocol):
    |       ----------- `R` declared here
-17 |     # same here
-18 |     def also_still_abstractmethod(self) -> None: ...
    |
 help: Change the body of `also_still_abstractmethod` to `return` or `return None` if it was not intended to be abstract
 
@@ -229,28 +215,19 @@ help: Change the body of `also_still_abstractmethod` to `return` or `return None
 error[abstract-method-in-final-class]: Final class `RaisesSub` has unimplemented abstract methods
   --> src/mdtest_snippet.py:28:7
    |
-27 | @final
 28 | class RaisesSub(Raises): ...  # error: [abstract-method-in-final-class]
    |       ^^^^^^^^^ `even_this_is_abstract` is unimplemented
-29 |
-30 | class AlsoRaises(Protocol):
    |
   ::: src/mdtest_snippet.py:24:9
    |
-23 | class Raises(Protocol):
 24 |     def even_this_is_abstract(self):
    |         --------------------- `even_this_is_abstract` declared as abstract on superclass `Raises`
-25 |         raise NotImplementedError
    |
 info: `Raises.even_this_is_abstract` is implicitly abstract because `Raises` is a `Protocol` class and `even_this_is_abstract` lacks an implementation
   --> src/mdtest_snippet.py:23:7
    |
-21 | class S(R): ...  # error: [abstract-method-in-final-class]
-22 |
 23 | class Raises(Protocol):
    |       ---------------- `Raises` declared here
-24 |     def even_this_is_abstract(self):
-25 |         raise NotImplementedError
    |
 
 ```
@@ -259,28 +236,19 @@ info: `Raises.even_this_is_abstract` is implicitly abstract because `Raises` is 
 error[abstract-method-in-final-class]: Final class `AlsoRaisesSub` has unimplemented abstract methods
   --> src/mdtest_snippet.py:35:7
    |
-34 | @final
 35 | class AlsoRaisesSub(AlsoRaises): ...  # error: [abstract-method-in-final-class]
    |       ^^^^^^^^^^^^^ `also_abstractmethod` is unimplemented
-36 |
-37 | type NotImplementedErrorAlias = NotImplementedError
    |
   ::: src/mdtest_snippet.py:31:9
    |
-30 | class AlsoRaises(Protocol):
 31 |     def also_abstractmethod(self) -> Never:
    |         ------------------- `also_abstractmethod` declared as abstract on superclass `AlsoRaises`
-32 |         raise NotImplementedError
    |
 info: `AlsoRaises.also_abstractmethod` is implicitly abstract because `AlsoRaises` is a `Protocol` class and `also_abstractmethod` lacks an implementation
   --> src/mdtest_snippet.py:30:7
    |
-28 | class RaisesSub(Raises): ...  # error: [abstract-method-in-final-class]
-29 |
 30 | class AlsoRaises(Protocol):
    |       -------------------- `AlsoRaises` declared here
-31 |     def also_abstractmethod(self) -> Never:
-32 |         raise NotImplementedError
    |
 
 ```
@@ -289,56 +257,40 @@ info: `AlsoRaises.also_abstractmethod` is implicitly abstract because `AlsoRaise
 error[abstract-method-in-final-class]: Final class `StrangeSub` has unimplemented abstract methods
   --> src/mdtest_snippet.py:45:11
    |
-44 |     @final
 45 |     class StrangeSub(Strange): ...  # error: [abstract-method-in-final-class]
    |           ^^^^^^^^^^ `weird_abstractmethod` is unimplemented
-46 |
-47 | class HasOverloads(Protocol):
    |
   ::: src/mdtest_snippet.py:41:13
    |
-39 | def _(x: NotImplementedErrorAlias):
-40 |     class Strange(Protocol):
 41 |         def weird_abstractmethod(self):
    |             -------------------- `weird_abstractmethod` declared as abstract on superclass `Strange`
-42 |             raise x
    |
 info: `Strange.weird_abstractmethod` is implicitly abstract because `Strange` is a `Protocol` class and `weird_abstractmethod` lacks an implementation
   --> src/mdtest_snippet.py:40:11
    |
-39 | def _(x: NotImplementedErrorAlias):
 40 |     class Strange(Protocol):
    |           ----------------- `Strange` declared here
-41 |         def weird_abstractmethod(self):
-42 |             raise x
    |
 
 ```
 
 ```
 error[abstract-method-in-final-class]: Final class `HasOverloadSub` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:51:9
+  --> src/mdtest_snippet.py:54:7
    |
-49 |     def foo(self) -> int: ...
-50 |     @overload
-51 |     def foo(self, x: int) -> str: ...
-   |         --- `foo` declared as abstract on superclass `HasOverloads`
-52 |
-53 | @final
 54 | class HasOverloadSub(HasOverloads): ...  # error: [abstract-method-in-final-class]
    |       ^^^^^^^^^^^^^^ `foo` is unimplemented
-55 |
-56 | class RaisesDifferentException(Protocol):
+   |
+  ::: src/mdtest_snippet.py:51:9
+   |
+51 |     def foo(self, x: int) -> str: ...
+   |         --- `foo` declared as abstract on superclass `HasOverloads`
    |
 info: `HasOverloads.foo` is implicitly abstract because `HasOverloads` is a `Protocol` class and `foo` lacks an implementation
   --> src/mdtest_snippet.py:47:7
    |
-45 |     class StrangeSub(Strange): ...  # error: [abstract-method-in-final-class]
-46 |
 47 | class HasOverloads(Protocol):
    |       ---------------------- `HasOverloads` declared here
-48 |     @overload
-49 |     def foo(self) -> int: ...
    |
 
 ```
@@ -347,28 +299,19 @@ info: `HasOverloads.foo` is implicitly abstract because `HasOverloads` is a `Pro
 error[abstract-method-in-final-class]: Final class `HasAbstractSub` has unimplemented abstract methods
    --> src/mdtest_snippet.py:123:7
     |
-122 | @final
 123 | class HasAbstractSub(HasAbstract): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^ `a` is unimplemented
-124 |
-125 | @final
     |
    ::: src/mdtest_snippet.py:72:9
     |
- 71 | class HasAbstract(Protocol):
  72 |     def a(self) -> int: ...
     |         - `a` declared as abstract on superclass `HasAbstract`
- 73 |
- 74 | class HasAbstract2(Protocol):
     |
 info: `HasAbstract.a` is implicitly abstract because `HasAbstract` is a `Protocol` class and `a` lacks an implementation
   --> src/mdtest_snippet.py:71:7
    |
-69 | class RaisesMultipleSub(RaisesMultiple): ...
-70 |
 71 | class HasAbstract(Protocol):
    |       --------------------- `HasAbstract` declared here
-72 |     def a(self) -> int: ...
    |
 
 ```
@@ -377,28 +320,19 @@ info: `HasAbstract.a` is implicitly abstract because `HasAbstract` is a `Protoco
 error[abstract-method-in-final-class]: Final class `HasAbstract2Sub` has unimplemented abstract methods
    --> src/mdtest_snippet.py:126:7
     |
-125 | @final
 126 | class HasAbstract2Sub(HasAbstract2): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
-127 |
-128 | @final
     |
    ::: src/mdtest_snippet.py:75:9
     |
- 74 | class HasAbstract2(Protocol):
  75 |     def a(self) -> int:
     |         - `a` declared as abstract on superclass `HasAbstract2`
- 76 |         pass
     |
 info: `HasAbstract2.a` is implicitly abstract because `HasAbstract2` is a `Protocol` class and `a` lacks an implementation
   --> src/mdtest_snippet.py:74:7
    |
-72 |     def a(self) -> int: ...
-73 |
 74 | class HasAbstract2(Protocol):
    |       ---------------------- `HasAbstract2` declared here
-75 |     def a(self) -> int:
-76 |         pass
    |
 
 ```
@@ -407,29 +341,19 @@ info: `HasAbstract2.a` is implicitly abstract because `HasAbstract2` is a `Proto
 error[abstract-method-in-final-class]: Final class `HasAbstract3Sub` has unimplemented abstract methods
    --> src/mdtest_snippet.py:129:7
     |
-128 | @final
 129 | class HasAbstract3Sub(HasAbstract4): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
-130 |
-131 | @final
     |
    ::: src/mdtest_snippet.py:83:9
     |
- 82 | class HasAbstract4(Protocol):
  83 |     def a(self) -> int:
     |         - `a` declared as abstract on superclass `HasAbstract4`
- 84 |         """My awesome docs"""
- 85 |         ...
     |
 info: `HasAbstract4.a` is implicitly abstract because `HasAbstract4` is a `Protocol` class and `a` lacks an implementation
   --> src/mdtest_snippet.py:82:7
    |
-80 |         """My awesome docs"""
-81 |
 82 | class HasAbstract4(Protocol):
    |       ---------------------- `HasAbstract4` declared here
-83 |     def a(self) -> int:
-84 |         """My awesome docs"""
    |
 
 ```
@@ -438,29 +362,19 @@ info: `HasAbstract4.a` is implicitly abstract because `HasAbstract4` is a `Proto
 error[abstract-method-in-final-class]: Final class `HasAbstract4Sub` has unimplemented abstract methods
    --> src/mdtest_snippet.py:132:7
     |
-131 | @final
 132 | class HasAbstract4Sub(HasAbstract4): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
-133 |
-134 | @final
     |
    ::: src/mdtest_snippet.py:83:9
     |
- 82 | class HasAbstract4(Protocol):
  83 |     def a(self) -> int:
     |         - `a` declared as abstract on superclass `HasAbstract4`
- 84 |         """My awesome docs"""
- 85 |         ...
     |
 info: `HasAbstract4.a` is implicitly abstract because `HasAbstract4` is a `Protocol` class and `a` lacks an implementation
   --> src/mdtest_snippet.py:82:7
    |
-80 |         """My awesome docs"""
-81 |
 82 | class HasAbstract4(Protocol):
    |       ---------------------- `HasAbstract4` declared here
-83 |     def a(self) -> int:
-84 |         """My awesome docs"""
    |
 
 ```
@@ -469,29 +383,19 @@ info: `HasAbstract4.a` is implicitly abstract because `HasAbstract4` is a `Proto
 error[abstract-method-in-final-class]: Final class `HasAbstract5Sub` has unimplemented abstract methods
    --> src/mdtest_snippet.py:135:7
     |
-134 | @final
 135 | class HasAbstract5Sub(HasAbstract5): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
-136 |
-137 | @final
     |
    ::: src/mdtest_snippet.py:88:9
     |
- 87 | class HasAbstract5(Protocol):
  88 |     def a(self) -> int:
     |         - `a` declared as abstract on superclass `HasAbstract5`
- 89 |         """My awesome docs"""
- 90 |         pass
     |
 info: `HasAbstract5.a` is implicitly abstract because `HasAbstract5` is a `Protocol` class and `a` lacks an implementation
   --> src/mdtest_snippet.py:87:7
    |
-85 |         ...
-86 |
 87 | class HasAbstract5(Protocol):
    |       ---------------------- `HasAbstract5` declared here
-88 |     def a(self) -> int:
-89 |         """My awesome docs"""
    |
 
 ```
@@ -500,29 +404,19 @@ info: `HasAbstract5.a` is implicitly abstract because `HasAbstract5` is a `Proto
 error[abstract-method-in-final-class]: Final class `HasAbstract6Sub` has unimplemented abstract methods
    --> src/mdtest_snippet.py:138:7
     |
-137 | @final
 138 | class HasAbstract6Sub(HasAbstract6): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
-139 |
-140 | @final
     |
    ::: src/mdtest_snippet.py:93:9
     |
- 92 | class HasAbstract6(Protocol):
  93 |     def a(self) -> int:
     |         - `a` declared as abstract on superclass `HasAbstract6`
- 94 |         """My awesome docs"""
- 95 |         pass
     |
 info: `HasAbstract6.a` is implicitly abstract because `HasAbstract6` is a `Protocol` class and `a` lacks an implementation
   --> src/mdtest_snippet.py:92:7
    |
-90 |         pass
-91 |
 92 | class HasAbstract6(Protocol):
    |       ---------------------- `HasAbstract6` declared here
-93 |     def a(self) -> int:
-94 |         """My awesome docs"""
    |
 
 ```
@@ -531,28 +425,19 @@ info: `HasAbstract6.a` is implicitly abstract because `HasAbstract6` is a `Proto
 error[abstract-method-in-final-class]: Final class `HasAbstract7Sub` has unimplemented abstract methods
    --> src/mdtest_snippet.py:141:7
     |
-140 | @final
 141 | class HasAbstract7Sub(HasAbstract7): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
-142 |
-143 | @final
     |
    ::: src/mdtest_snippet.py:105:9
     |
-104 | class HasAbstract7(Protocol):
 105 |     def a(self) -> int:
     |         - `a` declared as abstract on superclass `HasAbstract7`
-106 |         raise NotImplementedError
     |
 info: `HasAbstract7.a` is implicitly abstract because `HasAbstract7` is a `Protocol` class and `a` lacks an implementation
    --> src/mdtest_snippet.py:104:7
     |
-102 |         ...
-103 |
 104 | class HasAbstract7(Protocol):
     |       ---------------------- `HasAbstract7` declared here
-105 |     def a(self) -> int:
-106 |         raise NotImplementedError
     |
 
 ```
@@ -561,28 +446,19 @@ info: `HasAbstract7.a` is implicitly abstract because `HasAbstract7` is a `Proto
 error[abstract-method-in-final-class]: Final class `HasAbstract8Sub` has unimplemented abstract methods
    --> src/mdtest_snippet.py:144:7
     |
-143 | @final
 144 | class HasAbstract8Sub(HasAbstract8): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
-145 |
-146 | @final
     |
    ::: src/mdtest_snippet.py:109:9
     |
-108 | class HasAbstract8(Protocol):
 109 |     def a(self) -> int:
     |         - `a` declared as abstract on superclass `HasAbstract8`
-110 |         raise NotImplementedError()
     |
 info: `HasAbstract8.a` is implicitly abstract because `HasAbstract8` is a `Protocol` class and `a` lacks an implementation
    --> src/mdtest_snippet.py:108:7
     |
-106 |         raise NotImplementedError
-107 |
 108 | class HasAbstract8(Protocol):
     |       ---------------------- `HasAbstract8` declared here
-109 |     def a(self) -> int:
-110 |         raise NotImplementedError()
     |
 
 ```
@@ -591,29 +467,19 @@ info: `HasAbstract8.a` is implicitly abstract because `HasAbstract8` is a `Proto
 error[abstract-method-in-final-class]: Final class `HasAbstract9Sub` has unimplemented abstract methods
    --> src/mdtest_snippet.py:147:7
     |
-146 | @final
 147 | class HasAbstract9Sub(HasAbstract9): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
-148 |
-149 | @final
     |
    ::: src/mdtest_snippet.py:113:9
     |
-112 | class HasAbstract9(Protocol):
 113 |     def a(self) -> int:
     |         - `a` declared as abstract on superclass `HasAbstract9`
-114 |         """My awesome docs"""
-115 |         raise NotImplementedError
     |
 info: `HasAbstract9.a` is implicitly abstract because `HasAbstract9` is a `Protocol` class and `a` lacks an implementation
    --> src/mdtest_snippet.py:112:7
     |
-110 |         raise NotImplementedError()
-111 |
 112 | class HasAbstract9(Protocol):
     |       ---------------------- `HasAbstract9` declared here
-113 |     def a(self) -> int:
-114 |         """My awesome docs"""
     |
 
 ```
@@ -622,27 +488,19 @@ info: `HasAbstract9.a` is implicitly abstract because `HasAbstract9` is a `Proto
 error[abstract-method-in-final-class]: Final class `HasAbstract10Sub` has unimplemented abstract methods
    --> src/mdtest_snippet.py:150:7
     |
-149 | @final
 150 | class HasAbstract10Sub(HasAbstract10): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^^ `a` is unimplemented
     |
    ::: src/mdtest_snippet.py:118:9
     |
-117 | class HasAbstract10(Protocol):
 118 |     def a(self) -> int:
     |         - `a` declared as abstract on superclass `HasAbstract10`
-119 |         """My awesome docs"""
-120 |         raise NotImplementedError()
     |
 info: `HasAbstract10.a` is implicitly abstract because `HasAbstract10` is a `Protocol` class and `a` lacks an implementation
    --> src/mdtest_snippet.py:117:7
     |
-115 |         raise NotImplementedError
-116 |
 117 | class HasAbstract10(Protocol):
     |       ----------------------- `HasAbstract10` declared here
-118 |     def a(self) -> int:
-119 |         """My awesome docs"""
     |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_possibly-undefined…_(fc7b496fd1986deb).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_possibly-undefined…_(fc7b496fd1986deb).snap
@@ -94,24 +94,17 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 error[override-of-final-method]: Cannot override `A.method1`
   --> src/mdtest_snippet.py:40:9
    |
-39 | class B(A):
 40 |     def method1(self) -> None: ...  # error: [override-of-final-method]
    |         ^^^^^^^ Overrides a definition from superclass `A`
-41 |     def method2(self) -> None: ...  # error: [override-of-final-method]
-42 |     def method3(self) -> None: ...  # error: [override-of-final-method]
    |
 info: `A.method1` is decorated with `@final`, forbidding overrides
-  --> src/mdtest_snippet.py:8:9
-   |
- 6 | class A:
- 7 |     if coinflip():
- 8 |         @final
-   |         ------
- 9 |         def method1(self) -> None: ...
-   |             ------- `A.method1` defined here
-10 |
-11 |     else:
-   |
+ --> src/mdtest_snippet.py:8:9
+  |
+8 |         @final
+  |         ------
+9 |         def method1(self) -> None: ...
+  |             ------- `A.method1` defined here
+  |
 help: Remove the override of `method1`
 37 |         def method4(self) -> None: ...
 38 |
@@ -129,22 +122,16 @@ note: This is an unsafe fix and may change runtime behavior
 error[override-of-final-method]: Cannot override `A.method2`
   --> src/mdtest_snippet.py:41:9
    |
-39 | class B(A):
-40 |     def method1(self) -> None: ...  # error: [override-of-final-method]
 41 |     def method2(self) -> None: ...  # error: [override-of-final-method]
    |         ^^^^^^^ Overrides a definition from superclass `A`
-42 |     def method3(self) -> None: ...  # error: [override-of-final-method]
    |
 info: `A.method2` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.py:18:9
    |
-17 |     else:
 18 |         @final
    |         ------
 19 |         def method2(self) -> None: ...
    |             ------- `A.method2` defined here
-20 |
-21 |     if coinflip():
    |
 help: Remove the override of `method2`
 38 |
@@ -163,23 +150,16 @@ note: This is an unsafe fix and may change runtime behavior
 error[override-of-final-method]: Cannot override `A.method3`
   --> src/mdtest_snippet.py:42:9
    |
-40 |     def method1(self) -> None: ...  # error: [override-of-final-method]
-41 |     def method2(self) -> None: ...  # error: [override-of-final-method]
 42 |     def method3(self) -> None: ...  # error: [override-of-final-method]
    |         ^^^^^^^ Overrides a definition from superclass `A`
-43 |
-44 |     # check that autofixes don't introduce invalid syntax
    |
 info: `A.method3` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.py:22:9
    |
-21 |     if coinflip():
 22 |         @final
    |         ------
 23 |         def method3(self) -> None: ...
    |             ------- `A.method3` defined here
-24 |
-25 |     else:
    |
 help: Remove the override of `method3`
 39 | class B(A):
@@ -198,22 +178,16 @@ note: This is an unsafe fix and may change runtime behavior
 error[override-of-final-method]: Cannot override `A.method4`
   --> src/mdtest_snippet.py:49:5
    |
-47 |     # TODO: we should emit a Liskov violation here too
-48 |     # error: [override-of-final-method]
 49 |     method4 = 42
    |     ^^^^^^^ Overrides a definition from superclass `A`
-50 |     unrelated = 56  # fmt: skip
    |
 info: `A.method4` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.py:33:9
    |
-32 |     elif coinflip():
 33 |         @final
    |         ------
 34 |         def method4(self) -> None: ...
    |             ------- `A.method4` defined here
-35 |
-36 |     else:
    |
 help: Remove the override of `method4`
 
@@ -223,25 +197,17 @@ help: Remove the override of `method4`
 error[override-of-final-method]: Cannot override `A.method1`
   --> src/mdtest_snippet.py:55:13
    |
-53 | class C(A):
-54 |     if coinflip():
 55 |         def method1(self) -> None: ...  # error: [override-of-final-method]
    |             ^^^^^^^ Overrides a definition from superclass `A`
-56 |
-57 |     else:
    |
 info: `A.method1` is decorated with `@final`, forbidding overrides
-  --> src/mdtest_snippet.py:8:9
-   |
- 6 | class A:
- 7 |     if coinflip():
- 8 |         @final
-   |         ------
- 9 |         def method1(self) -> None: ...
-   |             ------- `A.method1` defined here
-10 |
-11 |     else:
-   |
+ --> src/mdtest_snippet.py:8:9
+  |
+8 |         @final
+  |         ------
+9 |         def method1(self) -> None: ...
+  |             ------- `A.method1` defined here
+  |
 help: Remove the override of `method1`
 
 ```
@@ -250,22 +216,16 @@ help: Remove the override of `method1`
 error[override-of-final-method]: Cannot override `A.method2`
   --> src/mdtest_snippet.py:61:13
    |
-60 |     if coinflip():
 61 |         def method2(self) -> None: ...  # error: [override-of-final-method]
    |             ^^^^^^^ Overrides a definition from superclass `A`
-62 |
-63 |     else:
    |
 info: `A.method2` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.py:18:9
    |
-17 |     else:
 18 |         @final
    |         ------
 19 |         def method2(self) -> None: ...
    |             ------- `A.method2` defined here
-20 |
-21 |     if coinflip():
    |
 help: Remove the override of `method2`
 
@@ -275,22 +235,16 @@ help: Remove the override of `method2`
 error[override-of-final-method]: Cannot override `A.method3`
   --> src/mdtest_snippet.py:67:13
    |
-66 |     if coinflip():
 67 |         def method3(self) -> None: ...  # error: [override-of-final-method]
    |             ^^^^^^^ Overrides a definition from superclass `A`
-68 |
-69 |     # TODO: we should emit Liskov violations here too:
    |
 info: `A.method3` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.py:22:9
    |
-21 |     if coinflip():
 22 |         @final
    |         ------
 23 |         def method3(self) -> None: ...
    |             ------- `A.method3` defined here
-24 |
-25 |     else:
    |
 help: Remove the override of `method3`
 
@@ -300,23 +254,16 @@ help: Remove the override of `method3`
 error[override-of-final-method]: Cannot override `A.method4`
   --> src/mdtest_snippet.py:71:9
    |
-69 |     # TODO: we should emit Liskov violations here too:
-70 |     if coinflip():
 71 |         method4 = 42  # error: [override-of-final-method]
    |         ^^^^^^^ Overrides a definition from superclass `A`
-72 |     else:
-73 |         method4 = 56
    |
 info: `A.method4` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.py:33:9
    |
-32 |     elif coinflip():
 33 |         @final
    |         ------
 34 |         def method4(self) -> None: ...
    |             ------- `A.method4` defined here
-35 |
-36 |     else:
    |
 help: Remove the override of `method4`
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Cannot_override_a_me…_(338615109711a91b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Cannot_override_a_me…_(338615109711a91b).snap
@@ -133,23 +133,16 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 error[override-of-final-method]: Cannot override `Parent.foo`
   --> src/mdtest_snippet.pyi:41:9
    |
-39 |     #
-40 |     # error: [override-of-final-method] "Cannot override final member `foo` from superclass `Parent`"
 41 |     def foo(self): ...
    |         ^^^ Overrides a definition from superclass `Parent`
-42 |     @property
-43 |     def my_property1(self) -> int: ...  # error: [override-of-final-method]
    |
 info: `Parent.foo` is decorated with `@final`, forbidding overrides
  --> src/mdtest_snippet.pyi:6:5
   |
-5 | class Parent:
 6 |     @final
   |     ------
 7 |     def foo(self): ...
   |         --- `Parent.foo` defined here
-8 |     @final
-9 |     @property
   |
 help: Remove the override of `foo`
 38 |     # which is different to the verbose diagnostic summary message:
@@ -168,25 +161,19 @@ note: This is an unsafe fix and may change runtime behavior
 error[override-of-final-method]: Cannot override `Parent.my_property1`
   --> src/mdtest_snippet.pyi:43:9
    |
-41 |     def foo(self): ...
-42 |     @property
 43 |     def my_property1(self) -> int: ...  # error: [override-of-final-method]
    |         ^^^^^^^^^^^^ Overrides a definition from superclass `Parent`
-44 |     @property
-45 |     def my_property2(self) -> int: ...  # error: [override-of-final-method]
    |
 info: `Parent.my_property1` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.pyi:8:5
    |
- 6 |     @final
- 7 |     def foo(self): ...
  8 |     @final
    |     ------
- 9 |     @property
+   |
+  ::: src/mdtest_snippet.pyi:10:9
+   |
 10 |     def my_property1(self) -> int: ...
    |         ------------ `Parent.my_property1` defined here
-11 |     @property
-12 |     @final
    |
 help: Remove the override of `my_property1`
 
@@ -196,24 +183,16 @@ help: Remove the override of `my_property1`
 error[override-of-final-method]: Cannot override `Parent.my_property2`
   --> src/mdtest_snippet.pyi:45:9
    |
-43 |     def my_property1(self) -> int: ...  # error: [override-of-final-method]
-44 |     @property
 45 |     def my_property2(self) -> int: ...  # error: [override-of-final-method]
    |         ^^^^^^^^^^^^ Overrides a definition from superclass `Parent`
-46 |     @my_property2.setter
-47 |     def my_property2(self, x: int) -> None: ...
    |
 info: `Parent.my_property2` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.pyi:12:5
    |
-10 |     def my_property1(self) -> int: ...
-11 |     @property
 12 |     @final
    |     ------
 13 |     def my_property2(self) -> int: ...
    |         ------------ `Parent.my_property2` defined here
-14 |     @property
-15 |     @final
    |
 help: Remove the getter and setter for `my_property2`
 
@@ -223,24 +202,16 @@ help: Remove the getter and setter for `my_property2`
 error[override-of-final-method]: Cannot override `Parent.my_property3`
   --> src/mdtest_snippet.pyi:49:9
    |
-47 |     def my_property2(self, x: int) -> None: ...
-48 |     @property
 49 |     def my_property3(self) -> int: ...  # error: [override-of-final-method]
    |         ^^^^^^^^^^^^ Overrides a definition from superclass `Parent`
-50 |     @my_property3.deleter
-51 |     def my_proeprty3(self) -> None: ...
    |
 info: `Parent.my_property3` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.pyi:15:5
    |
-13 |     def my_property2(self) -> int: ...
-14 |     @property
 15 |     @final
    |     ------
 16 |     def my_property3(self) -> int: ...
    |         ------------ `Parent.my_property3` defined here
-17 |     @final
-18 |     @classmethod
    |
 help: Remove the override of `my_property3`
 
@@ -250,25 +221,19 @@ help: Remove the override of `my_property3`
 error[override-of-final-method]: Cannot override `Parent.class_method1`
   --> src/mdtest_snippet.pyi:53:9
    |
-51 |     def my_proeprty3(self) -> None: ...
-52 |     @classmethod
 53 |     def class_method1(cls) -> int: ...  # error: [override-of-final-method]
    |         ^^^^^^^^^^^^^ Overrides a definition from superclass `Parent`
-54 |     @staticmethod
-55 |     def static_method1() -> int: ...  # error: [override-of-final-method]
    |
 info: `Parent.class_method1` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.pyi:17:5
    |
-15 |     @final
-16 |     def my_property3(self) -> int: ...
 17 |     @final
    |     ------
-18 |     @classmethod
+   |
+  ::: src/mdtest_snippet.pyi:19:9
+   |
 19 |     def class_method1(cls) -> int: ...
    |         ------------- `Parent.class_method1` defined here
-20 |     @classmethod
-21 |     @final
    |
 help: Remove the override of `class_method1`
 49 |     def my_property3(self) -> int: ...  # error: [override-of-final-method]
@@ -288,25 +253,19 @@ note: This is an unsafe fix and may change runtime behavior
 error[override-of-final-method]: Cannot override `Parent.static_method1`
   --> src/mdtest_snippet.pyi:55:9
    |
-53 |     def class_method1(cls) -> int: ...  # error: [override-of-final-method]
-54 |     @staticmethod
 55 |     def static_method1() -> int: ...  # error: [override-of-final-method]
    |         ^^^^^^^^^^^^^^ Overrides a definition from superclass `Parent`
-56 |     @classmethod
-57 |     def class_method2(cls) -> int: ...  # error: [override-of-final-method]
    |
 info: `Parent.static_method1` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.pyi:23:5
    |
-21 |     @final
-22 |     def class_method2(cls) -> int: ...
 23 |     @final
    |     ------
-24 |     @staticmethod
+   |
+  ::: src/mdtest_snippet.pyi:25:9
+   |
 25 |     def static_method1() -> int: ...
    |         -------------- `Parent.static_method1` defined here
-26 |     @staticmethod
-27 |     @final
    |
 help: Remove the override of `static_method1`
 51 |     def my_proeprty3(self) -> None: ...
@@ -326,24 +285,16 @@ note: This is an unsafe fix and may change runtime behavior
 error[override-of-final-method]: Cannot override `Parent.class_method2`
   --> src/mdtest_snippet.pyi:57:9
    |
-55 |     def static_method1() -> int: ...  # error: [override-of-final-method]
-56 |     @classmethod
 57 |     def class_method2(cls) -> int: ...  # error: [override-of-final-method]
    |         ^^^^^^^^^^^^^ Overrides a definition from superclass `Parent`
-58 |     @staticmethod
-59 |     def static_method2() -> int: ...  # error: [override-of-final-method]
    |
 info: `Parent.class_method2` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.pyi:21:5
    |
-19 |     def class_method1(cls) -> int: ...
-20 |     @classmethod
 21 |     @final
    |     ------
 22 |     def class_method2(cls) -> int: ...
    |         ------------- `Parent.class_method2` defined here
-23 |     @final
-24 |     @staticmethod
    |
 help: Remove the override of `class_method2`
 53 |     def class_method1(cls) -> int: ...  # error: [override-of-final-method]
@@ -363,24 +314,16 @@ note: This is an unsafe fix and may change runtime behavior
 error[override-of-final-method]: Cannot override `Parent.static_method2`
   --> src/mdtest_snippet.pyi:59:9
    |
-57 |     def class_method2(cls) -> int: ...  # error: [override-of-final-method]
-58 |     @staticmethod
 59 |     def static_method2() -> int: ...  # error: [override-of-final-method]
    |         ^^^^^^^^^^^^^^ Overrides a definition from superclass `Parent`
-60 |     def decorated_1(self): ...  # TODO: should emit [override-of-final-method]
-61 |     @lossy_decorator
    |
 info: `Parent.static_method2` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.pyi:27:5
    |
-25 |     def static_method1() -> int: ...
-26 |     @staticmethod
 27 |     @final
    |     ------
 28 |     def static_method2() -> int: ...
    |         -------------- `Parent.static_method2` defined here
-29 |     @lossy_decorator
-30 |     @final
    |
 help: Remove the override of `static_method2`
 55 |     def static_method1() -> int: ...  # error: [override-of-final-method]
@@ -400,21 +343,13 @@ note: This is an unsafe fix and may change runtime behavior
 error[invalid-method-override]: Invalid override of method `foo`
   --> src/mdtest_snippet.pyi:74:9
    |
-72 |     # error: [override-of-final-method]
-73 |     # error: [invalid-method-override]
 74 |     def foo(): ...
    |         ^^^^^ Definition is incompatible with `Parent.foo`
-75 |     @property
-76 |     # TODO: we should emit a Liskov violation here too
    |
   ::: src/mdtest_snippet.pyi:7:9
    |
- 5 | class Parent:
- 6 |     @final
  7 |     def foo(self): ...
    |         --------- `Parent.foo` defined here
- 8 |     @final
- 9 |     @property
    |
 info: `Grandchild.foo` is a staticmethod but `Parent.foo` is an instance method
 info: This violates the Liskov Substitution Principle
@@ -425,23 +360,16 @@ info: This violates the Liskov Substitution Principle
 error[override-of-final-method]: Cannot override `Parent.foo`
   --> src/mdtest_snippet.pyi:74:9
    |
-72 |     # error: [override-of-final-method]
-73 |     # error: [invalid-method-override]
 74 |     def foo(): ...
    |         ^^^ Overrides a definition from superclass `Parent`
-75 |     @property
-76 |     # TODO: we should emit a Liskov violation here too
    |
 info: `Parent.foo` is decorated with `@final`, forbidding overrides
  --> src/mdtest_snippet.pyi:6:5
   |
-5 | class Parent:
 6 |     @final
   |     ------
 7 |     def foo(self): ...
   |         --- `Parent.foo` defined here
-8 |     @final
-9 |     @property
   |
 help: Remove the override of `foo`
 68 |     # type or on an instance, it will behave the same from the caller's perspective. The only
@@ -463,25 +391,19 @@ note: This is an unsafe fix and may change runtime behavior
 error[override-of-final-method]: Cannot override `Parent.my_property1`
   --> src/mdtest_snippet.pyi:78:9
    |
-76 |     # TODO: we should emit a Liskov violation here too
-77 |     # error: [override-of-final-method]
 78 |     def my_property1(self) -> str: ...
    |         ^^^^^^^^^^^^ Overrides a definition from superclass `Parent`
-79 |     # TODO: we should emit a Liskov violation here too
-80 |     # error: [override-of-final-method]
    |
 info: `Parent.my_property1` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.pyi:8:5
    |
- 6 |     @final
- 7 |     def foo(self): ...
  8 |     @final
    |     ------
- 9 |     @property
+   |
+  ::: src/mdtest_snippet.pyi:10:9
+   |
 10 |     def my_property1(self) -> int: ...
    |         ------------ `Parent.my_property1` defined here
-11 |     @property
-12 |     @final
    |
 help: Remove the override of `my_property1`
 
@@ -491,25 +413,19 @@ help: Remove the override of `my_property1`
 error[override-of-final-method]: Cannot override `Parent.class_method1`
   --> src/mdtest_snippet.pyi:81:5
    |
-79 |     # TODO: we should emit a Liskov violation here too
-80 |     # error: [override-of-final-method]
 81 |     class_method1 = None
    |     ^^^^^^^^^^^^^ Overrides a definition from superclass `Parent`
-82 |
-83 | # Diagnostic edge case: `final` is very far away from the method definition in the source code:
    |
 info: `Parent.class_method1` is decorated with `@final`, forbidding overrides
   --> src/mdtest_snippet.pyi:17:5
    |
-15 |     @final
-16 |     def my_property3(self) -> int: ...
 17 |     @final
    |     ------
-18 |     @classmethod
+   |
+  ::: src/mdtest_snippet.pyi:19:9
+   |
 19 |     def class_method1(cls) -> int: ...
    |         ------------- `Parent.class_method1` defined here
-20 |     @classmethod
-21 |     @final
    |
 help: Remove the override of `class_method1`
 
@@ -519,27 +435,19 @@ help: Remove the override of `class_method1`
 error[override-of-final-method]: Cannot override `Foo.bar`
    --> src/mdtest_snippet.pyi:112:9
     |
-111 | class Baz(Foo):
 112 |     def bar(self): ...  # error: [override-of-final-method]
     |         ^^^ Overrides a definition from superclass `Foo`
     |
 info: `Foo.bar` is decorated with `@final`, forbidding overrides
    --> src/mdtest_snippet.pyi:90:5
     |
- 89 | class Foo:
  90 |     @final
     |     ------
- 91 |     @identity
- 92 |     @identity
     |
    ::: src/mdtest_snippet.pyi:109:9
     |
-107 |     @identity
-108 |     @identity
 109 |     def bar(self): ...
     |         --- `Foo.bar` defined here
-110 |
-111 | class Baz(Foo):
     |
 help: Remove the override of `bar`
 109 |     def bar(self): ...

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Diagnostic_edge_case…_(2389d52c5ecfa2bd).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Diagnostic_edge_case…_(2389d52c5ecfa2bd).snap
@@ -35,14 +35,12 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 error[override-of-final-method]: Cannot override `module1.Foo.f`
  --> src/module2.py:4:9
   |
-3 | class Foo(module1.Foo):
 4 |     def f(self): ...  # error: [override-of-final-method]
   |         ^ Overrides a definition from superclass `module1.Foo`
   |
 info: `module1.Foo.f` is decorated with `@final`, forbidding overrides
  --> src/module1.py:4:5
   |
-3 | class Foo:
 4 |     @final
   |     ------
 5 |     def f(self): ...

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Only_the_first_`@fin…_(9863b583f4c651c5).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Only_the_first_`@fin…_(9863b583f4c651c5).snap
@@ -33,25 +33,18 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 
 ```
 error[override-of-final-method]: Cannot override `A.f`
-  --> src/mdtest_snippet.py:9:9
-   |
- 7 | class B(A):
- 8 |     @final
- 9 |     def f(self): ...  # error: [override-of-final-method]
-   |         ^ Overrides a definition from superclass `A`
-10 |
-11 | class C(B):
-   |
+ --> src/mdtest_snippet.py:9:9
+  |
+9 |     def f(self): ...  # error: [override-of-final-method]
+  |         ^ Overrides a definition from superclass `A`
+  |
 info: `A.f` is decorated with `@final`, forbidding overrides
  --> src/mdtest_snippet.py:4:5
   |
-3 | class A:
 4 |     @final
   |     ------
 5 |     def f(self): ...
   |         - `A.f` defined here
-6 |
-7 | class B(A):
   |
 help: Remove the override of `f`
 5  |     def f(self): ...
@@ -71,22 +64,17 @@ note: This is an unsafe fix and may change runtime behavior
 error[override-of-final-method]: Cannot override `B.f`
   --> src/mdtest_snippet.py:14:9
    |
-12 |     @final
-13 |     # we only emit one error here, not two
 14 |     def f(self): ...  # error: [override-of-final-method]
    |         ^ Overrides a definition from superclass `B`
    |
 info: `B.f` is decorated with `@final`, forbidding overrides
-  --> src/mdtest_snippet.py:8:5
-   |
- 7 | class B(A):
- 8 |     @final
-   |     ------
- 9 |     def f(self): ...  # error: [override-of-final-method]
-   |         - `B.f` defined here
-10 |
-11 | class C(B):
-   |
+ --> src/mdtest_snippet.py:8:5
+  |
+8 |     @final
+  |     ------
+9 |     def f(self): ...  # error: [override-of-final-method]
+  |         - `B.f` defined here
+  |
 help: Remove the override of `f`
 9  |     def f(self): ...  # error: [override-of-final-method]
 10 |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overloaded_methods_d…_(861757f48340ed92).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overloaded_methods_d…_(861757f48340ed92).snap
@@ -133,24 +133,16 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 error[override-of-final-method]: Cannot override `Good.bar`
   --> src/stub.pyi:19:9
    |
-17 |     def bar(self, x: str) -> str: ...
-18 |     @overload
 19 |     def bar(self, x: int) -> int: ...  # error: [override-of-final-method]
    |         ^^^ Overrides a definition from superclass `Good`
-20 |     @overload
-21 |     def baz(self, x: str) -> str: ...
    |
 info: `Good.bar` is decorated with `@final`, forbidding overrides
  --> src/stub.pyi:5:5
   |
-3 | class Good:
-4 |     @overload
 5 |     @final
   |     ------
 6 |     def bar(self, x: str) -> str: ...
   |         --- `Good.bar` defined here
-7 |     @overload
-8 |     def bar(self, x: int) -> int: ...
   |
 help: Remove all overloads for `bar`
 13 |     def baz(self, x: int) -> int: ...
@@ -173,25 +165,19 @@ note: This is an unsafe fix and may change runtime behavior
 error[override-of-final-method]: Cannot override `Good.baz`
   --> src/stub.pyi:23:9
    |
-21 |     def baz(self, x: str) -> str: ...
-22 |     @overload
 23 |     def baz(self, x: int) -> int: ...  # error: [override-of-final-method]
    |         ^^^ Overrides a definition from superclass `Good`
-24 |
-25 | class Bad:
    |
 info: `Good.baz` is decorated with `@final`, forbidding overrides
   --> src/stub.pyi:9:5
    |
- 7 |     @overload
- 8 |     def bar(self, x: int) -> int: ...
  9 |     @final
    |     ------
-10 |     @overload
+   |
+  ::: src/stub.pyi:11:9
+   |
 11 |     def baz(self, x: str) -> str: ...
    |         --- `Good.baz` defined here
-12 |     @overload
-13 |     def baz(self, x: int) -> int: ...
    |
 help: Remove all overloads for `baz`
 17 |     def bar(self, x: str) -> str: ...
@@ -212,40 +198,37 @@ note: This is an unsafe fix and may change runtime behavior
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
-  --> src/stub.pyi:27:9
+  --> src/stub.pyi:31:9
    |
-25 | class Bad:
-26 |     @overload
-27 |     def bar(self, x: str) -> str: ...
-   |         --- First overload defined here
-28 |     @overload
-29 |     @final
-   |     ------
-30 |     # error: [invalid-overload]
 31 |     def bar(self, x: int) -> int: ...
    |         ^^^
-32 |     @overload
-33 |     def baz(self, x: str) -> str: ...
+   |
+  ::: src/stub.pyi:27:9
+   |
+27 |     def bar(self, x: str) -> str: ...
+   |         --- First overload defined here
+   |
+  ::: src/stub.pyi:29:5
+   |
+29 |     @final
+   |     ------
    |
 
 ```
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
-  --> src/stub.pyi:33:9
+  --> src/stub.pyi:37:9
    |
-31 |     def bar(self, x: int) -> int: ...
-32 |     @overload
+37 |     def baz(self, x: int) -> int: ...
+   |         ^^^
+   |
+  ::: src/stub.pyi:33:9
+   |
 33 |     def baz(self, x: str) -> str: ...
    |         --- First overload defined here
 34 |     @final
    |     ------
-35 |     @overload
-36 |     # error: [invalid-overload]
-37 |     def baz(self, x: int) -> int: ...
-   |         ^^^
-38 |
-39 | class ChildOfBad(Bad):
    |
 
 ```
@@ -254,22 +237,14 @@ error[invalid-overload]: `@final` decorator should be applied only to the first 
 error[override-of-final-method]: Cannot override `Bad.bar`
   --> src/stub.pyi:43:9
    |
-41 |     def bar(self, x: str) -> str: ...
-42 |     @overload
 43 |     def bar(self, x: int) -> int: ...  # error: [override-of-final-method]
    |         ^^^ Overrides a definition from superclass `Bad`
-44 |     @overload
-45 |     def baz(self, x: str) -> str: ...
    |
 info: `Bad.bar` is decorated with `@final`, forbidding overrides
   --> src/stub.pyi:27:9
    |
-25 | class Bad:
-26 |     @overload
 27 |     def bar(self, x: str) -> str: ...
    |         --- `Bad.bar` defined here
-28 |     @overload
-29 |     @final
    |
 help: Remove all overloads for `bar`
 37 |     def baz(self, x: int) -> int: ...
@@ -292,20 +267,14 @@ note: This is an unsafe fix and may change runtime behavior
 error[override-of-final-method]: Cannot override `Bad.baz`
   --> src/stub.pyi:47:9
    |
-45 |     def baz(self, x: str) -> str: ...
-46 |     @overload
 47 |     def baz(self, x: int) -> int: ...  # error: [override-of-final-method]
    |         ^^^ Overrides a definition from superclass `Bad`
    |
 info: `Bad.baz` is decorated with `@final`, forbidding overrides
   --> src/stub.pyi:33:9
    |
-31 |     def bar(self, x: int) -> int: ...
-32 |     @overload
 33 |     def baz(self, x: str) -> str: ...
    |         --- `Bad.baz` defined here
-34 |     @final
-35 |     @overload
    |
 help: Remove all overloads for `baz`
 41 |     def bar(self, x: str) -> str: ...
@@ -325,22 +294,17 @@ note: This is an unsafe fix and may change runtime behavior
 error[override-of-final-method]: Cannot override `Good.f`
   --> src/main.py:19:9
    |
-18 |     # error: [override-of-final-method]
 19 |     def f(self, x: int | str) -> int | str:
    |         ^ Overrides a definition from superclass `Good`
-20 |         return x
    |
 info: `Good.f` is decorated with `@final`, forbidding overrides
-  --> src/main.py:8:5
-   |
- 6 |     @overload
- 7 |     def f(self, x: int) -> int: ...
- 8 |     @final
-   |     ------
- 9 |     def f(self, x: int | str) -> int | str:
-   |         - `Good.f` defined here
-10 |         return x
-   |
+ --> src/main.py:8:5
+  |
+8 |     @final
+  |     ------
+9 |     def f(self, x: int | str) -> int | str:
+  |         - `Good.f` defined here
+  |
 help: Remove all overloads and the implementation for `f`
 10 |         return x
 11 |
@@ -367,37 +331,35 @@ note: This is an unsafe fix and may change runtime behavior
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
   --> src/main.py:24:5
    |
-22 | class Bad:
-23 |     @overload
 24 |     @final
    |     ------
 25 |     def f(self, x: str) -> str: ...  # error: [invalid-overload]
    |         ^
-26 |     @overload
-27 |     def f(self, x: int) -> int: ...
+   |
+  ::: src/main.py:28:9
+   |
 28 |     def f(self, x: int | str) -> int | str:
    |         - Implementation defined here
-29 |         return x
    |
 
 ```
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/main.py:31:5
+  --> src/main.py:33:9
    |
-29 |         return x
-30 |
-31 |     @final
-   |     ------
-32 |     @overload
 33 |     def g(self, x: str) -> str: ...  # error: [invalid-overload]
    |         ^
-34 |     @overload
-35 |     def g(self, x: int) -> int: ...
+   |
+  ::: src/main.py:31:5
+   |
+31 |     @final
+   |     ------
+   |
+  ::: src/main.py:36:9
+   |
 36 |     def g(self, x: int | str) -> int | str:
    |         - Implementation defined here
-37 |         return x
    |
 
 ```
@@ -406,33 +368,29 @@ error[invalid-overload]: `@final` decorator should be applied only to the overlo
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
   --> src/main.py:42:5
    |
-40 |     def h(self, x: str) -> str: ...
-41 |     @overload
 42 |     @final
    |     ------
 43 |     def h(self, x: int) -> int: ...  # error: [invalid-overload]
    |         ^
 44 |     def h(self, x: int | str) -> int | str:
    |         - Implementation defined here
-45 |         return x
    |
 
 ```
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/main.py:49:5
+  --> src/main.py:51:9
    |
-47 |     @overload
-48 |     def i(self, x: str) -> str: ...
-49 |     @final
-   |     ------
-50 |     @overload
 51 |     def i(self, x: int) -> int: ...  # error: [invalid-overload]
    |         ^
 52 |     def i(self, x: int | str) -> int | str:
    |         - Implementation defined here
-53 |         return x
+   |
+  ::: src/main.py:49:5
+   |
+49 |     @final
+   |     ------
    |
 
 ```
@@ -441,21 +399,14 @@ error[invalid-overload]: `@final` decorator should be applied only to the overlo
 error[override-of-final-method]: Cannot override `Bad.f`
   --> src/main.py:57:5
    |
-55 | class ChildOfBad(Bad):
-56 |     # TODO: these should all cause us to emit Liskov violations as well
 57 |     f = None  # error: [override-of-final-method]
    |     ^ Overrides a definition from superclass `Bad`
-58 |     g = None  # error: [override-of-final-method]
-59 |     h = None  # error: [override-of-final-method]
    |
 info: `Bad.f` is decorated with `@final`, forbidding overrides
   --> src/main.py:28:9
    |
-26 |     @overload
-27 |     def f(self, x: int) -> int: ...
 28 |     def f(self, x: int | str) -> int | str:
    |         - `Bad.f` defined here
-29 |         return x
    |
 help: Remove the override of `f`
 
@@ -465,21 +416,14 @@ help: Remove the override of `f`
 error[override-of-final-method]: Cannot override `Bad.g`
   --> src/main.py:58:5
    |
-56 |     # TODO: these should all cause us to emit Liskov violations as well
-57 |     f = None  # error: [override-of-final-method]
 58 |     g = None  # error: [override-of-final-method]
    |     ^ Overrides a definition from superclass `Bad`
-59 |     h = None  # error: [override-of-final-method]
-60 |     i = None  # error: [override-of-final-method]
    |
 info: `Bad.g` is decorated with `@final`, forbidding overrides
   --> src/main.py:36:9
    |
-34 |     @overload
-35 |     def g(self, x: int) -> int: ...
 36 |     def g(self, x: int | str) -> int | str:
    |         - `Bad.g` defined here
-37 |         return x
    |
 help: Remove the override of `g`
 
@@ -489,20 +433,14 @@ help: Remove the override of `g`
 error[override-of-final-method]: Cannot override `Bad.h`
   --> src/main.py:59:5
    |
-57 |     f = None  # error: [override-of-final-method]
-58 |     g = None  # error: [override-of-final-method]
 59 |     h = None  # error: [override-of-final-method]
    |     ^ Overrides a definition from superclass `Bad`
-60 |     i = None  # error: [override-of-final-method]
    |
 info: `Bad.h` is decorated with `@final`, forbidding overrides
   --> src/main.py:44:9
    |
-42 |     @final
-43 |     def h(self, x: int) -> int: ...  # error: [invalid-overload]
 44 |     def h(self, x: int | str) -> int | str:
    |         - `Bad.h` defined here
-45 |         return x
    |
 help: Remove the override of `h`
 
@@ -512,19 +450,14 @@ help: Remove the override of `h`
 error[override-of-final-method]: Cannot override `Bad.i`
   --> src/main.py:60:5
    |
-58 |     g = None  # error: [override-of-final-method]
-59 |     h = None  # error: [override-of-final-method]
 60 |     i = None  # error: [override-of-final-method]
    |     ^ Overrides a definition from superclass `Bad`
    |
 info: `Bad.i` is decorated with `@final`, forbidding overrides
   --> src/main.py:52:9
    |
-50 |     @overload
-51 |     def i(self, x: int) -> int: ...  # error: [invalid-overload]
 52 |     def i(self, x: int | str) -> int | str:
    |         - `Bad.i` defined here
-53 |         return x
    |
 help: Remove the override of `i`
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overloads_in_statica…_(29a698d9deaf7318).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overloads_in_statica…_(29a698d9deaf7318).snap
@@ -59,25 +59,17 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 error[override-of-final-method]: Cannot override `Foo.method`
   --> src/mdtest_snippet.pyi:31:9
    |
-29 |     def method(self, x: int) -> int: ...
-30 |     @overload
 31 |     def method(self, x: str) -> str: ...  # error: [override-of-final-method]
    |         ^^^^^^ Overrides a definition from superclass `Foo`
-32 |
-33 |     # This is fine: the only overload that is marked `@final`
    |
 info: `Foo.method` is decorated with `@final`, forbidding overrides
-  --> src/mdtest_snippet.pyi:7:9
-   |
- 5 |     if sys.version_info >= (3, 10):
- 6 |         @overload
- 7 |         @final
-   |         ------
- 8 |         def method(self, x: int) -> int: ...
-   |             ------ `Foo.method` defined here
- 9 |
-10 |     else:
-   |
+ --> src/mdtest_snippet.pyi:7:9
+  |
+7 |         @final
+  |         ------
+8 |         def method(self, x: int) -> int: ...
+  |             ------ `Foo.method` defined here
+  |
 help: Remove all overloads for `method`
 25 |     def method2(self, x: str) -> str: ...
 26 |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overriding_a_`@final…_(c004aaab38745318).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overriding_a_`@final…_(c004aaab38745318).snap
@@ -42,14 +42,12 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 error[override-of-final-method]: Cannot override `Base.method`
  --> src/derived.py:5:5
   |
-4 | class Derived(Base):
 5 |     method = replacement_method  # error: [override-of-final-method]
   |     ^^^^^^ Overrides a definition from superclass `Base`
   |
 info: `Base.method` is decorated with `@final`, forbidding overrides
  --> src/base.py:4:5
   |
-3 | class Base:
 4 |     @final
   |     ------
 5 |     def method(self) -> None: ...

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_`typing.Final`_-_Full_diagnostics_(174fdd8134fb325b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_`typing.Final`_-_Full_diagnostics_(174fdd8134fb325b).snap
@@ -75,18 +75,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
 
 ```
 error[invalid-assignment]: Reassignment of `Final` symbol `MY_CONSTANT` is not allowed
- --> src/mdtest_snippet.py:3:14
+ --> src/mdtest_snippet.py:7:1
   |
-1 | from typing import Final
-2 |
-3 | MY_CONSTANT: Final[int] = 1
-  |              ---------- Symbol declared as `Final` here
-4 |
-5 | # more code
-6 |
 7 | MY_CONSTANT = 2  # error: [invalid-assignment]
   | ^^^^^^^^^^^^^^^ Symbol later reassigned here
-8 | from _stat import ST_INO
+  |
+ ::: src/mdtest_snippet.py:3:14
+  |
+3 | MY_CONSTANT: Final[int] = 1
+  |              ---------- Symbol declared as `Final` here
   |
 
 ```
@@ -95,43 +92,38 @@ error[invalid-assignment]: Reassignment of `Final` symbol `MY_CONSTANT` is not a
 error[invalid-assignment]: Reassignment of `Final` symbol `ST_INO` is not allowed
   --> src/mdtest_snippet.py:10:1
    |
- 8 | from _stat import ST_INO
- 9 |
 10 | ST_INO = 1  # error: [invalid-assignment]
    | ^^^^^^^^^^ Reassignment of `Final` symbol
-11 | from typing import Final
    |
 
 ```
 
 ```
 error[invalid-assignment]: Cannot assign to final attribute `x` on type `Self@f`
-  --> src/mdtest_snippet.py:14:8
+  --> src/mdtest_snippet.py:17:9
    |
-13 | class C:
-14 |     x: Final[int] = 1
-   |        ---------- Attribute declared as `Final` here
-15 |
-16 |     def f(self):
 17 |         self.x = 2  # error: [invalid-assignment]
    |         ^^^^^^ `Final` attributes can only be assigned in the class body or `__init__`
-18 | from typing import Final
+   |
+  ::: src/mdtest_snippet.py:14:8
+   |
+14 |     x: Final[int] = 1
+   |        ---------- Attribute declared as `Final` here
    |
 
 ```
 
 ```
 error[invalid-assignment]: Cannot assign to final attribute `x` on type `C`
-  --> src/mdtest_snippet.py:21:8
+  --> src/mdtest_snippet.py:24:5
    |
-20 | class C:
-21 |     x: Final[int] = 1
-   |        ---------- Attribute declared as `Final` here
-22 |
-23 | def __init__(c: C):
 24 |     c.x = 2  # error: [invalid-assignment]
    |     ^^^ `Final` attributes can only be assigned in the class body or `__init__`
-25 | from typing import Final
+   |
+  ::: src/mdtest_snippet.py:21:8
+   |
+21 |     x: Final[int] = 1
+   |        ---------- Attribute declared as `Final` here
    |
 
 ```
@@ -140,60 +132,53 @@ error[invalid-assignment]: Cannot assign to final attribute `x` on type `C`
 error[final-without-value]: `Final` symbol `x` is not assigned a value
   --> src/mdtest_snippet.py:28:5
    |
-27 | class C:
 28 |     x: Final[int]  # error: [final-without-value]
    |     ^^^^^^^^^^^^^
-29 |
-30 |     def f(self):
    |
 
 ```
 
 ```
 error[invalid-assignment]: Cannot assign to final attribute `x` on type `Self@f`
-  --> src/mdtest_snippet.py:28:8
+  --> src/mdtest_snippet.py:31:9
    |
-27 | class C:
-28 |     x: Final[int]  # error: [final-without-value]
-   |        ---------- Attribute declared as `Final` here
-29 |
-30 |     def f(self):
 31 |         self.x = 2  # error: [invalid-assignment]
    |         ^^^^^^ `Final` attributes can only be assigned in the class body or `__init__`
-32 | from typing import Final
+   |
+  ::: src/mdtest_snippet.py:28:8
+   |
+28 |     x: Final[int]  # error: [final-without-value]
+   |        ---------- Attribute declared as `Final` here
    |
 
 ```
 
 ```
 error[invalid-assignment]: Invalid assignment to final attribute
-  --> src/mdtest_snippet.py:35:8
+  --> src/mdtest_snippet.py:38:9
    |
-34 | class C:
-35 |     x: Final[int] = 1
-   |        ---------- Attribute declared as `Final` here
-36 |
-37 |     def __init__(self):
 38 |         self.x = 2  # error: [invalid-assignment]
    |         ^^^^^^ `x` already has a value in the class body
-39 | from typing import Final
+   |
+  ::: src/mdtest_snippet.py:35:8
+   |
+35 |     x: Final[int] = 1
+   |        ---------- Attribute declared as `Final` here
    |
 
 ```
 
 ```
 error[invalid-assignment]: Cannot assign to final attribute `x` on type `Self@f`
-  --> src/mdtest_snippet.py:42:8
+  --> src/mdtest_snippet.py:46:9
    |
-41 | class Base:
-42 |     x: Final[int] = 1
-   |        ---------- Attribute declared as `Final` here
-43 |
-44 | class Child(Base):
-45 |     def f(self):
 46 |         self.x = 2  # error: [invalid-assignment]
    |         ^^^^^^ `Final` attributes can only be assigned in the class body or `__init__`
-47 | from typing import Final
+   |
+  ::: src/mdtest_snippet.py:42:8
+   |
+42 |     x: Final[int] = 1
+   |        ---------- Attribute declared as `Final` here
    |
 
 ```
@@ -202,10 +187,8 @@ error[invalid-assignment]: Cannot assign to final attribute `x` on type `Self@f`
 error[invalid-assignment]: Cannot assign to final attribute `x` on type `Self@f`
   --> src/mdtest_snippet.py:53:9
    |
-52 |     def f(self):
 53 |         self.x: Final[int] = 1  # error: [invalid-assignment]
    |         ^^^^^^ `Final` attributes can only be assigned in the class body or `__init__`
-54 | from typing import Final
    |
 
 ```
@@ -214,8 +197,6 @@ error[invalid-assignment]: Cannot assign to final attribute `x` on type `Self@f`
 error[final-without-value]: `Final` symbol `UNINITIALIZED` is not assigned a value
   --> src/mdtest_snippet.py:56:1
    |
-54 | from typing import Final
-55 |
 56 | UNINITIALIZED: Final[int]  # error: [final-without-value]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_`typing.Final`_-_Overriding_in_subcla…_-_Superclass_with_same…_(bac933843af030ce).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_`typing.Final`_-_Overriding_in_subcla…_-_Superclass_with_same…_(bac933843af030ce).snap
@@ -34,14 +34,12 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
 error[override-of-final-variable]: Cannot override `module_a.Foo.X`
  --> src/module_b.py:4:5
   |
-3 | class Foo(BaseFoo):
 4 |     X = 2  # error: [override-of-final-variable]
   |     ^ Overrides a final variable from superclass `module_a.Foo`
   |
 info: `module_a.Foo.X` is declared as `Final`, forbidding overrides
  --> src/module_a.py:4:5
   |
-3 | class Foo:
 4 |     X: Final[int] = 1
   |     - `module_a.Foo.X` defined here
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_me…_(3ffe352bb3a76715).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Bad_`__getitem__`_me…_(3ffe352bb3a76715).snap
@@ -30,10 +30,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 error[not-iterable]: Object of type `Iterable` is not iterable
  --> src/mdtest_snippet.py:8:10
   |
-7 | # error: [not-iterable]
 8 | for x in Iterable():
   |          ^^^^^^^^^^
-9 |     reveal_type(x)  # revealed: int
   |
 info: It has no `__iter__` method and its `__getitem__` method has an incorrect signature for the old-style iteration protocol
 info: `__getitem__` must be at least as permissive as `def __getitem__(self, key: int): ...` to satisfy the old-style iteration protocol

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Invalid_iterable_(3153247bb9a9b72a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Invalid_iterable_(3153247bb9a9b72a).snap
@@ -24,10 +24,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 error[not-iterable]: Object of type `Literal[123]` is not iterable
  --> src/mdtest_snippet.py:2:10
   |
-1 | nonsense = 123
 2 | for x in nonsense:  # error: [not-iterable]
   |          ^^^^^^^^
-3 |     pass
   |
 info: It doesn't have an `__iter__` method or a `__getitem__` method
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_New_over_old_style_i…_(a90ba167a7c191eb).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_New_over_old_style_i…_(a90ba167a7c191eb).snap
@@ -28,11 +28,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 error[not-iterable]: Object of type `NotIterable` is not iterable
  --> src/mdtest_snippet.py:6:10
   |
-4 |     __iter__: None = None
-5 |
 6 | for x in NotIterable():  # error: [not-iterable]
   |          ^^^^^^^^^^^^^
-7 |     pass
   |
 info: Its `__iter__` attribute has type `None`, which is not callable
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method…_(36425dbcbd793d2b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_No_`__iter__`_method…_(36425dbcbd793d2b).snap
@@ -27,10 +27,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 error[not-iterable]: Object of type `Bad` is not iterable
  --> src/mdtest_snippet.py:5:10
   |
-4 | # error: [not-iterable]
 5 | for x in Bad():
   |          ^^^^^
-6 |     reveal_type(x)  # revealed: Unknown
   |
 info: It has no `__iter__` method and its `__getitem__` attribute has type `None`, which is not callable
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callabl…_(49a21e4b7fe6e97b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly-not-callabl…_(49a21e4b7fe6e97b).snap
@@ -50,11 +50,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 error[not-iterable]: Object of type `Iterable1` may not be iterable
   --> src/mdtest_snippet.py:22:14
    |
-21 |     # error: [not-iterable]
 22 |     for x in Iterable1():
    |              ^^^^^^^^^^^
-23 |         # TODO... `int` might be ideal here?
-24 |         reveal_type(x)  # revealed: int | Unknown
    |
 info: It has no `__iter__` method and its `__getitem__` attribute is invalid
 info: `__getitem__` has type `CustomCallable`, which is not callable
@@ -65,11 +62,8 @@ info: `__getitem__` has type `CustomCallable`, which is not callable
 error[not-iterable]: Object of type `Iterable2` may not be iterable
   --> src/mdtest_snippet.py:27:14
    |
-26 |     # error: [not-iterable]
 27 |     for y in Iterable2():
    |              ^^^^^^^^^^^
-28 |         # TODO... `int` might be ideal here?
-29 |         reveal_type(y)  # revealed: int | Unknown
    |
 info: It has no `__iter__` method and its `__getitem__` attribute is invalid
 info: `__getitem__` has type `(bound method Iterable2.__getitem__(key: int) -> int) | None`, which is not callable

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__…_(6388761c90a0555c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__…_(6388761c90a0555c).snap
@@ -51,10 +51,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 error[not-iterable]: Object of type `Iterable1` may not be iterable
   --> src/mdtest_snippet.py:16:14
    |
-15 |     # error: [not-iterable]
 16 |     for x in Iterable1():
    |              ^^^^^^^^^^^
-17 |         reveal_type(x)  # revealed: int
    |
 info: Its `__iter__` method may have an invalid signature
 info: Type of `__iter__` is `(bound method Iterable1.__iter__() -> Iterator) | (bound method Iterable1.__iter__(invalid_extra_arg) -> Iterator)`
@@ -66,11 +64,8 @@ info: Expected signature for `__iter__` is `def __iter__(self): ...`
 error[not-iterable]: Object of type `Iterable2` may not be iterable
   --> src/mdtest_snippet.py:28:14
    |
-27 |     # error: [not-iterable]
 28 |     for x in Iterable2():
    |              ^^^^^^^^^^^
-29 |         # TODO: `int` would probably be better here:
-30 |         reveal_type(x)  # revealed: int | Unknown
    |
 info: Its `__iter__` attribute (with type `(bound method Iterable2.__iter__() -> Iterator) | None`) may not be callable
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__…_(6805a6032e504b63).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__…_(6805a6032e504b63).snap
@@ -47,11 +47,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 error[not-iterable]: Object of type `Iterable1` may not be iterable
   --> src/mdtest_snippet.py:20:14
    |
-19 |     # error: [not-iterable]
 20 |     for x in Iterable1():
    |              ^^^^^^^^^^^
-21 |         # TODO: `str` might be better
-22 |         reveal_type(x)  # revealed: str | Unknown
    |
 info: It has no `__iter__` method and its `__getitem__` attribute is invalid
 info: `__getitem__` has type `(bound method Iterable1.__getitem__(item: int) -> str) | None`, which is not callable
@@ -62,10 +59,8 @@ info: `__getitem__` has type `(bound method Iterable1.__getitem__(item: int) -> 
 error[not-iterable]: Object of type `Iterable2` may not be iterable
   --> src/mdtest_snippet.py:25:14
    |
-24 |     # error: [not-iterable]
 25 |     for y in Iterable2():
    |              ^^^^^^^^^^^
-26 |         reveal_type(y)  # revealed: str | int
    |
 info: It has no `__iter__` method and its `__getitem__` method (with type `(bound method Iterable2.__getitem__(item: int) -> str) | (bound method Iterable2.__getitem__(item: str) -> int)`) may have an incorrect signature for the old-style iteration protocol
 info: `__getitem__` must be at least as permissive as `def __getitem__(self, key: int): ...` to satisfy the old-style iteration protocol

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__…_(c626bde8651b643a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_invalid_`__…_(c626bde8651b643a).snap
@@ -55,10 +55,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 error[not-iterable]: Object of type `Iterable1` may not be iterable
   --> src/mdtest_snippet.py:28:14
    |
-27 |     # error: [not-iterable]
 28 |     for x in Iterable1():
    |              ^^^^^^^^^^^
-29 |         reveal_type(x)  # revealed: int | str
    |
 info: Its `__iter__` method returns an object of type `Iterator1`, which may have an invalid `__next__` method
 info: Expected signature for `__next__` is `def __next__(self): ...`
@@ -69,11 +67,8 @@ info: Expected signature for `__next__` is `def __next__(self): ...`
 error[not-iterable]: Object of type `Iterable2` may not be iterable
   --> src/mdtest_snippet.py:32:14
    |
-31 |     # error: [not-iterable]
 32 |     for y in Iterable2():
    |              ^^^^^^^^^^^
-33 |         # TODO: `int` would probably be better here:
-34 |         reveal_type(y)  # revealed: int | Unknown
    |
 info: Its `__iter__` method returns an object of type `Iterator2`, which has a `__next__` attribute that may not be callable
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_missing_`__…_(77269542b8e81774).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_missing_`__…_(77269542b8e81774).snap
@@ -58,11 +58,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 error[not-iterable]: Object of type `Iterable1` may not be iterable
   --> src/mdtest_snippet.py:31:14
    |
-30 |     # error: [not-iterable]
 31 |     for x in Iterable1():
    |              ^^^^^^^^^^^
-32 |         # TODO: `bytes | str` might be better
-33 |         reveal_type(x)  # revealed: bytes | str | Unknown
    |
 info: It may not have an `__iter__` method and its `__getitem__` attribute (with type `(bound method Iterable1.__getitem__(item: int) -> str) | None`) may not be callable
 
@@ -72,10 +69,8 @@ info: It may not have an `__iter__` method and its `__getitem__` attribute (with
 error[not-iterable]: Object of type `Iterable2` may not be iterable
   --> src/mdtest_snippet.py:36:14
    |
-35 |     # error: [not-iterable]
 36 |     for y in Iterable2():
    |              ^^^^^^^^^^^
-37 |         reveal_type(y)  # revealed: bytes | str | int
    |
 info: It may not have an `__iter__` method and its `__getitem__` method (with type `(bound method Iterable2.__getitem__(item: int) -> str) | (bound method Iterable2.__getitem__(item: str) -> int)`) may have an incorrect signature for the old-style iteration protocol
 info: `__getitem__` must be at least as permissive as `def __getitem__(self, key: int): ...` to satisfy the old-style iteration protocol

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_missing_`__…_(9f781babda99d74b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_missing_`__…_(9f781babda99d74b).snap
@@ -38,10 +38,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 error[not-iterable]: Object of type `Iterable` may not be iterable
   --> src/mdtest_snippet.py:16:14
    |
-15 |     # error: [not-iterable]
 16 |     for x in Iterable():
    |              ^^^^^^^^^^
-17 |         reveal_type(x)  # revealed: int | bytes
    |
 info: It may not have an `__iter__` method and its `__getitem__` method has an incorrect signature for the old-style iteration protocol
 info: `__getitem__` must be at least as permissive as `def __getitem__(self, key: int): ...` to satisfy the old-style iteration protocol

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_missing_`__…_(d8a02a0fcbb390a3).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Possibly_missing_`__…_(d8a02a0fcbb390a3).snap
@@ -37,10 +37,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 error[not-iterable]: Object of type `Iterable` may not be iterable
   --> src/mdtest_snippet.py:15:14
    |
-14 |     # error: [not-iterable]
 15 |     for x in Iterable():
    |              ^^^^^^^^^^
-16 |         reveal_type(x)  # revealed: int | bytes
    |
 info: It may not have an `__iter__` method or a `__getitem__` method
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterab…_(6177bb6d13a22241).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterab…_(6177bb6d13a22241).snap
@@ -38,11 +38,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 error[not-iterable]: Object of type `Test | Test2` may not be iterable
   --> src/mdtest_snippet.py:16:14
    |
-14 |     # TODO: Improve error message to state which union variant isn't iterable (https://github.com/astral-sh/ruff/issues/13989)
-15 |     # error: [not-iterable]
 16 |     for x in Test() if flag else Test2():
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-17 |         reveal_type(x)  # revealed: int
    |
 info: Its `__iter__` method returns an object of type `TestIter | int`, which may not have a `__next__` method
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterab…_(ba36fbef63a14969).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_Union_type_as_iterab…_(ba36fbef63a14969).snap
@@ -33,11 +33,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 error[not-iterable]: Object of type `Test | Literal[42]` may not be iterable
   --> src/mdtest_snippet.py:11:14
    |
- 9 | def _(flag: bool):
-10 |     # error: [not-iterable]
 11 |     for x in Test() if flag else 42:
    |              ^^^^^^^^^^^^^^^^^^^^^^
-12 |         reveal_type(x)  # revealed: int
    |
 info: It may not have an `__iter__` method and it doesn't have a `__getitem__` method
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_it…_(a1cdf01ad69ac37c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_With_non-callable_it…_(a1cdf01ad69ac37c).snap
@@ -33,13 +33,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 
 ```
 error[not-iterable]: Object of type `NotIterable` is not iterable
-  --> src/mdtest_snippet.py:9:14
-   |
- 8 |     # error: [not-iterable]
- 9 |     for x in NotIterable():
-   |              ^^^^^^^^^^^^^
-10 |         pass
-   |
+ --> src/mdtest_snippet.py:9:14
+  |
+9 |     for x in NotIterable():
+  |              ^^^^^^^^^^^^^
+  |
 info: Its `__iter__` attribute has type `int | None`, which is not callable
 
 ```
@@ -48,8 +46,6 @@ info: Its `__iter__` attribute has type `int | None`, which is not callable
 info[possibly-unresolved-reference]: Name `x` used when possibly not defined
   --> src/mdtest_snippet.py:14:17
    |
-12 |     # revealed: Unknown
-13 |     # error: [possibly-unresolved-reference]
 14 |     reveal_type(x)
    |                 ^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_…_(92e3fdd69edad63d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_does_not_…_(92e3fdd69edad63d).snap
@@ -28,10 +28,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 error[not-iterable]: Object of type `Bad` is not iterable
  --> src/mdtest_snippet.py:6:10
   |
-5 | # error: [not-iterable]
 6 | for x in Bad():
   |          ^^^^^
-7 |     reveal_type(x)  # revealed: Unknown
   |
 info: Its `__iter__` method returns an object of type `int`, which has no `__next__` method
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_wi…_(1136c0e783d61ba4).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_method_wi…_(1136c0e783d61ba4).snap
@@ -32,10 +32,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 error[not-iterable]: Object of type `Iterable` is not iterable
   --> src/mdtest_snippet.py:10:10
    |
- 9 | # error: [not-iterable]
 10 | for x in Iterable():
    |          ^^^^^^^^^^
-11 |     reveal_type(x)  # revealed: int
    |
 info: Its `__iter__` method has an invalid signature
 info: Expected signature `def __iter__(self): ...`

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_a…_(707bd02a22c4acc8).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/for.md_-_For_loops_-_`__iter__`_returns_a…_(707bd02a22c4acc8).snap
@@ -43,10 +43,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/loops/for.md
 error[not-iterable]: Object of type `Iterable1` is not iterable
   --> src/mdtest_snippet.py:17:10
    |
-16 | # error: [not-iterable]
 17 | for x in Iterable1():
    |          ^^^^^^^^^^^
-18 |     reveal_type(x)  # revealed: int
    |
 info: Its `__iter__` method returns an object of type `Iterator1`, which has an invalid `__next__` method
 info: Expected signature for `__next__` is `def __next__(self): ...`
@@ -57,10 +55,8 @@ info: Expected signature for `__next__` is `def __next__(self): ...`
 error[not-iterable]: Object of type `Iterable2` is not iterable
   --> src/mdtest_snippet.py:21:10
    |
-20 | # error: [not-iterable]
 21 | for y in Iterable2():
    |          ^^^^^^^^^^^
-22 |     reveal_type(y)  # revealed: Unknown
    |
 info: Its `__iter__` method returns an object of type `Iterator2`, which has a `__next__` attribute that is not callable
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/function.md_-_Call_expression_-_PEP-484_convention_f…_(ee99fadd6476677e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/function.md_-_Call_expression_-_PEP-484_convention_f…_(ee99fadd6476677e).snap
@@ -87,35 +87,27 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/call/function.md
 error[positional-only-parameter-as-kwarg]: Positional-only parameter 1 (`__x`) passed as keyword argument of function `f`
  --> src/mdtest_snippet.py:5:3
   |
-3 | f(1)
-4 | # error: [positional-only-parameter-as-kwarg]
 5 | f(__x=1)
   |   ^^^^^
-6 | from typing import overload
   |
 info: Function signature here
  --> src/mdtest_snippet.py:1:5
   |
 1 | def f(__x: int): ...
   |     ^^^^^^^^^^^
-2 |
-3 | f(1)
   |
 
 ```
 
 ```
 warning[invalid-legacy-positional-parameter]: Invalid use of the legacy convention for positional-only parameters
-  --> src/mdtest_snippet.py:9:7
-   |
- 8 | # error: [invalid-legacy-positional-parameter]
- 9 | def g(x: int, __y: str): ...
-   |       -       ^^^ Parameter name begins with `__` but will not be treated as positional-only
-   |       |
-   |       Prior parameter here was positional-or-keyword
-10 |
-11 | g(x=1, __y="foo")
-   |
+ --> src/mdtest_snippet.py:9:7
+  |
+9 | def g(x: int, __y: str): ...
+  |       -       ^^^ Parameter name begins with `__` but will not be treated as positional-only
+  |       |
+  |       Prior parameter here was positional-or-keyword
+  |
 info: A parameter can only be positional-only if it precedes all positional-or-keyword parameters
 
 ```
@@ -124,13 +116,10 @@ info: A parameter can only be positional-only if it precedes all positional-or-k
 warning[invalid-legacy-positional-parameter]: Invalid use of the legacy convention for positional-only parameters
   --> src/mdtest_snippet.py:20:8
    |
-19 | @overload
 20 | def g2(x: int, __y: str): ...  # error: [invalid-legacy-positional-parameter]
    |        -       ^^^ Parameter name begins with `__` but will not be treated as positional-only
    |        |
    |        Prior parameter here was positional-or-keyword
-21 | @overload
-22 | def g2(x: str, __y: int): ...  # error: [invalid-legacy-positional-parameter]
    |
 info: A parameter can only be positional-only if it precedes all positional-or-keyword parameters
 
@@ -140,13 +129,10 @@ info: A parameter can only be positional-only if it precedes all positional-or-k
 warning[invalid-legacy-positional-parameter]: Invalid use of the legacy convention for positional-only parameters
   --> src/mdtest_snippet.py:22:8
    |
-20 | def g2(x: int, __y: str): ...  # error: [invalid-legacy-positional-parameter]
-21 | @overload
 22 | def g2(x: str, __y: int): ...  # error: [invalid-legacy-positional-parameter]
    |        -       ^^^ Parameter name begins with `__` but will not be treated as positional-only
    |        |
    |        Prior parameter here was positional-or-keyword
-23 | def g2(x: str | int, __y: int | str): ...  # error: [invalid-legacy-positional-parameter]
    |
 info: A parameter can only be positional-only if it precedes all positional-or-keyword parameters
 
@@ -156,14 +142,10 @@ info: A parameter can only be positional-only if it precedes all positional-or-k
 warning[invalid-legacy-positional-parameter]: Invalid use of the legacy convention for positional-only parameters
   --> src/mdtest_snippet.py:23:8
    |
-21 | @overload
-22 | def g2(x: str, __y: int): ...  # error: [invalid-legacy-positional-parameter]
 23 | def g2(x: str | int, __y: int | str): ...  # error: [invalid-legacy-positional-parameter]
    |        -             ^^^ Parameter name begins with `__` but will not be treated as positional-only
    |        |
    |        Prior parameter here was positional-or-keyword
-24 |
-25 | T = TypeVar("T")
    |
 info: A parameter can only be positional-only if it precedes all positional-or-keyword parameters
 
@@ -173,13 +155,10 @@ info: A parameter can only be positional-only if it precedes all positional-or-k
 warning[invalid-legacy-positional-parameter]: Invalid use of the legacy convention for positional-only parameters
   --> src/mdtest_snippet.py:41:8
    |
-39 | # signature:
-40 | @copy_type(new_signature)
 41 | def g4(a, __b): ...  # error: [invalid-legacy-positional-parameter]
    |        -  ^^^ Parameter name begins with `__` but will not be treated as positional-only
    |        |
    |        Prior parameter here was positional-or-keyword
-42 | def h(__x__: str): ...
    |
 info: A parameter can only be positional-only if it precedes all positional-or-keyword parameters
 
@@ -189,14 +168,10 @@ info: A parameter can only be positional-only if it precedes all positional-or-k
 warning[invalid-legacy-positional-parameter]: Invalid use of the legacy convention for positional-only parameters
   --> src/mdtest_snippet.py:55:23
    |
-53 |     # a staticmethod works the same as a free function in the global scope)
-54 |     @staticmethod
 55 |     def static_method(self, __x: int): ...  # error: [invalid-legacy-positional-parameter]
    |                       ----  ^^^ Parameter name begins with `__` but will not be treated as positional-only
    |                       |
    |                       Prior parameter here was positional-or-keyword
-56 |     # `__new__` is a staticmethod, but the `cls` parameter works in the same way as the `cls`
-57 |     # parameter in a classmethod, and is always passed positionally at runtime,
    |
 info: A parameter can only be positional-only if it precedes all positional-or-keyword parameters
 
@@ -206,21 +181,14 @@ info: A parameter can only be positional-only if it precedes all positional-or-k
 error[positional-only-parameter-as-kwarg]: Positional-only parameter 2 (`__x`) passed as keyword argument of bound method `method`
   --> src/mdtest_snippet.py:63:14
    |
-62 | # error: [positional-only-parameter-as-kwarg]
 63 | C(42).method(__x=1)
    |              ^^^^^
-64 | # error: [positional-only-parameter-as-kwarg]
-65 | C.class_method(__x="1")
    |
 info: Method signature here
   --> src/mdtest_snippet.py:49:9
    |
-47 | i("foo", __y=42)  # fine
-48 | class C:
 49 |     def method(self, __x: int): ...
    |         ^^^^^^^^^^^^^^^^^^^^^^
-50 |     @classmethod
-51 |     def class_method(cls, __x: str): ...
    |
 
 ```
@@ -229,21 +197,14 @@ info: Method signature here
 error[positional-only-parameter-as-kwarg]: Positional-only parameter 2 (`__x`) passed as keyword argument of bound method `class_method`
   --> src/mdtest_snippet.py:65:16
    |
-63 | C(42).method(__x=1)
-64 | # error: [positional-only-parameter-as-kwarg]
 65 | C.class_method(__x="1")
    |                ^^^^^^^
-66 | C.static_method("x", __x=42)  # fine
    |
 info: Method signature here
   --> src/mdtest_snippet.py:51:9
    |
-49 |     def method(self, __x: int): ...
-50 |     @classmethod
 51 |     def class_method(cls, __x: str): ...
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-52 |     # (the name of the first parameter is irrelevant;
-53 |     # a staticmethod works the same as a free function in the global scope)
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/function.md_-_Call_expression_-_Wrong_argument_type_-_Diagnostics_for_unio…_(5396a8f9e7f88f71).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/function.md_-_Call_expression_-_Wrong_argument_type_-_Diagnostics_for_unio…_(5396a8f9e7f88f71).snap
@@ -38,23 +38,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/call/function.md
 error[invalid-argument-type]: Argument to function `f` is incorrect
   --> src/mdtest_snippet.py:14:7
    |
-12 |     d: list[str] | str | dict[str, str] | tuple[str, ...] | bytes | frozenset[str] | set[str] | Foo | Bar | Baz,
-13 | ):
 14 |     f(a)  # error: [invalid-argument-type]
    |       ^ Expected `Sized`, found `str | Foo`
-15 |     f(b)  # error: [invalid-argument-type]
-16 |     f(c)  # error: [invalid-argument-type]
    |
 info: Element `Foo` of this union is not assignable to `Sized`
 info: Function defined here
  --> src/mdtest_snippet.py:7:5
   |
-5 | class Baz: ...
-6 |
 7 | def f(x: Sized): ...
   |     ^ -------- Parameter declared here
-8 | def g(
-9 |     a: str | Foo,
   |
 
 ```
@@ -63,23 +55,15 @@ info: Function defined here
 error[invalid-argument-type]: Argument to function `f` is incorrect
   --> src/mdtest_snippet.py:15:7
    |
-13 | ):
-14 |     f(a)  # error: [invalid-argument-type]
 15 |     f(b)  # error: [invalid-argument-type]
    |       ^ Expected `Sized`, found `list[str] | str | dict[str, str] | ... omitted 5 union elements`
-16 |     f(c)  # error: [invalid-argument-type]
-17 |     f(d)  # error: [invalid-argument-type]
    |
 info: Element `Foo` of this union is not assignable to `Sized`
 info: Function defined here
  --> src/mdtest_snippet.py:7:5
   |
-5 | class Baz: ...
-6 |
 7 | def f(x: Sized): ...
   |     ^ -------- Parameter declared here
-8 | def g(
-9 |     a: str | Foo,
   |
 
 ```
@@ -88,22 +72,15 @@ info: Function defined here
 error[invalid-argument-type]: Argument to function `f` is incorrect
   --> src/mdtest_snippet.py:16:7
    |
-14 |     f(a)  # error: [invalid-argument-type]
-15 |     f(b)  # error: [invalid-argument-type]
 16 |     f(c)  # error: [invalid-argument-type]
    |       ^ Expected `Sized`, found `list[str] | str | dict[str, str] | ... omitted 6 union elements`
-17 |     f(d)  # error: [invalid-argument-type]
    |
 info: Union elements `Foo` and `Bar` are not assignable to `Sized`
 info: Function defined here
  --> src/mdtest_snippet.py:7:5
   |
-5 | class Baz: ...
-6 |
 7 | def f(x: Sized): ...
   |     ^ -------- Parameter declared here
-8 | def g(
-9 |     a: str | Foo,
   |
 
 ```
@@ -112,8 +89,6 @@ info: Function defined here
 error[invalid-argument-type]: Argument to function `f` is incorrect
   --> src/mdtest_snippet.py:17:7
    |
-15 |     f(b)  # error: [invalid-argument-type]
-16 |     f(c)  # error: [invalid-argument-type]
 17 |     f(d)  # error: [invalid-argument-type]
    |       ^ Expected `Sized`, found `list[str] | str | dict[str, str] | ... omitted 7 union elements`
    |
@@ -121,12 +96,8 @@ info: Union element `Foo`, and 2 more union elements, are not assignable to `Siz
 info: Function defined here
  --> src/mdtest_snippet.py:7:5
   |
-5 | class Baz: ...
-6 |
 7 | def f(x: Sized): ...
   |     ^ -------- Parameter declared here
-8 | def g(
-9 |     a: str | Foo,
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___L…_-_Inferring_a_bound_ty…_(d50204b9d91b7bd1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___L…_-_Inferring_a_bound_ty…_(d50204b9d91b7bd1).snap
@@ -32,20 +32,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/function
 error[invalid-argument-type]: Argument to function `f` is incorrect
   --> src/mdtest_snippet.py:11:15
    |
- 9 | reveal_type(f(True))  # revealed: Literal[True]
-10 | # error: [invalid-argument-type]
 11 | reveal_type(f("string"))  # revealed: Unknown
    |               ^^^^^^^^ Argument type `Literal["string"]` does not satisfy upper bound `int` of type variable `T`
    |
 info: Type variable defined here
  --> src/mdtest_snippet.py:3:1
   |
-1 | from typing import TypeVar
-2 |
 3 | T = TypeVar("T", bound=int)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-4 |
-5 | def f(x: T) -> T:
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___L…_-_Inferring_a_constrai…_(48ab83f977c109b4).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___L…_-_Inferring_a_constrai…_(48ab83f977c109b4).snap
@@ -33,20 +33,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/function
 error[invalid-argument-type]: Argument to function `f` is incorrect
   --> src/mdtest_snippet.py:12:15
    |
-10 | reveal_type(f(None))  # revealed: None
-11 | # error: [invalid-argument-type]
 12 | reveal_type(f("string"))  # revealed: Unknown
    |               ^^^^^^^^ Argument type `Literal["string"]` does not satisfy constraints (`int`, `None`) of type variable `T`
    |
 info: Type variable defined here
  --> src/mdtest_snippet.py:3:1
   |
-1 | from typing import TypeVar
-2 |
 3 | T = TypeVar("T", int, None)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-4 |
-5 | def f(x: T) -> T:
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___P…_-_Inferring_a_bound_ty…_(5935d14c26afe407).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___P…_-_Inferring_a_bound_ty…_(5935d14c26afe407).snap
@@ -30,19 +30,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/function
 error[invalid-argument-type]: Argument to function `f` is incorrect
  --> src/mdtest_snippet.py:9:15
   |
-7 | reveal_type(f(True))  # revealed: Literal[True]
-8 | # error: [invalid-argument-type]
 9 | reveal_type(f("string"))  # revealed: Unknown
   |               ^^^^^^^^ Argument type `Literal["string"]` does not satisfy upper bound `int` of type variable `T`
   |
 info: Type variable defined here
  --> src/mdtest_snippet.py:3:7
   |
-1 | from typing_extensions import reveal_type
-2 |
 3 | def f[T: int](x: T) -> T:
   |       ^^^^^^
-4 |     return x
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___P…_-_Inferring_a_constrai…_(d2c475fccc70a8e2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/functions.md_-_Generic_functions___P…_-_Inferring_a_constrai…_(d2c475fccc70a8e2).snap
@@ -31,19 +31,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/function
 error[invalid-argument-type]: Argument to function `f` is incorrect
   --> src/mdtest_snippet.py:10:15
    |
- 8 | reveal_type(f(None))  # revealed: None
- 9 | # error: [invalid-argument-type]
 10 | reveal_type(f("string"))  # revealed: Unknown
    |               ^^^^^^^^ Argument type `Literal["string"]` does not satisfy constraints (`int`, `None`) of type variable `T`
    |
 info: Type variable defined here
  --> src/mdtest_snippet.py:3:7
   |
-1 | from typing_extensions import reveal_type
-2 |
 3 | def f[T: (int, None)](x: T) -> T:
   |       ^^^^^^^^^^^^^^
-4 |     return x
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/implicit_type_aliase…_-_Implicit_type_aliase…_-_Generic_implicit_typ…_-_Snapshots_for_verbos…_(c495f90628efc0f0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/implicit_type_aliase…_-_Implicit_type_aliase…_-_Generic_implicit_typ…_-_Snapshots_for_verbos…_(c495f90628efc0f0).snap
@@ -36,13 +36,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
 error[not-subscriptable]: Cannot subscript non-generic type alias `ListOfInts2`
  --> src/mdtest_snippet.py:4:21
   |
-3 | # error: [not-subscriptable] "Cannot subscript non-generic type alias `ListOfInts2`"
 4 | DoublySpecialized = ListOfInts2[int]
   |                     -----------^^^^^
   |                     |
   |                     Alias to `list[int]`, which is already specialized
-5 |
-6 | ThreeInts = tuple[int, int, int]
   |
 
 ```
@@ -51,13 +48,10 @@ error[not-subscriptable]: Cannot subscript non-generic type alias `ListOfInts2`
 error[not-subscriptable]: Cannot subscript non-generic type `<class 'A[int]'>`
   --> src/mdtest_snippet.py:13:8
    |
-12 | def f(
 13 |     a: AliasForA[int],  # error: [not-subscriptable]
    |        ---------^^^^^
    |        |
    |        Type is already specialized
-14 |     b: ThreeInts[int],  # error: [not-subscriptable]
-15 | ): ...
    |
 
 ```
@@ -66,13 +60,10 @@ error[not-subscriptable]: Cannot subscript non-generic type `<class 'A[int]'>`
 error[not-subscriptable]: Cannot subscript non-generic type `<class 'tuple[int, int, int]'>`
   --> src/mdtest_snippet.py:14:8
    |
-12 | def f(
-13 |     a: AliasForA[int],  # error: [not-subscriptable]
 14 |     b: ThreeInts[int],  # error: [not-subscriptable]
    |        ---------^^^^^
    |        |
    |        Type is already specialized
-15 | ): ...
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/instance.md_-_Instance_subscript_-_`__getitem__`_unboun…_(b1b0f9ed2b7302b2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/instance.md_-_Instance_subscript_-_`__getitem__`_unboun…_(b1b0f9ed2b7302b2).snap
@@ -24,8 +24,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/instance.md
 error[not-subscriptable]: Cannot subscript object of type `NotSubscriptable` with no `__getitem__` method
  --> src/mdtest_snippet.py:3:5
   |
-1 | class NotSubscriptable: ...
-2 |
 3 | a = NotSubscriptable()[0]  # error: [not-subscriptable]
   |     ^^^^^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/instance_layout_conf…_-_Tests_for_ty's_`inst…_-_Builtins_with_implic…_(4c3d127986a58f11).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/instance_layout_conf…_-_Tests_for_ty's_`inst…_-_Builtins_with_implic…_(4c3d127986a58f11).snap
@@ -58,28 +58,22 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/instance_layout_conflict
 
 ```
 error[instance-layout-conflict]: Class will raise `TypeError` at runtime due to incompatible bases
-  --> src/mdtest_snippet.py:5:7
-   |
- 3 |   # fmt: off
- 4 |
- 5 |   class A(  # error: [instance-layout-conflict]
-   |  _______^
- 6 | |     int,
- 7 | |     str
- 8 | | ): ...
-   | |_^ Bases `int` and `str` cannot be combined in multiple inheritance
- 9 |
-10 |   class B:
-   |
+ --> src/mdtest_snippet.py:5:7
+  |
+5 |   class A(  # error: [instance-layout-conflict]
+  |  _______^
+6 | |     int,
+7 | |     str
+8 | | ): ...
+  | |_^ Bases `int` and `str` cannot be combined in multiple inheritance
+  |
 info: Two classes cannot coexist in a class's MRO if their instances have incompatible memory layouts
  --> src/mdtest_snippet.py:6:5
   |
-5 | class A(  # error: [instance-layout-conflict]
 6 |     int,
   |     --- `int` instances have a distinct memory layout because of the way `int` is implemented in a C extension
 7 |     str
   |     --- `str` instances have a distinct memory layout because of the way `str` is implemented in a C extension
-8 | ): ...
   |
 
 ```
@@ -88,26 +82,20 @@ info: Two classes cannot coexist in a class's MRO if their instances have incomp
 error[instance-layout-conflict]: Class will raise `TypeError` at runtime due to incompatible bases
   --> src/mdtest_snippet.py:13:7
    |
-11 |       __slots__ = ("b",)
-12 |
 13 |   class C(  # error: [instance-layout-conflict]
    |  _______^
 14 | |     int,
 15 | |     B,
 16 | | ): ...
    | |_^ Bases `int` and `B` cannot be combined in multiple inheritance
-17 |   class D(int): ...
    |
 info: Two classes cannot coexist in a class's MRO if their instances have incompatible memory layouts
   --> src/mdtest_snippet.py:14:5
    |
-13 | class C(  # error: [instance-layout-conflict]
 14 |     int,
    |     --- `int` instances have a distinct memory layout because of the way `int` is implemented in a C extension
 15 |     B,
    |     - `B` instances have a distinct memory layout because `B` defines non-empty `__slots__`
-16 | ): ...
-17 | class D(int): ...
    |
 
 ```
@@ -116,21 +104,16 @@ info: Two classes cannot coexist in a class's MRO if their instances have incomp
 error[instance-layout-conflict]: Class will raise `TypeError` at runtime due to incompatible bases
   --> src/mdtest_snippet.py:19:7
    |
-17 |   class D(int): ...
-18 |
 19 |   class E(  # error: [instance-layout-conflict]
    |  _______^
 20 | |     D,
 21 | |     str
 22 | | ): ...
    | |_^ Bases `D` and `str` cannot be combined in multiple inheritance
-23 |
-24 |   class F(int, bytes, bytearray): ...  # error: [instance-layout-conflict]
    |
 info: Two classes cannot coexist in a class's MRO if their instances have incompatible memory layouts
   --> src/mdtest_snippet.py:20:5
    |
-19 | class E(  # error: [instance-layout-conflict]
 20 |     D,
    |     -
    |     |
@@ -138,7 +121,6 @@ info: Two classes cannot coexist in a class's MRO if their instances have incomp
    |     `int` instances have a distinct memory layout because of the way `int` is implemented in a C extension
 21 |     str
    |     --- `str` instances have a distinct memory layout because of the way `str` is implemented in a C extension
-22 | ): ...
    |
 
 ```
@@ -147,25 +129,17 @@ info: Two classes cannot coexist in a class's MRO if their instances have incomp
 error[instance-layout-conflict]: Class will raise `TypeError` at runtime due to incompatible bases
   --> src/mdtest_snippet.py:24:7
    |
-22 | ): ...
-23 |
 24 | class F(int, bytes, bytearray): ...  # error: [instance-layout-conflict]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^ Bases `int`, `bytes` and `bytearray` cannot be combined in multiple inheritance
-25 |
-26 | @disjoint_base
    |
 info: Two classes cannot coexist in a class's MRO if their instances have incompatible memory layouts
   --> src/mdtest_snippet.py:24:9
    |
-22 | ): ...
-23 |
 24 | class F(int, bytes, bytearray): ...  # error: [instance-layout-conflict]
    |         ---  -----  --------- `bytearray` instances have a distinct memory layout because of the way `bytearray` is implemented in a C extension
    |         |    |
    |         |    `bytes` instances have a distinct memory layout because of the way `bytes` is implemented in a C extension
    |         `int` instances have a distinct memory layout because of the way `int` is implemented in a C extension
-25 |
-26 | @disjoint_base
    |
 
 ```
@@ -174,26 +148,20 @@ info: Two classes cannot coexist in a class's MRO if their instances have incomp
 error[instance-layout-conflict]: Class will raise `TypeError` at runtime due to incompatible bases
   --> src/mdtest_snippet.py:32:7
    |
-30 |   class H: ...
-31 |
 32 |   class I(  # error: [instance-layout-conflict]
    |  _______^
 33 | |     G,
 34 | |     H
 35 | | ): ...
    | |_^ Bases `G` and `H` cannot be combined in multiple inheritance
-36 |
-37 |   # fmt: on
    |
 info: Two classes cannot coexist in a class's MRO if their instances have incompatible memory layouts
   --> src/mdtest_snippet.py:33:5
    |
-32 | class I(  # error: [instance-layout-conflict]
 33 |     G,
    |     - `G` instances have a distinct memory layout because of the way `G` is implemented in a C extension
 34 |     H
    |     - `H` instances have a distinct memory layout because of the way `H` is implemented in a C extension
-35 | ): ...
    |
 
 ```
@@ -202,8 +170,6 @@ info: Two classes cannot coexist in a class's MRO if their instances have incomp
 error[invalid-generic-class]: Inconsistent type arguments for `Sequence` among class bases
   --> src/mdtest_snippet.py:39:7
    |
-37 | # fmt: on
-38 | # error: [invalid-generic-class]
 39 | class Foo(range, str): ...  # error: [subclass-of-final-class]
    |       ^^^^-----^^---^
    |           |      |
@@ -217,8 +183,6 @@ error[invalid-generic-class]: Inconsistent type arguments for `Sequence` among c
 error[subclass-of-final-class]: Class `Foo` cannot inherit from final class `range`
   --> src/mdtest_snippet.py:39:11
    |
-37 | # fmt: on
-38 | # error: [invalid-generic-class]
 39 | class Foo(range, str): ...  # error: [subclass-of-final-class]
    |           ^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/instance_layout_conf…_-_Tests_for_ty's_`inst…_-_`__slots__`___incompa…_(98b54233987eb654).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/instance_layout_conf…_-_Tests_for_ty's_`inst…_-_`__slots__`___incompa…_(98b54233987eb654).snap
@@ -31,8 +31,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/instance_layout_conflict
 error[instance-layout-conflict]: Class will raise `TypeError` at runtime due to incompatible bases
   --> src/mdtest_snippet.py:7:7
    |
- 5 |       __slots__ = ("c", "d")
- 6 |
  7 |   class C(  # error: [instance-layout-conflict]
    |  _______^
  8 | |     A,
@@ -41,14 +39,12 @@ error[instance-layout-conflict]: Class will raise `TypeError` at runtime due to 
    | |_^ Bases `A` and `B` cannot be combined in multiple inheritance
    |
 info: Two classes cannot coexist in a class's MRO if their instances have incompatible memory layouts
-  --> src/mdtest_snippet.py:8:5
-   |
- 7 | class C(  # error: [instance-layout-conflict]
- 8 |     A,
-   |     - `A` instances have a distinct memory layout because `A` defines non-empty `__slots__`
- 9 |     B,
-   |     - `B` instances have a distinct memory layout because `B` defines non-empty `__slots__`
-10 | ): ...
-   |
+ --> src/mdtest_snippet.py:8:5
+  |
+8 |     A,
+  |     - `A` instances have a distinct memory layout because `A` defines non-empty `__slots__`
+9 |     B,
+  |     - `B` instances have a distinct memory layout because `B` defines non-empty `__slots__`
+  |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on…_-_Operations_involving…_(492b1163b8163c05).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/instances.md_-_Binary_operations_on…_-_Operations_involving…_(492b1163b8163c05).snap
@@ -28,7 +28,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/binary/instances.md
 error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
  --> src/mdtest_snippet.py:7:8
   |
-6 | # error: [unsupported-bool-conversion]
 7 | 10 and a and True
   |        ^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/intersections.md_-_Comparison___Intersec…_-_Diagnostics_-_Unsupported_operator…_(27f95f68d1c826ec).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/intersections.md_-_Comparison___Intersec…_-_Diagnostics_-_Unsupported_operator…_(27f95f68d1c826ec).snap
@@ -49,14 +49,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/intersections
 error[unsupported-operator]: Unsupported `in` operation
   --> src/mdtest_snippet.py:10:25
    |
- 9 |             # error: [unsupported-operator] "Operator `in` is not supported between objects of type `Literal[2]` and `NonContainer1 & …
 10 |             reveal_type(2 in x)  # revealed: bool
    |                         -^^^^-
    |                         |    |
    |                         |    Has type `NonContainer1 & NonContainer2`
    |                         Has type `Literal[2]`
-11 | class Container:
-12 |     def __contains__(self, x) -> bool:
    |
 
 ```
@@ -65,14 +62,11 @@ error[unsupported-operator]: Unsupported `in` operation
 error[unsupported-operator]: Unsupported `in` operation
   --> src/mdtest_snippet.py:26:21
    |
-25 |         # error: [unsupported-operator] "Operator `in` is not supported between objects of type `Literal[2]` and `~NonContainer1`"
 26 |         reveal_type(2 in x)  # revealed: bool
    |                     -^^^^-
    |                     |    |
    |                     |    Has type `~NonContainer1`
    |                     Has type `Literal[2]`
-27 |
-28 |         reveal_type(2 is x)  # revealed: bool
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_AST_nodes_that_are_o…_(58a3839a9bc7026d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_AST_nodes_that_are_o…_(58a3839a9bc7026d).snap
@@ -31,12 +31,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
 error[invalid-type-form]: Int literals are not allowed in this context in a parameter annotation
  --> src/mdtest_snippet.py:3:8
   |
-1 | def bad(
-2 |     # error: [invalid-type-form]
 3 |     a: 42,
   |        ^^ Did you mean `typing.Literal[42]`?
-4 |     # error: [invalid-type-form]
-5 |     b: b"42",
   |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -47,12 +43,8 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 error[invalid-type-form]: Bytes literals are not allowed in this context in a parameter annotation
  --> src/mdtest_snippet.py:5:8
   |
-3 |     a: 42,
-4 |     # error: [invalid-type-form]
 5 |     b: b"42",
   |        ^^^^^ Did you mean `typing.Literal[b"42"]`?
-6 |     # error: [invalid-type-form]
-7 |     c: True,
   |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -63,12 +55,8 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 error[invalid-type-form]: Boolean literals are not allowed in this context in a parameter annotation
  --> src/mdtest_snippet.py:7:8
   |
-5 |     b: b"42",
-6 |     # error: [invalid-type-form]
 7 |     c: True,
   |        ^^^^ Did you mean `typing.Literal[True]`?
-8 |     # error: [invalid-syntax-in-forward-annotation]
-9 |     d: "invalid syntax",
   |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -77,13 +65,10 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 
 ```
 error[invalid-syntax-in-forward-annotation]: Syntax error in forward annotation: Unexpected token at the end of an expression
-  --> src/mdtest_snippet.py:9:8
-   |
- 7 |     c: True,
- 8 |     # error: [invalid-syntax-in-forward-annotation]
- 9 |     d: "invalid syntax",
-   |        ^^^^^^^^^^^^^^^^ Did you mean `typing.Literal["invalid syntax"]`?
-10 | ): ...
-   |
+ --> src/mdtest_snippet.py:9:8
+  |
+9 |     d: "invalid syntax",
+  |        ^^^^^^^^^^^^^^^^ Did you mean `typing.Literal["invalid syntax"]`?
+  |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_Dict-literal_or_set-…_(15737b0beb194b0e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_Dict-literal_or_set-…_(15737b0beb194b0e).snap
@@ -25,11 +25,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
 error[invalid-type-form]: Dict literals are not allowed in parameter annotations
  --> src/mdtest_snippet.py:2:8
   |
-1 | def _(
 2 |     x: {int: str},  # error: [invalid-type-form]
   |        ^^^^^^^^^^ Did you mean `dict[int, str]`?
-3 |     y: {str},  # error: [invalid-type-form]
-4 | ): ...
   |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -40,11 +37,8 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 error[invalid-type-form]: Set literals are not allowed in parameter annotations
  --> src/mdtest_snippet.py:3:8
   |
-1 | def _(
-2 |     x: {int: str},  # error: [invalid-type-form]
 3 |     y: {str},  # error: [invalid-type-form]
   |        ^^^^^ Did you mean `set[str]`?
-4 | ): ...
   |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_List-literal_used_wh…_(ba5cb09eaa3715d8).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_List-literal_used_wh…_(ba5cb09eaa3715d8).snap
@@ -31,11 +31,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
 error[invalid-type-form]: List literals are not allowed in this context in a parameter annotation
  --> src/mdtest_snippet.py:2:8
   |
-1 | def _(
 2 |     x: [int],  # error: [invalid-type-form]
   |        ^^^^^ Did you mean `list[int]`?
-3 | ) -> [int]:  # error: [invalid-type-form]
-4 |     return x
   |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -46,11 +43,8 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 error[invalid-type-form]: List literals are not allowed in this context in a return type annotation
  --> src/mdtest_snippet.py:3:6
   |
-1 | def _(
-2 |     x: [int],  # error: [invalid-type-form]
 3 | ) -> [int]:  # error: [invalid-type-form]
   |      ^^^^^ Did you mean `list[int]`?
-4 |     return x
   |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -59,15 +53,11 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 
 ```
 error[invalid-type-form]: List literals are not allowed in this context in a parameter annotation
-  --> src/mdtest_snippet.py:8:8
-   |
- 6 | # No special hints for these: it's unclear what the user meant:
- 7 | def _(
- 8 |     x: [int, str],  # error: [invalid-type-form]
-   |        ^^^^^^^^^^
- 9 | ) -> [int, str]:  # error: [invalid-type-form]
-10 |     return x
-   |
+ --> src/mdtest_snippet.py:8:8
+  |
+8 |     x: [int, str],  # error: [invalid-type-form]
+  |        ^^^^^^^^^^
+  |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
 
@@ -75,14 +65,11 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 
 ```
 error[invalid-type-form]: List literals are not allowed in this context in a return type annotation
-  --> src/mdtest_snippet.py:9:6
-   |
- 7 | def _(
- 8 |     x: [int, str],  # error: [invalid-type-form]
- 9 | ) -> [int, str]:  # error: [invalid-type-form]
-   |      ^^^^^^^^^^
-10 |     return x
-   |
+ --> src/mdtest_snippet.py:9:6
+  |
+9 | ) -> [int, str]:  # error: [invalid-type-form]
+  |      ^^^^^^^^^^
+  |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_Module-literal_used_…_(652fec4fd4a6c63a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_Module-literal_used_…_(652fec4fd4a6c63a).snap
@@ -38,8 +38,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
 error[invalid-type-form]: Module `datetime` is not valid in a parameter annotation
  --> src/foo.py:3:10
   |
-1 | import datetime
-2 |
 3 | def f(x: datetime): ...  # error: [invalid-type-form]
   |          ^^^^^^^^ Did you mean to use the module's member `datetime.datetime`?
   |
@@ -55,8 +53,6 @@ note: This is an unsafe fix and may change runtime behavior
 error[invalid-type-form]: Module `PIL.Image` is not valid in a parameter annotation
  --> src/bar.py:3:10
   |
-1 | from PIL import Image
-2 |
 3 | def g(x: Image): ...  # error: [invalid-type-form]
   |          ^^^^^ Did you mean to use the module's member `Image.Image`?
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_Special-cased_diagno…_(a4b698196d337a3f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_Special-cased_diagno…_(a4b698196d337a3f).snap
@@ -25,11 +25,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
 error[invalid-type-form]: Function `callable` is not valid in a parameter annotation
  --> src/mdtest_snippet.py:3:19
   |
-1 | # error: [invalid-type-form]
-2 | # error: [invalid-type-form]
 3 | def decorator(fn: callable) -> callable:
   |                   ^^^^^^^^ Did you mean `collections.abc.Callable`?
-4 |     return fn
   |
 
 ```
@@ -38,11 +35,8 @@ error[invalid-type-form]: Function `callable` is not valid in a parameter annota
 error[invalid-type-form]: Function `callable` is not valid in a return type annotation
  --> src/mdtest_snippet.py:3:32
   |
-1 | # error: [invalid-type-form]
-2 | # error: [invalid-type-form]
 3 | def decorator(fn: callable) -> callable:
   |                                ^^^^^^^^ Did you mean `collections.abc.Callable`?
-4 |     return fn
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_Tuple-literal_used_w…_(f61204fc81905069).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_Tuple-literal_used_w…_(f61204fc81905069).snap
@@ -33,11 +33,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
 error[invalid-type-form]: Tuple literals are not allowed in this context in a parameter annotation
  --> src/mdtest_snippet.py:2:8
   |
-1 | def _(
 2 |     x: (),  # error: [invalid-type-form]
   |        ^^ Did you mean `tuple[()]`?
-3 | ) -> ():  # error: [invalid-type-form]
-4 |     return x
   |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -48,12 +45,8 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 error[invalid-type-form]: Tuple literals are not allowed in this context in a return type annotation
  --> src/mdtest_snippet.py:3:6
   |
-1 | def _(
-2 |     x: (),  # error: [invalid-type-form]
 3 | ) -> ():  # error: [invalid-type-form]
   |      ^^ Did you mean `tuple[()]`?
-4 |     return x
-5 | def _(
   |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -64,12 +57,8 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 error[invalid-type-form]: Tuple literals are not allowed in this context in a parameter annotation
  --> src/mdtest_snippet.py:6:8
   |
-4 |     return x
-5 | def _(
 6 |     x: (int,),  # error: [invalid-type-form]
   |        ^^^^^^ Did you mean `tuple[int]`?
-7 | ) -> (int,):  # error: [invalid-type-form]
-8 |     return x
   |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -80,12 +69,8 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 error[invalid-type-form]: Tuple literals are not allowed in this context in a return type annotation
  --> src/mdtest_snippet.py:7:6
   |
-5 | def _(
-6 |     x: (int,),  # error: [invalid-type-form]
 7 | ) -> (int,):  # error: [invalid-type-form]
   |      ^^^^^^ Did you mean `tuple[int]`?
-8 |     return x
-9 | def _(
   |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -96,12 +81,8 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 error[invalid-type-form]: Tuple literals are not allowed in this context in a parameter annotation
   --> src/mdtest_snippet.py:10:8
    |
- 8 |     return x
- 9 | def _(
 10 |     x: (int, str),  # error: [invalid-type-form]
    |        ^^^^^^^^^^ Did you mean `tuple[int, str]`?
-11 | ) -> (int, str):  # error: [invalid-type-form]
-12 |     return x
    |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -112,11 +93,8 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 error[invalid-type-form]: Tuple literals are not allowed in this context in a return type annotation
   --> src/mdtest_snippet.py:11:6
    |
- 9 | def _(
-10 |     x: (int, str),  # error: [invalid-type-form]
 11 | ) -> (int, str):  # error: [invalid-type-form]
    |      ^^^^^^^^^^ Did you mean `tuple[int, str]`?
-12 |     return x
    |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Multiple_starred_exp…_(3fbab22ead236138).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Multiple_starred_exp…_(3fbab22ead236138).snap
@@ -48,33 +48,25 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
 error[invalid-type-form]: Multiple unpacked variadic tuples are not allowed in a `tuple` specialization
  --> src/mdtest_snippet.py:7:8
   |
-5 | def f(
-6 |     # error: [invalid-type-form] "Multiple unpacked variadic tuples are not allowed in a `tuple` specialization"
 7 |     x: tuple[*tuple[int, ...], *tuple[str, ...]],
   |        ^^^^^^----------------^^----------------^
   |              |                 |
   |              |                 Later unpacked variadic tuple
   |              First unpacked variadic tuple
-8 |     # error: [invalid-type-form] "Multiple unpacked variadic tuples are not allowed in a `tuple` specialization"
-9 |     x2: tuple[Unpack[tuple[int, ...]], Unpack[tuple[str, ...]]],
   |
 
 ```
 
 ```
 error[invalid-type-form]: Multiple unpacked variadic tuples are not allowed in a `tuple` specialization
-  --> src/mdtest_snippet.py:9:9
-   |
- 7 |     x: tuple[*tuple[int, ...], *tuple[str, ...]],
- 8 |     # error: [invalid-type-form] "Multiple unpacked variadic tuples are not allowed in a `tuple` specialization"
- 9 |     x2: tuple[Unpack[tuple[int, ...]], Unpack[tuple[str, ...]]],
-   |         ^^^^^^-----------------------^^-----------------------^
-   |               |                        |
-   |               |                        Later unpacked variadic tuple
-   |               First unpacked variadic tuple
-10 |     y: tuple[*tuple[int, ...], str, int, *tuple[str, ...]],  # error: [invalid-type-form]
-11 |     y2: tuple[Unpack[tuple[int, ...]], str, int, Unpack[tuple[str, ...]]],  # error: [invalid-type-form]
-   |
+ --> src/mdtest_snippet.py:9:9
+  |
+9 |     x2: tuple[Unpack[tuple[int, ...]], Unpack[tuple[str, ...]]],
+  |         ^^^^^^-----------------------^^-----------------------^
+  |               |                        |
+  |               |                        Later unpacked variadic tuple
+  |               First unpacked variadic tuple
+  |
 
 ```
 
@@ -82,15 +74,11 @@ error[invalid-type-form]: Multiple unpacked variadic tuples are not allowed in a
 error[invalid-type-form]: Multiple unpacked variadic tuples are not allowed in a `tuple` specialization
   --> src/mdtest_snippet.py:10:8
    |
- 8 |     # error: [invalid-type-form] "Multiple unpacked variadic tuples are not allowed in a `tuple` specialization"
- 9 |     x2: tuple[Unpack[tuple[int, ...]], Unpack[tuple[str, ...]]],
 10 |     y: tuple[*tuple[int, ...], str, int, *tuple[str, ...]],  # error: [invalid-type-form]
    |        ^^^^^^----------------^^^^^^^^^^^^----------------^
    |              |                           |
    |              |                           Later unpacked variadic tuple
    |              First unpacked variadic tuple
-11 |     y2: tuple[Unpack[tuple[int, ...]], str, int, Unpack[tuple[str, ...]]],  # error: [invalid-type-form]
-12 |     # Multiple unpacked elements are fine, as long as the unpacked elements are not variadic:
    |
 
 ```
@@ -99,15 +87,11 @@ error[invalid-type-form]: Multiple unpacked variadic tuples are not allowed in a
 error[invalid-type-form]: Multiple unpacked variadic tuples are not allowed in a `tuple` specialization
   --> src/mdtest_snippet.py:11:9
    |
- 9 |     x2: tuple[Unpack[tuple[int, ...]], Unpack[tuple[str, ...]]],
-10 |     y: tuple[*tuple[int, ...], str, int, *tuple[str, ...]],  # error: [invalid-type-form]
 11 |     y2: tuple[Unpack[tuple[int, ...]], str, int, Unpack[tuple[str, ...]]],  # error: [invalid-type-form]
    |         ^^^^^^-----------------------^^^^^^^^^^^^-----------------------^
    |               |                                  |
    |               |                                  Later unpacked variadic tuple
    |               First unpacked variadic tuple
-12 |     # Multiple unpacked elements are fine, as long as the unpacked elements are not variadic:
-13 |     z: tuple[*tuple[int, ...], *tuple[str]],
    |
 
 ```
@@ -116,15 +100,11 @@ error[invalid-type-form]: Multiple unpacked variadic tuples are not allowed in a
 error[invalid-type-form]: Multiple unpacked variadic tuples are not allowed in a `tuple` specialization
   --> src/mdtest_snippet.py:23:6
    |
-21 |     reveal_type(z2)  # revealed: tuple[*tuple[int, ...], str]
-22 |
 23 | T1 = tuple[int, *Ts, str, *Ts]  # error: [invalid-type-form]
    |      ^^^^^^^^^^^---^^^^^^^---^
    |                 |         |
    |                 |         Later unpacked variadic tuple
    |                 First unpacked variadic tuple
-24 |
-25 | def func3(t: tuple[*Ts]):
    |
 
 ```
@@ -133,8 +113,6 @@ error[invalid-type-form]: Multiple unpacked variadic tuples are not allowed in a
 error[invalid-type-form]: Multiple unpacked variadic tuples are not allowed in a `tuple` specialization
   --> src/mdtest_snippet.py:27:9
    |
-25 | def func3(t: tuple[*Ts]):
-26 |     t5: tuple[*tuple[str], *Ts]  # OK
 27 |     t6: tuple[*tuple[str, ...], *Ts]  # error: [invalid-type-form]
    |         ^^^^^^----------------^^---^
    |               |                 |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Basic_(16be9d90a741761).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Basic_(16be9d90a741761).snap
@@ -25,8 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:4:5
   |
-2 |     return x * x
-3 |
 4 | foo("hello")  # error: [invalid-argument-type]
   |     ^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
@@ -35,7 +33,6 @@ info: Function defined here
   |
 1 | def foo(x: int) -> int:
   |     ^^^ ------ Parameter declared here
-2 |     return x * x
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Calls_to_methods_(4b3b8695d519a02).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Calls_to_methods_(4b3b8695d519a02).snap
@@ -27,17 +27,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to bound method `square` is incorrect
  --> src/mdtest_snippet.py:6:10
   |
-5 | c = C()
 6 | c.square("hello")  # error: [invalid-argument-type]
   |          ^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
 info: Method defined here
  --> src/mdtest_snippet.py:2:9
   |
-1 | class C:
 2 |     def square(self, x: int) -> int:
   |         ^^^^^^       ------ Parameter declared here
-3 |         return x * x
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Different_files_(d02c38e2dd054b4c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Different_files_(d02c38e2dd054b4c).snap
@@ -31,8 +31,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:3:13
   |
-1 | import package
-2 |
 3 | package.foo("hello")  # error: [invalid-argument-type]
   |             ^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
@@ -41,7 +39,6 @@ info: Function defined here
   |
 1 | def foo(x: int) -> int:
   |     ^^^ ------ Parameter declared here
-2 |     return x * x
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Different_source_ord…_(9b0bf549733d3f0a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Different_source_ord…_(9b0bf549733d3f0a).snap
@@ -26,20 +26,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:2:9
   |
-1 | def bar():
 2 |     foo("hello")  # error: [invalid-argument-type]
   |         ^^^^^^^ Expected `int`, found `Literal["hello"]`
-3 |
-4 | def foo(x: int) -> int:
   |
 info: Function defined here
  --> src/mdtest_snippet.py:4:5
   |
-2 |     foo("hello")  # error: [invalid-argument-type]
-3 |
 4 | def foo(x: int) -> int:
   |     ^^^ ------ Parameter declared here
-5 |     return x * x
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Invariant_generic_cl…_(7ff1d501c5f64fe9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Invariant_generic_cl…_(7ff1d501c5f64fe9).snap
@@ -26,7 +26,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `modify` is incorrect
  --> src/mdtest_snippet.py:5:8
   |
-4 | xs: list[bool] = [True, False]
 5 | modify(xs)  # error: [invalid-argument-type]
   |        ^^ Expected `list[int]`, found `list[bool]`
   |
@@ -35,7 +34,6 @@ info: Function defined here
   |
 1 | def modify(xs: list[int]):
   |     ^^^^^^ ------------- Parameter declared here
-2 |     xs.append(42)
   |
 info: `list` is invariant in its type parameter
 info: Consider using the covariant supertype `collections.abc.Sequence`

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Many_parameters_(ee38fd34ceba3293).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Many_parameters_(ee38fd34ceba3293).snap
@@ -25,8 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:4:8
   |
-2 |     return x * y * z
-3 |
 4 | foo(1, "hello", 3)  # error: [invalid-argument-type]
   |        ^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
@@ -35,7 +33,6 @@ info: Function defined here
   |
 1 | def foo(x: int, y: int, z: int) -> int:
   |     ^^^         ------ Parameter declared here
-2 |     return x * y * z
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Many_parameters_acro…_(1d5d112808c49e9d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Many_parameters_acro…_(1d5d112808c49e9d).snap
@@ -29,8 +29,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:8:8
   |
-6 |     return x * y * z
-7 |
 8 | foo(1, "hello", 3)  # error: [invalid-argument-type]
   |        ^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
@@ -39,11 +37,11 @@ info: Function defined here
   |
 1 | def foo(
   |     ^^^
-2 |     x: int,
+  |
+ ::: src/mdtest_snippet.py:3:5
+  |
 3 |     y: int,
   |     ------ Parameter declared here
-4 |     z: int,
-5 | ) -> int:
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Many_parameters_with…_(4bc5c16cd568b8ec).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Many_parameters_with…_(4bc5c16cd568b8ec).snap
@@ -28,8 +28,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:7:5
   |
-5 | # error: [invalid-argument-type]
-6 | # error: [invalid-argument-type]
 7 | foo("a", "b", "c")
   |     ^^^ Expected `int`, found `Literal["a"]`
   |
@@ -38,7 +36,6 @@ info: Function defined here
   |
 1 | def foo(x: int, y: int, z: int) -> int:
   |     ^^^ ------ Parameter declared here
-2 |     return x * y * z
   |
 
 ```
@@ -47,8 +44,6 @@ info: Function defined here
 error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:7:10
   |
-5 | # error: [invalid-argument-type]
-6 | # error: [invalid-argument-type]
 7 | foo("a", "b", "c")
   |          ^^^ Expected `int`, found `Literal["b"]`
   |
@@ -57,7 +52,6 @@ info: Function defined here
   |
 1 | def foo(x: int, y: int, z: int) -> int:
   |     ^^^         ------ Parameter declared here
-2 |     return x * y * z
   |
 
 ```
@@ -66,8 +60,6 @@ info: Function defined here
 error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:7:15
   |
-5 | # error: [invalid-argument-type]
-6 | # error: [invalid-argument-type]
 7 | foo("a", "b", "c")
   |               ^^^ Expected `int`, found `Literal["c"]`
   |
@@ -76,7 +68,6 @@ info: Function defined here
   |
 1 | def foo(x: int, y: int, z: int) -> int:
   |     ^^^                 ------ Parameter declared here
-2 |     return x * y * z
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Numbers_special_case_(6d84dc3231c49ace).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Numbers_special_case_(6d84dc3231c49ace).snap
@@ -29,22 +29,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `f` is incorrect
  --> src/mdtest_snippet.py:5:3
   |
-3 | def f(x: Number): ...
-4 |
 5 | f(5)  # error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `Number`, found `Literal[5]`"
   |   ^ Expected `Number`, found `Literal[5]`
-6 |
-7 | def g(x: float):
   |
 info: Function defined here
  --> src/mdtest_snippet.py:3:5
   |
-1 | from numbers import Number
-2 |
 3 | def f(x: Number): ...
   |     ^ --------- Parameter declared here
-4 |
-5 | f(5)  # error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `Number`, found `Literal[5]`"
   |
 info: Types from the `numbers` module aren't supported for static type checking
 help: Consider using a protocol instead, such as `typing.SupportsFloat`
@@ -55,19 +47,14 @@ help: Consider using a protocol instead, such as `typing.SupportsFloat`
 error[invalid-argument-type]: Argument to function `f` is incorrect
  --> src/mdtest_snippet.py:8:7
   |
-7 | def g(x: float):
 8 |     f(x)  # error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `Number`, found `int | float`"
   |       ^ Expected `Number`, found `int | float`
   |
 info: Function defined here
  --> src/mdtest_snippet.py:3:5
   |
-1 | from numbers import Number
-2 |
 3 | def f(x: Number): ...
   |     ^ --------- Parameter declared here
-4 |
-5 | f(5)  # error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `Number`, found `Literal[5]`"
   |
 info: Types from the `numbers` module aren't supported for static type checking
 help: Consider using a protocol instead, such as `typing.SupportsFloat`

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Test_calling_a_funct…_(3b18271a821a59b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Test_calling_a_funct…_(3b18271a821a59b).snap
@@ -24,22 +24,16 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `loads` is incorrect
  --> src/mdtest_snippet.py:3:12
   |
-1 | import json
-2 |
 3 | json.loads(5)  # error: [invalid-argument-type]
   |            ^ Expected `str | bytes | bytearray`, found `Literal[5]`
   |
 info: Function defined here
    --> stdlib/json/__init__.pyi:224:5
     |
-222 |     """
-223 |
 224 | def loads(
     |     ^^^^^
 225 |     s: str | bytes | bytearray,
     |     -------------------------- Parameter declared here
-226 |     *,
-227 |     cls: type[JSONDecoder] | None = None,
     |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Tests_for_a_variety_…_-_Keyword_only_argumen…_(8d9f18c78137411).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Tests_for_a_variety_…_-_Keyword_only_argumen…_(8d9f18c78137411).snap
@@ -25,8 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:4:11
   |
-2 |     return x * y * z
-3 |
 4 | foo(1, 2, z="hello")  # error: [invalid-argument-type]
   |           ^^^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
@@ -35,7 +33,6 @@ info: Function defined here
   |
 1 | def foo(x: int, y: int, *, z: int = 0) -> int:
   |     ^^^                    ---------- Parameter declared here
-2 |     return x * y * z
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Tests_for_a_variety_…_-_Mix_of_arguments_(cfc64b1136058112).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Tests_for_a_variety_…_-_Mix_of_arguments_(cfc64b1136058112).snap
@@ -25,8 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:4:11
   |
-2 |     return x * y * z
-3 |
 4 | foo(1, 2, z="hello")  # error: [invalid-argument-type]
   |           ^^^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
@@ -35,7 +33,6 @@ info: Function defined here
   |
 1 | def foo(x: int, /, y: int, *, z: int = 0) -> int:
   |     ^^^                       ---------- Parameter declared here
-2 |     return x * y * z
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Tests_for_a_variety_…_-_One_keyword_argument_(cc34b2f7d19d427e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Tests_for_a_variety_…_-_One_keyword_argument_(cc34b2f7d19d427e).snap
@@ -25,8 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:4:11
   |
-2 |     return x * y * z
-3 |
 4 | foo(1, 2, "hello")  # error: [invalid-argument-type]
   |           ^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
@@ -35,7 +33,6 @@ info: Function defined here
   |
 1 | def foo(x: int, y: int, z: int = 0) -> int:
   |     ^^^                 ---------- Parameter declared here
-2 |     return x * y * z
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Tests_for_a_variety_…_-_Only_positional_(3dc93b1709eb3be9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Tests_for_a_variety_…_-_Only_positional_(3dc93b1709eb3be9).snap
@@ -25,8 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:4:8
   |
-2 |     return x * y * z
-3 |
 4 | foo(1, "hello", 3)  # error: [invalid-argument-type]
   |        ^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
@@ -35,7 +33,6 @@ info: Function defined here
   |
 1 | def foo(x: int, y: int, z: int, /) -> int:
   |     ^^^         ------ Parameter declared here
-2 |     return x * y * z
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Tests_for_a_variety_…_-_Synthetic_arguments_(4c09844bbbf47741).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Tests_for_a_variety_…_-_Synthetic_arguments_(4c09844bbbf47741).snap
@@ -27,17 +27,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to bound method `__call__` is incorrect
  --> src/mdtest_snippet.py:6:3
   |
-5 | c = C()
 6 | c("wrong")  # error: [invalid-argument-type]
   |   ^^^^^^^ Expected `int`, found `Literal["wrong"]`
   |
 info: Method defined here
  --> src/mdtest_snippet.py:2:9
   |
-1 | class C:
 2 |     def __call__(self, x: int) -> int:
   |         ^^^^^^^^       ------ Parameter declared here
-3 |         return 1
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Tests_for_a_variety_…_-_Variadic_arguments_(e26a3e7b2773a63b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Tests_for_a_variety_…_-_Variadic_arguments_(e26a3e7b2773a63b).snap
@@ -25,8 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:4:14
   |
-2 |     return len(numbers)
-3 |
 4 | foo(1, 2, 3, "hello", 5)  # error: [invalid-argument-type]
   |              ^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
@@ -35,7 +33,6 @@ info: Function defined here
   |
 1 | def foo(*numbers: int) -> int:
   |     ^^^ ------------- Parameter declared here
-2 |     return len(numbers)
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Tests_for_a_variety_…_-_Variadic_keyword_arg…_(4c855e39ea6baeaf).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Tests_for_a_variety_…_-_Variadic_keyword_arg…_(4c855e39ea6baeaf).snap
@@ -25,8 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:4:20
   |
-2 |     return len(numbers)
-3 |
 4 | foo(a=1, b=2, c=3, d="hello", e=5)  # error: [invalid-argument-type]
   |                    ^^^^^^^^^ Expected `int`, found `Literal["hello"]`
   |
@@ -35,7 +33,6 @@ info: Function defined here
   |
 1 | def foo(**numbers: int) -> int:
   |     ^^^ -------------- Parameter declared here
-2 |     return len(numbers)
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_TypeVars_with_bounds…_(25b61918ea9f5644).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_TypeVars_with_bounds…_(25b61918ea9f5644).snap
@@ -36,16 +36,12 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `needs_a_foo` is incorrect
  --> src/main.py:6:17
   |
-5 | def f[T: Foo](x: T) -> T:
 6 |     needs_a_foo(x)  # error: [invalid-argument-type]
   |                 ^ Expected `Foo`, found `T@f`
-7 |     return x
   |
 info: Function defined here
  --> src/module.py:3:5
   |
-1 | class Foo: ...
-2 |
 3 | def needs_a_foo(x: Foo): ...
   |     ^^^^^^^^^^^ ------ Parameter declared here
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Types_with_the_same_…_(34531e82322f6f21).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_argument_typ…_-_Invalid_argument_typ…_-_Types_with_the_same_…_(34531e82322f6f21).snap
@@ -34,16 +34,12 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argu
 error[invalid-argument-type]: Argument to function `needs_a_foo` is incorrect
  --> src/main.py:5:13
   |
-3 | class Foo: ...
-4 |
 5 | needs_a_foo(Foo())  # error: [invalid-argument-type]
   |             ^^^^^ Expected `module.Foo`, found `main.Foo`
   |
 info: Function defined here
  --> src/module.py:3:5
   |
-1 | class Foo: ...
-2 |
 3 | def needs_a_foo(x: Foo): ...
   |     ^^^^^^^^^^^ ------ Parameter declared here
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_assignment_s…_-_Invalid_assignment_d…_-_Multiline_expression…_(429392d5a8842ca6).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_assignment_s…_-_Invalid_assignment_d…_-_Multiline_expression…_(429392d5a8842ca6).snap
@@ -29,7 +29,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_assi
 error[invalid-assignment]: Object of type `Literal[15]` is not assignable to `str`
  --> src/mdtest_snippet.py:4:4
   |
-3 |   # error: [invalid-assignment]
 4 |   x: str = (
   |  ____---___^
   | |    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_assignment_s…_-_Invalid_assignment_d…_-_Multiple_targets_(655e9238f07236b2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_assignment_s…_-_Invalid_assignment_d…_-_Multiple_targets_(655e9238f07236b2).snap
@@ -27,14 +27,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_assi
 error[invalid-assignment]: Object of type `Literal["a"]` is not assignable to `int`
  --> src/mdtest_snippet.py:4:1
   |
-2 | y: str
-3 |
 4 | x, y = ("a", "b")  # error: [invalid-assignment]
   | -      ^^^^^^^^^^ Incompatible value of type `Literal["a"]`
   | |
   | Declared type `int`
-5 |
-6 | x, y = (0, 0)  # error: [invalid-assignment]
   |
 
 ```
@@ -43,8 +39,6 @@ error[invalid-assignment]: Object of type `Literal["a"]` is not assignable to `i
 error[invalid-assignment]: Object of type `Literal[0]` is not assignable to `str`
  --> src/mdtest_snippet.py:6:4
   |
-4 | x, y = ("a", "b")  # error: [invalid-assignment]
-5 |
 6 | x, y = (0, 0)  # error: [invalid-assignment]
   |    -   ^^^^^^ Incompatible value of type `Literal[0]`
   |    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_assignment_s…_-_Invalid_assignment_d…_-_Named_expression_(f3e81bd84a3c9ca3).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_assignment_s…_-_Invalid_assignment_d…_-_Named_expression_(f3e81bd84a3c9ca3).snap
@@ -24,8 +24,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_assi
 error[invalid-assignment]: Object of type `Literal["three"]` is not assignable to `int`
  --> src/mdtest_snippet.py:3:2
   |
-1 | x: int
-2 |
 3 | (x := "three")  # error: [invalid-assignment]
   |  -    ^^^^^^^ Incompatible value of type `Literal["three"]`
   |  |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_assignment_s…_-_Invalid_assignment_d…_-_Unannotated_assignme…_(9ca7498412f218b3).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_assignment_s…_-_Invalid_assignment_d…_-_Unannotated_assignme…_(9ca7498412f218b3).snap
@@ -23,7 +23,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_assi
 error[invalid-assignment]: Object of type `Literal["three"]` is not assignable to `int`
  --> src/mdtest_snippet.py:2:1
   |
-1 | x: int
 2 | x = "three"  # error: [invalid-assignment]
   | -   ^^^^^^^ Incompatible value of type `Literal["three"]`
   | |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_Basic_(f15db7dc447d0795).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_Basic_(f15db7dc447d0795).snap
@@ -23,17 +23,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_awai
 error[invalid-await]: `Literal[1]` is not awaitable
    --> src/mdtest_snippet.py:2:11
     |
-  1 | async def main() -> None:
   2 |     await 1  # error: [invalid-await]
     |           ^
     |
    ::: stdlib/builtins.pyi:348:7
     |
-347 | @disjoint_base
 348 | class int:
     |       --- type defined here
-349 |     """int([x]) -> integer
-350 |     int(x, base=10) -> integer
     |
 info: `__await__` is missing
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_Custom_type_with_mis…_(9ce1ee3cd1c9c8d1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_Custom_type_with_mis…_(9ce1ee3cd1c9c8d1).snap
@@ -26,7 +26,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_awai
 error[invalid-await]: `MissingAwait` is not awaitable
  --> src/mdtest_snippet.py:5:11
   |
-4 | async def main() -> None:
 5 |     await MissingAwait()  # error: [invalid-await]
   |           ^^^^^^^^^^^^^^
   |
@@ -34,7 +33,6 @@ error[invalid-await]: `MissingAwait` is not awaitable
   |
 1 | class MissingAwait:
   |       ------------ type defined here
-2 |     pass
   |
 info: `__await__` is missing
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_Custom_type_with_pos…_(a028edbafe180ca).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_Custom_type_with_pos…_(a028edbafe180ca).snap
@@ -30,17 +30,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_awai
 error[invalid-await]: `PossiblyUnbound` is not awaitable
  --> src/mdtest_snippet.py:9:11
   |
-8 | async def main() -> None:
 9 |     await PossiblyUnbound()  # error: [invalid-await]
   |           ^^^^^^^^^^^^^^^^^
   |
  ::: src/mdtest_snippet.py:5:13
   |
-3 | class PossiblyUnbound:
-4 |     if datetime.today().weekday() == 0:
 5 |         def __await__(self):
   |             --------------- method defined here
-6 |             yield
   |
 info: `__await__` may be missing
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_Invalid_union_return…_(fedf62ffaca0f2d7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_Invalid_union_return…_(fedf62ffaca0f2d7).snap
@@ -35,7 +35,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_awai
 error[invalid-await]: `UnawaitableUnion` is not awaitable
   --> src/mdtest_snippet.py:14:11
    |
-13 | async def main() -> None:
 14 |     await UnawaitableUnion()  # error: [invalid-await]
    |           ^^^^^^^^^^^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_Non-callable_`__awai…_(d78580fb6720e4ea).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_Non-callable_`__awai…_(d78580fb6720e4ea).snap
@@ -26,17 +26,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_awai
 error[invalid-await]: `NonCallableAwait` is not awaitable
    --> src/mdtest_snippet.py:5:11
     |
-  4 | async def main() -> None:
   5 |     await NonCallableAwait()  # error: [invalid-await]
     |           ^^^^^^^^^^^^^^^^^^
     |
    ::: stdlib/builtins.pyi:348:7
     |
-347 | @disjoint_base
 348 | class int:
     |       --- attribute defined here
-349 |     """int([x]) -> integer
-350 |     int(x, base=10) -> integer
     |
 info: `__await__` is not callable
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_`__await__`_definiti…_(15b05c126b6ae968).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_`__await__`_definiti…_(15b05c126b6ae968).snap
@@ -27,16 +27,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_awai
 error[invalid-await]: `InvalidAwaitArgs` is not awaitable
  --> src/mdtest_snippet.py:6:11
   |
-5 | async def main() -> None:
 6 |     await InvalidAwaitArgs()  # error: [invalid-await]
   |           ^^^^^^^^^^^^^^^^^^
   |
  ::: src/mdtest_snippet.py:2:18
   |
-1 | class InvalidAwaitArgs:
 2 |     def __await__(self, value: int):
   |                  ------------------ parameters here
-3 |         yield value
   |
 info: `__await__` requires arguments and cannot be called implicitly
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_`__await__`_definiti…_(ccb69f512135dd61).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_`__await__`_definiti…_(ccb69f512135dd61).snap
@@ -27,16 +27,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_awai
 error[invalid-await]: `InvalidAwaitReturn` is not awaitable
  --> src/mdtest_snippet.py:6:11
   |
-5 | async def main() -> None:
 6 |     await InvalidAwaitReturn()  # error: [invalid-await]
   |           ^^^^^^^^^^^^^^^^^^^^
   |
  ::: src/mdtest_snippet.py:2:9
   |
-1 | class InvalidAwaitReturn:
 2 |     def __await__(self) -> int:
   |         ---------------------- method defined here
-3 |         return 5
   |
 info: `__await__` returns `int`, which is not a valid iterator
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_type_paramet…_-_Invalid_Order_of_Leg…_(eaa359e8d6b3031d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_type_paramet…_-_Invalid_Order_of_Leg…_(eaa359e8d6b3031d).snap
@@ -55,24 +55,21 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_type
 error[invalid-generic-class]: Type parameters without defaults cannot follow type parameters with defaults
   --> src/mdtest_snippet.py:17:19
    |
-16 | # error: [invalid-generic-class] "Type parameter `T2` without a default cannot follow earlier parameter `T1` with a default"
 17 | class Foo(Generic[T1, T2]):
    |                   ^^^^^^
    |                   |
    |                   Type variable `T2` does not have a default
    |                   Earlier TypeVar `T1` does
-18 |     pass
    |
   ::: src/mdtest_snippet.py:3:1
    |
- 1 | from typing import TypeVar, Generic, Protocol
- 2 |
  3 | T1 = TypeVar("T1", default=int)
    | ------------------------------- `T1` defined here
- 4 |
+   |
+  ::: src/mdtest_snippet.py:5:1
+   |
  5 | T2 = TypeVar("T2")
    | ------------------ `T2` defined here
- 6 | T3 = TypeVar("T3")
    |
 
 ```
@@ -81,27 +78,21 @@ error[invalid-generic-class]: Type parameters without defaults cannot follow typ
 error[invalid-generic-class]: Type parameters without defaults cannot follow type parameters with defaults
   --> src/mdtest_snippet.py:20:19
    |
-18 |     pass
-19 |
 20 | class Bar(Generic[T2, T1, T3]):  # error: [invalid-generic-class]
    |                   ^^^^^^^^^^
    |                   |
    |                   Type variable `T3` does not have a default
    |                   Earlier TypeVar `T1` does
-21 |     pass
    |
   ::: src/mdtest_snippet.py:3:1
    |
- 1 | from typing import TypeVar, Generic, Protocol
- 2 |
  3 | T1 = TypeVar("T1", default=int)
    | ------------------------------- `T1` defined here
- 4 |
- 5 | T2 = TypeVar("T2")
+   |
+  ::: src/mdtest_snippet.py:6:1
+   |
  6 | T3 = TypeVar("T3")
    | ------------------ `T3` defined here
- 7 |
- 8 | DefaultStrT = TypeVar("DefaultStrT", default=str)
    |
 
 ```
@@ -110,25 +101,21 @@ error[invalid-generic-class]: Type parameters without defaults cannot follow typ
 error[invalid-generic-class]: Type parameters without defaults cannot follow type parameters with defaults
   --> src/mdtest_snippet.py:23:20
    |
-21 |     pass
-22 |
 23 | class Spam(Generic[T1, T2, DefaultStrT, T3]):  # error: [invalid-generic-class]
    |                    ^^^^^^^^^^^^^^^^^^^^^^^
    |                    |
    |                    Type variables `T2` and `T3` do not have defaults
    |                    Earlier TypeVar `T1` does
-24 |     pass
    |
   ::: src/mdtest_snippet.py:3:1
    |
- 1 | from typing import TypeVar, Generic, Protocol
- 2 |
  3 | T1 = TypeVar("T1", default=int)
    | ------------------------------- `T1` defined here
- 4 |
+   |
+  ::: src/mdtest_snippet.py:5:1
+   |
  5 | T2 = TypeVar("T2")
    | ------------------ `T2` defined here
- 6 | T3 = TypeVar("T3")
    |
 
 ```
@@ -137,25 +124,21 @@ error[invalid-generic-class]: Type parameters without defaults cannot follow typ
 error[invalid-generic-class]: Type parameters without defaults cannot follow type parameters with defaults
   --> src/mdtest_snippet.py:26:20
    |
-24 |     pass
-25 |
 26 | class Ham(Protocol[T1, T2, DefaultStrT, T3]):  # error: [invalid-generic-class]
    |                    ^^^^^^^^^^^^^^^^^^^^^^^
    |                    |
    |                    Type variables `T2` and `T3` do not have defaults
    |                    Earlier TypeVar `T1` does
-27 |     pass
    |
   ::: src/mdtest_snippet.py:3:1
    |
- 1 | from typing import TypeVar, Generic, Protocol
- 2 |
  3 | T1 = TypeVar("T1", default=int)
    | ------------------------------- `T1` defined here
- 4 |
+   |
+  ::: src/mdtest_snippet.py:5:1
+   |
  5 | T2 = TypeVar("T2")
    | ------------------ `T2` defined here
- 6 | T3 = TypeVar("T3")
    |
 
 ```
@@ -164,12 +147,8 @@ error[invalid-generic-class]: Type parameters without defaults cannot follow typ
 error[invalid-generic-class]: Cannot both inherit from subscripted `Protocol` and subscripted `Generic`
   --> src/mdtest_snippet.py:32:5
    |
-30 |     # error: [invalid-generic-class]
-31 |     # error: [invalid-generic-class]
 32 |     Protocol[T1, T2, DefaultStrT, T3],
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-33 |     Generic[T1, T2, DefaultStrT, T3],
-34 | ): ...
    |
 help: Remove the type parameters from the `Protocol` base
 29 | class VeryBad(
@@ -187,26 +166,21 @@ note: This is an unsafe fix and may change runtime behavior
 error[invalid-generic-class]: Type parameters without defaults cannot follow type parameters with defaults
   --> src/mdtest_snippet.py:32:14
    |
-30 |     # error: [invalid-generic-class]
-31 |     # error: [invalid-generic-class]
 32 |     Protocol[T1, T2, DefaultStrT, T3],
    |              ^^^^^^^^^^^^^^^^^^^^^^^
    |              |
    |              Type variables `T2` and `T3` do not have defaults
    |              Earlier TypeVar `T1` does
-33 |     Generic[T1, T2, DefaultStrT, T3],
-34 | ): ...
    |
   ::: src/mdtest_snippet.py:3:1
    |
- 1 | from typing import TypeVar, Generic, Protocol
- 2 |
  3 | T1 = TypeVar("T1", default=int)
    | ------------------------------- `T1` defined here
- 4 |
+   |
+  ::: src/mdtest_snippet.py:5:1
+   |
  5 | T2 = TypeVar("T2")
    | ------------------ `T2` defined here
- 6 | T3 = TypeVar("T3")
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/isinstance.md_-_Narrowing_for_`isins…_-_`classinfo`_is_an_in…_(eeef56c0ef87a30b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/isinstance.md_-_Narrowing_for_`isins…_-_`classinfo`_is_an_in…_(eeef56c0ef87a30b).snap
@@ -55,14 +55,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
 error[invalid-argument-type]: Invalid second argument to `isinstance`
  --> src/mdtest_snippet.py:5:8
   |
-3 | def _(x: int | list[int] | bytes):
-4 |     # error: [invalid-argument-type]
 5 |     if isinstance(x, list[int] | int):
   |        ^^^^^^^^^^^^^^---------------^
   |                      |
   |                      This `UnionType` instance contains non-class elements
-6 |         reveal_type(x)  # revealed: int | list[int] | bytes
-7 |     # error: [invalid-argument-type]
   |
 info: A `UnionType` instance can only be used as the second argument to `isinstance` if all elements are class objects
 info: Element `<class 'list[int]'>` in the union is not a class object
@@ -71,17 +67,13 @@ info: Element `<class 'list[int]'>` in the union is not a class object
 
 ```
 error[invalid-argument-type]: Invalid second argument to `isinstance`
-  --> src/mdtest_snippet.py:8:10
-   |
- 6 |         reveal_type(x)  # revealed: int | list[int] | bytes
- 7 |     # error: [invalid-argument-type]
- 8 |     elif isinstance(x, Literal[42] | list[int] | bytes):
-   |          ^^^^^^^^^^^^^^-------------------------------^
-   |                        |
-   |                        This `UnionType` instance contains non-class elements
- 9 |         reveal_type(x)  # revealed: int | list[int] | bytes
-10 |     # error: [invalid-argument-type]
-   |
+ --> src/mdtest_snippet.py:8:10
+  |
+8 |     elif isinstance(x, Literal[42] | list[int] | bytes):
+  |          ^^^^^^^^^^^^^^-------------------------------^
+  |                        |
+  |                        This `UnionType` instance contains non-class elements
+  |
 info: A `UnionType` instance can only be used as the second argument to `isinstance` if all elements are class objects
 info: Elements `<special-form 'Literal[42]'>` and `<class 'list[int]'>` in the union are not class objects
 
@@ -91,14 +83,10 @@ info: Elements `<special-form 'Literal[42]'>` and `<class 'list[int]'>` in the u
 error[invalid-argument-type]: Invalid second argument to `isinstance`
   --> src/mdtest_snippet.py:11:10
    |
- 9 |         reveal_type(x)  # revealed: int | list[int] | bytes
-10 |     # error: [invalid-argument-type]
 11 |     elif isinstance(x, Any | NamedTuple | list[int]):
    |          ^^^^^^^^^^^^^^----------------------------^
    |                        |
    |                        This `UnionType` instance contains non-class elements
-12 |         reveal_type(x)  # revealed: int | list[int] | bytes
-13 |     else:
    |
 info: A `UnionType` instance can only be used as the second argument to `isinstance` if all elements are class objects
 info: Element `<special-form 'typing.Any'>` in the union, and 2 more elements, are not class objects
@@ -109,14 +97,10 @@ info: Element `<special-form 'typing.Any'>` in the union, and 2 more elements, a
 error[invalid-argument-type]: Invalid second argument to `isinstance`
   --> src/mdtest_snippet.py:17:8
    |
-15 | def _(x: int | list[int] | bytes):
-16 |     # error: [invalid-argument-type]
 17 |     if isinstance(x, (int, list[int] | bytes)):
    |        ^^^^^^^^^^^^^^^^^^^^-----------------^^
    |                            |
    |                            This `UnionType` instance contains non-class elements
-18 |         reveal_type(x)  # revealed: int | list[int] | bytes
-19 |     else:
    |
 info: A `UnionType` instance can only be used as the second argument to `isinstance` if all elements are class objects
 info: Element `<class 'list[int]'>` in the union is not a class object
@@ -127,14 +111,10 @@ info: Element `<class 'list[int]'>` in the union is not a class object
 error[invalid-argument-type]: Invalid second argument to `isinstance`
   --> src/mdtest_snippet.py:23:8
    |
-21 | def _(x: int | list[int] | bytes):
-22 |     # error: [invalid-argument-type]
 23 |     if isinstance(x, (int, (str, list[int] | bytes))):
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------^^^
    |                                  |
    |                                  This `UnionType` instance contains non-class elements
-24 |         reveal_type(x)  # revealed: int | list[int] | bytes
-25 |     else:
    |
 info: A `UnionType` instance can only be used as the second argument to `isinstance` if all elements are class objects
 info: Element `<class 'list[int]'>` in the union is not a class object
@@ -145,12 +125,8 @@ info: Element `<class 'list[int]'>` in the union is not a class object
 error[invalid-argument-type]: Invalid second argument to `isinstance`
   --> src/mdtest_snippet.py:31:8
    |
-29 | def _(x: int | list[int] | bytes):
-30 |     # error: [invalid-argument-type]
 31 |     if isinstance(x, classes):
    |        ^^^^^^^^^^^^^^^^^^^^^^
-32 |         reveal_type(x)  # revealed: int | list[int] | bytes
-33 |     else:
    |
 info: A `UnionType` instance can only be used as the second argument to `isinstance` if all elements are class objects
 info: Element `<class 'list[int]'>` in the union `list[int] | bytes` is not a class object

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/issubclass.md_-_Narrowing_for_`issub…_-_`classinfo`_is_an_in…_(7bb66a0f412caac1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/issubclass.md_-_Narrowing_for_`issub…_-_`classinfo`_is_an_in…_(7bb66a0f412caac1).snap
@@ -47,14 +47,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/narrow/issubclass.md
 error[invalid-argument-type]: Invalid second argument to `issubclass`
  --> src/mdtest_snippet.py:3:8
   |
-1 | def _(x: type[int | list | bytes]):
-2 |     # error: [invalid-argument-type]
 3 |     if issubclass(x, int | list[int]):
   |        ^^^^^^^^^^^^^^---------------^
   |                      |
   |                      This `UnionType` instance contains non-class elements
-4 |         reveal_type(x)  # revealed: type[int | list[Unknown] | bytes]
-5 |     else:
   |
 info: A `UnionType` instance can only be used as the second argument to `issubclass` if all elements are class objects
 info: Element `<class 'list[int]'>` in the union is not a class object
@@ -63,17 +59,13 @@ info: Element `<class 'list[int]'>` in the union is not a class object
 
 ```
 error[invalid-argument-type]: Invalid second argument to `issubclass`
-  --> src/mdtest_snippet.py:9:8
-   |
- 7 | def _(x: type[int | list | bytes]):
- 8 |     # error: [invalid-argument-type]
- 9 |     if issubclass(x, (int, list[int] | bytes)):
-   |        ^^^^^^^^^^^^^^^^^^^^-----------------^^
-   |                            |
-   |                            This `UnionType` instance contains non-class elements
-10 |         reveal_type(x)  # revealed: type[int | list[Unknown] | bytes]
-11 |     else:
-   |
+ --> src/mdtest_snippet.py:9:8
+  |
+9 |     if issubclass(x, (int, list[int] | bytes)):
+  |        ^^^^^^^^^^^^^^^^^^^^-----------------^^
+  |                            |
+  |                            This `UnionType` instance contains non-class elements
+  |
 info: A `UnionType` instance can only be used as the second argument to `issubclass` if all elements are class objects
 info: Element `<class 'list[int]'>` in the union is not a class object
 
@@ -83,14 +75,10 @@ info: Element `<class 'list[int]'>` in the union is not a class object
 error[invalid-argument-type]: Invalid second argument to `issubclass`
   --> src/mdtest_snippet.py:15:8
    |
-13 | def _(x: type[int | list | bytes]):
-14 |     # error: [invalid-argument-type]
 15 |     if issubclass(x, (int, (str, list[int] | bytes))):
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------^^^
    |                                  |
    |                                  This `UnionType` instance contains non-class elements
-16 |         reveal_type(x)  # revealed: type[int | list[Unknown] | bytes]
-17 |     else:
    |
 info: A `UnionType` instance can only be used as the second argument to `issubclass` if all elements are class objects
 info: Element `<class 'list[int]'>` in the union is not a class object
@@ -101,12 +89,8 @@ info: Element `<class 'list[int]'>` in the union is not a class object
 error[invalid-argument-type]: Invalid second argument to `issubclass`
   --> src/mdtest_snippet.py:23:8
    |
-21 | def _(x: type[int | list | bytes]):
-22 |     # error: [invalid-argument-type]
 23 |     if issubclass(x, classes):
    |        ^^^^^^^^^^^^^^^^^^^^^^
-24 |         reveal_type(x)  # revealed: type[int | list[Unknown] | bytes]
-25 |     else:
    |
 info: A `UnionType` instance can only be used as the second argument to `issubclass` if all elements are class objects
 info: Element `<class 'list[int]'>` in the union `list[int] | bytes` is not a class object

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Boolean_parameters_m…_(3edf97b20f58fa11).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Boolean_parameters_m…_(3edf97b20f58fa11).snap
@@ -34,11 +34,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typev
 error[invalid-legacy-type-variable]: The `covariant` parameter of `TypeVar` cannot have an ambiguous truthiness
  --> src/mdtest_snippet.py:7:28
   |
-6 | # error: [invalid-legacy-type-variable]
 7 | T = TypeVar("T", covariant=cond())
   |                            ^^^^^^
-8 |
-9 | # error: [invalid-legacy-type-variable]
   |
 
 ```
@@ -47,11 +44,8 @@ error[invalid-legacy-type-variable]: The `covariant` parameter of `TypeVar` cann
 error[invalid-legacy-type-variable]: The `contravariant` parameter of `TypeVar` cannot have an ambiguous truthiness
   --> src/mdtest_snippet.py:10:32
    |
- 9 | # error: [invalid-legacy-type-variable]
 10 | U = TypeVar("U", contravariant=cond())
    |                                ^^^^^^
-11 |
-12 | # error: [invalid-legacy-type-variable]
    |
 
 ```
@@ -60,7 +54,6 @@ error[invalid-legacy-type-variable]: The `contravariant` parameter of `TypeVar` 
 error[invalid-legacy-type-variable]: The `infer_variance` parameter of `TypeVar` cannot have an ambiguous truthiness
   --> src/mdtest_snippet.py:13:33
    |
-12 | # error: [invalid-legacy-type-variable]
 13 | V = TypeVar("V", infer_variance=cond())
    |                                 ^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Cannot_be_both_covar…_(b7b0976739681470).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Cannot_be_both_covar…_(b7b0976739681470).snap
@@ -25,7 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typev
 error[invalid-legacy-type-variable]: A `TypeVar` cannot be both covariant and contravariant
  --> src/mdtest_snippet.py:4:5
   |
-3 | # error: [invalid-legacy-type-variable]
 4 | T = TypeVar("T", covariant=True, contravariant=True)
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Cannot_have_both_bou…_(4ca5f13621915554).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Cannot_have_both_bou…_(4ca5f13621915554).snap
@@ -25,7 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typev
 error[invalid-legacy-type-variable]: A `TypeVar` cannot have both a bound and constraints
  --> src/mdtest_snippet.py:4:5
   |
-3 | # error: [invalid-legacy-type-variable]
 4 | T = TypeVar("T", int, str, bound=bytes)
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Cannot_have_only_one…_(8b0258f5188209c6).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Cannot_have_only_one…_(8b0258f5188209c6).snap
@@ -25,7 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typev
 error[invalid-legacy-type-variable]: A `TypeVar` cannot have exactly one constraint
  --> src/mdtest_snippet.py:4:18
   |
-3 | # error: [invalid-legacy-type-variable]
 4 | T = TypeVar("T", int)
   |                  ^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Invalid_feature_for_…_(72827c64b5c73d05).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Invalid_feature_for_…_(72827c64b5c73d05).snap
@@ -25,7 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typev
 error[invalid-legacy-type-variable]: The `default` parameter of `typing.TypeVar` was added in Python 3.13
  --> src/mdtest_snippet.py:4:18
   |
-3 | # error: [invalid-legacy-type-variable]
 4 | T = TypeVar("T", default=int)
   |                  ^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Invalid_keyword_argu…_(39164266ada3dc2f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Invalid_keyword_argu…_(39164266ada3dc2f).snap
@@ -25,7 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typev
 error[invalid-legacy-type-variable]: Unknown keyword argument `invalid_keyword` in `TypeVar` creation
  --> src/mdtest_snippet.py:4:18
   |
-3 | # error: [invalid-legacy-type-variable]
 4 | T = TypeVar("T", invalid_keyword=True)
   |                  ^^^^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Must_be_directly_ass…_(c2e3e46852bb268f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Must_be_directly_ass…_(c2e3e46852bb268f).snap
@@ -29,12 +29,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typev
 error[invalid-legacy-type-variable]: A `TypeVar` definition must be a simple variable assignment
  --> src/mdtest_snippet.py:5:14
   |
-3 | T = TypeVar("T")
-4 | # error: [invalid-legacy-type-variable]
 5 | U: TypeVar = TypeVar("U")
   |              ^^^^^^^^^^^^
-6 |
-7 | # error: [invalid-legacy-type-variable]
   |
 
 ```
@@ -43,7 +39,6 @@ error[invalid-legacy-type-variable]: A `TypeVar` definition must be a simple var
 error[invalid-legacy-type-variable]: A `TypeVar` definition must be a simple variable assignment
  --> src/mdtest_snippet.py:8:30
   |
-7 | # error: [invalid-legacy-type-variable]
 8 | tuple_with_typevar = ("foo", TypeVar("W"))
   |                              ^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Must_have_a_name_(79a4ce09338e666b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Must_have_a_name_(79a4ce09338e666b).snap
@@ -25,7 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typev
 error[invalid-legacy-type-variable]: The `name` parameter of `TypeVar` is required.
  --> src/mdtest_snippet.py:4:5
   |
-3 | # error: [invalid-legacy-type-variable]
 4 | T = TypeVar()
   |     ^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Name_can't_be_given_…_(8f6aed0dba79e995).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Name_can't_be_given_…_(8f6aed0dba79e995).snap
@@ -25,7 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typev
 error[invalid-legacy-type-variable]: The `name` parameter of `TypeVar` can only be provided once.
  --> src/mdtest_snippet.py:4:18
   |
-3 | # error: [invalid-legacy-type-variable]
 4 | T = TypeVar("T", name="T")
   |                  ^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_No_variadic_argument…_(9d57505425233fd8).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_No_variadic_argument…_(9d57505425233fd8).snap
@@ -30,11 +30,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typev
 error[invalid-legacy-type-variable]: Starred arguments are not supported in `TypeVar` creation
  --> src/mdtest_snippet.py:6:18
   |
-5 | # error: [invalid-legacy-type-variable]
 6 | T = TypeVar("T", *types)
   |                  ^^^^^^
-7 |
-8 | # error: [invalid-legacy-type-variable]
   |
 
 ```
@@ -43,7 +40,6 @@ error[invalid-legacy-type-variable]: Starred arguments are not supported in `Typ
 error[invalid-legacy-type-variable]: Starred arguments are not supported in `TypeVar` creation
  --> src/mdtest_snippet.py:9:18
   |
-8 | # error: [invalid-legacy-type-variable]
 9 | S = TypeVar("S", **{"bound": int})
   |                  ^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_`TypeVar`_parameter_…_(8424f2b8bc4351f9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_`TypeVar`_parameter_…_(8424f2b8bc4351f9).snap
@@ -25,7 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typev
 warning[mismatched-type-name]: The name passed to `TypeVar` must match the variable it is assigned to
  --> src/mdtest_snippet.py:4:13
   |
-3 | # error: [mismatched-type-name]
 4 | T = TypeVar("Q")
   |             ^^^ Expected "T", got "Q"
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/literal_string.md_-_`LiteralString`_-_Usages_-_Parameterized_(ec84ce49ea235791).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/literal_string.md_-_`LiteralString`_-_Usages_-_Parameterized_(ec84ce49ea235791).snap
@@ -28,11 +28,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/literal_stri
 error[invalid-type-form]: `LiteralString` expects no type parameter
  --> src/mdtest_snippet.py:4:4
   |
-3 | # error: [invalid-type-form]
 4 | a: LiteralString[str]
   |    ^^^^^^^^^^^^^^^^^^
-5 |
-6 | # error: [invalid-type-form]
   |
 
 ```
@@ -41,7 +38,6 @@ error[invalid-type-form]: `LiteralString` expects no type parameter
 error[invalid-type-form]: `LiteralString` expects no type parameter
  --> src/mdtest_snippet.py:7:4
   |
-6 | # error: [invalid-type-form]
 7 | b: LiteralString["foo"]
   |    -------------^^^^^^^
   |    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membersh…_-_Return_type_that_doe…_(feccf6b9da1e7cd3).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/membership_test.md_-_Comparison___Membersh…_-_Return_type_that_doe…_(feccf6b9da1e7cd3).snap
@@ -30,14 +30,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/instances/mem
 
 ```
 error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
-  --> src/mdtest_snippet.py:9:1
-   |
- 8 | # error: [unsupported-bool-conversion]
- 9 | 10 in WithContains()
-   | ^^^^^^^^^^^^^^^^^^^^
-10 | # error: [unsupported-bool-conversion]
-11 | 10 not in WithContains()
-   |
+ --> src/mdtest_snippet.py:9:1
+  |
+9 | 10 in WithContains()
+  | ^^^^^^^^^^^^^^^^^^^^
+  |
 info: `__bool__` on `NotBoolable` must be callable
 
 ```
@@ -46,8 +43,6 @@ info: `__bool__` on `NotBoolable` must be callable
 error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
   --> src/mdtest_snippet.py:11:1
    |
- 9 | 10 in WithContains()
-10 | # error: [unsupported-bool-conversion]
 11 | 10 not in WithContains()
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/metaclass.md_-_Diagnostic_range_(4940b37ce546ecbf).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/metaclass.md_-_Diagnostic_range_(4940b37ce546ecbf).snap
@@ -26,12 +26,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/metaclass.md
 error[invalid-metaclass]: Metaclass type `int` is not callable
  --> src/mdtest_snippet.py:3:13
   |
-1 | def _(n: int):
-2 |     # error: [invalid-metaclass]
 3 |     class B(metaclass=n):
   |             ^^^^^^^^^^^
-4 |         x = 1
-5 |         y = 2
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_`__init_subclass__`_-_Basics_(a1fb03132e42b69e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/methods.md_-_Methods_-_`@classmethod`_-_`__init_subclass__`_-_Basics_(a1fb03132e42b69e).snap
@@ -91,20 +91,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/call/methods.md
 error[missing-argument]: No argument provided for required parameter `arg` of function `__init_subclass__`
   --> src/mdtest_snippet.py:19:1
    |
-18 | # Single-base definitions
 19 | class MissingArg(RequiresArg): ...  # error: [missing-argument]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-20 | class InvalidType(RequiresArg, arg="foo"): ...  # error: [invalid-argument-type]
-21 | class Valid(RequiresArg, arg=1): ...
    |
 info: Parameter declared here
   --> src/mdtest_snippet.py:13:32
    |
-12 | class RequiresArg:
 13 |     def __init_subclass__(cls, arg: int): ...
    |                                ^^^^^^^^
-14 |
-15 | class NoArg:
    |
 
 ```
@@ -113,20 +107,14 @@ info: Parameter declared here
 error[invalid-argument-type]: Argument to function `__init_subclass__` is incorrect
   --> src/mdtest_snippet.py:20:32
    |
-18 | # Single-base definitions
-19 | class MissingArg(RequiresArg): ...  # error: [missing-argument]
 20 | class InvalidType(RequiresArg, arg="foo"): ...  # error: [invalid-argument-type]
    |                                ^^^^^^^^^ Expected `int`, found `Literal["foo"]`
-21 | class Valid(RequiresArg, arg=1): ...
    |
 info: Function defined here
   --> src/mdtest_snippet.py:13:9
    |
-12 | class RequiresArg:
 13 |     def __init_subclass__(cls, arg: int): ...
    |         ^^^^^^^^^^^^^^^^^      -------- Parameter declared here
-14 |
-15 | class NoArg:
    |
 
 ```
@@ -135,21 +123,14 @@ info: Function defined here
 error[missing-argument]: No argument provided for required parameter `arg` of function `__init_subclass__`
   --> src/mdtest_snippet.py:25:1
    |
-23 | # error: [missing-argument]
-24 | # error: [unknown-argument]
 25 | class IncorrectArg(RequiresArg, not_arg="foo"):
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-26 |     a = 1
-27 |     b = 2
    |
 info: Parameter declared here
   --> src/mdtest_snippet.py:13:32
    |
-12 | class RequiresArg:
 13 |     def __init_subclass__(cls, arg: int): ...
    |                                ^^^^^^^^
-14 |
-15 | class NoArg:
    |
 
 ```
@@ -158,38 +139,29 @@ info: Parameter declared here
 error[unknown-argument]: Argument `not_arg` does not match any known parameter of function `__init_subclass__`
   --> src/mdtest_snippet.py:25:33
    |
-23 | # error: [missing-argument]
-24 | # error: [unknown-argument]
 25 | class IncorrectArg(RequiresArg, not_arg="foo"):
    |                                 ^^^^^^^^^^^^^
-26 |     a = 1
-27 |     b = 2
    |
 info: Function signature here
   --> src/mdtest_snippet.py:13:9
    |
-12 | class RequiresArg:
 13 |     def __init_subclass__(cls, arg: int): ...
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-14 |
-15 | class NoArg:
    |
 
 ```
 
 ```
 error[non-callable-init-subclass]: Invalid definition of class `Bad`
-  --> src/mdtest_snippet.py:38:5
+  --> src/mdtest_snippet.py:41:7
    |
-37 | class NotCallableInitSubclass:
-38 |     __init_subclass__ = None
-   |     ----------------- `NotCallableInitSubclass.__init_subclass__` has type `None | Unknown`, which may not be callable
-39 |
-40 | # error: [non-callable-init-subclass] "Class `NotCallableInitSubclass` cannot be subclassed due to an `__init_subclass__` definition t…
 41 | class Bad(NotCallableInitSubclass):
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Superclass `NotCallableInitSubclass` cannot be subclassed
-42 |     a = 1
-43 |     b = 2
+   |
+  ::: src/mdtest_snippet.py:38:5
+   |
+38 |     __init_subclass__ = None
+   |     ----------------- `NotCallableInitSubclass.__init_subclass__` has type `None | Unknown`, which may not be callable
    |
 info: `__init_subclass__` on a superclass is implicitly called during creation of a class object
 info: See https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
@@ -200,20 +172,14 @@ info: See https://docs.python.org/3/reference/datamodel.html#customizing-class-c
 error[invalid-argument-type]: Argument to function `__init_subclass__` is incorrect
   --> src/mdtest_snippet.py:51:37
    |
-50 | # error: [invalid-argument-type]
 51 | class Invalid(Base, metaclass=type, arg="foo"): ...
    |                                     ^^^^^^^^^ Expected `int`, found `Literal["foo"]`
-52 | from typing import Literal, overload
    |
 info: Function defined here
   --> src/mdtest_snippet.py:46:9
    |
-44 |     c = 3
-45 | class Base:
 46 |     def __init_subclass__(cls, arg: int): ...
    |         ^^^^^^^^^^^^^^^^^      -------- Parameter declared here
-47 |
-48 | class Valid(Base, arg=5, metaclass=object): ...
    |
 
 ```
@@ -222,21 +188,14 @@ info: Function defined here
 error[no-matching-overload]: No overload of function `__init_subclass__` matches arguments
   --> src/mdtest_snippet.py:65:1
    |
-64 | # error: [no-matching-overload]
 65 | class InvalidType(Base, mode="b", arg=5):
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-66 |     a = 1
-67 |     b = 2
    |
 info: First overload defined here
   --> src/mdtest_snippet.py:56:9
    |
-54 | class Base:
-55 |     @overload
 56 |     def __init_subclass__(cls, mode: Literal["a"], arg: int) -> None: ...
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-57 |     @overload
-58 |     def __init_subclass__(cls, mode: Literal["b"], arg: str) -> None: ...
    |
 info: Possible overloads for function `__init_subclass__`:
 info:   (cls, mode: Literal["a"], arg: int) -> None
@@ -244,12 +203,8 @@ info:   (cls, mode: Literal["b"], arg: str) -> None
 info: Overload implementation defined here
   --> src/mdtest_snippet.py:59:9
    |
-57 |     @overload
-58 |     def __init_subclass__(cls, mode: Literal["b"], arg: str) -> None: ...
 59 |     def __init_subclass__(cls, mode: str, arg: int | str) -> None: ...
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-60 |
-61 | class Valid(Base, mode="a", arg=5): ...
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/missing_argument_par…_-_Missing_argument_for…_(b632d61c1d75f9fb).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/missing_argument_par…_-_Missing_argument_for…_(b632d61c1d75f9fb).snap
@@ -29,12 +29,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/missing_argu
 error[missing-argument]: No arguments provided for required parameters `*args`, `**kwargs`
  --> src/mdtest_snippet.py:5:9
   |
-3 | def decorator[**P](func: Callable[P, int]) -> Callable[P, None]:
-4 |     def wrapper(*args: P.args, **kwargs: P.kwargs) -> None:
 5 |         func()  # error: [missing-argument]
   |         ^^^^^^
-6 |         func(*args)  # error: [missing-argument]
-7 |         func(**kwargs)  # error: [missing-argument]
   |
 info: These arguments are required because `ParamSpec` `P` could represent any set of parameters at runtime
 
@@ -44,12 +40,8 @@ info: These arguments are required because `ParamSpec` `P` could represent any s
 error[missing-argument]: No argument provided for required parameter `**kwargs`
  --> src/mdtest_snippet.py:6:9
   |
-4 |     def wrapper(*args: P.args, **kwargs: P.kwargs) -> None:
-5 |         func()  # error: [missing-argument]
 6 |         func(*args)  # error: [missing-argument]
   |         ^^^^^^^^^^^
-7 |         func(**kwargs)  # error: [missing-argument]
-8 |     return wrapper
   |
 info: These arguments are required because `ParamSpec` `P` could represent any set of parameters at runtime
 
@@ -59,11 +51,8 @@ info: These arguments are required because `ParamSpec` `P` could represent any s
 error[missing-argument]: No argument provided for required parameter `*args`
  --> src/mdtest_snippet.py:7:9
   |
-5 |         func()  # error: [missing-argument]
-6 |         func(*args)  # error: [missing-argument]
 7 |         func(**kwargs)  # error: [missing-argument]
   |         ^^^^^^^^^^^^^^
-8 |     return wrapper
   |
 info: These arguments are required because `ParamSpec` `P` could represent any set of parameters at runtime
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_Unresolvable_MROs_in…_(e2b355c09a967862).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_Unresolvable_MROs_in…_(e2b355c09a967862).snap
@@ -28,8 +28,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/mro.md
 error[inconsistent-mro]: Cannot create a consistent method resolution order (MRO) for class `Baz` with bases list `[<special-form 'typing.Protocol[T]'>, <class 'Foo'>, <class 'Bar[T@Baz]'>]`
  --> src/mdtest_snippet.py:7:7
   |
-5 | class Foo(Protocol): ...
-6 | class Bar(Protocol[T]): ...
 7 | class Baz(Protocol[T], Foo, Bar[T]): ...  # error: [inconsistent-mro]
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_includes…_(d2532518c44112c8).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_includes…_(d2532518c44112c8).snap
@@ -49,11 +49,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/mro.md
 warning[unsupported-base]: Unsupported class base
   --> src/mdtest_snippet.py:17:11
    |
-16 | # error: 11 [unsupported-base] "Unsupported class base with type `<class 'A'> | <class 'B'>`"
 17 | class Foo(x): ...
    |           ^ Has type `<class 'A'> | <class 'B'>`
-18 |
-19 | reveal_mro(Foo)  # revealed: (<class 'Foo'>, Unknown, <class 'object'>)
    |
 info: ty cannot resolve a consistent method resolution order (MRO) for class `Foo` due to this base
 info: Only class objects or `Any` are supported as class bases
@@ -64,8 +61,6 @@ info: Only class objects or `Any` are supported as class bases
 warning[unsupported-base]: Unsupported class base
   --> src/mdtest_snippet.py:28:13
    |
-26 |         class C: ...
-27 |
 28 |     class D(C): ...  # error: [unsupported-base]
    |             ^ Has type `<class 'mdtest_snippet.<locals of function 'f'>.C @ src/mdtest_snippet.py:23:15'> | <class 'mdtest_snippet.<locals of function 'f'>.C @ src/mdtest_snippet.py:26:15'>`
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_lists_th…_(6f8d0bf648c4b305).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_lists_th…_(6f8d0bf648c4b305).snap
@@ -39,8 +39,6 @@ error[invalid-base]: Invalid class base with type `Literal[2]`
   |
 1 | class Foo(2): ...  # error: [invalid-base]
   |           ^
-2 | class Foo:
-3 |     def __mro_entries__(self, bases: tuple[type, ...]) -> tuple[type, ...]:
   |
 info: Definition of class `Foo` will raise `TypeError` at runtime
 
@@ -50,12 +48,8 @@ info: Definition of class `Foo` will raise `TypeError` at runtime
 warning[unsupported-base]: Unsupported class base
  --> src/mdtest_snippet.py:6:11
   |
-4 |         return ()
-5 |
 6 | class Bar(Foo()): ...  # error: [unsupported-base]
   |           ^^^^^ Has type `Foo`
-7 | class Bad1:
-8 |     def __mro_entries__(self, bases, extra_arg):
   |
 info: ty cannot resolve a consistent method resolution order (MRO) for class `Bar` due to this base
 info: Only class objects or `Any` are supported as class bases
@@ -66,11 +60,8 @@ info: Only class objects or `Any` are supported as class bases
 error[invalid-base]: Invalid class base with type `Bad1`
   --> src/mdtest_snippet.py:15:15
    |
-13 |         return 42
-14 |
 15 | class BadSub1(Bad1()): ...  # error: [invalid-base]
    |               ^^^^^^
-16 | class BadSub2(Bad2()): ...  # error: [invalid-base]
    |
 info: Definition of class `BadSub1` will raise `TypeError` at runtime
 info: An instance type is only a valid class base if it has a valid `__mro_entries__` method
@@ -83,7 +74,6 @@ info: Expected a signature at least as permissive as `def __mro_entries__(self, 
 error[invalid-base]: Invalid class base with type `Bad2`
   --> src/mdtest_snippet.py:16:15
    |
-15 | class BadSub1(Bad1()): ...  # error: [invalid-base]
 16 | class BadSub2(Bad2()): ...  # error: [invalid-base]
    |               ^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_lists_wi…_(ea7ebc83ec359b54).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_lists_wi…_(ea7ebc83ec359b54).snap
@@ -104,24 +104,16 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/mro.md
 error[duplicate-base]: Duplicate base class `str`
  --> src/mdtest_snippet.py:3:7
   |
-1 | from ty_extensions import reveal_mro
-2 |
 3 | class Foo(str, str): ...  # error: [duplicate-base] "Duplicate base class `str`"
   |       ^^^^^^^^^^^^^
-4 |
-5 | reveal_mro(Foo)  # revealed: (<class 'Foo'>, Unknown, <class 'object'>)
   |
 info: The definition of class `Foo` will raise `TypeError` at runtime
  --> src/mdtest_snippet.py:3:11
   |
-1 | from ty_extensions import reveal_mro
-2 |
 3 | class Foo(str, str): ...  # error: [duplicate-base] "Duplicate base class `str`"
   |           ---  ^^^ Class `str` later repeated here
   |           |
   |           Class `str` first included in bases list here
-4 |
-5 | reveal_mro(Foo)  # revealed: (<class 'Foo'>, Unknown, <class 'object'>)
   |
 
 ```
@@ -130,8 +122,6 @@ info: The definition of class `Foo` will raise `TypeError` at runtime
 error[duplicate-base]: Duplicate base class `Spam`
   --> src/mdtest_snippet.py:16:7
    |
-14 |   # error: [duplicate-base] "Duplicate base class `Spam`"
-15 |   # error: [duplicate-base] "Duplicate base class `Eggs`"
 16 |   class Ham(
    |  _______^
 17 | |     Spam,
@@ -142,23 +132,17 @@ error[duplicate-base]: Duplicate base class `Spam`
 22 | |     Eggs,
 23 | | ): ...
    | |_^
-24 |
-25 |   # fmt: on
    |
 info: The definition of class `Ham` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:17:5
+  --> src/mdtest_snippet.py:21:5
    |
-15 | # error: [duplicate-base] "Duplicate base class `Eggs`"
-16 | class Ham(
-17 |     Spam,
-   |     ---- Class `Spam` first included in bases list here
-18 |     Eggs,
-19 |     Bar,
-20 |     Baz,
 21 |     Spam,
    |     ^^^^ Class `Spam` later repeated here
-22 |     Eggs,
-23 | ): ...
+   |
+  ::: src/mdtest_snippet.py:17:5
+   |
+17 |     Spam,
+   |     ---- Class `Spam` first included in bases list here
    |
 
 ```
@@ -167,8 +151,6 @@ info: The definition of class `Ham` will raise `TypeError` at runtime
 error[duplicate-base]: Duplicate base class `Eggs`
   --> src/mdtest_snippet.py:16:7
    |
-14 |   # error: [duplicate-base] "Duplicate base class `Spam`"
-15 |   # error: [duplicate-base] "Duplicate base class `Eggs`"
 16 |   class Ham(
    |  _______^
 17 | |     Spam,
@@ -179,22 +161,17 @@ error[duplicate-base]: Duplicate base class `Eggs`
 22 | |     Eggs,
 23 | | ): ...
    | |_^
-24 |
-25 |   # fmt: on
    |
 info: The definition of class `Ham` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:18:5
+  --> src/mdtest_snippet.py:22:5
    |
-16 | class Ham(
-17 |     Spam,
-18 |     Eggs,
-   |     ---- Class `Eggs` first included in bases list here
-19 |     Bar,
-20 |     Baz,
-21 |     Spam,
 22 |     Eggs,
    |     ^^^^ Class `Eggs` later repeated here
-23 | ): ...
+   |
+  ::: src/mdtest_snippet.py:18:5
+   |
+18 |     Eggs,
+   |     ---- Class `Eggs` first included in bases list here
    |
 
 ```
@@ -203,22 +180,16 @@ info: The definition of class `Ham` will raise `TypeError` at runtime
 error[duplicate-base]: Duplicate base class `Mushrooms`
   --> src/mdtest_snippet.py:30:7
    |
-29 | class Mushrooms: ...
 30 | class Omelette(Spam, Eggs, Mushrooms, Mushrooms): ...  # error: [duplicate-base]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-31 |
-32 | reveal_mro(Omelette)  # revealed: (<class 'Omelette'>, Unknown, <class 'object'>)
    |
 info: The definition of class `Omelette` will raise `TypeError` at runtime
   --> src/mdtest_snippet.py:30:28
    |
-29 | class Mushrooms: ...
 30 | class Omelette(Spam, Eggs, Mushrooms, Mushrooms): ...  # error: [duplicate-base]
    |                            ---------  ^^^^^^^^^ Class `Mushrooms` later repeated here
    |                            |
    |                            Class `Mushrooms` first included in bases list here
-31 |
-32 | reveal_mro(Omelette)  # revealed: (<class 'Omelette'>, Unknown, <class 'object'>)
    |
 
 ```
@@ -227,7 +198,6 @@ info: The definition of class `Omelette` will raise `TypeError` at runtime
 error[duplicate-base]: Duplicate base class `Eggs`
   --> src/mdtest_snippet.py:37:7
    |
-36 |   # error: [duplicate-base] "Duplicate base class `Eggs`"
 37 |   class VeryEggyOmelette(
    |  _______^
 38 | |     Eggs,
@@ -241,28 +211,27 @@ error[duplicate-base]: Duplicate base class `Eggs`
 46 | |     Eggs,
 47 | | ): ...
    | |_^
-48 |
-49 |   # fmt: off
    |
 info: The definition of class `VeryEggyOmelette` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:38:5
+  --> src/mdtest_snippet.py:41:5
    |
-36 | # error: [duplicate-base] "Duplicate base class `Eggs`"
-37 | class VeryEggyOmelette(
-38 |     Eggs,
-   |     ---- Class `Eggs` first included in bases list here
-39 |     Ham,
-40 |     Spam,
 41 |     Eggs,
    |     ^^^^ Class `Eggs` later repeated here
-42 |     Mushrooms,
-43 |     Bar,
+   |
+  ::: src/mdtest_snippet.py:44:5
+   |
 44 |     Eggs,
    |     ^^^^ Class `Eggs` later repeated here
-45 |     Baz,
+   |
+  ::: src/mdtest_snippet.py:46:5
+   |
 46 |     Eggs,
    |     ^^^^ Class `Eggs` later repeated here
-47 | ): ...
+   |
+  ::: src/mdtest_snippet.py:38:5
+   |
+38 |     Eggs,
+   |     ---- Class `Eggs` first included in bases list here
    |
 
 ```
@@ -271,7 +240,6 @@ info: The definition of class `VeryEggyOmelette` will raise `TypeError` at runti
 error[duplicate-base]: Duplicate base class `A`
   --> src/mdtest_snippet.py:69:7
    |
-68 |   # error: [duplicate-base]
 69 |   class D(
    |  _______^
 70 | |     A,
@@ -279,20 +247,17 @@ error[duplicate-base]: Duplicate base class `A`
 72 | |     A,  # type: ignore[ty:duplicate-base]
 73 | | ): ...
    | |_^
-74 |
-75 |   # error: [duplicate-base]
    |
 info: The definition of class `D` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:70:5
+  --> src/mdtest_snippet.py:72:5
    |
-68 | # error: [duplicate-base]
-69 | class D(
-70 |     A,
-   |     - Class `A` first included in bases list here
-71 |     # error: [unused-type-ignore-comment]
 72 |     A,  # type: ignore[ty:duplicate-base]
    |     ^ Class `A` later repeated here
-73 | ): ...
+   |
+  ::: src/mdtest_snippet.py:70:5
+   |
+70 |     A,
+   |     - Class `A` first included in bases list here
    |
 
 ```
@@ -301,11 +266,8 @@ info: The definition of class `D` will raise `TypeError` at runtime
 warning[unused-type-ignore-comment]: Unused `type: ignore` directive
   --> src/mdtest_snippet.py:72:9
    |
-70 |     A,
-71 |     # error: [unused-type-ignore-comment]
 72 |     A,  # type: ignore[ty:duplicate-base]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-73 | ): ...
    |
 help: Remove the unused suppression comment
 69 | class D(
@@ -323,27 +285,20 @@ help: Remove the unused suppression comment
 error[duplicate-base]: Duplicate base class `A`
   --> src/mdtest_snippet.py:76:7
    |
-75 |   # error: [duplicate-base]
 76 |   class E(
    |  _______^
 77 | |     A,
 78 | |     A
 79 | | ):
    | |_^
-80 |       # error: [unused-type-ignore-comment]
-81 |       x: int  # type: ignore[ty:duplicate-base]
    |
 info: The definition of class `E` will raise `TypeError` at runtime
   --> src/mdtest_snippet.py:77:5
    |
-75 | # error: [duplicate-base]
-76 | class E(
 77 |     A,
    |     - Class `A` first included in bases list here
 78 |     A
    |     ^ Class `A` later repeated here
-79 | ):
-80 |     # error: [unused-type-ignore-comment]
    |
 
 ```
@@ -352,12 +307,8 @@ info: The definition of class `E` will raise `TypeError` at runtime
 warning[unused-type-ignore-comment]: Unused `type: ignore` directive
   --> src/mdtest_snippet.py:81:13
    |
-79 | ):
-80 |     # error: [unused-type-ignore-comment]
 81 |     x: int  # type: ignore[ty:duplicate-base]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-82 |
-83 | # fmt: on
    |
 help: Remove the unused suppression comment
 78 |     A

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_Edge_case___multiple_…_(f30babd05c89dce9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_Edge_case___multiple_…_(f30babd05c89dce9).snap
@@ -33,15 +33,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/named_tuple.md
 
 ```
 error[invalid-named-tuple]: NamedTuple field name cannot start with an underscore
-  --> src/mdtest_snippet.py:8:9
-   |
- 6 | class Foo(NamedTuple):
- 7 |     if coinflip():
- 8 |         _asdict: bool  # error: [invalid-named-tuple] "NamedTuple field `_asdict` cannot start with an underscore"
-   |         ^^^^^^^^^^^^^ Class definition will raise `TypeError` at runtime due to this field
- 9 |     else:
-10 |         # TODO: there should only be one diagnostic here...
-   |
+ --> src/mdtest_snippet.py:8:9
+  |
+8 |         _asdict: bool  # error: [invalid-named-tuple] "NamedTuple field `_asdict` cannot start with an underscore"
+  |         ^^^^^^^^^^^^^ Class definition will raise `TypeError` at runtime due to this field
+  |
 
 ```
 
@@ -49,8 +45,6 @@ error[invalid-named-tuple]: NamedTuple field name cannot start with an underscor
 error[invalid-named-tuple]: Cannot overwrite NamedTuple attribute `_asdict`
   --> src/mdtest_snippet.py:14:9
    |
-12 |         # error: [invalid-named-tuple] "Cannot overwrite NamedTuple attribute `_asdict`"
-13 |         # error: [invalid-named-tuple] "Cannot overwrite NamedTuple attribute `_asdict`"
 14 |         _asdict = True
    |         ^^^^^^^
    |
@@ -62,8 +56,6 @@ info: This will cause the class creation to fail at runtime
 error[invalid-named-tuple]: Cannot overwrite NamedTuple attribute `_asdict`
   --> src/mdtest_snippet.py:14:9
    |
-12 |         # error: [invalid-named-tuple] "Cannot overwrite NamedTuple attribute `_asdict`"
-13 |         # error: [invalid-named-tuple] "Cannot overwrite NamedTuple attribute `_asdict`"
 14 |         _asdict = True
    |         ^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_NamedTuples_cannot_h…_(e2ed186fe2b2fc35).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_NamedTuples_cannot_h…_(e2ed186fe2b2fc35).snap
@@ -49,12 +49,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/named_tuple.md
 error[invalid-named-tuple]: NamedTuple field name cannot start with an underscore
  --> src/mdtest_snippet.py:5:5
   |
-3 | class Foo(NamedTuple):
-4 |     # error: [invalid-named-tuple] "NamedTuple field `_bar` cannot start with an underscore"
 5 |     _bar: int
   |     ^^^^^^^^^ Class definition will raise `TypeError` at runtime due to this field
-6 |
-7 | class Bar(NamedTuple):
   |
 
 ```
@@ -63,10 +59,8 @@ error[invalid-named-tuple]: NamedTuple field name cannot start with an underscor
 error[invalid-named-tuple]: Field name `_x` in `NamedTuple()` cannot start with an underscore
   --> src/mdtest_snippet.py:15:39
    |
-14 | # error: [invalid-named-tuple] "Field name `_x` in `NamedTuple()` cannot start with an underscore"
 15 | Underscore = NamedTuple("Underscore", [("_x", int), ("y", str)])
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^ Will raise `ValueError` at runtime
-16 | reveal_type(Underscore)  # revealed: <class 'Underscore'>
    |
 
 ```
@@ -75,10 +69,8 @@ error[invalid-named-tuple]: Field name `_x` in `NamedTuple()` cannot start with 
 error[invalid-named-tuple]: Field name `class` in `NamedTuple()` cannot be a Python keyword
   --> src/mdtest_snippet.py:19:33
    |
-18 | # error: [invalid-named-tuple] "Field name `class` in `NamedTuple()` cannot be a Python keyword"
 19 | Keyword = NamedTuple("Keyword", [("x", int), ("class", str)])
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Will raise `ValueError` at runtime
-20 | reveal_type(Keyword)  # revealed: <class 'Keyword'>
    |
 
 ```
@@ -87,10 +79,8 @@ error[invalid-named-tuple]: Field name `class` in `NamedTuple()` cannot be a Pyt
 error[invalid-named-tuple]: Duplicate field name `x` in `NamedTuple()`
   --> src/mdtest_snippet.py:23:37
    |
-22 | # error: [invalid-named-tuple] "Duplicate field name `x` in `NamedTuple()`"
 23 | Duplicate = NamedTuple("Duplicate", [("x", int), ("y", str), ("x", float)])
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Field `x` already defined; will raise `ValueError` at runtime
-24 | reveal_type(Duplicate)  # revealed: <class 'Duplicate'>
    |
 
 ```
@@ -99,10 +89,8 @@ error[invalid-named-tuple]: Duplicate field name `x` in `NamedTuple()`
 error[invalid-named-tuple]: Field name `not valid` in `NamedTuple()` is not a valid identifier
   --> src/mdtest_snippet.py:27:33
    |
-26 | # error: [invalid-named-tuple] "Field name `not valid` in `NamedTuple()` is not a valid identifier"
 27 | Invalid = NamedTuple("Invalid", [("not valid", int), ("ok", str)])
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Will raise `ValueError` at runtime
-28 | reveal_type(Invalid)  # revealed: <class 'Invalid'>
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_`typing.NamedTuple`_-_Definition_(bbf79630502e65e9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_`typing.NamedTuple`_-_Definition_(bbf79630502e65e9).snap
@@ -41,35 +41,31 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/named_tuple.md
 
 ```
 error[invalid-named-tuple]: NamedTuple field without default value cannot follow field(s) with default value(s)
- --> src/mdtest_snippet.py:4:5
+ --> src/mdtest_snippet.py:6:5
   |
-3 | class Location(NamedTuple):
-4 |     altitude: float = 0.0
-  |     --------------------- Earlier field `altitude` defined here with a default value
-5 |     # error: [invalid-named-tuple] "NamedTuple field without default value cannot follow field(s) with default value(s): Field `latitud…
 6 |     latitude: float
   |     ^^^^^^^^^^^^^^^ Field `latitude` defined here without a default value
-7 |     # error: [invalid-named-tuple] "NamedTuple field without default value cannot follow field(s) with default value(s): Field `longitu…
-8 |     longitude: float
+  |
+ ::: src/mdtest_snippet.py:4:5
+  |
+4 |     altitude: float = 0.0
+  |     --------------------- Earlier field `altitude` defined here with a default value
   |
 
 ```
 
 ```
 error[invalid-named-tuple]: NamedTuple field without default value cannot follow field(s) with default value(s)
-  --> src/mdtest_snippet.py:4:5
-   |
- 3 | class Location(NamedTuple):
- 4 |     altitude: float = 0.0
-   |     --------------------- Earlier field `altitude` defined here with a default value
- 5 |     # error: [invalid-named-tuple] "NamedTuple field without default value cannot follow field(s) with default value(s): Field `latitu…
- 6 |     latitude: float
- 7 |     # error: [invalid-named-tuple] "NamedTuple field without default value cannot follow field(s) with default value(s): Field `longit…
- 8 |     longitude: float
-   |     ^^^^^^^^^^^^^^^^ Field `longitude` defined here without a default value
- 9 |
-10 | class StrangeLocation(NamedTuple):
-   |
+ --> src/mdtest_snippet.py:8:5
+  |
+8 |     longitude: float
+  |     ^^^^^^^^^^^^^^^^ Field `longitude` defined here without a default value
+  |
+ ::: src/mdtest_snippet.py:4:5
+  |
+4 |     altitude: float = 0.0
+  |     --------------------- Earlier field `altitude` defined here with a default value
+  |
 
 ```
 
@@ -77,30 +73,25 @@ error[invalid-named-tuple]: NamedTuple field without default value cannot follow
 error[invalid-named-tuple]: NamedTuple field without default value cannot follow field(s) with default value(s)
   --> src/mdtest_snippet.py:14:5
    |
-12 |     altitude: float = 0.0
-13 |     altitude: float
 14 |     altitude: float = 0.0
    |     --------------------- Earlier field `altitude` defined here with a default value
 15 |     latitude: float  # error: [invalid-named-tuple]
    |     ^^^^^^^^^^^^^^^ Field `latitude` defined here without a default value
-16 |     longitude: float  # error: [invalid-named-tuple]
    |
 
 ```
 
 ```
 error[invalid-named-tuple]: NamedTuple field without default value cannot follow field(s) with default value(s)
-  --> src/mdtest_snippet.py:14:5
+  --> src/mdtest_snippet.py:16:5
    |
-12 |     altitude: float = 0.0
-13 |     altitude: float
-14 |     altitude: float = 0.0
-   |     --------------------- Earlier field `altitude` defined here with a default value
-15 |     latitude: float  # error: [invalid-named-tuple]
 16 |     longitude: float  # error: [invalid-named-tuple]
    |     ^^^^^^^^^^^^^^^^ Field `longitude` defined here without a default value
-17 |
-18 | class VeryStrangeLocation(NamedTuple):
+   |
+  ::: src/mdtest_snippet.py:14:5
+   |
+14 |     altitude: float = 0.0
+   |     --------------------- Earlier field `altitude` defined here with a default value
    |
 
 ```
@@ -109,12 +100,8 @@ error[invalid-named-tuple]: NamedTuple field without default value cannot follow
 error[invalid-named-tuple]: NamedTuple field without default value cannot follow field(s) with default value(s)
   --> src/mdtest_snippet.py:20:5
    |
-18 | class VeryStrangeLocation(NamedTuple):
-19 |     altitude: float = 0.0
 20 |     latitude: float  # error: [invalid-named-tuple]
    |     ^^^^^^^^^^^^^^^ Field `latitude` defined here without a default value
-21 |     longitude: float  # error: [invalid-named-tuple]
-22 |     altitude: float = 0.0
    |
 info: Earlier field `altitude` was defined with a default value
 
@@ -124,11 +111,8 @@ info: Earlier field `altitude` was defined with a default value
 error[invalid-named-tuple]: NamedTuple field without default value cannot follow field(s) with default value(s)
   --> src/mdtest_snippet.py:21:5
    |
-19 |     altitude: float = 0.0
-20 |     latitude: float  # error: [invalid-named-tuple]
 21 |     longitude: float  # error: [invalid-named-tuple]
    |     ^^^^^^^^^^^^^^^^ Field `longitude` defined here without a default value
-22 |     altitude: float = 0.0
    |
 info: Earlier field `altitude` was defined with a default value
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_`typing.NamedTuple`_-_Multiple_Inheritance_(82ed33d1b3b433d8).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_`typing.NamedTuple`_-_Multiple_Inheritance_(82ed33d1b3b433d8).snap
@@ -55,10 +55,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/named_tuple.md
 error[invalid-named-tuple]: NamedTuple class `C` cannot use multiple inheritance except with `Generic[]`
  --> src/mdtest_snippet.py:4:21
   |
-3 | # error: [invalid-named-tuple] "NamedTuple class `C` cannot use multiple inheritance except with `Generic[]`"
 4 | class C(NamedTuple, object):
   |                     ^^^^^^
-5 |     id: int
   |
 
 ```
@@ -67,11 +65,8 @@ error[invalid-named-tuple]: NamedTuple class `C` cannot use multiple inheritance
 error[invalid-named-tuple]: NamedTuple class `D` cannot use multiple inheritance except with `Generic[]`
   --> src/mdtest_snippet.py:10:5
    |
- 9 | class D(
 10 |     int,  # error: [invalid-named-tuple]
    |     ^^^
-11 |     NamedTuple
-12 | ): ...
    |
 
 ```
@@ -80,11 +75,8 @@ error[invalid-named-tuple]: NamedTuple class `D` cannot use multiple inheritance
 error[invalid-named-tuple]: NamedTuple class `E` cannot use multiple inheritance except with `Generic[]`
   --> src/mdtest_snippet.py:17:21
    |
-16 | # error: [invalid-named-tuple]
 17 | class E(NamedTuple, Protocol): ...
    |                     ^^^^^^^^
-18 | from abc import ABC
-19 | from collections import namedtuple
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_`typing.NamedTuple`_-_Name_mismatch_diagno…_(8ca723b970e370d0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_`typing.NamedTuple`_-_Name_mismatch_diagno…_(8ca723b970e370d0).snap
@@ -28,11 +28,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/named_tuple.md
 warning[mismatched-type-name]: The name passed to `NamedTuple` must match the variable it is assigned to
  --> src/mdtest_snippet.py:5:23
   |
-4 | # error: [mismatched-type-name]
 5 | Mismatch = NamedTuple("WrongName", [("x", int)])
   |                       ^^^^^^^^^^^ Expected "Mismatch", got "WrongName"
-6 | reveal_type(Mismatch)  # revealed: <class 'WrongName'>
-7 | reveal_type(is_subtype_of(Mismatch, tuple[int]))  # revealed: ConstraintSet[Literal[True]]
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/new_types.md_-_NewType_-_The_assigned_name_sh…_(124f70124aebd214).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/new_types.md_-_NewType_-_The_assigned_name_sh…_(124f70124aebd214).snap
@@ -33,11 +33,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
 warning[mismatched-type-name]: The name passed to `NewType` must match the variable it is assigned to
  --> src/mdtest_snippet.py:5:18
   |
-4 | # error: [mismatched-type-name]
 5 | UserId = NewType("Id", int)
   |                  ^^^^ Expected "UserId", got "Id"
-6 | reveal_type(UserId)  # revealed: <NewType pseudo-class 'Id'>
-7 | reveal_type(is_subtype_of(UserId, int))  # revealed: ConstraintSet[Literal[True]]
   |
 
 ```
@@ -46,11 +43,8 @@ warning[mismatched-type-name]: The name passed to `NewType` must match the varia
 warning[mismatched-type-name]: The name passed to `NewType` must match the variable it is assigned to
   --> src/mdtest_snippet.py:11:26
    |
- 9 | Id = int
-10 | # error: [mismatched-type-name]
 11 | UsesExistingId = NewType("Id", "Id")
    |                          ^^^^ Expected "UsesExistingId", got "Id"
-12 | UsesExistingId(1)
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/new_types.md_-_NewType_-_The_base_of_a_`NewTy…_(9847ea9eddc316b4).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/new_types.md_-_NewType_-_The_base_of_a_`NewTy…_(9847ea9eddc316b4).snap
@@ -32,12 +32,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
 error[invalid-newtype]: invalid base for `typing.NewType`
  --> src/mdtest_snippet.py:6:28
   |
-4 |     code: int
-5 |
 6 | UserId = NewType("UserId", Id)  # error: [invalid-newtype]
   |                            ^^ type `Id`
-7 |
-8 | class Foo(TypedDict):
   |
 info: The base of a `NewType` is not allowed to be a protocol class.
 
@@ -47,8 +43,6 @@ info: The base of a `NewType` is not allowed to be a protocol class.
 error[invalid-newtype]: invalid base for `typing.NewType`
   --> src/mdtest_snippet.py:11:22
    |
- 9 |     a: int
-10 |
 11 | Bar = NewType("Bar", Foo)  # error: [invalid-newtype]
    |                      ^^^ type `Foo`
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/new_types.md_-_NewType_-_Trying_to_subclass_a…_(fd3c73e2a9f04).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/new_types.md_-_NewType_-_Trying_to_subclass_a…_(fd3c73e2a9f04).snap
@@ -26,8 +26,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
 error[invalid-base]: Cannot subclass an instance of NewType
  --> src/mdtest_snippet.py:5:11
   |
-3 | X = NewType("X", int)
-4 |
 5 | class Foo(X): ...  # error: [invalid-base]
   |           ^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_A_method_call_with_u…_(31cb5f881221158e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_A_method_call_with_u…_(31cb5f881221158e).snap
@@ -33,19 +33,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/no_matching_
 error[no-matching-overload]: No overload of bound method `bar` matches arguments
   --> src/mdtest_snippet.py:12:1
    |
-11 | foo = Foo()
 12 | foo.bar(b"wat")  # error: [no-matching-overload]
    | ^^^^^^^^^^^^^^^
    |
 info: First overload defined here
  --> src/mdtest_snippet.py:5:9
   |
-3 | class Foo:
-4 |     @overload
 5 |     def bar(self, x: int) -> int: ...
   |         ^^^^^^^^^^^^^^^^^^^^^^^^
-6 |     @overload
-7 |     def bar(self, x: str) -> str: ...
   |
 info: Possible overloads for bound method `bar`:
 info:   (self, x: int) -> int
@@ -53,11 +48,8 @@ info:   (self, x: str) -> str
 info: Overload implementation defined here
  --> src/mdtest_snippet.py:8:9
   |
-6 |     @overload
-7 |     def bar(self, x: str) -> str: ...
 8 |     def bar(self, x: int | str) -> int | str:
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-9 |         return x
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Call_to_function_wit…_(dd80c593d9136f35).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Call_to_function_wit…_(dd80c593d9136f35).snap
@@ -70,19 +70,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/no_matching_
 error[no-matching-overload]: No overload of function `foo` matches arguments
   --> src/mdtest_snippet.py:49:1
    |
-47 | def foo(a, b, c): ...
-48 |
 49 | foo(Foo(), Foo())  # error: [no-matching-overload]
    | ^^^^^^^^^^^^^^^^^
    |
 info: First overload defined here
  --> src/mdtest_snippet.py:6:5
   |
-5 | @overload
 6 | def foo(a: int, b: int, c: int): ...
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-7 | @overload
-8 | def foo(a: str, b: int, c: int): ...
   |
 info: Possible overloads for function `foo`:
 info:   (a: int, b: int, c: int) -> Unknown
@@ -109,12 +104,8 @@ info:   (a: int | float, b: int | float, c: int | float) -> Unknown
 info: Overload implementation defined here
   --> src/mdtest_snippet.py:47:5
    |
-45 | @overload
-46 | def foo(a: float, b: float, c: float): ...
 47 | def foo(a, b, c): ...
    |     ^^^^^^^^^^^^
-48 |
-49 | foo(Foo(), Foo())  # error: [no-matching-overload]
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Call_to_function_wit…_(f66e3a8a3977c472).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Call_to_function_wit…_(f66e3a8a3977c472).snap
@@ -150,19 +150,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/no_matching_
 error[no-matching-overload]: No overload of function `foo` matches arguments
    --> src/mdtest_snippet.py:129:1
     |
-127 | def foo(a, b, c): ...
-128 |
 129 | foo(Foo(), Foo())  # error: [no-matching-overload]
     | ^^^^^^^^^^^^^^^^^
     |
 info: First overload defined here
  --> src/mdtest_snippet.py:6:5
   |
-5 | @overload
 6 | def foo(a: int, b: int, c: int): ...
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-7 | @overload
-8 | def foo(a: str, b: int, c: int): ...
   |
 info: Possible overloads for function `foo`:
 info:   (a: int, b: int, c: int) -> Unknown
@@ -219,12 +214,8 @@ info: ... omitted 11 overloads
 info: Overload implementation defined here
    --> src/mdtest_snippet.py:127:5
     |
-125 | @overload
-126 | def foo(a: bool, b: float, c: float): ...
 127 | def foo(a, b, c): ...
     |     ^^^^^^^^^^^^
-128 |
-129 | foo(Foo(), Foo())  # error: [no-matching-overload]
     |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Calls_to_overloaded_…_(3553d085684e16a0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Calls_to_overloaded_…_(3553d085684e16a0).snap
@@ -31,19 +31,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/no_matching_
 error[no-matching-overload]: No overload of function `f` matches arguments
   --> src/mdtest_snippet.py:10:1
    |
- 8 |     return x
- 9 |
 10 | f(b"foo")  # error: [no-matching-overload]
    | ^^^^^^^^^
    |
 info: First overload defined here
  --> src/mdtest_snippet.py:4:5
   |
-3 | @overload
 4 | def f(x: int) -> int: ...
   |     ^^^^^^^^^^^^^^^^
-5 | @overload
-6 | def f(x: str) -> str: ...
   |
 info: Possible overloads for function `f`:
 info:   (x: int) -> int
@@ -51,11 +46,8 @@ info:   (x: str) -> str
 info: Overload implementation defined here
  --> src/mdtest_snippet.py:7:5
   |
-5 | @overload
-6 | def f(x: str) -> str: ...
 7 | def f(x: int | str) -> int | str:
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-8 |     return x
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Calls_to_overloaded_…_(36814b28492c01d2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Calls_to_overloaded_…_(36814b28492c01d2).snap
@@ -82,15 +82,12 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/no_matching_
 error[no-matching-overload]: No overload of function `f` matches arguments
   --> src/mdtest_snippet.py:61:1
    |
-59 |     return 0
-60 |
 61 | f(b"foo")  # error: [no-matching-overload]
    | ^^^^^^^^^
    |
 info: First overload defined here
   --> src/mdtest_snippet.py:4:5
    |
- 3 |   @overload
  4 |   def f(
    |  _____^
  5 | |     lion: int,
@@ -111,8 +108,6 @@ info: First overload defined here
 20 | |     hyena: int,
 21 | | ) -> int: ...
    | |________^
-22 |   @overload
-23 |   def f(
    |
 info: Possible overloads for function `f`:
 info:   (lion: int, turtle: int, tortoise: int, goat: int, capybara: int, chicken: int, ostrich: int, gorilla: int, giraffe: int, condor: int, kangaroo: int, anaconda: int, tarantula: int, millipede: int, leopard: int, hyena: int) -> int
@@ -120,8 +115,6 @@ info:   (lion: str, turtle: str, tortoise: str, goat: str, capybara: str, chicke
 info: Overload implementation defined here
   --> src/mdtest_snippet.py:41:5
    |
-39 |       hyena: str,
-40 |   ) -> str: ...
 41 |   def f(
    |  _____^
 42 | |     lion: int | str,
@@ -142,7 +135,6 @@ info: Overload implementation defined here
 57 | |     hyena: int | str,
 58 | | ) -> int | str:
    | |______________^
-59 |       return 0
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implemen…_(ab3f546bf004e24d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/not.md_-_Unary_not_-_Object_that_implemen…_(ab3f546bf004e24d).snap
@@ -26,7 +26,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/unary/not.md
 error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
  --> src/mdtest_snippet.py:5:1
   |
-4 | # error: [unsupported-bool-conversion]
 5 | not NotBoolable()
   | ^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Argument_type_expans…_-_Optimization___Limit_…_(cd61048adbc17331).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Argument_type_expans…_-_Optimization___Limit_…_(cd61048adbc17331).snap
@@ -81,8 +81,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/call/overloads.md
 error[no-matching-overload]: No overload of function `f` matches arguments
   --> src/mdtest_snippet.py:8:9
    |
- 6 |           # error: [no-matching-overload]
- 7 |           # revealed: Unknown
  8 | /         f(
  9 | |             A(),
 10 | |             a1=a,
@@ -117,18 +115,14 @@ error[no-matching-overload]: No overload of function `f` matches arguments
 39 | |             a30=a,
 40 | |         )
    | |_________^
-41 |       )
    |
 info: Limit of argument type expansion reached at argument 9
 info: First overload defined here
-  --> src/overloaded.pyi:8:5
-   |
- 7 | @overload
- 8 | def f() -> None: ...
-   |     ^^^^^^^^^^^
- 9 | @overload
-10 | def f(**kwargs: int) -> C: ...
-   |
+ --> src/overloaded.pyi:8:5
+  |
+8 | def f() -> None: ...
+  |     ^^^^^^^^^^^
+  |
 info: Possible overloads for function `f`:
 info:   () -> None
 info:   (**kwargs: int) -> C

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloa…_(84dadf8abd8f2f2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloa…_(84dadf8abd8f2f2).snap
@@ -38,12 +38,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 error[invalid-overload]: Overloaded function `func` requires at least two overloads
  --> src/mdtest_snippet.py:5:5
   |
-3 | @overload
-4 | # error: [invalid-overload]
 5 | def func(x: int) -> int: ...
   |     ^^^^ Only one overload defined here
-6 | def func(x: int | str) -> int | str:
-7 |     return x
   |
 
 ```
@@ -52,8 +48,6 @@ error[invalid-overload]: Overloaded function `func` requires at least two overlo
 error[invalid-overload]: Overloaded function `func` requires at least two overloads
  --> src/mdtest_snippet.pyi:5:5
   |
-3 | @overload
-4 | # error: [invalid-overload]
 5 | def func(x: int) -> int: ...
   |     ^^^^ Only one overload defined here
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@classmethod`_(aaa04d4cfa3adaba).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@classmethod`_(aaa04d4cfa3adaba).snap
@@ -75,18 +75,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 
 ```
 error[invalid-overload]: Overloaded function `try_from1` does not use the `@classmethod` decorator consistently
-  --> src/mdtest_snippet.py:13:9
+  --> src/mdtest_snippet.py:16:9
    |
-11 |     def try_from1(cls, x: int) -> CheckClassMethod: ...
-12 |     @overload
-13 |     def try_from1(cls, x: str) -> None: ...
-   |         --------- Missing here
-14 |     @classmethod
-15 |     # error: [invalid-overload] "Overloaded function `try_from1` does not use the `@classmethod` decorator consistently"
 16 |     def try_from1(cls, x: int | str) -> CheckClassMethod | None:
    |         ^^^^^^^^^
-17 |         if isinstance(x, int):
-18 |             return cls(x)
+   |
+  ::: src/mdtest_snippet.py:13:9
+   |
+13 |     def try_from1(cls, x: str) -> None: ...
+   |         --------- Missing here
    |
 
 ```
@@ -95,20 +92,13 @@ error[invalid-overload]: Overloaded function `try_from1` does not use the `@clas
 error[invalid-overload]: Overloaded function `try_from2` does not use the `@classmethod` decorator consistently
   --> src/mdtest_snippet.py:28:9
    |
-26 |     @classmethod
-27 |     # error: [invalid-overload]
 28 |     def try_from2(cls, x: int | str) -> CheckClassMethod | None:
    |         ^^^^^^^^^
-29 |         if isinstance(x, int):
-30 |             return cls(x)
    |
   ::: src/mdtest_snippet.py:22:9
    |
-21 |     @overload
 22 |     def try_from2(cls, x: int) -> CheckClassMethod: ...
    |         --------- Missing here
-23 |     @overload
-24 |     @classmethod
    |
 
 ```
@@ -117,14 +107,10 @@ error[invalid-overload]: Overloaded function `try_from2` does not use the `@clas
 error[invalid-overload]: Overloaded function `try_from3` does not use the `@classmethod` decorator consistently
   --> src/mdtest_snippet.py:40:9
    |
-38 |     def try_from3(cls, x: str) -> None: ...
-39 |     # error: [invalid-overload]
 40 |     def try_from3(cls, x: int | str) -> CheckClassMethod | None:
    |         ---------
    |         |
    |         Missing here
-41 |         if isinstance(x, int):
-42 |             # error: [call-non-callable]
    |
 
 ```
@@ -133,11 +119,8 @@ error[invalid-overload]: Overloaded function `try_from3` does not use the `@clas
 error[call-non-callable]: Object of type `CheckClassMethod` is not callable
   --> src/mdtest_snippet.py:43:20
    |
-41 |         if isinstance(x, int):
-42 |             # error: [call-non-callable]
 43 |             return cls(x)
    |                    ^^^^^^
-44 |         return None
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@final`_(f8e529ec23a61665).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@final`_(f8e529ec23a61665).snap
@@ -76,98 +76,88 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:13:5
+  --> src/mdtest_snippet.py:15:9
    |
-12 |     @overload
-13 |     @final
-   |     ------
-14 |     # error: [invalid-overload]
 15 |     def method2(self, x: int) -> int: ...
    |         ^^^^^^^
-16 |     @overload
-17 |     def method2(self, x: str) -> str: ...
+   |
+  ::: src/mdtest_snippet.py:13:5
+   |
+13 |     @final
+   |     ------
+   |
+  ::: src/mdtest_snippet.py:18:9
+   |
 18 |     def method2(self, x: int | str) -> int | str:
    |         ------- Implementation defined here
-19 |         return x
    |
 
 ```
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:24:5
+  --> src/mdtest_snippet.py:26:9
    |
-22 |     def method3(self, x: int) -> int: ...
-23 |     @overload
-24 |     @final
-   |     ------
-25 |     # error: [invalid-overload]
 26 |     def method3(self, x: str) -> str: ...
    |         ^^^^^^^
 27 |     def method3(self, x: int | str) -> int | str:
    |         ------- Implementation defined here
-28 |         return x
+   |
+  ::: src/mdtest_snippet.py:24:5
+   |
+24 |     @final
+   |     ------
    |
 
 ```
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
-  --> src/mdtest_snippet.pyi:10:9
+  --> src/mdtest_snippet.pyi:14:9
    |
- 8 |     def method1(self, x: str) -> str: ...
- 9 |     @overload
+14 |     def method2(self, x: str) -> str: ...
+   |         ^^^^^^^
+   |
+  ::: src/mdtest_snippet.pyi:10:9
+   |
 10 |     def method2(self, x: int) -> int: ...
    |         ------- First overload defined here
 11 |     @final
    |     ------
-12 |     @overload
-13 |     # error: [invalid-overload]
-14 |     def method2(self, x: str) -> str: ...
-   |         ^^^^^^^
-15 |     @overload
-16 |     def method3(self, x: int) -> int: ...
    |
 
 ```
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
-  --> src/mdtest_snippet.pyi:16:9
+  --> src/mdtest_snippet.pyi:19:9
    |
-14 |     def method2(self, x: str) -> str: ...
-15 |     @overload
+19 |     def method3(self, x: str) -> int: ...  # error: [invalid-overload]
+   |         ^^^^^^^
+   |
+  ::: src/mdtest_snippet.pyi:16:9
+   |
 16 |     def method3(self, x: int) -> int: ...
    |         ------- First overload defined here
 17 |     @final
    |     ------
-18 |     @overload
-19 |     def method3(self, x: str) -> int: ...  # error: [invalid-overload]
-   |         ^^^^^^^
-20 |     @overload
-21 |     @final
    |
 
 ```
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
-  --> src/mdtest_snippet.pyi:16:9
+  --> src/mdtest_snippet.pyi:21:5
    |
-14 |     def method2(self, x: str) -> str: ...
-15 |     @overload
-16 |     def method3(self, x: int) -> int: ...
-   |         ------- First overload defined here
-17 |     @final
-18 |     @overload
-19 |     def method3(self, x: str) -> int: ...  # error: [invalid-overload]
-20 |     @overload
 21 |     @final
    |     ------
 22 |     def method3(self, x: bytes) -> bytes: ...  # error: [invalid-overload]
    |         ^^^^^^^
-23 |     @overload
-24 |     def method3(self, x: bytearray) -> bytearray: ...
+   |
+  ::: src/mdtest_snippet.pyi:16:9
+   |
+16 |     def method3(self, x: int) -> int: ...
+   |         ------- First overload defined here
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@override`_(2df210735ca532f9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@override`_(2df210735ca532f9).snap
@@ -84,56 +84,57 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 
 ```
 error[invalid-overload]: `@override` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:24:5
+  --> src/mdtest_snippet.py:26:9
    |
-22 |     def method(self, x: int) -> int: ...
-23 |     @overload
-24 |     @override
-   |     ---------
-25 |     # error: [invalid-overload]
 26 |     def method(self, x: str) -> str: ...
    |         ^^^^^^
 27 |     def method(self, x: int | str) -> int | str:
    |         ------ Implementation defined here
-28 |         return x
+   |
+  ::: src/mdtest_snippet.py:24:5
+   |
+24 |     @override
+   |     ---------
    |
 
 ```
 
 ```
 error[invalid-overload]: `@override` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:32:5
+  --> src/mdtest_snippet.py:34:9
    |
-30 | class Sub3(Base):
-31 |     @overload
-32 |     @override
-   |     ---------
-33 |     # error: [invalid-overload]
 34 |     def method(self, x: int) -> int: ...
    |         ^^^^^^
-35 |     @overload
-36 |     def method(self, x: str) -> str: ...
+   |
+  ::: src/mdtest_snippet.py:32:5
+   |
+32 |     @override
+   |     ---------
+   |
+  ::: src/mdtest_snippet.py:37:9
+   |
 37 |     def method(self, x: int | str) -> int | str:
    |         ------ Implementation defined here
-38 |         return x
    |
 
 ```
 
 ```
 error[invalid-overload]: `@override` decorator should be applied only to the first overload
-  --> src/mdtest_snippet.pyi:18:9
+  --> src/mdtest_snippet.pyi:22:9
    |
-16 | class Sub2(Base):
-17 |     @overload
-18 |     def method(self, x: int) -> int: ...
-   |         ------ First overload defined here
-19 |     @overload
-20 |     @override
-   |     ---------
-21 |     # error: [invalid-overload]
 22 |     def method(self, x: str) -> str: ...
    |         ^^^^^^
+   |
+  ::: src/mdtest_snippet.pyi:18:9
+   |
+18 |     def method(self, x: int) -> int: ...
+   |         ------ First overload defined here
+   |
+  ::: src/mdtest_snippet.pyi:20:5
+   |
+20 |     @override
+   |     ---------
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Overload_without_an_…_-_Regular_modules_(5c8e81664d1c7470).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Overload_without_an_…_-_Regular_modules_(5c8e81664d1c7470).snap
@@ -35,12 +35,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 error[invalid-overload]: Overloads for function `func` must be followed by a non-`@overload`-decorated implementation function
  --> src/mdtest_snippet.py:5:5
   |
-3 | @overload
-4 | # error: [invalid-overload] "Overloads for function `func` must be followed by a non-`@overload`-decorated implementation function"
 5 | def func(x: int) -> int: ...
   |     ^^^^
-6 | @overload
-7 | def func(x: str) -> str: ...
   |
 info: Attempting to call `func` will raise `TypeError` at runtime
 info: Overloaded functions without implementations are only permitted:
@@ -56,12 +52,8 @@ info: See https://docs.python.org/3/library/typing.html#typing.overload for more
 error[invalid-overload]: Overloads for function `method` must be followed by a non-`@overload`-decorated implementation function
   --> src/mdtest_snippet.py:12:9
    |
-10 |     @overload
-11 |     # error: [invalid-overload] "Overloads for function `method` must be followed by a non-`@overload`-decorated implementation functi…
 12 |     def method(self, x: int) -> int: ...
    |         ^^^^^^
-13 |     @overload
-14 |     def method(self, x: str) -> str: ...
    |
 info: Attempting to call `method` will raise `TypeError` at runtime
 info: Overloaded functions without implementations are only permitted:

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_`@overload`-decorate…_(d17a1580f99a6402).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_`@overload`-decorate…_(d17a1580f99a6402).snap
@@ -53,12 +53,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 warning[useless-overload-body]: Useless body for `@overload`-decorated function `foo`
   --> src/mdtest_snippet.py:23:5
    |
-21 | @overload
-22 | def foo(x: int) -> int:
 23 |     return x  # error: [useless-overload-body]
    |     ^^^^^^^^ This statement will never be executed
-24 |
-25 | @overload
    |
 info: `@overload`-decorated functions are solely for type checkers and must be overwritten at runtime by a non-`@overload`-decorated implementation
 help: Consider replacing this function body with `...` or `pass`
@@ -69,12 +65,8 @@ help: Consider replacing this function body with `...` or `pass`
 warning[useless-overload-body]: Useless body for `@overload`-decorated function `foo`
   --> src/mdtest_snippet.py:29:5
    |
-27 |     """Docstring"""
-28 |     pass
 29 |     print("oh no, a string")  # error: [useless-overload-body]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ This statement will never be executed
-30 |
-31 | def foo(x):
    |
 info: `@overload`-decorated functions are solely for type checkers and must be overwritten at runtime by a non-`@overload`-decorated implementation
 help: Consider replacing this function body with `...` or `pass`

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/override.md_-_`typing.override`_-_Basics_(b7c220f8171f11f0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/override.md_-_`typing.override`_-_Basics_(b7c220f8171f11f0).snap
@@ -193,33 +193,28 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/override.md
 
 ```
 error[invalid-explicit-override]: Method `___reprrr__` is decorated with `@override` but does not override anything
-   --> src/mdtest_snippet.pyi:97:5
-    |
- 96 | class Invalid:
- 97 |     @override
-    |     ---------
- 98 |     def ___reprrr__(self): ...  # error: [invalid-explicit-override]
-    |         ^^^^^^^^^^^
- 99 |     @override
-100 |     @classmethod
-    |
+  --> src/mdtest_snippet.pyi:97:5
+   |
+97 |     @override
+   |     ---------
+98 |     def ___reprrr__(self): ...  # error: [invalid-explicit-override]
+   |         ^^^^^^^^^^^
+   |
 info: No `___reprrr__` definitions were found on any superclasses of `Invalid`
 
 ```
 
 ```
 error[invalid-explicit-override]: Method `foo` is decorated with `@override` but does not override anything
-   --> src/mdtest_snippet.pyi:99:5
+   --> src/mdtest_snippet.pyi:101:9
     |
- 97 |     @override
- 98 |     def ___reprrr__(self): ...  # error: [invalid-explicit-override]
- 99 |     @override
-    |     ---------
-100 |     @classmethod
 101 |     def foo(self): ...  # error: [invalid-explicit-override]
     |         ^^^
-102 |     @classmethod
-103 |     @override
+    |
+   ::: src/mdtest_snippet.pyi:99:5
+    |
+ 99 |     @override
+    |     ---------
     |
 info: No `foo` definitions were found on any superclasses of `Invalid`
 
@@ -229,14 +224,10 @@ info: No `foo` definitions were found on any superclasses of `Invalid`
 error[invalid-explicit-override]: Method `bar` is decorated with `@override` but does not override anything
    --> src/mdtest_snippet.pyi:103:5
     |
-101 |     def foo(self): ...  # error: [invalid-explicit-override]
-102 |     @classmethod
 103 |     @override
     |     ---------
 104 |     def bar(self): ...  # error: [invalid-explicit-override]
     |         ^^^
-105 |     @staticmethod
-106 |     @override
     |
 info: No `bar` definitions were found on any superclasses of `Invalid`
 
@@ -246,14 +237,10 @@ info: No `bar` definitions were found on any superclasses of `Invalid`
 error[invalid-explicit-override]: Method `baz` is decorated with `@override` but does not override anything
    --> src/mdtest_snippet.pyi:106:5
     |
-104 |     def bar(self): ...  # error: [invalid-explicit-override]
-105 |     @staticmethod
 106 |     @override
     |     ---------
 107 |     def baz(): ...  # error: [invalid-explicit-override]
     |         ^^^
-108 |     @override
-109 |     @staticmethod
     |
 info: No `baz` definitions were found on any superclasses of `Invalid`
 
@@ -261,17 +248,15 @@ info: No `baz` definitions were found on any superclasses of `Invalid`
 
 ```
 error[invalid-explicit-override]: Method `eggs` is decorated with `@override` but does not override anything
-   --> src/mdtest_snippet.pyi:108:5
+   --> src/mdtest_snippet.pyi:110:9
     |
-106 |     @override
-107 |     def baz(): ...  # error: [invalid-explicit-override]
-108 |     @override
-    |     ---------
-109 |     @staticmethod
 110 |     def eggs(): ...  # error: [invalid-explicit-override]
     |         ^^^^
-111 |     @property
-112 |     @override
+    |
+   ::: src/mdtest_snippet.pyi:108:5
+    |
+108 |     @override
+    |     ---------
     |
 info: No `eggs` definitions were found on any superclasses of `Invalid`
 
@@ -281,14 +266,10 @@ info: No `eggs` definitions were found on any superclasses of `Invalid`
 error[invalid-explicit-override]: Method `bad_property1` is decorated with `@override` but does not override anything
    --> src/mdtest_snippet.pyi:112:5
     |
-110 |     def eggs(): ...  # error: [invalid-explicit-override]
-111 |     @property
 112 |     @override
     |     ---------
 113 |     def bad_property1(self) -> int: ...  # error: [invalid-explicit-override]
     |         ^^^^^^^^^^^^^
-114 |     @override
-115 |     @property
     |
 info: No `bad_property1` definitions were found on any superclasses of `Invalid`
 
@@ -296,17 +277,15 @@ info: No `bad_property1` definitions were found on any superclasses of `Invalid`
 
 ```
 error[invalid-explicit-override]: Method `bad_property2` is decorated with `@override` but does not override anything
-   --> src/mdtest_snippet.pyi:114:5
+   --> src/mdtest_snippet.pyi:116:9
     |
-112 |     @override
-113 |     def bad_property1(self) -> int: ...  # error: [invalid-explicit-override]
-114 |     @override
-    |     ---------
-115 |     @property
 116 |     def bad_property2(self) -> int: ...  # error: [invalid-explicit-override]
     |         ^^^^^^^^^^^^^
-117 |     @property
-118 |     @override
+    |
+   ::: src/mdtest_snippet.pyi:114:5
+    |
+114 |     @override
+    |     ---------
     |
 info: No `bad_property2` definitions were found on any superclasses of `Invalid`
 
@@ -316,14 +295,10 @@ info: No `bad_property2` definitions were found on any superclasses of `Invalid`
 error[invalid-explicit-override]: Method `bad_settable_property` is decorated with `@override` but does not override anything
    --> src/mdtest_snippet.pyi:118:5
     |
-116 |     def bad_property2(self) -> int: ...  # error: [invalid-explicit-override]
-117 |     @property
 118 |     @override
     |     ---------
 119 |     def bad_settable_property(self) -> int: ...  # error: [invalid-explicit-override]
     |         ^^^^^^^^^^^^^^^^^^^^^
-120 |     @bad_settable_property.setter
-121 |     def bad_settable_property(self, x: int) -> None: ...
     |
 info: No `bad_settable_property` definitions were found on any superclasses of `Invalid`
 
@@ -333,20 +308,13 @@ info: No `bad_settable_property` definitions were found on any superclasses of `
 error[invalid-method-override]: Invalid override of method `class_method1`
    --> src/mdtest_snippet.pyi:143:9
     |
-141 |     @staticmethod
-142 |     @override
 143 |     def class_method1() -> int: ...  # error: [invalid-method-override]
     |         ^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.class_method1`
-144 |     @classmethod
-145 |     @override
     |
    ::: src/mdtest_snippet.pyi:19:9
     |
- 18 |     @classmethod
  19 |     def class_method1(cls) -> int: ...
     |         ------------------------- `Parent.class_method1` defined here
- 20 |     @staticmethod
- 21 |     def static_method1() -> int: ...
     |
 info: `LiskovViolatingButNotOverrideViolating.class_method1` is a staticmethod but `Parent.class_method1` is a classmethod
 info: This violates the Liskov Substitution Principle
@@ -357,18 +325,13 @@ info: This violates the Liskov Substitution Principle
 error[invalid-explicit-override]: Method `bar` is decorated with `@override` but does not override anything
    --> src/mdtest_snippet.pyi:174:9
     |
-172 |     @identity
-173 |     @identity
 174 |     def bar(self): ...  # error: [invalid-explicit-override]
     |         ^^^
     |
    ::: src/mdtest_snippet.pyi:155:5
     |
-154 | class Foo:
 155 |     @override
     |     ---------
-156 |     @identity
-157 |     @identity
     |
 info: No `bar` definitions were found on any superclasses of `Foo`
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/paramspec.md_-_Legacy_`ParamSpec`_-_Validating_`ParamSpe…_(648be2a43987ffd8).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/paramspec.md_-_Legacy_`ParamSpec`_-_Validating_`ParamSpe…_(648be2a43987ffd8).snap
@@ -106,12 +106,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspe
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/main.py:24:9
    |
-22 | def invalid(
-23 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 24 |     a1: P,
    |         ^
-25 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
-26 |     a3: Callable[[P], int],
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -126,12 +122,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/main.py:26:19
    |
-24 |     a1: P,
-25 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 26 |     a3: Callable[[P], int],
    |                   ^
-27 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
-28 |     a4: Callable[..., P],
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -146,12 +138,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/main.py:28:23
    |
-26 |     a3: Callable[[P], int],
-27 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 28 |     a4: Callable[..., P],
    |                       ^
-29 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
-30 |     a5: Callable[Concatenate[P, ...], int],
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -166,12 +154,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/main.py:30:30
    |
-28 |     a4: Callable[..., P],
-29 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 30 |     a5: Callable[Concatenate[P, ...], int],
    |                              ^
-31 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
-32 |     a6: P | int,
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -186,12 +170,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/main.py:32:9
    |
-30 |     a5: Callable[Concatenate[P, ...], int],
-31 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 32 |     a6: P | int,
    |         ^
-33 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
-34 |     a7: Union[P, int],
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -206,12 +186,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/main.py:34:15
    |
-32 |     a6: P | int,
-33 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 34 |     a7: Union[P, int],
    |               ^
-35 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
-36 |     a8: Optional[P],
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -226,12 +202,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/main.py:36:18
    |
-34 |     a7: Union[P, int],
-35 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 36 |     a8: Optional[P],
    |                  ^
-37 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
-38 |     a9: Annotated[P, "metadata"],
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -246,12 +218,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/main.py:38:19
    |
-36 |     a8: Optional[P],
-37 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 38 |     a9: Annotated[P, "metadata"],
    |                   ^
-39 |     # error: [invalid-type-form] "The first argument to `Callable` must be either a list of types, ParamSpec, Concatenate, or `...`"
-40 |     a10: Callable["[int, str]", str],
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -266,12 +234,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: The first argument to `Callable` must be either a list of types, ParamSpec, Concatenate, or `...`
   --> src/main.py:40:19
    |
-38 |     a9: Annotated[P, "metadata"],
-39 |     # error: [invalid-type-form] "The first argument to `Callable` must be either a list of types, ParamSpec, Concatenate, or `...`"
 40 |     a10: Callable["[int, str]", str],
    |                   ^^^^^^^^^^^^
-41 |     # error: [invalid-type-form] "The first argument to `Callable` must be either a list of types, ParamSpec, Concatenate, or `...`"
-42 |     a11: Callable["...", int],
    |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -282,11 +246,8 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 error[invalid-type-form]: The first argument to `Callable` must be either a list of types, ParamSpec, Concatenate, or `...`
   --> src/main.py:42:19
    |
-40 |     a10: Callable["[int, str]", str],
-41 |     # error: [invalid-type-form] "The first argument to `Callable` must be either a list of types, ParamSpec, Concatenate, or `...`"
 42 |     a11: Callable["...", int],
    |                   ^^^^^
-43 | ) -> None: ...
    |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -297,10 +258,8 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a return type annotation
   --> src/main.py:46:25
    |
-45 | # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 46 | def invalid_return() -> P:
    |                         ^
-47 |     raise NotImplementedError
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -315,12 +274,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a type expression
   --> src/main.py:51:8
    |
-49 | def invalid_variable_annotation(y: Any) -> None:
-50 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 51 |     x: P = y
    |        ^
-52 |
-53 | def invalid_with_qualifier(y: Any) -> None:
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -335,12 +290,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a type expression
   --> src/main.py:55:14
    |
-53 | def invalid_with_qualifier(y: Any) -> None:
-54 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 55 |     x: Final[P] = y
    |              ^
-56 |
-57 | # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -355,10 +306,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a return type annotation
   --> src/main.py:58:38
    |
-57 | # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 58 | def invalid_stringified_return() -> "P":
    |                                      ^
-59 |     raise NotImplementedError
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -373,12 +322,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/main.py:63:9
    |
-61 | def invalid_stringified_annotation(
-62 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 63 |     a: "P",
    |         ^
-64 | ) -> None: ...
-65 | def invalid_stringified_variable_annotation(y: Any) -> None:
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -393,12 +338,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a type expression
   --> src/main.py:67:9
    |
-65 | def invalid_stringified_variable_annotation(y: Any) -> None:
-66 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 67 |     x: "P" = y
    |         ^
-68 |
-69 | class InvalidSpecializationTarget(Generic[P]):
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -413,12 +354,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `Q` is not valid in this context in a parameter annotation
   --> src/main.py:74:37
    |
-72 | def invalid_specialization(
-73 |     # error: [invalid-type-form] "Bare ParamSpec `Q` is not valid in this context"
 74 |     a: InvalidSpecializationTarget[[Q]],
    |                                     ^
-75 |     # error: [invalid-type-form] "Bare ParamSpec `Q` is not valid in this context"
-76 |     b: InvalidSpecializationTarget[Q,],
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -433,11 +370,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `Q` is not valid in this context in a parameter annotation
   --> src/main.py:76:36
    |
-74 |     a: InvalidSpecializationTarget[[Q]],
-75 |     # error: [invalid-type-form] "Bare ParamSpec `Q` is not valid in this context"
 76 |     b: InvalidSpecializationTarget[Q,],
    |                                    ^
-77 | ) -> None: ...
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/paramspec.md_-_Legacy_`ParamSpec`_-_`ParamSpec`_cannot_s…_(c9dbdc7b13b704a4).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/paramspec.md_-_Legacy_`ParamSpec`_-_`ParamSpec`_cannot_s…_(c9dbdc7b13b704a4).snap
@@ -47,23 +47,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspe
 error[invalid-type-arguments]: ParamSpec `P` cannot be used to specialize type variable `T`
   --> src/mdtest_snippet.py:11:20
    |
- 9 | def func(c: Callable[P, None]):
-10 |     # error: [invalid-type-arguments] "ParamSpec `P` cannot be used to specialize type variable `T`"
 11 |     a: OnlyTypeVar[P]
    |                    ^
-12 |
-13 | class OnlyParamSpec(Generic[P]):
    |
   ::: src/mdtest_snippet.py:3:1
    |
- 1 | from typing import Generic, Callable, TypeVar, ParamSpec
- 2 |
  3 | T = TypeVar("T")
    | - Type variable `T` defined here
  4 | P = ParamSpec("P")
    | - ParamSpec `P` defined here
- 5 |
- 6 | class OnlyTypeVar(Generic[T]):
    |
 
 ```
@@ -72,7 +64,6 @@ error[invalid-type-arguments]: ParamSpec `P` cannot be used to specialize type v
 error[invalid-type-arguments]: Type argument for `ParamSpec` must be either a list of types, `ParamSpec`, `Concatenate`, or `...`
   --> src/mdtest_snippet.py:26:34
    |
-25 | # error: [invalid-type-arguments] "Type argument for `ParamSpec` must be either a list of types, `ParamSpec`, `Concatenate`, or `...`"
 26 | def func3(c: ParamSpecAndTypeVar[T, int], other: T): ...
    |                                  ^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/paramspec.md_-_PEP_695_`ParamSpec`_-_Validating_`ParamSpe…_(327594c6dacd8ad).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/paramspec.md_-_PEP_695_`ParamSpec`_-_Validating_`ParamSpe…_(327594c6dacd8ad).snap
@@ -84,12 +84,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspe
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/mdtest_snippet.py:11:9
    |
- 9 | def invalid[**P](
-10 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 11 |     a1: P,
    |         ^
-12 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
-13 |     a3: Callable[[P], int],
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -104,12 +100,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/mdtest_snippet.py:13:19
    |
-11 |     a1: P,
-12 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 13 |     a3: Callable[[P], int],
    |                   ^
-14 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
-15 |     a4: Callable[..., P],
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -124,12 +116,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/mdtest_snippet.py:15:23
    |
-13 |     a3: Callable[[P], int],
-14 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 15 |     a4: Callable[..., P],
    |                       ^
-16 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
-17 |     a5: Callable[Concatenate[P, ...], int],
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -144,12 +132,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/mdtest_snippet.py:17:30
    |
-15 |     a4: Callable[..., P],
-16 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 17 |     a5: Callable[Concatenate[P, ...], int],
    |                              ^
-18 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
-19 |     a6: P | int,
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -164,12 +148,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/mdtest_snippet.py:19:9
    |
-17 |     a5: Callable[Concatenate[P, ...], int],
-18 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 19 |     a6: P | int,
    |         ^
-20 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
-21 |     a7: Union[P, int],
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -184,12 +164,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/mdtest_snippet.py:21:15
    |
-19 |     a6: P | int,
-20 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 21 |     a7: Union[P, int],
    |               ^
-22 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
-23 |     a8: Optional[P],
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -204,12 +180,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/mdtest_snippet.py:23:18
    |
-21 |     a7: Union[P, int],
-22 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 23 |     a8: Optional[P],
    |                  ^
-24 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
-25 |     a9: Annotated[P, "metadata"],
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -224,11 +196,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/mdtest_snippet.py:25:19
    |
-23 |     a8: Optional[P],
-24 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 25 |     a9: Annotated[P, "metadata"],
    |                   ^
-26 | ) -> None: ...
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -243,10 +212,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a return type annotation
   --> src/mdtest_snippet.py:29:30
    |
-28 | # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 29 | def invalid_return[**P]() -> P:
    |                              ^
-30 |     raise NotImplementedError
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -261,11 +228,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a type alias value
   --> src/mdtest_snippet.py:33:19
    |
-32 | # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 33 | type Alias[**P] = P
    |                   ^
-34 |
-35 | def invalid_variable_annotation[**P](y: Any) -> None:
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -280,12 +244,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a type expression
   --> src/mdtest_snippet.py:37:8
    |
-35 | def invalid_variable_annotation[**P](y: Any) -> None:
-36 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 37 |     x: P = y
    |        ^
-38 |
-39 | def invalid_with_qualifier[**P](y: Any) -> None:
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -300,12 +260,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a type expression
   --> src/mdtest_snippet.py:41:14
    |
-39 | def invalid_with_qualifier[**P](y: Any) -> None:
-40 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 41 |     x: Final[P] = y
    |              ^
-42 |
-43 | # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -320,10 +276,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a return type annotation
   --> src/mdtest_snippet.py:44:43
    |
-43 | # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 44 | def invalid_stringified_return[**P]() -> "P":
    |                                           ^
-45 |     raise NotImplementedError
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -338,12 +292,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a parameter annotation
   --> src/mdtest_snippet.py:49:9
    |
-47 | def invalid_stringified_annotation[**P](
-48 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 49 |     a: "P",
    |         ^
-50 | ) -> None: ...
-51 | def invalid_stringified_variable_annotation[**P](y: Any) -> None:
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -358,12 +308,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `P` is not valid in this context in a type expression
   --> src/mdtest_snippet.py:53:9
    |
-51 | def invalid_stringified_variable_annotation[**P](y: Any) -> None:
-52 |     # error: [invalid-type-form] "Bare ParamSpec `P` is not valid in this context"
 53 |     x: "P" = y
    |         ^
-54 |
-55 | class InvalidSpecializationTarget[**P]:
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -378,12 +324,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `Q` is not valid in this context in a parameter annotation
   --> src/mdtest_snippet.py:60:37
    |
-58 | def invalid_specialization[**Q](
-59 |     # error: [invalid-type-form] "Bare ParamSpec `Q` is not valid in this context"
 60 |     a: InvalidSpecializationTarget[[Q]],
    |                                     ^
-61 |     # error: [invalid-type-form] "Bare ParamSpec `Q` is not valid in this context"
-62 |     b: InvalidSpecializationTarget[Q,],
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`
@@ -398,11 +340,8 @@ info:  - or as part of an argument list when specializing a generic class
 error[invalid-type-form]: Bare ParamSpec `Q` is not valid in this context in a parameter annotation
   --> src/mdtest_snippet.py:62:36
    |
-60 |     a: InvalidSpecializationTarget[[Q]],
-61 |     # error: [invalid-type-form] "Bare ParamSpec `Q` is not valid in this context"
 62 |     b: InvalidSpecializationTarget[Q,],
    |                                    ^
-63 | ) -> None: ...
    |
 info: A bare ParamSpec is only valid:
 info:  - as the first argument to `Callable`

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/paramspec.md_-_PEP_695_`ParamSpec`_-_`ParamSpec`_cannot_s…_(8243f67799c93e3c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/paramspec.md_-_PEP_695_`ParamSpec`_-_`ParamSpec`_cannot_s…_(8243f67799c93e3c).snap
@@ -48,25 +48,20 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspe
 
 ```
 error[invalid-type-arguments]: ParamSpec `P` cannot be used to specialize type variable `T`
-  --> src/mdtest_snippet.py:9:9
+  --> src/mdtest_snippet.py:11:20
    |
- 7 |     attr: Callable[P, T]
- 8 |
- 9 | def f[**P, T]():
-   |         - ParamSpec `P` defined here
-10 |     # error: [invalid-type-arguments] "ParamSpec `P` cannot be used to specialize type variable `T`"
 11 |     a: OnlyTypeVar[P]
    |                    ^
-12 |
-13 |     # error: [invalid-type-arguments] "ParamSpec `P` cannot be used to specialize type variable `T`"
    |
   ::: src/mdtest_snippet.py:3:19
    |
- 1 | from typing import Callable
- 2 |
  3 | class OnlyTypeVar[T]:
    |                   - Type variable `T` defined here
- 4 |     attr: T
+   |
+  ::: src/mdtest_snippet.py:9:9
+   |
+ 9 | def f[**P, T]():
+   |         - ParamSpec `P` defined here
    |
 
 ```
@@ -75,24 +70,18 @@ error[invalid-type-arguments]: ParamSpec `P` cannot be used to specialize type v
 error[invalid-type-arguments]: ParamSpec `P` cannot be used to specialize type variable `T`
   --> src/mdtest_snippet.py:14:28
    |
-13 |     # error: [invalid-type-arguments] "ParamSpec `P` cannot be used to specialize type variable `T`"
 14 |     b: TypeVarAndParamSpec[P, [int]]
    |                            ^
-15 |
-16 | class OnlyParamSpec[**P]:
    |
   ::: src/mdtest_snippet.py:6:27
    |
- 4 |     attr: T
- 5 |
  6 | class TypeVarAndParamSpec[T, **P]:
    |                           - Type variable `T` defined here
- 7 |     attr: Callable[P, T]
- 8 |
+   |
+  ::: src/mdtest_snippet.py:9:9
+   |
  9 | def f[**P, T]():
    |         - ParamSpec `P` defined here
-10 |     # error: [invalid-type-arguments] "ParamSpec `P` cannot be used to specialize type variable `T`"
-11 |     a: OnlyTypeVar[P]
    |
 
 ```
@@ -101,7 +90,6 @@ error[invalid-type-arguments]: ParamSpec `P` cannot be used to specialize type v
 error[invalid-type-arguments]: Type argument for `ParamSpec` must be either a list of types, `ParamSpec`, `Concatenate`, or `...`
   --> src/mdtest_snippet.py:29:37
    |
-28 | # error: [invalid-type-arguments] "Type argument for `ParamSpec` must be either a list of types, `ParamSpec`, `Concatenate`, or `...`"
 29 | def func3[T](c: ParamSpecAndTypeVar[T, int], other: T): ...
    |                                     ^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/paramspec_subcall_er…_-_`ParamSpec`_error_lo…_-_Functions_(1249b2f4f6837bd8).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/paramspec_subcall_er…_-_`ParamSpec`_error_lo…_-_Functions_(1249b2f4f6837bd8).snap
@@ -47,69 +47,48 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_
 
 ```
 error[invalid-argument-type]: Argument to function `foo` is incorrect
-  --> src/mdtest_snippet.py:9:10
-   |
- 7 | # error: [invalid-argument-type]
- 8 | # error: [unknown-argument]
- 9 | foo(fn1, "a", 2, c="c", unknown=1)
-   |          ^^^ Expected `int`, found `Literal["a"]`
-10 |
-11 | def fn2(a: int) -> None: ...
-   |
+ --> src/mdtest_snippet.py:9:10
+  |
+9 | foo(fn1, "a", 2, c="c", unknown=1)
+  |          ^^^ Expected `int`, found `Literal["a"]`
+  |
 info: Function defined here
  --> src/mdtest_snippet.py:3:5
   |
-1 | from typing import Callable
-2 |
 3 | def foo[**P, T](fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs): ...
   |     ^^^         ------------------ Parameter declared here
-4 | def fn1(a: int, b: int, c: int) -> None: ...
   |
 
 ```
 
 ```
 error[invalid-argument-type]: Argument to function `foo` is incorrect
-  --> src/mdtest_snippet.py:9:18
-   |
- 7 | # error: [invalid-argument-type]
- 8 | # error: [unknown-argument]
- 9 | foo(fn1, "a", 2, c="c", unknown=1)
-   |                  ^^^^^ Expected `int`, found `Literal["c"]`
-10 |
-11 | def fn2(a: int) -> None: ...
-   |
+ --> src/mdtest_snippet.py:9:18
+  |
+9 | foo(fn1, "a", 2, c="c", unknown=1)
+  |                  ^^^^^ Expected `int`, found `Literal["c"]`
+  |
 info: Function defined here
  --> src/mdtest_snippet.py:3:5
   |
-1 | from typing import Callable
-2 |
 3 | def foo[**P, T](fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs): ...
   |     ^^^                                            ------------------ Parameter declared here
-4 | def fn1(a: int, b: int, c: int) -> None: ...
   |
 
 ```
 
 ```
 error[unknown-argument]: Argument `unknown` does not match any known parameter of function `foo`
-  --> src/mdtest_snippet.py:9:25
-   |
- 7 | # error: [invalid-argument-type]
- 8 | # error: [unknown-argument]
- 9 | foo(fn1, "a", 2, c="c", unknown=1)
-   |                         ^^^^^^^^^
-10 |
-11 | def fn2(a: int) -> None: ...
-   |
+ --> src/mdtest_snippet.py:9:25
+  |
+9 | foo(fn1, "a", 2, c="c", unknown=1)
+  |                         ^^^^^^^^^
+  |
 info: Function signature here
  --> src/mdtest_snippet.py:3:5
   |
-1 | from typing import Callable
-2 |
 3 | def foo[**P, T](fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs): ...
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-4 | def fn1(a: int, b: int, c: int) -> None: ...
   |
 
 ```
@@ -118,20 +97,14 @@ info: Function signature here
 error[too-many-positional-arguments]: Too many positional arguments to function `foo`: expected 1, got 3
   --> src/mdtest_snippet.py:14:13
    |
-13 | # error: [too-many-positional-arguments]
 14 | foo(fn2, 1, 2, 3)
    |             ^
-15 |
-16 | def fn3(a: int, /) -> None: ...
    |
 info: Function signature here
  --> src/mdtest_snippet.py:3:5
   |
-1 | from typing import Callable
-2 |
 3 | def foo[**P, T](fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs): ...
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-4 | def fn1(a: int, b: int, c: int) -> None: ...
   |
 
 ```
@@ -140,20 +113,14 @@ info: Function signature here
 error[positional-only-parameter-as-kwarg]: Positional-only parameter 1 (`a`) passed as keyword argument of function `foo`
   --> src/mdtest_snippet.py:19:10
    |
-18 | # error: [positional-only-parameter-as-kwarg]
 19 | foo(fn3, a=1)
    |          ^^^
-20 |
-21 | def fn4(a: int, b: int) -> None: ...
    |
 info: Function signature here
  --> src/mdtest_snippet.py:3:5
   |
-1 | from typing import Callable
-2 |
 3 | def foo[**P, T](fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs): ...
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-4 | def fn1(a: int, b: int, c: int) -> None: ...
   |
 
 ```
@@ -162,21 +129,14 @@ info: Function signature here
 error[missing-argument]: No argument provided for required parameter `b` of function `foo`
   --> src/mdtest_snippet.py:25:1
    |
-23 | # error: [parameter-already-assigned]
-24 | # error: [missing-argument]
 25 | foo(fn4, 1, a=2)
    | ^^^^^^^^^^^^^^^^
-26 |
-27 | # error: [missing-argument]
    |
 info: Parameter declared here
  --> src/mdtest_snippet.py:3:37
   |
-1 | from typing import Callable
-2 |
 3 | def foo[**P, T](fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs): ...
   |                                     ^^^^^^^^^^^^^
-4 | def fn1(a: int, b: int, c: int) -> None: ...
   |
 
 ```
@@ -185,12 +145,8 @@ info: Parameter declared here
 error[parameter-already-assigned]: Multiple values provided for parameter `a` of function `foo`
   --> src/mdtest_snippet.py:25:13
    |
-23 | # error: [parameter-already-assigned]
-24 | # error: [missing-argument]
 25 | foo(fn4, 1, a=2)
    |             ^^^
-26 |
-27 | # error: [missing-argument]
    |
 
 ```
@@ -199,18 +155,14 @@ error[parameter-already-assigned]: Multiple values provided for parameter `a` of
 error[missing-argument]: No arguments provided for required parameters `a`, `b` of function `foo`
   --> src/mdtest_snippet.py:28:1
    |
-27 | # error: [missing-argument]
 28 | foo(fn4)
    | ^^^^^^^^
    |
 info: Parameters declared here
  --> src/mdtest_snippet.py:3:16
   |
-1 | from typing import Callable
-2 |
 3 | def foo[**P, T](fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs): ...
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-4 | def fn1(a: int, b: int, c: int) -> None: ...
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/paramspec_subcall_er…_-_`ParamSpec`_error_lo…_-_Methods_(47b1586cd7a6d124).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/paramspec_subcall_er…_-_`ParamSpec`_error_lo…_-_Methods_(47b1586cd7a6d124).snap
@@ -34,19 +34,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_
 error[invalid-argument-type]: Argument to bound method `method` is incorrect
   --> src/mdtest_snippet.py:13:17
    |
-11 | # error: [invalid-argument-type]
-12 | # error: [unknown-argument]
 13 | foo.method(fn1, "a", 2, c="c", unknown=1)
    |                 ^^^ Expected `int`, found `Literal["a"]`
    |
 info: Method defined here
  --> src/mdtest_snippet.py:4:9
   |
-3 | class Foo:
 4 |     def method[**P, T](self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs): ...
   |         ^^^^^^         ---- Parameter declared here
-5 |
-6 | def fn1(a: int, b: int, c: int) -> None: ...
   |
 
 ```
@@ -55,19 +50,14 @@ info: Method defined here
 error[invalid-argument-type]: Argument to bound method `method` is incorrect
   --> src/mdtest_snippet.py:13:25
    |
-11 | # error: [invalid-argument-type]
-12 | # error: [unknown-argument]
 13 | foo.method(fn1, "a", 2, c="c", unknown=1)
    |                         ^^^^^ Expected `int`, found `Literal["c"]`
    |
 info: Method defined here
  --> src/mdtest_snippet.py:4:9
   |
-3 | class Foo:
 4 |     def method[**P, T](self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs): ...
   |         ^^^^^^                                   ------------- Parameter declared here
-5 |
-6 | def fn1(a: int, b: int, c: int) -> None: ...
   |
 
 ```
@@ -76,19 +66,14 @@ info: Method defined here
 error[unknown-argument]: Argument `unknown` does not match any known parameter of bound method `method`
   --> src/mdtest_snippet.py:13:32
    |
-11 | # error: [invalid-argument-type]
-12 | # error: [unknown-argument]
 13 | foo.method(fn1, "a", 2, c="c", unknown=1)
    |                                ^^^^^^^^^
    |
 info: Method signature here
  --> src/mdtest_snippet.py:4:9
   |
-3 | class Foo:
 4 |     def method[**P, T](self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs): ...
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-5 |
-6 | def fn1(a: int, b: int, c: int) -> None: ...
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/pep695_type_aliases.…_-_PEP_695_type_aliases_-_Stringified_values_(5d8e1185129f8ae4).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/pep695_type_aliases.…_-_PEP_695_type_aliases_-_Stringified_values_(5d8e1185129f8ae4).snap
@@ -30,15 +30,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
 error[unsupported-operator]: Unsupported `|` operation
  --> src/mdtest_snippet.py:6:10
   |
-4 |     reveal_type(obj)  # revealed: int | str
-5 | # error: [unsupported-operator]
 6 | type Y = "int" | str
   |          -----^^^---
   |          |       |
   |          |       Has type `<class 'str'>`
   |          Has type `Literal["int"]`
-7 |
-8 | def g(obj: Y):
   |
 info: A type alias scope is lazy but will be executed at runtime if the `__value__` property is accessed
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_cl…_(288988036f34ddcf).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_cl…_(288988036f34ddcf).snap
@@ -46,11 +46,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 error[call-non-callable]: Object of type `<special-form 'typing.Protocol'>` is not callable
  --> src/mdtest_snippet.py:4:13
   |
-3 | # error: [call-non-callable]
 4 | reveal_type(Protocol())  # revealed: Unknown
   |             ^^^^^^^^^^
-5 |
-6 | class MyProtocol(Protocol):
   |
 
 ```
@@ -59,20 +56,14 @@ error[call-non-callable]: Object of type `<special-form 'typing.Protocol'>` is n
 error[call-non-callable]: Cannot instantiate class `MyProtocol`
   --> src/mdtest_snippet.py:10:13
    |
- 9 | # error: [call-non-callable] "Cannot instantiate class `MyProtocol`"
 10 | reveal_type(MyProtocol())  # revealed: MyProtocol
    |             ^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-11 |
-12 | class GenericProtocol[T](Protocol):
    |
 info: Protocol classes cannot be instantiated
  --> src/mdtest_snippet.py:6:7
   |
-4 | reveal_type(Protocol())  # revealed: Unknown
-5 |
 6 | class MyProtocol(Protocol):
   |       ^^^^^^^^^^^^^^^^^^^^ `MyProtocol` declared as a protocol here
-7 |     x: int
   |
 
 ```
@@ -81,19 +72,14 @@ info: Protocol classes cannot be instantiated
 error[call-non-callable]: Cannot instantiate class `GenericProtocol`
   --> src/mdtest_snippet.py:16:13
    |
-15 | # error: [call-non-callable] "Cannot instantiate class `GenericProtocol`"
 16 | reveal_type(GenericProtocol[int]())  # revealed: GenericProtocol[int]
    |             ^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-17 | class SubclassOfMyProtocol(MyProtocol): ...
    |
 info: Protocol classes cannot be instantiated
   --> src/mdtest_snippet.py:12:7
    |
-10 | reveal_type(MyProtocol())  # revealed: MyProtocol
-11 |
 12 | class GenericProtocol[T](Protocol):
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `GenericProtocol` declared as a protocol here
-13 |     x: T
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Diagnostics_and_auto…_(310665856cfe2424).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Diagnostics_and_auto…_(310665856cfe2424).snap
@@ -53,12 +53,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 error[invalid-generic-class]: Cannot both inherit from subscripted `Protocol` and subscripted `Generic`
  --> src/mdtest_snippet.py:5:11
   |
-3 | T = TypeVar("T")
-4 |
 5 | class Foo(Protocol[T], Generic[T]): ...  # error: [invalid-generic-class]
   |           ^^^^^^^^^^^
-6 |
-7 | # fmt: off
   |
 help: Remove the type parameters from the `Protocol` base
 2 |
@@ -77,14 +73,11 @@ note: This is an unsafe fix and may change runtime behavior
 error[invalid-generic-class]: Cannot both inherit from subscripted `Protocol` and subscripted `Generic`
   --> src/mdtest_snippet.py:10:11
    |
- 9 |   # error: [invalid-generic-class]
 10 |   class Bar(Protocol[
    |  ___________^
 11 | |   T,
 12 | | ], Generic[T]): ...
    | |_^
-13 |
-14 |   class Spam(  # docs
    |
 help: Remove the type parameters from the `Protocol` base
 7  | # fmt: off
@@ -105,16 +98,12 @@ note: This is an unsafe fix and may change runtime behavior
 error[invalid-generic-class]: Cannot both inherit from subscripted `Protocol` and subscripted `Generic`
   --> src/mdtest_snippet.py:16:3
    |
-14 |   class Spam(  # docs
-15 |     # error: [invalid-generic-class]
 16 | /   Protocol[  # some comment
 17 | |     # another comment
 18 | |     T,  # just love my comments
 19 | |     # very well documented code
 20 | | ],  # important comma!
    | |_^
-21 |     # and a newline...
-22 |     Generic[  # look at this
    |
 help: Remove the type parameters from the `Protocol` base
 13 |
@@ -137,8 +126,6 @@ note: This is an unsafe fix and may change runtime behavior
 error[invalid-generic-class]: Cannot both inherit from subscripted `Protocol` and use PEP 695 type variables
   --> src/mdtest_snippet.py:32:14
    |
-30 | # fmt: on
-31 |
 32 | class Foo[T](Protocol[T]): ...  # error: [invalid-generic-class]
    |              ^^^^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Diagnostics_for_prot…_(585a3e9545d41b64).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Diagnostics_for_prot…_(585a3e9545d41b64).snap
@@ -66,21 +66,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 warning[ambiguous-protocol-member]: Cannot assign to undeclared variable in the body of a protocol class
   --> src/a.py:12:5
    |
-11 |     # error: [ambiguous-protocol-member]
 12 |     a = None  # type: int
    |     ^^^^^^^^ Consider adding an annotation for `a`
-13 |     # error: [ambiguous-protocol-member]
-14 |     b = ...  # type: str
    |
 info: Assigning to an undeclared variable in a protocol class leads to an ambiguous interface
  --> src/a.py:6:7
   |
-4 |     return True
-5 |
 6 | class A(Protocol):
   |       ^^^^^^^^^^^ `A` declared as a protocol here
-7 |     # The `x` and `y` members attempt to use Python-2-style type comments
-8 |     # to indicate that the type should be `int | None` and `str` respectively,
   |
 info: No declarations found for `a` in the body of `A` or any of its superclasses
 
@@ -90,22 +83,14 @@ info: No declarations found for `a` in the body of `A` or any of its superclasse
 warning[ambiguous-protocol-member]: Cannot assign to undeclared variable in the body of a protocol class
   --> src/a.py:14:5
    |
-12 |     a = None  # type: int
-13 |     # error: [ambiguous-protocol-member]
 14 |     b = ...  # type: str
    |     ^^^^^^^ Consider adding an annotation for `b`
-15 |
-16 |     if coinflip():
    |
 info: Assigning to an undeclared variable in a protocol class leads to an ambiguous interface
  --> src/a.py:6:7
   |
-4 |     return True
-5 |
 6 | class A(Protocol):
   |       ^^^^^^^^^^^ `A` declared as a protocol here
-7 |     # The `x` and `y` members attempt to use Python-2-style type comments
-8 |     # to indicate that the type should be `int | None` and `str` respectively,
   |
 info: No declarations found for `b` in the body of `A` or any of its superclasses
 
@@ -115,21 +100,14 @@ info: No declarations found for `b` in the body of `A` or any of its superclasse
 warning[ambiguous-protocol-member]: Cannot assign to undeclared variable in the body of a protocol class
   --> src/a.py:17:9
    |
-16 |     if coinflip():
 17 |         c = 1  # error: [ambiguous-protocol-member]
    |         ^^^^^ Consider adding an annotation, e.g. `c: int = ...`
-18 |     else:
-19 |         c = 2
    |
 info: Assigning to an undeclared variable in a protocol class leads to an ambiguous interface
  --> src/a.py:6:7
   |
-4 |     return True
-5 |
 6 | class A(Protocol):
   |       ^^^^^^^^^^^ `A` declared as a protocol here
-7 |     # The `x` and `y` members attempt to use Python-2-style type comments
-8 |     # to indicate that the type should be `int | None` and `str` respectively,
   |
 info: No declarations found for `c` in the body of `A` or any of its superclasses
 
@@ -139,20 +117,14 @@ info: No declarations found for `c` in the body of `A` or any of its superclasse
 warning[ambiguous-protocol-member]: Cannot assign to undeclared variable in the body of a protocol class
   --> src/a.py:22:9
    |
-21 |     # error: [ambiguous-protocol-member]
 22 |     for d in range(42):
    |         ^ `d` is not declared as a protocol member
-23 |         pass
    |
 info: Assigning to an undeclared variable in a protocol class leads to an ambiguous interface
  --> src/a.py:6:7
   |
-4 |     return True
-5 |
 6 | class A(Protocol):
   |       ^^^^^^^^^^^ `A` declared as a protocol here
-7 |     # The `x` and `y` members attempt to use Python-2-style type comments
-8 |     # to indicate that the type should be `int | None` and `str` respectively,
   |
 info: No declarations found for `d` in the body of `A` or any of its superclasses
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Invalid_calls_to_`ge…_(3d0c4ee818c4d8d5).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Invalid_calls_to_`ge…_(3d0c4ee818c4d8d5).snap
@@ -33,23 +33,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 error[invalid-argument-type]: Invalid argument to `get_protocol_members`
  --> src/mdtest_snippet.py:5:1
   |
-3 | class NotAProtocol: ...
-4 |
 5 | get_protocol_members(NotAProtocol)  # error: [invalid-argument-type]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-6 |
-7 | class AlsoNotAProtocol(NotAProtocol, object): ...
   |
 info: Only protocol classes can be passed to `get_protocol_members`
 info: `NotAProtocol` is declared here, but it is not a protocol class:
  --> src/mdtest_snippet.py:3:7
   |
-1 | from typing_extensions import Protocol, get_protocol_members
-2 |
 3 | class NotAProtocol: ...
   |       ^^^^^^^^^^^^
-4 |
-5 | get_protocol_members(NotAProtocol)  # error: [invalid-argument-type]
   |
 info: A class is only a protocol class if it directly inherits from `typing.Protocol` or `typing_extensions.Protocol`
 info: See https://typing.python.org/en/latest/spec/protocol.html#
@@ -58,24 +50,17 @@ info: See https://typing.python.org/en/latest/spec/protocol.html#
 
 ```
 error[invalid-argument-type]: Invalid argument to `get_protocol_members`
-  --> src/mdtest_snippet.py:9:1
-   |
- 7 | class AlsoNotAProtocol(NotAProtocol, object): ...
- 8 |
- 9 | get_protocol_members(AlsoNotAProtocol)  # error: [invalid-argument-type]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-10 | class GenericProtocol[T](Protocol): ...
-   |
+ --> src/mdtest_snippet.py:9:1
+  |
+9 | get_protocol_members(AlsoNotAProtocol)  # error: [invalid-argument-type]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
+  |
 info: Only protocol classes can be passed to `get_protocol_members`
 info: `AlsoNotAProtocol` is declared here, but it is not a protocol class:
  --> src/mdtest_snippet.py:7:7
   |
-5 | get_protocol_members(NotAProtocol)  # error: [invalid-argument-type]
-6 |
 7 | class AlsoNotAProtocol(NotAProtocol, object): ...
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-8 |
-9 | get_protocol_members(AlsoNotAProtocol)  # error: [invalid-argument-type]
   |
 info: A class is only a protocol class if it directly inherits from `typing.Protocol` or `typing_extensions.Protocol`
 info: See https://typing.python.org/en/latest/spec/protocol.html#

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Match_class_patterns…_(8ae0e231033b78e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Match_class_patterns…_(8ae0e231033b78e).snap
@@ -50,21 +50,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 error[isinstance-against-protocol]: Class `HasX` cannot be used in a class pattern
   --> src/mdtest_snippet.py:12:14
    |
-10 | def match_non_runtime_checkable(arg: object):
-11 |     match arg:
 12 |         case HasX():  # error: [isinstance-against-protocol]
    |              ^^^^ This will raise `TypeError` at runtime
-13 |             reveal_type(arg)  # revealed: HasX
-14 |         case _:
    |
 info: `HasX` is declared as a protocol class, but it is not declared as runtime-checkable
  --> src/mdtest_snippet.py:3:7
   |
-1 | from typing_extensions import Protocol, runtime_checkable
-2 |
 3 | class HasX(Protocol):
   |       ^^^^^^^^^^^^^^ `HasX` declared here
-4 |     x: int
   |
 info: A protocol class can only be used in a match class pattern if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
@@ -75,20 +68,14 @@ info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
 error[isinstance-against-protocol]: Class `HasX` cannot be used in a class pattern
   --> src/mdtest_snippet.py:28:28
    |
-26 | def match_nested_non_runtime_checkable(arg: Wrapper):
-27 |     match arg:
 28 |         case Wrapper(inner=HasX()):  # error: [isinstance-against-protocol]
    |                            ^^^^ This will raise `TypeError` at runtime
-29 |             pass
    |
 info: `HasX` is declared as a protocol class, but it is not declared as runtime-checkable
  --> src/mdtest_snippet.py:3:7
   |
-1 | from typing_extensions import Protocol, runtime_checkable
-2 |
 3 | class HasX(Protocol):
   |       ^^^^^^^^^^^^^^ `HasX` declared here
-4 |     x: int
   |
 info: A protocol class can only be used in a match class pattern if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Narrowing_of_protoco…_(98257e7c2300373).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Narrowing_of_protoco…_(98257e7c2300373).snap
@@ -101,20 +101,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 error[isinstance-against-protocol]: Class `HasX` cannot be used as the second argument to `isinstance`
  --> src/mdtest_snippet.py:7:8
   |
-6 | def f(arg: object, arg2: type):
 7 |     if isinstance(arg, HasX):  # error: [isinstance-against-protocol]
   |        ^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-8 |         reveal_type(arg)  # revealed: HasX
-9 |     else:
   |
 info: `HasX` is declared as a protocol class, but it is not declared as runtime-checkable
  --> src/mdtest_snippet.py:3:7
   |
-1 | from typing_extensions import Protocol
-2 |
 3 | class HasX(Protocol):
   |       ^^^^^^^^^^^^^^ `HasX` declared here
-4 |     x: int
   |
 info: A protocol class can only be used in `isinstance` checks if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
@@ -125,21 +119,14 @@ info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
 error[isinstance-against-protocol]: Class `HasX` cannot be used as the second argument to `issubclass`
   --> src/mdtest_snippet.py:12:8
    |
-10 |         reveal_type(arg)  # revealed: ~HasX
-11 |
 12 |     if issubclass(arg2, HasX):  # error: [isinstance-against-protocol]
    |        ^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-13 |         reveal_type(arg2)  # revealed: type[HasX]
-14 |     else:
    |
 info: `HasX` is declared as a protocol class, but it is not declared as runtime-checkable
  --> src/mdtest_snippet.py:3:7
   |
-1 | from typing_extensions import Protocol
-2 |
 3 | class HasX(Protocol):
   |       ^^^^^^^^^^^^^^ `HasX` declared here
-4 |     x: int
   |
 info: A protocol class can only be used in `issubclass` checks if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
@@ -150,22 +137,14 @@ info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
 error[isinstance-against-protocol]: Class `RuntimeCheckableHasX` cannot be used as the second argument to `issubclass`
   --> src/mdtest_snippet.py:43:8
    |
-41 | def f(arg1: type):
-42 |     # error: [isinstance-against-protocol] "`RuntimeCheckableHasX` cannot be used as the second argument to `issubclass` as it is a pr…
 43 |     if issubclass(arg1, RuntimeCheckableHasX):
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-44 |         reveal_type(arg1)  # revealed: type[RuntimeCheckableHasX]
-45 |     else:
    |
 info: A protocol class cannot be used in `issubclass` checks if it has non-method members
   --> src/mdtest_snippet.py:20:5
    |
-18 | @runtime_checkable
-19 | class RuntimeCheckableHasX(Protocol):
 20 |     x: int
    |     ^ Non-method member `x` declared here
-21 |
-22 | def f(arg: object):
    |
 
 ```
@@ -174,23 +153,15 @@ info: A protocol class cannot be used in `issubclass` checks if it has non-metho
 error[isinstance-against-protocol]: Class `MultipleNonMethodMembers` cannot be used as the second argument to `issubclass`
   --> src/mdtest_snippet.py:48:8
    |
-46 |         reveal_type(arg1)  # revealed: type & ~type[RuntimeCheckableHasX]
-47 |
 48 |     if issubclass(arg1, MultipleNonMethodMembers):  # error: [isinstance-against-protocol]
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-49 |         reveal_type(arg1)  # revealed: type[MultipleNonMethodMembers]
-50 |     else:
    |
 info: A protocol class cannot be used in `issubclass` checks if it has non-method members
 info: `MultipleNonMethodMembers` has non-method members `a` and `b`
   --> src/mdtest_snippet.py:39:5
    |
-37 | class MultipleNonMethodMembers(Protocol):
-38 |     b: int
 39 |     a: int
    |     ^ Non-method member `a` declared here
-40 |
-41 | def f(arg1: type):
    |
 
 ```
@@ -199,20 +170,14 @@ info: `MultipleNonMethodMembers` has non-method members `a` and `b`
 error[isinstance-against-protocol]: Class `HasX` cannot be used as the second argument to `isinstance`
   --> src/mdtest_snippet.py:63:5
    |
-61 |         reveal_type(arg1)  # revealed: type & ~type[OnlyClassmethodMembers]
-62 | def g(arg: object, arg2: type):
 63 |     isinstance(arg, (HasX, RuntimeCheckableHasX))  # error: [isinstance-against-protocol]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-64 |     isinstance(arg, (HasX, int))  # error: [isinstance-against-protocol]
    |
 info: `HasX` is declared as a protocol class, but it is not declared as runtime-checkable
  --> src/mdtest_snippet.py:3:7
   |
-1 | from typing_extensions import Protocol
-2 |
 3 | class HasX(Protocol):
   |       ^^^^^^^^^^^^^^ `HasX` declared here
-4 |     x: int
   |
 info: A protocol class can only be used in `isinstance` checks if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
@@ -223,21 +188,14 @@ info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
 error[isinstance-against-protocol]: Class `HasX` cannot be used as the second argument to `isinstance`
   --> src/mdtest_snippet.py:64:5
    |
-62 | def g(arg: object, arg2: type):
-63 |     isinstance(arg, (HasX, RuntimeCheckableHasX))  # error: [isinstance-against-protocol]
 64 |     isinstance(arg, (HasX, int))  # error: [isinstance-against-protocol]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-65 |
-66 |     # error: [isinstance-against-protocol]
    |
 info: `HasX` is declared as a protocol class, but it is not declared as runtime-checkable
  --> src/mdtest_snippet.py:3:7
   |
-1 | from typing_extensions import Protocol
-2 |
 3 | class HasX(Protocol):
   |       ^^^^^^^^^^^^^^ `HasX` declared here
-4 |     x: int
   |
 info: A protocol class can only be used in `isinstance` checks if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
@@ -248,21 +206,14 @@ info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
 error[isinstance-against-protocol]: Class `HasX` cannot be used as the second argument to `issubclass`
   --> src/mdtest_snippet.py:68:5
    |
-66 |     # error: [isinstance-against-protocol]
-67 |     # error: [isinstance-against-protocol]
 68 |     issubclass(arg2, (HasX, RuntimeCheckableHasX))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-69 |
-70 |     issubclass(arg2, (HasX, OnlyMethodMembers))  # error: [isinstance-against-protocol]
    |
 info: `HasX` is declared as a protocol class, but it is not declared as runtime-checkable
  --> src/mdtest_snippet.py:3:7
   |
-1 | from typing_extensions import Protocol
-2 |
 3 | class HasX(Protocol):
   |       ^^^^^^^^^^^^^^ `HasX` declared here
-4 |     x: int
   |
 info: A protocol class can only be used in `issubclass` checks if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
@@ -273,22 +224,14 @@ info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
 error[isinstance-against-protocol]: Class `RuntimeCheckableHasX` cannot be used as the second argument to `issubclass`
   --> src/mdtest_snippet.py:68:5
    |
-66 |     # error: [isinstance-against-protocol]
-67 |     # error: [isinstance-against-protocol]
 68 |     issubclass(arg2, (HasX, RuntimeCheckableHasX))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-69 |
-70 |     issubclass(arg2, (HasX, OnlyMethodMembers))  # error: [isinstance-against-protocol]
    |
 info: A protocol class cannot be used in `issubclass` checks if it has non-method members
   --> src/mdtest_snippet.py:20:5
    |
-18 | @runtime_checkable
-19 | class RuntimeCheckableHasX(Protocol):
 20 |     x: int
    |     ^ Non-method member `x` declared here
-21 |
-22 | def f(arg: object):
    |
 
 ```
@@ -297,21 +240,14 @@ info: A protocol class cannot be used in `issubclass` checks if it has non-metho
 error[isinstance-against-protocol]: Class `HasX` cannot be used as the second argument to `issubclass`
   --> src/mdtest_snippet.py:70:5
    |
-68 |     issubclass(arg2, (HasX, RuntimeCheckableHasX))
-69 |
 70 |     issubclass(arg2, (HasX, OnlyMethodMembers))  # error: [isinstance-against-protocol]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-71 | def g2(arg: object, arg2: type):
-72 |     isinstance(arg, (int, (HasX, str)))  # error: [isinstance-against-protocol]
    |
 info: `HasX` is declared as a protocol class, but it is not declared as runtime-checkable
  --> src/mdtest_snippet.py:3:7
   |
-1 | from typing_extensions import Protocol
-2 |
 3 | class HasX(Protocol):
   |       ^^^^^^^^^^^^^^ `HasX` declared here
-4 |     x: int
   |
 info: A protocol class can only be used in `issubclass` checks if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
@@ -322,21 +258,14 @@ info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
 error[isinstance-against-protocol]: Class `HasX` cannot be used as the second argument to `isinstance`
   --> src/mdtest_snippet.py:72:5
    |
-70 |     issubclass(arg2, (HasX, OnlyMethodMembers))  # error: [isinstance-against-protocol]
-71 | def g2(arg: object, arg2: type):
 72 |     isinstance(arg, (int, (HasX, str)))  # error: [isinstance-against-protocol]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-73 |
-74 |     # error: [isinstance-against-protocol]
    |
 info: `HasX` is declared as a protocol class, but it is not declared as runtime-checkable
  --> src/mdtest_snippet.py:3:7
   |
-1 | from typing_extensions import Protocol
-2 |
 3 | class HasX(Protocol):
   |       ^^^^^^^^^^^^^^ `HasX` declared here
-4 |     x: int
   |
 info: A protocol class can only be used in `isinstance` checks if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
@@ -347,20 +276,14 @@ info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
 error[isinstance-against-protocol]: Class `HasX` cannot be used as the second argument to `issubclass`
   --> src/mdtest_snippet.py:76:5
    |
-74 |     # error: [isinstance-against-protocol]
-75 |     # error: [isinstance-against-protocol]
 76 |     issubclass(arg2, (int, (HasX, RuntimeCheckableHasX)))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-77 | classes = (HasX, int)
    |
 info: `HasX` is declared as a protocol class, but it is not declared as runtime-checkable
  --> src/mdtest_snippet.py:3:7
   |
-1 | from typing_extensions import Protocol
-2 |
 3 | class HasX(Protocol):
   |       ^^^^^^^^^^^^^^ `HasX` declared here
-4 |     x: int
   |
 info: A protocol class can only be used in `issubclass` checks if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
@@ -371,21 +294,14 @@ info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable
 error[isinstance-against-protocol]: Class `RuntimeCheckableHasX` cannot be used as the second argument to `issubclass`
   --> src/mdtest_snippet.py:76:5
    |
-74 |     # error: [isinstance-against-protocol]
-75 |     # error: [isinstance-against-protocol]
 76 |     issubclass(arg2, (int, (HasX, RuntimeCheckableHasX)))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
-77 | classes = (HasX, int)
    |
 info: A protocol class cannot be used in `issubclass` checks if it has non-method members
   --> src/mdtest_snippet.py:20:5
    |
-18 | @runtime_checkable
-19 | class RuntimeCheckableHasX(Protocol):
 20 |     x: int
    |     ^ Non-method member `x` declared here
-21 |
-22 | def f(arg: object):
    |
 
 ```
@@ -394,18 +310,14 @@ info: A protocol class cannot be used in `issubclass` checks if it has non-metho
 error[isinstance-against-protocol]: Class `HasX` cannot be used as the second argument to `isinstance`
   --> src/mdtest_snippet.py:80:5
    |
-79 | def h(arg: object):
 80 |     isinstance(arg, classes)  # error: [isinstance-against-protocol]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ This call will raise `TypeError` at runtime
    |
 info: `HasX` is declared as a protocol class, but it is not declared as runtime-checkable
  --> src/mdtest_snippet.py:3:7
   |
-1 | from typing_extensions import Protocol
-2 |
 3 | class HasX(Protocol):
   |       ^^^^^^^^^^^^^^ `HasX` declared here
-4 |     x: int
   |
 info: A protocol class can only be used in `isinstance` checks if it is decorated with `@typing.runtime_checkable` or `@typing_extensions.runtime_checkable`
 info: See https://docs.python.org/3/library/typing.html#typing.runtime_checkable

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Protocol_members_in_…_(21be5d9bdab1c844).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Protocol_members_in_…_(21be5d9bdab1c844).snap
@@ -36,21 +36,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 warning[ambiguous-protocol-member]: Cannot assign to undeclared variable in the body of a protocol class
   --> src/mdtest_snippet.py:12:9
    |
-10 |     else:
-11 |         d: int
 12 |         e = 56  # error: [ambiguous-protocol-member]
    |         ^^^^^^ Consider adding an annotation, e.g. `e: int = ...`
-13 |         def f(self) -> None: ...
    |
 info: Assigning to an undeclared variable in a protocol class leads to an ambiguous interface
  --> src/mdtest_snippet.py:4:7
   |
-2 | from typing_extensions import Protocol, get_protocol_members
-3 |
 4 | class Foo(Protocol):
   |       ^^^^^^^^^^^^^ `Foo` declared as a protocol here
-5 |     if sys.version_info >= (3, 10):
-6 |         a: int
   |
 info: No declarations found for `e` in the body of `Foo` or any of its superclasses
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Diagnostics_for_`emp…_(f44e56404a51ca26).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Diagnostics_for_`emp…_(f44e56404a51ca26).snap
@@ -28,7 +28,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 error[empty-body]: Function always implicitly returns `None`, which is not assignable to return type `str`
  --> src/mdtest_snippet.py:7:25
   |
-6 | class Concrete(Abstract):
 7 |     def method(self) -> str: ...  # error: [empty-body]
   |                         ^^^
   |
@@ -42,11 +41,8 @@ info: Class `Concrete` has `typing.Protocol` in its MRO, but it is not a protoco
 info: Only classes that directly inherit from `typing.Protocol` or `typing_extensions.Protocol` are considered protocol classes
  --> src/mdtest_snippet.py:6:7
   |
-4 |     def method(self) -> str: ...
-5 |
 6 | class Concrete(Abstract):
   |       ^^^^^^^^^^^^^^^^^^ `Protocol` not present in `Concrete`'s immediate bases
-7 |     def method(self) -> str: ...  # error: [empty-body]
   |
 info: See https://typing.python.org/en/latest/spec/protocol.html#
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions_-_Asynchronous_(408134055c24a538).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions_-_Asynchronous_(408134055c24a538).snap
@@ -42,11 +42,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 error[invalid-return-type]: Return type does not match returned value
   --> src/mdtest_snippet.py:16:18
    |
-14 |     yield 42
-15 |
 16 | async def j() -> str:  # error: [invalid-return-type]
    |                  ^^^ expected `str`, found `types.AsyncGeneratorType`
-17 |     yield 42
    |
 info: Function is inferred as returning `types.AsyncGeneratorType` because it is an async generator function
 info: See https://docs.python.org/3/glossary.html#term-asynchronous-generator for more details
@@ -57,8 +54,6 @@ info: See https://docs.python.org/3/glossary.html#term-asynchronous-generator fo
 error[invalid-syntax]: `return` with value in async generator
   --> src/mdtest_snippet.py:21:5
    |
-19 | async def k() -> typing.AsyncGenerator:
-20 |     yield 42
 21 |     return 2  # error: [invalid-syntax] "`return` with value in async generator"
    |     ^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions_-_Synchronous_(6a32ec69d15117b8).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions_-_Synchronous_(6a32ec69d15117b8).snap
@@ -57,11 +57,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 error[invalid-return-type]: Return type does not match returned value
   --> src/mdtest_snippet.py:19:12
    |
-17 |     yield from i()
-18 |
 19 | def j() -> str:  # error: [invalid-return-type]
    |            ^^^ expected `str`, found `types.GeneratorType`
-20 |     yield 42
    |
 info: Function is inferred as returning `types.GeneratorType` because it is a generator function
 info: See https://docs.python.org/3/glossary.html#term-generator for more details
@@ -70,34 +67,30 @@ info: See https://docs.python.org/3/glossary.html#term-generator for more detail
 
 ```
 error[invalid-return-type]: Return type does not match returned value
-  --> src/mdtest_snippet.py:22:30
+  --> src/mdtest_snippet.py:24:12
    |
-20 |     yield 42
-21 |
-22 | def invalid_return_type() -> typing.Generator[None, None, None]:
-   |                              ---------------------------------- Expected `None` because of return type
-23 |     yield
 24 |     return ""  # error: [invalid-return-type]
    |            ^^ expected `None`, found `Literal[""]`
-25 | def wrong_return() -> typing.Generator[int, int, int]:
-26 |     yield 1
+   |
+  ::: src/mdtest_snippet.py:22:30
+   |
+22 | def invalid_return_type() -> typing.Generator[None, None, None]:
+   |                              ---------------------------------- Expected `None` because of return type
    |
 
 ```
 
 ```
 error[invalid-return-type]: Return type does not match returned value
-  --> src/mdtest_snippet.py:25:23
+  --> src/mdtest_snippet.py:27:12
    |
-23 |     yield
-24 |     return ""  # error: [invalid-return-type]
-25 | def wrong_return() -> typing.Generator[int, int, int]:
-   |                       ------------------------------- Expected `int` because of return type
-26 |     yield 1
 27 |     return ""  # error: [invalid-return-type]
    |            ^^ expected `int`, found `Literal[""]`
-28 | def bare_return_ok() -> typing.Generator[int, int, None]:
-29 |     yield 1
+   |
+  ::: src/mdtest_snippet.py:25:23
+   |
+25 | def wrong_return() -> typing.Generator[int, int, int]:
+   |                       ------------------------------- Expected `int` because of return type
    |
 
 ```
@@ -106,12 +99,8 @@ error[invalid-return-type]: Return type does not match returned value
 error[invalid-return-type]: Function always implicitly returns `None`, which is not assignable to return type `int`
   --> src/mdtest_snippet.py:31:25
    |
-29 |     yield 1
-30 |
 31 | def missing_return() -> typing.Generator[int, int, int]:  # error: [invalid-return-type]
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-32 |     yield 1
-33 | def iterator_must_not_return() -> typing.Iterator[int]:
    |
 info: Consider changing the return annotation to `-> None` or adding a `return` statement
 
@@ -119,16 +108,15 @@ info: Consider changing the return annotation to `-> None` or adding a `return` 
 
 ```
 error[invalid-return-type]: Return type does not match returned value
-  --> src/mdtest_snippet.py:33:35
+  --> src/mdtest_snippet.py:36:12
    |
-31 | def missing_return() -> typing.Generator[int, int, int]:  # error: [invalid-return-type]
-32 |     yield 1
-33 | def iterator_must_not_return() -> typing.Iterator[int]:
-   |                                   -------------------- Expected `None` because of return type
-34 |     yield 2
-35 |     # error: [invalid-return-type]
 36 |     return "foo"
    |            ^^^^^ expected `None`, found `Literal["foo"]`
+   |
+  ::: src/mdtest_snippet.py:33:35
+   |
+33 | def iterator_must_not_return() -> typing.Iterator[int]:
+   |                                   -------------------- Expected `None` because of return type
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_…_(94c036c5d3803ab2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_…_(94c036c5d3803ab2).snap
@@ -33,36 +33,30 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 
 ```
 error[invalid-return-type]: Return type does not match returned value
- --> src/mdtest_snippet.py:1:22
+ --> src/mdtest_snippet.py:6:16
+  |
+6 |         return 1
+  |                ^ expected `str`, found `Literal[1]`
+  |
+ ::: src/mdtest_snippet.py:1:22
   |
 1 | def f(cond: bool) -> str:
   |                      --- Expected `str` because of return type
-2 |     if cond:
-3 |         return "a"
-4 |     else:
-5 |         # error: [invalid-return-type]
-6 |         return 1
-  |                ^ expected `str`, found `Literal[1]`
-7 |
-8 | def f(cond: bool) -> str:
   |
 
 ```
 
 ```
 error[invalid-return-type]: Return type does not match returned value
-  --> src/mdtest_snippet.py:8:22
+  --> src/mdtest_snippet.py:11:16
    |
- 6 |         return 1
- 7 |
- 8 | def f(cond: bool) -> str:
-   |                      --- Expected `str` because of return type
- 9 |     if cond:
-10 |         # error: [invalid-return-type]
 11 |         return 1
    |                ^ expected `str`, found `Literal[1]`
-12 |     else:
-13 |         # error: [invalid-return-type]
+   |
+  ::: src/mdtest_snippet.py:8:22
+   |
+ 8 | def f(cond: bool) -> str:
+   |                      --- Expected `str` because of return type
    |
 
 ```
@@ -71,19 +65,13 @@ error[invalid-return-type]: Return type does not match returned value
 error[invalid-return-type]: Return type does not match returned value
   --> src/mdtest_snippet.py:14:16
    |
-12 |     else:
-13 |         # error: [invalid-return-type]
 14 |         return 2
    |                ^ expected `str`, found `Literal[2]`
    |
   ::: src/mdtest_snippet.py:8:22
    |
- 6 |         return 1
- 7 |
  8 | def f(cond: bool) -> str:
    |                      --- Expected `str` because of return type
- 9 |     if cond:
-10 |         # error: [invalid-return-type]
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_ret…_(393cb38bf7119649).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_ret…_(393cb38bf7119649).snap
@@ -43,11 +43,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 error[invalid-return-type]: Function can implicitly return `None`, which is not assignable to return type `int`
  --> src/mdtest_snippet.py:6:22
   |
-5 | # error: [invalid-return-type]
 6 | def f(cond: bool) -> int:
   |                      ^^^
-7 |     if cond:
-8 |         return 1
   |
 
 ```
@@ -56,11 +53,8 @@ error[invalid-return-type]: Function can implicitly return `None`, which is not 
 error[invalid-return-type]: Function always implicitly returns `None`, which is not assignable to return type `int`
   --> src/mdtest_snippet.py:11:22
    |
-10 | # error: [invalid-return-type]
 11 | def f(cond: bool) -> int:
    |                      ^^^
-12 |     if cond:
-13 |         raise ValueError()
    |
 info: Consider changing the return annotation to `-> None` or adding a `return` statement
 
@@ -70,11 +64,8 @@ info: Consider changing the return annotation to `-> None` or adding a `return` 
 error[invalid-return-type]: Function can implicitly return `None`, which is not assignable to return type `int`
   --> src/mdtest_snippet.py:16:22
    |
-15 | # error: [invalid-return-type]
 16 | def f(cond: bool) -> int:
    |                      ^^^
-17 |     if cond:
-18 |         cond = False
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_ret…_(3d2d19aa49b28f1c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_implicit_ret…_(3d2d19aa49b28f1c).snap
@@ -24,10 +24,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 error[invalid-return-type]: Function always implicitly returns `None`, which is not assignable to return type `int`
  --> src/mdtest_snippet.py:2:12
   |
-1 | # error: [invalid-return-type]
 2 | def f() -> int:
   |            ^^^
-3 |     print("hello")
   |
 info: Consider changing the return annotation to `-> None` or adding a `return` statement
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_(a91e0c67519cd77f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_(a91e0c67519cd77f).snap
@@ -51,10 +51,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 error[invalid-return-type]: Function always implicitly returns `None`, which is not assignable to return type `int`
  --> src/mdtest_snippet.py:2:12
   |
-1 | # error: [invalid-return-type]
 2 | def f() -> int:
   |            ^^^
-3 |     1
   |
 info: Consider changing the return annotation to `-> None` or adding a `return` statement
 
@@ -62,34 +60,30 @@ info: Consider changing the return annotation to `-> None` or adding a `return` 
 
 ```
 error[invalid-return-type]: Return type does not match returned value
- --> src/mdtest_snippet.py:5:12
+ --> src/mdtest_snippet.py:7:12
   |
-3 |     1
-4 |
-5 | def f() -> str:
-  |            --- Expected `str` because of return type
-6 |     # error: [invalid-return-type]
 7 |     return 1
   |            ^ expected `str`, found `Literal[1]`
-8 |
-9 | def f() -> int:
+  |
+ ::: src/mdtest_snippet.py:5:12
+  |
+5 | def f() -> str:
+  |            --- Expected `str` because of return type
   |
 
 ```
 
 ```
 error[invalid-return-type]: Return type does not match returned value
-  --> src/mdtest_snippet.py:9:12
+  --> src/mdtest_snippet.py:11:5
    |
- 7 |     return 1
- 8 |
- 9 | def f() -> int:
-   |            --- Expected `int` because of return type
-10 |     # error: [invalid-return-type]
 11 |     return
    |     ^^^^^^ expected `int`, found `None`
-12 |
-13 | from typing import TypeVar
+   |
+  ::: src/mdtest_snippet.py:9:12
+   |
+ 9 | def f() -> int:
+   |            --- Expected `int` because of return type
    |
 
 ```
@@ -98,11 +92,8 @@ error[invalid-return-type]: Return type does not match returned value
 error[empty-body]: Function always implicitly returns `None`, which is not assignable to return type `T@m`
   --> src/mdtest_snippet.py:18:16
    |
-17 | # error: [empty-body]
 18 | def m(x: T) -> T: ...
    |                ^
-19 |
-20 | class A[T]: ...
    |
 info: Consider changing the return annotation to `-> None` or adding a `return` statement
 info: Functions with empty bodies and non-`None` return types are only permitted:
@@ -115,32 +106,30 @@ info:  - or as `@abstractmethod`-decorated methods on abstract classes
 
 ```
 error[invalid-return-type]: Return type does not match returned value
-  --> src/mdtest_snippet.py:22:12
+  --> src/mdtest_snippet.py:24:12
    |
-20 | class A[T]: ...
-21 |
-22 | def f() -> A[int]:
-   |            ------ Expected `mdtest_snippet.A[int]` because of return type
-23 |     class A[T]: ...
 24 |     return A[int]()  # error: [invalid-return-type]
    |            ^^^^^^^^ expected `mdtest_snippet.A[int]`, found `mdtest_snippet.<locals of function 'f'>.A[int]`
-25 |
-26 | class B: ...
+   |
+  ::: src/mdtest_snippet.py:22:12
+   |
+22 | def f() -> A[int]:
+   |            ------ Expected `mdtest_snippet.A[int]` because of return type
    |
 
 ```
 
 ```
 error[invalid-return-type]: Return type does not match returned value
-  --> src/mdtest_snippet.py:28:12
+  --> src/mdtest_snippet.py:30:12
    |
-26 | class B: ...
-27 |
-28 | def g() -> B:
-   |            - Expected `mdtest_snippet.B` because of return type
-29 |     class B: ...
 30 |     return B()  # error: [invalid-return-type]
    |            ^^^ expected `mdtest_snippet.B`, found `mdtest_snippet.<locals of function 'g'>.B`
+   |
+  ::: src/mdtest_snippet.py:28:12
+   |
+28 | def g() -> B:
+   |            - Expected `mdtest_snippet.B` because of return type
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_…_(c3a523878447af6b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_…_(c3a523878447af6b).snap
@@ -32,15 +32,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 
 ```
 error[invalid-return-type]: Return type does not match returned value
- --> src/mdtest_snippet.pyi:1:12
+ --> src/mdtest_snippet.pyi:3:12
+  |
+3 |     return ...
+  |            ^^^ expected `int`, found `EllipsisType`
+  |
+ ::: src/mdtest_snippet.pyi:1:12
   |
 1 | def f() -> int:
   |            --- Expected `int` because of return type
-2 |     # error: [invalid-return-type]
-3 |     return ...
-  |            ^^^ expected `int`, found `EllipsisType`
-4 |
-5 | # error: [invalid-return-type]
   |
 
 ```
@@ -49,11 +49,8 @@ error[invalid-return-type]: Return type does not match returned value
 error[invalid-return-type]: Function always implicitly returns `None`, which is not assignable to return type `int`
  --> src/mdtest_snippet.pyi:6:14
   |
-5 | # error: [invalid-return-type]
 6 | def foo() -> int:
   |              ^^^
-7 |     print("...")
-8 |     ...
   |
 info: Consider changing the return annotation to `-> None` or adding a `return` statement
 
@@ -63,11 +60,8 @@ info: Consider changing the return annotation to `-> None` or adding a `return` 
 error[invalid-return-type]: Function always implicitly returns `None`, which is not assignable to return type `int`
   --> src/mdtest_snippet.pyi:11:14
    |
-10 | # error: [invalid-return-type]
 11 | def foo() -> int:
    |              ^^^
-12 |     f"""{foo} is a function that ..."""
-13 |     ...
    |
 info: Consider changing the return annotation to `-> None` or adding a `return` statement
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Com…_-_Chained_comparisons_…_(c391c13e2abc18a0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/rich_comparison.md_-_Comparison___Rich_Com…_-_Chained_comparisons_…_(c391c13e2abc18a0).snap
@@ -37,11 +37,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/instances/ric
 error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
   --> src/mdtest_snippet.py:12:1
    |
-11 | # error: [unsupported-bool-conversion]
 12 | 10 < Comparable() < 20
    | ^^^^^^^^^^^^^^^^^
-13 | # error: [unsupported-bool-conversion]
-14 | 10 < Comparable() < Comparable()
    |
 info: `__bool__` on `NotBoolable` must be callable
 
@@ -51,12 +48,8 @@ info: `__bool__` on `NotBoolable` must be callable
 error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
   --> src/mdtest_snippet.py:14:1
    |
-12 | 10 < Comparable() < 20
-13 | # error: [unsupported-bool-conversion]
 14 | 10 < Comparable() < Comparable()
    | ^^^^^^^^^^^^^^^^^
-15 |
-16 | Comparable() < Comparable()  # fine
    |
 info: `__bool__` on `NotBoolable` must be callable
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Nested_formal_typeva…_-_Generic_class_within…_(3259718bf20b45a2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Nested_formal_typeva…_-_Generic_class_within…_(3259718bf20b45a2).snap
@@ -27,36 +27,30 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[shadowed-type-variable]: Generic class `Bad1` uses type variable `T` already bound by an enclosing scope
- --> src/mdtest_snippet.py:3:5
+ --> src/mdtest_snippet.py:6:11
   |
-1 | from typing import Iterable
-2 |
-3 | def f[T](x: T, y: T) -> None:
-  |     ------------------------ Type variable `T` is bound in this enclosing scope
-4 |     class Ok[S]: ...
-5 |     # error: [shadowed-type-variable]
 6 |     class Bad1[T]: ...
   |           ^^^^ `T` used in class definition here
-7 |     # error: [shadowed-type-variable]
-8 |     class Bad2(Iterable[T]): ...
+  |
+ ::: src/mdtest_snippet.py:3:5
+  |
+3 | def f[T](x: T, y: T) -> None:
+  |     ------------------------ Type variable `T` is bound in this enclosing scope
   |
 
 ```
 
 ```
 error[shadowed-type-variable]: Generic class `Bad2` uses type variable `T` already bound by an enclosing scope
- --> src/mdtest_snippet.py:3:5
+ --> src/mdtest_snippet.py:8:11
   |
-1 | from typing import Iterable
-2 |
-3 | def f[T](x: T, y: T) -> None:
-  |     ------------------------ Type variable `T` is bound in this enclosing scope
-4 |     class Ok[S]: ...
-5 |     # error: [shadowed-type-variable]
-6 |     class Bad1[T]: ...
-7 |     # error: [shadowed-type-variable]
 8 |     class Bad2(Iterable[T]): ...
   |           ^^^^^^^^^^^^^^^^^ `T` used in class definition here
+  |
+ ::: src/mdtest_snippet.py:3:5
+  |
+3 | def f[T](x: T, y: T) -> None:
+  |     ------------------------ Type variable `T` is bound in this enclosing scope
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Nested_formal_typeva…_-_Generic_class_within…_(711fb86287c4d87b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Nested_formal_typeva…_-_Generic_class_within…_(711fb86287c4d87b).snap
@@ -27,36 +27,30 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[shadowed-type-variable]: Generic class `Bad1` uses type variable `T` already bound by an enclosing scope
- --> src/mdtest_snippet.py:3:7
+ --> src/mdtest_snippet.py:6:11
   |
-1 | from typing import Iterable
-2 |
-3 | class C[T]:
-  |       - Type variable `T` is bound in this enclosing scope
-4 |     class Ok1[S]: ...
-5 |     # error: [shadowed-type-variable]
 6 |     class Bad1[T]: ...
   |           ^^^^ `T` used in class definition here
-7 |     # error: [shadowed-type-variable]
-8 |     class Bad2(Iterable[T]): ...
+  |
+ ::: src/mdtest_snippet.py:3:7
+  |
+3 | class C[T]:
+  |       - Type variable `T` is bound in this enclosing scope
   |
 
 ```
 
 ```
 error[shadowed-type-variable]: Generic class `Bad2` uses type variable `T` already bound by an enclosing scope
- --> src/mdtest_snippet.py:3:7
+ --> src/mdtest_snippet.py:8:11
   |
-1 | from typing import Iterable
-2 |
-3 | class C[T]:
-  |       - Type variable `T` is bound in this enclosing scope
-4 |     class Ok1[S]: ...
-5 |     # error: [shadowed-type-variable]
-6 |     class Bad1[T]: ...
-7 |     # error: [shadowed-type-variable]
 8 |     class Bad2(Iterable[T]): ...
   |           ^^^^^^^^^^^^^^^^^ `T` used in class definition here
+  |
+ ::: src/mdtest_snippet.py:3:7
+  |
+3 | class C[T]:
+  |       - Type variable `T` is bound in this enclosing scope
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Nested_formal_typeva…_-_Generic_function_wit…_(f58a51442a16371e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Nested_formal_typeva…_-_Generic_function_wit…_(f58a51442a16371e).snap
@@ -26,7 +26,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 error[shadowed-type-variable]: Generic function `bad` uses type variable `T` already bound by an enclosing scope
  --> src/mdtest_snippet.py:5:9
   |
-4 |     # error: [shadowed-type-variable]
 5 |     def bad[T](a: T, b: T) -> None: ...
   |         ^^^ `T` used in function definition here
   |
@@ -34,7 +33,6 @@ error[shadowed-type-variable]: Generic function `bad` uses type variable `T` alr
   |
 1 | def f[T](x: T, y: T) -> None:
   |     ------------------------ Type variable `T` is bound in this enclosing scope
-2 |     def ok[S](a: S, b: S) -> None: ...
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Nested_formal_typeva…_-_Generic_method_withi…_(c19e9277cf9fafb5).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Nested_formal_typeva…_-_Generic_method_withi…_(c19e9277cf9fafb5).snap
@@ -26,7 +26,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 error[shadowed-type-variable]: Generic function `bad` uses type variable `T` already bound by an enclosing scope
  --> src/mdtest_snippet.py:5:9
   |
-4 |     # error: [shadowed-type-variable]
 5 |     def bad[T](self, a: T, b: T) -> None: ...
   |         ^^^ `T` used in function definition here
   |
@@ -34,7 +33,6 @@ error[shadowed-type-variable]: Generic function `bad` uses type variable `T` alr
   |
 1 | class C[T]:
   |       - Type variable `T` is bound in this enclosing scope
-2 |     def ok[S](self, a: S, b: S) -> None: ...
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Function_nested_in_c…_(1a50b4ccb10b95dd).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Function_nested_in_c…_(1a50b4ccb10b95dd).snap
@@ -23,14 +23,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[invalid-type-variable-default]: Invalid default for type parameter `U`
- --> src/mdtest_snippet.py:1:9
+ --> src/mdtest_snippet.py:3:15
+  |
+3 |     def f[U = T](self): ...
+  |               ^ `T` is a type parameter bound in an outer scope
+  |
+ ::: src/mdtest_snippet.py:1:9
   |
 1 | class C[T]:
   |         - `T` defined here
-2 |     # error: [invalid-type-variable-default]
-3 |     def f[U = T](self): ...
-  |               ^ `T` is a type parameter bound in an outer scope
-4 |     def g[U = int](self): ...  # OK
   |
 info: See https://typing.python.org/en/latest/spec/generics.html#scoping-rules
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Legacy_TypeVar_in_me…_(2ed4c18a38ed9090).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Legacy_TypeVar_in_me…_(2ed4c18a38ed9090).snap
@@ -28,17 +28,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[invalid-type-variable-default]: Invalid use of type variable `T2`
- --> src/mdtest_snippet.py:4:1
+ --> src/mdtest_snippet.py:8:25
   |
-3 | T1 = TypeVar("T1")
-4 | T2 = TypeVar("T2", default=T1)
-  | ------------------------------ `T2` defined here
-5 |
-6 | class Foo(Generic[T1]):
-7 |     # error: [invalid-type-variable-default] "Invalid use of type variable `T2`: default of `T2` refers to out-of-scope type variable …
 8 |     def method(self, x: T2) -> T2:
   |                         ^^ Default of `T2` references out-of-scope type variable `T1`
-9 |         return x
+  |
+ ::: src/mdtest_snippet.py:4:1
+  |
+4 | T2 = TypeVar("T2", default=T1)
+  | ------------------------------ `T2` defined here
   |
 info: See https://typing.python.org/en/latest/spec/generics.html#scoping-rules
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Legacy_TypeVar_in_ne…_(a1aca17ea750ffdd).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Legacy_TypeVar_in_ne…_(a1aca17ea750ffdd).snap
@@ -29,19 +29,16 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[invalid-type-variable-default]: Invalid use of type variable `U`
-  --> src/mdtest_snippet.py:4:1
-   |
- 3 | T = TypeVar("T")
- 4 | U = TypeVar("U", default=T)
-   | --------------------------- `U` defined here
- 5 |
- 6 | def outer(x: T) -> T:
- 7 |     # error: [invalid-type-variable-default]
- 8 |     def inner(y: U) -> U:
-   |                  ^ Default of `U` references out-of-scope type variable `T`
- 9 |         return y
-10 |     return x
-   |
+ --> src/mdtest_snippet.py:8:18
+  |
+8 |     def inner(y: U) -> U:
+  |                  ^ Default of `U` references out-of-scope type variable `T`
+  |
+ ::: src/mdtest_snippet.py:4:1
+  |
+4 | U = TypeVar("U", default=T)
+  | --------------------------- `U` defined here
+  |
 info: See https://typing.python.org/en/latest/spec/generics.html#scoping-rules
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Legacy_TypeVar_order…_(d075a45828c9dbc5).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Legacy_TypeVar_order…_(d075a45828c9dbc5).snap
@@ -43,26 +43,20 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[invalid-type-variable-default]: Type parameters without defaults cannot follow type parameters with defaults
-  --> src/mdtest_snippet.py:9:10
-   |
- 8 | # error: [invalid-type-variable-default]
- 9 | def f(x: T1, y: T2) -> tuple[T1, T2]:
-   |          --     ^^ Type variable `T2` does not have a default
-   |          |
-   |          Earlier TypeVar `T1` has a default
-10 |     return x, y
-   |
-  ::: src/mdtest_snippet.py:3:1
-   |
- 1 | from typing import TypeVar
- 2 |
- 3 | T1 = TypeVar("T1", default=int)
-   | ------------------------------- `T1` defined here
- 4 | T2 = TypeVar("T2")
-   | ------------------ `T2` defined here
- 5 | T3 = TypeVar("T3")
- 6 | DefaultStrT = TypeVar("DefaultStrT", default=str)
-   |
+ --> src/mdtest_snippet.py:9:10
+  |
+9 | def f(x: T1, y: T2) -> tuple[T1, T2]:
+  |          --     ^^ Type variable `T2` does not have a default
+  |          |
+  |          Earlier TypeVar `T1` has a default
+  |
+ ::: src/mdtest_snippet.py:3:1
+  |
+3 | T1 = TypeVar("T1", default=int)
+  | ------------------------------- `T1` defined here
+4 | T2 = TypeVar("T2")
+  | ------------------ `T2` defined here
+  |
 
 ```
 
@@ -70,23 +64,20 @@ error[invalid-type-variable-default]: Type parameters without defaults cannot fo
 error[invalid-type-variable-default]: Type parameters without defaults cannot follow type parameters with defaults
   --> src/mdtest_snippet.py:13:17
    |
-12 | # error: [invalid-type-variable-default]
 13 | def g(x: T2, y: T1, z: T3) -> tuple[T2, T1, T3]:
    |                 --     ^^ Type variable `T3` does not have a default
    |                 |
    |                 Earlier TypeVar `T1` has a default
-14 |     return x, y, z
    |
   ::: src/mdtest_snippet.py:3:1
    |
- 1 | from typing import TypeVar
- 2 |
  3 | T1 = TypeVar("T1", default=int)
    | ------------------------------- `T1` defined here
- 4 | T2 = TypeVar("T2")
+   |
+  ::: src/mdtest_snippet.py:5:1
+   |
  5 | T3 = TypeVar("T3")
    | ------------------ `T3` defined here
- 6 | DefaultStrT = TypeVar("DefaultStrT", default=str)
    |
 
 ```
@@ -95,23 +86,17 @@ error[invalid-type-variable-default]: Type parameters without defaults cannot fo
 error[invalid-type-variable-default]: Type parameters without defaults cannot follow type parameters with defaults
   --> src/mdtest_snippet.py:17:10
    |
-16 | # error: [invalid-type-variable-default]
 17 | def h(x: T1, y: T2, z: DefaultStrT, w: T3) -> tuple[T1, T2, DefaultStrT, T3]:
    |          --     ^^ Type variables `T2` and `T3` do not have defaults
    |          |
    |          Earlier TypeVar `T1` has a default
-18 |     return x, y, z, w
    |
   ::: src/mdtest_snippet.py:3:1
    |
- 1 | from typing import TypeVar
- 2 |
  3 | T1 = TypeVar("T1", default=int)
    | ------------------------------- `T1` defined here
  4 | T2 = TypeVar("T2")
    | ------------------ `T2` defined here
- 5 | T3 = TypeVar("T3")
- 6 | DefaultStrT = TypeVar("DefaultStrT", default=str)
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Legacy_TypeVar_with_…_(ce8defbeaf54e06c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Legacy_TypeVar_with_…_(ce8defbeaf54e06c).snap
@@ -31,16 +31,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[invalid-type-variable-default]: Invalid use of type variable `U`
- --> src/mdtest_snippet.py:4:1
+ --> src/mdtest_snippet.py:7:12
   |
-3 | T = TypeVar("T", default=int)
-4 | U = TypeVar("U", default=T)
-  | --------------------------- `U` defined here
-5 |
-6 | # error: [invalid-type-variable-default]
 7 | def bad(y: U, z: T) -> tuple[U, T]:
   |            ^ Default of `U` references later type parameter `T`
-8 |     return y, z
+  |
+ ::: src/mdtest_snippet.py:4:1
+  |
+4 | U = TypeVar("U", default=T)
+  | --------------------------- `U` defined here
   |
 info: See https://typing.python.org/en/latest/spec/generics.html#scoping-rules
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Nested_functions_(3f2ee9fa81da0177).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Nested_functions_(3f2ee9fa81da0177).snap
@@ -23,14 +23,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[invalid-type-variable-default]: Invalid default for type parameter `U`
- --> src/mdtest_snippet.py:1:11
+ --> src/mdtest_snippet.py:3:19
+  |
+3 |     def inner[U = T](): ...
+  |                   ^ `T` is a type parameter bound in an outer scope
+  |
+ ::: src/mdtest_snippet.py:1:11
   |
 1 | def outer[T]():
   |           - `T` defined here
-2 |     # error: [invalid-type-variable-default] "Type parameter `U` cannot use outer-scope type parameter `T` as its default"
-3 |     def inner[U = T](): ...
-  |                   ^ `T` is a type parameter bound in an outer scope
-4 |     def ok[U = int](): ...  # OK
   |
 info: See https://typing.python.org/en/latest/spec/generics.html#scoping-rules
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Type_alias_nested_in…_(de027dcc5360f252).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Type_alias_nested_in…_(de027dcc5360f252).snap
@@ -24,15 +24,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[invalid-type-variable-default]: Invalid default for type parameter `U`
- --> src/mdtest_snippet.py:1:9
+ --> src/mdtest_snippet.py:3:20
+  |
+3 |     type Alias[U = T] = list[U]
+  |                    ^ `T` is a type parameter bound in an outer scope
+  |
+ ::: src/mdtest_snippet.py:1:9
   |
 1 | class C[T]:
   |         - `T` defined here
-2 |     # error: [invalid-type-variable-default]
-3 |     type Alias[U = T] = list[U]
-  |                    ^ `T` is a type parameter bound in an outer scope
-4 |
-5 |     type Ok[U = int] = list[U]  # OK
   |
 info: See https://typing.python.org/en/latest/spec/generics.html#scoping-rules
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/semantic_syntax_erro…_-_Semantic_syntax_erro…_-_`async`_comprehensio…_-_Python_3.10_(96aa8ec77d46553d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/semantic_syntax_erro…_-_Semantic_syntax_erro…_-_`async`_comprehensio…_-_Python_3.10_(96aa8ec77d46553d).snap
@@ -37,27 +37,19 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syn
 error[invalid-syntax]: cannot use an asynchronous comprehension inside of a synchronous comprehension on Python 3.10 (syntax was added in 3.11)
  --> src/mdtest_snippet.py:6:19
   |
-4 | async def f():
-5 |     # error: 19 [invalid-syntax] "cannot use an asynchronous comprehension inside of a synchronous comprehension on Python 3.10 (syntax…
 6 |     return {n: [x async for x in elements(n)] for n in range(3)}
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-7 | async def test():
-8 |     # error: [not-iterable] "Object of type `range` is not async-iterable"
   |
 
 ```
 
 ```
 error[not-iterable]: Object of type `range` is not async-iterable
-  --> src/mdtest_snippet.py:9:59
-   |
- 7 | async def test():
- 8 |     # error: [not-iterable] "Object of type `range` is not async-iterable"
- 9 |     return [[x async for x in elements(n)] async for n in range(3)]
-   |                                                           ^^^^^^^^
-10 | async def f():
-11 |     [x for x in [1]] and [x async for x in elements(1)]
-   |
+ --> src/mdtest_snippet.py:9:59
+  |
+9 |     return [[x async for x in elements(n)] async for n in range(3)]
+  |                                                           ^^^^^^^^
+  |
 info: It has no `__aiter__` method
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/semantic_syntax_erro…_-_Semantic_syntax_erro…_-_`break`_and_`continu…_(3143ba0a999d644).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/semantic_syntax_erro…_-_Semantic_syntax_erro…_-_`break`_and_`continu…_(3143ba0a999d644).snap
@@ -38,7 +38,6 @@ error[invalid-syntax]: `break` outside loop
   |
 1 | break  # error: [invalid-syntax]
   | ^^^^^
-2 | continue  # error: [invalid-syntax]
   |
 
 ```
@@ -47,24 +46,19 @@ error[invalid-syntax]: `break` outside loop
 error[invalid-syntax]: `continue` outside loop
  --> src/mdtest_snippet.py:2:1
   |
-1 | break  # error: [invalid-syntax]
 2 | continue  # error: [invalid-syntax]
   | ^^^^^^^^
-3 |
-4 | for x in range(42):
   |
 
 ```
 
 ```
 error[invalid-syntax]: `break` outside loop
-  --> src/mdtest_snippet.py:9:9
-   |
- 8 |     def _():
- 9 |         break  # error: [invalid-syntax]
-   |         ^^^^^
-10 |         continue  # error: [invalid-syntax]
-   |
+ --> src/mdtest_snippet.py:9:9
+  |
+9 |         break  # error: [invalid-syntax]
+  |         ^^^^^
+  |
 
 ```
 
@@ -72,12 +66,8 @@ error[invalid-syntax]: `break` outside loop
 error[invalid-syntax]: `continue` outside loop
   --> src/mdtest_snippet.py:10:9
    |
- 8 |     def _():
- 9 |         break  # error: [invalid-syntax]
 10 |         continue  # error: [invalid-syntax]
    |         ^^^^^^^^
-11 |
-12 |     class Fine:
    |
 
 ```
@@ -86,11 +76,8 @@ error[invalid-syntax]: `continue` outside loop
 error[invalid-syntax]: `break` outside loop
   --> src/mdtest_snippet.py:14:9
    |
-12 |     class Fine:
-13 |         # this is invalid syntax despite it being in an eager-nested scope!
 14 |         break  # error: [invalid-syntax]
    |         ^^^^^
-15 |         continue  # error: [invalid-syntax]
    |
 
 ```
@@ -99,8 +86,6 @@ error[invalid-syntax]: `break` outside loop
 error[invalid-syntax]: `continue` outside loop
   --> src/mdtest_snippet.py:15:9
    |
-13 |         # this is invalid syntax despite it being in an eager-nested scope!
-14 |         break  # error: [invalid-syntax]
 15 |         continue  # error: [invalid-syntax]
    |         ^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/semantic_syntax_erro…_-_Semantic_syntax_erro…_-_name_is_parameter_an…_(99bae53daf67ae6e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/semantic_syntax_erro…_-_Semantic_syntax_erro…_-_name_is_parameter_an…_(99bae53daf67ae6e).snap
@@ -52,26 +52,19 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syn
 error[invalid-syntax]: name `a` is parameter and global
  --> src/mdtest_snippet.py:4:12
   |
-3 | def f(a):
 4 |     global a  # error: [invalid-syntax]
   |            ^
-5 |
-6 | def g(a):
   |
 
 ```
 
 ```
 error[invalid-syntax]: name `a` is parameter and global
-  --> src/mdtest_snippet.py:8:16
-   |
- 6 | def g(a):
- 7 |     if True:
- 8 |         global a  # error: [invalid-syntax]
-   |                ^
- 9 |
-10 | def h(a):
-   |
+ --> src/mdtest_snippet.py:8:16
+  |
+8 |         global a  # error: [invalid-syntax]
+  |                ^
+  |
 
 ```
 
@@ -79,12 +72,8 @@ error[invalid-syntax]: name `a` is parameter and global
 error[invalid-syntax]: name `a` is parameter and global
   --> src/mdtest_snippet.py:16:16
    |
-14 | def i(a):
-15 |     try:
 16 |         global a  # error: [invalid-syntax]
    |                ^
-17 |     except Exception:
-18 |         pass
    |
 
 ```
@@ -93,12 +82,8 @@ error[invalid-syntax]: name `a` is parameter and global
 error[invalid-syntax]: name `a` is parameter and global
   --> src/mdtest_snippet.py:22:12
    |
-20 | def f(a):
-21 |     a = 1
 22 |     global a  # error: [invalid-syntax]
    |            ^
-23 |
-24 | def f(a):
    |
 
 ```
@@ -107,12 +92,8 @@ error[invalid-syntax]: name `a` is parameter and global
 error[invalid-syntax]: name `a` is parameter and global
   --> src/mdtest_snippet.py:27:12
    |
-25 |     a = 1
-26 |     a = 2
 27 |     global a  # error: [invalid-syntax]
    |            ^
-28 |
-29 | def f(a):
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shado…_(c8ff9e3a079e8bd5).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_class_shado…_(c8ff9e3a079e8bd5).snap
@@ -24,8 +24,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/shadowing.md
 error[invalid-assignment]: Object of type `Literal[1]` is not assignable to `<class 'C'>`
  --> src/mdtest_snippet.py:3:1
   |
-1 | class C: ...
-2 |
 3 | C = 1  # error: [invalid-assignment]
   | -   ^ Incompatible value of type `Literal[1]`
   | |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_sh…_(a1515328b775ebc1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/shadowing.md_-_Shadowing_-_Implicit_function_sh…_(a1515328b775ebc1).snap
@@ -24,8 +24,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/shadowing.md
 error[invalid-assignment]: Object of type `Literal[1]` is not assignable to `def f() -> Unknown`
  --> src/mdtest_snippet.py:3:1
   |
-1 | def f(): ...
-2 |
 3 | f = 1  # error: [invalid-assignment]
   | -   ^ Incompatible value of type `Literal[1]`
   | |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/single_matching_over…_-_Single_matching_over…_-_Call_to_function_wit…_(8fdf5a06afc7d4fe).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/single_matching_over…_-_Single_matching_over…_-_Call_to_function_wit…_(8fdf5a06afc7d4fe).snap
@@ -157,19 +157,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/single_match
 error[invalid-argument-type]: Argument to function `foo` is incorrect
  --> src/mdtest_snippet.py:5:5
   |
-3 | from overloaded import foo
-4 |
 5 | foo("foo")  # error: [invalid-argument-type]
   |     ^^^^^ Expected `int`, found `Literal["foo"]`
   |
 info: Matching overload defined here
  --> src/overloaded.pyi:4:5
   |
-3 | @overload
 4 | def foo(a: int): ...
   |     ^^^ ------ Parameter declared here
-5 | @overload
-6 | def foo(a: int, b: int, c: int): ...
   |
 info: Non-matching overloads for function `foo`:
 info:   (a: int, b: int, c: int) -> Unknown

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/single_matching_over…_-_Single_matching_over…_-_Limited_number_of_ov…_(93e9a157fdca3ab2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/single_matching_over…_-_Single_matching_over…_-_Limited_number_of_ov…_(93e9a157fdca3ab2).snap
@@ -37,20 +37,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/single_match
 error[invalid-argument-type]: Argument to function `f` is incorrect
  --> src/mdtest_snippet.py:3:3
   |
-1 | from overloaded import f
-2 |
 3 | f("a")  # error: [invalid-argument-type]
   |   ^^^ Expected `int`, found `Literal["a"]`
   |
 info: Matching overload defined here
  --> src/overloaded.pyi:6:5
   |
-4 | def f() -> None: ...
-5 | @overload
 6 | def f(x: int) -> int: ...
   |     ^ ------ Parameter declared here
-7 | @overload
-8 | def f(x: int, y: int) -> int: ...
   |
 info: Non-matching overloads for function `f`:
 info:   () -> None

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/special_form_attribu…_-_Diagnostics_for_inva…_(249d635e74a41c9e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/special_form_attribu…_-_Diagnostics_for_inva…_(249d635e74a41c9e).snap
@@ -41,12 +41,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/special_form
 error[unresolved-attribute]: Special form `typing.Any` has no attribute `foo`
   --> src/mdtest_snippet.py:14:1
    |
-12 |             self.y: Final = LiteralString
-13 |
 14 | X.foo  # error: [unresolved-attribute]
    | ^^^^^
-15 | X.aaaaooooooo  # error: [unresolved-attribute]
-16 | Foo.X.startswith  # error: [unresolved-attribute]
    |
 help: Objects with type `Any` have a `foo` attribute, but the symbol `typing.Any` does not itself inhabit the type `Any`
 help: This error may indicate that `X` was defined as `X = typing.Any` when `X: typing.Any` was intended
@@ -57,11 +53,8 @@ help: This error may indicate that `X` was defined as `X = typing.Any` when `X: 
 error[unresolved-attribute]: Special form `typing.Any` has no attribute `aaaaooooooo`
   --> src/mdtest_snippet.py:15:1
    |
-14 | X.foo  # error: [unresolved-attribute]
 15 | X.aaaaooooooo  # error: [unresolved-attribute]
    | ^^^^^^^^^^^^^
-16 | Foo.X.startswith  # error: [unresolved-attribute]
-17 | Foo.Bar().y.startswith  # error: [unresolved-attribute]
    |
 help: Objects with type `Any` have an `aaaaooooooo` attribute, but the symbol `typing.Any` does not itself inhabit the type `Any`
 help: This error may indicate that `X` was defined as `X = typing.Any` when `X: typing.Any` was intended
@@ -72,11 +65,8 @@ help: This error may indicate that `X` was defined as `X = typing.Any` when `X: 
 error[unresolved-attribute]: Special form `typing.LiteralString` has no attribute `startswith`
   --> src/mdtest_snippet.py:16:1
    |
-14 | X.foo  # error: [unresolved-attribute]
-15 | X.aaaaooooooo  # error: [unresolved-attribute]
 16 | Foo.X.startswith  # error: [unresolved-attribute]
    | ^^^^^^^^^^^^^^^^
-17 | Foo.Bar().y.startswith  # error: [unresolved-attribute]
    |
 help: Objects with type `LiteralString` have a `startswith` attribute, but the symbol `typing.LiteralString` does not itself inhabit the type `LiteralString`
 help: This error may indicate that `Foo.X` was defined as `Foo.X = typing.LiteralString` when `Foo.X: typing.LiteralString` was intended
@@ -87,12 +77,8 @@ help: This error may indicate that `Foo.X` was defined as `Foo.X = typing.Litera
 error[unresolved-attribute]: Special form `typing.LiteralString` has no attribute `startswith`
   --> src/mdtest_snippet.py:17:1
    |
-15 | X.aaaaooooooo  # error: [unresolved-attribute]
-16 | Foo.X.startswith  # error: [unresolved-attribute]
 17 | Foo.Bar().y.startswith  # error: [unresolved-attribute]
    | ^^^^^^^^^^^^^^^^^^^^^^
-18 |
-19 | # `Foo().b` resolves `Self` to `Foo`, so `.a` is valid.
    |
 help: Objects with type `LiteralString` have a `startswith` attribute, but the symbol `typing.LiteralString` does not itself inhabit the type `LiteralString`
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/string.md_-_String_annotations_-_Partially_deferred_a…_-_Python_less_than_3.1…_(5e6477d05ddea33f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/string.md_-_String_annotations_-_Partially_deferred_a…_-_Python_less_than_3.1…_(5e6477d05ddea33f).snap
@@ -86,15 +86,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/string.md
 error[unsupported-operator]: Unsupported `|` operation
   --> src/mdtest_snippet.py:19:8
    |
-17 | def f(
-18 |     # error: [unsupported-operator]
 19 |     a: int | "Foo",
    |        ---^^^-----
    |        |     |
    |        |     Has type `Literal["Foo"]`
    |        Has type `<class 'int'>`
-20 |     # error: [unsupported-operator]
-21 |     b: int | "memoryview" | bytes,
    |
 info: All parameter annotations are evaluated at runtime by default on Python <3.14
 info: Python 3.13 was assumed when inferring types because it was specified on the command line
@@ -106,15 +102,11 @@ help: Put quotes around the whole union rather than just certain elements
 error[unsupported-operator]: Unsupported `|` operation
   --> src/mdtest_snippet.py:21:8
    |
-19 |     a: int | "Foo",
-20 |     # error: [unsupported-operator]
 21 |     b: int | "memoryview" | bytes,
    |        ---^^^------------
    |        |     |
    |        |     Has type `Literal["memoryview"]`
    |        Has type `<class 'int'>`
-22 |     # error: [unsupported-operator]
-23 |     c: "TD" | None,
    |
 info: All parameter annotations are evaluated at runtime by default on Python <3.14
 info: Python 3.13 was assumed when inferring types because it was specified on the command line
@@ -126,15 +118,11 @@ help: Put quotes around the whole union rather than just certain elements
 error[unsupported-operator]: Unsupported `|` operation
   --> src/mdtest_snippet.py:23:8
    |
-21 |     b: int | "memoryview" | bytes,
-22 |     # error: [unsupported-operator]
 23 |     c: "TD" | None,
    |        ----^^^----
    |        |      |
    |        |      Has type `None`
    |        Has type `Literal["TD"]`
-24 |     # error: [unsupported-operator]
-25 |     d: "P" | None,
    |
 info: All parameter annotations are evaluated at runtime by default on Python <3.14
 info: Python 3.13 was assumed when inferring types because it was specified on the command line
@@ -146,15 +134,11 @@ help: Put quotes around the whole union rather than just certain elements
 error[unsupported-operator]: Unsupported `|` operation
   --> src/mdtest_snippet.py:25:8
    |
-23 |     c: "TD" | None,
-24 |     # error: [unsupported-operator]
 25 |     d: "P" | None,
    |        ---^^^----
    |        |     |
    |        |     Has type `None`
    |        Has type `Literal["P"]`
-26 |     # fine: `TypeVar.__or__` accepts strings at runtime
-27 |     e: T | "Foo",
    |
 info: All parameter annotations are evaluated at runtime by default on Python <3.14
 info: Python 3.13 was assumed when inferring types because it was specified on the command line
@@ -166,12 +150,8 @@ help: Put quotes around the whole union rather than just certain elements
 error[unsupported-operator]: Unsupported `|` operation
   --> src/mdtest_snippet.py:33:8
    |
-31 |     g: UsesMeta | "Foo",
-32 |     # error: [unsupported-operator]
 33 |     h: None | None,
    |        ^^^^^^^^^^^ Both operands have type `None`
-34 |     # error: [unresolved-reference] "SomethingUndefined"
-35 |     # error: [unresolved-reference] "SomethingAlsoUndefined"
    |
 info: All parameter annotations are evaluated at runtime by default on Python <3.14
 info: Python 3.13 was assumed when inferring types because it was specified on the command line
@@ -182,12 +162,8 @@ info: Python 3.13 was assumed when inferring types because it was specified on t
 error[unresolved-reference]: Name `SomethingUndefined` used when not defined
   --> src/mdtest_snippet.py:36:8
    |
-34 |     # error: [unresolved-reference] "SomethingUndefined"
-35 |     # error: [unresolved-reference] "SomethingAlsoUndefined"
 36 |     i: SomethingUndefined | SomethingAlsoUndefined,
    |        ^^^^^^^^^^^^^^^^^^
-37 |     # error: [unsupported-operator]
-38 |     # error: [unsupported-operator]
    |
 
 ```
@@ -196,12 +172,8 @@ error[unresolved-reference]: Name `SomethingUndefined` used when not defined
 error[unresolved-reference]: Name `SomethingAlsoUndefined` used when not defined
   --> src/mdtest_snippet.py:36:29
    |
-34 |     # error: [unresolved-reference] "SomethingUndefined"
-35 |     # error: [unresolved-reference] "SomethingAlsoUndefined"
 36 |     i: SomethingUndefined | SomethingAlsoUndefined,
    |                             ^^^^^^^^^^^^^^^^^^^^^^
-37 |     # error: [unsupported-operator]
-38 |     # error: [unsupported-operator]
    |
 
 ```
@@ -210,15 +182,11 @@ error[unresolved-reference]: Name `SomethingAlsoUndefined` used when not defined
 error[unsupported-operator]: Unsupported `|` operation
   --> src/mdtest_snippet.py:39:8
    |
-37 |     # error: [unsupported-operator]
-38 |     # error: [unsupported-operator]
 39 |     j: list["int" | None] | "bytes",
    |        ------------------^^^-------
    |        |                    |
    |        |                    Has type `Literal["bytes"]`
    |        Has type `<class 'list[int | None]'>`
-40 | ):
-41 |     reveal_type(a)  # revealed: int | Foo
    |
 info: All parameter annotations are evaluated at runtime by default on Python <3.14
 info: Python 3.13 was assumed when inferring types because it was specified on the command line
@@ -230,15 +198,11 @@ help: Put quotes around the whole union rather than just certain elements
 error[unsupported-operator]: Unsupported `|` operation
   --> src/mdtest_snippet.py:39:13
    |
-37 |     # error: [unsupported-operator]
-38 |     # error: [unsupported-operator]
 39 |     j: list["int" | None] | "bytes",
    |             -----^^^----
    |             |       |
    |             |       Has type `None`
    |             Has type `Literal["int"]`
-40 | ):
-41 |     reveal_type(a)  # revealed: int | Foo
    |
 info: All parameter annotations are evaluated at runtime by default on Python <3.14
 info: Python 3.13 was assumed when inferring types because it was specified on the command line
@@ -250,14 +214,11 @@ help: Put quotes around the whole union rather than just certain elements
 error[unsupported-operator]: Unsupported `|` operation
   --> src/mdtest_snippet.py:56:10
    |
-55 | # error: [unsupported-operator]
 56 | X = list["int" | None]
    |          -----^^^----
    |          |       |
    |          |       Has type `None`
    |          Has type `Literal["int"]`
-57 |
-58 | if TYPE_CHECKING:
    |
 info: All type expressions are evaluated at runtime by default on Python <3.14
 info: Python 3.13 was assumed when inferring types because it was specified on the command line

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Explicit_Super_Objec…_(b753048091f275c0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Explicit_Super_Objec…_(b753048091f275c0).snap
@@ -127,12 +127,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/class/super.md
 error[unresolved-attribute]: Object of type `<super: <class 'C'>, C>` has no attribute `c`
   --> src/mdtest_snippet.py:20:1
    |
-18 | super(C, C()).a
-19 | super(C, C()).b
 20 | super(C, C()).c  # error: [unresolved-attribute]
    | ^^^^^^^^^^^^^^^
-21 |
-22 | super(B, C()).a
    |
 
 ```
@@ -141,10 +137,8 @@ error[unresolved-attribute]: Object of type `<super: <class 'C'>, C>` has no att
 error[unresolved-attribute]: Object of type `<super: <class 'B'>, C>` has no attribute `b`
   --> src/mdtest_snippet.py:23:1
    |
-22 | super(B, C()).a
 23 | super(B, C()).b  # error: [unresolved-attribute]
    | ^^^^^^^^^^^^^^^
-24 | super(B, C()).c  # error: [unresolved-attribute]
    |
 
 ```
@@ -153,12 +147,8 @@ error[unresolved-attribute]: Object of type `<super: <class 'B'>, C>` has no att
 error[unresolved-attribute]: Object of type `<super: <class 'B'>, C>` has no attribute `c`
   --> src/mdtest_snippet.py:24:1
    |
-22 | super(B, C()).a
-23 | super(B, C()).b  # error: [unresolved-attribute]
 24 | super(B, C()).c  # error: [unresolved-attribute]
    | ^^^^^^^^^^^^^^^
-25 |
-26 | super(A, C()).a  # error: [unresolved-attribute]
    |
 
 ```
@@ -167,12 +157,8 @@ error[unresolved-attribute]: Object of type `<super: <class 'B'>, C>` has no att
 error[unresolved-attribute]: Object of type `<super: <class 'A'>, C>` has no attribute `a`
   --> src/mdtest_snippet.py:26:1
    |
-24 | super(B, C()).c  # error: [unresolved-attribute]
-25 |
 26 | super(A, C()).a  # error: [unresolved-attribute]
    | ^^^^^^^^^^^^^^^
-27 | super(A, C()).b  # error: [unresolved-attribute]
-28 | super(A, C()).c  # error: [unresolved-attribute]
    |
 
 ```
@@ -181,10 +167,8 @@ error[unresolved-attribute]: Object of type `<super: <class 'A'>, C>` has no att
 error[unresolved-attribute]: Object of type `<super: <class 'A'>, C>` has no attribute `b`
   --> src/mdtest_snippet.py:27:1
    |
-26 | super(A, C()).a  # error: [unresolved-attribute]
 27 | super(A, C()).b  # error: [unresolved-attribute]
    | ^^^^^^^^^^^^^^^
-28 | super(A, C()).c  # error: [unresolved-attribute]
    |
 
 ```
@@ -193,12 +177,8 @@ error[unresolved-attribute]: Object of type `<super: <class 'A'>, C>` has no att
 error[unresolved-attribute]: Object of type `<super: <class 'A'>, C>` has no attribute `c`
   --> src/mdtest_snippet.py:28:1
    |
-26 | super(A, C()).a  # error: [unresolved-attribute]
-27 | super(A, C()).b  # error: [unresolved-attribute]
 28 | super(A, C()).c  # error: [unresolved-attribute]
    | ^^^^^^^^^^^^^^^
-29 |
-30 | reveal_type(super(C, C()).a)  # revealed: bound method C.a() -> Unknown
    |
 
 ```
@@ -207,12 +187,8 @@ error[unresolved-attribute]: Object of type `<super: <class 'A'>, C>` has no att
 error[invalid-super-argument]: `<Protocol with members 'bar'>` is an abstract/structural type in `super(<class 'object'>, <Protocol with members 'bar'>)` call
   --> src/mdtest_snippet.py:78:21
    |
-76 |         # error: [invalid-super-argument]
-77 |         # revealed: Unknown
 78 |         reveal_type(super(object, x))
    |                     ^^^^^^^^^^^^^^^^
-79 |
-80 |     # error: [invalid-super-argument]
    |
 
 ```
@@ -221,26 +197,18 @@ error[invalid-super-argument]: `<Protocol with members 'bar'>` is an abstract/st
 error[invalid-super-argument]: `(int, str, /) -> bool` is an abstract/structural type in `super(<class 'object'>, (int, str, /) -> bool)` call
   --> src/mdtest_snippet.py:82:17
    |
-80 |     # error: [invalid-super-argument]
-81 |     # revealed: Unknown
 82 |     reveal_type(super(object, z))
    |                 ^^^^^^^^^^^^^^^^
-83 |
-84 |     is_list = g(x)
    |
 
 ```
 
 ```
 error[invalid-super-argument]: `types.GenericAlias` instance `list[int]` is not a valid class
-   --> src/mdtest_snippet.py:98:13
-    |
- 96 | # error: [invalid-super-argument]
- 97 | # revealed: Unknown
- 98 | reveal_type(super(list[int], []))
-    |             ^^^^^^^^^^^^^^^^^^^^
- 99 | class Super:
-100 |     def method(self) -> int:
-    |
+  --> src/mdtest_snippet.py:98:13
+   |
+98 | reveal_type(super(list[int], []))
+   |             ^^^^^^^^^^^^^^^^^^^^
+   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Implicit_Super_Objec…_(f9e5e48e3a4a4c12).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Implicit_Super_Objec…_(f9e5e48e3a4a4c12).snap
@@ -164,11 +164,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/class/super.md
 error[invalid-super-argument]: `S@method7` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method7)` call
   --> src/mdtest_snippet.py:82:21
    |
-80 |         # error: [invalid-super-argument]
-81 |         # revealed: Unknown
 82 |         reveal_type(super())
    |                     ^^^^^^^
-83 |         return self
    |
 info: Type variable `S` has `object` as its implicit upper bound
 info: `object` is not an instance or subclass of `<class 'Foo'>`
@@ -180,11 +177,8 @@ help: Consider adding an upper bound to type variable `S`
 error[invalid-super-argument]: `S@method8` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method8)` call
   --> src/mdtest_snippet.py:88:21
    |
-86 |         # error: [invalid-super-argument]
-87 |         # revealed: Unknown
 88 |         reveal_type(super())
    |                     ^^^^^^^
-89 |         return self
    |
 info: Type variable `S` has upper bound `int`
 info: `int` is not an instance or subclass of `<class 'Foo'>`
@@ -195,11 +189,8 @@ info: `int` is not an instance or subclass of `<class 'Foo'>`
 error[invalid-super-argument]: `S@method9` is not an instance or subclass of `<class 'Foo'>` in `super(<class 'Foo'>, S@method9)` call
   --> src/mdtest_snippet.py:94:21
    |
-92 |         # error: [invalid-super-argument]
-93 |         # revealed: Unknown
 94 |         reveal_type(super())
    |                     ^^^^^^^
-95 |         return self
    |
 info: Type variable `S` has constraints `int, str`
 info: `int | str` is not an instance or subclass of `<class 'Foo'>`
@@ -210,12 +201,8 @@ info: `int | str` is not an instance or subclass of `<class 'Foo'>`
 error[invalid-super-argument]: `S@method10` is a type variable with an abstract/structural type as its bounds or constraints, in `super(<class 'Foo'>, S@method10)` call
    --> src/mdtest_snippet.py:100:21
     |
- 98 |         # error: [invalid-super-argument]
- 99 |         # revealed: Unknown
 100 |         reveal_type(super())
     |                     ^^^^^^^
-101 |         return self
-102 |     # TypeVar bounded by `type[Foo]` rather than `Foo`
     |
 info: Type variable `S` has upper bound `(...) -> str`
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Metaclasses_(faeb52a8cd1533b3).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Metaclasses_(faeb52a8cd1533b3).snap
@@ -61,12 +61,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/class/super.md
 error[invalid-super-argument]: `<class 'OtherBase'>` is not an instance or subclass of `<class 'Meta'>` in `super(<class 'Meta'>, <class 'OtherBase'>)` call
   --> src/mdtest_snippet.py:34:1
    |
-32 |     pass
-33 |
 34 | super(Meta, OtherBase)  # error: [invalid-super-argument]
    | ^^^^^^^^^^^^^^^^^^^^^^
-35 |
-36 | T = TypeVar("T", bound=int)
    |
 
 ```
@@ -75,8 +71,6 @@ error[invalid-super-argument]: `<class 'OtherBase'>` is not an instance or subcl
 error[invalid-super-argument]: `type[T@__call__]` is not an instance or subclass of `<class 'BoundIntMeta'>` in `super(<class 'BoundIntMeta'>, type[T@__call__])` call
   --> src/mdtest_snippet.py:40:16
    |
-38 | class BoundIntMeta(type):
-39 |     def __call__(cls: type[T]) -> T:
 40 |         return super(BoundIntMeta, cls).__call__()  # error: [invalid-super-argument]
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Invalid_Usages_-_Diagnostic_when_the_…_(93e8ab913ead83b2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Invalid_Usages_-_Diagnostic_when_the_…_(93e8ab913ead83b2).snap
@@ -32,8 +32,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/class/super.md
 error[invalid-super-argument]: Argument is not a valid class
   --> src/mdtest_snippet.py:11:5
    |
- 9 |         class A: ...
-10 |
 11 |     super(A, A())  # error: [invalid-super-argument]
    |     ^^^^^^^^^^^^^ Argument has type `<class 'mdtest_snippet.<locals of function 'f'>.A @ src/mdtest_snippet.py:6:15'> | <class 'mdtest_snippet.<locals of function 'f'>.A @ src/mdtest_snippet.py:9:15'>`
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/sync.md_-_With_statements_-_Accidental_use_of_no…_(b07503f9b773ea61).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/sync.md_-_With_statements_-_Accidental_use_of_no…_(b07503f9b773ea61).snap
@@ -28,10 +28,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/with/sync.md
 error[invalid-context-manager]: Object of type `Manager` cannot be used with `with` because it does not implement `__enter__` and `__exit__`
  --> src/mdtest_snippet.py:6:6
   |
-5 | # error: [invalid-context-manager] "Object of type `Manager` cannot be used with `with` because it does not implement `__enter__` and `…
 6 | with Manager():
   |      ^^^^^^^^^
-7 |     pass
   |
 info: Objects of type `Manager` can be used as async context managers
 info: Consider using `async with` here

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_…_(f45f1da2f8ca693d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Chained_comparisons_…_(f45f1da2f8ca693d).snap
@@ -38,11 +38,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
 error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable | Literal[False]`
   --> src/mdtest_snippet.py:15:1
    |
-14 | # error: [unsupported-bool-conversion]
 15 | a < b < b
    | ^^^^^
-16 |
-17 | a < b  # fine
    |
 info: `__bool__` on `NotBoolable | Literal[False]` must be callable
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elemen…_(39b614d4707c0661).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elemen…_(39b614d4707c0661).snap
@@ -31,20 +31,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
 error[invalid-method-override]: Invalid override of method `__eq__`
    --> src/mdtest_snippet.py:6:9
     |
-  4 | class A:
-  5 |     # error: [invalid-method-override]
   6 |     def __eq__(self, other) -> NotBoolable:
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `object.__eq__`
-  7 |         return NotBoolable()
     |
    ::: stdlib/builtins.pyi:142:9
     |
-140 |     def __setattr__(self, name: str, value: Any, /) -> None: ...
-141 |     def __delattr__(self, name: str, /) -> None: ...
 142 |     def __eq__(self, value: object, /) -> bool: ...
     |         -------------------------------------- `object.__eq__` defined here
-143 |     def __ne__(self, value: object, /) -> bool: ...
-144 |     def __str__(self) -> str: ...  # noqa: Y029
     |
 info: This violates the Liskov Substitution Principle
 help: It is recommended for `__eq__` to work with arbitrary objects, for example:
@@ -61,7 +54,6 @@ help
 error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
   --> src/mdtest_snippet.py:10:1
    |
- 9 | # error: [unsupported-bool-conversion]
 10 | (A(),) == (A(),)
    | ^^^^^^^^^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Heterogeneous_-_Value_Comparisons_-_Comparison_Unsupport…_(966dd82bd3668d0e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Heterogeneous_-_Value_Comparisons_-_Comparison_Unsupport…_(966dd82bd3668d0e).snap
@@ -50,14 +50,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:11:13
    |
-10 | # error: [unsupported-operator] "Operator `<` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[Lite…
 11 | reveal_type(a < b)  # revealed: Unknown
    |             -^^^-
    |             |   |
    |             |   Has type `tuple[Literal[1], Literal["hello"]]`
    |             Has type `tuple[Literal[1], Literal[2]]`
-12 | # error: [unsupported-operator] "Operator `<=` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[Lit…
-13 | reveal_type(a <= b)  # revealed: Unknown
    |
 info: Operation fails because operator `<` is not supported between the tuple elements at index 2 (of type `Literal[2]` and `Literal["hello"]`)
 
@@ -67,15 +64,11 @@ info: Operation fails because operator `<` is not supported between the tuple el
 error[unsupported-operator]: Unsupported `<=` operation
   --> src/mdtest_snippet.py:13:13
    |
-11 | reveal_type(a < b)  # revealed: Unknown
-12 | # error: [unsupported-operator] "Operator `<=` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[Lit…
 13 | reveal_type(a <= b)  # revealed: Unknown
    |             -^^^^-
    |             |    |
    |             |    Has type `tuple[Literal[1], Literal["hello"]]`
    |             Has type `tuple[Literal[1], Literal[2]]`
-14 | # error: [unsupported-operator] "Operator `>` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[Lite…
-15 | reveal_type(a > b)  # revealed: Unknown
    |
 info: Operation fails because operator `<=` is not supported between the tuple elements at index 2 (of type `Literal[2]` and `Literal["hello"]`)
 
@@ -85,15 +78,11 @@ info: Operation fails because operator `<=` is not supported between the tuple e
 error[unsupported-operator]: Unsupported `>` operation
   --> src/mdtest_snippet.py:15:13
    |
-13 | reveal_type(a <= b)  # revealed: Unknown
-14 | # error: [unsupported-operator] "Operator `>` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[Lite…
 15 | reveal_type(a > b)  # revealed: Unknown
    |             -^^^-
    |             |   |
    |             |   Has type `tuple[Literal[1], Literal["hello"]]`
    |             Has type `tuple[Literal[1], Literal[2]]`
-16 | # error: [unsupported-operator] "Operator `>=` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[Lit…
-17 | reveal_type(a >= b)  # revealed: Unknown
    |
 info: Operation fails because operator `>` is not supported between the tuple elements at index 2 (of type `Literal[2]` and `Literal["hello"]`)
 
@@ -103,15 +92,11 @@ info: Operation fails because operator `>` is not supported between the tuple el
 error[unsupported-operator]: Unsupported `>=` operation
   --> src/mdtest_snippet.py:17:13
    |
-15 | reveal_type(a > b)  # revealed: Unknown
-16 | # error: [unsupported-operator] "Operator `>=` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[Lit…
 17 | reveal_type(a >= b)  # revealed: Unknown
    |             -^^^^-
    |             |    |
    |             |    Has type `tuple[Literal[1], Literal["hello"]]`
    |             Has type `tuple[Literal[1], Literal[2]]`
-18 | # error: [unsupported-operator]
-19 | # error: [unsupported-operator]
    |
 info: Operation fails because operator `>=` is not supported between the tuple elements at index 2 (of type `Literal[2]` and `Literal["hello"]`)
 
@@ -121,14 +106,10 @@ info: Operation fails because operator `>=` is not supported between the tuple e
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:20:13
    |
-18 | # error: [unsupported-operator]
-19 | # error: [unsupported-operator]
 20 | reveal_type((object(),) < (object(),) < (object(),))  # revealed: Unknown
    |             -----------^^^-----------
    |             |
    |             Both operands have type `tuple[object]`
-21 | a = (1, 2)
-22 | b = (999999, "hello")
    |
 info: Operation fails because operator `<` is not supported between the tuple elements at index 1 (both of type `object`)
 
@@ -138,14 +119,10 @@ info: Operation fails because operator `<` is not supported between the tuple el
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:20:27
    |
-18 | # error: [unsupported-operator]
-19 | # error: [unsupported-operator]
 20 | reveal_type((object(),) < (object(),) < (object(),))  # revealed: Unknown
    |                           -----------^^^-----------
    |                           |
    |                           Both operands have type `tuple[object]`
-21 | a = (1, 2)
-22 | b = (999999, "hello")
    |
 info: Operation fails because operator `<` is not supported between the tuple elements at index 1 (both of type `object`)
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Homogeneous_-_Tuples_with_Prefixes…_(c25079c01f6d8eb3).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Homogeneous_-_Tuples_with_Prefixes…_(c25079c01f6d8eb3).snap
@@ -34,15 +34,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
 error[unsupported-operator]: Unsupported `<` operation
  --> src/mdtest_snippet.py:7:5
   |
-5 |     # Prefix `int` vs. prefix `str` are not comparable.
-6 |     # error: [unsupported-operator]
 7 |     prefix_int_var_str < prefix_str_var_int
   |     ------------------^^^------------------
   |     |                    |
   |     |                    Has type `tuple[str, *tuple[int, ...]]`
   |     Has type `tuple[int, *tuple[str, ...]]`
-8 | def _(
-9 |     prefix_int_var_int: tuple[int, *tuple[int, ...]],
   |
 info: Operation fails because operator `<` is not supported between objects of type `int` and `str`
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Homogeneous_-_Unsupported_Comparis…_(400a427b33d53e00).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Homogeneous_-_Unsupported_Comparis…_(400a427b33d53e00).snap
@@ -60,15 +60,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:12:5
    |
-10 |     # Ordering comparisons between incompatible types should emit errors
-11 |     # error: [unsupported-operator] "Operator `<` is not supported between objects of type `tuple[int, ...]` and `tuple[str, ...]`"
 12 |     a < b
    |     -^^^-
    |     |   |
    |     |   Has type `tuple[str, ...]`
    |     Has type `tuple[int, ...]`
-13 |     # error: [unsupported-operator] "Operator `<` is not supported between objects of type `tuple[str, ...]` and `tuple[int, ...]`"
-14 |     b < a
    |
 info: Operation fails because operator `<` is not supported between objects of type `int` and `str`
 
@@ -78,15 +74,11 @@ info: Operation fails because operator `<` is not supported between objects of t
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:14:5
    |
-12 |     a < b
-13 |     # error: [unsupported-operator] "Operator `<` is not supported between objects of type `tuple[str, ...]` and `tuple[int, ...]`"
 14 |     b < a
    |     -^^^-
    |     |   |
    |     |   Has type `tuple[int, ...]`
    |     Has type `tuple[str, ...]`
-15 |     # error: [unsupported-operator] "Operator `<` is not supported between objects of type `tuple[int, ...]` and `tuple[str]`"
-16 |     a < c
    |
 info: Operation fails because operator `<` is not supported between objects of type `str` and `int`
 
@@ -96,15 +88,11 @@ info: Operation fails because operator `<` is not supported between objects of t
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:16:5
    |
-14 |     b < a
-15 |     # error: [unsupported-operator] "Operator `<` is not supported between objects of type `tuple[int, ...]` and `tuple[str]`"
 16 |     a < c
    |     -^^^-
    |     |   |
    |     |   Has type `tuple[str]`
    |     Has type `tuple[int, ...]`
-17 |     # error: [unsupported-operator] "Operator `<` is not supported between objects of type `tuple[str]` and `tuple[int, ...]`"
-18 |     c < a
    |
 info: Operation fails because operator `<` is not supported between objects of type `int` and `str`
 
@@ -114,15 +102,11 @@ info: Operation fails because operator `<` is not supported between objects of t
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:18:5
    |
-16 |     a < c
-17 |     # error: [unsupported-operator] "Operator `<` is not supported between objects of type `tuple[str]` and `tuple[int, ...]`"
 18 |     c < a
    |     -^^^-
    |     |   |
    |     |   Has type `tuple[int, ...]`
    |     Has type `tuple[str]`
-19 | def _(
-20 |     var_int: tuple[int, ...],
    |
 info: Operation fails because operator `<` is not supported between objects of type `str` and `int`
 
@@ -132,15 +116,11 @@ info: Operation fails because operator `<` is not supported between objects of t
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:28:5
    |
-26 |     # Position 1 (if `var_int` has 2+ elements): `str` vs. `int` are not comparable.
-27 |     # error: [unsupported-operator]
 28 |     fixed_int_str < var_int
    |     -------------^^^-------
    |     |               |
    |     |               Has type `tuple[int, ...]`
    |     Has type `tuple[int, str]`
-29 |
-30 |     # Variable `tuple[int, ...]` vs. fixed `tuple[int, str]`:
    |
 info: Operation fails because operator `<` is not supported between objects of type `str` and `int`
 
@@ -150,15 +130,11 @@ info: Operation fails because operator `<` is not supported between objects of t
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:34:5
    |
-32 |     # Position 1 (if `var_int` has 2+ elements): `int` vs. `str` are not comparable.
-33 |     # error: [unsupported-operator]
 34 |     var_int < fixed_int_str
    |     -------^^^-------------
    |     |         |
    |     |         Has type `tuple[int, str]`
    |     Has type `tuple[int, ...]`
-35 |
-36 |     # Variable `tuple[str, ...]` vs. fixed `tuple[int, str]`:
    |
 info: Operation fails because operator `<` is not supported between objects of type `int` and `str`
 
@@ -168,8 +144,6 @@ info: Operation fails because operator `<` is not supported between objects of t
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:39:5
    |
-37 |     # Position 0: `str` vs. `int` are not comparable.
-38 |     # error: [unsupported-operator]
 39 |     var_str < fixed_int_str
    |     -------^^^-------------
    |     |         |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/ty_extensions.md_-_`ty_extensions`_-_Diagnostic_snapshots_(662547cd88c67f9f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/ty_extensions.md_-_`ty_extensions`_-_Diagnostic_snapshots_(662547cd88c67f9f).snap
@@ -40,17 +40,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/ty_extensions.md
 
 ```
 error[static-assert-error]: Static assertion error: argument evaluates to `False`
-  --> src/mdtest_snippet.py:9:1
-   |
- 7 | # evaluates to False
- 8 | # error: [static-assert-error]
- 9 | static_assert(1 > 2)
-   | ^^^^^^^^^^^^^^-----^
-   |               |
-   |               Inferred type of argument is `Literal[False]`
-10 |
-11 | # evaluates to False, with a message as the second argument
-   |
+ --> src/mdtest_snippet.py:9:1
+  |
+9 | static_assert(1 > 2)
+  | ^^^^^^^^^^^^^^-----^
+  |               |
+  |               Inferred type of argument is `Literal[False]`
+  |
 
 ```
 
@@ -58,14 +54,10 @@ error[static-assert-error]: Static assertion error: argument evaluates to `False
 error[static-assert-error]: Static assertion error: with a message
   --> src/mdtest_snippet.py:13:1
    |
-11 | # evaluates to False, with a message as the second argument
-12 | # error: [static-assert-error]
 13 | static_assert(1 > 2, "with a message")
    | ^^^^^^^^^^^^^^-----^^^^^^^^^^^^^^^^^^^
    |               |
    |               Inferred type of argument is `Literal[False]`
-14 |
-15 | # evaluates to something falsey
    |
 
 ```
@@ -74,14 +66,10 @@ error[static-assert-error]: Static assertion error: with a message
 error[static-assert-error]: Static assertion error: argument of type `Literal[""]` is always falsy
   --> src/mdtest_snippet.py:17:1
    |
-15 | # evaluates to something falsey
-16 | # error: [static-assert-error]
 17 | static_assert("")
    | ^^^^^^^^^^^^^^--^
    |               |
    |               Inferred type of argument is `Literal[""]`
-18 |
-19 | # evaluates to something ambiguous
    |
 
 ```
@@ -90,8 +78,6 @@ error[static-assert-error]: Static assertion error: argument of type `Literal[""
 error[static-assert-error]: Static assertion error: argument of type `int` has an ambiguous static truthiness
   --> src/mdtest_snippet.py:21:1
    |
-19 | # evaluates to something ambiguous
-20 | # error: [static-assert-error]
 21 | static_assert(secrets.randbelow(2))
    | ^^^^^^^^^^^^^^--------------------^
    |               |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/type.md_-_Calls_to_`type()`_-_MRO_error_highlighti…_(12acd974e75461ea).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/type.md_-_Calls_to_`type()`_-_MRO_error_highlighti…_(12acd974e75461ea).snap
@@ -24,8 +24,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/call/type.md
 error[duplicate-base]: Duplicate base class <class 'A'> in class `Dup`
  --> src/mdtest_snippet.py:3:7
   |
-1 | class A: ...
-2 |
 3 | Dup = type("Dup", (A, A), {})  # error: [duplicate-base]
   |       ^^^^^^^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/type.md_-_Calls_to_`type()`_-_`inconsistent-mro`_e…_(839db6a431c3b705).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/type.md_-_Calls_to_`type()`_-_`inconsistent-mro`_e…_(839db6a431c3b705).snap
@@ -51,12 +51,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/call/type.md
 error[inconsistent-mro]: Cannot create a consistent method resolution order (MRO) for class `Foo1` with bases list `[<special-form 'typing.Generic[K, V]'>, <class 'dict'>]`
  --> src/mdtest_snippet.py:6:7
   |
-4 | V = TypeVar("V")
-5 |
 6 | class Foo1(Generic[K, V], dict): ...  # error: [inconsistent-mro]
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^
-7 |
-8 | # fmt: off
   |
 help: Move `Generic[K, V]` to the end of the bases list
 3 | K = TypeVar("K")
@@ -75,8 +71,6 @@ note: This is an unsafe fix and may change runtime behavior
 error[inconsistent-mro]: Cannot create a consistent method resolution order (MRO) for class `Foo2` with bases list `[<special-form 'typing.Generic[K, V]'>, <class 'dict'>]`
   --> src/mdtest_snippet.py:10:7
    |
- 8 |   # fmt: off
- 9 |
 10 |   class Foo2(  # error: [inconsistent-mro]
    |  _______^
 11 | |     # comment1
@@ -86,8 +80,6 @@ error[inconsistent-mro]: Cannot create a consistent method resolution order (MRO
 15 | |     # comment5
 16 | | ): ...
    | |_^
-17 |
-18 |   class Foo3(Generic[K, V], dict, metaclass=type): ...  # error: [inconsistent-mro]
    |
 help: Move `Generic[K, V]` to the end of the bases list
 9  |
@@ -108,12 +100,8 @@ note: This is an unsafe fix and may change runtime behavior
 error[inconsistent-mro]: Cannot create a consistent method resolution order (MRO) for class `Foo3` with bases list `[<special-form 'typing.Generic[K, V]'>, <class 'dict'>]`
   --> src/mdtest_snippet.py:18:7
    |
-16 | ): ...
-17 |
 18 | class Foo3(Generic[K, V], dict, metaclass=type): ...  # error: [inconsistent-mro]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-19 |
-20 | class Foo4(  # error: [inconsistent-mro]
    |
 help: Move `Generic[K, V]` to the end of the bases list
 15 |     # comment5
@@ -132,8 +120,6 @@ note: This is an unsafe fix and may change runtime behavior
 error[inconsistent-mro]: Cannot create a consistent method resolution order (MRO) for class `Foo4` with bases list `[<special-form 'typing.Generic[K, V]'>, <class 'dict'>]`
   --> src/mdtest_snippet.py:20:7
    |
-18 |   class Foo3(Generic[K, V], dict, metaclass=type): ...  # error: [inconsistent-mro]
-19 |
 20 |   class Foo4(  # error: [inconsistent-mro]
    |  _______^
 21 | |     # comment1
@@ -145,8 +131,6 @@ error[inconsistent-mro]: Cannot create a consistent method resolution order (MRO
 27 | |     # comment7
 28 | | ): ...
    | |_^
-29 |
-30 |   # fmt: on
    |
 help: Move `Generic[K, V]` to the end of the bases list
 19 |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/type.md_-_Calls_to_`type()`_-_`instance-layout-con…_(d3fedd90588465f3).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/type.md_-_Calls_to_`type()`_-_`instance-layout-con…_(d3fedd90588465f3).snap
@@ -36,25 +36,19 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/call/type.md
 
 ```
 error[instance-layout-conflict]: Class will raise `TypeError` at runtime due to incompatible bases
-  --> src/mdtest_snippet.py:8:5
-   |
- 7 | # error: [instance-layout-conflict]
- 8 | X = type("X", (A, B), {})
-   |     ^^^^^^^^^^^^^^^^^^^^^ Bases `A` and `B` cannot be combined in multiple inheritance
- 9 | class C:
-10 |     __slots__ = ("x",)
-   |
+ --> src/mdtest_snippet.py:8:5
+  |
+8 | X = type("X", (A, B), {})
+  |     ^^^^^^^^^^^^^^^^^^^^^ Bases `A` and `B` cannot be combined in multiple inheritance
+  |
 info: Two classes cannot coexist in a class's MRO if their instances have incompatible memory layouts
-  --> src/mdtest_snippet.py:8:16
-   |
- 7 | # error: [instance-layout-conflict]
- 8 | X = type("X", (A, B), {})
-   |                -  - `B` instances have a distinct memory layout because `B` defines non-empty `__slots__`
-   |                |
-   |                `A` instances have a distinct memory layout because `A` defines non-empty `__slots__`
- 9 | class C:
-10 |     __slots__ = ("x",)
-   |
+ --> src/mdtest_snippet.py:8:16
+  |
+8 | X = type("X", (A, B), {})
+  |                -  - `B` instances have a distinct memory layout because `B` defines non-empty `__slots__`
+  |                |
+  |                `A` instances have a distinct memory layout because `A` defines non-empty `__slots__`
+  |
 
 ```
 
@@ -62,8 +56,6 @@ info: Two classes cannot coexist in a class's MRO if their instances have incomp
 error[instance-layout-conflict]: Class will raise `TypeError` at runtime due to incompatible bases
   --> src/mdtest_snippet.py:17:5
    |
-15 | bases: tuple[type[C], type[D]] = (C, D)
-16 | # error: [instance-layout-conflict]
 17 | Y = type("Y", bases, {})
    |     ^^^^^^^^^^^^^^^^^^^^ Bases `C` and `D` cannot be combined in multiple inheritance
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Class_header_validat…_(25381f371caa1401).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Class_header_validat…_(25381f371caa1401).snap
@@ -41,20 +41,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/typed_dict.md
 error[invalid-typed-dict-header]: TypedDict class `Foo` can only inherit from TypedDict classes
    --> src/mdtest_snippet.py:3:22
     |
-  1 | from typing import TypedDict
-  2 |
   3 | class Foo(TypedDict, int): ...  # error: [invalid-typed-dict-header]
     |                      ^^^ `int` is not a `TypedDict` class
-  4 |
-  5 | # This even fails at runtime!
     |
    ::: stdlib/builtins.pyi:348:7
     |
-347 | @disjoint_base
 348 | class int:
     |       --- `int` defined here
-349 |     """int([x]) -> integer
-350 |     int(x, base=10) -> integer
     |
 
 ```
@@ -63,18 +56,13 @@ error[invalid-typed-dict-header]: TypedDict class `Foo` can only inherit from Ty
 error[invalid-typed-dict-header]: TypedDict class `Foo2` can only inherit from TypedDict classes
    --> src/mdtest_snippet.py:6:23
     |
-  5 | # This even fails at runtime!
   6 | class Foo2(TypedDict, object): ...  # error: [invalid-typed-dict-header]
     |                       ^^^^^^ `object` is not a `TypedDict` class
-  7 | class Bar(TypedDict, total=42): ...  # error: [invalid-argument-type]
-  8 | class Baz(TypedDict, closed=None): ...  # error: [invalid-argument-type]
     |
    ::: stdlib/builtins.pyi:121:7
     |
-120 | @disjoint_base
 121 | class object:
     |       ------ `object` defined here
-122 |     """The base class of the class hierarchy.
     |
 
 ```
@@ -83,27 +71,19 @@ error[invalid-typed-dict-header]: TypedDict class `Foo2` can only inherit from T
 error[invalid-argument-type]: Invalid argument to parameter `total` in `TypedDict` definition
  --> src/mdtest_snippet.py:7:22
   |
-5 | # This even fails at runtime!
-6 | class Foo2(TypedDict, object): ...  # error: [invalid-typed-dict-header]
 7 | class Bar(TypedDict, total=42): ...  # error: [invalid-argument-type]
   |                      ^^^^^^^^ Expected either `True` or `False`, got object of type `Literal[42]`
-8 | class Baz(TypedDict, closed=None): ...  # error: [invalid-argument-type]
-9 | def f(is_total: bool):
   |
 
 ```
 
 ```
 error[invalid-argument-type]: Invalid argument to parameter `closed` in `TypedDict` definition
-  --> src/mdtest_snippet.py:8:22
-   |
- 6 | class Foo2(TypedDict, object): ...  # error: [invalid-typed-dict-header]
- 7 | class Bar(TypedDict, total=42): ...  # error: [invalid-argument-type]
- 8 | class Baz(TypedDict, closed=None): ...  # error: [invalid-argument-type]
-   |                      ^^^^^^^^^^^ Expected either `True` or `False`, got object of type `None`
- 9 | def f(is_total: bool):
-10 |     class VeryDynamic(TypedDict, total=is_total): ...  # error: [invalid-argument-type]
-   |
+ --> src/mdtest_snippet.py:8:22
+  |
+8 | class Baz(TypedDict, closed=None): ...  # error: [invalid-argument-type]
+  |                      ^^^^^^^^^^^ Expected either `True` or `False`, got object of type `None`
+  |
 
 ```
 
@@ -111,12 +91,8 @@ error[invalid-argument-type]: Invalid argument to parameter `closed` in `TypedDi
 error[invalid-argument-type]: Invalid argument to parameter `total` in `TypedDict` definition
   --> src/mdtest_snippet.py:10:34
    |
- 8 | class Baz(TypedDict, closed=None): ...  # error: [invalid-argument-type]
- 9 | def f(is_total: bool):
 10 |     class VeryDynamic(TypedDict, total=is_total): ...  # error: [invalid-argument-type]
    |                                  ^^^^^^^^^^^^^^ Expected either `True` or `False`, got object of type `bool`
-11 | class Bazzzz(TypedDict, weird=56): ...  # error: [unknown-argument]
-12 | from abc import ABCMeta
    |
 
 ```
@@ -125,11 +101,8 @@ error[invalid-argument-type]: Invalid argument to parameter `total` in `TypedDic
 error[unknown-argument]: Unknown keyword argument `weird` in `TypedDict` definition
   --> src/mdtest_snippet.py:11:25
    |
- 9 | def f(is_total: bool):
-10 |     class VeryDynamic(TypedDict, total=is_total): ...  # error: [invalid-argument-type]
 11 | class Bazzzz(TypedDict, weird=56): ...  # error: [unknown-argument]
    |                         ^^^^^^^^
-12 | from abc import ABCMeta
    |
 
 ```
@@ -138,12 +111,8 @@ error[unknown-argument]: Unknown keyword argument `weird` in `TypedDict` definit
 error[invalid-typed-dict-header]: Custom metaclasses are not supported in `TypedDict` definitions
   --> src/mdtest_snippet.py:14:23
    |
-12 | from abc import ABCMeta
-13 |
 14 | class Spam(TypedDict, metaclass=ABCMeta): ...  # error: [invalid-typed-dict-header]
    |                       ^^^^^^^^^^^^^^^^^
-15 |
-16 | # This one works at runtime, but the metaclass is still `typing._TypedDictMeta`,
    |
 
 ```
@@ -152,12 +121,8 @@ error[invalid-typed-dict-header]: Custom metaclasses are not supported in `Typed
 error[invalid-typed-dict-header]: Custom metaclasses are not supported in `TypedDict` definitions
   --> src/mdtest_snippet.py:18:22
    |
-16 | # This one works at runtime, but the metaclass is still `typing._TypedDictMeta`,
-17 | # so there doesn't seem to be any reason why you'd want to do this
 18 | class Ham(TypedDict, metaclass=type): ...  # error: [invalid-typed-dict-header]
    |                      ^^^^^^^^^^^^^^
-19 | def f(kwargs: dict):
-20 |     class Eggs(TypedDict, **kwargs): ...  # error: [invalid-typed-dict-header]
    |
 
 ```
@@ -166,8 +131,6 @@ error[invalid-typed-dict-header]: Custom metaclasses are not supported in `Typed
 error[invalid-typed-dict-header]: Keyword-variadic arguments are not supported in `TypedDict` definitions
   --> src/mdtest_snippet.py:20:27
    |
-18 | class Ham(TypedDict, metaclass=type): ...  # error: [invalid-typed-dict-header]
-19 | def f(kwargs: dict):
 20 |     class Eggs(TypedDict, **kwargs): ...  # error: [invalid-typed-dict-header]
    |                           ^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Diagnostics_(e5289abf5c570c29).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Diagnostics_(e5289abf5c570c29).snap
@@ -76,16 +76,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/typed_dict.md
 
 ```
 error[invalid-key]: Unknown key "nane" for TypedDict `Person`
-  --> src/mdtest_snippet.py:8:5
-   |
- 7 | def access_invalid_literal_string_key(person: Person):
- 8 |     person["nane"]  # error: [invalid-key]
-   |     ------ ^^^^^^ Did you mean "name"?
-   |     |
-   |     TypedDict `Person`
- 9 |
-10 | NAME_KEY: Final = "nane"
-   |
+ --> src/mdtest_snippet.py:8:5
+  |
+8 |     person["nane"]  # error: [invalid-key]
+  |     ------ ^^^^^^ Did you mean "name"?
+  |     |
+  |     TypedDict `Person`
+  |
 5  |     age: int | None
 6  |
 7  | def access_invalid_literal_string_key(person: Person):
@@ -102,13 +99,10 @@ note: This is an unsafe fix and may change runtime behavior
 error[invalid-key]: Unknown key "nane" for TypedDict `Person`
   --> src/mdtest_snippet.py:13:5
    |
-12 | def access_invalid_key(person: Person):
 13 |     person[NAME_KEY]  # error: [invalid-key]
    |     ------ ^^^^^^^^ Unknown key "nane" - did you mean "name"?
    |     |
    |     TypedDict `Person`
-14 |
-15 | def access_with_str_key(person: Person, str_key: str):
    |
 
 ```
@@ -117,11 +111,8 @@ error[invalid-key]: Unknown key "nane" for TypedDict `Person`
 error[invalid-key]: TypedDict `Person` can only be subscripted with a string literal key, got key of type `str`
   --> src/mdtest_snippet.py:16:12
    |
-15 | def access_with_str_key(person: Person, str_key: str):
 16 |     person[str_key]  # error: [invalid-key]
    |            ^^^^^^^
-17 |
-18 | def write_to_key_with_wrong_type(person: Person):
    |
 
 ```
@@ -130,24 +121,17 @@ error[invalid-key]: TypedDict `Person` can only be subscripted with a string lit
 error[invalid-assignment]: Invalid assignment to key "age" with declared type `int | None` on TypedDict `Person`
   --> src/mdtest_snippet.py:19:5
    |
-18 | def write_to_key_with_wrong_type(person: Person):
 19 |     person["age"] = "42"  # error: [invalid-assignment]
    |     ------ -----    ^^^^ value of type `Literal["42"]`
    |     |      |
    |     |      key has declared type `int | None`
    |     TypedDict `Person`
-20 |
-21 | def write_to_non_existing_key(person: Person):
    |
 info: Item declaration
  --> src/mdtest_snippet.py:5:5
   |
-3 | class Person(TypedDict):
-4 |     name: str
 5 |     age: int | None
   |     --------------- Item declared here
-6 |
-7 | def access_invalid_literal_string_key(person: Person):
   |
 
 ```
@@ -156,13 +140,10 @@ info: Item declaration
 error[invalid-key]: Unknown key "nane" for TypedDict `Person`
   --> src/mdtest_snippet.py:22:5
    |
-21 | def write_to_non_existing_key(person: Person):
 22 |     person["nane"] = "Alice"  # error: [invalid-key]
    |     ------ ^^^^^^ Did you mean "name"?
    |     |
    |     TypedDict `Person`
-23 |
-24 | def write_to_non_literal_string_key(person: Person, str_key: str):
    |
 19 |     person["age"] = "42"  # error: [invalid-assignment]
 20 |
@@ -180,11 +161,8 @@ note: This is an unsafe fix and may change runtime behavior
 error[invalid-key]: TypedDict `Person` can only be subscripted with a string literal key, got key of type `str`.
   --> src/mdtest_snippet.py:25:12
    |
-24 | def write_to_non_literal_string_key(person: Person, str_key: str):
 25 |     person[str_key] = "Alice"  # error: [invalid-key]
    |            ^^^^^^^
-26 |
-27 | def create_with_invalid_string_key():
    |
 
 ```
@@ -193,15 +171,11 @@ error[invalid-key]: TypedDict `Person` can only be subscripted with a string lit
 error[invalid-key]: Unknown key "unknown" for TypedDict `Person`
   --> src/mdtest_snippet.py:29:21
    |
-27 | def create_with_invalid_string_key():
-28 |     # error: [invalid-key]
 29 |     alice: Person = {"name": "Alice", "age": 30, "unknown": "Foo"}
    |                     -----------------------------^^^^^^^^^--------
    |                     |                            |
    |                     |                            Unknown key "unknown"
    |                     TypedDict `Person`
-30 |
-31 |     # error: [invalid-key]
    |
 
 ```
@@ -210,10 +184,8 @@ error[invalid-key]: Unknown key "unknown" for TypedDict `Person`
 error[invalid-key]: Unknown key "unknown" for TypedDict `Person`
   --> src/mdtest_snippet.py:32:11
    |
-31 |     # error: [invalid-key]
 32 |     bob = Person(name="Bob", age=25, unknown="Bar")
    |           ------ TypedDict `Person`  ^^^^^^^^^^^^^ Unknown key "unknown"
-33 | from typing_extensions import ReadOnly
    |
 
 ```
@@ -222,21 +194,16 @@ error[invalid-key]: Unknown key "unknown" for TypedDict `Person`
 error[invalid-assignment]: Cannot assign to key "id" on TypedDict `Employee`
   --> src/mdtest_snippet.py:40:5
    |
-39 | def write_to_readonly_key(employee: Employee):
 40 |     employee["id"] = 42  # error: [invalid-assignment]
    |     -------- ^^^^ key is marked read-only
    |     |
    |     TypedDict `Employee`
-41 | def write_to_non_existing_key_single_quotes(person: Person):
-42 |     # error: [invalid-key]
    |
 info: Item declaration
   --> src/mdtest_snippet.py:36:5
    |
-35 | class Employee(TypedDict):
 36 |     id: ReadOnly[int]
    |     ----------------- Read-only item declared here
-37 |     name: str
    |
 
 ```
@@ -245,14 +212,10 @@ info: Item declaration
 error[invalid-key]: Unknown key "nane" for TypedDict `Person`
   --> src/mdtest_snippet.py:43:5
    |
-41 | def write_to_non_existing_key_single_quotes(person: Person):
-42 |     # error: [invalid-key]
 43 |     person['nane'] = "Alice"  # fmt: skip
    |     ------ ^^^^^^ Did you mean 'name'?
    |     |
    |     TypedDict `Person`
-44 | class MovieBase(TypedDict):
-45 |     name: str
    |
 40 |     employee["id"] = 42  # error: [invalid-assignment]
 41 | def write_to_non_existing_key_single_quotes(person: Person):
@@ -270,21 +233,14 @@ note: This is an unsafe fix and may change runtime behavior
 error[invalid-typed-dict-field]: Cannot overwrite TypedDict field `name`
   --> src/mdtest_snippet.py:48:5
    |
-47 | class BadMovie(MovieBase):
 48 |     name: int  # error: [invalid-typed-dict-field]
    |     ^^^^^^^^^ Inherited mutable field type `str` is incompatible with `int`
-49 |
-50 | class LeftBase(TypedDict):
    |
 info: Field declaration
   --> src/mdtest_snippet.py:45:5
    |
-43 |     person['nane'] = "Alice"  # fmt: skip
-44 | class MovieBase(TypedDict):
 45 |     name: str
    |     --------- Inherited field `name` declared here on base `MovieBase`
-46 |
-47 | class BadMovie(MovieBase):
    |
 
 ```
@@ -293,29 +249,20 @@ info: Field declaration
 error[invalid-typed-dict-field]: Cannot overwrite TypedDict field `value` while merging base classes
   --> src/mdtest_snippet.py:56:7
    |
-54 |     value: str
-55 |
 56 | class BadMerge(LeftBase, RightBase):  # error: [invalid-typed-dict-field]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Inherited mutable field type `str` is incompatible with `int`
-57 |     pass
    |
 info: Field declaration
   --> src/mdtest_snippet.py:51:5
    |
-50 | class LeftBase(TypedDict):
 51 |     value: int
    |     ---------- Field `value` already inherited from another base here
-52 |
-53 | class RightBase(TypedDict):
    |
 info: Field declaration
   --> src/mdtest_snippet.py:54:5
    |
-53 | class RightBase(TypedDict):
 54 |     value: str
    |     ---------- Inherited field `value` declared here on base `RightBase`
-55 |
-56 | class BadMerge(LeftBase, RightBase):  # error: [invalid-typed-dict-field]
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Error_cases_-_`typing.TypedDict`_i…_(9df67eb93e3df341).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Error_cases_-_`typing.TypedDict`_i…_(9df67eb93e3df341).snap
@@ -25,7 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/typed_dict.md
 error[invalid-type-form]: The special form `typing.TypedDict` is not allowed in type expressions
  --> src/mdtest_snippet.py:4:4
   |
-3 | # error: [invalid-type-form] "The special form `typing.TypedDict` is not allowed in type expressions"
 4 | x: TypedDict = {"name": "Alice"}
   |    ^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Function_syntax_with…_(4b18755412dfaff1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Function_syntax_with…_(4b18755412dfaff1).snap
@@ -117,11 +117,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/typed_dict.md
 error[too-many-positional-arguments]: Too many positional arguments to function `TypedDict`: expected 2, got 3
  --> src/mdtest_snippet.py:4:22
   |
-3 | # error: [too-many-positional-arguments] "Too many positional arguments to function `TypedDict`: expected 2, got 3"
 4 | TypedDict("Foo", {}, {})
   |                      ^^
-5 | # error: [missing-argument] "No arguments provided for required parameters `typename` and `fields` of function `TypedDict`"
-6 | TypedDict()
   |
 
 ```
@@ -130,27 +127,19 @@ error[too-many-positional-arguments]: Too many positional arguments to function 
 error[missing-argument]: No arguments provided for required parameters `typename` and `fields` of function `TypedDict`
  --> src/mdtest_snippet.py:6:1
   |
-4 | TypedDict("Foo", {}, {})
-5 | # error: [missing-argument] "No arguments provided for required parameters `typename` and `fields` of function `TypedDict`"
 6 | TypedDict()
   | ^^^^^^^^^^^
-7 | # error: [missing-argument] "No argument provided for required parameter `fields` of function `TypedDict`"
-8 | TypedDict("Foo")
   |
 
 ```
 
 ```
 error[missing-argument]: No argument provided for required parameter `fields` of function `TypedDict`
-  --> src/mdtest_snippet.py:8:1
-   |
- 6 | TypedDict()
- 7 | # error: [missing-argument] "No argument provided for required parameter `fields` of function `TypedDict`"
- 8 | TypedDict("Foo")
-   | ^^^^^^^^^^^^^^^^
- 9 |
-10 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
-   |
+ --> src/mdtest_snippet.py:8:1
+  |
+8 | TypedDict("Foo")
+  | ^^^^^^^^^^^^^^^^
+  |
 
 ```
 
@@ -158,11 +147,8 @@ error[missing-argument]: No argument provided for required parameter `fields` of
 error[invalid-argument-type]: Invalid argument to parameter `typename` of `TypedDict()`
   --> src/mdtest_snippet.py:11:18
    |
-10 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
 11 | Bad1 = TypedDict(123, {"name": str})
    |                  ^^^ Expected `str`, found `Literal[123]`
-12 |
-13 | # error: [mismatched-type-name] "The name passed to `TypedDict` must match the variable it is assigned to: Expected "BadTypedDict3", g…
    |
 
 ```
@@ -171,10 +157,8 @@ error[invalid-argument-type]: Invalid argument to parameter `typename` of `Typed
 warning[mismatched-type-name]: The name passed to `TypedDict` must match the variable it is assigned to
   --> src/mdtest_snippet.py:14:27
    |
-13 | # error: [mismatched-type-name] "The name passed to `TypedDict` must match the variable it is assigned to: Expected "BadTypedDict3", g…
 14 | BadTypedDict3 = TypedDict("WrongName", {"name": str})
    |                           ^^^^^^^^^^^ Expected "BadTypedDict3", got "WrongName"
-15 | reveal_type(BadTypedDict3)  # revealed: <class 'WrongName'>
    |
 
 ```
@@ -183,12 +167,8 @@ warning[mismatched-type-name]: The name passed to `TypedDict` must match the var
 warning[mismatched-type-name]: The name passed to `TypedDict` must match the variable it is assigned to
   --> src/mdtest_snippet.py:19:19
    |
-17 | def f(x: str) -> None:
-18 |     # error: [mismatched-type-name] "The name passed to `TypedDict` must match the variable it is assigned to: Expected "Y", got varia…
 19 |     Y = TypedDict(x, {})
    |                   ^ Expected "Y", got variable of type `str`
-20 |
-21 | def g(x: str) -> None:
    |
 
 ```
@@ -197,11 +177,8 @@ warning[mismatched-type-name]: The name passed to `TypedDict` must match the var
 error[invalid-argument-type]: Expected a dict literal for parameter `fields` of `TypedDict()`
   --> src/mdtest_snippet.py:28:26
    |
-27 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
 28 | Bad2 = TypedDict("Bad2", "not a dict")
    |                          ^^^^^^^^^^^^
-29 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
-30 | TypedDict("Bad2", "not a dict")
    |
 
 ```
@@ -210,12 +187,8 @@ error[invalid-argument-type]: Expected a dict literal for parameter `fields` of 
 error[invalid-argument-type]: Expected a dict literal for parameter `fields` of `TypedDict()`
   --> src/mdtest_snippet.py:30:19
    |
-28 | Bad2 = TypedDict("Bad2", "not a dict")
-29 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
 30 | TypedDict("Bad2", "not a dict")
    |                   ^^^^^^^^^^^^
-31 |
-32 | def get_fields() -> dict[str, object]:
    |
 
 ```
@@ -224,11 +197,8 @@ error[invalid-argument-type]: Expected a dict literal for parameter `fields` of 
 error[invalid-argument-type]: Expected a dict literal for parameter `fields` of `TypedDict()`
   --> src/mdtest_snippet.py:36:28
    |
-35 | # error: [invalid-argument-type] "Expected a dict literal for parameter `fields` of `TypedDict()`"
 36 | Bad2b = TypedDict("Bad2b", get_fields())
    |                            ^^^^^^^^^^^^
-37 |
-38 | # error: [invalid-argument-type] "Invalid argument to parameter `total` of `TypedDict()`"
    |
 
 ```
@@ -237,11 +207,8 @@ error[invalid-argument-type]: Expected a dict literal for parameter `fields` of 
 error[invalid-argument-type]: Invalid argument to parameter `total` of `TypedDict()`
   --> src/mdtest_snippet.py:39:47
    |
-38 | # error: [invalid-argument-type] "Invalid argument to parameter `total` of `TypedDict()`"
 39 | Bad3 = TypedDict("Bad3", {"name": str}, total="not a bool")
    |                                               ^^^^^^^^^^^^ Expected either `True` or `False`, got object of type `Literal["not a bool"]`
-40 |
-41 | # error: [invalid-argument-type] "Invalid argument to parameter `closed` of `TypedDict()`"
    |
 
 ```
@@ -250,11 +217,8 @@ error[invalid-argument-type]: Invalid argument to parameter `total` of `TypedDic
 error[invalid-argument-type]: Invalid argument to parameter `closed` of `TypedDict()`
   --> src/mdtest_snippet.py:42:48
    |
-41 | # error: [invalid-argument-type] "Invalid argument to parameter `closed` of `TypedDict()`"
 42 | Bad4 = TypedDict("Bad4", {"name": str}, closed=123)
    |                                                ^^^ Expected either `True` or `False`, got object of type `Literal[123]`
-43 |
-44 | tup = ("foo", "bar")
    |
 
 ```
@@ -263,11 +227,8 @@ error[invalid-argument-type]: Invalid argument to parameter `closed` of `TypedDi
 error[invalid-argument-type]: Variadic positional arguments are not supported in `TypedDict()` calls
   --> src/mdtest_snippet.py:48:18
    |
-47 | # error: [invalid-argument-type] "Variadic positional arguments are not supported in `TypedDict()` calls"
 48 | Bad5 = TypedDict(*tup)
    |                  ^^^^
-49 |
-50 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
    |
 
 ```
@@ -276,11 +237,8 @@ error[invalid-argument-type]: Variadic positional arguments are not supported in
 error[invalid-argument-type]: Variadic keyword arguments are not supported in `TypedDict()` calls
   --> src/mdtest_snippet.py:51:41
    |
-50 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
 51 | Bad6 = TypedDict("Bad6", {"name": str}, **kw)
    |                                         ^^^^
-52 |
-53 | # error: [invalid-argument-type] "Variadic positional and keyword arguments are not supported in `TypedDict()` calls"
    |
 
 ```
@@ -289,11 +247,8 @@ error[invalid-argument-type]: Variadic keyword arguments are not supported in `T
 error[invalid-argument-type]: Variadic positional and keyword arguments are not supported in `TypedDict()` calls
   --> src/mdtest_snippet.py:54:18
    |
-53 | # error: [invalid-argument-type] "Variadic positional and keyword arguments are not supported in `TypedDict()` calls"
 54 | Bad7 = TypedDict(*tup, "foo", "bar", **kw)
    |                  ^^^^                ----
-55 |
-56 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
    |
 
 ```
@@ -302,12 +257,8 @@ error[invalid-argument-type]: Variadic positional and keyword arguments are not 
 error[invalid-argument-type]: Variadic keyword arguments are not supported in `TypedDict()` calls
   --> src/mdtest_snippet.py:58:28
    |
-56 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
-57 | # error: [unknown-argument] "Argument `random_other_arg` does not match any known parameter of function `TypedDict`"
 58 | Bad7b = TypedDict("Bad7b", **kw, random_other_arg=56)
    |                            ^^^^
-59 |
-60 | kwargs = {"x": int}
    |
 
 ```
@@ -316,12 +267,8 @@ error[invalid-argument-type]: Variadic keyword arguments are not supported in `T
 error[unknown-argument]: Argument `random_other_arg` does not match any known parameter of function `TypedDict`
   --> src/mdtest_snippet.py:58:34
    |
-56 | # error: [invalid-argument-type] "Variadic keyword arguments are not supported in `TypedDict()` calls"
-57 | # error: [unknown-argument] "Argument `random_other_arg` does not match any known parameter of function `TypedDict`"
 58 | Bad7b = TypedDict("Bad7b", **kw, random_other_arg=56)
    |                                  ^^^^^^^^^^^^^^^^^^^
-59 |
-60 | kwargs = {"x": int}
    |
 
 ```
@@ -330,11 +277,8 @@ error[unknown-argument]: Argument `random_other_arg` does not match any known pa
 error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
   --> src/mdtest_snippet.py:63:29
    |
-62 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
 63 | Bad8 = TypedDict("Bad8", {**kwargs})
    |                             ^^^^^^
-64 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-65 | TypedDict("Bad8", {**kwargs})
    |
 
 ```
@@ -343,12 +287,8 @@ error[invalid-argument-type]: Keyword splats are not allowed in the `fields` par
 error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
   --> src/mdtest_snippet.py:65:22
    |
-63 | Bad8 = TypedDict("Bad8", {**kwargs})
-64 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
 65 | TypedDict("Bad8", {**kwargs})
    |                      ^^^^^^
-66 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-67 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
    |
 
 ```
@@ -357,12 +297,8 @@ error[invalid-argument-type]: Keyword splats are not allowed in the `fields` par
 error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
   --> src/mdtest_snippet.py:68:31
    |
-66 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-67 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
 68 | Bad81 = TypedDict("Bad81", {**kwargs, **kwargs})
    |                               ^^^^^^
-69 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-70 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
    |
 
 ```
@@ -371,12 +307,8 @@ error[invalid-argument-type]: Keyword splats are not allowed in the `fields` par
 error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
   --> src/mdtest_snippet.py:68:41
    |
-66 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-67 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
 68 | Bad81 = TypedDict("Bad81", {**kwargs, **kwargs})
    |                                         ^^^^^^
-69 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-70 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
    |
 
 ```
@@ -385,12 +317,8 @@ error[invalid-argument-type]: Keyword splats are not allowed in the `fields` par
 error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
   --> src/mdtest_snippet.py:71:23
    |
-69 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-70 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
 71 | TypedDict("Bad81", {**kwargs, **kwargs})
    |                       ^^^^^^
-72 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-73 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
    |
 
 ```
@@ -399,12 +327,8 @@ error[invalid-argument-type]: Keyword splats are not allowed in the `fields` par
 error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
   --> src/mdtest_snippet.py:71:33
    |
-69 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-70 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
 71 | TypedDict("Bad81", {**kwargs, **kwargs})
    |                                 ^^^^^^
-72 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-73 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
    |
 
 ```
@@ -413,12 +337,8 @@ error[invalid-argument-type]: Keyword splats are not allowed in the `fields` par
 error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
   --> src/mdtest_snippet.py:74:31
    |
-72 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-73 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
 74 | Bad82 = TypedDict("Bad82", {**kwargs, "foo": []})
    |                               ^^^^^^
-75 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-76 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
    |
 
 ```
@@ -427,12 +347,8 @@ error[invalid-argument-type]: Keyword splats are not allowed in the `fields` par
 error[invalid-type-form]: List literals are not allowed in this context in a type expression
   --> src/mdtest_snippet.py:74:46
    |
-72 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-73 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
 74 | Bad82 = TypedDict("Bad82", {**kwargs, "foo": []})
    |                                              ^^
-75 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-76 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
    |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -443,12 +359,8 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 error[invalid-argument-type]: Keyword splats are not allowed in the `fields` parameter to `TypedDict()`
   --> src/mdtest_snippet.py:77:23
    |
-75 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-76 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
 77 | TypedDict("Bad82", {**kwargs, "foo": []})
    |                       ^^^^^^
-78 |
-79 | def get_name() -> str:
    |
 
 ```
@@ -457,12 +369,8 @@ error[invalid-argument-type]: Keyword splats are not allowed in the `fields` par
 error[invalid-type-form]: List literals are not allowed in this context in a type expression
   --> src/mdtest_snippet.py:77:38
    |
-75 | # error: [invalid-argument-type] "Keyword splats are not allowed in the `fields` parameter to `TypedDict()`"
-76 | # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
 77 | TypedDict("Bad82", {**kwargs, "foo": []})
    |                                      ^^
-78 |
-79 | def get_name() -> str:
    |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -473,11 +381,8 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 error[invalid-argument-type]: Expected a string-literal key in the `fields` dict of `TypedDict()`
   --> src/mdtest_snippet.py:85:27
    |
-84 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
 85 | Bad9 = TypedDict("Bad9", {name: int})
    |                           ^^^^ Found `str`
-86 |
-87 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
    |
 
 ```
@@ -486,12 +391,8 @@ error[invalid-argument-type]: Expected a string-literal key in the `fields` dict
 error[invalid-argument-type]: Expected a string-literal key in the `fields` dict of `TypedDict()`
   --> src/mdtest_snippet.py:89:29
    |
-87 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
-88 | # error: [invalid-type-form]
 89 | Bad10 = TypedDict("Bad10", {name: 42})
    |                             ^^^^ Found `str`
-90 |
-91 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
    |
 
 ```
@@ -500,12 +401,8 @@ error[invalid-argument-type]: Expected a string-literal key in the `fields` dict
 error[invalid-type-form]: Int literals are not allowed in this context in a type expression
   --> src/mdtest_snippet.py:89:35
    |
-87 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
-88 | # error: [invalid-type-form]
 89 | Bad10 = TypedDict("Bad10", {name: 42})
    |                                   ^^ Did you mean `typing.Literal[42]`?
-90 |
-91 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
    |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -516,12 +413,8 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 error[invalid-argument-type]: Expected a string-literal key in the `fields` dict of `TypedDict()`
   --> src/mdtest_snippet.py:93:33
    |
-91 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
-92 | # error: [invalid-type-form] "Int literals are not allowed in this context in a type expression"
 93 | class Bad11(TypedDict("Bad11", {name: 42})): ...
    |                                 ^^^^ Found `str`
-94 |
-95 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
    |
 
 ```
@@ -530,12 +423,8 @@ error[invalid-argument-type]: Expected a string-literal key in the `fields` dict
 error[invalid-type-form]: Int literals are not allowed in this context in a type expression
   --> src/mdtest_snippet.py:93:39
    |
-91 | # error: [invalid-argument-type] "Expected a string-literal key in the `fields` dict of `TypedDict()`"
-92 | # error: [invalid-type-form] "Int literals are not allowed in this context in a type expression"
 93 | class Bad11(TypedDict("Bad11", {name: 42})): ...
    |                                       ^^ Did you mean `typing.Literal[42]`?
-94 |
-95 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
    |
 info: See the following page for a reference on valid type expressions:
 info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
@@ -546,7 +435,6 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 error[invalid-argument-type]: Invalid argument to parameter `typename` of `TypedDict()`
   --> src/mdtest_snippet.py:96:23
    |
-95 | # error: [invalid-argument-type] "Invalid argument to parameter `typename` of `TypedDict()`: Expected `str`, found `Literal[123]`"
 96 | class Bad12(TypedDict(123, {"field": int})): ...
    |                       ^^^ Expected `str`, found `Literal[123]`
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Only_annotated_decla…_(bef70731cae5b8af).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Only_annotated_decla…_(bef70731cae5b8af).snap
@@ -46,12 +46,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/typed_dict.md
 error[invalid-typed-dict-statement]: invalid statement in TypedDict class body
   --> src/mdtest_snippet.py:17:5
    |
-15 |     a: int
-16 |     # error: [invalid-typed-dict-statement] "invalid statement in TypedDict class body"
 17 |     42
    |     ^^
-18 |     # error: [invalid-typed-dict-statement] "TypedDict item cannot have a value"
-19 |     b: str = "hello"
    |
 info: Only annotated declarations (`<name>: <type>`) are allowed.
 
@@ -61,12 +57,8 @@ info: Only annotated declarations (`<name>: <type>`) are allowed.
 error[invalid-typed-dict-statement]: TypedDict item cannot have a value
   --> src/mdtest_snippet.py:19:14
    |
-17 |     42
-18 |     # error: [invalid-typed-dict-statement] "TypedDict item cannot have a value"
 19 |     b: str = "hello"
    |              ^^^^^^^
-20 |     # error: [invalid-typed-dict-statement] "TypedDict class cannot have methods"
-21 |     def bar(self): ...
    |
 
 ```
@@ -75,12 +67,8 @@ error[invalid-typed-dict-statement]: TypedDict item cannot have a value
 error[invalid-typed-dict-statement]: TypedDict class cannot have methods
   --> src/mdtest_snippet.py:21:5
    |
-19 |     b: str = "hello"
-20 |     # error: [invalid-typed-dict-statement] "TypedDict class cannot have methods"
 21 |     def bar(self): ...
    |     ^^^^^^^^^^^^^^^^^^
-22 | class Baz(Bar):
-23 |     # error: [invalid-typed-dict-statement]
    |
 
 ```
@@ -89,8 +77,6 @@ error[invalid-typed-dict-statement]: TypedDict class cannot have methods
 error[invalid-typed-dict-statement]: TypedDict class cannot have methods
   --> src/mdtest_snippet.py:24:5
    |
-22 |   class Baz(Bar):
-23 |       # error: [invalid-typed-dict-statement]
 24 | /     def baz(self):
 25 | |         pass
    | |____________^

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Redundant_cast_warni…_(75ac240a2d1f7108).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Redundant_cast_warni…_(75ac240a2d1f7108).snap
@@ -32,10 +32,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/typed_dict.md
 warning[redundant-cast]: Value is already of type `Foo2`
   --> src/mdtest_snippet.py:10:5
    |
- 9 | foo: Foo2 = {"x": 1}
 10 | _ = cast(Foo2, foo)  # error: [redundant-cast]
    |     ^^^^^^^^^^^^^^^
-11 | _ = cast(Bar2, foo)  # error: [redundant-cast]
    |
 
 ```
@@ -44,8 +42,6 @@ warning[redundant-cast]: Value is already of type `Foo2`
 warning[redundant-cast]: Value is already of type `Bar2`
   --> src/mdtest_snippet.py:11:5
    |
- 9 | foo: Foo2 = {"x": 1}
-10 | _ = cast(Foo2, foo)  # error: [redundant-cast]
 11 | _ = cast(Bar2, foo)  # error: [redundant-cast]
    |     ^^^^^^^^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union.md_-_Union_-_Diagnostics_for_PEP-…_(8fa61a3cfe810040).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union.md_-_Union_-_Diagnostics_for_PEP-…_(8fa61a3cfe810040).snap
@@ -55,8 +55,6 @@ error[unsupported-operator]: Unsupported `|` operation
   |    |     |
   |    |     Has type `<class 'str'>`
   |    Has type `<class 'int'>`
-2 |
-3 | class Foo:
   |
 info: PEP 604 `|` unions are only available on Python 3.10+ unless they are quoted
 info: Python 3.9 was assumed when resolving types because it was specified on the command line
@@ -67,15 +65,11 @@ info: Python 3.9 was assumed when resolving types because it was specified on th
 error[unsupported-operator]: Unsupported `|` operation
  --> src/a.py:5:17
   |
-3 | class Foo:
-4 |     def __init__(self):
 5 |         self.x: int | str = 42  # error: [unsupported-operator]
   |                 ---^^^---
   |                 |     |
   |                 |     Has type `<class 'str'>`
   |                 Has type `<class 'int'>`
-6 |
-7 | d = {}
   |
 info: PEP 604 `|` unions are only available on Python 3.10+ unless they are quoted
 info: Python 3.9 was assumed when resolving types because it was specified on the command line
@@ -86,7 +80,6 @@ info: Python 3.9 was assumed when resolving types because it was specified on th
 error[unsupported-operator]: Unsupported `|` operation
  --> src/a.py:8:7
   |
-7 | d = {}
 8 | d[0]: int | str = 42  # error: [unsupported-operator]
   |       ---^^^---
   |       |     |
@@ -102,14 +95,11 @@ info: Python 3.9 was assumed when resolving types because it was specified on th
 error[unsupported-operator]: Unsupported `|` operation
   --> src/b.py:15:5
    |
-13 | # only stringifies *type annotations*, not arbitrary runtime expressions
-14 |
 15 | X = str | int  # error: [unsupported-operator]
    |     ---^^^---
    |     |     |
    |     |     Has type `<class 'int'>`
    |     Has type `<class 'str'>`
-16 | Y = tuple[str | int, ...]  # error: [unsupported-operator]
    |
 info: PEP 604 `|` unions are only available on Python 3.10+ unless they are quoted
 info: `from __future__ import annotations` has no effect outside type annotations
@@ -121,7 +111,6 @@ info: Python 3.9 was assumed when resolving types because it was specified on th
 error[unsupported-operator]: Unsupported `|` operation
   --> src/b.py:16:11
    |
-15 | X = str | int  # error: [unsupported-operator]
 16 | Y = tuple[str | int, ...]  # error: [unsupported-operator]
    |           ---^^^---
    |           |     |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union.md_-_Unions_in_calls_-_Union_of_intersectio…_(db3e1dc3b7caa912).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union.md_-_Unions_in_calls_-_Union_of_intersectio…_(db3e1dc3b7caa912).snap
@@ -42,18 +42,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/call/union.md
 error[invalid-argument-type]: Argument to bound method `__call__` is incorrect
   --> src/mdtest_snippet.py:21:7
    |
-19 |     # error: [invalid-argument-type]
-20 |     # error: [invalid-argument-type]
 21 |     f(None)
    |       ^^^^ Expected `int`, found `None`
    |
 info: Method defined here
  --> src/mdtest_snippet.py:5:9
   |
-4 | class IntCaller:
 5 |     def __call__(self, x: int) -> int:
   |         ^^^^^^^^       ------ Parameter declared here
-6 |         return x
   |
 info: Intersection element `IntCaller` is incompatible with this call site
 info: Attempted to call intersection type `IntCaller & StrCaller`
@@ -65,19 +61,15 @@ info: Attempted to call union type `(IntCaller & StrCaller) | BytesCaller`
 error[invalid-argument-type]: Argument to bound method `__call__` is incorrect
   --> src/mdtest_snippet.py:21:7
    |
-19 |     # error: [invalid-argument-type]
-20 |     # error: [invalid-argument-type]
 21 |     f(None)
    |       ^^^^ Expected `str`, found `None`
    |
 info: Method defined here
-  --> src/mdtest_snippet.py:9:9
-   |
- 8 | class StrCaller:
- 9 |     def __call__(self, x: str) -> str:
-   |         ^^^^^^^^       ------ Parameter declared here
-10 |         return x
-   |
+ --> src/mdtest_snippet.py:9:9
+  |
+9 |     def __call__(self, x: str) -> str:
+  |         ^^^^^^^^       ------ Parameter declared here
+  |
 info: Intersection element `StrCaller` is incompatible with this call site
 info: Attempted to call intersection type `IntCaller & StrCaller`
 info: Attempted to call union type `(IntCaller & StrCaller) | BytesCaller`
@@ -88,18 +80,14 @@ info: Attempted to call union type `(IntCaller & StrCaller) | BytesCaller`
 error[invalid-argument-type]: Argument to bound method `__call__` is incorrect
   --> src/mdtest_snippet.py:21:7
    |
-19 |     # error: [invalid-argument-type]
-20 |     # error: [invalid-argument-type]
 21 |     f(None)
    |       ^^^^ Expected `bytes`, found `None`
    |
 info: Method defined here
   --> src/mdtest_snippet.py:13:9
    |
-12 | class BytesCaller:
 13 |     def __call__(self, x: bytes) -> bytes:
    |         ^^^^^^^^       -------- Parameter declared here
-14 |         return x
    |
 info: Union variant `BytesCaller` is incompatible with this call site
 info: Attempted to call union type `(IntCaller & StrCaller) | BytesCaller`

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_A_smaller_scale_exam…_(c24ecd8582e5eb2f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_A_smaller_scale_exam…_(c24ecd8582e5eb2f).snap
@@ -35,19 +35,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 error[invalid-argument-type]: Argument to function `f2` is incorrect
   --> src/mdtest_snippet.py:14:11
    |
-12 |     # error: [too-many-positional-arguments]
-13 |     # error: [invalid-argument-type]
 14 |     x = f(3)
    |           ^ Expected `str`, found `Literal[3]`
    |
 info: Function defined here
  --> src/mdtest_snippet.py:4:5
   |
-2 |     return 0
-3 |
 4 | def f2(name: str) -> int:
   |     ^^ --------- Parameter declared here
-5 |     return 0
   |
 info: Union variant `def f2(name: str) -> int` is incompatible with this call site
 info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int)`
@@ -58,8 +53,6 @@ info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> in
 error[too-many-positional-arguments]: Too many positional arguments to function `f1`: expected 0, got 1
   --> src/mdtest_snippet.py:14:11
    |
-12 |     # error: [too-many-positional-arguments]
-13 |     # error: [invalid-argument-type]
 14 |     x = f(3)
    |           ^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Multiple_variants_bu…_(d840ac443ca8ec7f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Multiple_variants_bu…_(d840ac443ca8ec7f).snap
@@ -34,19 +34,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 error[invalid-argument-type]: Argument to function `f2` is incorrect
   --> src/mdtest_snippet.py:13:11
    |
-11 |         f = f2
-12 |     # error: [invalid-argument-type]
 13 |     x = f(3)
    |           ^ Expected `str`, found `Literal[3]`
    |
 info: Function defined here
  --> src/mdtest_snippet.py:4:5
   |
-2 |     return 0
-3 |
 4 | def f2(name: str) -> int:
   |     ^^ --------- Parameter declared here
-5 |     return 0
   |
 info: Union variant `def f2(name: str) -> int` is incompatible with this call site
 info: Attempted to call union type `(def f1(a: int) -> int) | (def f2(name: str) -> int)`

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Attribute_access_on_…_(7bdb97302c27c412).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Attribute_access_on_…_(7bdb97302c27c412).snap
@@ -38,8 +38,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 error[invalid-argument-type]: Argument to bound method `foo` is incorrect
   --> src/mdtest_snippet.py:17:12
    |
-15 |     # error: [invalid-argument-type]
-16 |     # error: [invalid-argument-type]
 17 |     return x.foo(y)
    |            ^^^^^^^^ Argument type `T@_` does not satisfy upper bound `A` of type variable `Self`
    |
@@ -52,8 +50,6 @@ info: Attempted to call union type `(bound method T@_.foo(x: int) -> T@_) | (bou
 error[invalid-argument-type]: Argument to bound method `foo` is incorrect
   --> src/mdtest_snippet.py:17:12
    |
-15 |     # error: [invalid-argument-type]
-16 |     # error: [invalid-argument-type]
 17 |     return x.foo(y)
    |            ^^^^^^^^ Argument type `T@_` does not satisfy upper bound `B` of type variable `Self`
    |
@@ -66,18 +62,14 @@ info: Attempted to call union type `(bound method T@_.foo(x: int) -> T@_) | (bou
 error[invalid-argument-type]: Argument to bound method `foo` is incorrect
   --> src/mdtest_snippet.py:17:18
    |
-15 |     # error: [invalid-argument-type]
-16 |     # error: [invalid-argument-type]
 17 |     return x.foo(y)
    |                  ^ Expected `str`, found `int`
    |
 info: Method defined here
  --> src/mdtest_snippet.py:8:9
   |
-7 | class B:
 8 |     def foo(self, x: str) -> Self:
   |         ^^^       ------ Parameter declared here
-9 |         return self
   |
 info: Union variant `bound method T@_.foo(x: str) -> T@_` is incompatible with this call site
 info: Attempted to call union type `(bound method T@_.foo(x: int) -> T@_) | (bound method T@_.foo(x: str) -> T@_)`

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Cover_keyword_argume…_(ad1d489710ee2a34).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Cover_keyword_argume…_(ad1d489710ee2a34).snap
@@ -35,8 +35,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 error[parameter-already-assigned]: Multiple values provided for parameter `name` of function `f1`
   --> src/mdtest_snippet.py:14:18
    |
-12 |     # error: [parameter-already-assigned]
-13 |     # error: [unknown-argument]
 14 |     y = f("foo", name="bar", unknown="quux")
    |                  ^^^^^^^^^^
    |
@@ -49,8 +47,6 @@ info: Attempted to call union type `(def f1(name: str) -> int) | (def any(...) -
 error[unknown-argument]: Argument `unknown` does not match any known parameter of function `f1`
   --> src/mdtest_snippet.py:14:30
    |
-12 |     # error: [parameter-already-assigned]
-13 |     # error: [unknown-argument]
 14 |     y = f("foo", name="bar", unknown="quux")
    |                              ^^^^^^^^^^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Cover_non-keyword_re…_(707b284610419a54).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Cover_non-keyword_re…_(707b284610419a54).snap
@@ -81,8 +81,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 error[call-non-callable]: Object of type `Literal[5]` is not callable
   --> src/mdtest_snippet.py:60:9
    |
-58 |     # error: [call-non-callable] "Object of type `Literal[5]` is not callable"
-59 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly missing `__call__` method)"
 60 |     x = f(3)
    |         ^^^^
    |
@@ -95,8 +93,6 @@ info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> in
 error[call-non-callable]: Object of type `PossiblyNotCallable` is not callable (possibly missing `__call__` method)
   --> src/mdtest_snippet.py:60:9
    |
-58 |     # error: [call-non-callable] "Object of type `Literal[5]` is not callable"
-59 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly missing `__call__` method)"
 60 |     x = f(3)
    |         ^^^^
    |
@@ -109,8 +105,6 @@ info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> in
 error[missing-argument]: No argument provided for required parameter `b` of function `f3`
   --> src/mdtest_snippet.py:60:9
    |
-58 |     # error: [call-non-callable] "Object of type `Literal[5]` is not callable"
-59 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly missing `__call__` method)"
 60 |     x = f(3)
    |         ^^^^
    |
@@ -123,19 +117,14 @@ info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> in
 error[no-matching-overload]: No overload of function `f6` matches arguments
   --> src/mdtest_snippet.py:60:9
    |
-58 |     # error: [call-non-callable] "Object of type `Literal[5]` is not callable"
-59 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly missing `__call__` method)"
 60 |     x = f(3)
    |         ^^^^
    |
 info: First overload defined here
   --> src/mdtest_snippet.py:24:5
    |
-23 | @overload
 24 | def f6() -> None: ...
    |     ^^^^^^^^^^^^
-25 | @overload
-26 | def f6(x: str, y: str) -> str: ...
    |
 info: Possible overloads for function `f6`:
 info:   () -> None
@@ -143,11 +132,8 @@ info:   (x: str, y: str) -> str
 info: Overload implementation defined here
   --> src/mdtest_snippet.py:27:5
    |
-25 | @overload
-26 | def f6(x: str, y: str) -> str: ...
 27 | def f6(x: str | None = None, y: str | None = None) -> str | None:
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-28 |     return x + y if x and y else None
    |
 info: Union variant `Overload[() -> None, (x: str, y: str) -> str]` is incompatible with this call site
 info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | ... omitted 5 union elements`
@@ -158,19 +144,14 @@ info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> in
 error[invalid-argument-type]: Argument to function `f2` is incorrect
   --> src/mdtest_snippet.py:60:11
    |
-58 |     # error: [call-non-callable] "Object of type `Literal[5]` is not callable"
-59 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly missing `__call__` method)"
 60 |     x = f(3)
    |           ^ Expected `str`, found `Literal[3]`
    |
 info: Function defined here
  --> src/mdtest_snippet.py:7:5
   |
-5 |     return 0
-6 |
 7 | def f2(name: str) -> int:
   |     ^^ --------- Parameter declared here
-8 |     return 0
   |
 info: Union variant `def f2(name: str) -> int` is incompatible with this call site
 info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | ... omitted 5 union elements`
@@ -181,19 +162,14 @@ info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> in
 error[invalid-argument-type]: Argument to function `f4` is incorrect
   --> src/mdtest_snippet.py:60:11
    |
-58 |     # error: [call-non-callable] "Object of type `Literal[5]` is not callable"
-59 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly missing `__call__` method)"
 60 |     x = f(3)
    |           ^ Argument type `Literal[3]` does not satisfy upper bound `str` of type variable `T`
    |
 info: Type variable defined here
   --> src/mdtest_snippet.py:13:8
    |
-11 |     return 0
-12 |
 13 | def f4[T: str](x: T) -> int:
    |        ^^^^^^
-14 |     return 0
    |
 info: Union variant `def f4[T](x: T) -> int` is incompatible with this call site
 info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> int) | (def f3(a: int, b: int) -> int) | ... omitted 5 union elements`
@@ -204,20 +180,14 @@ info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> in
 error[invalid-argument-type]: Argument to function `f5` is incorrect
   --> src/mdtest_snippet.py:60:11
    |
-58 |     # error: [call-non-callable] "Object of type `Literal[5]` is not callable"
-59 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly missing `__call__` method)"
 60 |     x = f(3)
    |           ^ Expected `str`, found `Literal[3]`
    |
 info: Matching overload defined here
   --> src/mdtest_snippet.py:19:5
    |
-17 | def f5() -> None: ...
-18 | @overload
 19 | def f5(x: str) -> str: ...
    |     ^^ ------ Parameter declared here
-20 | def f5(x: str | None = None) -> str | None:
-21 |     return x
    |
 info: Non-matching overloads for function `f5`:
 info:   () -> None
@@ -230,8 +200,6 @@ info: Attempted to call union type `(def f1() -> int) | (def f2(name: str) -> in
 error[too-many-positional-arguments]: Too many positional arguments to function `f1`: expected 0, got 1
   --> src/mdtest_snippet.py:60:11
    |
-58 |     # error: [call-non-callable] "Object of type `Literal[5]` is not callable"
-59 |     # error: [call-non-callable] "Object of type `PossiblyNotCallable` is not callable (possibly missing `__call__` method)"
 60 |     x = f(3)
    |           ^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Truncation_for_long_…_(ec94b5e857284ef3).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Truncation_for_long_…_(ec94b5e857284ef3).snap
@@ -37,19 +37,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 error[invalid-argument-type]: Argument to function `f1` is incorrect
   --> src/mdtest_snippet.py:16:8
    |
-14 |     x = n
-15 |     # error: [invalid-argument-type]
 16 |     f1(x)
    |        ^ Expected `Literal[1, 2, 3, 4, 5, ... omitted 3 literals] | A | B | ... omitted 4 union elements`, found `int`
    |
 info: Function defined here
   --> src/mdtest_snippet.py:10:5
    |
- 8 | class F: ...
- 9 |
 10 | def f1(x: Union[Literal[1, 2, 3, 4, 5, 6, 7, 8], A, B, C, D, E, F]) -> int:
    |     ^^ ----------------------------------------------------------- Parameter declared here
-11 |     return 0
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Union_with_overloade…_(4408ade1316b97c0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Union_with_overloade…_(4408ade1316b97c0).snap
@@ -25,8 +25,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 error[unresolved-attribute]: Attribute `split` is not defined on `int` in union `bytes | str | int`
  --> src/mdtest_snippet.py:4:5
   |
-2 |     # error: [invalid-argument-type]
-3 |     # error: [unresolved-attribute]
 4 |     x.split(" ")
   |     ^^^^^^^
   |
@@ -37,19 +35,14 @@ error[unresolved-attribute]: Attribute `split` is not defined on `int` in union 
 error[invalid-argument-type]: Argument to bound method `split` is incorrect
  --> src/mdtest_snippet.py:4:13
   |
-2 |     # error: [invalid-argument-type]
-3 |     # error: [unresolved-attribute]
 4 |     x.split(" ")
   |             ^^^ Expected `Buffer | None`, found `Literal[" "]`
   |
 info: Method defined here
     --> stdlib/builtins.pyi:1761:9
      |
-1759 |         """
-1760 |
 1761 |     def split(self, sep: ReadableBuffer | None = None, maxsplit: SupportsIndex = -1) -> list[bytes]:
      |         ^^^^^       --------------------------------- Parameter declared here
-1762 |         """Return a list of the sections in the bytes, using sep as the delimiter.
      |
 info: Union variant `bound method bytes.split(sep: Buffer | None = None, maxsplit: SupportsIndex = -1) -> list[bytes]` is incompatible with this call site
 info: Attempted to call union type `(bound method bytes.split(sep: Buffer | None = None, maxsplit: SupportsIndex = -1) -> list[bytes]) | (Overload[(sep: LiteralString | None = None, maxsplit: SupportsIndex = -1) -> list[LiteralString], (sep: str | None = None, maxsplit: SupportsIndex = -1) -> list[str]])`

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unions.md_-_Comparison___Unions_-_Unsupported_operatio…_(e15acf820f65e3e4).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unions.md_-_Comparison___Unions_-_Unsupported_operatio…_(e15acf820f65e3e4).snap
@@ -39,14 +39,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/unions.md
 error[unsupported-operator]: Unsupported `in` operation
   --> src/mdtest_snippet.py:10:14
    |
- 8 |     cc: tuple[str] | tuple[str, str],
- 9 | ):
 10 |     result = 1 in x  # error: "Operator `in` is not supported"
    |              -^^^^-
    |              |    |
    |              |    Has type `list[int] | Literal[1]`
    |              Has type `Literal[1]`
-11 |     reveal_type(result)  # revealed: bool
    |
 info: Operation fails because operator `in` is not supported between two objects of type `Literal[1]`
 
@@ -56,13 +53,10 @@ info: Operation fails because operator `in` is not supported between two objects
 error[unsupported-operator]: Unsupported `in` operation
   --> src/mdtest_snippet.py:13:15
    |
-11 |     reveal_type(result)  # revealed: bool
-12 |
 13 |     result2 = y in x  # error: [unsupported-operator]
    |               -^^^^-
    |               |
    |               Both operands have type `list[int] | Literal[1]`
-14 |     reveal_type(result)  # revealed: bool
    |
 info: Operation fails because operator `in` is not supported between objects of type `list[int]` and `Literal[1]`
 
@@ -72,15 +66,11 @@ info: Operation fails because operator `in` is not supported between objects of 
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:16:15
    |
-14 |     reveal_type(result)  # revealed: bool
-15 |
 16 |     result3 = aa < cc  # error: [unsupported-operator]
    |               --^^^--
    |               |    |
    |               |    Has type `tuple[str] | tuple[str, str]`
    |               Has type `tuple[int]`
-17 |     result4 = cc < aa  # error: [unsupported-operator]
-18 |     result5 = bb < cc  # error: [unsupported-operator]
    |
 info: Operation fails because operator `<` is not supported between objects of type `int` and `str`
 
@@ -90,13 +80,11 @@ info: Operation fails because operator `<` is not supported between objects of t
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:17:15
    |
-16 |     result3 = aa < cc  # error: [unsupported-operator]
 17 |     result4 = cc < aa  # error: [unsupported-operator]
    |               --^^^--
    |               |    |
    |               |    Has type `tuple[int]`
    |               Has type `tuple[str] | tuple[str, str]`
-18 |     result5 = bb < cc  # error: [unsupported-operator]
    |
 info: Operation fails because operator `<` is not supported between objects of type `str` and `int`
 
@@ -106,8 +94,6 @@ info: Operation fails because operator `<` is not supported between objects of t
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:18:15
    |
-16 |     result3 = aa < cc  # error: [unsupported-operator]
-17 |     result4 = cc < aa  # error: [unsupported-operator]
 18 |     result5 = bb < cc  # error: [unsupported-operator]
    |               --^^^--
    |               |    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unknown_argument.md_-_Unknown_argument_dia…_(f419c2a8e2ce2412).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unknown_argument.md_-_Unknown_argument_dia…_(f419c2a8e2ce2412).snap
@@ -45,19 +45,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unknown_argu
 error[unknown-argument]: Argument `d` does not match any known parameter of function `f`
  --> src/main.py:3:18
   |
-1 | from module import f, g, Foo
-2 |
 3 | f(a=1, b=2, c=3, d=42)  # error: [unknown-argument]
   |                  ^^^^
-4 |
-5 | def coinflip() -> bool:
   |
 info: Function signature here
  --> src/module.py:1:5
   |
 1 | def f(a, b, c=42): ...
   |     ^^^^^^^^^^^^^
-2 | def g(a, b): ...
   |
 
 ```
@@ -66,12 +61,8 @@ info: Function signature here
 error[unknown-argument]: Argument `d` does not match any known parameter of function `f`
   --> src/main.py:12:13
    |
-10 | # error: [unknown-argument]
-11 | # error: [unknown-argument]
 12 | h(a=1, b=2, d=42)
    |             ^^^^
-13 |
-14 | Foo().method(a=1, b=2, c=3)  # error: [unknown-argument]
    |
 info: Union variant `def f(a, b, c=42) -> Unknown` is incompatible with this call site
 info: Attempted to call union type `(def f(a, b, c=42) -> Unknown) | (def g(a, b) -> Unknown)`
@@ -82,12 +73,8 @@ info: Attempted to call union type `(def f(a, b, c=42) -> Unknown) | (def g(a, b
 error[unknown-argument]: Argument `d` does not match any known parameter of function `g`
   --> src/main.py:12:13
    |
-10 | # error: [unknown-argument]
-11 | # error: [unknown-argument]
 12 | h(a=1, b=2, d=42)
    |             ^^^^
-13 |
-14 | Foo().method(a=1, b=2, c=3)  # error: [unknown-argument]
    |
 info: Union variant `def g(a, b) -> Unknown` is incompatible with this call site
 info: Attempted to call union type `(def f(a, b, c=42) -> Unknown) | (def g(a, b) -> Unknown)`
@@ -98,15 +85,12 @@ info: Attempted to call union type `(def f(a, b, c=42) -> Unknown) | (def g(a, b
 error[unknown-argument]: Argument `c` does not match any known parameter of bound method `method`
   --> src/main.py:14:24
    |
-12 | h(a=1, b=2, d=42)
-13 |
 14 | Foo().method(a=1, b=2, c=3)  # error: [unknown-argument]
    |                        ^^^
    |
 info: Method signature here
  --> src/module.py:5:9
   |
-4 | class Foo:
 5 |     def method(self, a, b): ...
   |         ^^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unreachable.md_-_Unreachable_code_-_`Never`-inferred_var…_(6ce5aa6d2a0ce029).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unreachable.md_-_Unreachable_code_-_`Never`-inferred_var…_(6ce5aa6d2a0ce029).snap
@@ -35,8 +35,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/unreachable.md
 error[invalid-type-form]: Variable of type `Never` is not allowed in a parameter annotation
  --> src/main.py:3:10
   |
-1 | import module
-2 |
 3 | def f(x: module.AwesomeAPI): ...  # error: [invalid-type-form]
   |          ^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_An_unresolvable_impo…_(72d090df51ea97b8).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_An_unresolvable_impo…_(72d090df51ea97b8).snap
@@ -26,8 +26,6 @@ error[unresolved-import]: Cannot resolve imported module `does_not_exist`
   |
 1 | import does_not_exist  # error: [unresolved-import]
   |        ^^^^^^^^^^^^^^
-2 |
-3 | x = does_not_exist.foo
   |
 info: Searched in the following paths during module resolution:
 info:   1. /src (first-party code)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_Using_`from`_with_an…_(6cff507dc64a1bff).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_Using_`from`_with_an…_(6cff507dc64a1bff).snap
@@ -26,8 +26,6 @@ error[unresolved-import]: Cannot resolve imported module `.does_not_exist.foo.ba
   |
 1 | from .does_not_exist.foo.bar import add  # error: [unresolved-import]
   |       ^^^^^^^^^^^^^^^^^^^^^^
-2 |
-3 | stat = add(10, 15)
   |
 info: Searched in the following paths during module resolution:
 info:   1. /src (first-party code)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_Using_`from`_with_an…_(9da56616d6332a83).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_Using_`from`_with_an…_(9da56616d6332a83).snap
@@ -26,8 +26,6 @@ error[unresolved-import]: Cannot resolve imported module `.does_not_exist`
   |
 1 | from .does_not_exist import add  # error: [unresolved-import]
   |       ^^^^^^^^^^^^^^
-2 |
-3 | stat = add(10, 15)
   |
 info: Searched in the following paths during module resolution:
 info:   1. /src (first-party code)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_Using_`from`_with_an…_(9fa713dfa17cc404).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_Using_`from`_with_an…_(9fa713dfa17cc404).snap
@@ -26,8 +26,6 @@ error[unresolved-import]: Cannot resolve imported module `does_not_exist`
   |
 1 | from does_not_exist import add  # error: [unresolved-import]
   |      ^^^^^^^^^^^^^^
-2 |
-3 | stat = add(10, 15)
   |
 info: Searched in the following paths during module resolution:
 info:   1. /src (first-party code)

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_Using_`from`_with_to…_(4b8ba6ee48180cdd).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_import.md_-_Unresolved_import_di…_-_Using_`from`_with_to…_(4b8ba6ee48180cdd).snap
@@ -38,8 +38,6 @@ error[unresolved-import]: Cannot resolve imported module `....foo`
   |
 1 | from ....foo import add  # error: [unresolved-import]
   |          ^^^
-2 |
-3 | stat = add(10, 15)
   |
 help: The module can be resolved if the number of leading dots is reduced
 help: Did you mean `...foo`?

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_reference…_-_Diagnostics_for_unre…_-_Typing_builtin_has_I…_-_Info_not_present_bef…_(41702a6f6d20b082).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_reference…_-_Diagnostics_for_unre…_-_Typing_builtin_has_I…_-_Info_not_present_bef…_(41702a6f6d20b082).snap
@@ -25,7 +25,6 @@ error[unresolved-reference]: Name `List` used when not defined
   |
 1 | foo: List[int]  # error: [unresolved-reference]
   |      ^^^^
-2 | bar: Type  # error: [unresolved-reference]
   |
 
 ```
@@ -34,7 +33,6 @@ error[unresolved-reference]: Name `List` used when not defined
 error[unresolved-reference]: Name `Type` used when not defined
  --> src/mdtest_snippet.py:2:6
   |
-1 | foo: List[int]  # error: [unresolved-reference]
 2 | bar: Type  # error: [unresolved-reference]
   |      ^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_reference…_-_Diagnostics_for_unre…_-_Typing_builtin_has_I…_-_Info_present_in_Pyth…_(1028a80959504fc9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unresolved_reference…_-_Diagnostics_for_unre…_-_Typing_builtin_has_I…_-_Info_present_in_Pyth…_(1028a80959504fc9).snap
@@ -25,7 +25,6 @@ error[unresolved-reference]: Name `List` used when not defined
   |
 1 | foo: List[int]  # error: [unresolved-reference]
   |      ^^^^ Did you mean `list`?
-2 | bar: Type  # error: [unresolved-reference]
   |
 
 ```
@@ -34,7 +33,6 @@ error[unresolved-reference]: Name `List` used when not defined
 error[unresolved-reference]: Name `Type` used when not defined
  --> src/mdtest_snippet.py:2:6
   |
-1 | foo: List[int]  # error: [unresolved-reference]
 2 | bar: Type  # error: [unresolved-reference]
   |      ^^^^ Did you mean `type`?
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported.md_-_Comparison___Unsuppor…_(c13dd5902282489a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported.md_-_Comparison___Unsuppor…_(c13dd5902282489a).snap
@@ -49,14 +49,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/unsupported.m
 error[unsupported-operator]: Unsupported `in` operation
  --> src/mdtest_snippet.py:3:9
   |
-1 | def _(flag: bool, flag1: bool, flag2: bool):
-2 |     class A: ...
 3 |     a = 1 in 7  # error: "Operator `in` is not supported between objects of type `Literal[1]` and `Literal[7]`"
   |         -^^^^-
   |         |    |
   |         |    Has type `Literal[7]`
   |         Has type `Literal[1]`
-4 |     reveal_type(a)  # revealed: bool
   |
 
 ```
@@ -65,14 +62,11 @@ error[unsupported-operator]: Unsupported `in` operation
 error[unsupported-operator]: Unsupported `not in` operation
  --> src/mdtest_snippet.py:6:9
   |
-4 |     reveal_type(a)  # revealed: bool
-5 |
 6 |     b = 0 not in 10  # error: "Operator `not in` is not supported between objects of type `Literal[0]` and `Literal[10]`"
   |         -^^^^^^^^--
   |         |        |
   |         |        Has type `Literal[10]`
   |         Has type `Literal[0]`
-7 |     reveal_type(b)  # revealed: bool
   |
 
 ```
@@ -81,13 +75,11 @@ error[unsupported-operator]: Unsupported `not in` operation
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:10:9
    |
- 9 |     # error: [unsupported-operator] "Operator `<` is not supported between objects of type `object` and `Literal[5]`"
 10 |     c = object() < 5
    |         --------^^^-
    |         |          |
    |         |          Has type `Literal[5]`
    |         Has type `object`
-11 |     reveal_type(c)  # revealed: Unknown
    |
 
 ```
@@ -96,13 +88,11 @@ error[unsupported-operator]: Unsupported `<` operation
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:14:9
    |
-13 |     # error: [unsupported-operator] "Operator `<` is not supported between objects of type `Literal[5]` and `object`"
 14 |     d = 5 < object()
    |         -^^^--------
    |         |   |
    |         |   Has type `object`
    |         Has type `Literal[5]`
-15 |     reveal_type(d)  # revealed: Unknown
    |
 
 ```
@@ -111,14 +101,11 @@ error[unsupported-operator]: Unsupported `<` operation
 error[unsupported-operator]: Unsupported `in` operation
   --> src/mdtest_snippet.py:19:9
    |
-17 |     int_literal_or_str_literal = 1 if flag else "foo"
-18 |     # error: "Operator `in` is not supported between objects of type `Literal[42]` and `Literal[1, "foo"]`"
 19 |     e = 42 in int_literal_or_str_literal
    |         --^^^^--------------------------
    |         |     |
    |         |     Has type `Literal[1, "foo"]`
    |         Has type `Literal[42]`
-20 |     reveal_type(e)  # revealed: bool
    |
 info: Operation fails because operator `in` is not supported between objects of type `Literal[42]` and `Literal[1]`
 
@@ -128,13 +115,11 @@ info: Operation fails because operator `in` is not supported between objects of 
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:23:9
    |
-22 |     # error: [unsupported-operator] "Operator `<` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[…
 23 |     f = (1, 2) < (1, "hello")
    |         ------^^^------------
    |         |        |
    |         |        Has type `tuple[Literal[1], Literal["hello"]]`
    |         Has type `tuple[Literal[1], Literal[2]]`
-24 |     reveal_type(f)  # revealed: Unknown
    |
 info: Operation fails because operator `<` is not supported between the tuple elements at index 2 (of type `Literal[2]` and `Literal["hello"]`)
 
@@ -144,12 +129,10 @@ info: Operation fails because operator `<` is not supported between the tuple el
 error[unsupported-operator]: Unsupported `<` operation
   --> src/mdtest_snippet.py:27:9
    |
-26 |     # error: [unsupported-operator] "Operator `<` is not supported between two objects of type `tuple[bool, A]`"
 27 |     g = (flag1, A()) < (flag2, A())
    |         ------------^^^------------
    |         |
    |         Both operands have type `tuple[bool, A]`
-28 |     reveal_type(g)  # revealed: Unknown
    |
 info: Operation fails because operator `<` is not supported between the tuple elements at index 2 (both of type `A`)
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_base_dyn…_-_Unsupported_base_for…_-_Enum_base_(4873196c8b48364).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_base_dyn…_-_Unsupported_base_for…_-_Enum_base_(4873196c8b48364).snap
@@ -27,8 +27,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 error[invalid-base]: Invalid base for class created via `type()`
  --> src/mdtest_snippet.py:6:16
   |
-4 |     pass
-5 |
 6 | X = type("X", (MyEnum,), {})  # error: [invalid-base]
   |                ^^^^^^ Has type `<class 'MyEnum'>`
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_base_dyn…_-_Unsupported_base_for…_-_Enum_with_members_(81bef9a8e1230854).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_base_dyn…_-_Unsupported_base_for…_-_Enum_with_members_(81bef9a8e1230854).snap
@@ -28,8 +28,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 error[subclass-of-final-class]: Class `X` cannot inherit from final class `Color`
  --> src/mdtest_snippet.py:7:16
   |
-5 |     GREEN = 2
-6 |
 7 | X = type("X", (Color,), {})  # error: [subclass-of-final-class]
   |                ^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_base_dyn…_-_Unsupported_base_for…_-_`@final`_class_(ea69d237256b3762).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_base_dyn…_-_Unsupported_base_for…_-_`@final`_class_(ea69d237256b3762).snap
@@ -28,8 +28,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 error[subclass-of-final-class]: Class `X` cannot inherit from final class `FinalClass`
  --> src/mdtest_snippet.py:7:16
   |
-5 |     pass
-6 |
 7 | X = type("X", (FinalClass,), {})  # error: [subclass-of-final-class]
   |                ^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_base_dyn…_-_Unsupported_base_for…_-_`Generic`_base_(d455f46a27cec685).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_base_dyn…_-_Unsupported_base_for…_-_`Generic`_base_(d455f46a27cec685).snap
@@ -26,8 +26,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 error[invalid-base]: Invalid base for class created via `type()`
  --> src/mdtest_snippet.py:5:16
   |
-3 | T = TypeVar("T")
-4 |
 5 | X = type("X", (Generic[T],), {})  # error: [invalid-base]
   |                ^^^^^^^^^^ Has type `<special-form 'typing.Generic[T]'>`
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_base_dyn…_-_Unsupported_base_for…_-_`Protocol`_base_(99c9bde73664dd51).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_base_dyn…_-_Unsupported_base_for…_-_`Protocol`_base_(99c9bde73664dd51).snap
@@ -24,8 +24,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 info[unsupported-dynamic-base]: Unsupported base for class created via `type()`
  --> src/mdtest_snippet.py:3:16
   |
-1 | from typing import Protocol
-2 |
 3 | X = type("X", (Protocol,), {})  # error: [unsupported-dynamic-base]
   |                ^^^^^^^^ Has type `<special-form 'typing.Protocol'>`
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_base_dyn…_-_Unsupported_base_for…_-_`TypedDict`_base_(6f76171c88fc8760).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_base_dyn…_-_Unsupported_base_for…_-_`TypedDict`_base_(6f76171c88fc8760).snap
@@ -24,8 +24,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 error[invalid-base]: Invalid base for class created via `type()`
  --> src/mdtest_snippet.py:3:16
   |
-1 | from typing_extensions import TypedDict
-2 |
 3 | X = type("X", (TypedDict,), {})  # error: [invalid-base]
   |                ^^^^^^^^^ Has type `<special-form 'typing.TypedDict'>`
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Has_a_`__bool__`_att…_(2721d40bf12fe8b7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Has_a_`__bool__`_att…_(2721d40bf12fe8b7).snap
@@ -28,7 +28,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
  --> src/mdtest_snippet.py:7:8
   |
-6 | # error: [unsupported-bool-conversion]
 7 | 10 and a and True
   |        ^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Has_a_`__bool__`_met…_(15636dc4074e5335).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Has_a_`__bool__`_met…_(15636dc4074e5335).snap
@@ -29,19 +29,16 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
  --> src/mdtest_snippet.py:8:8
   |
-7 | # error: [unsupported-bool-conversion]
 8 | 10 and a and True
   |        ^
   |
 info: `str` is not assignable to `bool`
  --> src/mdtest_snippet.py:2:9
   |
-1 | class NotBoolable:
 2 |     def __bool__(self) -> str:
   |         --------          ^^^ Incorrect return type
   |         |
   |         Method defined here
-3 |         return "wat"
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Has_a_`__bool__`_met…_(ce8b8da49eaf4cda).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Has_a_`__bool__`_met…_(ce8b8da49eaf4cda).snap
@@ -29,19 +29,16 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 error[unsupported-bool-conversion]: Boolean conversion is not supported for type `NotBoolable`
  --> src/mdtest_snippet.py:8:8
   |
-7 | # error: [unsupported-bool-conversion]
 8 | 10 and a and True
   |        ^
   |
 info: `__bool__` methods must only have a `self` parameter
  --> src/mdtest_snippet.py:2:9
   |
-1 | class NotBoolable:
 2 |     def __bool__(self, foo):
   |         --------^^^^^^^^^^^ Incorrect parameters
   |         |
   |         Method defined here
-3 |         return False
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Part_of_a_union_wher…_(7cca8063ea43c1a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_bool_con…_-_Different_ways_that_…_-_Part_of_a_union_wher…_(7cca8063ea43c1a).snap
@@ -36,7 +36,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/unsupported_
 error[unsupported-bool-conversion]: Boolean conversion is not supported for union `NotBoolable1 | NotBoolable2 | NotBoolable3` because `NotBoolable1` doesn't implement `__bool__` correctly
   --> src/mdtest_snippet.py:15:8
    |
-14 | # error: [unsupported-bool-conversion]
 15 | 10 and get() and True
    |        ^^^^^
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_A_constrained_defaul…_(b62ed1f409042cc).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_A_constrained_defaul…_(b62ed1f409042cc).snap
@@ -32,7 +32,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/variable
 error[invalid-type-variable-default]: TypeVar default is inconsistent with the TypeVar's constraints
   --> src/mdtest_snippet.py:11:18
    |
-10 | # error: [invalid-type-variable-default]
 11 | U = TypeVar("U", bool, complex, default=T1)
    |                  -------------          ^^ Constraint `int` of default `T1` is not one of the constraints of `U`
    |                  |
@@ -40,11 +39,8 @@ error[invalid-type-variable-default]: TypeVar default is inconsistent with the T
    |
   ::: src/mdtest_snippet.py:3:1
    |
- 1 | from typing import Generic, TypeVar
- 2 |
  3 | T1 = TypeVar("T1", int, str)
    | ---------------------------- `T1` defined here
- 4 | T2 = TypeVar("T2", int, str, bool)
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_A_constrained_defaul…_(d9ffda7fd9cdf840).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_A_constrained_defaul…_(d9ffda7fd9cdf840).snap
@@ -36,21 +36,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/variable
 error[invalid-type-variable-default]: TypeVar default is not assignable to the TypeVar's upper bound
   --> src/mdtest_snippet.py:11:26
    |
-10 | # error: [invalid-type-variable-default] "Default `T1` of TypeVar `U` is not assignable to upper bound `int` of `U` because constraint…
 11 | U = TypeVar("U", default=T1, bound=int)
    |                          ^^        --- Upper bound of `U`
    |                          |
    |                          Constraint `str` of default `T1` is not assignable to upper bound of `U`
-12 |
-13 | # OK: `T2`'s constraints are `int` and `bool`,
    |
   ::: src/mdtest_snippet.py:3:1
    |
- 1 | from typing import Generic, TypeVar
- 2 |
  3 | T1 = TypeVar("T1", int, str)
    | ---------------------------- `T1` defined here
- 4 | T2 = TypeVar("T2", int, bool)
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_A_non-constrained_de…_(ff24930259abfb3).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_A_non-constrained_de…_(ff24930259abfb3).snap
@@ -31,21 +31,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/variable
 error[invalid-type-variable-default]: TypeVar default is inconsistent with the TypeVar's constraints
  --> src/mdtest_snippet.py:7:18
   |
-6 | # error: [invalid-type-variable-default]
 7 | S = TypeVar("S", float, str, default=T1)
   |                  ----------          ^^ Bounded TypeVar cannot be used as the default for a constrained TypeVar
   |                  |
   |                  Constraints of `S`
-8 |
-9 | # error: [invalid-type-variable-default]
   |
  ::: src/mdtest_snippet.py:3:1
   |
-1 | from typing import Generic, TypeVar
-2 |
 3 | T1 = TypeVar("T1", bound=int)
   | ----------------------------- `T1` defined here
-4 | T2 = TypeVar("T2")
   |
 info: `T1` has bound `int` but is not constrained
 
@@ -55,7 +49,6 @@ info: `T1` has bound `int` but is not constrained
 error[invalid-type-variable-default]: TypeVar default is inconsistent with the TypeVar's constraints
   --> src/mdtest_snippet.py:10:18
    |
- 9 | # error: [invalid-type-variable-default]
 10 | U = TypeVar("U", str, bytes, default=T2)
    |                  ----------          ^^ Unbounded TypeVar cannot be used as the default for a constrained TypeVar
    |                  |
@@ -63,11 +56,8 @@ error[invalid-type-variable-default]: TypeVar default is inconsistent with the T
    |
   ::: src/mdtest_snippet.py:4:1
    |
- 3 | T1 = TypeVar("T1", bound=int)
  4 | T2 = TypeVar("T2")
    | ------------------ `T2` defined here
- 5 |
- 6 | # error: [invalid-type-variable-default]
    |
 info: `T2` has no bound or constraints
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_An_unbounded_default…_(a2759fd9d2731a7d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_An_unbounded_default…_(a2759fd9d2731a7d).snap
@@ -25,18 +25,17 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/variable
 
 ```
 error[invalid-type-variable-default]: TypeVar default is not assignable to the TypeVar's upper bound
- --> src/mdtest_snippet.py:3:1
+ --> src/mdtest_snippet.py:6:26
   |
-1 | from typing import Generic, TypeVar
-2 |
-3 | T1 = TypeVar("T1")
-  | ------------------ `T1` defined here
-4 |
-5 | # error: [invalid-type-variable-default] "Default `T1` of TypeVar `S` is not assignable to upper bound `int` of `S` because its upper b…
 6 | S = TypeVar("S", default=T1, bound=int)
   |                          ^^        --- Upper bound of `S`
   |                          |
   |                          Upper bound `object` of default `T1` is not assignable to upper bound of `S`
+  |
+ ::: src/mdtest_snippet.py:3:1
+  |
+3 | T1 = TypeVar("T1")
+  | ------------------ `T1` defined here
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_Concrete_default_wit…_(30284a6490652e58).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_Concrete_default_wit…_(30284a6490652e58).snap
@@ -34,13 +34,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/variable
 error[invalid-type-variable-default]: TypeVar default is inconsistent with the TypeVar's constraints
  --> src/mdtest_snippet.py:4:18
   |
-3 | # error: [invalid-type-variable-default] "TypeVar default is inconsistent with the TypeVar's constraints: `bytes` is not one of the con…
 4 | T = TypeVar("T", int, str, default=bytes)
   |                  --------          ^^^^^ `bytes` is not one of the constraints of `T`
   |                  |
   |                  Constraints of `T`
-5 |
-6 | S = TypeVar("S", int, str, default=int)
   |
 
 ```
@@ -49,14 +46,10 @@ error[invalid-type-variable-default]: TypeVar default is inconsistent with the T
 error[invalid-type-variable-default]: TypeVar default is inconsistent with the TypeVar's constraints
   --> src/mdtest_snippet.py:10:18
    |
- 8 | # A subtype is not sufficient; the default must be exactly one of the constraints.
- 9 | # error: [invalid-type-variable-default] "TypeVar default is inconsistent with the TypeVar's constraints: `bool` is not one of the con…
 10 | U = TypeVar("U", int, str, default=bool)
    |                  --------          ^^^^ `bool` is not one of the constraints of `U`
    |                  |
    |                  Constraints of `U`
-11 |
-12 | # `Any` is always allowed as a default, even for constrained TypeVars.
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_Concrete_default_wit…_(37f9b6583c0633f5).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_Concrete_default_wit…_(37f9b6583c0633f5).snap
@@ -27,13 +27,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/variable
 error[invalid-type-variable-default]: TypeVar default is not assignable to the TypeVar's upper bound
  --> src/mdtest_snippet.py:4:24
   |
-3 | # error: [invalid-type-variable-default] "TypeVar default is not assignable to the TypeVar's upper bound"
 4 | T = TypeVar("T", bound=str, default=int)
   |                        ---          ^^^ Default of `T`
   |                        |
   |                        Upper bound of `T`
-5 |
-6 | S = TypeVar("S", bound=float, default=int)
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_Default_TypeVar's_bo…_(fcd7ad5416c91629).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_Default_TypeVar's_bo…_(fcd7ad5416c91629).snap
@@ -33,7 +33,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/variable
 error[invalid-type-variable-default]: TypeVar default is not assignable to the TypeVar's upper bound
   --> src/mdtest_snippet.py:12:26
    |
-11 | # error: [invalid-type-variable-default] "Default `T3` of TypeVar `U` is not assignable to upper bound `int | float` of `U` because it…
 12 | U = TypeVar("U", default=T3, bound=float)
    |                          ^^        ----- Upper bound of `U`
    |                          |
@@ -41,12 +40,8 @@ error[invalid-type-variable-default]: TypeVar default is not assignable to the T
    |
   ::: src/mdtest_snippet.py:5:1
    |
- 3 | T1 = TypeVar("T1", bound=int)
- 4 | T2 = TypeVar("T2", bound=float)
  5 | T3 = TypeVar("T3", bound=str)
    | ----------------------------- `T3` defined here
- 6 |
- 7 | # OK: `float` in a type expression means `int | float`,
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Shadowing_checks_use…_(7e6bb178099059fe).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Shadowing_checks_use…_(7e6bb178099059fe).snap
@@ -33,48 +33,40 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/variable
 
 ```
 warning[mismatched-type-name]: The name passed to `TypeVar` must match the variable it is assigned to
-  --> src/mdtest_snippet.py:8:13
+ --> src/mdtest_snippet.py:8:13
+  |
+8 | Q = TypeVar("T")
+  |             ^^^ Expected "Q", got "T"
+  |
+
+```
+
+```
+error[shadowed-type-variable]: Generic class `Bad` uses type variable `Q` already bound by an enclosing scope
+  --> src/mdtest_snippet.py:14:11
    |
- 6 | # This recovers as the `Q` binding for source-level name resolution.
- 7 | # error: [mismatched-type-name]
- 8 | Q = TypeVar("T")
-   |             ^^^ Expected "Q", got "T"
- 9 |
+14 |     class Bad(Generic[Q]): ...
+   |           ^^^^^^^^^^^^^^^ `Q` used in class definition here
+   |
+  ::: src/mdtest_snippet.py:10:7
+   |
 10 | class Outer(Generic[Q]):
+   |       ----------------- Type variable `Q` is bound in this enclosing scope
    |
 
 ```
 
 ```
 error[shadowed-type-variable]: Generic class `Bad` uses type variable `Q` already bound by an enclosing scope
-  --> src/mdtest_snippet.py:10:7
+  --> src/mdtest_snippet.py:14:11
    |
- 8 | Q = TypeVar("T")
- 9 |
-10 | class Outer(Generic[Q]):
-   |       ----------------- Type variable `Q` is bound in this enclosing scope
-11 |     class Ok(Generic[S]): ...
-12 |     # error: [shadowed-type-variable]
-13 |     # error: [shadowed-type-variable]
 14 |     class Bad(Generic[Q]): ...
    |           ^^^^^^^^^^^^^^^ `Q` used in class definition here
    |
-
-```
-
-```
-error[shadowed-type-variable]: Generic class `Bad` uses type variable `Q` already bound by an enclosing scope
-  --> src/mdtest_snippet.py:10:7
+  ::: src/mdtest_snippet.py:10:7
    |
- 8 | Q = TypeVar("T")
- 9 |
 10 | class Outer(Generic[Q]):
    |       ----------------- Type variable `Q` is bound in this enclosing scope
-11 |     class Ok(Generic[S]): ...
-12 |     # error: [shadowed-type-variable]
-13 |     # error: [shadowed-type-variable]
-14 |     class Bad(Generic[Q]): ...
-   |           ^^^^^^^^^^^^^^^ `Q` used in class definition here
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/version_related_synt…_-_Version-related_synt…_-_`match`_statement_-_Before_3.10_(2545eaa83b635b8b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/version_related_synt…_-_Version-related_synt…_-_`match`_statement_-_Before_3.10_(2545eaa83b635b8b).snap
@@ -26,8 +26,6 @@ error[invalid-syntax]: Cannot use `match` statement on Python 3.9 (syntax was ad
   |
 1 | match 2:  # error: 1 [invalid-syntax] "Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)"
   | ^^^^^
-2 |     case 1:
-3 |         print("it's one")
   |
 info: Python 3.9 was assumed when parsing syntax because it was specified on the command line
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/yield_and_yield_from…_-_`yield`_and_`yield_f…_-_Error_cases_-_Invalid_`yield`_type_(1300c06a97026cce).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/yield_and_yield_from…_-_`yield`_and_`yield_f…_-_Error_cases_-_Invalid_`yield`_type_(1300c06a97026cce).snap
@@ -24,15 +24,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/expression/yield_and_yie
 
 ```
 error[invalid-yield]: Yield expression type does not match annotation
- --> src/mdtest_snippet.py:3:28
+ --> src/mdtest_snippet.py:5:11
   |
-1 | from typing import Generator
-2 |
-3 | def invalid_generator() -> Generator[int, None, None]:
-  |                            -------------------------- Function annotated with yield type `int` here
-4 |     # error: [invalid-yield] "Yield type `Literal[""]` does not match annotated yield type `int`"
 5 |     yield ""
   |           ^^ expression of type `Literal[""]`, expected `int`
+  |
+ ::: src/mdtest_snippet.py:3:28
+  |
+3 | def invalid_generator() -> Generator[int, None, None]:
+  |                            -------------------------- Function annotated with yield type `int` here
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/yield_and_yield_from…_-_`yield`_and_`yield_f…_-_Error_cases_-_Non_generator_functi…_(c14a872d57170530).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/yield_and_yield_from…_-_`yield`_and_`yield_f…_-_Error_cases_-_Non_generator_functi…_(c14a872d57170530).snap
@@ -26,17 +26,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/expression/yield_and_yie
 
 ```
 error[invalid-return-type]: Return type does not match returned value
- --> src/mdtest_snippet.py:3:18
+ --> src/mdtest_snippet.py:5:12
   |
-1 | from typing import Generator
-2 |
-3 | def non_gen() -> Generator[int, int, None]:
-  |                  ------------------------- Expected `Generator[int, int, None]` because of return type
-4 |     # error: [invalid-return-type]
 5 |     return 1
   |            ^ expected `Generator[int, int, None]`, found `Literal[1]`
-6 |
-7 | reveal_type(non_gen)  # revealed: def non_gen() -> Generator[int, int, None]
+  |
+ ::: src/mdtest_snippet.py:3:18
+  |
+3 | def non_gen() -> Generator[int, int, None]:
+  |                  ------------------------- Expected `Generator[int, int, None]` because of return type
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/yield_and_yield_from…_-_`yield`_and_`yield_f…_-_Error_cases_-_`yield_from`_with_in…_(63388cb3d15fdc10).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/yield_and_yield_from…_-_`yield`_and_`yield_f…_-_Error_cases_-_`yield_from`_with_in…_(63388cb3d15fdc10).snap
@@ -27,15 +27,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/expression/yield_and_yie
 
 ```
 error[invalid-yield]: Send type does not match annotation
- --> src/mdtest_snippet.py:6:16
+ --> src/mdtest_snippet.py:8:16
   |
-4 |     x = yield 1
-5 |
-6 | def outer() -> Generator[int, str, None]:
-  |                ------------------------- Function annotated with send type `str` here
-7 |     # error: [invalid-yield] "Send type `int` does not match annotated send type `str`"
 8 |     yield from inner()
   |                ^^^^^^^ generator with send type `int`, expected `str`
+  |
+ ::: src/mdtest_snippet.py:6:16
+  |
+6 | def outer() -> Generator[int, str, None]:
+  |                ------------------------- Function annotated with send type `str` here
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
@@ -26,8 +26,6 @@ a = test + 3  # ty: ignore[possibly-unresolved-reference]
 warning[unused-ignore-comment]: Unused `ty: ignore` directive
  --> src/mdtest_snippet.py:3:15
   |
-1 | test = 10
-2 | # snapshot
 3 | a = test + 3  # ty: ignore[possibly-unresolved-reference]
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
@@ -51,11 +49,8 @@ print(a)
 warning[unused-ignore-comment]: Unused `ty: ignore` directive
  --> src/mdtest_snippet.py:3:15
   |
-1 | # snapshot: unused-ignore-comment
-2 | # error: [unresolved-reference]
 3 | a = test + 3  # ty: ignore[possibly-unresolved-reference]
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-4 | print(a)
   |
 help: Remove the unused suppression comment
 1 | # snapshot: unused-ignore-comment
@@ -87,7 +82,6 @@ a = 10 / 0  # ty: ignore[division-by-zero, unused-ignore-comment]
 warning[unused-ignore-comment]: Unused `ty: ignore` directive: 'unused-ignore-comment'
  --> src/mdtest_snippet.py:2:44
   |
-1 | # snapshot
 2 | a = 10 / 0  # ty: ignore[division-by-zero, unused-ignore-comment]
   |                                            ^^^^^^^^^^^^^^^^^^^^^
   |
@@ -110,11 +104,8 @@ a = 10 / 2  # ty: ignore[division-by-zero, unresolved-reference]
 warning[unused-ignore-comment]: Unused `ty: ignore` directive
  --> src/mdtest_snippet.py:2:13
   |
-1 | # snapshot
 2 | a = 10 / 2  # ty: ignore[division-by-zero, unresolved-reference]
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-3 | # snapshot
-4 | # snapshot
   |
 help: Remove the unused suppression comment
 1 | # snapshot
@@ -135,12 +126,8 @@ a = 10 / 0  # ty: ignore[invalid-assignment, division-by-zero, unresolved-refere
 warning[unused-ignore-comment]: Unused `ty: ignore` directive: 'invalid-assignment'
  --> src/mdtest_snippet.py:5:26
   |
-3 | # snapshot
-4 | # snapshot
 5 | a = 10 / 0  # ty: ignore[invalid-assignment, division-by-zero, unresolved-reference]
   |                          ^^^^^^^^^^^^^^^^^^
-6 | # snapshot
-7 | a = 10 / 0  # ty: ignore[invalid-assignment, unresolved-reference, division-by-zero]
   |
 help: Remove the unused suppression code
 2 | a = 10 / 2  # ty: ignore[division-by-zero, unresolved-reference]
@@ -155,12 +142,8 @@ help: Remove the unused suppression code
 warning[unused-ignore-comment]: Unused `ty: ignore` directive: 'unresolved-reference'
  --> src/mdtest_snippet.py:5:64
   |
-3 | # snapshot
-4 | # snapshot
 5 | a = 10 / 0  # ty: ignore[invalid-assignment, division-by-zero, unresolved-reference]
   |                                                                ^^^^^^^^^^^^^^^^^^^^
-6 | # snapshot
-7 | a = 10 / 0  # ty: ignore[invalid-assignment, unresolved-reference, division-by-zero]
   |
 help: Remove the unused suppression code
 2 | a = 10 / 2  # ty: ignore[division-by-zero, unresolved-reference]
@@ -181,8 +164,6 @@ a = 10 / 0  # ty: ignore[invalid-assignment, unresolved-reference, division-by-z
 warning[unused-ignore-comment]: Unused `ty: ignore` directive: 'invalid-assignment', 'unresolved-reference'
  --> src/mdtest_snippet.py:7:26
   |
-5 | a = 10 / 0  # ty: ignore[invalid-assignment, division-by-zero, unresolved-reference]
-6 | # snapshot
 7 | a = 10 / 0  # ty: ignore[invalid-assignment, unresolved-reference, division-by-zero]
   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
@@ -315,7 +296,6 @@ a = 10 + 4  # ty: ignore[division-by-zer]
 warning[ignore-comment-unknown-rule]: Unknown rule `division-by-zer`. Did you mean `division-by-zero`?
  --> src/mdtest_snippet.py:2:26
   |
-1 | # snapshot
 2 | a = 10 + 4  # ty: ignore[division-by-zer]
   |                          ^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/type_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/type_ignore.md
@@ -166,15 +166,11 @@ a = (3
 
 ```snapshot
 warning[unused-ignore-comment]: Unused `ty: ignore` directive
-  --> src/mdtest_snippet.py:9:9
-   |
- 7 | a = (3
- 8 |   # snapshot
- 9 |   + 2)  # ty:ignore[division-by-zero] # fmt: skip
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-10 | a = (3
-11 |   # snapshot
-   |
+ --> src/mdtest_snippet.py:9:9
+  |
+9 |   + 2)  # ty:ignore[division-by-zero] # fmt: skip
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
 help: Remove the unused suppression comment
 6  |   + 2  # type: ignore # fmt: skip
 7  | a = (3
@@ -196,8 +192,6 @@ a = (3
 warning[unused-ignore-comment]: Unused `ty: ignore` directive
   --> src/mdtest_snippet.py:12:21
    |
-10 | a = (3
-11 |   # snapshot
 12 |   + 2)  # fmt: skip # ty:ignore[division-by-zero]
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -312,7 +306,6 @@ a = 10 / 2  # type: ignore[mypy-code, ty:division-by-zero]
 warning[unused-type-ignore-comment]: Unused `type: ignore` directive: 'division-by-zero'
  --> src/mdtest_snippet.py:2:39
   |
-1 | # snapshot
 2 | a = 10 / 2  # type: ignore[mypy-code, ty:division-by-zero]
   |                                       ^^^^^^^^^^^^^^^^^^^
   |
@@ -333,7 +326,6 @@ a = 10 / 2  # type: ignore[ty:division-by-zero]
 warning[unused-type-ignore-comment]: Unused `type: ignore` directive
  --> src/mdtest_snippet.py:2:13
   |
-1 | # snapshot
 2 | a = 10 / 2  # type: ignore[ty:division-by-zero]
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
@@ -354,7 +346,6 @@ a = 10 / 2  # type: ignore[ty:division-by]
 warning[ignore-comment-unknown-rule]: Unknown rule `division-by`. Did you mean `division-by-zero`?
  --> src/mdtest_snippet.py:2:28
   |
-1 | # snapshot
 2 | a = 10 / 2  # type: ignore[ty:division-by]
   |                            ^^^^^^^^^^^^^^
   |

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -778,6 +778,12 @@ fn diagnostic_display_config() -> DisplayDiagnosticConfig {
         .color(false)
         .show_fix_diff(true)
         .with_fix_applicability(Applicability::DisplayOnly)
+        // Surrounding context in source annotations can be confusing in mdtests,
+        // since you may get to see context from the *subsequent* code block (all
+        // code blocks are merged into a single file). It also leads to a lot of
+        // duplication in general. So we just set it to zero here for concise
+        // and clear snapshots.
+        .context(0)
 }
 
 fn render_diagnostic(db: &mut Db, diagnostic: &Diagnostic) -> String {


### PR DESCRIPTION
## Summary

Surrounding context in source annotations can be confusing in mdtests, since you may get to see context from the *subsequent* code block (all code blocks are merged into a single file). It also leads to a lot of duplication in general. So we just set it to zero here for concise and clear snapshots.
