### PR TITLE
[ty] Avoid panic from double inference with missing functional Enum names

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -1752,6 +1752,31 @@ Color = Enum()
 reveal_type(Color)  # revealed: Enum
 ```
 
+### Missing `names` argument
+
+```py
+from enum import Enum
+
+# This is invalid at runtime but should not panic.
+Enum("Color")  # error: [missing-argument]
+
+# error: [missing-argument]
+# error: [invalid-argument-type]
+Enum(123)
+
+# error: [missing-argument]
+# error: [invalid-argument-type]
+Enum("Color", start="0")
+
+# error: [missing-argument]
+# error: [invalid-argument-type]
+Enum("Color", type=1)
+
+# error: [missing-argument]
+# error: [unknown-argument]
+Enum("Color", bad_kwarg=True)
+```
+
 ### Non-literal name
 
 Non-literal names should still be recognized as creating an enum class.

--- a/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
@@ -11,7 +11,7 @@ use crate::{
         class::{DynamicEnumAnchor, DynamicEnumLiteral, EnumSpec},
         constraints::ConstraintSetBuilder,
         diagnostic::{
-            INVALID_ARGUMENT_TYPE, INVALID_BASE, PARAMETER_ALREADY_ASSIGNED,
+            INVALID_ARGUMENT_TYPE, INVALID_BASE, MISSING_ARGUMENT, PARAMETER_ALREADY_ASSIGNED,
             TOO_MANY_POSITIONAL_ARGUMENTS, UNKNOWN_ARGUMENT, report_mismatched_type_name,
         },
         infer::TypeInferenceBuilder,
@@ -364,6 +364,29 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let name_arg = name_arg?;
 
+        let Some(names_arg) = names_arg else {
+            self.infer_expression(name_arg, TypeContext::default());
+            for kw in keywords {
+                self.infer_expression(&kw.value, TypeContext::default());
+            }
+
+            self.infer_enum_name_argument(name_arg, base_class);
+            if let Some(keyword) = start_kw {
+                self.infer_enum_start_argument(&keyword.value);
+            }
+            if let Some(keyword) = type_kw {
+                self.infer_enum_mixin_argument(&keyword.value, base_class);
+            }
+
+            if let Some(builder) = self.context.report_lint(&MISSING_ARGUMENT, call_expr) {
+                builder.into_diagnostic(format_args!(
+                    "Missing required argument `names` to `{base_name}()`"
+                ));
+            }
+
+            return Some(base_class.to_instance(db));
+        };
+
         for arg in args {
             self.infer_expression(arg, TypeContext::default());
         }
@@ -392,8 +415,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ));
         }
 
-        // Without `names`, this is a value-lookup call, not functional enum creation.
-        let names_arg = names_arg?;
         let name_ty = self.expression_type(name_arg);
         let name = name_ty
             .as_string_literal()


### PR DESCRIPTION
## Summary

Given `Enum("Color")`, we inferred the first argument, then returned `None` later if `names_arg` was empty, which led us to double-infer the first argument.

Closes https://github.com/astral-sh/ty/issues/3272.
