### PR TITLE
[`ruff`] Ignore `RUF029` when function is decorated with `asynccontextmanager`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF029.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF029.py
@@ -97,3 +97,12 @@ def setup_app(app_arg: FastAPI, non_app: str) -> None:
     async def get_root() -> str:
         return "Hello World!"
 
+
+# asynccontextmanager-decorated functions must be async even without await
+
+from contextlib import asynccontextmanager
+
+
+@asynccontextmanager
+async def pass_7():  # OK: decorated with asynccontextmanager
+    yield

--- a/crates/ruff_linter/src/rules/ruff/rules/unused_async.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unused_async.rs
@@ -156,10 +156,7 @@ where
 }
 
 /// Returns `true` if the function is decorated with `contextlib.asynccontextmanager`.
-fn is_async_context_manager(
-    function_def: &ast::StmtFunctionDef,
-    semantic: &SemanticModel,
-) -> bool {
+fn is_async_context_manager(function_def: &ast::StmtFunctionDef, semantic: &SemanticModel) -> bool {
     function_def.decorator_list.iter().any(|decorator| {
         semantic
             .resolve_qualified_name(&decorator.expression)
@@ -222,4 +219,3 @@ pub(crate) fn unused_async(
         );
     }
 }
-

--- a/crates/ruff_linter/src/rules/ruff/rules/unused_async.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unused_async.rs
@@ -3,6 +3,7 @@ use ruff_python_ast::identifier::Identifier;
 use ruff_python_ast::visitor::source_order;
 use ruff_python_ast::{self as ast, AnyNodeRef, Expr, Stmt};
 use ruff_python_semantic::Modules;
+use ruff_python_semantic::SemanticModel;
 use ruff_python_semantic::analyze::function_type::is_stub;
 
 use crate::Violation;
@@ -154,6 +155,23 @@ where
     }
 }
 
+/// Returns `true` if the function is decorated with `contextlib.asynccontextmanager`.
+fn is_async_context_manager(
+    function_def: &ast::StmtFunctionDef,
+    semantic: &SemanticModel,
+) -> bool {
+    function_def.decorator_list.iter().any(|decorator| {
+        semantic
+            .resolve_qualified_name(&decorator.expression)
+            .is_some_and(|qualified_name| {
+                matches!(
+                    qualified_name.segments(),
+                    ["contextlib", "asynccontextmanager"]
+                )
+            })
+    })
+}
+
 /// RUF029
 pub(crate) fn unused_async(
     checker: &Checker,
@@ -183,6 +201,12 @@ pub(crate) fn unused_async(
         return;
     }
 
+    // Ignore functions decorated with `contextlib.asynccontextmanager`, which are
+    // required to be `async` even if they don't use `await`.
+    if is_async_context_manager(function_def, checker.semantic()) {
+        return;
+    }
+
     let found_await_or_async = {
         let mut visitor = AsyncExprVisitor::default();
         source_order::walk_body(&mut visitor, body);
@@ -198,3 +222,4 @@ pub(crate) fn unused_async(
         );
     }
 }
+


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Ignore `RUF029` when function is decorated with `asynccontextmanager`. For example I ran across this when working with FastAPI lifespan https://fastapi.tiangolo.com/advanced/events/

```python
@asynccontextmanager
async def lifespan(app: FastAPI):
    # Load the ML model
    ml_models["answer_to_everything"] = fake_answer_to_everything_ml_model
    yield
    # Clean up the ML models and release the resources
    ml_models.clear()


app = FastAPI(lifespan=lifespan)
```

## Test Plan

Test fixture added
