### PR TITLE
[ty] Fix cases where `invalid-key` fix doesn't converge, and `override-of-final-method` produces invalid syntax

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Unknown_key_for_all_…_(8a0f0e8ceccc51b2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Unknown_key_for_all_…_(8a0f0e8ceccc51b2).snap
@@ -36,16 +36,10 @@ error[invalid-key]: Unknown key "nane" for TypedDict `Person`
   --> src/mdtest_snippet.py:14:5
    |
 14 |     being["nane"] = "unknown"
-   |     ----- ^^^^^^ Did you mean "name"?
+   |     ----- ^^^^^^ Unknown key "nane"
    |     |
    |     TypedDict `Person` in union type `Person | Animal`
    |
-11 | def _(being: Person | Animal) -> None:
-12 |     # error: [invalid-key]
-13 |     # error: [invalid-key]
-   -     being["nane"] = "unknown"
-14 +     being["name"] = "unknown"
-note: This is an unsafe fix and may change runtime behavior
 
 ```
 
@@ -54,15 +48,9 @@ error[invalid-key]: Unknown key "nane" for TypedDict `Animal`
   --> src/mdtest_snippet.py:14:5
    |
 14 |     being["nane"] = "unknown"
-   |     ----- ^^^^^^ Did you mean "name"?
+   |     ----- ^^^^^^ Unknown key "nane"
    |     |
    |     TypedDict `Animal` in union type `Person | Animal`
    |
-11 | def _(being: Person | Animal) -> None:
-12 |     # error: [invalid-key]
-13 |     # error: [invalid-key]
-   -     being["nane"] = "unknown"
-14 +     being["name"] = "unknown"
-note: This is an unsafe fix and may change runtime behavior
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1775,9 +1775,11 @@ RecursiveKey = list["RecursiveKey | None"]
 class Person(TypedDict):
     name: str
     age: int | None
+    leg: str
 
 class Animal(TypedDict):
     name: str
+    log: str
 
 class Movie(TypedDict):
     name: str
@@ -1824,6 +1826,10 @@ def _(
 
     # error: [invalid-key] "Unknown key "age" for TypedDict `Animal`"
     reveal_type(being["age"])  # revealed: int | None | Unknown
+
+    # error: [invalid-key]
+    # error: [invalid-key]
+    reveal_type(being["legs"])  # revealed: Unknown
 ```
 
 ### Writing

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1873,7 +1873,7 @@ def _(being: Person | Animal):
     # error: [invalid-assignment] "Invalid assignment to key "name" with declared type `str` on TypedDict `Animal`: value of type `Literal[1]`"
     being["name"] = 1
 
-    # error: [invalid-key] "Unknown key "leg" for TypedDict `Animal` - did you mean "legs"?"
+    # error: [invalid-key] "Unknown key "leg" for TypedDict `Animal`"
     being["leg"] = "unknown"
 
 def _(centaur: Intersection[Person, Animal]):

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -35,10 +35,10 @@ use ruff_db::{
     diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity},
     parsed::parsed_module,
 };
-use ruff_diagnostics::{Edit, Fix};
+use ruff_diagnostics::{Edit, Fix, IsolationLevel};
 use ruff_python_ast::name::Name;
 use ruff_python_ast::token::parentheses_iterator;
-use ruff_python_ast::{self as ast, AnyNodeRef, PythonVersion, StringFlags};
+use ruff_python_ast::{self as ast, AnyNodeRef, HasNodeIndex, PythonVersion, StringFlags};
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
 use std::fmt::{self, Formatter};
@@ -5162,7 +5162,20 @@ pub(crate) fn report_invalid_key_on_typed_dict<'db>(
                 });
 
                 let existing_keys = items.keys().map(Name::as_str);
-                if let Some(suggestion) = did_you_mean(existing_keys, key) {
+
+                let suggestion = did_you_mean(existing_keys, key).filter(|suggestion| {
+                    full_object_ty.is_none_or(|full_object_ty| {
+                        full_object_ty
+                            .subscript(
+                                db,
+                                Type::string_literal(db, suggestion),
+                                ast::ExprContext::Store,
+                            )
+                            .is_ok()
+                    })
+                });
+
+                if let Some(suggestion) = suggestion {
                     if let AnyNodeRef::ExprStringLiteral(literal) = key_node {
                         let quoted_suggestion = format!(
                             "{quote}{suggestion}{quote}",
@@ -5867,6 +5880,14 @@ pub(super) fn report_overridden_final_method<'db>(
                     .contains(overload.node(db, context.file(), context.module()))
             });
 
+        let isolate = IsolationLevel::Group(
+            class_node
+                .node_index()
+                .load()
+                .as_u32()
+                .expect("`parsed_module` should have assigned a node index"),
+        );
+
         match function.overloads_and_implementation(db) {
             ([first_overload, rest @ ..], None) => {
                 diagnostic.help(format_args!("Remove all overloads for `{member}`"));
@@ -5875,6 +5896,7 @@ pub(super) fn report_overridden_final_method<'db>(
                         overload_deletion(first_overload),
                         rest.iter().map(overload_deletion),
                     )
+                    .isolate(isolate)
                 }));
             }
             ([first_overload, rest @ ..], Some(implementation)) => {
@@ -5886,13 +5908,14 @@ pub(super) fn report_overridden_final_method<'db>(
                         overload_deletion(first_overload),
                         rest.iter().chain([&implementation]).map(overload_deletion),
                     )
+                    .isolate(isolate)
                 }));
             }
             ([], Some(implementation)) => {
                 diagnostic.help(format_args!("Remove the override of `{member}`"));
-                diagnostic.set_optional_fix(
-                    should_fix.then(|| Fix::unsafe_edit(overload_deletion(&implementation))),
-                );
+                diagnostic.set_optional_fix(should_fix.then(|| {
+                    Fix::unsafe_edit(overload_deletion(&implementation)).isolate(isolate)
+                }));
             }
             ([], None) => {
                 // Should be impossible to get here: how would we even infer a function as a function

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -5163,19 +5163,9 @@ pub(crate) fn report_invalid_key_on_typed_dict<'db>(
 
                 let existing_keys = items.keys().map(Name::as_str);
 
-                let suggestion = did_you_mean(existing_keys, key).filter(|suggestion| {
-                    full_object_ty.is_none_or(|full_object_ty| {
-                        full_object_ty
-                            .subscript(
-                                db,
-                                Type::string_literal(db, suggestion),
-                                ast::ExprContext::Store,
-                            )
-                            .is_ok()
-                    })
-                });
-
-                if let Some(suggestion) = suggestion {
+                if !matches!(full_object_ty, Some(Type::Union(_) | Type::Intersection(_)))
+                    && let Some(suggestion) = did_you_mean(existing_keys, key)
+                {
                     if let AnyNodeRef::ExprStringLiteral(literal) = key_node {
                         let quoted_suggestion = format!(
                             "{quote}{suggestion}{quote}",

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -125,6 +125,7 @@ pub(crate) enum SubscriptErrorKind<'db> {
     InvalidTypedDictKey {
         typed_dict: TypedDictType<'db>,
         slice_ty: Type<'db>,
+        full_object_ty: Option<Type<'db>>,
     },
     /// The type does not support subscripting via the expected dunder.
     NotSubscriptable {
@@ -184,6 +185,21 @@ impl<'db> SubscriptError<'db> {
 }
 
 impl<'db> SubscriptErrorKind<'db> {
+    fn with_full_object_ty(self, full_object_ty: Type<'db>) -> Self {
+        match self {
+            Self::InvalidTypedDictKey {
+                typed_dict,
+                slice_ty,
+                ..
+            } => Self::InvalidTypedDictKey {
+                typed_dict,
+                slice_ty,
+                full_object_ty: Some(full_object_ty),
+            },
+            other => other,
+        }
+    }
+
     fn report_diagnostic(
         &self,
         context: &InferContext<'db, '_>,
@@ -289,6 +305,7 @@ impl<'db> SubscriptErrorKind<'db> {
             Self::InvalidTypedDictKey {
                 typed_dict,
                 slice_ty,
+                full_object_ty,
             } => {
                 let typed_dict_ty = Type::TypedDict(*typed_dict);
                 report_invalid_key_on_typed_dict(
@@ -296,7 +313,7 @@ impl<'db> SubscriptErrorKind<'db> {
                     value_node.into(),
                     slice_node.into(),
                     typed_dict_ty,
-                    None,
+                    *full_object_ty,
                     *slice_ty,
                     typed_dict.items(db),
                 );
@@ -361,8 +378,14 @@ where
                 builder = builder.add(result);
             }
             Err(error) => {
+                let full_object_ty = Type::Union(union);
                 builder = builder.add(error.result_type());
-                errors.extend(error.into_errors());
+                errors.extend(
+                    error
+                        .into_errors()
+                        .into_iter()
+                        .map(|error| error.with_full_object_ty(full_object_ty)),
+                );
             }
         }
     }
@@ -413,15 +436,21 @@ where
 
     let mut builder = IntersectionBuilder::new(db);
     let mut collected_errors = Vec::new();
+    let full_object_ty = Type::Intersection(intersection);
 
     for error in errors {
         if !any_has_method || error.any_method_available() {
             builder = builder.add_positive(error.result_type());
             let error_iter = error.into_errors().into_iter();
             if any_has_method {
-                collected_errors.extend(error_iter.filter(SubscriptErrorKind::method_available));
+                collected_errors.extend(
+                    error_iter
+                        .filter(SubscriptErrorKind::method_available)
+                        .map(|error| error.with_full_object_ty(full_object_ty)),
+                );
             } else {
-                collected_errors.extend(error_iter);
+                collected_errors
+                    .extend(error_iter.map(|error| error.with_full_object_ty(full_object_ty)));
             }
         }
     }
@@ -457,6 +486,7 @@ fn typed_dict_subscript<'db>(
             SubscriptErrorKind::InvalidTypedDictKey {
                 typed_dict,
                 slice_ty,
+                full_object_ty: None,
             },
         ));
     };
@@ -468,6 +498,7 @@ fn typed_dict_subscript<'db>(
                 SubscriptErrorKind::InvalidTypedDictKey {
                     typed_dict,
                     slice_ty,
+                    full_object_ty: None,
                 },
             ))
         },


### PR DESCRIPTION
## Summary

I discovered these two issues when I integrated fixes into mdtests as part of https://github.com/astral-sh/ruff/pull/24097. 

* `invalid-key`: The fix never converges if the key is valid for some but not all union variants and the suggested key isn't available on all union variants. See https://play.ty.dev/e6b01d0f-92d2-4a33-b4bc-bc6ef92d64ce The solution here is to only suggest a key that we can successfully resolve.
* `override-of-final-method`: The fix can produce invalid syntax when applying all fixes in a file at once because it can result in removing all methods of a `class`, without inserting a dummy body. The fix here is to run the fixes in isolation, keyed by the enclosing class. This has the downside that a class with 10+ overriden final methods still doesn't converge, but I consider this unlikely and something we can look into when it happens in practice.

## Test Plan

The tests in https://play.ty.dev/e6b01d0f-92d2-4a33-b4bc-bc6ef92d64ce pass after applying those two fixes. 
