### PR TITLE
[ty] Avoid double inference for `namedtuple(typename=T, field_names=x, **{})`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -666,6 +666,9 @@ Bad1 = collections.namedtuple("Bad1", "x y", typename="Bad1")
 
 # error: [parameter-already-assigned] "Multiple values provided for parameter `field_names` of `namedtuple`"
 Bad2 = collections.namedtuple("Bad2", "x y", field_names="a b")
+
+# This is valid at runtime and should not panic.
+collections.namedtuple(typename="NT4", field_names="x", **{})
 ```
 
 The `rename`, `defaults`, and `module` keyword arguments:

--- a/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
@@ -164,11 +164,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             self.infer_expression(fields_arg, TypeContext::default());
 
             for kw in keywords {
-                if let Some(arg) = kw.arg.as_ref() {
-                    if name_from_keyword && arg.id.as_str() == "typename" {
+                if let Some(arg) = kw.arg.as_deref() {
+                    if name_from_keyword && arg == "typename" {
                         continue;
                     }
-                    if fields_from_keyword && arg.id.as_str() == "field_names" {
+                    if fields_from_keyword && arg == "field_names" {
                         continue;
                     }
                 }

--- a/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
@@ -161,7 +161,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // If any argument is a starred expression or any keyword is a double-starred expression,
         // we can't statically determine the arguments, so fall back to normal call binding.
         if has_starred || has_double_starred {
+            self.infer_expression(fields_arg, TypeContext::default());
+
             for kw in keywords {
+                if let Some(arg) = kw.arg.as_ref() {
+                    if name_from_keyword && arg.id.as_str() == "typename" {
+                        continue;
+                    }
+                    if fields_from_keyword && arg.id.as_str() == "field_names" {
+                        continue;
+                    }
+                }
                 self.infer_expression(&kw.value, TypeContext::default());
             }
             return fallback();


### PR DESCRIPTION
## Summary

In `namedtuple(typename=T, field_names=x, **{})`, we infer the `field_names` argument, then re-infer it a second time if a `**` kwargs is provided.
