### PR TITLE
[ty] Fix `ClassVar[Self]` assignment checks for class objects

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -201,8 +201,9 @@ class Sub(Base): ...
 reveal_type(Sub.all_instances)  # revealed: list[Sub]
 ```
 
-Assignments through exact class objects should bind `Self` when writing a `ClassVar`. Symbolic
-subclass objects remain conservative because a `type[Base]` value can be any subclass of `Base`.
+Assignments through class objects should bind `Self` when writing a `ClassVar`, matching read-side
+behavior. This remains permissive for `type[Base]` values even though `ClassVar[Self]` in non-final
+classes is unsound.
 
 ```py
 from typing import ClassVar, Self, TypeVar
@@ -223,12 +224,14 @@ reveal_type(SavedSub.latest)  # revealed: SavedSub
 
 SavedSub.latest = SavedSub()
 
-def store_bad(cls: type[Saved]) -> None:
-    cls.latest = Saved()  # error: [invalid-assignment]
+SavedSub.latest = Saved()  # error: [invalid-assignment]
+
+def store_saved(cls: type[Saved]) -> None:
+    cls.latest = Saved()
 
 T = TypeVar("T", bound=Saved)
 
-def store_ok(cls: type[T], value: T) -> None:
+def store_generic(cls: type[T], value: T) -> None:
     cls.latest = value
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -201,7 +201,8 @@ class Sub(Base): ...
 reveal_type(Sub.all_instances)  # revealed: list[Sub]
 ```
 
-Assignments through `type(self)` should bind `Self` to the instance type when writing a `ClassVar`.
+Assignments through exact class objects should bind `Self` when writing a `ClassVar`, while symbolic
+subclass objects remain conservative.
 
 ```py
 from typing import ClassVar, Self, TypeVar
@@ -212,7 +213,7 @@ class Saved:
     def save(self) -> None:
         type(self).latest = self
 
-Saved.latest = Saved()  # error: [invalid-assignment]
+Saved.latest = Saved()
 
 reveal_type(Saved.latest)  # revealed: Saved
 

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -201,6 +201,61 @@ class Sub(Base): ...
 reveal_type(Sub.all_instances)  # revealed: list[Sub]
 ```
 
+Assignments through `type(self)` should bind `Self` to the instance type when writing a `ClassVar`.
+
+```py
+from typing import ClassVar, Self, TypeVar
+
+class Saved:
+    latest: ClassVar[Self]
+
+    def save(self) -> None:
+        type(self).latest = self
+
+Saved.latest = Saved()  # error: [invalid-assignment]
+
+reveal_type(Saved.latest)  # revealed: Saved
+
+class SavedSub(Saved): ...
+
+reveal_type(SavedSub.latest)  # revealed: SavedSub
+
+def store_bad(cls: type[Saved]) -> None:
+    cls.latest = Saved()  # error: [invalid-assignment]
+
+T = TypeVar("T", bound=Saved)
+
+def store_ok(cls: type[T], value: T) -> None:
+    cls.latest = value
+```
+
+Assignments through gradual class objects remain permissive.
+
+```py
+from typing import Any, ClassVar, reveal_type
+
+class DynamicSaved:
+    count: ClassVar[int]
+
+def store_any(cls: type[Any], value: Any) -> None:
+    cls.count = value
+    reveal_type(cls.count)  # revealed: Any
+```
+
+Assignments through generic aliases still resolve class variables.
+
+```py
+from typing import ClassVar, Generic, TypeVar, reveal_type
+
+T = TypeVar("T")
+
+class Box(Generic[T]):
+    count: ClassVar[int]
+
+Box[int].count = 1
+reveal_type(Box[int].count)  # revealed: int
+```
+
 ## Combining `ClassVar` and `Final` in normal classes
 
 An attribute on a class body that is annotated as `Final` is implicitly treated as a class variable.

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -201,8 +201,8 @@ class Sub(Base): ...
 reveal_type(Sub.all_instances)  # revealed: list[Sub]
 ```
 
-Assignments through exact class objects should bind `Self` when writing a `ClassVar`, while symbolic
-subclass objects remain conservative.
+Assignments through exact class objects should bind `Self` when writing a `ClassVar`. Symbolic
+subclass objects remain conservative because a `type[Base]` value can be any subclass of `Base`.
 
 ```py
 from typing import ClassVar, Self, TypeVar
@@ -220,6 +220,8 @@ reveal_type(Saved.latest)  # revealed: Saved
 class SavedSub(Saved): ...
 
 reveal_type(SavedSub.latest)  # revealed: SavedSub
+
+SavedSub.latest = SavedSub()
 
 def store_bad(cls: type[Saved]) -> None:
     cls.latest = Saved()  # error: [invalid-assignment]

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2500,6 +2500,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     infer_value_ty(self, TypeContext::default());
                     return true;
                 };
+                let class_attr_self_ty = match object_ty {
+                    Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
+                        // Preserve symbolic subtype information for `type[Self]`, `type[T]`, and
+                        // gradual forms, but avoid collapsing concrete class objects to instances.
+                        SubclassOfInner::Dynamic(_) | SubclassOfInner::TypeVar(_) => {
+                            Some(subclass_of.to_instance(db))
+                        }
+                        SubclassOfInner::Class(_) => None,
+                    },
+                    Type::ClassLiteral(_) | Type::GenericAlias(_) => None,
+                    _ => unreachable!(),
+                };
 
                 match meta_attr {
                     PlaceAndQualifiers {
@@ -2522,6 +2534,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         // attribute resolution.
                         let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
 
+                        let meta_attr_ty = meta_attr_ty.bind_self_typevars(db, object_ty);
                         // Perform loud inference without type context, as we may encounter multiple equally
                         // applicable type contexts during attribute resolution.
                         let value_ty = infer_value_ty.infer_loud(self, TypeContext::default());
@@ -2569,6 +2582,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 ..
                             } = fallback_attr
                             {
+                                let class_attr_ty = class_attr_self_ty
+                                    .map(|self_ty| class_attr_ty.bind_self_typevars(db, self_ty))
+                                    .unwrap_or(class_attr_ty);
                                 let value_ty = infer_value_ty
                                     .infer_silent(self, TypeContext::new(Some(class_attr_ty)));
                                 (
@@ -2609,6 +2625,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             qualifiers,
                         }) = fallback_attr
                         {
+                            let class_attr_ty = class_attr_self_ty
+                                .map(|self_ty| class_attr_ty.bind_self_typevars(db, self_ty))
+                                .unwrap_or(class_attr_ty);
                             let value_ty =
                                 infer_value_ty(self, TypeContext::new(Some(class_attr_ty)));
                             if emit_diagnostics

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2782,7 +2782,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         // attribute resolution.
                         let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
 
-                        let meta_attr_ty = meta_attr_ty.bind_self_typevars(db, object_ty);
                         // Perform loud inference without type context, as we may encounter multiple equally
                         // applicable type contexts during attribute resolution.
                         let value_ty = infer_value_ty.infer_loud(self, TypeContext::default());

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2756,6 +2756,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     infer_value_ty(self, TypeContext::default());
                     return true;
                 };
+                let class_attr_self_ty = match object_ty {
+                    Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
+                        // Preserve symbolic subtype information for `type[Self]`, `type[T]`, and
+                        // gradual forms, but avoid collapsing concrete class objects to instances.
+                        SubclassOfInner::Dynamic(_) | SubclassOfInner::TypeVar(_) => {
+                            Some(subclass_of.to_instance(db))
+                        }
+                        SubclassOfInner::Class(_) => None,
+                    },
+                    Type::ClassLiteral(_) | Type::GenericAlias(_) => None,
+                    _ => unreachable!(),
+                };
 
                 match meta_attr {
                     PlaceAndQualifiers {
@@ -2778,6 +2790,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         // attribute resolution.
                         let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
 
+                        let meta_attr_ty = meta_attr_ty.bind_self_typevars(db, object_ty);
                         // Perform loud inference without type context, as we may encounter multiple equally
                         // applicable type contexts during attribute resolution.
                         let value_ty = infer_value_ty.infer_loud(self, TypeContext::default());
@@ -2840,6 +2853,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 ..
                             } = fallback_attr
                             {
+                                let class_attr_ty = class_attr_self_ty
+                                    .map(|self_ty| class_attr_ty.bind_self_typevars(db, self_ty))
+                                    .unwrap_or(class_attr_ty);
                                 let value_ty = infer_value_ty
                                     .infer_silent(self, TypeContext::new(Some(class_attr_ty)));
                                 (
@@ -2880,6 +2896,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             qualifiers,
                         }) = fallback_attr
                         {
+                            let class_attr_ty = class_attr_self_ty
+                                .map(|self_ty| class_attr_ty.bind_self_typevars(db, self_ty))
+                                .unwrap_or(class_attr_ty);
                             let value_ty =
                                 infer_value_ty(self, TypeContext::new(Some(class_attr_ty)));
                             if emit_diagnostics

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2757,15 +2757,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     return true;
                 };
                 let class_attr_self_ty = match object_ty {
+                    Type::ClassLiteral(_) | Type::GenericAlias(_) => object_ty.to_instance(db),
                     Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
                         // Preserve symbolic subtype information for `type[Self]`, `type[T]`, and
-                        // gradual forms, but avoid collapsing concrete class objects to instances.
+                        // gradual forms, but avoid collapsing `type[Concrete]` to `Concrete`.
                         SubclassOfInner::Dynamic(_) | SubclassOfInner::TypeVar(_) => {
                             Some(subclass_of.to_instance(db))
                         }
                         SubclassOfInner::Class(_) => None,
                     },
-                    Type::ClassLiteral(_) | Type::GenericAlias(_) => None,
                     _ => unreachable!(),
                 };
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2756,17 +2756,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     infer_value_ty(self, TypeContext::default());
                     return true;
                 };
-                let class_attr_self_ty = match object_ty {
-                    Type::ClassLiteral(_) | Type::GenericAlias(_) => object_ty.to_instance(db),
-                    Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
-                        // Preserve symbolic subtype information for `type[Self]`, `type[T]`, and
-                        // gradual forms, but avoid collapsing `type[Concrete]` to `Concrete`.
-                        SubclassOfInner::Dynamic(_) | SubclassOfInner::TypeVar(_) => {
-                            Some(subclass_of.to_instance(db))
-                        }
-                        SubclassOfInner::Class(_) => None,
-                    },
-                    _ => unreachable!(),
+                let Some(class_attr_self_ty) = object_ty.to_instance(db) else {
+                    infer_value_ty(self, TypeContext::default());
+                    return true;
                 };
 
                 match meta_attr {
@@ -2853,9 +2845,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 ..
                             } = fallback_attr
                             {
-                                let class_attr_ty = class_attr_self_ty
-                                    .map(|self_ty| class_attr_ty.bind_self_typevars(db, self_ty))
-                                    .unwrap_or(class_attr_ty);
+                                let class_attr_ty =
+                                    class_attr_ty.bind_self_typevars(db, class_attr_self_ty);
                                 let value_ty = infer_value_ty
                                     .infer_silent(self, TypeContext::new(Some(class_attr_ty)));
                                 (
@@ -2896,9 +2887,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             qualifiers,
                         }) = fallback_attr
                         {
-                            let class_attr_ty = class_attr_self_ty
-                                .map(|self_ty| class_attr_ty.bind_self_typevars(db, self_ty))
-                                .unwrap_or(class_attr_ty);
+                            let class_attr_ty =
+                                class_attr_ty.bind_self_typevars(db, class_attr_self_ty);
                             let value_ty =
                                 infer_value_ty(self, TypeContext::new(Some(class_attr_ty)));
                             if emit_diagnostics


### PR DESCRIPTION
## Summary

Given:

```python
from typing import ClassVar, Self, TypeVar

class Saved:
    latest: ClassVar[Self]

    def save(self) -> None:
        type(self).latest = self

class SavedSub(Saved): ...

T = TypeVar("T", bound=Saved)

def store_bad(cls: type[Saved]) -> None:
    cls.latest = Saved()  # currently allowed

def store_ok(cls: type[T], value: T) -> None:
    cls.latest = value    # OK
```

On main, we show errors on `type(self).latest = self`, `cls.latest = Saved()`, and `cls.latest = value`. This PR updates class-object assignment checking to bind `Self` against the class object’s instance type before validating assignments to a `ClassVar[Self]`. That allows assignments like `type(self).latest = self` and generic-safe assignments like `cls.latest = value`.

This preserves our current read semantics for `ClassVar[Self]`: subclass access such as `SavedSub.latest` is treated as `SavedSub`. That behavior is known to be unsound for non-final classes, and per https://github.com/astral-sh/ty/issues/3274#issuecomment-4272242396, we may reject `Self` in attributes of non-final classes in the future...

Closes https://github.com/astral-sh/ty/issues/3274.
