### PR TITLE
[ty] Optimize signature checking based on number of arguments

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -2196,6 +2196,51 @@ static_assert(is_subtype_of(RegularCallableTypeOf[overload_ab], RegularCallableT
 static_assert(is_subtype_of(RegularCallableTypeOf[overload_ba], RegularCallableTypeOf[overload_ab]))
 ```
 
+#### Overloaded callable with many arity-incompatible overloads
+
+When an overloaded source callable has many overloads with different arities, overloads whose
+positional parameter count is less than the target's should be quickly rejected without expensive
+per-parameter type comparisons.
+
+`many_overloads.pyi`:
+
+```pyi
+from typing import overload
+
+@overload
+def many(a: int) -> int: ...
+@overload
+def many(a: int, b: int) -> int: ...
+@overload
+def many(a: int, b: int, c: int) -> int: ...
+@overload
+def many(a: int, b: int, c: int, d: int) -> int: ...
+@overload
+def many(a: int, b: int, c: int, d: int, e: int) -> int: ...
+```
+
+```py
+from ty_extensions import RegularCallableTypeOf, is_subtype_of, static_assert
+from many_overloads import many
+
+def two_args(a: int, b: int) -> int:
+    return 0
+
+def five_args(a: int, b: int, c: int, d: int, e: int) -> int:
+    return 0
+
+def six_args(a: int, b: int, c: int, d: int, e: int, f: int) -> int:
+    return 0
+
+def variadic_args(*args: int) -> int:
+    return 0
+
+static_assert(is_subtype_of(RegularCallableTypeOf[many], RegularCallableTypeOf[two_args]))
+static_assert(is_subtype_of(RegularCallableTypeOf[many], RegularCallableTypeOf[five_args]))
+static_assert(not is_subtype_of(RegularCallableTypeOf[many], RegularCallableTypeOf[six_args]))
+static_assert(not is_subtype_of(RegularCallableTypeOf[many], RegularCallableTypeOf[variadic_args]))
+```
+
 ### Generic callables
 
 A generic callable can be considered equivalent to an intersection of all of its possible

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -2237,6 +2237,60 @@ static_assert(is_subtype_of(RegularCallableTypeOf[many], RegularCallableTypeOf[f
 static_assert(not is_subtype_of(RegularCallableTypeOf[many], RegularCallableTypeOf[six_args]))
 ```
 
+#### Variadic arity incompatibility
+
+If the target has `*args` or `**kwargs` but the source does not, the source cannot absorb the
+unbounded positional or keyword arguments that the target accepts.
+
+```py
+from ty_extensions import CallableTypeOf, is_subtype_of, static_assert
+
+def fixed_two(a: int, b: int, /) -> int:
+    return 0
+
+def star_args(a: int, /, *args: int) -> int:
+    return 0
+
+def star_kwargs(a: int, /, **kwargs: int) -> int:
+    return 0
+
+# Target has `*args`, source doesn't.
+static_assert(not is_subtype_of(CallableTypeOf[fixed_two], CallableTypeOf[star_args]))
+
+# Target has `**kwargs`, source doesn't.
+static_assert(not is_subtype_of(CallableTypeOf[fixed_two], CallableTypeOf[star_kwargs]))
+
+# Source has `*args`, target doesn't — not rejected by arity alone.
+def many_pos(a: int, /, *args: int) -> int:
+    return 0
+
+static_assert(is_subtype_of(CallableTypeOf[many_pos], CallableTypeOf[fixed_two]))
+```
+
+#### Source requires more positional-only parameters than target
+
+If the source has more required positional-only parameters than the target, then the target accepts
+calls with fewer positional arguments than the source requires.
+
+```py
+from ty_extensions import CallableTypeOf, is_subtype_of, static_assert
+
+def source_three(a: int, b: int, c: int, /) -> int:
+    return 0
+
+def target_three(a: int, b: int, c: int, /) -> int:
+    return 0
+
+def target_two_with_default(a: int, b: int, c: int = 0, /) -> int:
+    return 0
+
+# Target has a default, so it can be called with 2 positionals. Source requires 3.
+static_assert(not is_subtype_of(CallableTypeOf[source_three], CallableTypeOf[target_two_with_default]))
+
+# Equal required positional-only counts: not rejected by arity.
+static_assert(is_subtype_of(CallableTypeOf[source_three], CallableTypeOf[target_three]))
+```
+
 ### Generic callables
 
 A generic callable can be considered equivalent to an intersection of all of its possible

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -2196,6 +2196,47 @@ static_assert(is_subtype_of(RegularCallableTypeOf[overload_ab], RegularCallableT
 static_assert(is_subtype_of(RegularCallableTypeOf[overload_ba], RegularCallableTypeOf[overload_ab]))
 ```
 
+#### Overloaded callable with many arity-incompatible overloads
+
+When an overloaded source callable has many overloads with different arities, overloads whose
+positional parameter count is less than the target's should be quickly rejected without expensive
+per-parameter type comparisons.
+
+`many_overloads.pyi`:
+
+```pyi
+from typing import overload
+
+@overload
+def many(a: int) -> int: ...
+@overload
+def many(a: int, b: int) -> int: ...
+@overload
+def many(a: int, b: int, c: int) -> int: ...
+@overload
+def many(a: int, b: int, c: int, d: int) -> int: ...
+@overload
+def many(a: int, b: int, c: int, d: int, e: int) -> int: ...
+```
+
+```py
+from ty_extensions import RegularCallableTypeOf, is_subtype_of, static_assert
+from many_overloads import many
+
+def two_args(a: int, b: int) -> int:
+    return 0
+
+def five_args(a: int, b: int, c: int, d: int, e: int) -> int:
+    return 0
+
+def six_args(a: int, b: int, c: int, d: int, e: int, f: int) -> int:
+    return 0
+
+static_assert(is_subtype_of(RegularCallableTypeOf[many], RegularCallableTypeOf[two_args]))
+static_assert(is_subtype_of(RegularCallableTypeOf[many], RegularCallableTypeOf[five_args]))
+static_assert(not is_subtype_of(RegularCallableTypeOf[many], RegularCallableTypeOf[six_args]))
+```
+
 ### Generic callables
 
 A generic callable can be considered equivalent to an intersection of all of its possible

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1234,6 +1234,36 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
         }
 
+        // Fast path: if the target accepts positional calls that the source cannot accept, reject
+        // without checking return types or individual parameter types. The full parameter
+        // comparison below reaches the same result, but only after doing work that is expensive for
+        // large overload sets.
+        if source.parameters.is_standard()
+            && target.parameters.is_standard()
+            && source.parameters.variadic().is_none()
+        {
+            let source_positional = source.parameters.positional().count();
+            let target_positional = target.parameters.positional().count();
+            let target_accepts_extra_positionals =
+                target_positional > source_positional || target.parameters.variadic().is_some();
+
+            if target_accepts_extra_positionals {
+                if target_positional > source_positional
+                    && let Some(ParameterKind::KeywordOnly { name, .. }) = source
+                        .parameters
+                        .iter()
+                        .nth(source_positional)
+                        .map(Parameter::kind)
+                {
+                    self.provide_context(|| ErrorContext::ParameterMustAcceptPositionalArguments {
+                        name: name.clone(),
+                    });
+                }
+
+                return self.never();
+            }
+        }
+
         let mut result = self.always();
 
         // Avoid returning early after checking the return types in case there is a `ParamSpec` type
@@ -2590,6 +2620,12 @@ impl<'db> Parameters<'db> {
 
     pub(crate) const fn is_top(&self) -> bool {
         matches!(self.kind, ParametersKind::Top)
+    }
+
+    /// Returns `true` if the parameters are a standard parameter list (not gradual, top,
+    /// `ParamSpec`, or `Concatenate`).
+    pub(crate) const fn is_standard(&self) -> bool {
+        matches!(self.kind, ParametersKind::Standard)
     }
 
     /// Returns the bound `ParamSpec` type variable if the parameter list is exactly `P`.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1222,6 +1222,20 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
         }
 
+        // Fast path: if target has more positional parameters than source and source has no
+        // `*args` to absorb them, then source cannot handle all argument combinations that
+        // target accepts. Skip the expensive return-type and per-parameter type comparisons.
+        if source.parameters.is_standard()
+            && target.parameters.is_standard()
+            && !source.parameters.iter().any(Parameter::is_variadic)
+        {
+            let source_positional = source.parameters.positional().count();
+            let target_positional = target.parameters.positional().count();
+            if target_positional > source_positional {
+                return self.never();
+            }
+        }
+
         let mut result = self.always();
 
         let mut check_types = |type1: Type<'db>, type2: Type<'db>| {
@@ -2484,6 +2498,12 @@ impl<'db> Parameters<'db> {
 
     pub(crate) const fn is_top(&self) -> bool {
         matches!(self.kind, ParametersKind::Top)
+    }
+
+    /// Returns `true` if the parameters are a standard parameter list (not gradual, top,
+    /// `ParamSpec`, or `Concatenate`).
+    pub(crate) const fn is_standard(&self) -> bool {
+        matches!(self.kind, ParametersKind::Standard)
     }
 
     /// Returns the bound `ParamSpec` type variable if the parameter list is exactly `P`.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1222,16 +1222,55 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
         }
 
-        // Fast path: if target has more positional parameters than source and source has no
-        // `*args` to absorb them, then source cannot handle all argument combinations that
-        // target accepts. Skip the expensive return-type and per-parameter type comparisons.
-        if source.parameters.is_standard()
-            && target.parameters.is_standard()
-            && !source.parameters.iter().any(Parameter::is_variadic)
-        {
-            let source_positional = source.parameters.positional().count();
-            let target_positional = target.parameters.positional().count();
-            if target_positional > source_positional {
+        // Fast paths: reject incompatible arities before doing any per-parameter type comparisons.
+        if source.parameters.is_standard() && target.parameters.is_standard() {
+            let source_has_variadic = source.parameters.iter().any(Parameter::is_variadic);
+            let source_has_keyword_variadic =
+                source.parameters.iter().any(Parameter::is_keyword_variadic);
+            let target_has_variadic = target.parameters.iter().any(Parameter::is_variadic);
+            let target_has_keyword_variadic =
+                target.parameters.iter().any(Parameter::is_keyword_variadic);
+
+            // If target has `*args` but source doesn't, then target accepts unbounded positional
+            // arguments that source cannot absorb. Likewise for `**kwargs` and arbitrary keyword
+            // names.
+            if (target_has_variadic && !source_has_variadic)
+                || (target_has_keyword_variadic && !source_has_keyword_variadic)
+            {
+                return self.never();
+            }
+
+            // If target has more positional parameters than source and source has no `*args` to
+            // absorb them, then source cannot handle all argument combinations that target accepts.
+            if !source_has_variadic {
+                let source_positional = source.parameters.positional().count();
+                let target_positional = target.parameters.positional().count();
+                if target_positional > source_positional {
+                    return self.never();
+                }
+            }
+
+            // If source has more required positional-only parameters than target, then target
+            // accepts calls with fewer positional arguments than source requires. (Positional-only
+            // parameters must be passed positionally; other required parameters can be passed by
+            // keyword, so they don't raise target's minimum positional-argument count.)
+            let count_required_positional_only = |parameters: &Parameters<'db>| {
+                parameters
+                    .iter()
+                    .filter(|p| {
+                        matches!(
+                            p.kind(),
+                            ParameterKind::PositionalOnly {
+                                default_type: None,
+                                ..
+                            }
+                        )
+                    })
+                    .count()
+            };
+            if count_required_positional_only(&source.parameters)
+                > count_required_positional_only(&target.parameters)
+            {
                 return self.never();
             }
         }


### PR DESCRIPTION
## Summary

This PR adds a fast path to signature subtyping that checks positional parameter count compatibility (along with a few other cases) before doing expensive per-parameter type comparisons. In short, if the signatures have a different number of positional arguments, they can't match up.

Not much movement on CodSpeed, but the `more-itertools` improvement at least seems to be real based on local benchmarking (17x faster or something like that).
