### PR TITLE
[ty] Do not suggest argument completion when at value of keyword argument

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -8733,6 +8733,30 @@ re.match('', '', fla<CURSOR>
         );
     }
 
+    #[test]
+    fn call_keyword_argument_at_value() {
+        let builder = completion_test_builder(
+            "\
+def bar(y_true,y_pred): ...
+
+y_true = 1
+y_pred = 2
+
+bar(y_true=y<CURSOR>
+",
+        );
+
+        assert_snapshot!(
+            builder.skip_keywords().skip_builtins().skip_auto_import().build().snapshot(),
+            @r###"
+        y_pred=
+        y_true=
+        y_pred
+        y_true
+        "###
+        );
+    }
+
     // Ideally, we should favour completions that are definitely raisable
     // here. However, doing so would require `exception_ty` to fall back to
     // token matching when AST-matching fails, making the function signficantly

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -8756,8 +8756,6 @@ bar(y_true=y<CURSOR>
         assert_snapshot!(
             builder.skip_keywords().skip_builtins().skip_auto_import().build().snapshot(),
             @r###"
-        y_pred=
-        y_true=
         y_pred
         y_true
         "###

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -1409,7 +1409,14 @@ fn add_argument_completions<'db>(
     completions: &mut Completions<'db>,
 ) {
     let mut in_arguments = false;
-    for node in cursor.covering_node.ancestors() {
+    let ancestors = cursor.covering_node.ancestors();
+    let parents = cursor.covering_node.ancestors().skip(1);
+    for (node, parent) in ancestors.zip(parents) {
+        if let ast::AnyNodeRef::Keyword(kw) = parent
+            && node.ptr_eq(AnyNodeRef::from(&kw.value))
+        {
+            return;
+        }
         match node {
             ast::AnyNodeRef::Arguments(_) => {
                 in_arguments = true;


### PR DESCRIPTION
In the following situation:

```python
def foo(y_true,y_pred): ...

y_true = 1
y_pred = 2

foo(y_true=y<CURSOR>)
```

the completion suggestions began with `y_true=` and `y_pred=`. But it is never the right thing to suggest an argument completion (i.e. `something=`) when the cursor is at the _value_ of a keyword argument. So this PR introduces an early exit to the logic for deciding to suggest arguments.