### PR TITLE
[ty] Preserve iterable intersection inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -447,6 +447,31 @@ A(f(1))
 A(f([]))
 ```
 
+Intersection type contexts should preserve intersection semantics when solving generic return
+types:
+
+```py
+from typing import Any, Iterable
+from ty_extensions import Intersection
+
+def first[T](it: Iterable[T]) -> T:
+    raise NotImplementedError
+
+class P: ...
+class Q: ...
+
+def _(x: Any):
+    assert isinstance(x, list)
+    reveal_type(x)  # revealed: Any & Top[list[Unknown]]
+    reveal_type(first(x))  # revealed: Any
+    reveal_type(enumerate(x))  # revealed: enumerate[Any]
+    for _, item in enumerate(x):
+        reveal_type(item)  # revealed: Any
+
+def _(i: Intersection[list[P], list[Q]]):
+    reveal_type(first(i))  # revealed: P & Q
+```
+
 ## Conditional expressions
 
 The type context is propagated through both branches of conditional expressions:

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2189,11 +2189,17 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 // It's important that this arm comes after the `TypeVar` arm above, so that a bare
                 // typevar bound to an intersection gets the whole thing.
                 //
-                // It's sufficient for one intersection element to satisfy the constraints here.
-                // They don't all have to.
+                // Each successful element can contribute additional constraints to inferred
+                // type variables. We therefore infer against each positive element separately,
+                // then intersect the resulting type mappings for typevars inferred by multiple
+                // matching elements.
                 let mut first_error = None;
                 let mut found_matching_element = false;
+                let original_types = self.types.clone();
+                let mut merged_inferred: FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>> =
+                    FxHashMap::default();
                 for positive in actual_intersection.iter_positive(self.db) {
+                    self.types = original_types.clone();
                     let result = self.infer_map_impl(formal, positive, polarity, f, seen);
                     if let Err(err) = result {
                         // TODO: `infer_map_impl` can have side effects even in the error case, so
@@ -2209,8 +2215,36 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                             .is_never_satisfied(self.db)
                         {
                             found_matching_element = true;
+                            for (&identity, &inferred_ty) in &self.types {
+                                if original_types.get(&identity) == Some(&inferred_ty) {
+                                    continue;
+                                }
+                                merged_inferred
+                                    .entry(identity)
+                                    .and_modify(|existing| {
+                                        *existing = IntersectionType::from_two_elements(
+                                            self.db,
+                                            *existing,
+                                            inferred_ty,
+                                        );
+                                    })
+                                    .or_insert(inferred_ty);
+                            }
                         }
                     }
+                }
+                self.types = original_types;
+                for (identity, inferred_ty) in merged_inferred {
+                    self.types
+                        .entry(identity)
+                        .and_modify(|existing| {
+                            *existing = IntersectionType::from_two_elements(
+                                self.db,
+                                *existing,
+                                inferred_ty,
+                            );
+                        })
+                        .or_insert(inferred_ty);
                 }
                 if !found_matching_element && let Some(error) = first_error {
                     return Err(error);
@@ -2257,6 +2291,42 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         seen,
                     );
                 }
+            }
+
+            (Type::ProtocolInstance(formal_protocol), _)
+                if formal_protocol
+                    .to_nominal_instance()
+                    .is_some_and(|formal_nominal| {
+                        formal_nominal
+                            .known_class(self.db)
+                            .is_some_and(|known_class| {
+                                matches!(known_class, KnownClass::Iterable | KnownClass::Iterator)
+                            })
+                    }) =>
+            {
+                let formal_nominal = formal_protocol.to_nominal_instance().unwrap();
+                let Some(formal_alias) = formal_nominal.class(self.db).into_generic_alias() else {
+                    return Ok(());
+                };
+                let Some(formal_element_ty) =
+                    formal_alias.specialization(self.db).types(self.db).first()
+                else {
+                    return Ok(());
+                };
+                let Ok(actual_iterable) = actual.try_iterate(self.db) else {
+                    return Ok(());
+                };
+
+                let actual_element_ty = actual_iterable.homogeneous_element_type(self.db);
+                let variance = TypeVarVariance::Covariant.compose(polarity);
+                self.infer_map_impl(
+                    *formal_element_ty,
+                    actual_element_ty,
+                    variance,
+                    &mut f,
+                    seen,
+                )?;
+                return Ok(());
             }
 
             (formal, Type::NominalInstance(actual_nominal)) => {

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -459,6 +459,28 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // we can.
         let mut result = self.never();
 
+        if !matches!(ty, Type::ProtocolInstance(_))
+            && let Some(nominal_protocol) = protocol.to_nominal_instance()
+            && nominal_protocol.known_class(db).is_some_and(|known_class| {
+                matches!(known_class, KnownClass::Iterable | KnownClass::Iterator)
+            })
+            && let Some(protocol_alias) = nominal_protocol.class(db).into_generic_alias()
+            && let Some(expected_element_ty) = protocol_alias.specialization(db).types(db).first()
+            && let Ok(iterated) = ty.try_iterate(db)
+        {
+            result = result.or(db, self.constraints, || {
+                self.check_type_pair(
+                    db,
+                    iterated.homogeneous_element_type(db),
+                    *expected_element_ty,
+                )
+            });
+
+            if result.is_always_satisfied(db) {
+                return result;
+            }
+        }
+
         if let Some(nominal_instance) = protocol.to_nominal_instance() {
             // if `ty` and `protocol` are *both* protocols, we also need to treat `ty` as if it
             // were a nominal type, or we won't consider a protocol `P` that explicitly inherits

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1141,6 +1141,35 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         })
                 }),
 
+            (Type::Intersection(_), Type::ProtocolInstance(target_proto))
+                if target_proto
+                    .to_nominal_instance()
+                    .is_some_and(|nominal_protocol| {
+                        nominal_protocol.known_class(db).is_some_and(|known_class| {
+                            matches!(known_class, KnownClass::Iterable | KnownClass::Iterator)
+                        })
+                    }) =>
+            {
+                let Some(nominal_protocol) = target_proto.to_nominal_instance() else {
+                    return self.never();
+                };
+                let Some(protocol_alias) = nominal_protocol.class(db).into_generic_alias() else {
+                    return self.never();
+                };
+                let Some(expected_element_ty) = protocol_alias.specialization(db).types(db).first()
+                else {
+                    return self.never();
+                };
+                let Ok(iterated) = source.try_iterate(db) else {
+                    return self.never();
+                };
+                self.check_type_pair(
+                    db,
+                    iterated.homogeneous_element_type(db),
+                    *expected_element_ty,
+                )
+            }
+
             (Type::Intersection(intersection), _) => {
                 // An intersection type is a subtype of another type if at least one of its
                 // positive elements is a subtype of that type. If there are no positive elements,


### PR DESCRIPTION

  ## Summary

  Fixes iterable generic inference for intersection-typed inputs.

  This addresses the case from `astral-sh/ty#3259` where:
  - `Any & Top[list[Unknown]]` assigned to `Iterable[T]` could wrongly solve
  `T` to `object`
  - `Intersection[list[P], list[Q]]` could wrongly solve `T` to `P | Q`
  instead of `P & Q`

  ## What changed

  - preserve intersection semantics when merging inferred typevar mappings
  across matching intersection elements
  - infer `Iterable[T]` / `Iterator[T]` from `try_iterate()` so iterable
  intersections keep their yielded element type
  - align relation/protocol checks for intersected iterables with the same
  yielded-element logic
  - add a regression mdtest covering both reported cases

  ## Verification

  Ran:
  ```bash
  cargo test -p ty_python_semantic --test mdtest bidirectional --
  --nocapture

  Result:

  - 1 passed

  ## Related

  - astral-sh/ty#3259