### PR TITLE
[ty] Avoid panic from functional `Enum(value=...)`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -1760,9 +1760,16 @@ from enum import Enum
 # This is invalid at runtime but should not panic.
 Enum("Color")  # error: [missing-argument]
 
+# This is invalid at runtime but should not panic.
+Enum(value="Color")  # error: [missing-argument]
+
 # error: [missing-argument]
 # error: [invalid-argument-type]
 Enum(123)
+
+# error: [missing-argument]
+# error: [invalid-argument-type]
+Enum(value=123)
 
 # error: [missing-argument]
 # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
@@ -365,7 +365,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let name_arg = name_arg?;
 
         let Some(names_arg) = names_arg else {
-            self.infer_expression(name_arg, TypeContext::default());
+            for arg in args {
+                self.infer_expression(arg, TypeContext::default());
+            }
             for kw in keywords {
                 self.infer_expression(&kw.value, TypeContext::default());
             }


### PR DESCRIPTION
## Summary

Given `Enum(value="Color")`, we were inferring the name twice.

See: https://github.com/astral-sh/ruff/pull/24638#issuecomment-4245749409.
