### PR TITLE
[ty] Fix unnecessary `ty:ignore` comments inserted by `--add-ignore` for diagnostics starting on the same line

### DIFF
--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -562,6 +562,53 @@ mod tests {
         "#);
     }
 
+    // A same-code suppression inserted at the end of a narrower multiline range can land on the
+    // start line of a wider multiline range, which makes the wider range's own suppression
+    // redundant.
+    #[test]
+    fn same_code_multiline_suppressions_with_different_ranges_can_become_redundant() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                from typing import TypeAlias
+
+                JsonValue: TypeAlias = dict[str, "JsonValue"] | list["JsonValue"] | int
+
+
+                def get_data() -> dict[str, JsonValue]:
+                    return {"home_assistant": {"entities": [{"entity_id": "sensor.test"}]}}
+
+
+                def f() -> None:
+                    diag = get_data()
+                    diag["home_assistant"]["entities"] = sorted(
+                        diag["home_assistant"]["entities"], key=lambda ent: ent["entity_id"]
+                    )
+                "#
+        ),
+         @r#"
+        Added 4 suppressions
+
+        ## Fixed source
+
+        ```py
+        from typing import TypeAlias
+
+        JsonValue: TypeAlias = dict[str, "JsonValue"] | list["JsonValue"] | int
+
+
+        def get_data() -> dict[str, JsonValue]:
+            return {"home_assistant": {"entities": [{"entity_id": "sensor.test"}]}}
+
+
+        def f() -> None:
+            diag = get_data()
+            diag["home_assistant"]["entities"] = sorted(  # ty:ignore[invalid-assignment]
+                diag["home_assistant"]["entities"], key=lambda ent: ent["entity_id"]  # ty:ignore[invalid-argument-type, not-subscriptable]
+            )
+        ```
+        "#);
+    }
+
     #[test]
     fn return_type() {
         assert_snapshot!(

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -9,7 +9,6 @@ use ruff_db::source::source_text;
 use ruff_diagnostics::{Edit, Fix};
 use ruff_python_ast::token::TokenKind;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
-use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 
 use crate::Db;
@@ -24,53 +23,88 @@ use crate::suppression::{SuppressionKind, SuppressionTarget, Suppressions, suppr
 pub fn suppress_all(db: &dyn Db, file: File, ids_with_range: &[(LintName, TextRange)]) -> Vec<Fix> {
     let suppressions = suppressions(db, file);
     let source = source_text(db, file);
+    let parsed = parsed_module(db, file).load(db);
+    let tokens = parsed.tokens();
 
     // Compute the full suppression ranges for each diagnostic.
-    let ids_full_range: Vec<_> = ids_with_range
+    let mut ids_full_range: Vec<_> = ids_with_range
         .iter()
         .map(|&(id, range)| (id, suppression_range(db, file, range)))
         .collect();
 
+    // Sort the suppression ranges by their start position and length (end position).
+    // This ensures that a diagnostic with a shorter range is processed before
+    // a diagnostic starting on the same line, but with a wider range (ends on a later line).
+    //
+    // ```
+    // diag["home_assistant"]["entities"] = sorted(
+    // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ wider range
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ narrower range
+    //     diag["home_assistant"]["entities"], key=lambda ent: ent["entity_id"]
+    // )  # end of the wider range
+    // ^ wider range
+    // ```
+    //
+    // This is important because a suppression inserted at the end of a narrower range
+    // can result in a start-line suppression for a wider range. In the example above,
+    // inserting a `ty:ignore` after `sorted(` suppresses the diagnostic with the narrower range
+    // but also the diagnostic with the wider range (because the suppression is on its start line).
+    ids_full_range.sort_unstable_by_key(|(_, range)| (range.start(), range.end()));
+
     // 1. Group the diagnostics by their line-start position and try to add
     //    the suppression to an existing `ty: ignore` comment on that line.
-    let mut by_start: BTreeMap<_, (BTreeSet<LintName>, SmallVec<[usize; 2]>)> = BTreeMap::new();
+    let mut by_start: BTreeMap<_, BTreeSet<LintName>> = BTreeMap::new();
 
-    for (i, &(id, range)) in ids_full_range.iter().enumerate() {
-        let (lints, indices) = by_start.entry(range.start()).or_default();
+    for &(id, range) in &ids_full_range {
+        let lints = by_start.entry(range.start()).or_default();
         lints.insert(id);
-        indices.push(i);
     }
 
     let mut fixes = Vec::with_capacity(ids_full_range.len());
 
-    // Tracks the indices in `ids_with_range` for which we pushed a
-    // fix to `fixes`
-    let mut fixed = FxHashSet::default();
+    // Tracks which lints get inserted by line. The offset is the line's start offset.
+    // This is necessary to avoid inserting an end of line suppression if the diagnostic
+    // was suppressed by inserting a suppression on its start line.
+    // This also allows deduplicating suppressions for diagnostics with different ranges
+    // where an end-suppression of one diagnostic becomes a start-suppression for another
+    // (see the example with the wider range above).
+    let mut by_line = BTreeMap::<TextSize, BTreeSet<LintName>>::new();
 
-    for (start_offset, (lints, original_indices)) in by_start {
+    for (start_offset, lints) in by_start {
         let codes: SmallVec<[LintName; 2]> = lints.into_iter().collect();
         if let Some(add_to_start) =
             add_to_existing_suppression(suppressions, &source, &codes, start_offset)
         {
-            // Mark the diagnostics as fixed, so that we don't generate a fix at the end of the line.
-            fixed.extend(original_indices);
+            by_line
+                .entry(start_offset)
+                .or_default()
+                .extend(codes.iter().copied());
             fixes.push(add_to_start);
         }
     }
 
     // 2. Group the diagnostics by their end position and try to add the code to an
-    //    existing `ty: ignore` comment or insert a new `ty: ignore` comment. But only do this
-    //    for diagnostics for which we haven't pushed a start-line fix.
+    //    existing `ty: ignore` comment or insert a new `ty: ignore` comment.
     let mut by_end: BTreeMap<TextSize, BTreeSet<LintName>> = BTreeMap::new();
 
-    for (i, (id, range)) in ids_full_range.into_iter().enumerate() {
-        if fixed.contains(&i) {
-            // We already pushed a fix that appends the suppression to an existing suppression on the
-            // start line.
+    for (id, range) in ids_full_range {
+        // Skip end-line suppressions when we already inserted a same-code suppression on the
+        // range's start line. This happens either because we appended to an existing ignore
+        // comment on that line, or because a narrower multiline range ends on that same line.
+        if by_line
+            .get(&range.start())
+            .is_some_and(|planned_codes| planned_codes.contains(&id))
+        {
             continue;
         }
 
         by_end.entry(range.end()).or_default().insert(id);
+        // Record the physical line where this end-line suppression will be inserted so wider
+        // same-code ranges starting there can be recognized as already covered.
+        by_line
+            .entry(line_start(tokens, range.end()))
+            .or_default()
+            .insert(id);
     }
 
     for (end_offset, lints) in by_end {
@@ -128,23 +162,7 @@ fn suppression_range(db: &dyn Db, file: File, range: TextRange) -> TextRange {
     // Always insert a new suppression at the end of the range to avoid having to deal with multiline strings
     // etc. Also make sure to not pass a sub-token range to `Tokens::after`.
     let parsed = parsed_module(db, file).load(db);
-    let before_token_range = match parsed.tokens().at_offset(range.start()) {
-        ruff_python_ast::token::TokenAt::None => range,
-        ruff_python_ast::token::TokenAt::Single(token) => token.range(),
-        ruff_python_ast::token::TokenAt::Between(..) => range,
-    };
-    let before_tokens = parsed.tokens().before(before_token_range.start());
-
-    let line_start = before_tokens
-        .iter()
-        .rfind(|token| {
-            matches!(
-                token.kind(),
-                TokenKind::Newline | TokenKind::NonLogicalNewline
-            )
-        })
-        .map(Ranged::end)
-        .unwrap_or(TextSize::default());
+    let line_start = line_start(parsed.tokens(), range.start());
 
     let after_token_range = match parsed.tokens().at_offset(range.end()) {
         ruff_python_ast::token::TokenAt::None => range,
@@ -164,6 +182,26 @@ fn suppression_range(db: &dyn Db, file: File, range: TextRange) -> TextRange {
         .unwrap_or(range.end());
 
     TextRange::new(line_start, line_end)
+}
+
+fn line_start(tokens: &ruff_python_ast::token::Tokens, offset: TextSize) -> TextSize {
+    let token_range = match tokens.at_offset(offset) {
+        ruff_python_ast::token::TokenAt::None => TextRange::empty(offset),
+        ruff_python_ast::token::TokenAt::Single(token) => token.range(),
+        ruff_python_ast::token::TokenAt::Between(..) => TextRange::empty(offset),
+    };
+
+    tokens
+        .before(token_range.start())
+        .iter()
+        .rfind(|token| {
+            matches!(
+                token.kind(),
+                TokenKind::Newline | TokenKind::NonLogicalNewline
+            )
+        })
+        .map(Ranged::end)
+        .unwrap_or_default()
 }
 
 fn append_to_existing_or_add_end_of_line_suppression(


### PR DESCRIPTION
## Summary

This PR fixes an issue where `--add-ignore` inserted a redundant `ty: ignore` suppression, resulting in a `unused-ignore-comment` warning.

```
diag["home_assistant"]["entities"] = sorted(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ wider range
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ narrower range
    diag["home_assistant"]["entities"], key=lambda ent: ent["entity_id"]
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
)  # end of the wider range
^ wider range
```

ty emits two diagnostics `invalid-assignment` diagnostics in this example:

1. One, whose suppression range extends to the narrower range, that is, it only covers `diag["home_assistant"]["entities"] = sorted(`
1. One, whose suppression range covers the entire statement (because the `invalid-assignment` intentionally extends to cover the entire right-hand side expression. 

ty first added the suppression for 1. by inserting a new suppression comment at the end of the narrower range. That is, it fixed the above code to:


```py
diag["home_assistant"]["entities"] = sorted(  # ty:ignore[invalid-assignment]
    diag["home_assistant"]["entities"], key=lambda ent: ent["entity_id"]
range
)
```

This, on its own, is sufficient to suppress both diagnostics (because ty allows suppressing diagnostics on both the diagnostic's start and end lines).

However, ty inserted a second suppression for 2, by adding a new suppression comment at the end of the wider range, resulting in:

```py
diag["home_assistant"]["entities"] = sorted(  # ty:ignore[invalid-assignment]
    diag["home_assistant"]["entities"], key=lambda ent: ent["entity_id"]
range
)  #ty:ignore[invalid-assignment]
```

ty already accounts for the case that a diagnostic can both be suppressed by inserting a suppression at its start or end line, and it deduplicates those suppressions. However, it didn't account for the case where inserting an end suppression (for the narrower range) results in a start-line suppression for a diagnostic with a wider range. 

This PR extends the deduplication logic to account for this case.


## Test Plan

Added test. 

Ran `ty check --add-ignore` on homeassistant core and verified that it no longer results in any unused ignore comment warnings
