### PR TITLE
Fix mdtest.py for Rust 1.95

### DIFF
--- a/crates/ty_python_semantic/mdtest.py
+++ b/crates/ty_python_semantic/mdtest.py
@@ -110,12 +110,12 @@ class MDTestRunner:
         return True
 
     def _get_executable_path_from_json(self, json_output: str) -> None:
-        for json_line in json_output.splitlines():
+        for json_line in json_output.splitlines()[::-1]:
             try:
                 data = json.loads(json_line)
             except json.JSONDecodeError:
                 continue
-            if data.get("target", {}).get("name") == "mdtest":
+            if data.get("target", {}).get("name") == "mdtest" and data["executable"]:
                 self.mdtest_executable = Path(data["executable"])
                 break
         else:


### PR DESCRIPTION
## Summary

I've upgraded my local toolchain to Rust 1.95, but it broke mdtest.py:

```pytb
~/dev/ruff (main)⚡ % uv run crates/ty_python_semantic/mdtest.py
Traceback (most recent call last):
  File "/Users/alexw/dev/ruff/crates/ty_python_semantic/mdtest.py", line 349, in <module>
    main()
    ~~~~^^
  File "/Users/alexw/dev/ruff/crates/ty_python_semantic/mdtest.py", line 343, in main
    runner.watch()
    ~~~~~~~~~~~~^^
  File "/Users/alexw/dev/ruff/crates/ty_python_semantic/mdtest.py", line 227, in watch
    self._recompile_tests("Compiling tests...", message_on_success=False)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alexw/dev/ruff/crates/ty_python_semantic/mdtest.py", line 106, in _recompile_tests
    self._get_executable_path_from_json(json_output)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/Users/alexw/dev/ruff/crates/ty_python_semantic/mdtest.py", line 119, in _get_executable_path_from_json
    self.mdtest_executable = Path(data["executable"])
                             ~~~~^^^^^^^^^^^^^^^^^^^^
  File "/Users/alexw/Library/Application Support/uv/python/cpython-3.13.8-macos-aarch64-none/lib/python3.13/pathlib/_local.py", line 503, in __init__
    super().__init__(*args)
    ~~~~~~~~~~~~~~~~^^^^^^^
  File "/Users/alexw/Library/Application Support/uv/python/cpython-3.13.8-macos-aarch64-none/lib/python3.13/pathlib/_local.py", line 132, in __init__
    raise TypeError(
    ...<2 lines>...
        f"not {type(path).__name__!r}")
TypeError: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'NoneType'
```

The cause seems to be that `cargo test --package ty_python_semantic --test mdtest --message-format json` spits out multiple JSON mappings where `target.name == "mdtest"`, but only for the last of these mappings is `target.executable` set to a string -- for earlier mappings where `target.name == "mdtest"`, `target.executable` is set to `None`. That breaks this part of mdtest.py: https://github.com/astral-sh/ruff/blob/53554b1cfe837f2eb992a81794480699478f1116/crates/ty_python_semantic/mdtest.py#L112-L124

This PR keeps us iterating through the JSON mappings until we find one where both `target.name == "mdtest"` _and_ `target.executable` is not `None`. The PR also adds a micro-optimisation where we iterate through the lines of stdout in reverse order, since the relevant mapping is likely to be the last one that was spat out by the cargo invocation.

## Test Plan

`uv run crates/ty_python_semantic/mdtest.py` no longer fails for me locally (with the Rust 1.95 toolchain installed).
