### PR TITLE
[ty] Avoid merging snapshots if equivalent

### DIFF
--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1627,7 +1627,9 @@ impl<'db> UseDefMapBuilder<'db> {
         let mut snapshot_definitions_iter = snapshot.symbol_states.into_iter();
         for current in &mut self.symbol_states {
             if let Some(snapshot) = snapshot_definitions_iter.next() {
-                current.merge(snapshot, &mut self.reachability_constraints);
+                if *current != snapshot {
+                    current.merge(snapshot, &mut self.reachability_constraints);
+                }
             } else {
                 current.merge(
                     PlaceState::undefined(snapshot.reachability),
@@ -1640,7 +1642,9 @@ impl<'db> UseDefMapBuilder<'db> {
         let mut snapshot_definitions_iter = snapshot.member_states.into_iter();
         for current in &mut self.member_states {
             if let Some(snapshot) = snapshot_definitions_iter.next() {
-                current.merge(snapshot, &mut self.reachability_constraints);
+                if *current != snapshot {
+                    current.merge(snapshot, &mut self.reachability_constraints);
+                }
             } else {
                 current.merge(
                     PlaceState::undefined(snapshot.reachability),

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1633,7 +1633,9 @@ impl<'db> UseDefMapBuilder<'db> {
         let mut snapshot_definitions_iter = snapshot.symbol_states.into_iter();
         for current in &mut self.symbol_states {
             if let Some(snapshot) = snapshot_definitions_iter.next() {
-                current.merge(snapshot, &mut self.reachability_constraints);
+                if *current != snapshot {
+                    current.merge(snapshot, &mut self.reachability_constraints);
+                }
             } else {
                 current.merge(
                     PlaceState::undefined(snapshot.reachability),
@@ -1646,7 +1648,9 @@ impl<'db> UseDefMapBuilder<'db> {
         let mut snapshot_definitions_iter = snapshot.member_states.into_iter();
         for current in &mut self.member_states {
             if let Some(snapshot) = snapshot_definitions_iter.next() {
-                current.merge(snapshot, &mut self.reachability_constraints);
+                if *current != snapshot {
+                    current.merge(snapshot, &mut self.reachability_constraints);
+                }
             } else {
                 current.merge(
                     PlaceState::undefined(snapshot.reachability),


### PR DESCRIPTION
## Summary

The idea here is: most of the time, most bindings don't change in an `if` block or equivalent. For example, given:
```python
def f(x: int, y: str, z: list[int]) -> None:
    a = 1
    b = "hello"
    c = []
    if x > 0:
        a = 2
```

`a` changed, but all the other symbols were unchanged, so we can avoid running the full merge for the `PlaceState` for all other symbols.

This doesn't show up in any of our standard benchmarks, but it's a pretty simple optimization and shows a 38% speedup for an example like:
```python
class BigClass:
    def __init__(self, data: dict[str, int]) -> None:
        if "field_0" in data: self.field_0 = data["field_0"]
        else: self.field_0 = 0
        ...  # 2000 fields
```
