### PR TITLE
[`airflow`] Add mixed-content support to AIR201

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR201.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR201.py
@@ -115,14 +115,85 @@ task_17 = BashOperator(
 )
 
 
-# Cases that should NOT trigger AIR201:
+# Mixed-content cases that SHOULD trigger AIR201:
 
-# Mixed content (not just xcom_pull) — the modern replacement
-# for this pattern is: bash_command="echo {{ task_1.output }}"
+# Positional arg with surrounding text (was previously non-triggering; now detected)
 task_10 = BashOperator(
     task_id="task_10",
-    bash_command="echo {{ ti.xcom_pull(task_ids='task_1') }}",
+    bash_command="echo {{ ti.xcom_pull(task_ids='task_1') }}",  # AIR201
 )
+
+# task_ids= keyword with text before
+task_mc1 = BashOperator(
+    task_id="task_mc1",
+    bash_command="result: {{ ti.xcom_pull(task_ids='task_1') }}",  # AIR201
+)
+
+# task_id= keyword (singular) with surrounding text
+task_mc2 = BashOperator(
+    task_id="task_mc2",
+    bash_command="echo {{ ti.xcom_pull(task_id='task_1') }}",  # AIR201
+)
+
+# list-wrapped task_ids with surrounding text
+task_mc3 = BashOperator(
+    task_id="task_mc3",
+    bash_command="echo {{ ti.xcom_pull(task_ids=['task_1']) }}",  # AIR201
+)
+
+# tuple-wrapped task_ids with surrounding text
+task_mc4 = BashOperator(
+    task_id="task_mc4",
+    bash_command="echo {{ ti.xcom_pull(task_ids=('task_1',)) }}",  # AIR201
+)
+
+# key='return_value' with surrounding text
+task_mc5 = BashOperator(
+    task_id="task_mc5",
+    bash_command="echo {{ ti.xcom_pull(task_ids='task_1', key='return_value') }}",  # AIR201
+)
+
+# task_instance receiver in mixed-content
+task_mc6 = BashOperator(
+    task_id="task_mc6",
+    bash_command="echo {{ task_instance.xcom_pull('task_1') }}",  # AIR201
+)
+
+# Two xcom_pull patterns in one string — each flagged independently (same task_id)
+task_mc7 = BashOperator(
+    task_id="task_mc7",
+    bash_command="{{ ti.xcom_pull('task_1') }} and {{ ti.xcom_pull('task_1') }}",  # AIR201, AIR201
+)
+
+# Two xcom_pull patterns in one string referencing DIFFERENT task_ids — each
+# flagged and fixed independently, verifying the scanner handles distinct
+# task variable references within the same template string
+task_mc11 = BashOperator(
+    task_id="task_mc11",
+    bash_command="{{ ti.xcom_pull('task_1') }} and {{ ti.xcom_pull('task_2') }}",  # AIR201, AIR201
+)
+
+# Subscript access within the Jinja block — only xcom_pull call is replaced,
+# subscript and surrounding {{ }} are preserved
+task_mc8 = BashOperator(
+    task_id="task_mc8",
+    bash_command="{{ ti.xcom_pull('task_1')['item'] }}",  # AIR201
+)
+
+# Triple-quoted string — raw-source scanner is quote-agnostic
+task_mc9 = BashOperator(
+    task_id="task_mc9",
+    bash_command="""echo {{ ti.xcom_pull('task_1') }}""",  # AIR201
+)
+
+# Mixed-content with unknown task_id (violation reported, no fix available)
+task_mc10 = BashOperator(
+    task_id="task_mc10",
+    bash_command="echo {{ ti.xcom_pull('unknown_task') }}",  # AIR201 (no fix)
+)
+
+
+# Cases that should NOT trigger AIR201:
 
 # Additional keyword arguments (non-default key)
 task_11 = BashOperator(
@@ -173,4 +244,33 @@ dag = DAG(
     dag_id="my_dag",
     schedule=None,
     description="{{ ti.xcom_pull(task_ids='task_1') }}",
+)
+
+# Non-triggering: kebab-case task ID in pure-template form (not a valid Python identifier)
+task_nt1 = BashOperator(
+    task_id="task_nt1",
+    bash_command="{{ ti.xcom_pull('kebab-task') }}",
+)
+
+# Non-triggering: kebab-case task ID in mixed-content form
+task_nt2 = BashOperator(
+    task_id="task_nt2",
+    bash_command="echo {{ ti.xcom_pull('kebab-task') }}",
+)
+
+# Non-triggering: dotted group task ID (not a valid Python identifier; future
+# rule could suggest group['task'].output once Airflow supports that syntax)
+task_nt3 = BashOperator(
+    task_id="task_nt3",
+    bash_command="{{ ti.xcom_pull('group_1.task_1') }}",
+)
+
+# Non-triggering: f-string arguments are ExprFString, not ExprStringLiteral,
+# and are excluded by as_string_literal_expr(). The runtime value of this
+# f-string is "{{ ti.xcom_pull('task_1') }}" — a valid Jinja template — but
+# the task ID is determined at runtime via {task_1.task_id}, so AIR201 cannot
+# statically analyze it.
+task_nt4 = BashOperator(
+    task_id="task_nt4",
+    bash_command=f"{{{{ ti.xcom_pull('{task_1.task_id}') }}}}",
 )

--- a/crates/ruff_linter/src/rules/airflow/rules/xcom_pull_in_template_string.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/xcom_pull_in_template_string.rs
@@ -3,7 +3,7 @@ use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast as ast;
 use ruff_python_semantic::Modules;
 use ruff_python_trivia::Cursor;
-use ruff_text_size::Ranged;
+use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::checkers::ast::Checker;
 use crate::rules::airflow::helpers::is_airflow_builtin_or_provider;
@@ -11,8 +11,11 @@ use crate::{FixAvailability, Violation};
 
 /// ## What it does
 /// Checks for Airflow operator keyword arguments that use a Jinja template
-/// string containing a single `xcom_pull` call to retrieve another task's
-/// output.
+/// string containing an `xcom_pull` call to retrieve another task's output,
+/// including both pure-template strings (where the entire value is an
+/// `xcom_pull` expression) and mixed-content strings (where `xcom_pull`
+/// appears alongside other text). Template values built with f-strings are
+/// not processed by this rule, since they are harder to analyze statically.
 ///
 /// ## Why is this bad?
 /// Using `{{ ti.xcom_pull(task_ids='some_task') }}` as a string template to
@@ -31,6 +34,10 @@ use crate::{FixAvailability, Violation};
 ///     task_id="task_2",
 ///     op_args="{{ ti.xcom_pull(task_ids='task_1') }}",
 /// )
+/// task_3 = PythonOperator(
+///     task_id="task_3",
+///     op_args="echo {{ ti.xcom_pull(task_ids='task_1') }}",
+/// )
 /// ```
 ///
 /// Use instead:
@@ -43,15 +50,23 @@ use crate::{FixAvailability, Violation};
 ///     task_id="task_2",
 ///     op_args=task_1.output,
 /// )
+/// task_3 = PythonOperator(
+///     task_id="task_3",
+///     op_args="echo {{ task_1.output }}",
+/// )
 /// ```
 ///
 /// ## Fix safety
 /// The fix is always unsafe because the variable in scope that matches the
 /// task ID may not be the Airflow task object that produced the `XCom` value.
+/// For pure-template strings the entire argument is replaced with a Python
+/// expression; for mixed-content strings only the `xcom_pull` call within
+/// the Jinja block is replaced in-place.
 #[derive(ViolationMetadata)]
 #[violation_metadata(preview_since = "0.15.11")]
 pub(crate) struct AirflowXcomPullInTemplateString {
     task_id: String,
+    fix_title_style: FixTitleStyle,
 }
 
 impl Violation for AirflowXcomPullInTemplateString {
@@ -59,15 +74,76 @@ impl Violation for AirflowXcomPullInTemplateString {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let AirflowXcomPullInTemplateString { task_id } = self;
+        let AirflowXcomPullInTemplateString { task_id, .. } = self;
         format!(
             "Use the `.output` attribute on the task object for \"{task_id}\" instead of `xcom_pull` in a template string"
         )
     }
 
     fn fix_title(&self) -> Option<String> {
-        let AirflowXcomPullInTemplateString { task_id } = self;
-        Some(format!("Replace with `{task_id}.output`"))
+        let AirflowXcomPullInTemplateString {
+            task_id,
+            fix_title_style,
+        } = self;
+        match fix_title_style {
+            FixTitleStyle::MixedContent => {
+                Some(format!("Replace with `{{{{ {task_id}.output }}}}`"))
+            }
+            FixTitleStyle::PureTemplate => Some(format!("Replace with `{task_id}.output`")),
+        }
+    }
+}
+
+/// Controls the wording of the fix title emitted by the AIR201 violation.
+///
+/// Pure-template fixes replace the entire Python argument with a bare
+/// expression (`task_id.output`). Mixed-content fixes replace only the
+/// `xcom_pull` call within the Jinja block, so the title shows the Jinja
+/// form (`{{ task_id.output }}`).
+#[derive(Debug, PartialEq, Eq, Hash)]
+enum FixTitleStyle {
+    PureTemplate,
+    MixedContent,
+}
+
+/// Within-source byte range and task ID for a single `xcom_pull` occurrence
+/// found by the mixed-content scanner. Offsets are relative to the start of
+/// the raw source slice passed to `scan_xcom_pull_patterns`; the caller is
+/// responsible for translating them to absolute file positions by adding the
+/// literal's `TextSize` start.
+///
+/// `u32` matches the `TextSize` representation used throughout Ruff and
+/// encodes the 4 GiB file-size invariant at the type level rather than
+/// deferring to a late `u32::try_from` conversion.
+struct XcomPullMatch {
+    /// Byte offset within the raw source slice where `ti` or `task_instance` starts.
+    source_start: u32,
+    /// Byte offset within the raw source slice just past the closing `)`.
+    source_end: u32,
+    task_id: String,
+}
+
+impl XcomPullMatch {
+    /// Construct a match, asserting the range invariant in debug builds.
+    fn new(source_start: u32, source_end: u32, task_id: String) -> Self {
+        debug_assert!(
+            source_start <= source_end,
+            "source_start ({source_start}) must not exceed source_end ({source_end})"
+        );
+        Self {
+            source_start,
+            source_end,
+            task_id,
+        }
+    }
+
+    /// Translate the within-source offsets to an absolute `TextRange` in the
+    /// file by adding the string literal's start position.
+    fn absolute_range(&self, literal_start: TextSize) -> TextRange {
+        TextRange::new(
+            literal_start + TextSize::new(self.source_start),
+            literal_start + TextSize::new(self.source_end),
+        )
     }
 }
 
@@ -102,12 +178,20 @@ pub(crate) fn xcom_pull_in_template_string(checker: &Checker, call: &ast::ExprCa
             continue;
         };
 
+        // `to_str()` decodes escape sequences; the pure-template parser needs
+        // the logical character sequence. The mixed-content scanner uses
+        // `locator().slice()` (raw source bytes) instead, so that its byte
+        // offsets align with the physical file positions used for fixes.
         let string_value = string_literal.value.to_str();
 
+        // Pure-template path: the entire string value is a single xcom_pull
+        // Jinja expression. The fix replaces the whole argument with a Python
+        // attribute access expression.
         if let Some(task_id) = parse_xcom_pull_template(string_value) {
             let mut diagnostic = checker.report_diagnostic(
                 AirflowXcomPullInTemplateString {
                     task_id: task_id.clone(),
+                    fix_title_style: FixTitleStyle::PureTemplate,
                 },
                 arg_value.range(),
             );
@@ -120,77 +204,215 @@ pub(crate) fn xcom_pull_in_template_string(checker: &Checker, call: &ast::ExprCa
                     arg_value.range(),
                 )));
             }
+            continue;
+        }
+
+        // Mixed-content path: xcom_pull appears alongside other content within
+        // the string. Each occurrence gets its own diagnostic; the fix replaces
+        // only the `ti.xcom_pull(...)` sub-range in-place, preserving the
+        // surrounding text (including Jinja delimiters and trailing subscripts).
+        //
+        // Skip implicitly concatenated strings: the scanner computes fix ranges
+        // as byte offsets into the raw source slice of the full expression range,
+        // which works correctly only when all parts form a single contiguous span
+        // with no intermediate quote boundaries separating them.
+        if string_literal.value.is_implicit_concatenated() {
+            continue;
+        }
+        let raw_source = checker.locator().slice(string_literal.range());
+        let literal_start = string_literal.start();
+        for scan_match in scan_xcom_pull_patterns(raw_source) {
+            let mut diagnostic = checker.report_diagnostic(
+                AirflowXcomPullInTemplateString {
+                    task_id: scan_match.task_id.clone(),
+                    fix_title_style: FixTitleStyle::MixedContent,
+                },
+                arg_value.range(),
+            );
+
+            if checker
+                .semantic()
+                .lookup_symbol(&scan_match.task_id)
+                .is_some()
+            {
+                // Translate within-source byte offsets to absolute file positions.
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+                    format!("{}.output", scan_match.task_id),
+                    scan_match.absolute_range(literal_start),
+                )));
+            }
         }
     }
 }
 
-/// Parse a Jinja template string to extract a single `xcom_pull` task ID.
+/// Return all `(ti|task_instance).xcom_pull(...)` matches found in `source`.
 ///
-/// Returns the task ID if the entire string is a single `{{ ti.xcom_pull(task_ids='...') }}`
-/// or `{{ task_instance.xcom_pull(task_ids='...') }}` template. The `task_ids` value may also
-/// be wrapped in a list or tuple (e.g. `task_ids=['...']`), and an optional
-/// `key='return_value'` argument is allowed in either order (since it is the
-/// default). Returns `None` if the string contains other content, multiple
-/// task IDs, or non-default keyword arguments.
-fn parse_xcom_pull_template(s: &str) -> Option<String> {
+/// `source` is the raw file content of a string literal (including its
+/// surrounding quote characters). The returned offsets are byte positions
+/// within `source`, covering exactly `ti.xcom_pull(args)` — not the
+/// surrounding `{{ }}` Jinja delimiters. The caller translates them to
+/// absolute file positions by adding the literal's start offset.
+///
+/// The scanner is quote-agnostic: the `ti.xcom_pull(` pattern cannot appear
+/// in the quote characters themselves, so no quote-style handling is needed.
+fn scan_xcom_pull_patterns(source: &str) -> Vec<XcomPullMatch> {
+    let mut matches = Vec::new();
+    let mut pos = 0;
+
+    while pos < source.len() {
+        let remaining = &source[pos..];
+        let mut cursor = Cursor::new(remaining);
+
+        // Try to parse an identifier at the current position. If there is
+        // none (e.g. we are on punctuation, whitespace, or a non-ASCII
+        // Unicode character), advance past the full codepoint so we never
+        // split a multi-byte UTF-8 sequence and trigger a string-slice panic.
+        let Some(receiver) = parse_identifier(&mut cursor) else {
+            let ch_len = remaining.chars().next().map_or(1, char::len_utf8);
+            pos += ch_len;
+            continue;
+        };
+
+        if !is_xcom_pull_receiver(receiver) {
+            // Skip the entire identifier so we don't re-examine its suffix
+            // (e.g. `multi_ti` must not match as `ti` at offset 6).
+            pos += receiver.len();
+            continue;
+        }
+
+        // Attempt to parse `.xcom_pull(args)`. If this fails, the cursor may
+        // have consumed characters beyond the receiver (e.g. whitespace and a
+        // different method name), so advance by the full amount consumed rather
+        // than just the receiver length to avoid redundant re-scanning.
+        let Some(task_id_str) = parse_xcom_pull_method_and_args(&mut cursor) else {
+            let consumed = remaining.len() - cursor.as_str().len();
+            pos += consumed.max(receiver.len());
+            continue;
+        };
+
+        // `parse_xcom_pull_args` guarantees the task ID is a non-empty valid
+        // Python identifier, so we can push the match directly.
+        // `consumed` covers exactly `receiver.method(args)` — the cursor is
+        // positioned past the closing `)` and no further.
+        //
+        // Convert to u32 at the point of collection; silently skip the match
+        // on overflow (source files are expected to be well under 4 GiB).
+        let consumed = remaining.len() - cursor.as_str().len();
+        if let (Ok(start_u32), Ok(end_u32)) = (u32::try_from(pos), u32::try_from(pos + consumed)) {
+            matches.push(XcomPullMatch::new(
+                start_u32,
+                end_u32,
+                task_id_str.to_string(),
+            ));
+        }
+        // Advance past the entire match to avoid re-examining it.
+        pos += consumed;
+    }
+
+    matches
+}
+
+/// Returns `true` if `s` is a valid Python identifier.
+///
+/// Uses the same `parse_identifier` cursor helper as the template parser to
+/// ensure consistent behavior: `s` must start with an ASCII letter or
+/// underscore, consist only of ASCII alphanumerics and underscores, and be
+/// non-empty.
+///
+/// # TODO(airflow)
+/// Task IDs that fail this check (e.g. `kebab-case` or `group.task`) are
+/// silently skipped. A future AIR rule could enforce that task IDs are valid
+/// Python identifiers. Dotted IDs like `group.task` represent task group
+/// members; once Airflow adds support for the `group['task'].output` syntax
+/// they could be replaced automatically.
+fn is_valid_python_identifier(s: &str) -> bool {
     let mut cursor = Cursor::new(s);
-    eat_whitespace(&mut cursor);
+    parse_identifier(&mut cursor).is_some() && cursor.is_eof()
+}
 
-    if !cursor.eat_char2('{', '{') {
-        return None;
-    }
-    eat_whitespace(&mut cursor);
+/// Returns `true` if `name` is a recognised `xcom_pull` receiver (`ti` or
+/// `task_instance`). Used consistently by both detection paths so that adding
+/// a new alias requires a single change.
+fn is_xcom_pull_receiver(name: &str) -> bool {
+    name == "ti" || name == "task_instance"
+}
 
-    let receiver = parse_identifier(&mut cursor)?;
-    if receiver != "ti" && receiver != "task_instance" {
-        return None;
-    }
-    eat_whitespace(&mut cursor);
+/// Advance the cursor past `.xcom_pull(args)`, where the receiver has already
+/// been parsed and validated. Returns the task ID on success, or `None` if the
+/// method name is not `xcom_pull`, the opening `(` is absent, or the argument
+/// list is invalid.
+///
+/// Shared by both the pure-template parser and the mixed-content scanner to
+/// avoid duplicating the method + argument parsing sequence.
+fn parse_xcom_pull_method_and_args<'a>(cursor: &mut Cursor<'a>) -> Option<&'a str> {
+    parse_xcom_pull_method(cursor)?;
+    parse_xcom_pull_args(cursor)
+}
+
+/// Advance the cursor past `.xcom_pull(`, consuming optional whitespace around
+/// the dot and before the opening parenthesis. Returns `None` — without
+/// advancing the cursor past the receiver — if the sequence is not present or
+/// the method name is not `xcom_pull`.
+///
+/// Called after the receiver identifier has already been parsed and validated.
+fn parse_xcom_pull_method(cursor: &mut Cursor) -> Option<()> {
+    eat_whitespace(cursor);
     if !cursor.eat_char('.') {
         return None;
     }
-    eat_whitespace(&mut cursor);
-    if parse_identifier(&mut cursor)? != "xcom_pull" {
+    eat_whitespace(cursor);
+    if parse_identifier(cursor)? != "xcom_pull" {
         return None;
     }
-
-    eat_whitespace(&mut cursor);
+    eat_whitespace(cursor);
     if !cursor.eat_char('(') {
         return None;
     }
-    eat_whitespace(&mut cursor);
+    Some(())
+}
 
-    // Parse xcom_pull arguments. We accept:
-    //   xcom_pull('task_1')
-    //   xcom_pull(task_ids='task_1', key='return_value')
-    //   xcom_pull(key='return_value', task_ids='task_1')
-    let mut task_id = None;
+/// Parse the argument list of an `xcom_pull(...)` call, with the cursor
+/// positioned immediately after the opening `(`. On success the cursor is
+/// positioned after the closing `)`.
+///
+/// Accepts the same argument forms used by both the pure-template and
+/// mixed-content detection paths:
+/// - positional: `'task_id'`, `['task_id']`, `('task_id',)`
+/// - keyword: `task_ids='task_id'`, `task_id='task_id'`
+/// - optional `key='return_value'` in either order
+///
+/// Returns a non-empty reference into the source for the task ID string, or
+/// `None` if the argument list is invalid, contains unsupported forms, or
+/// yields an empty task ID.
+fn parse_xcom_pull_args<'a>(cursor: &mut Cursor<'a>) -> Option<&'a str> {
+    let mut task_id: Option<&'a str> = None;
     let mut saw_keyword = false;
     let mut saw_key = false;
 
     loop {
+        eat_whitespace(cursor);
         if cursor.eat_char(')') {
             break;
         }
 
-        if let Some(identifier) = parse_identifier(&mut cursor) {
-            saw_keyword = true;
-
-            eat_whitespace(&mut cursor);
+        if let Some(identifier) = parse_identifier(cursor) {
+            // Keyword argument: must be followed by `=`.
+            eat_whitespace(cursor);
             if !cursor.eat_char('=') {
                 return None;
             }
-            eat_whitespace(&mut cursor);
+            saw_keyword = true;
+            eat_whitespace(cursor);
 
             match identifier {
                 "task_ids" | "task_id" => {
                     if task_id.is_some() {
                         return None;
                     }
-                    task_id = Some(parse_task_id_value(&mut cursor)?);
+                    task_id = Some(parse_task_id_value(cursor)?);
                 }
                 "key" => {
-                    if saw_key || parse_quoted_string(&mut cursor)? != "return_value" {
+                    if saw_key || parse_quoted_string(cursor)? != "return_value" {
                         return None;
                     }
                     saw_key = true;
@@ -202,12 +424,11 @@ fn parse_xcom_pull_template(s: &str) -> Option<String> {
             if saw_keyword || task_id.is_some() {
                 return None;
             }
-            task_id = Some(parse_task_id_value(&mut cursor)?);
+            task_id = Some(parse_task_id_value(cursor)?);
         }
 
-        eat_whitespace(&mut cursor);
+        eat_whitespace(cursor);
         if cursor.eat_char(',') {
-            eat_whitespace(&mut cursor);
             continue;
         }
         if cursor.eat_char(')') {
@@ -216,19 +437,52 @@ fn parse_xcom_pull_template(s: &str) -> Option<String> {
         return None;
     }
 
-    let task_id = task_id?;
+    // Enforce postconditions here so every call site receives a guaranteed
+    // non-empty, valid-Python-identifier task ID without additional checks.
+    let id = task_id?;
+    if id.is_empty() || !is_valid_python_identifier(id) {
+        None
+    } else {
+        Some(id)
+    }
+}
 
+/// Parse a Jinja template string to extract a single `xcom_pull` task ID.
+///
+/// Returns the task ID if the entire string is a single `{{ ti.xcom_pull(task_ids='...') }}`
+/// or `{{ task_instance.xcom_pull(task_ids='...') }}` template. The `task_ids` value may also
+/// be wrapped in a list or tuple (e.g. `task_ids=['...']`), and an optional
+/// `key='return_value'` argument is allowed in either order (since it is the
+/// default). Returns `None` if the string contains other content, multiple
+/// task IDs, non-default keyword arguments, or a task ID that is not a valid
+/// Python identifier.
+fn parse_xcom_pull_template(s: &str) -> Option<String> {
+    let mut cursor = Cursor::new(s);
     eat_whitespace(&mut cursor);
 
+    if !cursor.eat_char2('{', '{') {
+        return None;
+    }
+    eat_whitespace(&mut cursor);
+
+    let receiver = parse_identifier(&mut cursor)?;
+    if !is_xcom_pull_receiver(receiver) {
+        return None;
+    }
+    let task_id = parse_xcom_pull_method_and_args(&mut cursor)?;
+
+    eat_whitespace(&mut cursor);
     if !cursor.eat_char2('}', '}') {
         return None;
     }
     eat_whitespace(&mut cursor);
 
-    if !cursor.is_eof() || task_id.is_empty() {
+    if !cursor.is_eof() {
         return None;
     }
 
+    // `parse_xcom_pull_args` already validates that the task ID is a
+    // non-empty Python identifier, so no additional check is needed here.
     Some(task_id.to_string())
 }
 
@@ -305,7 +559,121 @@ fn parse_task_id_value<'a>(cursor: &mut Cursor<'a>) -> Option<&'a str> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_xcom_pull_template;
+    use super::{is_valid_python_identifier, parse_xcom_pull_template, scan_xcom_pull_patterns};
+
+    // --- is_valid_python_identifier ---
+
+    #[test]
+    fn test_valid_identifier_simple() {
+        assert!(is_valid_python_identifier("task_1"));
+        assert!(is_valid_python_identifier("my_task"));
+        assert!(is_valid_python_identifier("_private"));
+        assert!(is_valid_python_identifier("task"));
+        assert!(is_valid_python_identifier("_"));
+    }
+
+    #[test]
+    fn test_rejects_kebab_case() {
+        assert!(!is_valid_python_identifier("kebab-case"));
+        assert!(!is_valid_python_identifier("my-task"));
+    }
+
+    #[test]
+    fn test_rejects_dotted_id() {
+        assert!(!is_valid_python_identifier("group.task"));
+        assert!(!is_valid_python_identifier("group_1.task_1"));
+    }
+
+    #[test]
+    fn test_rejects_digit_only_start() {
+        assert!(!is_valid_python_identifier("1task"));
+        assert!(!is_valid_python_identifier("123"));
+    }
+
+    #[test]
+    fn test_rejects_empty() {
+        assert!(!is_valid_python_identifier(""));
+    }
+
+    // --- scan_xcom_pull_patterns ---
+
+    #[test]
+    fn test_scan_mixed_content_positional() {
+        let raw = r#""echo {{ ti.xcom_pull('task_1') }}""#;
+        let matches = scan_xcom_pull_patterns(raw);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].task_id, "task_1");
+    }
+
+    #[test]
+    fn test_scan_mixed_content_keyword() {
+        let raw = r#""result: {{ ti.xcom_pull(task_ids='task_1') }}""#;
+        let matches = scan_xcom_pull_patterns(raw);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].task_id, "task_1");
+    }
+
+    #[test]
+    fn test_scan_multiple_occurrences() {
+        let raw = r#""{{ ti.xcom_pull('task_1') }} and {{ ti.xcom_pull('task_2') }}""#;
+        let matches = scan_xcom_pull_patterns(raw);
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].task_id, "task_1");
+        assert_eq!(matches[1].task_id, "task_2");
+    }
+
+    #[test]
+    fn test_scan_skips_kebab_case() {
+        let raw = r#""echo {{ ti.xcom_pull('kebab-task') }}""#;
+        let matches = scan_xcom_pull_patterns(raw);
+        assert_eq!(matches.len(), 0);
+    }
+
+    #[test]
+    fn test_scan_skips_dotted_id() {
+        let raw = r#""echo {{ ti.xcom_pull('group.task') }}""#;
+        let matches = scan_xcom_pull_patterns(raw);
+        assert_eq!(matches.len(), 0);
+    }
+
+    #[test]
+    fn test_scan_no_false_positive_on_longer_receiver() {
+        // `multi_ti` must not match as `ti`.
+        let raw = r#""{{ multi_ti.xcom_pull('task_1') }}""#;
+        let matches = scan_xcom_pull_patterns(raw);
+        assert_eq!(matches.len(), 0);
+    }
+
+    #[test]
+    fn test_scan_offsets_cover_only_call() {
+        // The match range must cover exactly `ti.xcom_pull('task_1')`,
+        // not the surrounding `{{ }}` or Python quotes.
+        let raw = r#""{{ ti.xcom_pull('task_1') }}""#;
+        let matches = scan_xcom_pull_patterns(raw);
+        assert_eq!(matches.len(), 1);
+        let m = &matches[0];
+        let start = m.source_start as usize;
+        let end = m.source_end as usize;
+        assert_eq!(&raw[start..end], "ti.xcom_pull('task_1')");
+    }
+
+    // --- parse_xcom_pull_template (existing + new identifier-gate tests) ---
+
+    #[test]
+    fn test_rejects_kebab_case_in_pure_template() {
+        assert_eq!(
+            parse_xcom_pull_template("{{ ti.xcom_pull(task_ids='kebab-case') }}"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rejects_dotted_id_in_pure_template() {
+        assert_eq!(
+            parse_xcom_pull_template("{{ ti.xcom_pull(task_ids='group.task') }}"),
+            None
+        );
+    }
 
     #[test]
     fn test_basic_ti_xcom_pull() {

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR201_AIR201.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR201_AIR201.py.snap
@@ -311,3 +311,274 @@ AIR201 Use the `.output` attribute on the task object for "unknown_task" instead
 115 | )
     |
 help: Replace with `unknown_task.output`
+
+AIR201 [*] Use the `.output` attribute on the task object for "task_1" instead of `xcom_pull` in a template string
+   --> AIR201.py:123:18
+    |
+121 | task_10 = BashOperator(
+122 |     task_id="task_10",
+123 |     bash_command="echo {{ ti.xcom_pull(task_ids='task_1') }}",  # AIR201
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+124 | )
+    |
+help: Replace with `{{ task_1.output }}`
+120 | # Positional arg with surrounding text (was previously non-triggering; now detected)
+121 | task_10 = BashOperator(
+122 |     task_id="task_10",
+    -     bash_command="echo {{ ti.xcom_pull(task_ids='task_1') }}",  # AIR201
+123 +     bash_command="echo {{ task_1.output }}",  # AIR201
+124 | )
+125 |
+126 | # task_ids= keyword with text before
+note: This is an unsafe fix and may change runtime behavior
+
+AIR201 [*] Use the `.output` attribute on the task object for "task_1" instead of `xcom_pull` in a template string
+   --> AIR201.py:129:18
+    |
+127 | task_mc1 = BashOperator(
+128 |     task_id="task_mc1",
+129 |     bash_command="result: {{ ti.xcom_pull(task_ids='task_1') }}",  # AIR201
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+130 | )
+    |
+help: Replace with `{{ task_1.output }}`
+126 | # task_ids= keyword with text before
+127 | task_mc1 = BashOperator(
+128 |     task_id="task_mc1",
+    -     bash_command="result: {{ ti.xcom_pull(task_ids='task_1') }}",  # AIR201
+129 +     bash_command="result: {{ task_1.output }}",  # AIR201
+130 | )
+131 |
+132 | # task_id= keyword (singular) with surrounding text
+note: This is an unsafe fix and may change runtime behavior
+
+AIR201 [*] Use the `.output` attribute on the task object for "task_1" instead of `xcom_pull` in a template string
+   --> AIR201.py:135:18
+    |
+133 | task_mc2 = BashOperator(
+134 |     task_id="task_mc2",
+135 |     bash_command="echo {{ ti.xcom_pull(task_id='task_1') }}",  # AIR201
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+136 | )
+    |
+help: Replace with `{{ task_1.output }}`
+132 | # task_id= keyword (singular) with surrounding text
+133 | task_mc2 = BashOperator(
+134 |     task_id="task_mc2",
+    -     bash_command="echo {{ ti.xcom_pull(task_id='task_1') }}",  # AIR201
+135 +     bash_command="echo {{ task_1.output }}",  # AIR201
+136 | )
+137 |
+138 | # list-wrapped task_ids with surrounding text
+note: This is an unsafe fix and may change runtime behavior
+
+AIR201 [*] Use the `.output` attribute on the task object for "task_1" instead of `xcom_pull` in a template string
+   --> AIR201.py:141:18
+    |
+139 | task_mc3 = BashOperator(
+140 |     task_id="task_mc3",
+141 |     bash_command="echo {{ ti.xcom_pull(task_ids=['task_1']) }}",  # AIR201
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+142 | )
+    |
+help: Replace with `{{ task_1.output }}`
+138 | # list-wrapped task_ids with surrounding text
+139 | task_mc3 = BashOperator(
+140 |     task_id="task_mc3",
+    -     bash_command="echo {{ ti.xcom_pull(task_ids=['task_1']) }}",  # AIR201
+141 +     bash_command="echo {{ task_1.output }}",  # AIR201
+142 | )
+143 |
+144 | # tuple-wrapped task_ids with surrounding text
+note: This is an unsafe fix and may change runtime behavior
+
+AIR201 [*] Use the `.output` attribute on the task object for "task_1" instead of `xcom_pull` in a template string
+   --> AIR201.py:147:18
+    |
+145 | task_mc4 = BashOperator(
+146 |     task_id="task_mc4",
+147 |     bash_command="echo {{ ti.xcom_pull(task_ids=('task_1',)) }}",  # AIR201
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+148 | )
+    |
+help: Replace with `{{ task_1.output }}`
+144 | # tuple-wrapped task_ids with surrounding text
+145 | task_mc4 = BashOperator(
+146 |     task_id="task_mc4",
+    -     bash_command="echo {{ ti.xcom_pull(task_ids=('task_1',)) }}",  # AIR201
+147 +     bash_command="echo {{ task_1.output }}",  # AIR201
+148 | )
+149 |
+150 | # key='return_value' with surrounding text
+note: This is an unsafe fix and may change runtime behavior
+
+AIR201 [*] Use the `.output` attribute on the task object for "task_1" instead of `xcom_pull` in a template string
+   --> AIR201.py:153:18
+    |
+151 | task_mc5 = BashOperator(
+152 |     task_id="task_mc5",
+153 |     bash_command="echo {{ ti.xcom_pull(task_ids='task_1', key='return_value') }}",  # AIR201
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+154 | )
+    |
+help: Replace with `{{ task_1.output }}`
+150 | # key='return_value' with surrounding text
+151 | task_mc5 = BashOperator(
+152 |     task_id="task_mc5",
+    -     bash_command="echo {{ ti.xcom_pull(task_ids='task_1', key='return_value') }}",  # AIR201
+153 +     bash_command="echo {{ task_1.output }}",  # AIR201
+154 | )
+155 |
+156 | # task_instance receiver in mixed-content
+note: This is an unsafe fix and may change runtime behavior
+
+AIR201 [*] Use the `.output` attribute on the task object for "task_1" instead of `xcom_pull` in a template string
+   --> AIR201.py:159:18
+    |
+157 | task_mc6 = BashOperator(
+158 |     task_id="task_mc6",
+159 |     bash_command="echo {{ task_instance.xcom_pull('task_1') }}",  # AIR201
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+160 | )
+    |
+help: Replace with `{{ task_1.output }}`
+156 | # task_instance receiver in mixed-content
+157 | task_mc6 = BashOperator(
+158 |     task_id="task_mc6",
+    -     bash_command="echo {{ task_instance.xcom_pull('task_1') }}",  # AIR201
+159 +     bash_command="echo {{ task_1.output }}",  # AIR201
+160 | )
+161 |
+162 | # Two xcom_pull patterns in one string — each flagged independently (same task_id)
+note: This is an unsafe fix and may change runtime behavior
+
+AIR201 [*] Use the `.output` attribute on the task object for "task_1" instead of `xcom_pull` in a template string
+   --> AIR201.py:165:18
+    |
+163 | task_mc7 = BashOperator(
+164 |     task_id="task_mc7",
+165 |     bash_command="{{ ti.xcom_pull('task_1') }} and {{ ti.xcom_pull('task_1') }}",  # AIR201, AIR201
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+166 | )
+    |
+help: Replace with `{{ task_1.output }}`
+162 | # Two xcom_pull patterns in one string — each flagged independently (same task_id)
+163 | task_mc7 = BashOperator(
+164 |     task_id="task_mc7",
+    -     bash_command="{{ ti.xcom_pull('task_1') }} and {{ ti.xcom_pull('task_1') }}",  # AIR201, AIR201
+165 +     bash_command="{{ task_1.output }} and {{ ti.xcom_pull('task_1') }}",  # AIR201, AIR201
+166 | )
+167 |
+168 | # Two xcom_pull patterns in one string referencing DIFFERENT task_ids — each
+note: This is an unsafe fix and may change runtime behavior
+
+AIR201 [*] Use the `.output` attribute on the task object for "task_1" instead of `xcom_pull` in a template string
+   --> AIR201.py:165:18
+    |
+163 | task_mc7 = BashOperator(
+164 |     task_id="task_mc7",
+165 |     bash_command="{{ ti.xcom_pull('task_1') }} and {{ ti.xcom_pull('task_1') }}",  # AIR201, AIR201
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+166 | )
+    |
+help: Replace with `{{ task_1.output }}`
+162 | # Two xcom_pull patterns in one string — each flagged independently (same task_id)
+163 | task_mc7 = BashOperator(
+164 |     task_id="task_mc7",
+    -     bash_command="{{ ti.xcom_pull('task_1') }} and {{ ti.xcom_pull('task_1') }}",  # AIR201, AIR201
+165 +     bash_command="{{ ti.xcom_pull('task_1') }} and {{ task_1.output }}",  # AIR201, AIR201
+166 | )
+167 |
+168 | # Two xcom_pull patterns in one string referencing DIFFERENT task_ids — each
+note: This is an unsafe fix and may change runtime behavior
+
+AIR201 [*] Use the `.output` attribute on the task object for "task_1" instead of `xcom_pull` in a template string
+   --> AIR201.py:173:18
+    |
+171 | task_mc11 = BashOperator(
+172 |     task_id="task_mc11",
+173 |     bash_command="{{ ti.xcom_pull('task_1') }} and {{ ti.xcom_pull('task_2') }}",  # AIR201, AIR201
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+174 | )
+    |
+help: Replace with `{{ task_1.output }}`
+170 | # task variable references within the same template string
+171 | task_mc11 = BashOperator(
+172 |     task_id="task_mc11",
+    -     bash_command="{{ ti.xcom_pull('task_1') }} and {{ ti.xcom_pull('task_2') }}",  # AIR201, AIR201
+173 +     bash_command="{{ task_1.output }} and {{ ti.xcom_pull('task_2') }}",  # AIR201, AIR201
+174 | )
+175 |
+176 | # Subscript access within the Jinja block — only xcom_pull call is replaced,
+note: This is an unsafe fix and may change runtime behavior
+
+AIR201 [*] Use the `.output` attribute on the task object for "task_2" instead of `xcom_pull` in a template string
+   --> AIR201.py:173:18
+    |
+171 | task_mc11 = BashOperator(
+172 |     task_id="task_mc11",
+173 |     bash_command="{{ ti.xcom_pull('task_1') }} and {{ ti.xcom_pull('task_2') }}",  # AIR201, AIR201
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+174 | )
+    |
+help: Replace with `{{ task_2.output }}`
+170 | # task variable references within the same template string
+171 | task_mc11 = BashOperator(
+172 |     task_id="task_mc11",
+    -     bash_command="{{ ti.xcom_pull('task_1') }} and {{ ti.xcom_pull('task_2') }}",  # AIR201, AIR201
+173 +     bash_command="{{ ti.xcom_pull('task_1') }} and {{ task_2.output }}",  # AIR201, AIR201
+174 | )
+175 |
+176 | # Subscript access within the Jinja block — only xcom_pull call is replaced,
+note: This is an unsafe fix and may change runtime behavior
+
+AIR201 [*] Use the `.output` attribute on the task object for "task_1" instead of `xcom_pull` in a template string
+   --> AIR201.py:180:18
+    |
+178 | task_mc8 = BashOperator(
+179 |     task_id="task_mc8",
+180 |     bash_command="{{ ti.xcom_pull('task_1')['item'] }}",  # AIR201
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+181 | )
+    |
+help: Replace with `{{ task_1.output }}`
+177 | # subscript and surrounding {{ }} are preserved
+178 | task_mc8 = BashOperator(
+179 |     task_id="task_mc8",
+    -     bash_command="{{ ti.xcom_pull('task_1')['item'] }}",  # AIR201
+180 +     bash_command="{{ task_1.output['item'] }}",  # AIR201
+181 | )
+182 |
+183 | # Triple-quoted string — raw-source scanner is quote-agnostic
+note: This is an unsafe fix and may change runtime behavior
+
+AIR201 [*] Use the `.output` attribute on the task object for "task_1" instead of `xcom_pull` in a template string
+   --> AIR201.py:186:18
+    |
+184 | task_mc9 = BashOperator(
+185 |     task_id="task_mc9",
+186 |     bash_command="""echo {{ ti.xcom_pull('task_1') }}""",  # AIR201
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+187 | )
+    |
+help: Replace with `{{ task_1.output }}`
+183 | # Triple-quoted string — raw-source scanner is quote-agnostic
+184 | task_mc9 = BashOperator(
+185 |     task_id="task_mc9",
+    -     bash_command="""echo {{ ti.xcom_pull('task_1') }}""",  # AIR201
+186 +     bash_command="""echo {{ task_1.output }}""",  # AIR201
+187 | )
+188 |
+189 | # Mixed-content with unknown task_id (violation reported, no fix available)
+note: This is an unsafe fix and may change runtime behavior
+
+AIR201 Use the `.output` attribute on the task object for "unknown_task" instead of `xcom_pull` in a template string
+   --> AIR201.py:192:18
+    |
+190 | task_mc10 = BashOperator(
+191 |     task_id="task_mc10",
+192 |     bash_command="echo {{ ti.xcom_pull('unknown_task') }}",  # AIR201 (no fix)
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+193 | )
+    |
+help: Replace with `{{ unknown_task.output }}`


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

AIR201 previously only flagged template strings whose _entire_ value is a jinja template `{{ ti.xcom_pull(...) }}`, leaving strings like `"echo {{ ti.xcom_pull('task_1') }}"` ignored. This PR:
1. Extends the rule to detect `xcom_pull` calls embedded within larger strings ("mixed-content"), while keeping the pure-template path intact. 
2. Adds identifier validation so patterns whose task ID is not a valid Python identifier (e.g. `kebab-task`, `group_1.task_1`) are skipped.

The need for these additions became apparent in the context of https://github.com/apache/airflow/pull/65197.

Future work includes handling grouped task (`group_id.task_id`) replacement (after https://github.com/apache/airflow/pull/64430 is merged).

> [!IMPORTANT]
> Disclosure: content below this point was AI-generated, with minor manual tweaks

### Examples

- Pure-template (unchanged behaviour)
  ```python
  # Before — flagged and fixed as before
  bash_command="{{ ti.xcom_pull(task_ids='task_1') }}"
  # Fix replaces the whole argument:
  bash_command=task_1.output
  ```

- Mixed-content (new)
  ```python
  # Before — not flagged; now detected
  bash_command="echo {{ ti.xcom_pull(task_ids='task_1') }}"
  # Fix replaces only the xcom_pull call in-place, preserving surrounding content:
  bash_command="echo {{ task_1.output }}"
  ```

- Multiple occurrences in a single string each get their own independent diagnostic and fix:
  ```python
  bash_command="{{ ti.xcom_pull('task_1') }} and {{ ti.xcom_pull('task_2') }}"
  # Two AIR201 violations; applied independently:
  bash_command="{{ task_1.output }} and {{ task_2.output }}"
  ```

- Trailing subscript access within the Jinja block

  ```python
  bash_command="{{ ti.xcom_pull('task_1')['item'] }}"
  # Fix:
  bash_command="{{ task_1.output['item'] }}"
  ```

## Test Plan

Added 19 new test cases:

| Case | Description |
|------|-------------|
| `task_10`, `task_mc1`–`task_mc6` | Mixed-content, one occurrence — covers positional arg, `task_ids=`, `task_id=` (singular), list-wrapped, tuple-wrapped, `key='return_value'`, and `task_instance` receiver |
| `task_mc7` | Two occurrences of the same task ID in one string — two independent fixes |
| `task_mc11` | Two occurrences of different task IDs in one string — two independent fixes with distinct replacements |
| `task_mc8` | Subscript access within the Jinja block — fix preserves `['item']` and `{{ }}` |
| `task_mc9` | Triple-quoted string — scanner is quote-agnostic |
| `task_mc10` | Mixed-content with unknown task ID — violation reported, no fix available |
| `task_nt1` | Kebab-case task ID, pure-template form — no violation |
| `task_nt2` | Kebab-case task ID, mixed-content form — no violation |
| `task_nt3` | Dotted group task ID (`group_1.task_1`) — no violation |
| `task_nt4` | F-string argument — excluded by `as_string_literal_expr()` (AST type is `ExprFString`, not `ExprStringLiteral`); runtime value would be `{{ ti.xcom_pull('task_1') }}` but task ID is only known at runtime |

<!-- How was it tested? -->
