### PR TITLE
[ty] Fix various overflows with recursive type aliases

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -2618,9 +2618,9 @@ fn completion_kind_from_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Comp
             | Type::KnownInstance(_)
             | Type::AlwaysTruthy
             | Type::AlwaysFalsy => return None,
-            Type::TypeAlias(alias) => {
-                visitor.visit(ty, || imp(db, alias.value_type(db), visitor))?
-            }
+            Type::TypeAlias(alias) => visitor.visit(ty, || {
+                alias.visit_value(db, || None, |value_ty| imp(db, value_ty, visitor))
+            })?,
         })
     }
     imp(db, ty, &CompletionKindVisitor::default())

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -291,6 +291,52 @@ a: int | MaybeInt = MaybeInt("42")  # OK
 b: int = MaybeInt("42")  # error: [invalid-assignment]
 ```
 
+### `__new__` returning a recursive alias union
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+type RecursiveNewReturn = RecursiveNew | RecursiveNewReturn
+
+class RecursiveNew:
+    def __new__(cls, value: int) -> RecursiveNewReturn:
+        raise NotImplementedError
+
+    def __init__(self, value: str) -> None: ...
+
+# error: [invalid-argument-type] "Argument to `RecursiveNew.__init__` is incorrect: Expected `str`, found `Literal[1]`"
+reveal_type(RecursiveNew(1))  # revealed: RecursiveNew
+```
+
+### Metaclass `__call__` returning a recursive alias union
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+type RecursiveMetaCallReturn = RecursiveMetaCall | RecursiveMetaCallReturn
+
+class RecursiveMeta(type):
+    def __call__(cls, value: int) -> RecursiveMetaCallReturn:
+        raise NotImplementedError
+
+class RecursiveMetaCall(metaclass=RecursiveMeta):
+    def __new__(cls, value: str) -> RecursiveMetaCall:
+        raise NotImplementedError
+
+# error: [invalid-argument-type] "Argument to constructor `RecursiveMetaCall.__new__` is incorrect: Expected `str`, found `Literal[1]`"
+reveal_type(RecursiveMetaCall(1))  # revealed: RecursiveMetaCall
+```
+
 ### `__new__` returning an intersection type
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/call/dunder.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/dunder.md
@@ -171,6 +171,30 @@ class_with_callable_dunder = ClassWithNonMethodDunder()
 reveal_type(class_with_callable_dunder[0])  # revealed: str
 ```
 
+Recursive aliases in the dunder annotation should still terminate when we look up and call the
+dunder via `type(obj)`:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import reveal_type
+
+class G:
+    def __call__(self, key: int) -> "RecursiveGetItem":
+        return self
+
+type RecursiveGetItem = G | RecursiveGetItem
+
+class C:
+    __getitem__: RecursiveGetItem = G()
+
+def f(x: C):
+    reveal_type(x[0])  # revealed: G | Unknown
+```
+
 ## Dunders are looked up using the descriptor protocol
 
 Here, we demonstrate that the descriptor protocol is invoked when looking up a dunder method. Note

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -156,6 +156,33 @@ class Cyclic:
 reveal_type(Cyclic("").data)
 ```
 
+## Meta-type lookups through recursive aliases
+
+Recursive aliases can show up in class-body annotations and in operations that need the meta type,
+such as `__class__` lookup. These should not recurse indefinitely.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import reveal_type
+
+class G:
+    pass
+
+type RecursiveAlias = G | RecursiveAlias
+
+class C:
+    x: RecursiveAlias
+
+reveal_type(C.x)  # revealed: G
+
+def f(x: RecursiveAlias):
+    reveal_type(x.__class__)  # revealed: type[G]
+```
+
 ## Lazy cached property behind `hasattr`
 
 This pattern used to panic with "too many cycle iterations".

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -433,6 +433,28 @@ type Bar[T] = int | Foo[T]
 def _(x: Bar[int]):
     # TODO: should be `int | list[int]`
     reveal_type(x)  # revealed: int | list[int] | Any
+
+#### Parser-recovery regressions
+
+# Regression tests for crashy subscript/call cases involving cyclic aliases.
+from typing import Any
+from ty_extensions import Not
+
+type CrashySubscript = list[Not[CrashySubscript] | CrashySubscript]
+
+def _(x: CrashySubscript):
+    # error: [invalid-syntax] "Expected index or slice expression"
+    reveal_type(x[])  # revealed: Unknown
+    reveal_type(x[0])  # revealed: ~list[Any] | list[Any]
+
+def _(x: CrashySubscript, y: Any):
+    reveal_type(x[y])  # revealed: Unknown
+
+# error: [invalid-syntax] "Expected an expression"
+type CrashyCall = | CrashyCall
+
+def _(x: CrashyCall):
+    reveal_type(x())  # revealed: Unknown
 ```
 
 ### With legacy generic

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -501,6 +501,24 @@ def assign_recursive_alias_attribute(x: RecursiveAttributeAlias):
 def delete_recursive_alias_attribute(x: RecursiveAttributeAlias):
     del x.attr
 
+class RecursiveMissingAttribute: ...
+
+type RecursiveMissingAttributeAlias = RecursiveMissingAttribute | RecursiveMissingAttributeAlias
+
+def load_missing_recursive_alias_attribute(x: RecursiveMissingAttributeAlias):
+    # error: [unresolved-attribute] "Attribute `missing` is not defined on `RecursiveMissingAttribute` in union `RecursiveMissingAttributeAlias`"
+    reveal_type(x.missing)  # revealed: Divergent
+
+def delete_missing_recursive_alias_attribute(x: RecursiveMissingAttributeAlias):
+    # error: [unresolved-attribute] "Attribute `missing` is not defined on `RecursiveMissingAttribute` in union `RecursiveMissingAttributeAlias`"
+    del x.missing
+
+type RecursiveIntAttributeAlias = int | RecursiveIntAttributeAlias
+
+def load_missing_recursive_int_alias_attribute(x: RecursiveIntAttributeAlias):
+    # error: [unresolved-attribute] "Attribute `missing` is not defined on `int` in union `RecursiveIntAttributeAlias`"
+    reveal_type(x.missing)  # revealed: Divergent
+
 class RecursiveKwargs(TypedDict):
     kind: Literal["a"]
     a: int

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -661,7 +661,7 @@ def expand_recursive_tuple_argument(x: RecursiveTuple):
 def overloaded_recursive_tuple_variadic(x: int) -> int: ...
 @overload
 def overloaded_recursive_tuple_variadic(x: int, y: int) -> str: ...
-def overloaded_recursive_tuple_variadic(*args: object) -> object:
+def overloaded_recursive_tuple_variadic(*args: object, **kwargs: object) -> object:
     return args
 
 def expand_recursive_variadic_tuple_argument(x: RecursiveTuple):

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -439,6 +439,157 @@ def _(x: Bar[int]):
     reveal_type(x)  # revealed: int | list[int]
 ```
 
+### Recursive aliases in operations
+
+```py
+from typing import Callable, Iterator, Literal, TypedDict, overload
+from ty_extensions import all_members, has_member
+
+class RecursiveItem: ...
+
+type RecursiveUnion = RecursiveItem | RecursiveUnion
+
+def subscript_recursive_alias(x: RecursiveUnion):
+    # error: [not-subscriptable] "Cannot subscript object of type `RecursiveItem` with no `__getitem__` method"
+    reveal_type(x[0])  # revealed: Unknown
+
+class RecursiveIterableItem:
+    def __iter__(self) -> Iterator["RecursiveIterable"]:
+        return iter([self])
+
+type RecursiveIterable = RecursiveIterableItem | RecursiveIterable
+
+def iterate_recursive_alias(x: RecursiveIterable):
+    for y in x:
+        reveal_type(y)  # revealed: RecursiveIterableItem | Unknown
+
+def star_recursive_alias(x: RecursiveIterable):
+    def g(*args: object): ...
+
+    g(*x)
+
+class RecursiveCallable:
+    def __call__(self) -> "DunderRecursive":
+        return self
+
+type DunderRecursive = RecursiveCallable | DunderRecursive
+
+class HasRecursiveLen:
+    __len__: DunderRecursive = RecursiveCallable()
+
+def len_recursive_alias(x: HasRecursiveLen):
+    # error: [invalid-argument-type] "Argument to function `len` is incorrect: Expected `Sized`, found `HasRecursiveLen`"
+    reveal_type(len(x))  # revealed: int
+
+class RecursiveMembers:
+    attr: int
+
+type RecursiveMembersAlias = RecursiveMembers | RecursiveMembersAlias
+
+def list_recursive_alias_members(x: RecursiveMembersAlias):
+    all_members(x)
+    reveal_type(has_member(x, "attr"))  # revealed: Literal[False]
+
+class RecursiveAttribute:
+    attr: int
+
+type RecursiveAttributeAlias = RecursiveAttribute | RecursiveAttributeAlias
+
+def assign_recursive_alias_attribute(x: RecursiveAttributeAlias):
+    x.attr = 1
+
+def delete_recursive_alias_attribute(x: RecursiveAttributeAlias):
+    del x.attr
+
+class RecursiveKwargs(TypedDict):
+    kind: Literal["a"]
+    a: int
+
+type RecursiveKwargsAlias = RecursiveKwargs | RecursiveKwargsAlias
+
+def call_with_recursive_kwargs_alias(x: RecursiveKwargsAlias):
+    def g(a: int): ...
+
+    g(**x)
+
+def narrow_recursive_typed_dict_alias(x: RecursiveKwargsAlias):
+    if x["kind"] == "a":
+        reveal_type(x)  # revealed: RecursiveKwargs
+
+type RecursiveDecoratorReturn = Callable[[int], int] | RecursiveDecoratorReturn
+
+def recursive_decorator_return(fn: Callable[[int], int]) -> RecursiveDecoratorReturn: ...
+@recursive_decorator_return
+def decorated(x: int) -> int:
+    return x
+
+reveal_type(decorated)  # revealed: ((int, /) -> int) | Unknown
+
+class BaseWithMethod:
+    def method(self) -> None: ...
+
+class RecursiveSuperOwner(BaseWithMethod): ...
+
+type RecursiveSuperOwnerAlias = RecursiveSuperOwner | RecursiveSuperOwnerAlias
+
+def recursive_super_owner(x: RecursiveSuperOwnerAlias):
+    super(RecursiveSuperOwner, x).method()
+
+type RecursiveTuple = tuple[RecursiveTuple]
+
+@overload
+def overloaded_recursive_tuple(x: int) -> int: ...
+@overload
+def overloaded_recursive_tuple(x: str) -> str: ...
+def overloaded_recursive_tuple(x: object) -> object:
+    return x
+
+def expand_recursive_tuple_argument(x: RecursiveTuple):
+    # error: [no-matching-overload] "No overload of function `overloaded_recursive_tuple` matches arguments"
+    reveal_type(overloaded_recursive_tuple(x))  # revealed: Unknown
+
+@overload
+def overloaded_recursive_tuple_variadic(x: int) -> int: ...
+@overload
+def overloaded_recursive_tuple_variadic(x: int, y: int) -> str: ...
+def overloaded_recursive_tuple_variadic(*args: object) -> object:
+    return args
+
+def expand_recursive_variadic_tuple_argument(x: RecursiveTuple):
+    # error: [invalid-argument-type] "Argument to function `overloaded_recursive_tuple_variadic` is incorrect: Expected `int`, found `RecursiveTuple`"
+    reveal_type(overloaded_recursive_tuple_variadic(*x))  # revealed: Unknown
+
+type RecursiveClassInfo = type[int] | RecursiveClassInfo
+
+def narrow_recursive_classinfo(x: object, y: RecursiveClassInfo):
+    if isinstance(x, y):
+        reveal_type(x)  # revealed: object
+
+def narrow_recursive_subclassinfo(x: type[object], y: RecursiveClassInfo):
+    if issubclass(x, y):
+        reveal_type(x)  # revealed: type
+
+type RecursiveSingleValuedTuple = tuple[None, RecursiveSingleValuedTuple]
+
+def narrow_recursive_single_valued_tuple(x: object, y: RecursiveSingleValuedTuple):
+    if x == y:
+        reveal_type(x)  # revealed: object
+```
+
+### Parser-recovery operation regressions
+
+```py
+# error: [invalid-syntax] "Expected an expression"
+type CrashyOperation = | CrashyOperation
+
+def subscript_recovered_alias(x: CrashyOperation):
+    reveal_type(x[0])  # revealed: Unknown
+
+def iterate_recovered_alias(x: CrashyOperation):
+    for y in x:
+        reveal_type(y)  # revealed: Unknown
+```
+
 ### With legacy generic
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -161,6 +161,22 @@ def f(x: Foo[int]):
     reveal_type(x.foo())  # revealed: int
 ```
 
+## Attribute assignment through generic aliases
+
+```py
+class ConfigEntry[T]:
+    data: dict[str, object]
+    runtime_data: T
+
+class RuntimeData:
+    def __init__(self, value: object): ...
+
+type RuntimeDataConfigEntry = ConfigEntry[RuntimeData]
+
+def f(entry: RuntimeDataConfigEntry):
+    entry.runtime_data = RuntimeData(entry.data["key"])
+```
+
 ## Stringified values
 
 Stringifying the right-hand side of a type alias is redundant, but allowed:

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -443,7 +443,7 @@ def _(x: Bar[int]):
 
 ```py
 from typing import Callable, Iterator, Literal, TypedDict, overload
-from ty_extensions import all_members, has_member
+from ty_extensions import Intersection, Not, all_members, has_member
 
 class RecursiveItem: ...
 
@@ -542,6 +542,81 @@ def decorated(x: int) -> int:
     return x
 
 reveal_type(decorated)  # revealed: ((int, /) -> int) | Unknown
+
+type RecursiveCallableSpecialization[T] = Callable[[], RecursiveCallableSpecialization[list[T]]]
+
+def reveal_recursive_callable_specialization(x: RecursiveCallableSpecialization[int]):
+    reveal_type(x)  # revealed: () -> RecursiveCallableSpecialization[list[int]]
+
+type RecursiveTruthinessSpecialization[T] = int | RecursiveTruthinessSpecialization[list[T]]
+
+def reveal_recursive_truthiness_specialization(x: RecursiveTruthinessSpecialization[int]):
+    reveal_type(x)  # revealed: int
+
+def positive_intersection_recursive_truthiness_specialization(
+    x: Intersection[RecursiveTruthinessSpecialization[int], object],
+):
+    reveal_type(x)  # revealed: int
+
+def negative_recursive_truthiness_specialization(
+    x: Not[RecursiveTruthinessSpecialization[int]],
+):
+    reveal_type(x)  # revealed: ~int & ~RecursiveTruthinessSpecialization[list[int]]
+
+def negative_intersection_recursive_truthiness_specialization(
+    x: Intersection[object, Not[RecursiveTruthinessSpecialization[int]]],
+):
+    reveal_type(x)  # revealed: ~int & ~RecursiveTruthinessSpecialization[list[list[int]]]
+
+def bool_recursive_specialization(x: RecursiveTruthinessSpecialization[int]):
+    if x:
+        pass
+
+def infer_recursive_truthiness_specialization[T](x: RecursiveTruthinessSpecialization[T]) -> T:
+    raise NotImplementedError
+
+def call_infer_recursive_truthiness_specialization(x: RecursiveTruthinessSpecialization[int]):
+    infer_recursive_truthiness_specialization(x)
+
+def accept_negative_recursive_truthiness_specialization[T](x: T) -> None:
+    pass
+
+def call_accept_negative_recursive_truthiness_specialization(
+    x: Not[RecursiveTruthinessSpecialization[int]],
+):
+    accept_negative_recursive_truthiness_specialization(x)
+
+def compare_recursive_specialization(x: RecursiveTruthinessSpecialization[int]):
+    reveal_type(x == 1)  # revealed: bool
+
+def binary_recursive_specialization(x: RecursiveTruthinessSpecialization[int]):
+    reveal_type(x + 1)  # revealed: int
+
+type RecursiveSubscriptSpecialization[T] = list[RecursiveSubscriptSpecialization[list[T]]]
+
+def head_recursive_subscript_specialization[T](x: RecursiveSubscriptSpecialization[T]) -> T:
+    raise NotImplementedError
+
+def call_head_recursive_subscript_specialization(x: RecursiveSubscriptSpecialization[int]):
+    reveal_type(head_recursive_subscript_specialization(x))  # revealed: int
+
+def subscript_recursive_specialization(x: RecursiveSubscriptSpecialization[int]):
+    reveal_type(x[0])  # revealed: list[RecursiveSubscriptSpecialization[list[list[int]]]]
+
+type RecursiveClassInfoSpecialization[T] = type[int] | RecursiveClassInfoSpecialization[list[T]]
+
+def isinstance_recursive_specialization(obj: object, classinfo: RecursiveClassInfoSpecialization[int]):
+    if isinstance(obj, classinfo):
+        reveal_type(obj)  # revealed: object
+
+def issubclass_recursive_specialization(obj: type[object], classinfo: RecursiveClassInfoSpecialization[int]):
+    if issubclass(obj, classinfo):
+        reveal_type(obj)  # revealed: type
+
+def match_recursive_classinfo_specialization(obj: object, classinfo: RecursiveClassInfoSpecialization[int]):
+    match obj:
+        case classinfo():
+            reveal_type(obj)  # revealed: object
 
 class BaseWithMethod:
     def method(self) -> None: ...
@@ -830,6 +905,26 @@ type CallableGuard = TypeGuard[Callable[[], CallableGuard]]
 
 reveal_type(CallableIs)  # revealed: TypeAliasType
 reveal_type(CallableGuard)  # revealed: TypeAliasType
+```
+
+### Recursive generic aliases in special forms don't stack overflow
+
+```py
+from typing import Literal, reveal_type
+from typing_extensions import TypeIs
+
+type RecursiveLiteralSpecialization[T] = Literal[1] | RecursiveLiteralSpecialization[list[T]]
+type RecursiveIsSpecialization[T] = int | RecursiveIsSpecialization[list[T]]
+type RecursiveDuplicateSpecialization[T] = RecursiveIsSpecialization[T] | RecursiveIsSpecialization[T]
+
+def is_recursive(x: object) -> TypeIs[RecursiveIsSpecialization[int]]:
+    return True
+
+reveal_type(RecursiveLiteralSpecialization)  # revealed: TypeAliasType
+reveal_type(RecursiveDuplicateSpecialization)  # revealed: TypeAliasType
+
+# error: [invalid-type-form] "Type arguments for `Literal` must be `None`, a literal value (int, bool, str, or bytes), or an enum member"
+x: Literal[RecursiveLiteralSpecialization[int]]
 ```
 
 ### Recursive alias in binary operators doesn't stack overflow

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -458,7 +458,7 @@ def _(x: Bar[int]):
 ### Recursive aliases in operations
 
 ```py
-from typing import Callable, Iterator, Literal, TypedDict, overload
+from typing import Callable, Concatenate, Iterator, Literal, TypedDict, overload
 from ty_extensions import Intersection, Not, all_members, has_member
 
 class RecursiveItem: ...
@@ -563,6 +563,21 @@ type RecursiveCallableSpecialization[T] = Callable[[], RecursiveCallableSpeciali
 
 def reveal_recursive_callable_specialization(x: RecursiveCallableSpecialization[int]):
     reveal_type(x)  # revealed: () -> RecursiveCallableSpecialization[list[int]]
+
+type RecursiveConcatenateCallable[**P] = Callable[[], RecursiveConcatenateCallable[Concatenate[int, P]]]
+
+def reveal_recursive_concatenate_callable(x: RecursiveConcatenateCallable):
+    reveal_type(x)  # revealed: () -> RecursiveConcatenateCallable[(int, /, *args: Unknown, **kwargs: Unknown)]
+
+type RecursiveParamspecCallable[**P] = Callable[P, RecursiveParamspecCallable[Concatenate[int, P]]]
+
+def reveal_recursive_paramspec_callable(x: RecursiveParamspecCallable):
+    reveal_type(x)  # revealed: (...) -> RecursiveParamspecCallable[(int, /, *args: Unknown, **kwargs: Unknown)]
+
+type RecursiveUnionCallable[T] = Callable[[RecursiveUnionCallable[T]], RecursiveUnionCallable[T | RecursiveUnionCallable[T]]]
+
+def reveal_recursive_union_callable(x: RecursiveUnionCallable[int]):
+    reveal_type(x)  # revealed: (RecursiveUnionCallable[int], /) -> RecursiveUnionCallable[int | RecursiveUnionCallable[int]]
 
 type RecursiveTruthinessSpecialization[T] = int | RecursiveTruthinessSpecialization[list[T]]
 

--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -735,6 +735,19 @@ def _(a: A | None):
     return {}
 ```
 
+Callable promotion visits parameters with promotion disabled and returns with promotion enabled, so
+those two traversals should not share cached intersection results:
+
+```py
+from typing import Literal
+from ty_extensions import Intersection, Not
+
+def f(x: Intersection[int, Not[Literal[2]]]) -> Intersection[int, Not[Literal[2]]]:
+    return x
+
+reveal_type([f])  # revealed: list[(x: int & ~Literal[2]) -> int]
+```
+
 ## Module-literal types are not promoted
 
 Since module-literal types are "literal" types in a certain sense (each type is a singleton type),

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -514,9 +514,9 @@ impl<'db> SemanticModel<'db> {
                     .iter()
                     .flat_map(|element| collect(db, *element, visitor))
                     .collect(),
-                Type::TypeAlias(alias) => {
-                    visitor.visit(ty, || collect(db, alias.value_type(db), visitor))
-                }
+                Type::TypeAlias(alias) => visitor.visit(ty, || {
+                    alias.visit_value(db, Vec::new, |value_ty| collect(db, value_ty, visitor))
+                }),
                 _ => Vec::new(),
             }
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4,8 +4,7 @@ use ruff_diagnostics::{Edit, Fix};
 use rustc_hash::FxHashMap;
 
 use std::borrow::Cow;
-use std::cell::{OnceCell, RefCell};
-use std::hash::Hash;
+use std::cell::OnceCell;
 use std::iter;
 use std::rc::Rc;
 use std::time::Duration;
@@ -19,7 +18,6 @@ use ruff_db::files::File;
 use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
-use salsa::plumbing::AsId;
 use smallvec::smallvec_inline;
 use ty_module_resolver::{KnownModule, Module, ModuleName, resolve_module};
 
@@ -247,89 +245,6 @@ struct ApplyMaterializationEquivalence;
 type MaterializationEquivalenceVisitor<'db> =
     Rc<CycleDetector<ApplyMaterializationEquivalence, (Type<'db>, Type<'db>), bool>>;
 
-#[derive(Debug, Default, Clone, Copy)]
-struct ActiveMaterializationKinds {
-    top: u32,
-    bottom: u32,
-}
-
-impl ActiveMaterializationKinds {
-    fn contains(self, kind: MaterializationKind) -> bool {
-        match kind {
-            MaterializationKind::Top => self.top > 0,
-            MaterializationKind::Bottom => self.bottom > 0,
-        }
-    }
-
-    fn insert(&mut self, kind: MaterializationKind) {
-        match kind {
-            MaterializationKind::Top => self.top += 1,
-            MaterializationKind::Bottom => self.bottom += 1,
-        }
-    }
-
-    fn remove(&mut self, kind: MaterializationKind) {
-        match kind {
-            MaterializationKind::Top => self.top -= 1,
-            MaterializationKind::Bottom => self.bottom -= 1,
-        }
-    }
-
-    fn is_empty(self) -> bool {
-        self.top == 0 && self.bottom == 0
-    }
-}
-
-#[derive(Debug)]
-struct MaterializationPolarityDetector<T> {
-    seen: RefCell<FxHashMap<T, ActiveMaterializationKinds>>,
-}
-
-impl<T> Default for MaterializationPolarityDetector<T> {
-    fn default() -> Self {
-        Self {
-            seen: RefCell::new(FxHashMap::default()),
-        }
-    }
-}
-
-impl<T: Hash + Eq + Clone> MaterializationPolarityDetector<T> {
-    fn visit<R>(
-        &self,
-        item: &T,
-        materialization_kind: MaterializationKind,
-        on_cycle: impl FnOnce() -> R,
-        func: impl FnOnce() -> R,
-    ) -> R {
-        {
-            let mut seen = self.seen.borrow_mut();
-            if seen
-                .get(item)
-                .is_some_and(|active| active.contains(materialization_kind.flip()))
-            {
-                return on_cycle();
-            }
-
-            seen.entry(item.clone())
-                .or_default()
-                .insert(materialization_kind);
-        }
-
-        let ret = func();
-
-        let mut seen = self.seen.borrow_mut();
-        let entry = seen
-            .get_mut(item)
-            .expect("active materialization entry must exist");
-        entry.remove(materialization_kind);
-        if entry.is_empty() {
-            seen.remove(item);
-        }
-
-        ret
-    }
-}
-
 /// A [`TypeTransformer`] that is used in `apply_type_mapping` methods.
 ///
 /// Materialization is the only mapping mode that needs to visit the same type under two different
@@ -339,7 +254,6 @@ pub(crate) struct ApplyTypeMappingVisitor<'db> {
     default: OnceCell<TypeTransformer<'db, ApplyDefaultTypeMapping>>,
     top_materialization: OnceCell<TypeTransformer<'db, ApplyTopMaterialization>>,
     bottom_materialization: OnceCell<TypeTransformer<'db, ApplyBottomMaterialization>>,
-    materialization_polarity: OnceCell<MaterializationPolarityDetector<Type<'db>>>,
     materialization_equivalence: OnceCell<MaterializationEquivalenceVisitor<'db>>,
     invariant_relation: OnceCell<ActiveRecursionDetector<(Type<'db>, Type<'db>)>>,
 }
@@ -348,11 +262,6 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
     fn materialization_equivalence(&self) -> &MaterializationEquivalenceVisitor<'db> {
         self.materialization_equivalence
             .get_or_init(|| Rc::new(CycleDetector::new(true)))
-    }
-
-    fn materialization_polarity(&self) -> &MaterializationPolarityDetector<Type<'db>> {
-        self.materialization_polarity
-            .get_or_init(MaterializationPolarityDetector::default)
     }
 
     fn invariant_relation(&self) -> &ActiveRecursionDetector<(Type<'db>, Type<'db>)> {
@@ -381,35 +290,6 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
                 .get_or_init(TypeTransformer::default)
                 .visit(ty, func),
         }
-    }
-
-    fn visit_materialization_polarity(
-        &self,
-        db: &'db dyn Db,
-        ty: Type<'db>,
-        materialization_kind: MaterializationKind,
-        func: impl FnOnce() -> Type<'db>,
-    ) -> Type<'db> {
-        let polarity_key = ty.expand_eagerly(db);
-        self.materialization_polarity().visit(
-            &polarity_key,
-            materialization_kind,
-            || {
-                let cycle = DivergentType::new(InternedType::new(db, polarity_key).as_id())
-                    .materialized(materialization_kind);
-                Type::Divergent(cycle)
-            },
-            || match materialization_kind {
-                MaterializationKind::Top => self
-                    .top_materialization
-                    .get_or_init(TypeTransformer::default)
-                    .visit(ty, func),
-                MaterializationKind::Bottom => self
-                    .bottom_materialization
-                    .get_or_init(TypeTransformer::default)
-                    .visit(ty, func),
-            },
-        )
     }
 
     pub(crate) fn is_equivalent_to_materialization(
@@ -444,7 +324,6 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
             default: OnceCell::new(),
             top_materialization: OnceCell::new(),
             bottom_materialization: OnceCell::new(),
-            materialization_polarity: OnceCell::new(),
             materialization_equivalence,
             invariant_relation: OnceCell::new(),
         }
@@ -457,7 +336,6 @@ impl Default for ApplyTypeMappingVisitor<'_> {
             default: OnceCell::new(),
             top_materialization: OnceCell::new(),
             bottom_materialization: OnceCell::new(),
-            materialization_polarity: OnceCell::new(),
             materialization_equivalence: OnceCell::new(),
             invariant_relation: OnceCell::new(),
         }
@@ -1477,17 +1355,6 @@ impl<'db> Type<'db> {
 
     pub(crate) fn has_divergent_eager_expansion(self, db: &'db dyn Db) -> bool {
         any_over_type(db, self.expand_eagerly(db), false, |ty| ty.is_divergent())
-    }
-
-    pub(crate) fn has_materialization_oscillation(self, db: &'db dyn Db) -> bool {
-        any_over_type(db, self, true, |ty| {
-            matches!(ty, Type::Intersection(intersection)
-                if intersection.is_simple_negation(db)
-                    && intersection
-                        .negative(db)
-                        .iter()
-                        .any(|negative| negative.has_divergent_eager_expansion(db)))
-        })
     }
 
     pub(crate) const fn as_special_form(self) -> Option<SpecialFormType> {
@@ -5930,7 +5797,7 @@ impl<'db> Type<'db> {
                 element.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
             }),
             Type::Intersection(intersection) => {
-                let apply_mapping = || {
+                visitor.visit(db, self, type_mapping, || {
                     let mut builder = IntersectionBuilder::new(db);
                     for positive in intersection.positive(db) {
                         builder = builder.add_positive(
@@ -5950,18 +5817,7 @@ impl<'db> Type<'db> {
                         }
                     }
                     builder.build()
-                };
-
-                match type_mapping {
-                    TypeMapping::Materialize(materialization_kind) => visitor
-                        .visit_materialization_polarity(
-                            db,
-                            self,
-                            *materialization_kind,
-                            apply_mapping,
-                        ),
-                    _ => visitor.visit(db, self, type_mapping, apply_mapping),
-                }
+                })
             }
 
             // TODO(jelle): Materialize should be handled differently, since TypeIs is invariant
@@ -6019,13 +5875,6 @@ impl<'db> Type<'db> {
                 // incomplete.
                 if !is_recursive && alias.value_type(db) == mapped {
                     self
-                } else if is_recursive
-                    && matches!(type_mapping, TypeMapping::Materialize(_))
-                    && alias
-                        .raw_value_type(db)
-                        .has_materialization_oscillation(db)
-                {
-                    mapped.expand_eagerly(db)
                 } else {
                     mapped
                 }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4,7 +4,8 @@ use ruff_diagnostics::{Edit, Fix};
 use rustc_hash::FxHashMap;
 
 use std::borrow::Cow;
-use std::cell::OnceCell;
+use std::cell::{OnceCell, RefCell};
+use std::hash::Hash;
 use std::iter;
 use std::rc::Rc;
 use std::time::Duration;
@@ -18,10 +19,12 @@ use ruff_db::files::File;
 use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
+use salsa::plumbing::AsId;
 use smallvec::smallvec_inline;
 use ty_module_resolver::{KnownModule, Module, ModuleName, resolve_module};
 
 pub(crate) use self::callable::UpcastPolicy;
+use self::cyclic::ActiveRecursionDetector;
 pub use self::cyclic::CycleDetector;
 pub(crate) use self::cyclic::TypeTransformer;
 pub(crate) use self::diagnostic::register_lints;
@@ -244,6 +247,89 @@ struct ApplyMaterializationEquivalence;
 type MaterializationEquivalenceVisitor<'db> =
     Rc<CycleDetector<ApplyMaterializationEquivalence, (Type<'db>, Type<'db>), bool>>;
 
+#[derive(Debug, Default, Clone, Copy)]
+struct ActiveMaterializationKinds {
+    top: u32,
+    bottom: u32,
+}
+
+impl ActiveMaterializationKinds {
+    fn contains(self, kind: MaterializationKind) -> bool {
+        match kind {
+            MaterializationKind::Top => self.top > 0,
+            MaterializationKind::Bottom => self.bottom > 0,
+        }
+    }
+
+    fn insert(&mut self, kind: MaterializationKind) {
+        match kind {
+            MaterializationKind::Top => self.top += 1,
+            MaterializationKind::Bottom => self.bottom += 1,
+        }
+    }
+
+    fn remove(&mut self, kind: MaterializationKind) {
+        match kind {
+            MaterializationKind::Top => self.top -= 1,
+            MaterializationKind::Bottom => self.bottom -= 1,
+        }
+    }
+
+    fn is_empty(self) -> bool {
+        self.top == 0 && self.bottom == 0
+    }
+}
+
+#[derive(Debug)]
+struct MaterializationPolarityDetector<T> {
+    seen: RefCell<FxHashMap<T, ActiveMaterializationKinds>>,
+}
+
+impl<T> Default for MaterializationPolarityDetector<T> {
+    fn default() -> Self {
+        Self {
+            seen: RefCell::new(FxHashMap::default()),
+        }
+    }
+}
+
+impl<T: Hash + Eq + Clone> MaterializationPolarityDetector<T> {
+    fn visit<R>(
+        &self,
+        item: &T,
+        materialization_kind: MaterializationKind,
+        on_cycle: impl FnOnce() -> R,
+        func: impl FnOnce() -> R,
+    ) -> R {
+        {
+            let mut seen = self.seen.borrow_mut();
+            if seen
+                .get(item)
+                .is_some_and(|active| active.contains(materialization_kind.flip()))
+            {
+                return on_cycle();
+            }
+
+            seen.entry(item.clone())
+                .or_default()
+                .insert(materialization_kind);
+        }
+
+        let ret = func();
+
+        let mut seen = self.seen.borrow_mut();
+        let entry = seen
+            .get_mut(item)
+            .expect("active materialization entry must exist");
+        entry.remove(materialization_kind);
+        if entry.is_empty() {
+            seen.remove(item);
+        }
+
+        ret
+    }
+}
+
 /// A [`TypeTransformer`] that is used in `apply_type_mapping` methods.
 ///
 /// Materialization is the only mapping mode that needs to visit the same type under two different
@@ -253,7 +339,9 @@ pub(crate) struct ApplyTypeMappingVisitor<'db> {
     default: OnceCell<TypeTransformer<'db, ApplyDefaultTypeMapping>>,
     top_materialization: OnceCell<TypeTransformer<'db, ApplyTopMaterialization>>,
     bottom_materialization: OnceCell<TypeTransformer<'db, ApplyBottomMaterialization>>,
+    materialization_polarity: OnceCell<MaterializationPolarityDetector<Type<'db>>>,
     materialization_equivalence: OnceCell<MaterializationEquivalenceVisitor<'db>>,
+    invariant_relation: OnceCell<ActiveRecursionDetector<(Type<'db>, Type<'db>)>>,
 }
 
 impl<'db> ApplyTypeMappingVisitor<'db> {
@@ -262,8 +350,19 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
             .get_or_init(|| Rc::new(CycleDetector::new(true)))
     }
 
+    fn materialization_polarity(&self) -> &MaterializationPolarityDetector<Type<'db>> {
+        self.materialization_polarity
+            .get_or_init(MaterializationPolarityDetector::default)
+    }
+
+    fn invariant_relation(&self) -> &ActiveRecursionDetector<(Type<'db>, Type<'db>)> {
+        self.invariant_relation
+            .get_or_init(ActiveRecursionDetector::default)
+    }
+
     pub(crate) fn visit(
         &self,
+        _db: &'db dyn Db,
         ty: Type<'db>,
         type_mapping: &TypeMapping<'_, 'db>,
         func: impl FnOnce() -> Type<'db>,
@@ -284,6 +383,35 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
         }
     }
 
+    fn visit_materialization_polarity(
+        &self,
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        materialization_kind: MaterializationKind,
+        func: impl FnOnce() -> Type<'db>,
+    ) -> Type<'db> {
+        let polarity_key = ty.expand_eagerly(db);
+        self.materialization_polarity().visit(
+            &polarity_key,
+            materialization_kind,
+            || {
+                let cycle = DivergentType::new(InternedType::new(db, polarity_key).as_id())
+                    .materialized(materialization_kind);
+                Type::Divergent(cycle)
+            },
+            || match materialization_kind {
+                MaterializationKind::Top => self
+                    .top_materialization
+                    .get_or_init(TypeTransformer::default)
+                    .visit(ty, func),
+                MaterializationKind::Bottom => self
+                    .bottom_materialization
+                    .get_or_init(TypeTransformer::default)
+                    .visit(ty, func),
+            },
+        )
+    }
+
     pub(crate) fn is_equivalent_to_materialization(
         &self,
         db: &'db dyn Db,
@@ -293,6 +421,17 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
         self.materialization_equivalence().visit((left, right), || {
             left.is_equivalent_to_with_materialization_visitor(db, right, self)
         })
+    }
+
+    pub(crate) fn visit_invariant_relation<R>(
+        &self,
+        source: Type<'db>,
+        target: Type<'db>,
+        on_cycle: impl FnOnce() -> R,
+        func: impl FnOnce() -> R,
+    ) -> R {
+        self.invariant_relation()
+            .visit(&(source, target), on_cycle, func)
     }
 
     pub(crate) fn for_new_materialization_root(&self) -> Self {
@@ -305,7 +444,9 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
             default: OnceCell::new(),
             top_materialization: OnceCell::new(),
             bottom_materialization: OnceCell::new(),
+            materialization_polarity: OnceCell::new(),
             materialization_equivalence,
+            invariant_relation: OnceCell::new(),
         }
     }
 }
@@ -316,7 +457,9 @@ impl Default for ApplyTypeMappingVisitor<'_> {
             default: OnceCell::new(),
             top_materialization: OnceCell::new(),
             bottom_materialization: OnceCell::new(),
+            materialization_polarity: OnceCell::new(),
             materialization_equivalence: OnceCell::new(),
+            invariant_relation: OnceCell::new(),
         }
     }
 }
@@ -1213,7 +1356,7 @@ impl<'db> Type<'db> {
         match self {
             Type::NominalInstance(instance) => Some(instance.class(db)),
             Type::ProtocolInstance(instance) => instance.to_nominal_instance().map(|i| i.class(db)),
-            Type::TypeAlias(alias) => alias.value_type(db).nominal_class(db),
+            Type::TypeAlias(_) => self.resolve_type_alias(db).nominal_class(db),
             Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).nominal_class(db),
             Type::TypeVar(typevar) => {
                 let TypeVarBoundOrConstraints::UpperBound(bound) =
@@ -1332,6 +1475,21 @@ impl<'db> Type<'db> {
         any_over_type(db, self, false, |ty| ty.is_dynamic())
     }
 
+    pub(crate) fn has_divergent_eager_expansion(self, db: &'db dyn Db) -> bool {
+        any_over_type(db, self.expand_eagerly(db), false, |ty| ty.is_divergent())
+    }
+
+    pub(crate) fn has_materialization_oscillation(self, db: &'db dyn Db) -> bool {
+        any_over_type(db, self, true, |ty| {
+            matches!(ty, Type::Intersection(intersection)
+                if intersection.is_simple_negation(db)
+                    && intersection
+                        .negative(db)
+                        .iter()
+                        .any(|negative| negative.has_divergent_eager_expansion(db)))
+        })
+    }
+
     pub(crate) const fn as_special_form(self) -> Option<SpecialFormType> {
         match self {
             Type::SpecialForm(special_form) => Some(special_form),
@@ -1365,7 +1523,13 @@ impl<'db> Type<'db> {
     pub(crate) fn resolve_type_alias(self, db: &'db dyn Db) -> Type<'db> {
         let mut ty = self;
         while let Type::TypeAlias(alias) = ty {
-            ty = alias.value_type(db);
+            let value_ty = alias.value_type(db);
+            let expanded_value_ty = value_ty.expand_eagerly(db);
+            ty = if expanded_value_ty.is_divergent() {
+                expanded_value_ty
+            } else {
+                value_ty
+            };
         }
         ty
     }
@@ -2280,7 +2444,7 @@ impl<'db> Type<'db> {
             Type::TypeIs(type_is) => type_is.is_bound(db),
             Type::TypeGuard(type_guard) => type_guard.is_bound(db),
             Type::TypedDict(_) => false,
-            Type::TypeAlias(alias) => alias.value_type(db).is_singleton(db),
+            Type::TypeAlias(_) => self.resolve_type_alias(db).is_singleton(db),
             Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).is_singleton(db),
         }
     }
@@ -2351,7 +2515,7 @@ impl<'db> Type<'db> {
             Type::TypeIs(type_is) => type_is.is_bound(db),
             Type::TypeGuard(type_guard) => type_guard.is_bound(db),
 
-            Type::TypeAlias(alias) => alias.value_type(db).is_single_valued(db),
+            Type::TypeAlias(_) => self.resolve_type_alias(db).is_single_valued(db),
 
             Type::Dynamic(_)
             | Type::Divergent(_)
@@ -2479,8 +2643,8 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::TypeAlias(alias) => alias
-                .value_type(db)
+            Type::TypeAlias(_) => (*self)
+                .resolve_type_alias(db)
                 .find_name_in_mro_with_policy(db, name, policy),
 
             Type::FunctionLiteral(_)
@@ -2690,7 +2854,7 @@ impl<'db> Type<'db> {
 
             Type::TypedDict(_) => Place::Undefined.into(),
 
-            Type::TypeAlias(alias) => alias.value_type(db).instance_member(db, name),
+            Type::TypeAlias(_) => (*self).resolve_type_alias(db).instance_member(db, name),
         }
     }
 
@@ -3409,8 +3573,8 @@ impl<'db> Type<'db> {
                     .member_lookup_with_policy(db, name, policy)
             }
 
-            Type::TypeAlias(alias) => alias
-                .value_type(db)
+            Type::TypeAlias(_) => self
+                .resolve_type_alias(db)
                 .member_lookup_with_policy(db, name, policy),
 
             _ if policy.no_instance_fallback() => self.invoke_descriptor_protocol(
@@ -3750,8 +3914,32 @@ impl<'db> Type<'db> {
     /// elements. It's usually best to only worry about "callability" relative to a particular
     /// argument list, via [`try_call`][Self::try_call] and [`CallErrorKind::NotCallable`].
     fn bindings(self, db: &'db dyn Db) -> Bindings<'db> {
+        let recursion_guard = ActiveRecursionDetector::default();
+        self.bindings_impl(db, &recursion_guard)
+    }
+
+    fn unknown_bindings() -> Bindings<'db> {
+        let unknown = Type::unknown();
+        Binding::single(unknown, Signature::dynamic(unknown)).into()
+    }
+
+    fn bindings_impl(
+        self,
+        db: &'db dyn Db,
+        recursion_guard: &ActiveRecursionDetector<Type<'db>>,
+    ) -> Bindings<'db> {
+        recursion_guard.visit(&self, Self::unknown_bindings, || {
+            self.bindings_inner(db, recursion_guard)
+        })
+    }
+
+    fn bindings_inner(
+        self,
+        db: &'db dyn Db,
+        recursion_guard: &ActiveRecursionDetector<Type<'db>>,
+    ) -> Bindings<'db> {
         if let Some(fallback) = self.materialized_divergent_fallback() {
-            return fallback.bindings(db);
+            return fallback.bindings_impl(db, recursion_guard);
         }
 
         match self {
@@ -3763,11 +3951,16 @@ impl<'db> Type<'db> {
             Type::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => CallableBinding::not_callable(self).into(),
-                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound.bindings(db),
+                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                        bound.bindings_impl(db, recursion_guard)
+                    }
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                         Bindings::from_union(
                             self,
-                            constraints.elements(db).iter().map(|ty| ty.bindings(db)),
+                            constraints
+                                .elements(db)
+                                .iter()
+                                .map(|constraint| constraint.bindings_impl(db, recursion_guard)),
                         )
                     }
                 }
@@ -4011,17 +4204,20 @@ impl<'db> Type<'db> {
                 SubclassOfInner::TypeVar(tvar) => {
                     let constructor_instance_type = Type::TypeVar(tvar);
                     let bindings = match tvar.typevar(db).bound_or_constraints(db) {
-                        None => KnownClass::Type.to_instance(db).bindings(db),
+                        None => KnownClass::Type
+                            .to_instance(db)
+                            .bindings_impl(db, recursion_guard),
                         Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                            bound.to_meta_type(db).bindings(db)
+                            bound.to_meta_type(db).bindings_impl(db, recursion_guard)
                         }
                         Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                             Bindings::from_union(
                                 self,
-                                constraints
-                                    .elements(db)
-                                    .iter()
-                                    .map(|ty| ty.to_meta_type(db).bindings(db)),
+                                constraints.elements(db).iter().map(|constraint| {
+                                    constraint
+                                        .to_meta_type(db)
+                                        .bindings_impl(db, recursion_guard)
+                                }),
                             )
                         }
                     };
@@ -4070,7 +4266,7 @@ impl<'db> Type<'db> {
                         definedness: boundness,
                         ..
                     }) => {
-                        let mut bindings = dunder_callable.bindings(db);
+                        let mut bindings = dunder_callable.bindings_impl(db, recursion_guard);
                         bindings.replace_callable_type(dunder_callable, self);
                         if boundness == Definedness::PossiblyUndefined {
                             bindings.set_dunder_call_is_possibly_unbound();
@@ -4093,14 +4289,14 @@ impl<'db> Type<'db> {
                 union
                     .elements(db)
                     .iter()
-                    .map(|element| element.bindings(db)),
+                    .map(|element| element.bindings_impl(db, recursion_guard)),
             ),
 
             Type::Intersection(intersection) => Bindings::from_intersection(
                 self,
                 intersection
                     .positive_elements_or_object(db)
-                    .map(|element| element.bindings(db)),
+                    .map(|element| element.bindings_impl(db, recursion_guard)),
             ),
 
             Type::DataclassDecorator(_) => {
@@ -4125,9 +4321,9 @@ impl<'db> Type<'db> {
             Type::SpecialForm(_) => CallableBinding::not_callable(self).into(),
 
             Type::LiteralValue(literal) => match literal.kind() {
-                LiteralValueTypeKind::Enum(enum_literal) => {
-                    enum_literal.enum_class_instance(db).bindings(db)
-                }
+                LiteralValueTypeKind::Enum(enum_literal) => enum_literal
+                    .enum_class_instance(db)
+                    .bindings_impl(db, recursion_guard),
                 _ => CallableBinding::not_callable(self).into(),
             },
 
@@ -4144,11 +4340,11 @@ impl<'db> Type<'db> {
             )
             .into(),
 
-            Type::KnownInstance(known_instance) => {
-                known_instance.instance_fallback(db).bindings(db)
-            }
+            Type::KnownInstance(known_instance) => known_instance
+                .instance_fallback(db)
+                .bindings_impl(db, recursion_guard),
 
-            Type::TypeAlias(alias) => alias.value_type(db).bindings(db),
+            Type::TypeAlias(alias) => alias.value_type(db).bindings_impl(db, recursion_guard),
 
             Type::PropertyInstance(_)
             | Type::AlwaysFalsy
@@ -5157,7 +5353,7 @@ impl<'db> Type<'db> {
             // has no instance type. Otherwise, synthesize a typevar with bound or constraints
             // mapped through `to_instance`.
             Type::TypeVar(bound_typevar) => Some(Type::TypeVar(bound_typevar.to_instance(db)?)),
-            Type::TypeAlias(alias) => alias.value_type(db).to_instance(db),
+            Type::TypeAlias(_) => self.resolve_type_alias(db).to_instance(db),
             Type::Intersection(_) => Some(todo_type!("Type::Intersection.to_instance")),
             // An instance of class `C` may itself have instances if `C` is a subclass of `type`.
             Type::NominalInstance(instance)
@@ -5397,7 +5593,7 @@ impl<'db> Type<'db> {
 
             Type::Intersection(_) => Ok(todo_type!("Type::Intersection.in_type_expression")),
 
-            Type::TypeAlias(alias) => alias.value_type(db).in_type_expression(
+            Type::TypeAlias(_) => self.resolve_type_alias(db).in_type_expression(
                 db,
                 scope_id,
                 typevar_binding_context,
@@ -5425,13 +5621,43 @@ impl<'db> Type<'db> {
     /// See `Self::dunder_class` for more details.
     #[must_use]
     pub(crate) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {
+        let recursion_guard = ActiveRecursionDetector::default();
+        self.to_meta_type_impl(db, &recursion_guard)
+    }
+
+    fn to_meta_type_impl(
+        self,
+        db: &'db dyn Db,
+        recursion_guard: &ActiveRecursionDetector<Type<'db>>,
+    ) -> Type<'db> {
+        recursion_guard.visit(
+            &self,
+            || {
+                let expanded = self.expand_eagerly(db);
+                if expanded == self {
+                    Type::unknown()
+                } else {
+                    expanded.to_meta_type_impl(db, recursion_guard)
+                }
+            },
+            || self.to_meta_type_inner(db, recursion_guard),
+        )
+    }
+
+    fn to_meta_type_inner(
+        self,
+        db: &'db dyn Db,
+        recursion_guard: &ActiveRecursionDetector<Type<'db>>,
+    ) -> Type<'db> {
         match self {
             Type::Never => Type::Never,
             Type::NominalInstance(instance) => instance.to_meta_type(db),
             Type::KnownInstance(known_instance) => known_instance.to_meta_type(db),
             Type::SpecialForm(special_form) => special_form.to_meta_type(db),
             Type::PropertyInstance(_) => KnownClass::Property.to_class_literal(db),
-            Type::Union(union) => union.map(db, |ty| ty.to_meta_type(db)),
+            Type::Union(union) => {
+                union.map(db, |element| element.to_meta_type_impl(db, recursion_guard))
+            }
             Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool.to_class_literal(db),
             Type::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Bool(_) => KnownClass::Bool.to_class_literal(db),
@@ -5479,8 +5705,12 @@ impl<'db> Type<'db> {
                     todo_type!("TypedDict synthesized meta-type").expect_dynamic(),
                 ),
             },
-            Type::TypeAlias(alias) => alias.value_type(db).to_meta_type(db),
-            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).to_meta_type(db),
+            Type::TypeAlias(_) => self
+                .resolve_type_alias(db)
+                .to_meta_type_impl(db, recursion_guard),
+            Type::NewTypeInstance(newtype) => newtype
+                .concrete_base_type(db)
+                .to_meta_type_impl(db, recursion_guard),
         }
     }
 
@@ -5584,7 +5814,7 @@ impl<'db> Type<'db> {
             Type::TypeVar(bound_typevar) => bound_typevar.apply_type_mapping_impl(db, type_mapping, visitor),
             Type::KnownInstance(known_instance) => known_instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
 
-            Type::FunctionLiteral(function) => visitor.visit(self, type_mapping, || {
+            Type::FunctionLiteral(function) => visitor.visit(db, self, type_mapping, || {
                 match type_mapping {
                     // Promote the types within the signature before promoting the signature to its
                     // callable form.
@@ -5632,7 +5862,7 @@ impl<'db> Type<'db> {
                 instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
             },
 
-            Type::NewTypeInstance(newtype) => visitor.visit(self, type_mapping, || {
+            Type::NewTypeInstance(newtype) => visitor.visit(db, self, type_mapping, || {
                 Type::NewTypeInstance(newtype.map_base_class_type(db, |class_type| {
                     class_type.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
                 }))
@@ -5700,25 +5930,42 @@ impl<'db> Type<'db> {
                 element.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
             }),
             Type::Intersection(intersection) => {
-                let mut builder = IntersectionBuilder::new(db);
-                for positive in intersection.positive(db) {
-                    builder =
-                        builder.add_positive(positive.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
-                }
-                // Promotion should remove negative contributions from intersections,
-                // so we don't preserve them here when promotion is enabled.
-                if !matches!(type_mapping, TypeMapping::Promote(PromotionMode::On, _)) {
-                    for negative in intersection.negative(db) {
-                        builder = builder.add_negative(
-                            negative.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor),
+                let apply_mapping = || {
+                    let mut builder = IntersectionBuilder::new(db);
+                    for positive in intersection.positive(db) {
+                        builder = builder.add_positive(
+                            positive.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                         );
                     }
+                    // Promotion should remove negative contributions from intersections,
+                    // so we don't preserve them here when promotion is enabled.
+                    if !matches!(type_mapping, TypeMapping::Promote(PromotionMode::On, _)) {
+                        for negative in intersection.negative(db) {
+                            builder = builder.add_negative(negative.apply_type_mapping_impl(
+                                db,
+                                &type_mapping.flip(),
+                                tcx,
+                                visitor,
+                            ));
+                        }
+                    }
+                    builder.build()
+                };
+
+                match type_mapping {
+                    TypeMapping::Materialize(materialization_kind) => visitor
+                        .visit_materialization_polarity(
+                            db,
+                            self,
+                            *materialization_kind,
+                            apply_mapping,
+                        ),
+                    _ => visitor.visit(db, self, type_mapping, apply_mapping),
                 }
-                builder.build()
             }
 
             // TODO(jelle): Materialize should be handled differently, since TypeIs is invariant
-            Type::TypeIs(type_is) => visitor.visit(self, type_mapping, || {
+            Type::TypeIs(type_is) => visitor.visit(db, self, type_mapping, || {
                 type_is.with_type(
                     db,
                     type_is
@@ -5727,7 +5974,7 @@ impl<'db> Type<'db> {
                 )
             }),
 
-            Type::TypeGuard(type_guard) => visitor.visit(self, type_mapping, || {
+            Type::TypeGuard(type_guard) => visitor.visit(db, self, type_mapping, || {
                 type_guard.with_type(
                     db,
                     type_guard
@@ -5751,7 +5998,7 @@ impl<'db> Type<'db> {
                 // IMPORTANT: All processing must happen inside a single visitor.visit() call so that if we encounter
                 // this same TypeAlias again (e.g., in `type RecursiveT = int | tuple[RecursiveT, ...]`), the visitor
                 // will detect the cycle and return the fallback value.
-                let mapped = visitor.visit(self, type_mapping, || {
+                let mapped = visitor.visit(db, self, type_mapping, || {
                     match type_mapping {
                         TypeMapping::EagerExpansion => unreachable!("handled above"),
 
@@ -5762,7 +6009,8 @@ impl<'db> Type<'db> {
                     }
                 });
 
-                let is_recursive = any_over_type(db, alias.raw_value_type(db).expand_eagerly(db), false, |ty| ty.is_divergent());
+                let is_recursive = alias.raw_value_type(db).has_divergent_eager_expansion(db)
+                    || any_over_type(db, mapped, false, |ty| ty == self);
 
                 // If the type mapping does not result in any change to this (non-recursive) type alias, do not expand it.
                 //
@@ -5771,6 +6019,13 @@ impl<'db> Type<'db> {
                 // incomplete.
                 if !is_recursive && alias.value_type(db) == mapped {
                     self
+                } else if is_recursive
+                    && matches!(type_mapping, TypeMapping::Materialize(_))
+                    && alias
+                        .raw_value_type(db)
+                        .has_materialization_oscillation(db)
+                {
+                    mapped.expand_eagerly(db)
                 } else {
                     mapped
                 }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -22,6 +22,7 @@ use smallvec::smallvec_inline;
 use ty_module_resolver::{KnownModule, Module, ModuleName, resolve_module};
 
 pub(crate) use self::callable::UpcastPolicy;
+use self::cyclic::ActiveRecursionDetector;
 pub use self::cyclic::CycleDetector;
 pub(crate) use self::cyclic::TypeTransformer;
 pub(crate) use self::diagnostic::register_lints;
@@ -241,6 +242,8 @@ fn definition_expression_type<'db>(
 }
 
 struct ApplyDefaultTypeMapping;
+struct ApplyPromoteOnTypeMapping;
+struct ApplyPromoteOffTypeMapping;
 struct ApplyTopMaterialization;
 struct ApplyBottomMaterialization;
 struct ApplyMaterializationEquivalence;
@@ -250,11 +253,13 @@ type MaterializationEquivalenceVisitor<'db> =
 
 /// A [`TypeTransformer`] that is used in `apply_type_mapping` methods.
 ///
-/// Materialization is the only mapping mode that needs to visit the same type under two different
-/// mappings within a single recursive call chain (`Top` and `Bottom`). Keep separate cycle caches
-/// for those modes so invariant checks can safely reuse one visitor.
+/// Promotion and materialization can visit the same type under two different mappings within a
+/// single recursive call chain. Keep separate cycle caches for those modes so invariant checks and
+/// callable promotion can safely reuse one visitor.
 pub(crate) struct ApplyTypeMappingVisitor<'db> {
     default: OnceCell<TypeTransformer<'db, ApplyDefaultTypeMapping>>,
+    promote_on: OnceCell<TypeTransformer<'db, ApplyPromoteOnTypeMapping>>,
+    promote_off: OnceCell<TypeTransformer<'db, ApplyPromoteOffTypeMapping>>,
     top_materialization: OnceCell<TypeTransformer<'db, ApplyTopMaterialization>>,
     bottom_materialization: OnceCell<TypeTransformer<'db, ApplyBottomMaterialization>>,
     materialization_equivalence: OnceCell<MaterializationEquivalenceVisitor<'db>>,
@@ -274,6 +279,14 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
         func: impl FnOnce() -> Type<'db>,
     ) -> Type<'db> {
         match type_mapping {
+            TypeMapping::Promote(PromotionMode::On, _) => self
+                .promote_on
+                .get_or_init(TypeTransformer::default)
+                .visit_type(db, ty, func),
+            TypeMapping::Promote(PromotionMode::Off, _) => self
+                .promote_off
+                .get_or_init(TypeTransformer::default)
+                .visit_type(db, ty, func),
             TypeMapping::Materialize(MaterializationKind::Top) => self
                 .top_materialization
                 .get_or_init(TypeTransformer::default)
@@ -308,6 +321,8 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
 
         Self {
             default: OnceCell::new(),
+            promote_on: OnceCell::new(),
+            promote_off: OnceCell::new(),
             top_materialization: OnceCell::new(),
             bottom_materialization: OnceCell::new(),
             materialization_equivalence,
@@ -319,6 +334,8 @@ impl Default for ApplyTypeMappingVisitor<'_> {
     fn default() -> Self {
         Self {
             default: OnceCell::new(),
+            promote_on: OnceCell::new(),
+            promote_off: OnceCell::new(),
             top_materialization: OnceCell::new(),
             bottom_materialization: OnceCell::new(),
             materialization_equivalence: OnceCell::new(),
@@ -1368,11 +1385,72 @@ impl<'db> Type<'db> {
     /// If this type is a `Type::TypeAlias`, recursively resolves it to its
     /// underlying value type. Otherwise, returns `self` unchanged.
     pub(crate) fn resolve_type_alias(self, db: &'db dyn Db) -> Type<'db> {
-        let mut ty = self;
-        while let Type::TypeAlias(alias) = ty {
-            ty = alias.value_type(db);
+        let recursion_detector = ActiveRecursionDetector::default();
+        self.resolve_type_alias_impl(db, &recursion_detector)
+    }
+
+    fn resolve_type_alias_impl(
+        self,
+        db: &'db dyn Db,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) -> Type<'db> {
+        match self {
+            Type::TypeAlias(alias) => recursion_detector.visit(
+                &self,
+                || self,
+                || {
+                    alias
+                        .value_type(db)
+                        .resolve_type_alias_impl(db, recursion_detector)
+                },
+            ),
+            _ => self,
         }
-        ty
+    }
+
+    /// If this type is a type alias, visit its value type with active-recursion tracking.
+    ///
+    /// The caller owns the fallback result because different operations need different conservative
+    /// answers when a recursive alias points back to itself.
+    pub(crate) fn visit_type_alias_value<R>(
+        self,
+        db: &'db dyn Db,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+        on_cycle: impl FnOnce() -> R,
+        visit_value: impl FnOnce(Type<'db>) -> R,
+    ) -> R {
+        if let Type::TypeAlias(alias) = self {
+            recursion_detector.visit(&self, on_cycle, || visit_value(alias.value_type(db)))
+        } else {
+            visit_value(self)
+        }
+    }
+
+    /// If this type is a type alias, visit its value type with active-recursion tracking.
+    ///
+    /// This variant returns `R::default()` when a recursive alias points back to itself. Use this
+    /// for predicate and extraction operations where "not available" is the conservative answer.
+    pub(crate) fn visit_type_alias_value_or_default<R: Default>(
+        self,
+        db: &'db dyn Db,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+        visit_value: impl FnOnce(Type<'db>) -> R,
+    ) -> R {
+        self.visit_type_alias_value(db, recursion_detector, R::default, visit_value)
+    }
+
+    /// If this type is a type alias, visit its value type with active-recursion tracking.
+    ///
+    /// This variant returns `true` when a recursive alias points back to itself. Use this for
+    /// validation operations where emitting an error from an unexpanded recursive component would
+    /// be less accurate than accepting the operation.
+    pub(crate) fn visit_type_alias_value_or_assume_valid(
+        self,
+        db: &'db dyn Db,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+        visit_value: impl FnOnce(Type<'db>) -> bool,
+    ) -> bool {
+        self.visit_type_alias_value(db, recursion_detector, || true, visit_value)
     }
 
     /// Returns `Some(UnionType)` if this type behaves like a union. Apart from explicit unions,
@@ -2169,6 +2247,15 @@ impl<'db> Type<'db> {
     /// Note: This function aims to have no false positives, but might return `false`
     /// for more complicated types that are actually singletons.
     pub(crate) fn is_singleton(self, db: &'db dyn Db) -> bool {
+        let recursion_detector = ActiveRecursionDetector::default();
+        self.is_singleton_impl(db, &recursion_detector)
+    }
+
+    fn is_singleton_impl(
+        self,
+        db: &'db dyn Db,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) -> bool {
         match self {
             Type::Dynamic(_) | Type::Divergent(_) | Type::Never => false,
 
@@ -2218,7 +2305,7 @@ impl<'db> Type<'db> {
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
                         .elements(db)
                         .iter()
-                        .all(|constraint| constraint.is_singleton(db)),
+                        .all(|constraint| constraint.is_singleton_impl(db, recursion_detector)),
                 }
             }
 
@@ -2286,13 +2373,28 @@ impl<'db> Type<'db> {
             Type::TypeIs(type_is) => type_is.is_bound(db),
             Type::TypeGuard(type_guard) => type_guard.is_bound(db),
             Type::TypedDict(_) => false,
-            Type::TypeAlias(alias) => alias.value_type(db).is_singleton(db),
-            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).is_singleton(db),
+            Type::TypeAlias(_) => {
+                self.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
+                    value_ty.is_singleton_impl(db, recursion_detector)
+                })
+            }
+            Type::NewTypeInstance(newtype) => newtype
+                .concrete_base_type(db)
+                .is_singleton_impl(db, recursion_detector),
         }
     }
 
     /// Return true if this type is non-empty and all inhabitants of this type compare equal.
     pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
+        let recursion_detector = ActiveRecursionDetector::default();
+        self.is_single_valued_impl(db, &recursion_detector)
+    }
+
+    pub(crate) fn is_single_valued_impl(
+        self,
+        db: &'db dyn Db,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) -> bool {
         match self {
             // Each `partial()` call creates a distinct object at runtime.
             Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_)) => false,
@@ -2335,7 +2437,7 @@ impl<'db> Type<'db> {
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
                         .elements(db)
                         .iter()
-                        .all(|constraint| constraint.is_single_valued(db)),
+                        .all(|constraint| constraint.is_single_valued_impl(db, recursion_detector)),
                 }
             }
 
@@ -2344,8 +2446,12 @@ impl<'db> Type<'db> {
                 false
             }
 
-            Type::NominalInstance(instance) => instance.is_single_valued(db),
-            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).is_single_valued(db),
+            Type::NominalInstance(instance) => {
+                instance.is_single_valued_impl(db, recursion_detector)
+            }
+            Type::NewTypeInstance(newtype) => newtype
+                .concrete_base_type(db)
+                .is_single_valued_impl(db, recursion_detector),
 
             Type::BoundSuper(_) => {
                 // At runtime two super instances never compare equal, even if their arguments are identical.
@@ -2360,7 +2466,11 @@ impl<'db> Type<'db> {
             Type::TypeIs(type_is) => type_is.is_bound(db),
             Type::TypeGuard(type_guard) => type_guard.is_bound(db),
 
-            Type::TypeAlias(alias) => alias.value_type(db).is_single_valued(db),
+            Type::TypeAlias(_) => {
+                self.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
+                    value_ty.is_single_valued_impl(db, recursion_detector)
+                })
+            }
 
             Type::Dynamic(_)
             | Type::Divergent(_)
@@ -3664,7 +3774,11 @@ impl<'db> Type<'db> {
     /// In the second case, the return type of `len()` in `typeshed` (`int`)
     /// is used as a fallback.
     fn len(&self, db: &'db dyn Db) -> Option<Type<'db>> {
-        fn non_negative_int_literal<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
+        fn non_negative_int_literal_impl<'db>(
+            db: &'db dyn Db,
+            ty: Type<'db>,
+            recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+        ) -> Option<Type<'db>> {
             match ty {
                 // TODO: Emit diagnostic for non-integers and negative integers
                 Type::LiteralValue(literal) => match literal.kind() {
@@ -3672,8 +3786,13 @@ impl<'db> Type<'db> {
                     LiteralValueTypeKind::Bool(value) => Some(Type::int_literal(i64::from(value))),
                     _ => None,
                 },
-                Type::Union(union) => {
-                    union.try_map(db, |element| non_negative_int_literal(db, *element))
+                Type::Union(union) => union.try_map(db, |element| {
+                    non_negative_int_literal_impl(db, *element, recursion_detector)
+                }),
+                Type::TypeAlias(_) => {
+                    ty.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
+                        non_negative_int_literal_impl(db, value_ty, recursion_detector)
+                    })
                 }
                 _ => None,
             }
@@ -3703,7 +3822,8 @@ impl<'db> Type<'db> {
             Err(CallDunderError::CallError(_, bindings)) => bindings.return_type(db),
         };
 
-        non_negative_int_literal(db, return_ty)
+        let recursion_detector = ActiveRecursionDetector::default();
+        non_negative_int_literal_impl(db, return_ty, &recursion_detector)
     }
 
     /// If this type is a `ParamSpec` type variable, returns it. Otherwise, returns `None`.
@@ -3792,8 +3912,23 @@ impl<'db> Type<'db> {
     /// elements. It's usually best to only worry about "callability" relative to a particular
     /// argument list, via [`try_call`][Self::try_call] and [`CallErrorKind::NotCallable`].
     fn bindings(self, db: &'db dyn Db) -> Bindings<'db> {
+        let recursion_detector = ActiveRecursionDetector::default();
+        self.bindings_impl(db, &recursion_detector)
+    }
+
+    /// Returns dynamic call bindings used as the conservative fallback for recursive callability.
+    fn unknown_bindings() -> Bindings<'db> {
+        let unknown = Type::unknown();
+        Binding::single(unknown, Signature::dynamic(unknown)).into()
+    }
+
+    fn bindings_impl(
+        self,
+        db: &'db dyn Db,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) -> Bindings<'db> {
         if let Some(fallback) = self.materialized_divergent_fallback() {
-            return fallback.bindings(db);
+            return fallback.bindings_impl(db, recursion_detector);
         }
 
         match self {
@@ -3805,11 +3940,16 @@ impl<'db> Type<'db> {
             Type::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => CallableBinding::not_callable(self).into(),
-                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound.bindings(db),
+                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                        bound.bindings_impl(db, recursion_detector)
+                    }
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                         Bindings::from_union(
                             self,
-                            constraints.elements(db).iter().map(|ty| ty.bindings(db)),
+                            constraints
+                                .elements(db)
+                                .iter()
+                                .map(|constraint| constraint.bindings_impl(db, recursion_detector)),
                         )
                     }
                 }
@@ -4044,17 +4184,20 @@ impl<'db> Type<'db> {
                 SubclassOfInner::TypeVar(tvar) => {
                     let constructor_instance_type = Type::TypeVar(tvar);
                     let bindings = match tvar.typevar(db).bound_or_constraints(db) {
-                        None => KnownClass::Type.to_instance(db).bindings(db),
+                        None => KnownClass::Type
+                            .to_instance(db)
+                            .bindings_impl(db, recursion_detector),
                         Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                            bound.to_meta_type(db).bindings(db)
+                            bound.to_meta_type(db).bindings_impl(db, recursion_detector)
                         }
                         Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                             Bindings::from_union(
                                 self,
-                                constraints
-                                    .elements(db)
-                                    .iter()
-                                    .map(|ty| ty.to_meta_type(db).bindings(db)),
+                                constraints.elements(db).iter().map(|constraint| {
+                                    constraint
+                                        .to_meta_type(db)
+                                        .bindings_impl(db, recursion_detector)
+                                }),
                             )
                         }
                     };
@@ -4103,7 +4246,7 @@ impl<'db> Type<'db> {
                         definedness: boundness,
                         ..
                     }) => {
-                        let mut bindings = dunder_callable.bindings(db);
+                        let mut bindings = dunder_callable.bindings_impl(db, recursion_detector);
                         bindings.replace_callable_type(dunder_callable, self);
                         if boundness == Definedness::PossiblyUndefined {
                             bindings.set_dunder_call_is_possibly_unbound();
@@ -4126,14 +4269,14 @@ impl<'db> Type<'db> {
                 union
                     .elements(db)
                     .iter()
-                    .map(|element| element.bindings(db)),
+                    .map(|element| element.bindings_impl(db, recursion_detector)),
             ),
 
             Type::Intersection(intersection) => Bindings::from_intersection(
                 self,
                 intersection
                     .positive_elements_or_object(db)
-                    .map(|element| element.bindings(db)),
+                    .map(|element| element.bindings_impl(db, recursion_detector)),
             ),
 
             Type::DataclassDecorator(_) => {
@@ -4158,9 +4301,9 @@ impl<'db> Type<'db> {
             Type::SpecialForm(_) => CallableBinding::not_callable(self).into(),
 
             Type::LiteralValue(literal) => match literal.kind() {
-                LiteralValueTypeKind::Enum(enum_literal) => {
-                    enum_literal.enum_class_instance(db).bindings(db)
-                }
+                LiteralValueTypeKind::Enum(enum_literal) => enum_literal
+                    .enum_class_instance(db)
+                    .bindings_impl(db, recursion_detector),
                 _ => CallableBinding::not_callable(self).into(),
             },
 
@@ -4178,14 +4321,19 @@ impl<'db> Type<'db> {
             .into(),
 
             Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
-                Type::Callable(partial.partial(db)).bindings(db)
+                Type::Callable(partial.partial(db)).bindings_impl(db, recursion_detector)
             }
 
-            Type::KnownInstance(known_instance) => {
-                known_instance.instance_fallback(db).bindings(db)
-            }
+            Type::KnownInstance(known_instance) => known_instance
+                .instance_fallback(db)
+                .bindings_impl(db, recursion_detector),
 
-            Type::TypeAlias(alias) => alias.value_type(db).bindings(db),
+            Type::TypeAlias(_) => self.visit_type_alias_value(
+                db,
+                recursion_detector,
+                Self::unknown_bindings,
+                |value_ty| value_ty.bindings_impl(db, recursion_detector),
+            ),
 
             Type::PropertyInstance(_)
             | Type::AlwaysFalsy
@@ -5513,13 +5661,24 @@ impl<'db> Type<'db> {
     /// See `Self::dunder_class` for more details.
     #[must_use]
     pub(crate) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {
+        let recursion_detector = ActiveRecursionDetector::default();
+        self.to_meta_type_impl(db, &recursion_detector)
+    }
+
+    fn to_meta_type_impl(
+        self,
+        db: &'db dyn Db,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) -> Type<'db> {
         match self {
             Type::Never => Type::Never,
             Type::NominalInstance(instance) => instance.to_meta_type(db),
             Type::KnownInstance(known_instance) => known_instance.to_meta_type(db),
             Type::SpecialForm(special_form) => special_form.to_meta_type(db),
             Type::PropertyInstance(_) => KnownClass::Property.to_class_literal(db),
-            Type::Union(union) => union.map(db, |ty| ty.to_meta_type(db)),
+            Type::Union(union) => union.map(db, |element| {
+                element.to_meta_type_impl(db, recursion_detector)
+            }),
             Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool.to_class_literal(db),
             Type::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Bool(_) => KnownClass::Bool.to_class_literal(db),
@@ -5567,8 +5726,22 @@ impl<'db> Type<'db> {
                     todo_type!("TypedDict synthesized meta-type").expect_dynamic(),
                 ),
             },
-            Type::TypeAlias(alias) => alias.value_type(db).to_meta_type(db),
-            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).to_meta_type(db),
+            Type::TypeAlias(_) => self.visit_type_alias_value(
+                db,
+                recursion_detector,
+                || {
+                    let expanded = self.expand_eagerly(db);
+                    if expanded == self {
+                        Type::unknown()
+                    } else {
+                        expanded.to_meta_type_impl(db, recursion_detector)
+                    }
+                },
+                |value_ty| value_ty.to_meta_type_impl(db, recursion_detector),
+            ),
+            Type::NewTypeInstance(newtype) => newtype
+                .concrete_base_type(db)
+                .to_meta_type_impl(db, recursion_detector),
         }
     }
 
@@ -5788,21 +5961,27 @@ impl<'db> Type<'db> {
                 element.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
             }),
             Type::Intersection(intersection) => {
-                let mut builder = IntersectionBuilder::new(db);
-                for positive in intersection.positive(db) {
-                    builder =
-                        builder.add_positive(positive.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
-                }
-                // Promotion should remove negative contributions from intersections,
-                // so we don't preserve them here when promotion is enabled.
-                if !matches!(type_mapping, TypeMapping::Promote(PromotionMode::On, _)) {
-                    for negative in intersection.negative(db) {
-                        builder = builder.add_negative(
-                            negative.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor),
+                visitor.visit(db, self, type_mapping, || {
+                    let mut builder = IntersectionBuilder::new(db);
+                    for positive in intersection.positive(db) {
+                        builder = builder.add_positive(
+                            positive.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                         );
                     }
-                }
-                builder.build()
+                    // Promotion should remove negative contributions from intersections,
+                    // so we don't preserve them here when promotion is enabled.
+                    if !matches!(type_mapping, TypeMapping::Promote(PromotionMode::On, _)) {
+                        for negative in intersection.negative(db) {
+                            builder = builder.add_negative(negative.apply_type_mapping_impl(
+                                db,
+                                &type_mapping.flip(),
+                                tcx,
+                                visitor,
+                            ));
+                        }
+                    }
+                    builder.build()
+                })
             }
 
             Type::TypeIs(type_is) => visitor.visit(db, self, type_mapping, || {
@@ -5828,9 +6007,7 @@ impl<'db> Type<'db> {
                     // For EagerExpansion, expand the raw value type. This path relies on Salsa's cycle
                     // detection rather than the visitor's cycle detection, because the visitor tracks
                     // Type values and `RecursiveList` is different from `RecursiveList[T]`.
-                    TypeMapping::EagerExpansion => {
-                        alias.raw_value_type(db).expand_eagerly(db)
-                    },
+                    TypeMapping::EagerExpansion => alias.raw_value_type(db).expand_eagerly(db),
                     // When specializing a generic type alias, instead of specializing the expanded type, the type alias itself is specialized.
                     // Without this special handling, recursive type aliases would result in cycles, returning an unspecialized fallback type.
                     TypeMapping::ApplySpecialization(specialization)
@@ -5870,12 +6047,19 @@ impl<'db> Type<'db> {
                         // this same TypeAlias again (e.g., in `type RecursiveT = int | tuple[RecursiveT, ...]`), the visitor
                         // will detect the cycle and return the fallback value.
                         let mapped = visitor.visit(db, self, type_mapping, || {
-                            let value_type = alias.raw_value_type(db).apply_type_mapping_impl(db, type_mapping, tcx, visitor);
-                            alias.apply_function_specialization(db, value_type).apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                            let value_type = alias.raw_value_type(db).apply_type_mapping_impl(
+                                db,
+                                type_mapping,
+                                tcx,
+                                visitor,
+                            );
+                            alias
+                                .apply_function_specialization(db, value_type)
+                                .apply_type_mapping_impl(db, type_mapping, tcx, visitor)
                         });
 
-                        // If the type mapping does not result in any change to this type alias, keep the
-                        // alias node instead of eagerly expanding it.
+                        // If the type mapping does not result in any change to this type alias, do
+                        // not expand it.
                         if alias.value_type(db) == mapped {
                             self
                         } else {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -18,13 +18,13 @@ use ruff_db::files::File;
 use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
+use salsa::plumbing::AsId;
 use smallvec::smallvec_inline;
 use ty_module_resolver::{KnownModule, Module, ModuleName, resolve_module};
 
 pub(crate) use self::callable::UpcastPolicy;
 pub use self::cyclic::CycleDetector;
 pub(crate) use self::cyclic::TypeTransformer;
-use self::cyclic::visit_type_alias;
 pub(crate) use self::diagnostic::register_lints;
 pub use self::diagnostic::{TypeCheckDiagnostics, UNDEFINED_REVEAL, UNRESOLVED_REFERENCE};
 pub(crate) use self::infer::{
@@ -246,6 +246,8 @@ struct ApplyPromoteOnTypeMapping;
 struct ApplyPromoteOffTypeMapping;
 struct ApplyTopMaterialization;
 struct ApplyBottomMaterialization;
+struct ApplySpecializationWithTopMaterialization;
+struct ApplySpecializationWithBottomMaterialization;
 struct ApplyMaterializationEquivalence;
 
 type MaterializationEquivalenceVisitor<'db> =
@@ -254,14 +256,18 @@ type MaterializationEquivalenceVisitor<'db> =
 /// A [`TypeTransformer`] that is used in `apply_type_mapping` methods.
 ///
 /// Promotion and materialization can visit the same type under two different mappings within a
-/// single recursive call chain. Keep separate cycle caches for those modes so invariant checks and
-/// callable promotion can safely reuse one visitor.
+/// single recursive call chain. Keep separate cycle caches for those modes so invariant checks,
+/// materialized specialization, and callable promotion can safely reuse one visitor.
 pub(crate) struct ApplyTypeMappingVisitor<'db> {
     default: OnceCell<TypeTransformer<'db, ApplyDefaultTypeMapping>>,
     promote_on: OnceCell<TypeTransformer<'db, ApplyPromoteOnTypeMapping>>,
     promote_off: OnceCell<TypeTransformer<'db, ApplyPromoteOffTypeMapping>>,
     top_materialization: OnceCell<TypeTransformer<'db, ApplyTopMaterialization>>,
     bottom_materialization: OnceCell<TypeTransformer<'db, ApplyBottomMaterialization>>,
+    specialization_top_materialization:
+        OnceCell<TypeTransformer<'db, ApplySpecializationWithTopMaterialization>>,
+    specialization_bottom_materialization:
+        OnceCell<TypeTransformer<'db, ApplySpecializationWithBottomMaterialization>>,
     materialization_equivalence: OnceCell<MaterializationEquivalenceVisitor<'db>>,
 }
 
@@ -295,6 +301,20 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
                 .bottom_materialization
                 .get_or_init(TypeTransformer::default)
                 .visit_type(db, ty, func),
+            TypeMapping::ApplySpecializationWithMaterialization {
+                materialization_kind: MaterializationKind::Top,
+                ..
+            } => self
+                .specialization_top_materialization
+                .get_or_init(TypeTransformer::default)
+                .visit_type(db, ty, func),
+            TypeMapping::ApplySpecializationWithMaterialization {
+                materialization_kind: MaterializationKind::Bottom,
+                ..
+            } => self
+                .specialization_bottom_materialization
+                .get_or_init(TypeTransformer::default)
+                .visit_type(db, ty, func),
             _ => self
                 .default
                 .get_or_init(TypeTransformer::default)
@@ -325,6 +345,8 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
             promote_off: OnceCell::new(),
             top_materialization: OnceCell::new(),
             bottom_materialization: OnceCell::new(),
+            specialization_top_materialization: OnceCell::new(),
+            specialization_bottom_materialization: OnceCell::new(),
             materialization_equivalence,
         }
     }
@@ -338,6 +360,8 @@ impl Default for ApplyTypeMappingVisitor<'_> {
             promote_off: OnceCell::new(),
             top_materialization: OnceCell::new(),
             bottom_materialization: OnceCell::new(),
+            specialization_top_materialization: OnceCell::new(),
+            specialization_bottom_materialization: OnceCell::new(),
             materialization_equivalence: OnceCell::new(),
         }
     }
@@ -1235,7 +1259,9 @@ impl<'db> Type<'db> {
         match self {
             Type::NominalInstance(instance) => Some(instance.class(db)),
             Type::ProtocolInstance(instance) => instance.to_nominal_instance().map(|i| i.class(db)),
-            Type::TypeAlias(alias) => alias.value_type(db).nominal_class(db),
+            Type::TypeAlias(_) => {
+                self.visit_type_alias_value_or_default(db, |value_ty| value_ty.nominal_class(db))
+            }
             Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).nominal_class(db),
             Type::TypeVar(typevar) => {
                 let TypeVarBoundOrConstraints::UpperBound(bound) =
@@ -1386,11 +1412,9 @@ impl<'db> Type<'db> {
     /// underlying value type. Otherwise, returns `self` unchanged.
     pub(crate) fn resolve_type_alias(self, db: &'db dyn Db) -> Type<'db> {
         match self {
-            Type::TypeAlias(alias) => visit_type_alias(
-                alias,
-                || self,
-                || alias.value_type(db).resolve_type_alias(db),
-            ),
+            Type::TypeAlias(alias) => {
+                alias.visit_value(db, || self, |value_ty| value_ty.resolve_type_alias(db))
+            }
             _ => self,
         }
     }
@@ -1406,7 +1430,7 @@ impl<'db> Type<'db> {
         visit_value: impl FnOnce(Type<'db>) -> R,
     ) -> R {
         if let Type::TypeAlias(alias) = self {
-            visit_type_alias(alias, on_cycle, || visit_value(alias.value_type(db)))
+            alias.visit_value(db, on_cycle, visit_value)
         } else {
             visit_value(self)
         }
@@ -1830,14 +1854,13 @@ impl<'db> Type<'db> {
             | Type::DataclassTransformer(_)
             | Type::Callable(_)
             | Type::WrapperDescriptor(_)
-            | Type::TypeAlias(_)
             | Type::BoundMethod(_) => Type::Intersection(IntersectionType::new(
                 db,
                 FxOrderSet::default(),
                 NegativeIntersectionElements::Single(*self),
             )),
 
-            Type::Union(_) | Type::Intersection(_) => {
+            Type::Union(_) | Type::Intersection(_) | Type::TypeAlias(_) => {
                 IntersectionBuilder::new(db).add_negative(*self).build()
             }
         }
@@ -2196,6 +2219,17 @@ impl<'db> Type<'db> {
         f: &mut dyn FnMut(Type<'db>, TypeVarVariance),
         visitor: &SpecializationVisitor<'db>,
     ) {
+        if let Type::TypeAlias(_) = self {
+            self.visit_type_alias_value(
+                db,
+                || (),
+                |value_ty| {
+                    value_ty.visit_specialization_impl(db, polarity, f, visitor);
+                },
+            );
+            return;
+        }
+
         let Some(specialization) = self.class_specialization(db) else {
             match self {
                 Type::Union(union) => {
@@ -2208,11 +2242,6 @@ impl<'db> Type<'db> {
                         element.visit_specialization_impl(db, polarity, f, visitor);
                     }
                 }
-                Type::TypeAlias(alias) => visitor.visit(self, || {
-                    alias
-                        .value_type(db)
-                        .visit_specialization_impl(db, polarity, f, visitor);
-                }),
                 Type::Callable(callable) => {
                     for signature in callable.signatures(db) {
                         for parameter in signature.parameters() {
@@ -2582,9 +2611,14 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::TypeAlias(alias) => alias
-                .value_type(db)
-                .find_name_in_mro_with_policy(db, name, policy),
+            Type::TypeAlias(alias) => alias.visit_value(
+                db,
+                || {
+                    Type::divergent(alias.definition(db).as_id())
+                        .find_name_in_mro_with_policy(db, name, policy)
+                },
+                |value_ty| value_ty.find_name_in_mro_with_policy(db, name, policy),
+            ),
 
             Type::FunctionLiteral(_)
             | Type::Callable(_)
@@ -2793,7 +2827,11 @@ impl<'db> Type<'db> {
 
             Type::TypedDict(_) => Place::Undefined.into(),
 
-            Type::TypeAlias(alias) => alias.value_type(db).instance_member(db, name),
+            Type::TypeAlias(alias) => alias.visit_value(
+                db,
+                || Type::divergent(alias.definition(db).as_id()).instance_member(db, name),
+                |value_ty| value_ty.instance_member(db, name),
+            ),
         }
     }
 
@@ -5348,7 +5386,9 @@ impl<'db> Type<'db> {
             // has no instance type. Otherwise, synthesize a typevar with bound or constraints
             // mapped through `to_instance`.
             Type::TypeVar(bound_typevar) => Some(Type::TypeVar(bound_typevar.to_instance(db)?)),
-            Type::TypeAlias(alias) => alias.value_type(db).to_instance(db),
+            Type::TypeAlias(_) => {
+                self.visit_type_alias_value(db, || Some(self), |value_ty| value_ty.to_instance(db))
+            }
             Type::Intersection(_) => Some(todo_type!("Type::Intersection.to_instance")),
             // An instance of class `C` may itself have instances if `C` is a subclass of `type`.
             Type::NominalInstance(instance)
@@ -5597,11 +5637,17 @@ impl<'db> Type<'db> {
 
             Type::Intersection(_) => Ok(todo_type!("Type::Intersection.in_type_expression")),
 
-            Type::TypeAlias(alias) => alias.value_type(db).in_type_expression(
+            Type::TypeAlias(_) => (*self).visit_type_alias_value(
                 db,
-                scope_id,
-                typevar_binding_context,
-                inference_flags,
+                || Ok(*self),
+                |value_ty| {
+                    value_ty.in_type_expression(
+                        db,
+                        scope_id,
+                        typevar_binding_context,
+                        inference_flags,
+                    )
+                },
             ),
 
             Type::NewTypeInstance(_) => Err(InvalidTypeExpressionError {
@@ -5679,18 +5725,12 @@ impl<'db> Type<'db> {
                     todo_type!("TypedDict synthesized meta-type").expect_dynamic(),
                 ),
             },
-            Type::TypeAlias(_) => self.visit_type_alias_value(
-                db,
-                || {
-                    let expanded = self.expand_eagerly(db);
-                    if expanded == self {
-                        Type::unknown()
-                    } else {
-                        expanded.to_meta_type(db)
-                    }
-                },
-                |value_ty| value_ty.to_meta_type(db),
-            ),
+            Type::TypeAlias(alias) => {
+                let divergent = Type::divergent(alias.definition(db).as_id());
+                self.visit_type_alias_value(db, || divergent, |value_ty| value_ty.to_meta_type(db))
+                    .recursive_type_normalized_impl(db, divergent, false)
+                    .unwrap_or(divergent)
+            }
             Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).to_meta_type(db),
         }
     }
@@ -5912,22 +5952,47 @@ impl<'db> Type<'db> {
             }),
             Type::Intersection(intersection) => {
                 visitor.visit(db, self, type_mapping, || {
-                    let mut builder = IntersectionBuilder::new(db);
-                    for positive in intersection.positive(db) {
-                        builder = builder.add_positive(
-                            positive.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-                        );
+                    let drop_negative =
+                        matches!(type_mapping, TypeMapping::Promote(PromotionMode::On, _));
+                    let positive = intersection.positive(db);
+                    let negative = intersection.negative(db);
+                    let mut mapped_positive = Vec::with_capacity(positive.len());
+                    let mut mapped_negative = Vec::with_capacity(negative.len());
+                    let mut changed = drop_negative && !negative.is_empty();
+
+                    for positive in positive {
+                        let mapped =
+                            positive.apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+                        changed |= mapped != *positive;
+                        mapped_positive.push(mapped);
                     }
-                    // Promotion should remove negative contributions from intersections,
-                    // so we don't preserve them here when promotion is enabled.
-                    if !matches!(type_mapping, TypeMapping::Promote(PromotionMode::On, _)) {
-                        for negative in intersection.negative(db) {
-                            builder = builder.add_negative(negative.apply_type_mapping_impl(
+
+                    if !drop_negative {
+                        for negative in negative {
+                            let mapped = negative.apply_type_mapping_impl(
                                 db,
                                 &type_mapping.flip(),
                                 tcx,
                                 visitor,
-                            ));
+                            );
+                            changed |= mapped != *negative;
+                            mapped_negative.push(mapped);
+                        }
+                    }
+
+                    if !changed {
+                        return self;
+                    }
+
+                    let mut builder = IntersectionBuilder::new(db);
+                    for positive in mapped_positive {
+                        builder = builder.add_positive(positive);
+                    }
+                    // Promotion should remove negative contributions from intersections,
+                    // so we don't preserve them here when promotion is enabled.
+                    if !drop_negative {
+                        for negative in mapped_negative {
+                            builder = builder.add_negative(negative);
                         }
                     }
                     builder.build()
@@ -5954,10 +6019,18 @@ impl<'db> Type<'db> {
 
             Type::TypeAlias(alias) => {
                 match type_mapping {
-                    // For EagerExpansion, expand the raw value type. This path relies on Salsa's cycle
-                    // detection rather than the visitor's cycle detection, because the visitor tracks
-                    // Type values and `RecursiveList` is different from `RecursiveList[T]`.
-                    TypeMapping::EagerExpansion => alias.raw_value_type(db).expand_eagerly(db),
+                    // For EagerExpansion, expand the raw value type. Use active alias tracking in
+                    // addition to Salsa cycle detection because recursive generic aliases can
+                    // change specialization on every expansion.
+                    TypeMapping::EagerExpansion => {
+                        let divergent = Type::divergent(alias.definition(db).as_id());
+                        alias
+                            .visit_raw_value(db, || divergent, |value_ty| {
+                                value_ty.expand_eagerly(db)
+                            })
+                            .recursive_type_normalized_impl(db, divergent, false)
+                            .unwrap_or(divergent)
+                    }
                     // When specializing a generic type alias, instead of specializing the expanded type, the type alias itself is specialized.
                     // Without this special handling, recursive type aliases would result in cycles, returning an unspecialized fallback type.
                     TypeMapping::ApplySpecialization(specialization)
@@ -5989,28 +6062,31 @@ impl<'db> Type<'db> {
                         ))
                     }
                     _ => {
-                        // Do not call `value_type` here. `value_type` does the specialization internally, so `apply_type_mapping` is
-                        // performed without `visitor` inheritance. In the case of recursive type aliases, this leads to infinite recursion.
-                        // Instead, call `raw_value_type` and perform the specialization after the `visitor` cache has been created.
-                        //
-                        // IMPORTANT: All processing must happen inside a single visitor.visit() call so that if we encounter
-                        // this same TypeAlias again (e.g., in `type RecursiveT = int | tuple[RecursiveT, ...]`), the visitor
-                        // will detect the cycle and return the fallback value.
                         let mapped = visitor.visit(db, self, type_mapping, || {
-                            let value_type = alias.raw_value_type(db).apply_type_mapping_impl(
+                            // Do not call `value_type` here. `value_type` applies specialization
+                            // without this visitor. Keep the raw expansion, specialization, and
+                            // outer mapping in one visitor call, and use active alias tracking for
+                            // generic aliases whose specialization changes at each recursive step.
+                            alias.visit_raw_value(
                                 db,
-                                type_mapping,
-                                tcx,
-                                visitor,
-                            );
-                            alias
-                                .apply_function_specialization(db, value_type)
-                                .apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                                || self,
+                                |raw_value_type| {
+                                    let value_type = raw_value_type.apply_type_mapping_impl(
+                                        db,
+                                        type_mapping,
+                                        tcx,
+                                        visitor,
+                                    );
+                                    alias
+                                        .apply_function_specialization(db, value_type)
+                                        .apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                                },
+                            )
                         });
 
                         // If the type mapping does not result in any change to this type alias, do
                         // not expand it.
-                        if alias.value_type(db) == mapped {
+                        if alias.visit_value(db, || false, |value_type| value_type == mapped) {
                             self
                         } else {
                             mapped
@@ -6233,15 +6309,14 @@ impl<'db> Type<'db> {
                 );
             }
 
-            Type::TypeAlias(alias) => {
-                visitor.visit(self, || {
-                    alias.value_type(db).find_legacy_typevars_impl(
-                        db,
-                        binding_context,
-                        typevars,
-                        visitor,
-                    );
-                });
+            Type::TypeAlias(_) => {
+                self.visit_type_alias_value(
+                    db,
+                    || (),
+                    |value_ty| {
+                        value_ty.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                    },
+                );
             }
 
             Type::KnownInstance(known_instance) => match known_instance {
@@ -6461,7 +6536,9 @@ impl<'db> Type<'db> {
                 )),
             },
 
-            Self::TypeAlias(alias) => alias.value_type(db).definition(db),
+            Self::TypeAlias(alias) => {
+                alias.visit_value(db, || None, |value_ty| value_ty.definition(db))
+            }
             Self::NewTypeInstance(newtype) => Some(TypeDefinition::NewType(newtype.definition(db))),
 
             Self::PropertyInstance(property) => property

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -22,9 +22,9 @@ use smallvec::smallvec_inline;
 use ty_module_resolver::{KnownModule, Module, ModuleName, resolve_module};
 
 pub(crate) use self::callable::UpcastPolicy;
-use self::cyclic::ActiveRecursionDetector;
 pub use self::cyclic::CycleDetector;
 pub(crate) use self::cyclic::TypeTransformer;
+use self::cyclic::visit_type_alias;
 pub(crate) use self::diagnostic::register_lints;
 pub use self::diagnostic::{TypeCheckDiagnostics, UNDEFINED_REVEAL, UNRESOLVED_REFERENCE};
 pub(crate) use self::infer::{
@@ -1385,24 +1385,11 @@ impl<'db> Type<'db> {
     /// If this type is a `Type::TypeAlias`, recursively resolves it to its
     /// underlying value type. Otherwise, returns `self` unchanged.
     pub(crate) fn resolve_type_alias(self, db: &'db dyn Db) -> Type<'db> {
-        let recursion_detector = ActiveRecursionDetector::default();
-        self.resolve_type_alias_impl(db, &recursion_detector)
-    }
-
-    fn resolve_type_alias_impl(
-        self,
-        db: &'db dyn Db,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) -> Type<'db> {
         match self {
-            Type::TypeAlias(alias) => recursion_detector.visit(
-                &self,
+            Type::TypeAlias(alias) => visit_type_alias(
+                alias,
                 || self,
-                || {
-                    alias
-                        .value_type(db)
-                        .resolve_type_alias_impl(db, recursion_detector)
-                },
+                || alias.value_type(db).resolve_type_alias(db),
             ),
             _ => self,
         }
@@ -1415,12 +1402,11 @@ impl<'db> Type<'db> {
     pub(crate) fn visit_type_alias_value<R>(
         self,
         db: &'db dyn Db,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
         on_cycle: impl FnOnce() -> R,
         visit_value: impl FnOnce(Type<'db>) -> R,
     ) -> R {
         if let Type::TypeAlias(alias) = self {
-            recursion_detector.visit(&self, on_cycle, || visit_value(alias.value_type(db)))
+            visit_type_alias(alias, on_cycle, || visit_value(alias.value_type(db)))
         } else {
             visit_value(self)
         }
@@ -1433,10 +1419,9 @@ impl<'db> Type<'db> {
     pub(crate) fn visit_type_alias_value_or_default<R: Default>(
         self,
         db: &'db dyn Db,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
         visit_value: impl FnOnce(Type<'db>) -> R,
     ) -> R {
-        self.visit_type_alias_value(db, recursion_detector, R::default, visit_value)
+        self.visit_type_alias_value(db, R::default, visit_value)
     }
 
     /// If this type is a type alias, visit its value type with active-recursion tracking.
@@ -1447,10 +1432,9 @@ impl<'db> Type<'db> {
     pub(crate) fn visit_type_alias_value_or_assume_valid(
         self,
         db: &'db dyn Db,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
         visit_value: impl FnOnce(Type<'db>) -> bool,
     ) -> bool {
-        self.visit_type_alias_value(db, recursion_detector, || true, visit_value)
+        self.visit_type_alias_value(db, || true, visit_value)
     }
 
     /// Returns `Some(UnionType)` if this type behaves like a union. Apart from explicit unions,
@@ -1460,6 +1444,34 @@ impl<'db> Type<'db> {
             Type::Union(union) => Some(union),
             Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).as_union_like(db),
             _ => None,
+        }
+    }
+
+    /// Visits each element if this type behaves like a union.
+    ///
+    /// Unlike [`Type::as_union_like`], this keeps active type-alias recursion state alive while
+    /// visiting the elements. Use this for recursive walks over alias-backed unions.
+    pub(crate) fn visit_union_like_elements(
+        self,
+        db: &'db dyn Db,
+        visit_element: &mut impl FnMut(Type<'db>),
+    ) -> bool {
+        match self {
+            Type::Union(union) => {
+                for element in union.elements(db) {
+                    visit_element(*element);
+                }
+                true
+            }
+            Type::TypeAlias(_) => self.visit_type_alias_value(
+                db,
+                || true,
+                |value_ty| value_ty.visit_union_like_elements(db, visit_element),
+            ),
+            Type::NewTypeInstance(newtype) => newtype
+                .concrete_base_type(db)
+                .visit_union_like_elements(db, visit_element),
+            _ => false,
         }
     }
 
@@ -2247,15 +2259,6 @@ impl<'db> Type<'db> {
     /// Note: This function aims to have no false positives, but might return `false`
     /// for more complicated types that are actually singletons.
     pub(crate) fn is_singleton(self, db: &'db dyn Db) -> bool {
-        let recursion_detector = ActiveRecursionDetector::default();
-        self.is_singleton_impl(db, &recursion_detector)
-    }
-
-    fn is_singleton_impl(
-        self,
-        db: &'db dyn Db,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) -> bool {
         match self {
             Type::Dynamic(_) | Type::Divergent(_) | Type::Never => false,
 
@@ -2305,7 +2308,7 @@ impl<'db> Type<'db> {
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
                         .elements(db)
                         .iter()
-                        .all(|constraint| constraint.is_singleton_impl(db, recursion_detector)),
+                        .all(|constraint| constraint.is_singleton(db)),
                 }
             }
 
@@ -2374,27 +2377,14 @@ impl<'db> Type<'db> {
             Type::TypeGuard(type_guard) => type_guard.is_bound(db),
             Type::TypedDict(_) => false,
             Type::TypeAlias(_) => {
-                self.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
-                    value_ty.is_singleton_impl(db, recursion_detector)
-                })
+                self.visit_type_alias_value_or_default(db, |value_ty| value_ty.is_singleton(db))
             }
-            Type::NewTypeInstance(newtype) => newtype
-                .concrete_base_type(db)
-                .is_singleton_impl(db, recursion_detector),
+            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).is_singleton(db),
         }
     }
 
     /// Return true if this type is non-empty and all inhabitants of this type compare equal.
     pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
-        let recursion_detector = ActiveRecursionDetector::default();
-        self.is_single_valued_impl(db, &recursion_detector)
-    }
-
-    pub(crate) fn is_single_valued_impl(
-        self,
-        db: &'db dyn Db,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) -> bool {
         match self {
             // Each `partial()` call creates a distinct object at runtime.
             Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_)) => false,
@@ -2437,7 +2427,7 @@ impl<'db> Type<'db> {
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
                         .elements(db)
                         .iter()
-                        .all(|constraint| constraint.is_single_valued_impl(db, recursion_detector)),
+                        .all(|constraint| constraint.is_single_valued(db)),
                 }
             }
 
@@ -2446,12 +2436,8 @@ impl<'db> Type<'db> {
                 false
             }
 
-            Type::NominalInstance(instance) => {
-                instance.is_single_valued_impl(db, recursion_detector)
-            }
-            Type::NewTypeInstance(newtype) => newtype
-                .concrete_base_type(db)
-                .is_single_valued_impl(db, recursion_detector),
+            Type::NominalInstance(instance) => instance.is_single_valued(db),
+            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).is_single_valued(db),
 
             Type::BoundSuper(_) => {
                 // At runtime two super instances never compare equal, even if their arguments are identical.
@@ -2467,9 +2453,7 @@ impl<'db> Type<'db> {
             Type::TypeGuard(type_guard) => type_guard.is_bound(db),
 
             Type::TypeAlias(_) => {
-                self.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
-                    value_ty.is_single_valued_impl(db, recursion_detector)
-                })
+                self.visit_type_alias_value_or_default(db, |value_ty| value_ty.is_single_valued(db))
             }
 
             Type::Dynamic(_)
@@ -3528,9 +3512,11 @@ impl<'db> Type<'db> {
                     .member_lookup_with_policy(db, name, policy)
             }
 
-            Type::TypeAlias(alias) => alias
-                .value_type(db)
-                .member_lookup_with_policy(db, name, policy),
+            Type::TypeAlias(_) => self.visit_type_alias_value(
+                db,
+                || Place::Undefined.into(),
+                |value_ty| value_ty.member_lookup_with_policy(db, name, policy),
+            ),
 
             _ if policy.no_instance_fallback() => self.invoke_descriptor_protocol(
                 db,
@@ -3774,11 +3760,7 @@ impl<'db> Type<'db> {
     /// In the second case, the return type of `len()` in `typeshed` (`int`)
     /// is used as a fallback.
     fn len(&self, db: &'db dyn Db) -> Option<Type<'db>> {
-        fn non_negative_int_literal_impl<'db>(
-            db: &'db dyn Db,
-            ty: Type<'db>,
-            recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-        ) -> Option<Type<'db>> {
+        fn non_negative_int_literal_impl<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
             match ty {
                 // TODO: Emit diagnostic for non-integers and negative integers
                 Type::LiteralValue(literal) => match literal.kind() {
@@ -3786,14 +3768,12 @@ impl<'db> Type<'db> {
                     LiteralValueTypeKind::Bool(value) => Some(Type::int_literal(i64::from(value))),
                     _ => None,
                 },
-                Type::Union(union) => union.try_map(db, |element| {
-                    non_negative_int_literal_impl(db, *element, recursion_detector)
-                }),
-                Type::TypeAlias(_) => {
-                    ty.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
-                        non_negative_int_literal_impl(db, value_ty, recursion_detector)
-                    })
+                Type::Union(union) => {
+                    union.try_map(db, |element| non_negative_int_literal_impl(db, *element))
                 }
+                Type::TypeAlias(_) => ty.visit_type_alias_value_or_default(db, |value_ty| {
+                    non_negative_int_literal_impl(db, value_ty)
+                }),
                 _ => None,
             }
         }
@@ -3822,8 +3802,7 @@ impl<'db> Type<'db> {
             Err(CallDunderError::CallError(_, bindings)) => bindings.return_type(db),
         };
 
-        let recursion_detector = ActiveRecursionDetector::default();
-        non_negative_int_literal_impl(db, return_ty, &recursion_detector)
+        non_negative_int_literal_impl(db, return_ty)
     }
 
     /// If this type is a `ParamSpec` type variable, returns it. Otherwise, returns `None`.
@@ -3912,23 +3891,8 @@ impl<'db> Type<'db> {
     /// elements. It's usually best to only worry about "callability" relative to a particular
     /// argument list, via [`try_call`][Self::try_call] and [`CallErrorKind::NotCallable`].
     fn bindings(self, db: &'db dyn Db) -> Bindings<'db> {
-        let recursion_detector = ActiveRecursionDetector::default();
-        self.bindings_impl(db, &recursion_detector)
-    }
-
-    /// Returns dynamic call bindings used as the conservative fallback for recursive callability.
-    fn unknown_bindings() -> Bindings<'db> {
-        let unknown = Type::unknown();
-        Binding::single(unknown, Signature::dynamic(unknown)).into()
-    }
-
-    fn bindings_impl(
-        self,
-        db: &'db dyn Db,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) -> Bindings<'db> {
         if let Some(fallback) = self.materialized_divergent_fallback() {
-            return fallback.bindings_impl(db, recursion_detector);
+            return fallback.bindings(db);
         }
 
         match self {
@@ -3940,16 +3904,14 @@ impl<'db> Type<'db> {
             Type::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => CallableBinding::not_callable(self).into(),
-                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                        bound.bindings_impl(db, recursion_detector)
-                    }
+                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound.bindings(db),
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                         Bindings::from_union(
                             self,
                             constraints
                                 .elements(db)
                                 .iter()
-                                .map(|constraint| constraint.bindings_impl(db, recursion_detector)),
+                                .map(|constraint| constraint.bindings(db)),
                         )
                     }
                 }
@@ -4184,20 +4146,17 @@ impl<'db> Type<'db> {
                 SubclassOfInner::TypeVar(tvar) => {
                     let constructor_instance_type = Type::TypeVar(tvar);
                     let bindings = match tvar.typevar(db).bound_or_constraints(db) {
-                        None => KnownClass::Type
-                            .to_instance(db)
-                            .bindings_impl(db, recursion_detector),
+                        None => KnownClass::Type.to_instance(db).bindings(db),
                         Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                            bound.to_meta_type(db).bindings_impl(db, recursion_detector)
+                            bound.to_meta_type(db).bindings(db)
                         }
                         Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                             Bindings::from_union(
                                 self,
-                                constraints.elements(db).iter().map(|constraint| {
-                                    constraint
-                                        .to_meta_type(db)
-                                        .bindings_impl(db, recursion_detector)
-                                }),
+                                constraints
+                                    .elements(db)
+                                    .iter()
+                                    .map(|constraint| constraint.to_meta_type(db).bindings(db)),
                             )
                         }
                     };
@@ -4246,7 +4205,7 @@ impl<'db> Type<'db> {
                         definedness: boundness,
                         ..
                     }) => {
-                        let mut bindings = dunder_callable.bindings_impl(db, recursion_detector);
+                        let mut bindings = dunder_callable.bindings(db);
                         bindings.replace_callable_type(dunder_callable, self);
                         if boundness == Definedness::PossiblyUndefined {
                             bindings.set_dunder_call_is_possibly_unbound();
@@ -4269,14 +4228,14 @@ impl<'db> Type<'db> {
                 union
                     .elements(db)
                     .iter()
-                    .map(|element| element.bindings_impl(db, recursion_detector)),
+                    .map(|element| element.bindings(db)),
             ),
 
             Type::Intersection(intersection) => Bindings::from_intersection(
                 self,
                 intersection
                     .positive_elements_or_object(db)
-                    .map(|element| element.bindings_impl(db, recursion_detector)),
+                    .map(|element| element.bindings(db)),
             ),
 
             Type::DataclassDecorator(_) => {
@@ -4301,9 +4260,9 @@ impl<'db> Type<'db> {
             Type::SpecialForm(_) => CallableBinding::not_callable(self).into(),
 
             Type::LiteralValue(literal) => match literal.kind() {
-                LiteralValueTypeKind::Enum(enum_literal) => enum_literal
-                    .enum_class_instance(db)
-                    .bindings_impl(db, recursion_detector),
+                LiteralValueTypeKind::Enum(enum_literal) => {
+                    enum_literal.enum_class_instance(db).bindings(db)
+                }
                 _ => CallableBinding::not_callable(self).into(),
             },
 
@@ -4321,19 +4280,18 @@ impl<'db> Type<'db> {
             .into(),
 
             Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
-                Type::Callable(partial.partial(db)).bindings_impl(db, recursion_detector)
+                Type::Callable(partial.partial(db)).bindings(db)
             }
 
-            Type::KnownInstance(known_instance) => known_instance
-                .instance_fallback(db)
-                .bindings_impl(db, recursion_detector),
+            Type::KnownInstance(known_instance) => {
+                known_instance.instance_fallback(db).bindings(db)
+            }
 
-            Type::TypeAlias(_) => self.visit_type_alias_value(
-                db,
-                recursion_detector,
-                Self::unknown_bindings,
-                |value_ty| value_ty.bindings_impl(db, recursion_detector),
-            ),
+            Type::TypeAlias(_) => {
+                self.visit_type_alias_value(db, Self::unknown_bindings, |value_ty| {
+                    value_ty.bindings(db)
+                })
+            }
 
             Type::PropertyInstance(_)
             | Type::AlwaysFalsy
@@ -4344,6 +4302,12 @@ impl<'db> Type<'db> {
             | Type::TypeGuard(_)
             | Type::TypedDict(_) => CallableBinding::not_callable(self).into(),
         }
+    }
+
+    /// Returns dynamic call bindings used as the conservative fallback for recursive callability.
+    fn unknown_bindings() -> Bindings<'db> {
+        let unknown = Type::unknown();
+        Binding::single(unknown, Signature::dynamic(unknown)).into()
     }
 
     fn known_class_literal_bindings(
@@ -5661,24 +5625,13 @@ impl<'db> Type<'db> {
     /// See `Self::dunder_class` for more details.
     #[must_use]
     pub(crate) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {
-        let recursion_detector = ActiveRecursionDetector::default();
-        self.to_meta_type_impl(db, &recursion_detector)
-    }
-
-    fn to_meta_type_impl(
-        self,
-        db: &'db dyn Db,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) -> Type<'db> {
         match self {
             Type::Never => Type::Never,
             Type::NominalInstance(instance) => instance.to_meta_type(db),
             Type::KnownInstance(known_instance) => known_instance.to_meta_type(db),
             Type::SpecialForm(special_form) => special_form.to_meta_type(db),
             Type::PropertyInstance(_) => KnownClass::Property.to_class_literal(db),
-            Type::Union(union) => union.map(db, |element| {
-                element.to_meta_type_impl(db, recursion_detector)
-            }),
+            Type::Union(union) => union.map(db, |element| element.to_meta_type(db)),
             Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool.to_class_literal(db),
             Type::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Bool(_) => KnownClass::Bool.to_class_literal(db),
@@ -5728,20 +5681,17 @@ impl<'db> Type<'db> {
             },
             Type::TypeAlias(_) => self.visit_type_alias_value(
                 db,
-                recursion_detector,
                 || {
                     let expanded = self.expand_eagerly(db);
                     if expanded == self {
                         Type::unknown()
                     } else {
-                        expanded.to_meta_type_impl(db, recursion_detector)
+                        expanded.to_meta_type(db)
                     }
                 },
-                |value_ty| value_ty.to_meta_type_impl(db, recursion_detector),
+                |value_ty| value_ty.to_meta_type(db),
             ),
-            Type::NewTypeInstance(newtype) => newtype
-                .concrete_base_type(db)
-                .to_meta_type_impl(db, recursion_detector),
+            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).to_meta_type(db),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -305,10 +305,12 @@ impl<'db> Type<'db> {
                 LiteralValueTypeKind::Bytes(bytes) => Truthiness::from(!bytes.value(db).is_empty()),
             },
 
-            Type::TypeAlias(alias) => visitor.visit(*self, || {
-                alias
-                    .value_type(db)
-                    .try_bool_impl(db, allow_short_circuit, visitor)
+            Type::TypeAlias(_) => visitor.visit(*self, || {
+                (*self).visit_type_alias_value(
+                    db,
+                    || Ok(Truthiness::Ambiguous),
+                    |value_ty| value_ty.try_bool_impl(db, allow_short_circuit, visitor),
+                )
             })?,
             Type::NewTypeInstance(newtype) => {
                 newtype

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -13,7 +13,6 @@ use crate::{
         SubclassOfType, Type, TypeVarBoundOrConstraints, UnionBuilder,
         constraints::ConstraintSet,
         context::InferContext,
-        cyclic::ActiveRecursionDetector,
         diagnostic::{INVALID_SUPER_ARGUMENT, UNAVAILABLE_IMPLICIT_SUPER_ARGUMENTS},
         relation::EquivalenceChecker,
         signatures::{Parameter, Parameters, Signature},
@@ -488,24 +487,8 @@ impl<'db> BoundSuperType<'db> {
         pivot_class_type: Type<'db>,
         owner_type: Type<'db>,
     ) -> Result<Type<'db>, BoundSuperError<'db>> {
-        let recursion_detector = ActiveRecursionDetector::default();
-        Self::build_impl(db, pivot_class_type, owner_type, &recursion_detector)
-    }
-
-    fn build_impl(
-        db: &'db dyn Db,
-        pivot_class_type: Type<'db>,
-        owner_type: Type<'db>,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) -> Result<Type<'db>, BoundSuperError<'db>> {
-        let delegate_to = |type_to_delegate_to| {
-            BoundSuperType::build_impl(
-                db,
-                pivot_class_type,
-                type_to_delegate_to,
-                recursion_detector,
-            )
-        };
+        let delegate_to =
+            |type_to_delegate_to| BoundSuperType::build(db, pivot_class_type, type_to_delegate_to);
 
         // Delegate but rewrite errors to preserve TypeVar context.
         let delegate_with_error_mapped =
@@ -756,12 +739,7 @@ impl<'db> BoundSuperType<'db> {
                 return Ok(builder.build());
             }
             Type::TypeAlias(_) => {
-                return owner_type.visit_type_alias_value(
-                    db,
-                    recursion_detector,
-                    || Ok(Type::unknown()),
-                    delegate_to,
-                );
+                return owner_type.visit_type_alias_value(db, || Ok(Type::unknown()), delegate_to);
             }
             Type::TypeVar(bound_typevar) => {
                 let typevar = bound_typevar.typevar(db);

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -13,6 +13,7 @@ use crate::{
         SubclassOfType, Type, TypeVarBoundOrConstraints, UnionBuilder,
         constraints::ConstraintSet,
         context::InferContext,
+        cyclic::ActiveRecursionDetector,
         diagnostic::{INVALID_SUPER_ARGUMENT, UNAVAILABLE_IMPLICIT_SUPER_ARGUMENTS},
         relation::EquivalenceChecker,
         signatures::{Parameter, Parameters, Signature},
@@ -487,8 +488,24 @@ impl<'db> BoundSuperType<'db> {
         pivot_class_type: Type<'db>,
         owner_type: Type<'db>,
     ) -> Result<Type<'db>, BoundSuperError<'db>> {
-        let delegate_to =
-            |type_to_delegate_to| BoundSuperType::build(db, pivot_class_type, type_to_delegate_to);
+        let recursion_detector = ActiveRecursionDetector::default();
+        Self::build_impl(db, pivot_class_type, owner_type, &recursion_detector)
+    }
+
+    fn build_impl(
+        db: &'db dyn Db,
+        pivot_class_type: Type<'db>,
+        owner_type: Type<'db>,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) -> Result<Type<'db>, BoundSuperError<'db>> {
+        let delegate_to = |type_to_delegate_to| {
+            BoundSuperType::build_impl(
+                db,
+                pivot_class_type,
+                type_to_delegate_to,
+                recursion_detector,
+            )
+        };
 
         // Delegate but rewrite errors to preserve TypeVar context.
         let delegate_with_error_mapped =
@@ -738,8 +755,13 @@ impl<'db> BoundSuperType<'db> {
                 }
                 return Ok(builder.build());
             }
-            Type::TypeAlias(alias) => {
-                return delegate_to(alias.value_type(db));
+            Type::TypeAlias(_) => {
+                return owner_type.visit_type_alias_value(
+                    db,
+                    recursion_detector,
+                    || Ok(Type::unknown()),
+                    delegate_to,
+                );
             }
             Type::TypeVar(bound_typevar) => {
                 let typevar = bound_typevar.typevar(db);

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -460,7 +460,7 @@ pub(crate) fn is_expandable_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
                 || enum_metadata(db, class.class_literal(db)).is_some()
         }
         Type::Union(_) => true,
-        Type::TypeAlias(alias) => is_expandable_type(db, alias.value_type(db)),
+        Type::TypeAlias(_) => is_expandable_type(db, ty.resolve_type_alias(db)),
         _ => false,
     }
 }
@@ -521,7 +521,7 @@ fn expand_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
         }
         Type::Union(union) => Some(union.elements(db).to_vec()),
         // For type aliases, expand the underlying value type.
-        Type::TypeAlias(alias) => expand_type(db, alias.value_type(db)),
+        Type::TypeAlias(_) => expand_type(db, ty.resolve_type_alias(db)),
         // We don't handle `type[A | B]` here because it's already stored in the expanded form
         // i.e., `type[A] | type[B]` which is handled by the `Type::Union` case.
         _ => None,

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -6,7 +6,6 @@ use ruff_python_ast as ast;
 use rustc_hash::FxHashMap;
 
 use crate::Db;
-use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::enums::{enum_member_literals, enum_metadata};
 use crate::types::tuple::Tuple;
 use crate::types::typed_dict::extract_unpacked_typed_dict_keys_from_value_type;
@@ -496,15 +495,6 @@ impl<'a, 'db> FromIterator<(Argument<'a>, Option<Type<'db>>)> for CallArguments<
 ///
 /// In other words, it returns `true` if [`expand_type`] returns [`Some`] for the given type.
 pub(crate) fn is_expandable_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-    let recursion_detector = ActiveRecursionDetector::default();
-    is_expandable_type_impl(db, ty, &recursion_detector)
-}
-
-fn is_expandable_type_impl<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-    recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-) -> bool {
     match ty {
         Type::NominalInstance(instance) => {
             let class = instance.class(db);
@@ -512,16 +502,14 @@ fn is_expandable_type_impl<'db>(
                 || instance.tuple_spec(db).is_some_and(|spec| match &*spec {
                     Tuple::Fixed(fixed_length_tuple) => fixed_length_tuple
                         .iter_all_elements()
-                        .any(|element| is_expandable_type_impl(db, element, recursion_detector)),
+                        .any(|element| is_expandable_type(db, element)),
                     Tuple::Variable(_) => false,
                 })
                 || enum_metadata(db, class.class_literal(db)).is_some()
         }
         Type::Union(_) => true,
         Type::TypeAlias(_) => {
-            ty.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
-                is_expandable_type_impl(db, value_ty, recursion_detector)
-            })
+            ty.visit_type_alias_value_or_default(db, |value_ty| is_expandable_type(db, value_ty))
         }
         _ => false,
     }
@@ -531,15 +519,6 @@ fn is_expandable_type_impl<'db>(
 ///
 /// Returns [`None`] if the type cannot be expanded.
 fn expand_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
-    let recursion_detector = ActiveRecursionDetector::default();
-    expand_type_impl(db, ty, &recursion_detector)
-}
-
-fn expand_type_impl<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-    recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-) -> Option<Vec<Type<'db>>> {
     // NOTE: Update `is_expandable_type` if this logic changes accordingly.
     match ty {
         Type::NominalInstance(instance) => {
@@ -560,8 +539,7 @@ fn expand_type_impl<'db>(
                         let per_element: Vec<_> = fixed_length_tuple
                             .iter_all_elements()
                             .map(|element| {
-                                expand_type_impl(db, element, recursion_detector)
-                                    .unwrap_or_else(|| vec![element])
+                                expand_type(db, element).unwrap_or_else(|| vec![element])
                             })
                             .collect();
 
@@ -594,9 +572,7 @@ fn expand_type_impl<'db>(
         Type::Union(union) => Some(union.elements(db).to_vec()),
         // For type aliases, expand the underlying value type.
         Type::TypeAlias(_) => {
-            ty.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
-                expand_type_impl(db, value_ty, recursion_detector)
-            })
+            ty.visit_type_alias_value_or_default(db, |value_ty| expand_type(db, value_ty))
         }
         // We don't handle `type[A | B]` here because it's already stored in the expanded form
         // i.e., `type[A] | type[B]` which is handled by the `Type::Union` case.

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -6,6 +6,7 @@ use ruff_python_ast as ast;
 use rustc_hash::FxHashMap;
 
 use crate::Db;
+use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::enums::{enum_member_literals, enum_metadata};
 use crate::types::tuple::Tuple;
 use crate::types::typed_dict::extract_unpacked_typed_dict_keys_from_value_type;
@@ -495,6 +496,15 @@ impl<'a, 'db> FromIterator<(Argument<'a>, Option<Type<'db>>)> for CallArguments<
 ///
 /// In other words, it returns `true` if [`expand_type`] returns [`Some`] for the given type.
 pub(crate) fn is_expandable_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    let recursion_detector = ActiveRecursionDetector::default();
+    is_expandable_type_impl(db, ty, &recursion_detector)
+}
+
+fn is_expandable_type_impl<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+) -> bool {
     match ty {
         Type::NominalInstance(instance) => {
             let class = instance.class(db);
@@ -502,13 +512,17 @@ pub(crate) fn is_expandable_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
                 || instance.tuple_spec(db).is_some_and(|spec| match &*spec {
                     Tuple::Fixed(fixed_length_tuple) => fixed_length_tuple
                         .iter_all_elements()
-                        .any(|element| is_expandable_type(db, element)),
+                        .any(|element| is_expandable_type_impl(db, element, recursion_detector)),
                     Tuple::Variable(_) => false,
                 })
                 || enum_metadata(db, class.class_literal(db)).is_some()
         }
         Type::Union(_) => true,
-        Type::TypeAlias(alias) => is_expandable_type(db, alias.value_type(db)),
+        Type::TypeAlias(_) => {
+            ty.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
+                is_expandable_type_impl(db, value_ty, recursion_detector)
+            })
+        }
         _ => false,
     }
 }
@@ -517,6 +531,15 @@ pub(crate) fn is_expandable_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
 ///
 /// Returns [`None`] if the type cannot be expanded.
 fn expand_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
+    let recursion_detector = ActiveRecursionDetector::default();
+    expand_type_impl(db, ty, &recursion_detector)
+}
+
+fn expand_type_impl<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+) -> Option<Vec<Type<'db>>> {
     // NOTE: Update `is_expandable_type` if this logic changes accordingly.
     match ty {
         Type::NominalInstance(instance) => {
@@ -537,7 +560,8 @@ fn expand_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
                         let per_element: Vec<_> = fixed_length_tuple
                             .iter_all_elements()
                             .map(|element| {
-                                expand_type(db, element).unwrap_or_else(|| vec![element])
+                                expand_type_impl(db, element, recursion_detector)
+                                    .unwrap_or_else(|| vec![element])
                             })
                             .collect();
 
@@ -569,7 +593,11 @@ fn expand_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
         }
         Type::Union(union) => Some(union.elements(db).to_vec()),
         // For type aliases, expand the underlying value type.
-        Type::TypeAlias(alias) => expand_type(db, alias.value_type(db)),
+        Type::TypeAlias(_) => {
+            ty.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
+                expand_type_impl(db, value_ty, recursion_detector)
+            })
+        }
         // We don't handle `type[A | B]` here because it's already stored in the expanded form
         // i.e., `type[A] | type[B]` which is handled by the `Type::Union` case.
         _ => None,

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -2,7 +2,6 @@ use super::{ArgumentForms, Binding, Bindings, CallableBinding, CallableItem};
 use crate::db::Db;
 use crate::types::call::arguments::CallArguments;
 use crate::types::constraints::ConstraintSetBuilder;
-use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::generics::Specialization;
 use crate::types::signatures::Parameter;
 use crate::types::{BoundTypeVarInstance, ClassLiteral, DynamicType, Type, TypeContext};
@@ -567,28 +566,17 @@ fn constructor_returns_instance<'db>(
     class_literal: ClassLiteral<'db>,
     return_ty: Type<'db>,
 ) -> bool {
-    let recursion_detector = ActiveRecursionDetector::default();
-    constructor_returns_instance_impl(db, class_literal, return_ty, &recursion_detector)
-}
-
-fn constructor_returns_instance_impl<'db>(
-    db: &'db dyn Db,
-    class_literal: ClassLiteral<'db>,
-    return_ty: Type<'db>,
-    recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-) -> bool {
     match return_ty {
-        Type::TypeAlias(_) => {
-            return_ty.visit_type_alias_value_or_assume_valid(db, recursion_detector, |value_ty| {
-                constructor_returns_instance_impl(db, class_literal, value_ty, recursion_detector)
-            })
-        }
-        Type::Union(union) => union.elements(db).iter().all(|element| {
-            constructor_returns_instance_impl(db, class_literal, *element, recursion_detector)
+        Type::TypeAlias(_) => return_ty.visit_type_alias_value_or_assume_valid(db, |value_ty| {
+            constructor_returns_instance(db, class_literal, value_ty)
         }),
-        Type::Intersection(intersection) => intersection.iter_positive(db).any(|element| {
-            constructor_returns_instance_impl(db, class_literal, element, recursion_detector)
-        }),
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| constructor_returns_instance(db, class_literal, *element)),
+        Type::Intersection(intersection) => intersection
+            .iter_positive(db)
+            .any(|element| constructor_returns_instance(db, class_literal, element)),
         // Spec says an explicit `Any` return type should be considered non-instance.
         Type::Dynamic(DynamicType::Any) => false,
         // But a missing return annotation should be considered instance.

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -2,6 +2,7 @@ use super::{ArgumentForms, Binding, Bindings, CallableBinding, CallableItem};
 use crate::db::Db;
 use crate::types::call::arguments::CallArguments;
 use crate::types::constraints::ConstraintSetBuilder;
+use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::generics::Specialization;
 use crate::types::signatures::Parameter;
 use crate::types::{BoundTypeVarInstance, ClassLiteral, DynamicType, Type, TypeContext};
@@ -566,14 +567,28 @@ fn constructor_returns_instance<'db>(
     class_literal: ClassLiteral<'db>,
     return_ty: Type<'db>,
 ) -> bool {
-    match return_ty.resolve_type_alias(db) {
-        Type::Union(union) => union
-            .elements(db)
-            .iter()
-            .all(|element| constructor_returns_instance(db, class_literal, *element)),
-        Type::Intersection(intersection) => intersection
-            .iter_positive(db)
-            .any(|element| constructor_returns_instance(db, class_literal, element)),
+    let recursion_detector = ActiveRecursionDetector::default();
+    constructor_returns_instance_impl(db, class_literal, return_ty, &recursion_detector)
+}
+
+fn constructor_returns_instance_impl<'db>(
+    db: &'db dyn Db,
+    class_literal: ClassLiteral<'db>,
+    return_ty: Type<'db>,
+    recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+) -> bool {
+    match return_ty {
+        Type::TypeAlias(_) => {
+            return_ty.visit_type_alias_value_or_assume_valid(db, recursion_detector, |value_ty| {
+                constructor_returns_instance_impl(db, class_literal, value_ty, recursion_detector)
+            })
+        }
+        Type::Union(union) => union.elements(db).iter().all(|element| {
+            constructor_returns_instance_impl(db, class_literal, *element, recursion_detector)
+        }),
+        Type::Intersection(intersection) => intersection.iter_positive(db).any(|element| {
+            constructor_returns_instance_impl(db, class_literal, element, recursion_detector)
+        }),
         // Spec says an explicit `Any` return type should be considered non-instance.
         Type::Dynamic(DynamicType::Any) => false,
         // But a missing return annotation should be considered instance.

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -11,7 +11,6 @@ use crate::{
         LiteralValueTypeKind, MemberLookupPolicy, Parameter, Parameters, Signature,
         SubclassOfInner, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints, UnionType,
         constraints::{ConstraintSet, IteratorConstraintsExtension},
-        cyclic::ActiveRecursionDetector,
         known_instance::FunctoolsPartialInstance,
         relation::{TypeRelation, TypeRelationChecker},
         signatures::{CallableSignature, PartialSignatureApplication},
@@ -78,29 +77,8 @@ impl<'db> Type<'db> {
         policy: UpcastPolicy,
         context: CallableUpcastContext<'db>,
     ) -> Option<CallableTypes<'db>> {
-        let recursion_detector = ActiveRecursionDetector::default();
-        self.try_upcast_to_callable_with_policy_impl(
-            db,
-            policy,
-            context,
-            &recursion_detector,
-        )
-    }
-
-    fn try_upcast_to_callable_with_policy_impl(
-        self,
-        db: &'db dyn Db,
-        policy: UpcastPolicy,
-        context: CallableUpcastContext<'db>,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) -> Option<CallableTypes<'db>> {
         if let Some(fallback) = self.materialized_divergent_fallback() {
-            return fallback.try_upcast_to_callable_with_policy_impl(
-                db,
-                policy,
-                context,
-                recursion_detector,
-            );
+            return fallback.try_upcast_to_callable_with_policy_and_context(db, policy, context);
         }
 
         match self {
@@ -146,12 +124,7 @@ impl<'db> Type<'db> {
                 {
                     place
                         .ty
-                        .try_upcast_to_callable_with_policy_impl(
-                            db,
-                            policy,
-                            context,
-                            recursion_detector,
-                        )
+                        .try_upcast_to_callable_with_policy_and_context(db, policy, context)
                 } else {
                     None
                 }
@@ -164,12 +137,7 @@ impl<'db> Type<'db> {
 
             Type::NewTypeInstance(newtype) => newtype
                 .concrete_base_type(db)
-                .try_upcast_to_callable_with_policy_impl(
-                    db,
-                    policy,
-                    context,
-                    recursion_detector,
-                ),
+                .try_upcast_to_callable_with_policy_and_context(db, policy, context),
 
             Type::SubclassOf(subclass_of_ty) if policy == UpcastPolicy::Sound => {
                 Some(CallableTypes::one(CallableType::function_like(
@@ -185,12 +153,7 @@ impl<'db> Type<'db> {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                         let upcast_callables = bound
                             .to_meta_type(db)
-                            .try_upcast_to_callable_with_policy_impl(
-                                db,
-                                policy,
-                                context,
-                                recursion_detector,
-                            )?;
+                            .try_upcast_to_callable_with_policy_and_context(db, policy, context)?;
                         Some(upcast_callables.map(|callable| {
                             let signatures = callable
                                 .signatures(db)
@@ -208,11 +171,8 @@ impl<'db> Type<'db> {
                         for constraint in constraints.elements(db) {
                             let element_upcast = constraint
                                 .to_meta_type(db)
-                                .try_upcast_to_callable_with_policy_impl(
-                                    db,
-                                    policy,
-                                    context,
-                                    recursion_detector,
+                                .try_upcast_to_callable_with_policy_and_context(
+                                    db, policy, context,
                                 )?;
                             for callable in element_upcast.into_inner() {
                                 let signatures = callable
@@ -243,12 +203,7 @@ impl<'db> Type<'db> {
                 let mut callables = SmallVec::new();
                 for element in union.elements(db) {
                     let element_callable = element
-                        .try_upcast_to_callable_with_policy_impl(
-                            db,
-                            policy,
-                            context,
-                            recursion_detector,
-                        )?;
+                        .try_upcast_to_callable_with_policy_and_context(db, policy, context)?;
                     callables.extend(element_callable.into_inner());
                 }
                 Some(CallableTypes::new(callables))
@@ -257,26 +212,15 @@ impl<'db> Type<'db> {
             Type::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Enum(enum_literal) => enum_literal
                     .enum_class_instance(db)
-                    .try_upcast_to_callable_with_policy_impl(
-                        db,
-                        policy,
-                        context,
-                        recursion_detector,
-                    ),
+                    .try_upcast_to_callable_with_policy_and_context(db, policy, context),
                 _ => None,
             },
 
             Type::TypeAlias(_) => self.visit_type_alias_value(
                 db,
-                recursion_detector,
                 || Some(CallableTypes::one(CallableType::unknown(db))),
                 |value_ty| {
-                    value_ty.try_upcast_to_callable_with_policy_impl(
-                        db,
-                        policy,
-                        context,
-                        recursion_detector,
-                    )
+                    value_ty.try_upcast_to_callable_with_policy_and_context(db, policy, context)
                 },
             ),
 

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -11,6 +11,7 @@ use crate::{
         LiteralValueTypeKind, MemberLookupPolicy, Parameter, Parameters, Signature,
         SubclassOfInner, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints, UnionType,
         constraints::{ConstraintSet, IteratorConstraintsExtension},
+        cyclic::ActiveRecursionDetector,
         known_instance::FunctoolsPartialInstance,
         relation::{TypeRelation, TypeRelationChecker},
         signatures::{CallableSignature, PartialSignatureApplication},
@@ -77,8 +78,29 @@ impl<'db> Type<'db> {
         policy: UpcastPolicy,
         context: CallableUpcastContext<'db>,
     ) -> Option<CallableTypes<'db>> {
+        let recursion_detector = ActiveRecursionDetector::default();
+        self.try_upcast_to_callable_with_policy_impl(
+            db,
+            policy,
+            context,
+            &recursion_detector,
+        )
+    }
+
+    fn try_upcast_to_callable_with_policy_impl(
+        self,
+        db: &'db dyn Db,
+        policy: UpcastPolicy,
+        context: CallableUpcastContext<'db>,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) -> Option<CallableTypes<'db>> {
         if let Some(fallback) = self.materialized_divergent_fallback() {
-            return fallback.try_upcast_to_callable_with_policy_and_context(db, policy, context);
+            return fallback.try_upcast_to_callable_with_policy_impl(
+                db,
+                policy,
+                context,
+                recursion_detector,
+            );
         }
 
         match self {
@@ -124,7 +146,12 @@ impl<'db> Type<'db> {
                 {
                     place
                         .ty
-                        .try_upcast_to_callable_with_policy_and_context(db, policy, context)
+                        .try_upcast_to_callable_with_policy_impl(
+                            db,
+                            policy,
+                            context,
+                            recursion_detector,
+                        )
                 } else {
                     None
                 }
@@ -137,7 +164,12 @@ impl<'db> Type<'db> {
 
             Type::NewTypeInstance(newtype) => newtype
                 .concrete_base_type(db)
-                .try_upcast_to_callable_with_policy_and_context(db, policy, context),
+                .try_upcast_to_callable_with_policy_impl(
+                    db,
+                    policy,
+                    context,
+                    recursion_detector,
+                ),
 
             Type::SubclassOf(subclass_of_ty) if policy == UpcastPolicy::Sound => {
                 Some(CallableTypes::one(CallableType::function_like(
@@ -153,7 +185,12 @@ impl<'db> Type<'db> {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                         let upcast_callables = bound
                             .to_meta_type(db)
-                            .try_upcast_to_callable_with_policy_and_context(db, policy, context)?;
+                            .try_upcast_to_callable_with_policy_impl(
+                                db,
+                                policy,
+                                context,
+                                recursion_detector,
+                            )?;
                         Some(upcast_callables.map(|callable| {
                             let signatures = callable
                                 .signatures(db)
@@ -171,8 +208,11 @@ impl<'db> Type<'db> {
                         for constraint in constraints.elements(db) {
                             let element_upcast = constraint
                                 .to_meta_type(db)
-                                .try_upcast_to_callable_with_policy_and_context(
-                                    db, policy, context,
+                                .try_upcast_to_callable_with_policy_impl(
+                                    db,
+                                    policy,
+                                    context,
+                                    recursion_detector,
                                 )?;
                             for callable in element_upcast.into_inner() {
                                 let signatures = callable
@@ -203,7 +243,12 @@ impl<'db> Type<'db> {
                 let mut callables = SmallVec::new();
                 for element in union.elements(db) {
                     let element_callable = element
-                        .try_upcast_to_callable_with_policy_and_context(db, policy, context)?;
+                        .try_upcast_to_callable_with_policy_impl(
+                            db,
+                            policy,
+                            context,
+                            recursion_detector,
+                        )?;
                     callables.extend(element_callable.into_inner());
                 }
                 Some(CallableTypes::new(callables))
@@ -212,13 +257,28 @@ impl<'db> Type<'db> {
             Type::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Enum(enum_literal) => enum_literal
                     .enum_class_instance(db)
-                    .try_upcast_to_callable_with_policy_and_context(db, policy, context),
+                    .try_upcast_to_callable_with_policy_impl(
+                        db,
+                        policy,
+                        context,
+                        recursion_detector,
+                    ),
                 _ => None,
             },
 
-            Type::TypeAlias(alias) => alias
-                .value_type(db)
-                .try_upcast_to_callable_with_policy_and_context(db, policy, context),
+            Type::TypeAlias(_) => self.visit_type_alias_value(
+                db,
+                recursion_detector,
+                || Some(CallableTypes::one(CallableType::unknown(db))),
+                |value_ty| {
+                    value_ty.try_upcast_to_callable_with_policy_impl(
+                        db,
+                        policy,
+                        context,
+                        recursion_detector,
+                    )
+                },
+            ),
 
             Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderCall(function))
                 if context.is_recursive_reference(db, function) =>

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -30,8 +30,13 @@ use crate::types::generics::{
 };
 use crate::types::known_instance::DeprecatedInstance;
 use crate::types::member::Member;
-use crate::types::relation::{RelationContext, TypeRelation, TypeRelationChecker};
-use crate::types::signatures::{CallableSignature, Parameter, Parameters, Signature};
+use crate::types::relation::{
+    HasRelationToVisitor, InvariantRelationVisitor, IsDisjointVisitor, TypeRelation,
+    TypeRelationChecker,
+};
+use crate::types::signatures::{
+    CallableSignature, Parameter, Parameters, Signature, SignatureRelationVisitor,
+};
 use crate::types::tuple::TupleSpec;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, CallableTypes, DataclassParams,
@@ -1181,9 +1186,20 @@ impl<'db> ClassType<'db> {
     /// Return `true` if `other` is present in this class's MRO.
     pub(super) fn is_subclass_of(self, db: &'db dyn Db, target: ClassType<'db>) -> bool {
         let constraints = ConstraintSetBuilder::new();
-        let context = RelationContext::default(&constraints);
-        let checker =
-            TypeRelationChecker::subtyping(&constraints, InferableTypeVars::None, &context);
+        let relation_visitor = HasRelationToVisitor::default(&constraints);
+        let disjointness_visitor = IsDisjointVisitor::default(&constraints);
+        let signature_relation_visitor = SignatureRelationVisitor::default();
+        let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let materialization_visitor = ApplyTypeMappingVisitor::default();
+        let checker = TypeRelationChecker::subtyping(
+            &constraints,
+            InferableTypeVars::None,
+            &relation_visitor,
+            &disjointness_visitor,
+            &signature_relation_visitor,
+            &invariant_relation_visitor,
+            &materialization_visitor,
+        );
         checker
             .check_class_pair(db, self, target)
             .is_always_satisfied(db)

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -30,12 +30,8 @@ use crate::types::generics::{
 };
 use crate::types::known_instance::DeprecatedInstance;
 use crate::types::member::Member;
-use crate::types::relation::{
-    HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
-};
-use crate::types::signatures::{
-    CallableSignature, Parameter, Parameters, Signature, SignatureRelationVisitor,
-};
+use crate::types::relation::{RelationContext, TypeRelation, TypeRelationChecker};
+use crate::types::signatures::{CallableSignature, Parameter, Parameters, Signature};
 use crate::types::tuple::TupleSpec;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, CallableTypes, DataclassParams,
@@ -1185,18 +1181,9 @@ impl<'db> ClassType<'db> {
     /// Return `true` if `other` is present in this class's MRO.
     pub(super) fn is_subclass_of(self, db: &'db dyn Db, target: ClassType<'db>) -> bool {
         let constraints = ConstraintSetBuilder::new();
-        let relation_visitor = HasRelationToVisitor::default(&constraints);
-        let disjointness_visitor = IsDisjointVisitor::default(&constraints);
-        let signature_relation_visitor = SignatureRelationVisitor::default();
-        let materialization_visitor = ApplyTypeMappingVisitor::default();
-        let checker = TypeRelationChecker::subtyping(
-            &constraints,
-            InferableTypeVars::None,
-            &relation_visitor,
-            &disjointness_visitor,
-            &signature_relation_visitor,
-            &materialization_visitor,
-        );
+        let context = RelationContext::default(&constraints);
+        let checker =
+            TypeRelationChecker::subtyping(&constraints, InferableTypeVars::None, &context);
         checker
             .check_class_pair(db, self, target)
             .is_always_satisfied(db)

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -31,8 +31,8 @@ use crate::types::generics::{
 use crate::types::known_instance::DeprecatedInstance;
 use crate::types::member::Member;
 use crate::types::relation::{
-    HasRelationToVisitor, InvariantRelationVisitor, IsDisjointVisitor, TypeRelation,
-    TypeRelationChecker,
+    AliasRelationVisitor, HasRelationToVisitor, InvariantRelationVisitor, IsDisjointVisitor,
+    TypeRelation, TypeRelationChecker,
 };
 use crate::types::signatures::{
     CallableSignature, Parameter, Parameters, Signature, SignatureRelationVisitor,
@@ -1190,6 +1190,7 @@ impl<'db> ClassType<'db> {
         let disjointness_visitor = IsDisjointVisitor::default(&constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let alias_relation_visitor = AliasRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker::subtyping(
             &constraints,
@@ -1198,6 +1199,7 @@ impl<'db> ClassType<'db> {
             &disjointness_visitor,
             &signature_relation_visitor,
             &invariant_relation_visitor,
+            &alias_relation_visitor,
             &materialization_visitor,
         );
         checker

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -8,6 +8,7 @@ use crate::types::{
     TypeMapping, todo_type,
 };
 use crate::{Db, DisplaySettings};
+use salsa::plumbing::AsId;
 
 /// Enumeration of the possible kinds of types we allow in class bases.
 ///
@@ -151,7 +152,11 @@ impl<'db> ClassBase<'db> {
             // in which case we want to treat `Never` in a forgiving way and silence diagnostics
             Type::Never => Some(ClassBase::unknown()),
 
-            Type::TypeAlias(alias) => Self::try_from_type(db, alias.value_type(db), subclass),
+            Type::TypeAlias(alias) => alias.visit_value(
+                db,
+                || Self::try_from_type(db, Type::divergent(alias.definition(db).as_id()), subclass),
+                |value_ty| Self::try_from_type(db, value_ty, subclass),
+            ),
 
             Type::NewTypeInstance(newtype) => {
                 ClassBase::try_from_type(db, newtype.concrete_base_type(db), subclass)

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -25,7 +25,7 @@ use std::cmp::Eq;
 use std::hash::Hash;
 use std::marker::PhantomData;
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::FxIndexSet;
 use crate::types::Type;
@@ -129,5 +129,42 @@ impl<Tag, T: Hash + Eq + Clone, R: Clone> CycleDetector<Tag, T, R> {
 impl<Tag, T, R: Default> Default for CycleDetector<Tag, T, R> {
     fn default() -> Self {
         CycleDetector::new(R::default())
+    }
+}
+
+/// Recursion detection without memoization.
+///
+/// This is useful when a recursive operation needs a coinductive-style "we're already evaluating
+/// this, assume a conservative answer for now" step, but completed results are not safe to reuse
+/// for future visits to the same key.
+#[derive(Debug)]
+pub(crate) struct ActiveRecursionDetector<T> {
+    seen: RefCell<FxHashSet<T>>,
+}
+
+impl<T> Default for ActiveRecursionDetector<T> {
+    fn default() -> Self {
+        Self {
+            seen: RefCell::new(FxHashSet::default()),
+        }
+    }
+}
+
+impl<T: Hash + Eq + Clone> ActiveRecursionDetector<T> {
+    pub(crate) fn visit<R>(
+        &self,
+        item: &T,
+        on_cycle: impl FnOnce() -> R,
+        func: impl FnOnce() -> R,
+    ) -> R {
+        if !self.seen.borrow_mut().insert(item.clone()) {
+            return on_cycle();
+        }
+
+        let ret = func();
+
+        self.seen.borrow_mut().remove(item);
+
+        ret
     }
 }

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -54,12 +54,14 @@ enum TypeAliasKey {
     ManualPEP695(salsa::Id),
 }
 
-impl<'db> From<TypeAliasType<'db>> for TypeAliasKey {
-    fn from(type_alias: TypeAliasType<'db>) -> Self {
+impl TypeAliasKey {
+    fn from_type_alias(db: &dyn Db, type_alias: TypeAliasType<'_>) -> Self {
         match type_alias {
-            TypeAliasType::PEP695(type_alias) => TypeAliasKey::PEP695(type_alias.as_id()),
+            TypeAliasType::PEP695(type_alias) => {
+                TypeAliasKey::PEP695(type_alias.definition(db).as_id())
+            }
             TypeAliasType::ManualPEP695(type_alias) => {
-                TypeAliasKey::ManualPEP695(type_alias.as_id())
+                TypeAliasKey::ManualPEP695(type_alias.definition(db).as_id())
             }
         }
     }
@@ -71,12 +73,18 @@ std::thread_local! {
 }
 
 pub(crate) fn visit_type_alias<R>(
+    db: &dyn Db,
     type_alias: TypeAliasType<'_>,
     on_cycle: impl FnOnce() -> R,
     func: impl FnOnce() -> R,
 ) -> R {
-    ACTIVE_TYPE_ALIASES
-        .with(|detector| detector.visit(&TypeAliasKey::from(type_alias), on_cycle, func))
+    ACTIVE_TYPE_ALIASES.with(|detector| {
+        detector.visit(
+            &TypeAliasKey::from_type_alias(db, type_alias),
+            on_cycle,
+            func,
+        )
+    })
 }
 
 #[derive(Debug)]

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -68,8 +68,34 @@ impl TypeAliasKey {
 }
 
 std::thread_local! {
-    static ACTIVE_TYPE_ALIASES: ActiveRecursionDetector<TypeAliasKey> =
-        ActiveRecursionDetector::default();
+    static ACTIVE_TYPE_ALIASES: TypeAliasRecursionVisitor =
+        TypeAliasRecursionVisitor::default();
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct TypeAliasRecursionVisitor {
+    detector: ActiveRecursionDetector<TypeAliasKey>,
+}
+
+impl TypeAliasRecursionVisitor {
+    /// Visits a type alias with active-recursion tracking scoped to this visitor.
+    ///
+    /// Use this for recursive operations that need to share alias-recursion state across nested
+    /// type traversal, without marking the alias as active for unrelated work performed inside the
+    /// operation.
+    pub(crate) fn visit<R>(
+        &self,
+        db: &dyn Db,
+        type_alias: TypeAliasType<'_>,
+        on_cycle: impl FnOnce() -> R,
+        func: impl FnOnce() -> R,
+    ) -> R {
+        self.detector.visit(
+            &TypeAliasKey::from_type_alias(db, type_alias),
+            on_cycle,
+            func,
+        )
+    }
 }
 
 pub(crate) fn visit_type_alias<R>(
@@ -78,13 +104,7 @@ pub(crate) fn visit_type_alias<R>(
     on_cycle: impl FnOnce() -> R,
     func: impl FnOnce() -> R,
 ) -> R {
-    ACTIVE_TYPE_ALIASES.with(|detector| {
-        detector.visit(
-            &TypeAliasKey::from_type_alias(db, type_alias),
-            on_cycle,
-            func,
-        )
-    })
+    ACTIVE_TYPE_ALIASES.with(|visitor| visitor.visit(db, type_alias, on_cycle, func))
 }
 
 #[derive(Debug)]

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -166,9 +166,9 @@ impl<Tag, T, R: Default> Default for CycleDetector<Tag, T, R> {
 
 /// Recursion detection without memoization.
 ///
-/// This is useful when a recursive relation needs a coinductive-style "we're already proving this
-/// goal, assume it for now" step, but completed results are not safe to reuse for future visits to
-/// the same abstract key.
+/// This is useful when a recursive operation or relation needs a coinductive-style "we're already
+/// evaluating this, assume a conservative answer for now" step, but completed results are not safe
+/// to reuse for future visits to the same key.
 #[derive(Debug)]
 pub(crate) struct ActiveRecursionDetector<T> {
     seen: RefCell<FxHashSet<T>>,

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -26,10 +26,12 @@ use std::hash::Hash;
 use std::marker::PhantomData;
 
 use rustc_hash::{FxHashMap, FxHashSet};
+use salsa::plumbing::AsId;
 
 use crate::Db;
 use crate::FxIndexSet;
 use crate::types::Type;
+use crate::types::type_alias::TypeAliasType;
 
 pub(crate) type TypeTransformer<'db, Tag> = CycleDetector<Tag, Type<'db>, Type<'db>>;
 
@@ -45,6 +47,37 @@ impl<Tag> Default for TypeTransformer<'_, Tag> {
 }
 
 pub(crate) type PairVisitor<'db, Tag, C> = CycleDetector<Tag, (Type<'db>, Type<'db>), C>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum TypeAliasKey {
+    PEP695(salsa::Id),
+    ManualPEP695(salsa::Id),
+}
+
+impl<'db> From<TypeAliasType<'db>> for TypeAliasKey {
+    fn from(type_alias: TypeAliasType<'db>) -> Self {
+        match type_alias {
+            TypeAliasType::PEP695(type_alias) => TypeAliasKey::PEP695(type_alias.as_id()),
+            TypeAliasType::ManualPEP695(type_alias) => {
+                TypeAliasKey::ManualPEP695(type_alias.as_id())
+            }
+        }
+    }
+}
+
+std::thread_local! {
+    static ACTIVE_TYPE_ALIASES: ActiveRecursionDetector<TypeAliasKey> =
+        ActiveRecursionDetector::default();
+}
+
+pub(crate) fn visit_type_alias<R>(
+    type_alias: TypeAliasType<'_>,
+    on_cycle: impl FnOnce() -> R,
+    func: impl FnOnce() -> R,
+) -> R {
+    ACTIVE_TYPE_ALIASES
+        .with(|detector| detector.visit(&TypeAliasKey::from(type_alias), on_cycle, func))
+}
 
 #[derive(Debug)]
 pub struct CycleDetector<Tag, T, R> {

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1681,7 +1681,11 @@ fn is_instance_truthiness<'db>(
 
         Type::ClassLiteral(..) => always_true_if(is_instance(&KnownClass::Type.to_instance(db))),
 
-        Type::TypeAlias(alias) => is_instance_truthiness(db, alias.value_type(db), class),
+        Type::TypeAlias(alias) => alias.visit_value(
+            db,
+            || Truthiness::Ambiguous,
+            |value_ty| is_instance_truthiness(db, value_ty, class),
+        ),
 
         Type::TypeVar(bound_typevar) => match bound_typevar.typevar(db).bound_or_constraints(db) {
             None => is_instance_truthiness(db, Type::object(), class),

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1494,6 +1494,30 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         target_type: Type<'db>,
         target_materialization: MaterializationKind,
     ) -> ConstraintSet<'db, 'c> {
+        self.materialization_visitor.visit_invariant_relation(
+            source_type,
+            target_type,
+            || self.check_type_pair(db, source_type, target_type),
+            || {
+                self.check_subtyping_in_invariant_position_impl(
+                    db,
+                    source_type,
+                    source_materialization,
+                    target_type,
+                    target_materialization,
+                )
+            },
+        )
+    }
+
+    fn check_subtyping_in_invariant_position_impl(
+        &self,
+        db: &'db dyn Db,
+        source_type: Type<'db>,
+        source_materialization: MaterializationKind,
+        target_type: Type<'db>,
+        target_materialization: MaterializationKind,
+    ) -> ConstraintSet<'db, 'c> {
         let source_top =
             source_type.materialize(db, MaterializationKind::Top, self.materialization_visitor);
         let source_bottom = source_type.materialize(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -15,10 +15,11 @@ use crate::types::constraints::{
     Solutions,
 };
 use crate::types::relation::{
-    DisjointnessChecker, InvariantRelationGoal, RelationContext, TypeRelation, TypeRelationChecker,
+    DisjointnessChecker, HasRelationToVisitor, InvariantRelationGoal, InvariantRelationVisitor,
+    IsDisjointVisitor, TypeRelation, TypeRelationChecker,
 };
 use crate::types::signatures::{
-    CallableSignature, Parameters, ReturnCallableTypeVarScope,
+    CallableSignature, Parameters, ReturnCallableTypeVarScope, SignatureRelationVisitor,
 };
 use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
 use crate::types::type_alias::{walk_manual_pep_695_type_alias, walk_pep_695_type_alias};
@@ -1340,8 +1341,20 @@ impl<'db> Specialization<'db> {
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let context = RelationContext::default(constraints);
-        let checker = DisjointnessChecker::new(constraints, inferable, &context);
+        let relation_visitor = HasRelationToVisitor::default(constraints);
+        let disjointness_visitor = IsDisjointVisitor::default(constraints);
+        let signature_relation_visitor = SignatureRelationVisitor::default();
+        let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let materialization_visitor = ApplyTypeMappingVisitor::default();
+        let checker = DisjointnessChecker::new(
+            constraints,
+            inferable,
+            &relation_visitor,
+            &disjointness_visitor,
+            &signature_relation_visitor,
+            &invariant_relation_visitor,
+            &materialization_visitor,
+        );
         checker.check_specialization_pair(db, self, other)
     }
 
@@ -1521,7 +1534,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         target_type: Type<'db>,
         target_materialization: MaterializationKind,
     ) -> ConstraintSet<'db, 'c> {
-        self.context.visitors.invariant.visit(
+        self.invariant_relation_visitor.visit(
             &InvariantRelationGoal::new(
                 source_type,
                 source_materialization,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -15,10 +15,10 @@ use crate::types::constraints::{
     Solutions,
 };
 use crate::types::relation::{
-    DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
+    DisjointnessChecker, InvariantRelationGoal, RelationContext, TypeRelation, TypeRelationChecker,
 };
 use crate::types::signatures::{
-    CallableSignature, Parameters, ReturnCallableTypeVarScope, SignatureRelationVisitor,
+    CallableSignature, Parameters, ReturnCallableTypeVarScope,
 };
 use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
 use crate::types::type_alias::{walk_manual_pep_695_type_alias, walk_pep_695_type_alias};
@@ -1340,18 +1340,8 @@ impl<'db> Specialization<'db> {
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let relation_visitor = HasRelationToVisitor::default(constraints);
-        let disjointness_visitor = IsDisjointVisitor::default(constraints);
-        let signature_relation_visitor = SignatureRelationVisitor::default();
-        let materialization_visitor = ApplyTypeMappingVisitor::default();
-        let checker = DisjointnessChecker::new(
-            constraints,
-            inferable,
-            &relation_visitor,
-            &disjointness_visitor,
-            &signature_relation_visitor,
-            &materialization_visitor,
-        );
+        let context = RelationContext::default(constraints);
+        let checker = DisjointnessChecker::new(constraints, inferable, &context);
         checker.check_specialization_pair(db, self, other)
     }
 
@@ -1524,6 +1514,44 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     }
 
     fn check_subtyping_in_invariant_position(
+        &self,
+        db: &'db dyn Db,
+        source_type: Type<'db>,
+        source_materialization: MaterializationKind,
+        target_type: Type<'db>,
+        target_materialization: MaterializationKind,
+    ) -> ConstraintSet<'db, 'c> {
+        self.context.visitors.invariant.visit(
+            &InvariantRelationGoal::new(
+                source_type,
+                source_materialization,
+                target_type,
+                target_materialization,
+                self.relation,
+            ),
+            || self.check_type_pair(db, source_type, target_type),
+            || {
+                self.check_subtyping_in_invariant_position_impl(
+                    db,
+                    source_type,
+                    source_materialization,
+                    target_type,
+                    target_materialization,
+                )
+            },
+        )
+    }
+
+    /// Checks invariant-position subtyping once the source/target pair has been registered.
+    ///
+    /// The public wrapper guards this helper against recursive relation checks. That matters for
+    /// recursive aliases inside invariant containers, where materialization can otherwise revisit
+    /// the same pair before the first check completes:
+    ///
+    /// ```python
+    /// type RecursiveList = list[RecursiveList]
+    /// ```
+    fn check_subtyping_in_invariant_position_impl(
         &self,
         db: &'db dyn Db,
         source_type: Type<'db>,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -15,8 +15,8 @@ use crate::types::constraints::{
     Solutions,
 };
 use crate::types::relation::{
-    DisjointnessChecker, HasRelationToVisitor, InvariantRelationGoal, InvariantRelationVisitor,
-    IsDisjointVisitor, TypeRelation, TypeRelationChecker,
+    AliasRelationVisitor, DisjointnessChecker, HasRelationToVisitor, InvariantRelationGoal,
+    InvariantRelationVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
 };
 use crate::types::signatures::{
     CallableSignature, Parameters, ReturnCallableTypeVarScope, SignatureRelationVisitor,
@@ -1345,6 +1345,7 @@ impl<'db> Specialization<'db> {
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let alias_relation_visitor = AliasRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = DisjointnessChecker::new(
             constraints,
@@ -1353,6 +1354,7 @@ impl<'db> Specialization<'db> {
             &disjointness_visitor,
             &signature_relation_visitor,
             &invariant_relation_visitor,
+            &alias_relation_visitor,
             &materialization_visitor,
         );
         checker.check_specialization_pair(db, self, other)
@@ -2077,10 +2079,44 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let formal = formal.filter_disjoint_elements(self.db, actual, self.inferable);
 
         match (formal, actual) {
+            (Type::TypeAlias(formal_alias), Type::TypeAlias(actual_alias))
+                if formal_alias.definition(self.db) == actual_alias.definition(self.db) =>
+            {
+                let Some(generic_context) = formal_alias.generic_context(self.db) else {
+                    return formal.visit_type_alias_value(
+                        self.db,
+                        || Ok(()),
+                        |value_ty| self.infer_map_impl(value_ty, actual, polarity, f, seen),
+                    );
+                };
+
+                let formal_specialization = formal_alias
+                    .specialization(self.db)
+                    .unwrap_or_else(|| generic_context.default_specialization(self.db, None));
+                let actual_specialization = actual_alias
+                    .specialization(self.db)
+                    .unwrap_or_else(|| generic_context.default_specialization(self.db, None));
+
+                for (typevar, formal_ty, actual_ty) in itertools::izip!(
+                    generic_context.variables(self.db),
+                    formal_specialization.types(self.db),
+                    actual_specialization.types(self.db)
+                ) {
+                    let variance = typevar.variance_with_polarity(self.db, polarity);
+                    self.infer_map_impl(*formal_ty, *actual_ty, variance, &mut f, seen)?;
+                }
+
+                return Ok(());
+            }
+
             // Expand PEP 695 type aliases in the formal type.
             // This is necessary for solving generics like `def head[T](my_list: MyList[T]) -> T`.
-            (Type::TypeAlias(alias), _) => {
-                return self.infer_map_impl(alias.value_type(self.db), actual, polarity, f, seen);
+            (Type::TypeAlias(_), _) => {
+                return formal.visit_type_alias_value(
+                    self.db,
+                    || Ok(()),
+                    |value_ty| self.infer_map_impl(value_ty, actual, polarity, f, seen),
+                );
             }
 
             // TODO: We haven't implemented a full unification solver yet. If typevars appear in
@@ -2219,6 +2255,18 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             (Type::TypeVar(bound_typevar), ty) | (ty, Type::TypeVar(bound_typevar))
                 if bound_typevar.is_inferable(self.db, self.inferable) =>
             {
+                if let Type::Intersection(intersection) = ty
+                    && intersection
+                        .negative(self.db)
+                        .iter()
+                        .any(|negative| matches!(negative, Type::TypeAlias(_)))
+                {
+                    // A negative alias that remains in an intersection after set-theoretic
+                    // simplification is recursive. Avoid trying to structurally infer a typevar
+                    // from it; expanding the alias again can produce an unbounded chain of
+                    // increasingly specialized aliases.
+                    return Ok(());
+                }
                 match bound_typevar.typevar(self.db).bound_or_constraints(self.db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                         if polarity.is_contravariant() {
@@ -2566,8 +2614,12 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             // This is placed at the end of the match block to avoid expanding the type alias
             // when it can be matched directly against a type variable in the formal type,
             // e.g., `reveal_type(alias)` should reveal the type alias, not its value type.
-            (formal, Type::TypeAlias(alias)) => {
-                return self.infer_map_impl(formal, alias.value_type(self.db), polarity, f, seen);
+            (formal, Type::TypeAlias(_)) => {
+                return actual.visit_type_alias_value(
+                    self.db,
+                    || Ok(()),
+                    |value_ty| self.infer_map_impl(formal, value_ty, polarity, f, seen),
+                );
             }
 
             // TODO: Add more forms that we can structurally induct into: type[C], callables

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -44,6 +44,7 @@ use crate::types::callable::CallableTypeKind;
 use crate::types::class::{ClassLiteral, CodeGeneratorKind, MethodDecorator};
 use crate::types::constraints::{ConstraintSetBuilder, PathBounds, Solutions};
 use crate::types::context::InferContext;
+use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::diagnostic::{
     self, CALL_NON_CALLABLE, CONFLICTING_DECLARATIONS, CYCLIC_TYPE_ALIAS_DEFINITION,
     GeneratorMismatchKind, INEFFECTIVE_FINAL, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT,
@@ -2311,6 +2312,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         infer_value_ty: &mut dyn FnMut(&mut Self, TypeContext<'db>) -> Type<'db>,
         emit_diagnostics: bool,
     ) -> bool {
+        let recursion_detector = ActiveRecursionDetector::default();
+        self.validate_attribute_assignment_impl(
+            target,
+            object_ty,
+            attribute,
+            infer_value_ty,
+            emit_diagnostics,
+            &recursion_detector,
+        )
+    }
+
+    fn validate_attribute_assignment_impl(
+        &mut self,
+        target: &ast::ExprAttribute,
+        object_ty: Type<'db>,
+        attribute: &str,
+        infer_value_ty: &mut dyn FnMut(&mut Self, TypeContext<'db>) -> Type<'db>,
+        emit_diagnostics: bool,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) -> bool {
         let db = self.db();
 
         // This closure should only be called if `value_ty` was inferred with `attr_ty` as type context.
@@ -2353,12 +2374,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let value_ty = infer_value_ty.infer_loud(self, TypeContext::default());
 
                 if union.elements(self.db()).iter().all(|elem| {
-                    self.validate_attribute_assignment(
+                    self.validate_attribute_assignment_impl(
                         target,
                         *elem,
                         attribute,
                         &mut |builder, tcx| infer_value_ty.infer_silent(builder, tcx),
                         false,
+                        recursion_detector,
                     )
                 }) {
                     if emit_diagnostics {
@@ -2388,12 +2410,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 // TODO: Handle negative intersection elements
                 if intersection.positive(db).iter().any(|elem| {
-                    self.validate_attribute_assignment(
+                    self.validate_attribute_assignment_impl(
                         target,
                         *elem,
                         attribute,
                         &mut |builder, tcx| infer_value_ty.infer_silent(builder, tcx),
                         false,
+                        recursion_detector,
                     )
                 }) {
                     // Perform loud inference using the narrowed type context.
@@ -2423,12 +2446,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            Type::TypeAlias(alias) => self.validate_attribute_assignment(
-                target,
-                alias.value_type(self.db()),
-                attribute,
-                infer_value_ty,
-                emit_diagnostics,
+            Type::TypeAlias(_) => object_ty.visit_type_alias_value_or_assume_valid(
+                self.db(),
+                recursion_detector,
+                |value_ty| {
+                    self.validate_attribute_assignment_impl(
+                        target,
+                        value_ty,
+                        attribute,
+                        infer_value_ty,
+                        emit_diagnostics,
+                        recursion_detector,
+                    )
+                },
             ),
 
             // Super instances do not allow attribute assignment
@@ -3032,16 +3062,35 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         attribute: &str,
         emit_diagnostics: bool,
     ) -> bool {
+        let recursion_detector = ActiveRecursionDetector::default();
+        self.validate_attribute_deletion_impl(
+            target,
+            object_ty,
+            attribute,
+            emit_diagnostics,
+            &recursion_detector,
+        )
+    }
+
+    fn validate_attribute_deletion_impl(
+        &mut self,
+        target: &ast::ExprAttribute,
+        object_ty: Type<'db>,
+        attribute: &str,
+        emit_diagnostics: bool,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) -> bool {
         let db = self.db();
 
         match object_ty {
             Type::Union(union) => {
                 for element_ty in union.elements(db) {
-                    if !self.validate_attribute_deletion(
+                    if !self.validate_attribute_deletion_impl(
                         target,
                         *element_ty,
                         attribute,
                         emit_diagnostics,
+                        recursion_detector,
                     ) {
                         return false;
                     }
@@ -3051,13 +3100,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             Type::Intersection(intersection) => {
                 if intersection.positive(db).iter().any(|element_ty| {
-                    self.validate_attribute_deletion(target, *element_ty, attribute, false)
+                    self.validate_attribute_deletion_impl(
+                        target,
+                        *element_ty,
+                        attribute,
+                        false,
+                        recursion_detector,
+                    )
                 }) {
                     true
                 } else {
                     if emit_diagnostics && let Some(element_ty) = intersection.positive(db).first()
                     {
-                        self.validate_attribute_deletion(target, *element_ty, attribute, true);
+                        self.validate_attribute_deletion_impl(
+                            target,
+                            *element_ty,
+                            attribute,
+                            true,
+                            recursion_detector,
+                        );
                     }
                     false
                 }
@@ -3066,11 +3127,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Type aliases need their own arm so aliased unions and intersections reuse the
             // specialized handling above. `NewType` instances don't: dunder lookup and attribute
             // fallback already delegate through the concrete base type when needed.
-            Type::TypeAlias(alias) => self.validate_attribute_deletion(
-                target,
-                alias.value_type(db),
-                attribute,
-                emit_diagnostics,
+            Type::TypeAlias(_) => object_ty.visit_type_alias_value_or_assume_valid(
+                db,
+                recursion_detector,
+                |value_ty| {
+                    self.validate_attribute_deletion_impl(
+                        target,
+                        value_ty,
+                        attribute,
+                        emit_diagnostics,
+                        recursion_detector,
+                    )
+                },
             ),
 
             Type::NominalInstance(..)
@@ -4974,6 +5042,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             db: &'d dyn Db,
             ty: Type<'d>,
             kind: CallableTypeKind,
+            recursion_detector: &ActiveRecursionDetector<Type<'d>>,
         ) -> Option<Type<'d>> {
             match ty {
                 Type::Callable(callable) => Some(Type::Callable(CallableType::new(
@@ -4981,10 +5050,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     callable.signatures(db),
                     kind,
                 ))),
-                Type::Union(union) => {
-                    union.try_map(db, |element| propagate_callable_kind(db, *element, kind))
-                }
-                Type::TypeAlias(alias) => propagate_callable_kind(db, alias.value_type(db), kind),
+                Type::Union(union) => union.try_map(db, |element| {
+                    propagate_callable_kind(db, *element, kind, recursion_detector)
+                }),
+                Type::TypeAlias(_) => ty.visit_type_alias_value(
+                    db,
+                    recursion_detector,
+                    || Some(Type::unknown()),
+                    |value_ty| propagate_callable_kind(db, value_ty, kind, recursion_detector),
+                ),
                 // Intersections are currently not handled here because that would require
                 // the decorator to be explicitly annotated as returning an intersection.
                 Type::Intersection(_) => None,
@@ -5059,8 +5133,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // classmethod-like or staticmethod-like). See "Decorating a method with
         // a `Callable`-typed decorator" in `callables_as_descriptors.md` for the
         // extended explanation.
+        let recursion_detector = ActiveRecursionDetector::default();
         propagatable_kind
-            .and_then(|kind| propagate_callable_kind(self.db(), return_ty, kind))
+            .and_then(|kind| {
+                propagate_callable_kind(self.db(), return_ty, kind, &recursion_detector)
+            })
             .unwrap_or(return_ty)
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -44,7 +44,6 @@ use crate::types::callable::CallableTypeKind;
 use crate::types::class::{ClassLiteral, CodeGeneratorKind, MethodDecorator};
 use crate::types::constraints::{ConstraintSetBuilder, PathBounds, Solutions};
 use crate::types::context::InferContext;
-use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::diagnostic::{
     self, CALL_NON_CALLABLE, CONFLICTING_DECLARATIONS, CYCLIC_TYPE_ALIAS_DEFINITION,
     GeneratorMismatchKind, INEFFECTIVE_FINAL, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT,
@@ -2312,26 +2311,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         infer_value_ty: &mut dyn FnMut(&mut Self, TypeContext<'db>) -> Type<'db>,
         emit_diagnostics: bool,
     ) -> bool {
-        let recursion_detector = ActiveRecursionDetector::default();
-        self.validate_attribute_assignment_impl(
-            target,
-            object_ty,
-            attribute,
-            infer_value_ty,
-            emit_diagnostics,
-            &recursion_detector,
-        )
-    }
-
-    fn validate_attribute_assignment_impl(
-        &mut self,
-        target: &ast::ExprAttribute,
-        object_ty: Type<'db>,
-        attribute: &str,
-        infer_value_ty: &mut dyn FnMut(&mut Self, TypeContext<'db>) -> Type<'db>,
-        emit_diagnostics: bool,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) -> bool {
         let db = self.db();
 
         // This closure should only be called if `value_ty` was inferred with `attr_ty` as type context.
@@ -2374,13 +2353,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let value_ty = infer_value_ty.infer_loud(self, TypeContext::default());
 
                 if union.elements(self.db()).iter().all(|elem| {
-                    self.validate_attribute_assignment_impl(
+                    self.validate_attribute_assignment(
                         target,
                         *elem,
                         attribute,
                         &mut |builder, tcx| infer_value_ty.infer_silent(builder, tcx),
                         false,
-                        recursion_detector,
                     )
                 }) {
                     if emit_diagnostics {
@@ -2410,13 +2388,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 // TODO: Handle negative intersection elements
                 if intersection.positive(db).iter().any(|elem| {
-                    self.validate_attribute_assignment_impl(
+                    self.validate_attribute_assignment(
                         target,
                         *elem,
                         attribute,
                         &mut |builder, tcx| infer_value_ty.infer_silent(builder, tcx),
                         false,
-                        recursion_detector,
                     )
                 }) {
                     // Perform loud inference using the narrowed type context.
@@ -2446,20 +2423,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            Type::TypeAlias(_) => object_ty.visit_type_alias_value_or_assume_valid(
-                self.db(),
-                recursion_detector,
-                |value_ty| {
-                    self.validate_attribute_assignment_impl(
+            Type::TypeAlias(_) => {
+                object_ty.visit_type_alias_value_or_assume_valid(self.db(), |value_ty| {
+                    self.validate_attribute_assignment(
                         target,
                         value_ty,
                         attribute,
                         infer_value_ty,
                         emit_diagnostics,
-                        recursion_detector,
                     )
-                },
-            ),
+                })
+            }
 
             // Super instances do not allow attribute assignment
             Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Super) => {
@@ -3062,35 +3036,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         attribute: &str,
         emit_diagnostics: bool,
     ) -> bool {
-        let recursion_detector = ActiveRecursionDetector::default();
-        self.validate_attribute_deletion_impl(
-            target,
-            object_ty,
-            attribute,
-            emit_diagnostics,
-            &recursion_detector,
-        )
-    }
-
-    fn validate_attribute_deletion_impl(
-        &mut self,
-        target: &ast::ExprAttribute,
-        object_ty: Type<'db>,
-        attribute: &str,
-        emit_diagnostics: bool,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) -> bool {
         let db = self.db();
 
         match object_ty {
             Type::Union(union) => {
                 for element_ty in union.elements(db) {
-                    if !self.validate_attribute_deletion_impl(
+                    if !self.validate_attribute_deletion(
                         target,
                         *element_ty,
                         attribute,
                         emit_diagnostics,
-                        recursion_detector,
                     ) {
                         return false;
                     }
@@ -3100,25 +3055,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             Type::Intersection(intersection) => {
                 if intersection.positive(db).iter().any(|element_ty| {
-                    self.validate_attribute_deletion_impl(
-                        target,
-                        *element_ty,
-                        attribute,
-                        false,
-                        recursion_detector,
-                    )
+                    self.validate_attribute_deletion(target, *element_ty, attribute, false)
                 }) {
                     true
                 } else {
                     if emit_diagnostics && let Some(element_ty) = intersection.positive(db).first()
                     {
-                        self.validate_attribute_deletion_impl(
-                            target,
-                            *element_ty,
-                            attribute,
-                            true,
-                            recursion_detector,
-                        );
+                        self.validate_attribute_deletion(target, *element_ty, attribute, true);
                     }
                     false
                 }
@@ -3127,19 +3070,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Type aliases need their own arm so aliased unions and intersections reuse the
             // specialized handling above. `NewType` instances don't: dunder lookup and attribute
             // fallback already delegate through the concrete base type when needed.
-            Type::TypeAlias(_) => object_ty.visit_type_alias_value_or_assume_valid(
-                db,
-                recursion_detector,
-                |value_ty| {
-                    self.validate_attribute_deletion_impl(
-                        target,
-                        value_ty,
-                        attribute,
-                        emit_diagnostics,
-                        recursion_detector,
-                    )
-                },
-            ),
+            Type::TypeAlias(_) => {
+                object_ty.visit_type_alias_value_or_assume_valid(db, |value_ty| {
+                    self.validate_attribute_deletion(target, value_ty, attribute, emit_diagnostics)
+                })
+            }
 
             Type::NominalInstance(..)
             | Type::ProtocolInstance(_)
@@ -5042,7 +4977,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             db: &'d dyn Db,
             ty: Type<'d>,
             kind: CallableTypeKind,
-            recursion_detector: &ActiveRecursionDetector<Type<'d>>,
         ) -> Option<Type<'d>> {
             match ty {
                 Type::Callable(callable) => Some(Type::Callable(CallableType::new(
@@ -5050,14 +4984,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     callable.signatures(db),
                     kind,
                 ))),
-                Type::Union(union) => union.try_map(db, |element| {
-                    propagate_callable_kind(db, *element, kind, recursion_detector)
-                }),
+                Type::Union(union) => {
+                    union.try_map(db, |element| propagate_callable_kind(db, *element, kind))
+                }
                 Type::TypeAlias(_) => ty.visit_type_alias_value(
                     db,
-                    recursion_detector,
                     || Some(Type::unknown()),
-                    |value_ty| propagate_callable_kind(db, value_ty, kind, recursion_detector),
+                    |value_ty| propagate_callable_kind(db, value_ty, kind),
                 ),
                 // Intersections are currently not handled here because that would require
                 // the decorator to be explicitly annotated as returning an intersection.
@@ -5133,11 +5066,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // classmethod-like or staticmethod-like). See "Decorating a method with
         // a `Callable`-typed decorator" in `callables_as_descriptors.md` for the
         // extended explanation.
-        let recursion_detector = ActiveRecursionDetector::default();
         propagatable_kind
-            .and_then(|kind| {
-                propagate_callable_kind(self.db(), return_ty, kind, &recursion_detector)
-            })
+            .and_then(|kind| propagate_callable_kind(self.db(), return_ty, kind))
             .unwrap_or(return_ty)
     }
 
@@ -8731,11 +8661,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             attr_name: &str,
             missing_types: &mut FxIndexSet<Type<'db>>,
         ) {
-            if let Some(union) = ty.as_union_like(db) {
-                for element in union.elements(db) {
-                    union_elements_missing_attribute(db, *element, attr_name, missing_types);
-                }
-            } else if ty.member(db, attr_name).place.is_undefined() {
+            if ty.visit_union_like_elements(db, &mut |element| {
+                union_elements_missing_attribute(db, element, attr_name, missing_types);
+            }) {
+                return;
+            }
+
+            if ty.member(db, attr_name).place.is_undefined() {
                 missing_types.insert(ty);
             }
         }
@@ -8965,19 +8897,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     //
                     // On the other hand, we could be looking at a union where some elements have
                     // the attribute but others definitely don't. That's a very different case, and
-                    // we want it to be an error. Use `as_union_like` here to handle type aliases
-                    // of unions and `NewType`s of float/complex in addition to explicit unions.
-                    if let Some(union) = value_type.as_union_like(db) {
-                        let mut elements_missing_the_attribute = FxIndexSet::default();
-                        for element in union.elements(db) {
-                            union_elements_missing_attribute(
-                                db,
-                                *element,
-                                attr_name,
-                                &mut elements_missing_the_attribute,
-                            );
-                        }
-
+                    // we want it to be an error. Use `visit_union_like_elements` here to handle
+                    // type aliases of unions and `NewType`s of float/complex in addition to
+                    // explicit unions.
+                    let mut elements_missing_the_attribute = FxIndexSet::default();
+                    if value_type.visit_union_like_elements(db, &mut |element| {
+                        union_elements_missing_attribute(
+                            db,
+                            element,
+                            attr_name,
+                            &mut elements_missing_the_attribute,
+                        );
+                    }) {
                         if !elements_missing_the_attribute.is_empty() {
                             if let Some(builder) =
                                 self.context.report_lint(&UNRESOLVED_ATTRIBUTE, attribute)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9066,7 +9066,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             (_, Type::Never) => Type::Never,
 
             (_, Type::TypeAlias(alias)) => {
-                self.infer_unary_expression_type(op, alias.value_type(self.db()), unary)
+                let db = self.db();
+                alias.visit_value(db, Type::unknown, |value_ty| {
+                    self.infer_unary_expression_type(op, value_ty, unary)
+                })
             }
 
             (ast::UnaryOp::UAdd, Type::LiteralValue(literal)) => match literal.kind() {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -44,6 +44,7 @@ use crate::types::callable::CallableTypeKind;
 use crate::types::class::{ClassLiteral, CodeGeneratorKind, MethodDecorator};
 use crate::types::constraints::{ConstraintSetBuilder, PathBounds, Solutions};
 use crate::types::context::InferContext;
+use crate::types::cyclic::TypeAliasRecursionVisitor;
 use crate::types::diagnostic::{
     self, CALL_NON_CALLABLE, CONFLICTING_DECLARATIONS, CYCLIC_TYPE_ALIAS_DEFINITION,
     GeneratorMismatchKind, INEFFECTIVE_FINAL, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT,
@@ -2311,6 +2312,37 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         infer_value_ty: &mut dyn FnMut(&mut Self, TypeContext<'db>) -> Type<'db>,
         emit_diagnostics: bool,
     ) -> bool {
+        // Attribute assignment validation can infer the RHS while validating the LHS target type.
+        // For example:
+        //
+        //   type Entry = ConfigEntry[RuntimeData]
+        //   def f(entry: Entry):
+        //       entry.runtime_data = RuntimeData(entry.data["key"])
+        //
+        // While validating `entry.runtime_data`, we expand `Entry`. If that expansion uses the
+        // shared thread-local alias guard, then RHS inference of `entry.data` also sees `Entry` as
+        // active and incorrectly treats the member lookup as a recursive alias cycle. Keep alias
+        // recursion state scoped to this LHS validation traversal so unrelated RHS inference gets
+        // its own alias state.
+        self.validate_attribute_assignment_impl(
+            target,
+            object_ty,
+            attribute,
+            infer_value_ty,
+            emit_diagnostics,
+            &TypeAliasRecursionVisitor::default(),
+        )
+    }
+
+    fn validate_attribute_assignment_impl(
+        &mut self,
+        target: &ast::ExprAttribute,
+        object_ty: Type<'db>,
+        attribute: &str,
+        infer_value_ty: &mut dyn FnMut(&mut Self, TypeContext<'db>) -> Type<'db>,
+        emit_diagnostics: bool,
+        alias_visitor: &TypeAliasRecursionVisitor,
+    ) -> bool {
         let db = self.db();
 
         // This closure should only be called if `value_ty` was inferred with `attr_ty` as type context.
@@ -2353,12 +2385,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let value_ty = infer_value_ty.infer_loud(self, TypeContext::default());
 
                 if union.elements(self.db()).iter().all(|elem| {
-                    self.validate_attribute_assignment(
+                    self.validate_attribute_assignment_impl(
                         target,
                         *elem,
                         attribute,
                         &mut |builder, tcx| infer_value_ty.infer_silent(builder, tcx),
                         false,
+                        alias_visitor,
                     )
                 }) {
                     if emit_diagnostics {
@@ -2388,12 +2421,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 // TODO: Handle negative intersection elements
                 if intersection.positive(db).iter().any(|elem| {
-                    self.validate_attribute_assignment(
+                    self.validate_attribute_assignment_impl(
                         target,
                         *elem,
                         attribute,
                         &mut |builder, tcx| infer_value_ty.infer_silent(builder, tcx),
                         false,
+                        alias_visitor,
                     )
                 }) {
                     // Perform loud inference using the narrowed type context.
@@ -2423,17 +2457,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            Type::TypeAlias(_) => {
-                object_ty.visit_type_alias_value_or_assume_valid(self.db(), |value_ty| {
-                    self.validate_attribute_assignment(
+            Type::TypeAlias(alias) => alias.visit_value_with_recursion_visitor(
+                db,
+                alias_visitor,
+                || true,
+                |value_ty| {
+                    self.validate_attribute_assignment_impl(
                         target,
                         value_ty,
                         attribute,
                         infer_value_ty,
                         emit_diagnostics,
+                        alias_visitor,
                     )
-                })
-            }
+                },
+            ),
 
             // Super instances do not allow attribute assignment
             Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Super) => {

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -92,17 +92,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // `TypeAlias`, which uses `X | Y` syntax, where the returned type is not actually a union.
         // And attempting to enforce this more tightly showed a lot of potential false positives in
         // the ecosystem.
-        if left_ty.is_equivalent_to(db, right_ty) {
-            left_ty
-        } else {
-            UnionTypeInstance::from_value_expression_types(
-                db,
-                [left_ty, right_ty],
-                self.scope(),
-                self.typevar_binding_context,
-                self.inference_flags(),
-            )
-        }
+        UnionTypeInstance::from_value_expression_types(
+            db,
+            [left_ty, right_ty],
+            self.scope(),
+            self.typevar_binding_context,
+            self.inference_flags(),
+        )
     }
 
     /// Returns a `TypedDict` result when a PEP 584 special case succeeds, otherwise the inferred
@@ -362,25 +358,37 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 )
             }),
 
-            (Type::TypeAlias(alias), rhs, _) => visitor.visit((left_ty, op, right_ty), || {
-                self.infer_binary_expression_type_impl(
-                    node,
-                    emitted_division_by_zero_diagnostic,
-                    alias.value_type(db),
-                    rhs,
-                    op,
-                    visitor,
+            (Type::TypeAlias(_), rhs, _) => visitor.visit((left_ty, op, right_ty), || {
+                left_ty.visit_type_alias_value(
+                    db,
+                    || Some(Type::Never),
+                    |value_ty| {
+                        self.infer_binary_expression_type_impl(
+                            node,
+                            emitted_division_by_zero_diagnostic,
+                            value_ty,
+                            rhs,
+                            op,
+                            visitor,
+                        )
+                    },
                 )
             }),
 
-            (lhs, Type::TypeAlias(alias), _) => visitor.visit((left_ty, op, right_ty), || {
-                self.infer_binary_expression_type_impl(
-                    node,
-                    emitted_division_by_zero_diagnostic,
-                    lhs,
-                    alias.value_type(db),
-                    op,
-                    visitor,
+            (lhs, Type::TypeAlias(_), _) => visitor.visit((left_ty, op, right_ty), || {
+                right_ty.visit_type_alias_value(
+                    db,
+                    || Some(Type::Never),
+                    |value_ty| {
+                        self.infer_binary_expression_type_impl(
+                            node,
+                            emitted_division_by_zero_diagnostic,
+                            lhs,
+                            value_ty,
+                            op,
+                            visitor,
+                        )
+                    },
                 )
             }),
 

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -73,9 +73,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .collect_vec();
                     (!keys.is_empty()).then(|| UnionType::from_elements(db, keys))
                 }
-                Type::TypeAlias(alias) => {
-                    visitor.visit(ty, || imp(db, alias.value_type(db), visitor))
-                }
+                Type::TypeAlias(_) => visitor.visit(ty, || {
+                    ty.visit_type_alias_value_or_default(db, |value_ty| imp(db, value_ty, visitor))
+                }),
                 _ => None,
             }
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2,6 +2,7 @@ use itertools::Either;
 use ruff_python_ast::helpers::is_dotted_name;
 use ruff_python_ast::{self as ast, PythonVersion};
 use ruff_text_size::Ranged;
+use salsa::plumbing::AsId;
 
 use super::{DeferredExpressionState, TypeInferenceBuilder};
 use crate::types::diagnostic::{
@@ -1516,19 +1517,24 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                     "Cannot specialize non-generic type alias `{}`",
                                     type_alias.name(self.db())
                                 ));
-                                let secondary = self.context.secondary(&*subscript.value);
-                                let value_type = type_alias.raw_value_type(self.db());
-                                if value_type.is_specialized_generic(self.db()) {
-                                    diagnostic.annotate(secondary.message(format_args!(
-                                        "Alias to `{}`, which is already specialized",
-                                        value_type.display(self.db())
-                                    )));
-                                } else {
-                                    diagnostic.annotate(secondary.message(format_args!(
-                                        "Alias to `{}`, which is not generic",
-                                        value_type.display(self.db())
-                                    )));
-                                }
+                                type_alias.visit_raw_value(
+                                    self.db(),
+                                    || (),
+                                    |value_type| {
+                                        let secondary = self.context.secondary(&*subscript.value);
+                                        if value_type.is_specialized_generic(self.db()) {
+                                            diagnostic.annotate(secondary.message(format_args!(
+                                                "Alias to `{}`, which is already specialized",
+                                                value_type.display(self.db())
+                                            )));
+                                        } else {
+                                            diagnostic.annotate(secondary.message(format_args!(
+                                                "Alias to `{}`, which is not generic",
+                                                value_type.display(self.db())
+                                            )));
+                                        }
+                                    },
+                                );
                             }
 
                             Type::unknown()
@@ -2165,7 +2171,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
                 _ => {
                     let narrowed = self.infer_type_expression(arguments_slice);
-                    let expanded = narrowed.expand_eagerly(self.db());
+                    let expanded = if let Type::TypeAlias(alias) = narrowed {
+                        alias.visit_value(
+                            self.db(),
+                            || Type::divergent(alias.definition(self.db()).as_id()),
+                            |value_ty| value_ty.expand_eagerly(self.db()),
+                        )
+                    } else {
+                        narrowed.expand_eagerly(self.db())
+                    };
 
                     if expanded.is_divergent() {
                         expanded
@@ -2506,8 +2520,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 match subscript_ty {
                     // type aliases to literal types
                     Type::KnownInstance(KnownInstanceType::TypeAliasType(type_alias)) => {
-                        let value_ty = type_alias.value_type(self.db());
-                        if value_ty.is_literal_or_union_of_literals(self.db()) {
+                        let value_ty = type_alias.visit_value(
+                            self.db(),
+                            || None,
+                            |value_ty| {
+                                value_ty
+                                    .is_literal_or_union_of_literals(self.db())
+                                    .then_some(value_ty)
+                            },
+                        );
+                        if let Some(value_ty) = value_ty {
                             return Ok(value_ty);
                         }
                     }

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -251,13 +251,17 @@ pub(super) fn infer_binary_type_comparison<'db>(
             )
         }
 
-        (Type::TypeAlias(alias), right) => Some(visitor.visit((left, op, right), || {
-            infer_binary_type_comparison(context, alias.value_type(db), op, right, range, visitor)
-        })),
+        (Type::TypeAlias(_), right) => Some(left.visit_type_alias_value(
+            db,
+            || Ok(KnownClass::Bool.to_instance(db)),
+            |value_ty| infer_binary_type_comparison(context, value_ty, op, right, range, visitor),
+        )),
 
-        (left, Type::TypeAlias(alias)) => Some(visitor.visit((left, op, right), || {
-            infer_binary_type_comparison(context, left, op, alias.value_type(db), range, visitor)
-        })),
+        (left, Type::TypeAlias(_)) => Some(right.visit_type_alias_value(
+            db,
+            || Ok(KnownClass::Bool.to_instance(db)),
+            |value_ty| infer_binary_type_comparison(context, left, op, value_ty, range, visitor),
+        )),
 
         // `try_dunder` works for almost all `NewType`s, but not for `NewType`s of `float` and
         // `complex`, where the concrete base type is a union. In that case it turns out the

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -16,13 +16,16 @@ use crate::place::PlaceAndQualifiers;
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
 };
-use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::enums::is_single_member_enum;
 use crate::types::generics::{InferableTypeVars, walk_specialization};
 use crate::types::protocol_class::{
     ProtocolClass, has_all_protocol_members_defined, walk_protocol_interface,
 };
-use crate::types::relation::{DisjointnessChecker, RelationContext, TypeRelationChecker};
+use crate::types::relation::{
+    DisjointnessChecker, HasRelationToVisitor, InvariantRelationVisitor, IsDisjointVisitor,
+    TypeRelationChecker,
+};
+use crate::types::signatures::SignatureRelationVisitor;
 use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ErrorContext,
@@ -383,25 +386,14 @@ impl<'db> NominalInstanceType<'db> {
         }
     }
 
-    pub(super) fn is_single_valued_impl(
-        self,
-        db: &'db dyn Db,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) -> bool {
+    pub(super) fn is_single_valued(self, db: &'db dyn Db) -> bool {
         match self.0 {
-            NominalInstanceInner::ExactTuple(tuple) => {
-                tuple.is_single_valued_impl(db, recursion_detector)
-            }
+            NominalInstanceInner::ExactTuple(tuple) => tuple.is_single_valued(db),
             NominalInstanceInner::Object => false,
             NominalInstanceInner::NonTuple(class) => class
                 .known(db)
                 .and_then(KnownClass::is_single_valued)
-                .or_else(|| {
-                    Some(
-                        self.tuple_spec(db)?
-                            .is_single_valued_impl(db, recursion_detector),
-                    )
-                })
+                .or_else(|| Some(self.tuple_spec(db)?.is_single_valued(db)))
                 .unwrap_or_else(|| is_single_member_enum(db, class.class_literal(db))),
         }
     }
@@ -741,9 +733,20 @@ impl<'db> ProtocolInstanceType<'db> {
             _: (),
         ) -> bool {
             let constraints = ConstraintSetBuilder::new();
-            let context = RelationContext::default(&constraints);
-            let checker =
-                TypeRelationChecker::subtyping(&constraints, InferableTypeVars::None, &context);
+            let relation_visitor = HasRelationToVisitor::default(&constraints);
+            let disjointness_visitor = IsDisjointVisitor::default(&constraints);
+            let signature_relation_visitor = SignatureRelationVisitor::default();
+            let invariant_relation_visitor = InvariantRelationVisitor::default();
+            let materialization_visitor = ApplyTypeMappingVisitor::default();
+            let checker = TypeRelationChecker::subtyping(
+                &constraints,
+                InferableTypeVars::None,
+                &relation_visitor,
+                &disjointness_visitor,
+                &signature_relation_visitor,
+                &invariant_relation_visitor,
+                &materialization_visitor,
+            );
             checker
                 .check_type_satisfies_protocol(db, Type::object(), protocol)
                 .is_always_satisfied(db)

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -16,15 +16,13 @@ use crate::place::PlaceAndQualifiers;
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
 };
+use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::enums::is_single_member_enum;
 use crate::types::generics::{InferableTypeVars, walk_specialization};
 use crate::types::protocol_class::{
     ProtocolClass, has_all_protocol_members_defined, walk_protocol_interface,
 };
-use crate::types::relation::{
-    DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelationChecker,
-};
-use crate::types::signatures::SignatureRelationVisitor;
+use crate::types::relation::{DisjointnessChecker, RelationContext, TypeRelationChecker};
 use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ErrorContext,
@@ -385,14 +383,25 @@ impl<'db> NominalInstanceType<'db> {
         }
     }
 
-    pub(super) fn is_single_valued(self, db: &'db dyn Db) -> bool {
+    pub(super) fn is_single_valued_impl(
+        self,
+        db: &'db dyn Db,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) -> bool {
         match self.0 {
-            NominalInstanceInner::ExactTuple(tuple) => tuple.is_single_valued(db),
+            NominalInstanceInner::ExactTuple(tuple) => {
+                tuple.is_single_valued_impl(db, recursion_detector)
+            }
             NominalInstanceInner::Object => false,
             NominalInstanceInner::NonTuple(class) => class
                 .known(db)
                 .and_then(KnownClass::is_single_valued)
-                .or_else(|| Some(self.tuple_spec(db)?.is_single_valued(db)))
+                .or_else(|| {
+                    Some(
+                        self.tuple_spec(db)?
+                            .is_single_valued_impl(db, recursion_detector),
+                    )
+                })
                 .unwrap_or_else(|| is_single_member_enum(db, class.class_literal(db))),
         }
     }
@@ -732,18 +741,9 @@ impl<'db> ProtocolInstanceType<'db> {
             _: (),
         ) -> bool {
             let constraints = ConstraintSetBuilder::new();
-            let relation_visitor = HasRelationToVisitor::default(&constraints);
-            let disjointness_visitor = IsDisjointVisitor::default(&constraints);
-            let signature_relation_visitor = SignatureRelationVisitor::default();
-            let materialization_visitor = ApplyTypeMappingVisitor::default();
-            let checker = TypeRelationChecker::subtyping(
-                &constraints,
-                InferableTypeVars::None,
-                &relation_visitor,
-                &disjointness_visitor,
-                &signature_relation_visitor,
-                &materialization_visitor,
-            );
+            let context = RelationContext::default(&constraints);
+            let checker =
+                TypeRelationChecker::subtyping(&constraints, InferableTypeVars::None, &context);
             checker
                 .check_type_satisfies_protocol(db, Type::object(), protocol)
                 .is_always_satisfied(db)

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -22,8 +22,8 @@ use crate::types::protocol_class::{
     ProtocolClass, has_all_protocol_members_defined, walk_protocol_interface,
 };
 use crate::types::relation::{
-    DisjointnessChecker, HasRelationToVisitor, InvariantRelationVisitor, IsDisjointVisitor,
-    TypeRelationChecker,
+    AliasRelationVisitor, DisjointnessChecker, HasRelationToVisitor, InvariantRelationVisitor,
+    IsDisjointVisitor, TypeRelationChecker,
 };
 use crate::types::signatures::SignatureRelationVisitor;
 use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
@@ -737,6 +737,7 @@ impl<'db> ProtocolInstanceType<'db> {
             let disjointness_visitor = IsDisjointVisitor::default(&constraints);
             let signature_relation_visitor = SignatureRelationVisitor::default();
             let invariant_relation_visitor = InvariantRelationVisitor::default();
+            let alias_relation_visitor = AliasRelationVisitor::default();
             let materialization_visitor = ApplyTypeMappingVisitor::default();
             let checker = TypeRelationChecker::subtyping(
                 &constraints,
@@ -745,6 +746,7 @@ impl<'db> ProtocolInstanceType<'db> {
                 &disjointness_visitor,
                 &signature_relation_visitor,
                 &invariant_relation_visitor,
+                &alias_relation_visitor,
                 &materialization_visitor,
             );
             checker

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -6,7 +6,6 @@ use crate::{
         TypeVarBoundOrConstraints, UnionType,
         call::CallErrorKind,
         context::InferContext,
-        cyclic::ActiveRecursionDetector,
         diagnostic::NOT_ITERABLE,
         todo_type,
         tuple::{TupleSpec, TupleSpecBuilder},
@@ -95,20 +94,9 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         mode: EvaluationMode,
     ) -> Result<Cow<'db, TupleSpec<'db>>, IterationError<'db>> {
-        let recursion_detector = ActiveRecursionDetector::default();
-        self.try_iterate_with_mode_impl(db, mode, &recursion_detector)
-    }
-
-    fn try_iterate_with_mode_impl(
-        self,
-        db: &'db dyn Db,
-        mode: EvaluationMode,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) -> Result<Cow<'db, TupleSpec<'db>>, IterationError<'db>> {
         fn non_async_special_case<'db>(
             db: &'db dyn Db,
             ty: Type<'db>,
-            recursion_detector: &ActiveRecursionDetector<Type<'db>>,
         ) -> Option<Cow<'db, TupleSpec<'db>>> {
             // We will not infer precise heterogeneous tuple specs for literals with lengths above this threshold.
             // The threshold here is somewhat arbitrary and conservative; it could be increased if needed.
@@ -119,7 +107,7 @@ impl<'db> Type<'db> {
             match ty {
                 Type::NominalInstance(nominal) => nominal.tuple_spec(db),
                 Type::NewTypeInstance(newtype) => {
-                    non_async_special_case(db, newtype.concrete_base_type(db), recursion_detector)
+                    non_async_special_case(db, newtype.concrete_base_type(db))
                 }
                 Type::GenericAlias(alias) if alias.origin(db).is_tuple(db) => {
                     Some(Cow::Owned(TupleSpec::homogeneous(todo_type!(
@@ -169,16 +157,15 @@ impl<'db> Type<'db> {
                 }
                 Type::TypeAlias(_) => ty.visit_type_alias_value(
                     db,
-                    recursion_detector,
                     || Some(Cow::Owned(TupleSpec::homogeneous(Type::unknown()))),
-                    |value_ty| non_async_special_case(db, value_ty, recursion_detector),
+                    |value_ty| non_async_special_case(db, value_ty),
                 ),
                 Type::TypeVar(tvar) => match tvar.typevar(db).bound_or_constraints(db)? {
                     TypeVarBoundOrConstraints::UpperBound(bound) => {
-                        non_async_special_case(db, bound, recursion_detector)
+                        non_async_special_case(db, bound)
                     }
                     TypeVarBoundOrConstraints::Constraints(constraints) => {
-                        non_async_special_case(db, constraints.as_type(db), recursion_detector)
+                        non_async_special_case(db, constraints.as_type(db))
                     }
                 },
                 Type::Union(union) => {
@@ -187,23 +174,13 @@ impl<'db> Type<'db> {
                         let mut elements_iter = elements.iter();
                         let first_element_spec = elements_iter
                             .next()?
-                            .try_iterate_with_mode_impl(
-                                db,
-                                EvaluationMode::Sync,
-                                recursion_detector,
-                            )
+                            .try_iterate_with_mode(db, EvaluationMode::Sync)
                             .ok()?;
                         let mut builder = TupleSpecBuilder::from(&*first_element_spec);
                         for element in elements_iter {
                             builder = builder.union(
                                 db,
-                                &*element
-                                    .try_iterate_with_mode_impl(
-                                        db,
-                                        EvaluationMode::Sync,
-                                        recursion_detector,
-                                    )
-                                    .ok()?,
+                                &*element.try_iterate_with_mode(db, EvaluationMode::Sync).ok()?,
                             );
                         }
                         Some(Cow::Owned(builder.build()))
@@ -231,13 +208,7 @@ impl<'db> Type<'db> {
                     if flattened == ty {
                         let mut specs_iter = intersection.positive_elements_or_object(db).filter_map(
                             |element| {
-                                element
-                                    .try_iterate_with_mode_impl(
-                                        db,
-                                        EvaluationMode::Sync,
-                                        recursion_detector,
-                                    )
-                                    .ok()
+                                element.try_iterate_with_mode(db, EvaluationMode::Sync).ok()
                             },
                         );
                         let first_spec = specs_iter.next()?;
@@ -255,7 +226,7 @@ impl<'db> Type<'db> {
                     }
 
                     // Flattening changed the type; recursively iterate the flattened result.
-                    non_async_special_case(db, flattened, recursion_detector)
+                    non_async_special_case(db, flattened)
                 }
                 // N.B. This special case isn't strictly necessary, it's just an obvious optimization
                 Type::Dynamic(_) => Some(Cow::Owned(TupleSpec::homogeneous(ty))),
@@ -357,7 +328,7 @@ impl<'db> Type<'db> {
             };
         }
 
-        if let Some(special_case) = non_async_special_case(db, self, recursion_detector) {
+        if let Some(special_case) = non_async_special_case(db, self) {
             return Ok(special_case);
         }
 

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -226,7 +226,7 @@ impl<'db> Type<'db> {
                     }
 
                     // Flattening changed the type; recursively iterate the flattened result.
-                    non_async_special_case(db, flattened)
+                    flattened.try_iterate_with_mode(db, EvaluationMode::Sync).ok()
                 }
                 // N.B. This special case isn't strictly necessary, it's just an obvious optimization
                 Type::Dynamic(_) => Some(Cow::Owned(TupleSpec::homogeneous(ty))),

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -6,6 +6,7 @@ use crate::{
         TypeVarBoundOrConstraints, UnionType,
         call::CallErrorKind,
         context::InferContext,
+        cyclic::ActiveRecursionDetector,
         diagnostic::NOT_ITERABLE,
         todo_type,
         tuple::{TupleSpec, TupleSpecBuilder},
@@ -94,9 +95,20 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         mode: EvaluationMode,
     ) -> Result<Cow<'db, TupleSpec<'db>>, IterationError<'db>> {
+        let recursion_detector = ActiveRecursionDetector::default();
+        self.try_iterate_with_mode_impl(db, mode, &recursion_detector)
+    }
+
+    fn try_iterate_with_mode_impl(
+        self,
+        db: &'db dyn Db,
+        mode: EvaluationMode,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) -> Result<Cow<'db, TupleSpec<'db>>, IterationError<'db>> {
         fn non_async_special_case<'db>(
             db: &'db dyn Db,
             ty: Type<'db>,
+            recursion_detector: &ActiveRecursionDetector<Type<'db>>,
         ) -> Option<Cow<'db, TupleSpec<'db>>> {
             // We will not infer precise heterogeneous tuple specs for literals with lengths above this threshold.
             // The threshold here is somewhat arbitrary and conservative; it could be increased if needed.
@@ -106,7 +118,9 @@ impl<'db> Type<'db> {
 
             match ty {
                 Type::NominalInstance(nominal) => nominal.tuple_spec(db),
-                Type::NewTypeInstance(newtype) => non_async_special_case(db, newtype.concrete_base_type(db)),
+                Type::NewTypeInstance(newtype) => {
+                    non_async_special_case(db, newtype.concrete_base_type(db), recursion_detector)
+                }
                 Type::GenericAlias(alias) if alias.origin(db).is_tuple(db) => {
                     Some(Cow::Owned(TupleSpec::homogeneous(todo_type!(
                         "*tuple[] annotations"
@@ -153,23 +167,44 @@ impl<'db> Type<'db> {
                     // diagnostic in unreachable code.
                     Some(Cow::Owned(TupleSpec::homogeneous(Type::unknown())))
                 }
-                Type::TypeAlias(alias) => {
-                    non_async_special_case(db, alias.value_type(db))
-                }
+                Type::TypeAlias(_) => ty.visit_type_alias_value(
+                    db,
+                    recursion_detector,
+                    || Some(Cow::Owned(TupleSpec::homogeneous(Type::unknown()))),
+                    |value_ty| non_async_special_case(db, value_ty, recursion_detector),
+                ),
                 Type::TypeVar(tvar) => match tvar.typevar(db).bound_or_constraints(db)? {
                     TypeVarBoundOrConstraints::UpperBound(bound) => {
-                        non_async_special_case(db, bound)
+                        non_async_special_case(db, bound, recursion_detector)
                     }
-                    TypeVarBoundOrConstraints::Constraints(constraints) => non_async_special_case(db, constraints.as_type(db)),
+                    TypeVarBoundOrConstraints::Constraints(constraints) => {
+                        non_async_special_case(db, constraints.as_type(db), recursion_detector)
+                    }
                 },
                 Type::Union(union) => {
                     let elements = union.elements(db);
                     if elements.len() < MAX_TUPLE_LENGTH {
                         let mut elements_iter = elements.iter();
-                        let first_element_spec = elements_iter.next()?.try_iterate_with_mode(db, EvaluationMode::Sync).ok()?;
+                        let first_element_spec = elements_iter
+                            .next()?
+                            .try_iterate_with_mode_impl(
+                                db,
+                                EvaluationMode::Sync,
+                                recursion_detector,
+                            )
+                            .ok()?;
                         let mut builder = TupleSpecBuilder::from(&*first_element_spec);
                         for element in elements_iter {
-                            builder = builder.union(db, &*element.try_iterate_with_mode(db, EvaluationMode::Sync).ok()?);
+                            builder = builder.union(
+                                db,
+                                &*element
+                                    .try_iterate_with_mode_impl(
+                                        db,
+                                        EvaluationMode::Sync,
+                                        recursion_detector,
+                                    )
+                                    .ok()?,
+                            );
                         }
                         Some(Cow::Owned(builder.build()))
                     } else {
@@ -195,7 +230,15 @@ impl<'db> Type<'db> {
                     // If flattening didn't change anything, iterate the intersection directly.
                     if flattened == ty {
                         let mut specs_iter = intersection.positive_elements_or_object(db).filter_map(
-                            |element| element.try_iterate_with_mode(db, EvaluationMode::Sync).ok(),
+                            |element| {
+                                element
+                                    .try_iterate_with_mode_impl(
+                                        db,
+                                        EvaluationMode::Sync,
+                                        recursion_detector,
+                                    )
+                                    .ok()
+                            },
                         );
                         let first_spec = specs_iter.next()?;
                         let mut builder = TupleSpecBuilder::from(&*first_spec);
@@ -212,7 +255,7 @@ impl<'db> Type<'db> {
                     }
 
                     // Flattening changed the type; recursively iterate the flattened result.
-                    flattened.try_iterate(db).ok()
+                    non_async_special_case(db, flattened, recursion_detector)
                 }
                 // N.B. This special case isn't strictly necessary, it's just an obvious optimization
                 Type::Dynamic(_) => Some(Cow::Owned(TupleSpec::homogeneous(ty))),
@@ -314,7 +357,7 @@ impl<'db> Type<'db> {
             };
         }
 
-        if let Some(special_case) = non_async_special_case(db, self) {
+        if let Some(special_case) = non_async_special_case(db, self, recursion_detector) {
             return Ok(special_case);
         }
 

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -189,9 +189,11 @@ pub(super) fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Size
 impl<'db> VarianceInferable<'db> for KnownInstanceType<'db> {
     fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarVariance {
         match self {
-            KnownInstanceType::TypeAliasType(type_alias) => {
-                type_alias.raw_value_type(db).variance_of(db, typevar)
-            }
+            KnownInstanceType::TypeAliasType(type_alias) => type_alias.visit_raw_value(
+                db,
+                || TypeVarVariance::Bivariant,
+                |value_ty| value_ty.variance_of(db, typevar),
+            ),
             _ => TypeVarVariance::Bivariant,
         }
     }

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -19,7 +19,7 @@ use crate::{
     types::{
         ClassBase, ClassLiteral, KnownClass, KnownInstanceType, StaticClassLiteral,
         SubclassOfInner, Type, TypeVarBoundOrConstraints, class::CodeGeneratorKind,
-        cyclic::ActiveRecursionDetector, generics::Specialization,
+        generics::Specialization,
     },
 };
 use ty_python_core::{
@@ -155,28 +155,14 @@ struct AllMembers<'db> {
 
 impl<'db> AllMembers<'db> {
     fn of(db: &'db dyn Db, ty: Type<'db>) -> Self {
-        let recursion_detector = ActiveRecursionDetector::default();
-        Self::of_impl(db, ty, &recursion_detector)
-    }
-
-    fn of_impl(
-        db: &'db dyn Db,
-        ty: Type<'db>,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) -> Self {
         let mut all_members = Self {
             members: FxHashSet::default(),
         };
-        all_members.extend_with_type(db, ty, recursion_detector);
+        all_members.extend_with_type(db, ty);
         all_members
     }
 
-    fn extend_with_type(
-        &mut self,
-        db: &'db dyn Db,
-        ty: Type<'db>,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) {
+    fn extend_with_type(&mut self, db: &'db dyn Db, ty: Type<'db>) {
         match ty {
             Type::Union(union) => {
                 fn is_dynamic(db: &dyn Db, ty: Type<'_>) -> bool {
@@ -194,13 +180,13 @@ impl<'db> AllMembers<'db> {
 
                 let union = match union.filter(db, |&ty| !is_dynamic(db, ty)) {
                     Type::Union(union) => union,
-                    ty => return self.extend_with_type(db, ty, recursion_detector),
+                    ty => return self.extend_with_type(db, ty),
                 };
                 self.members.extend(
                     union
                         .elements(db)
                         .iter()
-                        .map(|ty| AllMembers::of_impl(db, *ty, recursion_detector).members)
+                        .map(|ty| AllMembers::of(db, *ty).members)
                         .reduce(|acc, members| acc.intersection(&members).cloned().collect())
                         .unwrap_or_default(),
                 );
@@ -210,7 +196,7 @@ impl<'db> AllMembers<'db> {
                 intersection
                     .positive(db)
                     .iter()
-                    .map(|ty| AllMembers::of_impl(db, *ty, recursion_detector).members)
+                    .map(|ty| AllMembers::of(db, *ty).members)
                     .reduce(|acc, members| acc.union(&members).cloned().collect())
                     .unwrap_or_default(),
             ),
@@ -224,52 +210,33 @@ impl<'db> AllMembers<'db> {
                         ty,
                         ClassLiteral::Static(class_literal),
                         specialization,
-                        recursion_detector,
                     );
                 } else {
                     // For dynamic classes, we can't enumerate instance members (requires body scope),
                     // but we can still add synthetic members for dataclass-like classes.
-                    self.extend_with_synthetic_members(
-                        db,
-                        ty,
-                        class.class_literal(db),
-                        None,
-                        recursion_detector,
-                    );
+                    self.extend_with_synthetic_members(db, ty, class.class_literal(db), None);
                 }
             }
 
             Type::NewTypeInstance(newtype) => {
-                self.extend_with_type(db, newtype.concrete_base_type(db), recursion_detector);
+                self.extend_with_type(db, newtype.concrete_base_type(db));
             }
 
             Type::ClassLiteral(class_literal) if class_literal.is_typed_dict(db) => {
-                self.extend_with_type(
-                    db,
-                    KnownClass::TypedDictFallback.to_class_literal(db),
-                    recursion_detector,
-                );
+                self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
             }
 
             Type::GenericAlias(generic_alias) if generic_alias.is_typed_dict(db) => {
-                self.extend_with_type(
-                    db,
-                    KnownClass::TypedDictFallback.to_class_literal(db),
-                    recursion_detector,
-                );
+                self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
             }
 
             Type::SubclassOf(subclass_of_type) if subclass_of_type.is_typed_dict(db) => {
-                self.extend_with_type(
-                    db,
-                    KnownClass::TypedDictFallback.to_class_literal(db),
-                    recursion_detector,
-                );
+                self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
             }
 
             Type::ClassLiteral(class_literal) => {
                 self.extend_with_class_members(db, ty, class_literal);
-                self.extend_with_synthetic_members(db, ty, class_literal, None, recursion_detector);
+                self.extend_with_synthetic_members(db, ty, class_literal, None);
                 if let Type::ClassLiteral(metaclass) = class_literal.metaclass(db) {
                     self.extend_with_class_members(db, ty, metaclass);
                 }
@@ -283,7 +250,6 @@ impl<'db> AllMembers<'db> {
                     ty,
                     ClassLiteral::Static(class_literal),
                     None,
-                    recursion_detector,
                 );
                 if let Type::ClassLiteral(metaclass) = class_literal.metaclass(db) {
                     self.extend_with_class_members(db, ty, metaclass);
@@ -292,7 +258,7 @@ impl<'db> AllMembers<'db> {
 
             Type::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
                 SubclassOfInner::Dynamic(_) => {
-                    self.extend_with_type(db, KnownClass::Type.to_instance(db), recursion_detector);
+                    self.extend_with_type(db, KnownClass::Type.to_instance(db));
                 }
                 _ => {
                     if let Some(class_type) = subclass_of_type.subclass_of().into_class(db) {
@@ -309,7 +275,6 @@ impl<'db> AllMembers<'db> {
                                 ty,
                                 ClassLiteral::Static(class_literal),
                                 specialization,
-                                recursion_detector,
                             );
                             if let Type::ClassLiteral(metaclass) = class_literal.metaclass(db) {
                                 self.extend_with_class_members(db, ty, metaclass);
@@ -324,15 +289,14 @@ impl<'db> AllMembers<'db> {
             | Type::Never
             | Type::AlwaysTruthy
             | Type::AlwaysFalsy => {
-                self.extend_with_type(db, Type::object(), recursion_detector);
+                self.extend_with_type(db, Type::object());
             }
 
             Type::TypeAlias(_) => {
                 let members = ty.visit_type_alias_value(
                     db,
-                    recursion_detector,
-                    || AllMembers::of_impl(db, Type::unknown(), recursion_detector).members,
-                    |value_ty| AllMembers::of_impl(db, value_ty, recursion_detector).members,
+                    || AllMembers::of(db, Type::unknown()).members,
+                    |value_ty| AllMembers::of(db, value_ty).members,
                 );
                 self.members.extend(members);
             }
@@ -340,17 +304,17 @@ impl<'db> AllMembers<'db> {
             Type::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => {
-                        self.extend_with_type(db, Type::object(), recursion_detector);
+                        self.extend_with_type(db, Type::object());
                     }
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                        self.extend_with_type(db, bound, recursion_detector);
+                        self.extend_with_type(db, bound);
                     }
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                         self.members.extend(
                             constraints
                                 .elements(db)
                                 .iter()
-                                .map(|ty| AllMembers::of_impl(db, *ty, recursion_detector).members)
+                                .map(|ty| AllMembers::of(db, *ty).members)
                                 .reduce(|acc, members| {
                                     acc.intersection(&members).cloned().collect()
                                 })
@@ -418,11 +382,7 @@ impl<'db> AllMembers<'db> {
                     ty: dunder_file_type,
                 });
 
-                self.extend_with_type(
-                    db,
-                    KnownClass::ModuleType.to_instance(db),
-                    recursion_detector,
-                );
+                self.extend_with_type(db, KnownClass::ModuleType.to_instance(db));
                 let module = literal.module(db);
 
                 let Some(file) = module.file(db) else {
@@ -604,22 +564,13 @@ impl<'db> AllMembers<'db> {
         ty: Type<'db>,
         class_literal: ClassLiteral<'db>,
         specialization: Option<Specialization<'db>>,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
     ) {
         match CodeGeneratorKind::from_class(db, class_literal, specialization) {
             Some(CodeGeneratorKind::NamedTuple) => {
                 if ty.is_nominal_instance() {
-                    self.extend_with_type(
-                        db,
-                        KnownClass::NamedTupleFallback.to_instance(db),
-                        recursion_detector,
-                    );
+                    self.extend_with_type(db, KnownClass::NamedTupleFallback.to_instance(db));
                 } else {
-                    self.extend_with_type(
-                        db,
-                        KnownClass::NamedTupleFallback.to_class_literal(db),
-                        recursion_detector,
-                    );
+                    self.extend_with_type(db, KnownClass::NamedTupleFallback.to_class_literal(db));
                 }
             }
             Some(CodeGeneratorKind::TypedDict) => {}

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -19,7 +19,7 @@ use crate::{
     types::{
         ClassBase, ClassLiteral, KnownClass, KnownInstanceType, StaticClassLiteral,
         SubclassOfInner, Type, TypeVarBoundOrConstraints, class::CodeGeneratorKind,
-        generics::Specialization,
+        cyclic::ActiveRecursionDetector, generics::Specialization,
     },
 };
 use ty_python_core::{
@@ -155,14 +155,28 @@ struct AllMembers<'db> {
 
 impl<'db> AllMembers<'db> {
     fn of(db: &'db dyn Db, ty: Type<'db>) -> Self {
+        let recursion_detector = ActiveRecursionDetector::default();
+        Self::of_impl(db, ty, &recursion_detector)
+    }
+
+    fn of_impl(
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) -> Self {
         let mut all_members = Self {
             members: FxHashSet::default(),
         };
-        all_members.extend_with_type(db, ty);
+        all_members.extend_with_type(db, ty, recursion_detector);
         all_members
     }
 
-    fn extend_with_type(&mut self, db: &'db dyn Db, ty: Type<'db>) {
+    fn extend_with_type(
+        &mut self,
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) {
         match ty {
             Type::Union(union) => {
                 fn is_dynamic(db: &dyn Db, ty: Type<'_>) -> bool {
@@ -180,13 +194,13 @@ impl<'db> AllMembers<'db> {
 
                 let union = match union.filter(db, |&ty| !is_dynamic(db, ty)) {
                     Type::Union(union) => union,
-                    ty => return self.extend_with_type(db, ty),
+                    ty => return self.extend_with_type(db, ty, recursion_detector),
                 };
                 self.members.extend(
                     union
                         .elements(db)
                         .iter()
-                        .map(|ty| AllMembers::of(db, *ty).members)
+                        .map(|ty| AllMembers::of_impl(db, *ty, recursion_detector).members)
                         .reduce(|acc, members| acc.intersection(&members).cloned().collect())
                         .unwrap_or_default(),
                 );
@@ -196,7 +210,7 @@ impl<'db> AllMembers<'db> {
                 intersection
                     .positive(db)
                     .iter()
-                    .map(|ty| AllMembers::of(db, *ty).members)
+                    .map(|ty| AllMembers::of_impl(db, *ty, recursion_detector).members)
                     .reduce(|acc, members| acc.union(&members).cloned().collect())
                     .unwrap_or_default(),
             ),
@@ -210,33 +224,52 @@ impl<'db> AllMembers<'db> {
                         ty,
                         ClassLiteral::Static(class_literal),
                         specialization,
+                        recursion_detector,
                     );
                 } else {
                     // For dynamic classes, we can't enumerate instance members (requires body scope),
                     // but we can still add synthetic members for dataclass-like classes.
-                    self.extend_with_synthetic_members(db, ty, class.class_literal(db), None);
+                    self.extend_with_synthetic_members(
+                        db,
+                        ty,
+                        class.class_literal(db),
+                        None,
+                        recursion_detector,
+                    );
                 }
             }
 
             Type::NewTypeInstance(newtype) => {
-                self.extend_with_type(db, newtype.concrete_base_type(db));
+                self.extend_with_type(db, newtype.concrete_base_type(db), recursion_detector);
             }
 
             Type::ClassLiteral(class_literal) if class_literal.is_typed_dict(db) => {
-                self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
+                self.extend_with_type(
+                    db,
+                    KnownClass::TypedDictFallback.to_class_literal(db),
+                    recursion_detector,
+                );
             }
 
             Type::GenericAlias(generic_alias) if generic_alias.is_typed_dict(db) => {
-                self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
+                self.extend_with_type(
+                    db,
+                    KnownClass::TypedDictFallback.to_class_literal(db),
+                    recursion_detector,
+                );
             }
 
             Type::SubclassOf(subclass_of_type) if subclass_of_type.is_typed_dict(db) => {
-                self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
+                self.extend_with_type(
+                    db,
+                    KnownClass::TypedDictFallback.to_class_literal(db),
+                    recursion_detector,
+                );
             }
 
             Type::ClassLiteral(class_literal) => {
                 self.extend_with_class_members(db, ty, class_literal);
-                self.extend_with_synthetic_members(db, ty, class_literal, None);
+                self.extend_with_synthetic_members(db, ty, class_literal, None, recursion_detector);
                 if let Type::ClassLiteral(metaclass) = class_literal.metaclass(db) {
                     self.extend_with_class_members(db, ty, metaclass);
                 }
@@ -250,6 +283,7 @@ impl<'db> AllMembers<'db> {
                     ty,
                     ClassLiteral::Static(class_literal),
                     None,
+                    recursion_detector,
                 );
                 if let Type::ClassLiteral(metaclass) = class_literal.metaclass(db) {
                     self.extend_with_class_members(db, ty, metaclass);
@@ -258,7 +292,7 @@ impl<'db> AllMembers<'db> {
 
             Type::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
                 SubclassOfInner::Dynamic(_) => {
-                    self.extend_with_type(db, KnownClass::Type.to_instance(db));
+                    self.extend_with_type(db, KnownClass::Type.to_instance(db), recursion_detector);
                 }
                 _ => {
                     if let Some(class_type) = subclass_of_type.subclass_of().into_class(db) {
@@ -275,6 +309,7 @@ impl<'db> AllMembers<'db> {
                                 ty,
                                 ClassLiteral::Static(class_literal),
                                 specialization,
+                                recursion_detector,
                             );
                             if let Type::ClassLiteral(metaclass) = class_literal.metaclass(db) {
                                 self.extend_with_class_members(db, ty, metaclass);
@@ -289,25 +324,33 @@ impl<'db> AllMembers<'db> {
             | Type::Never
             | Type::AlwaysTruthy
             | Type::AlwaysFalsy => {
-                self.extend_with_type(db, Type::object());
+                self.extend_with_type(db, Type::object(), recursion_detector);
             }
 
-            Type::TypeAlias(alias) => self.extend_with_type(db, alias.value_type(db)),
+            Type::TypeAlias(_) => {
+                let members = ty.visit_type_alias_value(
+                    db,
+                    recursion_detector,
+                    || AllMembers::of_impl(db, Type::unknown(), recursion_detector).members,
+                    |value_ty| AllMembers::of_impl(db, value_ty, recursion_detector).members,
+                );
+                self.members.extend(members);
+            }
 
             Type::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => {
-                        self.extend_with_type(db, Type::object());
+                        self.extend_with_type(db, Type::object(), recursion_detector);
                     }
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                        self.extend_with_type(db, bound);
+                        self.extend_with_type(db, bound, recursion_detector);
                     }
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                         self.members.extend(
                             constraints
                                 .elements(db)
                                 .iter()
-                                .map(|ty| AllMembers::of(db, *ty).members)
+                                .map(|ty| AllMembers::of_impl(db, *ty, recursion_detector).members)
                                 .reduce(|acc, members| {
                                     acc.intersection(&members).cloned().collect()
                                 })
@@ -375,7 +418,11 @@ impl<'db> AllMembers<'db> {
                     ty: dunder_file_type,
                 });
 
-                self.extend_with_type(db, KnownClass::ModuleType.to_instance(db));
+                self.extend_with_type(
+                    db,
+                    KnownClass::ModuleType.to_instance(db),
+                    recursion_detector,
+                );
                 let module = literal.module(db);
 
                 let Some(file) = module.file(db) else {
@@ -557,13 +604,22 @@ impl<'db> AllMembers<'db> {
         ty: Type<'db>,
         class_literal: ClassLiteral<'db>,
         specialization: Option<Specialization<'db>>,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
     ) {
         match CodeGeneratorKind::from_class(db, class_literal, specialization) {
             Some(CodeGeneratorKind::NamedTuple) => {
                 if ty.is_nominal_instance() {
-                    self.extend_with_type(db, KnownClass::NamedTupleFallback.to_instance(db));
+                    self.extend_with_type(
+                        db,
+                        KnownClass::NamedTupleFallback.to_instance(db),
+                        recursion_detector,
+                    );
                 } else {
-                    self.extend_with_type(db, KnownClass::NamedTupleFallback.to_class_literal(db));
+                    self.extend_with_type(
+                        db,
+                        KnownClass::NamedTupleFallback.to_class_literal(db),
+                        recursion_detector,
+                    );
                 }
             }
             Some(CodeGeneratorKind::TypedDict) => {}

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1211,7 +1211,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     }
                 }
                 Type::TypeVar(tvar) => find_underlying_class(db, tvar.typevar(db).upper_bound(db)?),
-                Type::TypeAlias(alias) => find_underlying_class(db, alias.value_type(db)),
+                Type::TypeAlias(_) => ty.visit_type_alias_value_or_default(db, |value_ty| {
+                    find_underlying_class(db, value_ty)
+                }),
                 _ => None,
             }
         }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1,6 +1,7 @@
 use crate::Db;
 use crate::reachability::{ReachabilityConstraintsExtension, sequence_pattern_type};
 use crate::subscript::PyIndex;
+use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::enums::{enum_member_literals, enum_metadata};
 use crate::types::function::KnownFunction;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
@@ -146,6 +147,17 @@ impl ClassInfoConstraintFunction {
         classinfo: Type<'db>,
         is_positive: bool,
     ) -> Option<Type<'db>> {
+        let recursion_detector = ActiveRecursionDetector::default();
+        self.generate_constraint_impl(db, classinfo, is_positive, &recursion_detector)
+    }
+
+    fn generate_constraint_impl<'db>(
+        self,
+        db: &'db dyn Db,
+        classinfo: Type<'db>,
+        is_positive: bool,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) -> Option<Type<'db>> {
         let constraint_from_class_literal = |class: ClassLiteral<'db>| match self {
             ClassInfoConstraintFunction::IsInstance => {
                 Type::instance(db, class.top_materialization(db))
@@ -156,8 +168,10 @@ impl ClassInfoConstraintFunction {
         };
 
         match classinfo {
-            Type::TypeAlias(alias) => {
-                self.generate_constraint(db, alias.value_type(db), is_positive)
+            Type::TypeAlias(_) => {
+                classinfo.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
+                    self.generate_constraint_impl(db, value_ty, is_positive, recursion_detector)
+                })
             }
             Type::ClassLiteral(class_literal) => Some(constraint_from_class_literal(class_literal)),
             Type::SubclassOf(subclass_of_ty) => {
@@ -189,10 +203,11 @@ impl ClassInfoConstraintFunction {
                 if intersection.negative(db).is_empty() {
                     let mut builder = IntersectionBuilder::new(db);
                     for element in intersection.positive(db) {
-                        builder = builder.add_positive(self.generate_constraint(
+                        builder = builder.add_positive(self.generate_constraint_impl(
                             db,
                             *element,
                             is_positive,
+                            recursion_detector,
                         )?);
                     }
                     Some(builder.build())
@@ -202,16 +217,20 @@ impl ClassInfoConstraintFunction {
                 }
             }
             Type::Union(union) => union.try_map(db, |element| {
-                self.generate_constraint(db, *element, is_positive)
+                self.generate_constraint_impl(db, *element, is_positive, recursion_detector)
             }),
             Type::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db)? {
                     TypeVarBoundOrConstraints::UpperBound(bound) => {
-                        self.generate_constraint(db, bound, is_positive)
+                        self.generate_constraint_impl(db, bound, is_positive, recursion_detector)
                     }
-                    TypeVarBoundOrConstraints::Constraints(constraints) => {
-                        self.generate_constraint(db, constraints.as_type(db), is_positive)
-                    }
+                    TypeVarBoundOrConstraints::Constraints(constraints) => self
+                        .generate_constraint_impl(
+                            db,
+                            constraints.as_type(db),
+                            is_positive,
+                            recursion_detector,
+                        ),
                 }
             }
 
@@ -222,9 +241,9 @@ impl ClassInfoConstraintFunction {
             Type::NominalInstance(nominal) => nominal.tuple_spec(db).and_then(|tuple| {
                 UnionType::try_from_elements(
                     db,
-                    tuple
-                        .iter_all_elements()
-                        .map(|element| self.generate_constraint(db, element, is_positive)),
+                    tuple.iter_all_elements().map(|element| {
+                        self.generate_constraint_impl(db, element, is_positive, recursion_detector)
+                    }),
                 )
             }),
 
@@ -237,32 +256,43 @@ impl ClassInfoConstraintFunction {
                         // which means that `isinstance(x, int | None)` works even though
                         // `None` is not a class literal.
                         if element.is_none(db) {
-                            self.generate_constraint(
+                            self.generate_constraint_impl(
                                 db,
                                 KnownClass::NoneType.to_class_literal(db),
                                 is_positive,
+                                recursion_detector,
                             )
                         } else {
-                            self.generate_constraint(db, element, is_positive)
+                            self.generate_constraint_impl(
+                                db,
+                                element,
+                                is_positive,
+                                recursion_detector,
+                            )
                         }
                     }),
                 )
             }
 
             Type::SpecialForm(form) => match form {
-                SpecialFormType::LegacyStdlibAlias(alias) => self.generate_constraint(
+                SpecialFormType::LegacyStdlibAlias(alias) => self.generate_constraint_impl(
                     db,
                     alias.aliased_class().to_class_literal(db),
                     is_positive,
+                    recursion_detector,
                 ),
-                SpecialFormType::Tuple => self.generate_constraint(
+                SpecialFormType::Tuple => self.generate_constraint_impl(
                     db,
                     KnownClass::Tuple.to_class_literal(db),
                     is_positive,
+                    recursion_detector,
                 ),
-                SpecialFormType::Type => {
-                    self.generate_constraint(db, KnownClass::Type.to_class_literal(db), is_positive)
-                }
+                SpecialFormType::Type => self.generate_constraint_impl(
+                    db,
+                    KnownClass::Type.to_class_literal(db),
+                    is_positive,
+                    recursion_detector,
+                ),
 
                 // We don't have a good meta-type for `Callable`s right now,
                 // so only apply `isinstance()` narrowing, not `issubclass()`
@@ -2097,17 +2127,33 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 // Return true if the given type is a `TypedDict` or a union or intersection that includes at least
 // one `TypedDict` (even if other types are also present), or a type alias to such a type.
 fn is_or_contains_typeddict<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    let recursion_detector = ActiveRecursionDetector::default();
+    is_or_contains_typeddict_impl(db, ty, &recursion_detector)
+}
+
+fn is_or_contains_typeddict_impl<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+) -> bool {
     match ty {
         Type::TypedDict(_) => true,
-        Type::Intersection(intersection) => intersection
-            .positive(db)
-            .iter()
-            .any(|intersection_element_ty| is_or_contains_typeddict(db, *intersection_element_ty)),
-        Type::Union(union) => union
-            .elements(db)
-            .iter()
-            .any(|union_member_ty| is_or_contains_typeddict(db, *union_member_ty)),
-        Type::TypeAlias(alias) => is_or_contains_typeddict(db, alias.value_type(db)),
+        Type::Intersection(intersection) => {
+            intersection
+                .positive(db)
+                .iter()
+                .any(|intersection_element_ty| {
+                    is_or_contains_typeddict_impl(db, *intersection_element_ty, recursion_detector)
+                })
+        }
+        Type::Union(union) => union.elements(db).iter().any(|union_member_ty| {
+            is_or_contains_typeddict_impl(db, *union_member_ty, recursion_detector)
+        }),
+        Type::TypeAlias(_) => {
+            ty.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
+                is_or_contains_typeddict_impl(db, value_ty, recursion_detector)
+            })
+        }
 
         Type::Dynamic(_)
         | Type::Divergent(_)
@@ -2161,6 +2207,16 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
     ty: Type<'db>,
     field_name: &str,
 ) -> bool {
+    let recursion_detector = ActiveRecursionDetector::default();
+    all_matching_typeddict_fields_have_literal_types_impl(db, ty, field_name, &recursion_detector)
+}
+
+fn all_matching_typeddict_fields_have_literal_types_impl<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    field_name: &str,
+    recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+) -> bool {
     let matching_field_is_literal = |typeddict: &TypedDictType<'db>| {
         // There's no matching field to check if `.get()` returns `None`.
         typeddict
@@ -2172,26 +2228,35 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
     match ty {
         Type::TypedDict(td) => matching_field_is_literal(&td),
         Type::Union(union) => union.elements(db).iter().all(|union_member_ty| {
-            !is_or_contains_typeddict(db, *union_member_ty)
-                || all_matching_typeddict_fields_have_literal_types(
+            !is_or_contains_typeddict_impl(db, *union_member_ty, recursion_detector)
+                || all_matching_typeddict_fields_have_literal_types_impl(
                     db,
                     *union_member_ty,
                     field_name,
+                    recursion_detector,
                 )
         }),
-        Type::TypeAlias(alias) => {
-            all_matching_typeddict_fields_have_literal_types(db, alias.value_type(db), field_name)
+        Type::TypeAlias(_) => {
+            ty.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
+                all_matching_typeddict_fields_have_literal_types_impl(
+                    db,
+                    value_ty,
+                    field_name,
+                    recursion_detector,
+                )
+            })
         }
         Type::Intersection(intersection) => {
             intersection
                 .positive(db)
                 .iter()
                 .all(|intersection_member_ty| {
-                    !is_or_contains_typeddict(db, *intersection_member_ty)
-                        || all_matching_typeddict_fields_have_literal_types(
+                    !is_or_contains_typeddict_impl(db, *intersection_member_ty, recursion_detector)
+                        || all_matching_typeddict_fields_have_literal_types_impl(
                             db,
                             *intersection_member_ty,
                             field_name,
+                            recursion_detector,
                         )
                 })
         }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1,7 +1,6 @@
 use crate::Db;
 use crate::reachability::{ReachabilityConstraintsExtension, sequence_pattern_type};
 use crate::subscript::PyIndex;
-use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::enums::{enum_member_literals, enum_metadata};
 use crate::types::function::KnownFunction;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
@@ -147,17 +146,6 @@ impl ClassInfoConstraintFunction {
         classinfo: Type<'db>,
         is_positive: bool,
     ) -> Option<Type<'db>> {
-        let recursion_detector = ActiveRecursionDetector::default();
-        self.generate_constraint_impl(db, classinfo, is_positive, &recursion_detector)
-    }
-
-    fn generate_constraint_impl<'db>(
-        self,
-        db: &'db dyn Db,
-        classinfo: Type<'db>,
-        is_positive: bool,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) -> Option<Type<'db>> {
         let constraint_from_class_literal = |class: ClassLiteral<'db>| match self {
             ClassInfoConstraintFunction::IsInstance => {
                 Type::instance(db, class.top_materialization(db))
@@ -168,11 +156,9 @@ impl ClassInfoConstraintFunction {
         };
 
         match classinfo {
-            Type::TypeAlias(_) => {
-                classinfo.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
-                    self.generate_constraint_impl(db, value_ty, is_positive, recursion_detector)
-                })
-            }
+            Type::TypeAlias(_) => classinfo.visit_type_alias_value_or_default(db, |value_ty| {
+                self.generate_constraint(db, value_ty, is_positive)
+            }),
             Type::ClassLiteral(class_literal) => Some(constraint_from_class_literal(class_literal)),
             Type::SubclassOf(subclass_of_ty) => {
                 // We can't narrow negatively from a `SubclassOf` type. `if !isinstance(x, y)`
@@ -203,11 +189,10 @@ impl ClassInfoConstraintFunction {
                 if intersection.negative(db).is_empty() {
                     let mut builder = IntersectionBuilder::new(db);
                     for element in intersection.positive(db) {
-                        builder = builder.add_positive(self.generate_constraint_impl(
+                        builder = builder.add_positive(self.generate_constraint(
                             db,
                             *element,
                             is_positive,
-                            recursion_detector,
                         )?);
                     }
                     Some(builder.build())
@@ -217,20 +202,16 @@ impl ClassInfoConstraintFunction {
                 }
             }
             Type::Union(union) => union.try_map(db, |element| {
-                self.generate_constraint_impl(db, *element, is_positive, recursion_detector)
+                self.generate_constraint(db, *element, is_positive)
             }),
             Type::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db)? {
                     TypeVarBoundOrConstraints::UpperBound(bound) => {
-                        self.generate_constraint_impl(db, bound, is_positive, recursion_detector)
+                        self.generate_constraint(db, bound, is_positive)
                     }
-                    TypeVarBoundOrConstraints::Constraints(constraints) => self
-                        .generate_constraint_impl(
-                            db,
-                            constraints.as_type(db),
-                            is_positive,
-                            recursion_detector,
-                        ),
+                    TypeVarBoundOrConstraints::Constraints(constraints) => {
+                        self.generate_constraint(db, constraints.as_type(db), is_positive)
+                    }
                 }
             }
 
@@ -241,9 +222,9 @@ impl ClassInfoConstraintFunction {
             Type::NominalInstance(nominal) => nominal.tuple_spec(db).and_then(|tuple| {
                 UnionType::try_from_elements(
                     db,
-                    tuple.iter_all_elements().map(|element| {
-                        self.generate_constraint_impl(db, element, is_positive, recursion_detector)
-                    }),
+                    tuple
+                        .iter_all_elements()
+                        .map(|element| self.generate_constraint(db, element, is_positive)),
                 )
             }),
 
@@ -256,43 +237,32 @@ impl ClassInfoConstraintFunction {
                         // which means that `isinstance(x, int | None)` works even though
                         // `None` is not a class literal.
                         if element.is_none(db) {
-                            self.generate_constraint_impl(
+                            self.generate_constraint(
                                 db,
                                 KnownClass::NoneType.to_class_literal(db),
                                 is_positive,
-                                recursion_detector,
                             )
                         } else {
-                            self.generate_constraint_impl(
-                                db,
-                                element,
-                                is_positive,
-                                recursion_detector,
-                            )
+                            self.generate_constraint(db, element, is_positive)
                         }
                     }),
                 )
             }
 
             Type::SpecialForm(form) => match form {
-                SpecialFormType::LegacyStdlibAlias(alias) => self.generate_constraint_impl(
+                SpecialFormType::LegacyStdlibAlias(alias) => self.generate_constraint(
                     db,
                     alias.aliased_class().to_class_literal(db),
                     is_positive,
-                    recursion_detector,
                 ),
-                SpecialFormType::Tuple => self.generate_constraint_impl(
+                SpecialFormType::Tuple => self.generate_constraint(
                     db,
                     KnownClass::Tuple.to_class_literal(db),
                     is_positive,
-                    recursion_detector,
                 ),
-                SpecialFormType::Type => self.generate_constraint_impl(
-                    db,
-                    KnownClass::Type.to_class_literal(db),
-                    is_positive,
-                    recursion_detector,
-                ),
+                SpecialFormType::Type => {
+                    self.generate_constraint(db, KnownClass::Type.to_class_literal(db), is_positive)
+                }
 
                 // We don't have a good meta-type for `Callable`s right now,
                 // so only apply `isinstance()` narrowing, not `issubclass()`
@@ -2127,33 +2097,19 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 // Return true if the given type is a `TypedDict` or a union or intersection that includes at least
 // one `TypedDict` (even if other types are also present), or a type alias to such a type.
 fn is_or_contains_typeddict<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-    let recursion_detector = ActiveRecursionDetector::default();
-    is_or_contains_typeddict_impl(db, ty, &recursion_detector)
-}
-
-fn is_or_contains_typeddict_impl<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-    recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-) -> bool {
     match ty {
         Type::TypedDict(_) => true,
-        Type::Intersection(intersection) => {
-            intersection
-                .positive(db)
-                .iter()
-                .any(|intersection_element_ty| {
-                    is_or_contains_typeddict_impl(db, *intersection_element_ty, recursion_detector)
-                })
-        }
-        Type::Union(union) => union.elements(db).iter().any(|union_member_ty| {
-            is_or_contains_typeddict_impl(db, *union_member_ty, recursion_detector)
+        Type::Intersection(intersection) => intersection
+            .positive(db)
+            .iter()
+            .any(|intersection_element_ty| is_or_contains_typeddict(db, *intersection_element_ty)),
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .any(|union_member_ty| is_or_contains_typeddict(db, *union_member_ty)),
+        Type::TypeAlias(_) => ty.visit_type_alias_value_or_default(db, |value_ty| {
+            is_or_contains_typeddict(db, value_ty)
         }),
-        Type::TypeAlias(_) => {
-            ty.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
-                is_or_contains_typeddict_impl(db, value_ty, recursion_detector)
-            })
-        }
 
         Type::Dynamic(_)
         | Type::Divergent(_)
@@ -2207,16 +2163,6 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
     ty: Type<'db>,
     field_name: &str,
 ) -> bool {
-    let recursion_detector = ActiveRecursionDetector::default();
-    all_matching_typeddict_fields_have_literal_types_impl(db, ty, field_name, &recursion_detector)
-}
-
-fn all_matching_typeddict_fields_have_literal_types_impl<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-    field_name: &str,
-    recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-) -> bool {
     let matching_field_is_literal = |typeddict: &TypedDictType<'db>| {
         // There's no matching field to check if `.get()` returns `None`.
         typeddict
@@ -2228,35 +2174,26 @@ fn all_matching_typeddict_fields_have_literal_types_impl<'db>(
     match ty {
         Type::TypedDict(td) => matching_field_is_literal(&td),
         Type::Union(union) => union.elements(db).iter().all(|union_member_ty| {
-            !is_or_contains_typeddict_impl(db, *union_member_ty, recursion_detector)
-                || all_matching_typeddict_fields_have_literal_types_impl(
+            !is_or_contains_typeddict(db, *union_member_ty)
+                || all_matching_typeddict_fields_have_literal_types(
                     db,
                     *union_member_ty,
                     field_name,
-                    recursion_detector,
                 )
         }),
-        Type::TypeAlias(_) => {
-            ty.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
-                all_matching_typeddict_fields_have_literal_types_impl(
-                    db,
-                    value_ty,
-                    field_name,
-                    recursion_detector,
-                )
-            })
-        }
+        Type::TypeAlias(_) => ty.visit_type_alias_value_or_default(db, |value_ty| {
+            all_matching_typeddict_fields_have_literal_types(db, value_ty, field_name)
+        }),
         Type::Intersection(intersection) => {
             intersection
                 .positive(db)
                 .iter()
                 .all(|intersection_member_ty| {
-                    !is_or_contains_typeddict_impl(db, *intersection_member_ty, recursion_detector)
-                        || all_matching_typeddict_fields_have_literal_types_impl(
+                    !is_or_contains_typeddict(db, *intersection_member_ty)
+                        || all_matching_typeddict_fields_have_literal_types(
                             db,
                             *intersection_member_ty,
                             field_name,
-                            recursion_detector,
                         )
                 })
         }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -814,6 +814,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
         disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
         signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
+        invariant_relation_visitor: &'a InvariantRelationVisitor<'db>,
+        alias_relation_visitor: &'a AliasRelationVisitor<'db>,
         materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         Self {
@@ -825,6 +827,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             relation_visitor,
             disjointness_visitor,
             signature_relation_visitor,
+            invariant_relation_visitor,
+            alias_relation_visitor,
             materialization_visitor,
         }
     }
@@ -834,6 +838,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
         disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
         signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
+        invariant_relation_visitor: &'a InvariantRelationVisitor<'db>,
+        alias_relation_visitor: &'a AliasRelationVisitor<'db>,
         materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         Self {
@@ -845,6 +851,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             relation_visitor,
             disjointness_visitor,
             signature_relation_visitor,
+            invariant_relation_visitor,
+            alias_relation_visitor,
             materialization_visitor,
         }
     }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -8,7 +8,7 @@ use crate::types::constraints::{
     ConstraintSetBuilder, IteratorConstraintsExtension, OptionConstraintsExtension,
     OwnedConstraintSet,
 };
-use crate::types::cyclic::PairVisitor;
+use crate::types::cyclic::{ActiveRecursionDetector, PairVisitor};
 use crate::types::enums::is_single_member_enum;
 use crate::types::function::FunctionDecorators;
 use crate::types::set_theoretic::RecursivelyDefined;
@@ -16,8 +16,8 @@ use crate::types::signatures::{ParametersKind, SignatureRelationVisitor};
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
-    MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType, SubclassOfInner,
-    SubclassOfType, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
+    MaterializationKind, MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType,
+    SubclassOfInner, SubclassOfType, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
 };
 use crate::{
     Db,
@@ -329,20 +329,15 @@ impl<'db> Type<'db> {
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let relation_visitor = HasRelationToVisitor::default(constraints);
-        let disjointness_visitor = IsDisjointVisitor::default(constraints);
-        let signature_relation_visitor = SignatureRelationVisitor::default();
-        let materialization_visitor = ApplyTypeMappingVisitor::default();
+        let context = RelationContext::default(constraints);
         let checker = TypeRelationChecker {
             constraints,
             inferable,
             relation: TypeRelation::SubtypingAssuming,
             context_tree: ErrorContextTree::disabled(),
             given: assuming,
-            relation_visitor: &relation_visitor,
-            disjointness_visitor: &disjointness_visitor,
-            signature_relation_visitor: &signature_relation_visitor,
-            materialization_visitor: &materialization_visitor,
+            context: &context,
+            materialization_visitor: &context.default_materialization,
         };
         checker.check_type_pair(db, self, target)
     }
@@ -369,16 +364,15 @@ impl<'db> Type<'db> {
         target: Type<'db>,
     ) -> ErrorContextTree<'db> {
         let builder = ConstraintSetBuilder::new();
+        let context = RelationContext::default(&builder);
         let checker = TypeRelationChecker {
             constraints: &builder,
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             context_tree: ErrorContextTree::enabled(),
             given: ConstraintSet::from_bool(&builder, false),
-            relation_visitor: &HasRelationToVisitor::default(&builder),
-            disjointness_visitor: &IsDisjointVisitor::default(&builder),
-            signature_relation_visitor: &SignatureRelationVisitor::default(),
-            materialization_visitor: &ApplyTypeMappingVisitor::default(),
+            context: &context,
+            materialization_visitor: &context.default_materialization,
         };
         checker.check_type_pair(db, self, target);
         checker.context_tree
@@ -494,20 +488,15 @@ impl<'db> Type<'db> {
         inferable: InferableTypeVars<'db>,
         relation: TypeRelation,
     ) -> ConstraintSet<'db, 'c> {
-        let relation_visitor = HasRelationToVisitor::default(constraints);
-        let disjointness_visitor = IsDisjointVisitor::default(constraints);
-        let signature_relation_visitor = SignatureRelationVisitor::default();
-        let materialization_visitor = ApplyTypeMappingVisitor::default();
+        let context = RelationContext::default(constraints);
         let checker = TypeRelationChecker {
             constraints,
             inferable,
             relation,
             context_tree: ErrorContextTree::disabled(),
             given: ConstraintSet::from_bool(constraints, false),
-            relation_visitor: &relation_visitor,
-            disjointness_visitor: &disjointness_visitor,
-            signature_relation_visitor: &signature_relation_visitor,
-            materialization_visitor: &materialization_visitor,
+            context: &context,
+            materialization_visitor: &context.default_materialization,
         };
         checker.check_type_pair(db, self, target)
     }
@@ -566,15 +555,11 @@ impl<'db> Type<'db> {
         constraints: &'c ConstraintSetBuilder<'db>,
         materialization_visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let relation_visitor = HasRelationToVisitor::default(constraints);
-        let disjointness_visitor = IsDisjointVisitor::default(constraints);
-        let signature_relation_visitor = SignatureRelationVisitor::default();
+        let context = RelationContext::default(constraints);
         let checker = EquivalenceChecker {
             constraints,
             given: ConstraintSet::from_bool(constraints, false),
-            relation_visitor: &relation_visitor,
-            disjointness_visitor: &disjointness_visitor,
-            signature_relation_visitor: &signature_relation_visitor,
+            context: &context,
             materialization_visitor,
         };
         checker.check_type_pair(db, self, other)
@@ -608,18 +593,13 @@ impl<'db> Type<'db> {
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let relation_visitor = HasRelationToVisitor::default(constraints);
-        let disjointness_visitor = IsDisjointVisitor::default(constraints);
-        let signature_relation_visitor = SignatureRelationVisitor::default();
-        let materialization_visitor = ApplyTypeMappingVisitor::default();
+        let context = RelationContext::default(constraints);
         let checker = DisjointnessChecker {
             constraints,
             inferable,
             given: ConstraintSet::from_bool(constraints, false),
-            disjointness_visitor: &disjointness_visitor,
-            relation_visitor: &relation_visitor,
-            signature_relation_visitor: &signature_relation_visitor,
-            materialization_visitor: &materialization_visitor,
+            context: &context,
+            materialization_visitor: &context.default_materialization,
         };
         checker.check_type_pair(db, self, other)
     }
@@ -647,6 +627,67 @@ impl<'db, 'c> IsDisjointVisitor<'db, 'c> {
     }
 }
 
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub(super) struct InvariantRelationGoal<'db> {
+    source_type: Type<'db>,
+    source_materialization: MaterializationKind,
+    target_type: Type<'db>,
+    target_materialization: MaterializationKind,
+    relation: TypeRelation,
+}
+
+impl<'db> InvariantRelationGoal<'db> {
+    pub(super) const fn new(
+        source_type: Type<'db>,
+        source_materialization: MaterializationKind,
+        target_type: Type<'db>,
+        target_materialization: MaterializationKind,
+        relation: TypeRelation,
+    ) -> Self {
+        Self {
+            source_type,
+            source_materialization,
+            target_type,
+            target_materialization,
+            relation,
+        }
+    }
+}
+
+pub(super) type InvariantRelationVisitor<'db> = ActiveRecursionDetector<InvariantRelationGoal<'db>>;
+
+pub(super) struct RelationVisitors<'db, 'c> {
+    relation: HasRelationToVisitor<'db, 'c>,
+    disjointness: IsDisjointVisitor<'db, 'c>,
+    pub(super) signature: SignatureRelationVisitor<'db>,
+    pub(super) invariant: InvariantRelationVisitor<'db>,
+}
+
+impl<'db, 'c> RelationVisitors<'db, 'c> {
+    fn default(constraints: &'c ConstraintSetBuilder<'db>) -> Self {
+        Self {
+            relation: HasRelationToVisitor::default(constraints),
+            disjointness: IsDisjointVisitor::default(constraints),
+            signature: SignatureRelationVisitor::default(),
+            invariant: InvariantRelationVisitor::default(),
+        }
+    }
+}
+
+pub(crate) struct RelationContext<'db, 'c> {
+    pub(super) visitors: RelationVisitors<'db, 'c>,
+    pub(super) default_materialization: ApplyTypeMappingVisitor<'db>,
+}
+
+impl<'db, 'c> RelationContext<'db, 'c> {
+    pub(crate) fn default(constraints: &'c ConstraintSetBuilder<'db>) -> Self {
+        Self {
+            visitors: RelationVisitors::default(constraints),
+            default_materialization: ApplyTypeMappingVisitor::default(),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
     pub(super) constraints: &'c ConstraintSetBuilder<'db>,
@@ -657,13 +698,11 @@ pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
 
     // N.B. these fields are private to reduce the risk of
     // "double-visiting" a given pair of types. You should
-    // generally only ever call `self.relation_visitor.visit()`
-    // or `self.disjointness_visitor.visit()` from
+    // generally only ever call `self.context.visitors.relation.visit()`
+    // or `self.context.visitors.disjointness.visit()` from
     // `check_type_pair`, never from `check_typeddict_pair` or
     // any other more "low-level" method.
-    relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
-    disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
-    pub(super) signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
+    pub(super) context: &'a RelationContext<'db, 'c>,
     pub(super) materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
 }
 
@@ -671,10 +710,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     pub(super) fn subtyping(
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
-        relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
-        disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
-        signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
-        materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
+        context: &'a RelationContext<'db, 'c>,
     ) -> Self {
         Self {
             constraints,
@@ -682,19 +718,14 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             relation: TypeRelation::Subtyping,
             context_tree: ErrorContextTree::disabled(),
             given: ConstraintSet::from_bool(constraints, false),
-            relation_visitor,
-            disjointness_visitor,
-            signature_relation_visitor,
-            materialization_visitor,
+            context,
+            materialization_visitor: &context.default_materialization,
         }
     }
 
     pub(super) fn constraint_set_assignability(
         constraints: &'c ConstraintSetBuilder<'db>,
-        relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
-        disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
-        signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
-        materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
+        context: &'a RelationContext<'db, 'c>,
     ) -> Self {
         Self {
             constraints,
@@ -702,10 +733,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             relation: TypeRelation::ConstraintSetAssignability,
             context_tree: ErrorContextTree::disabled(),
             given: ConstraintSet::from_bool(constraints, false),
-            relation_visitor,
-            disjointness_visitor,
-            signature_relation_visitor,
-            materialization_visitor,
+            context,
+            materialization_visitor: &context.default_materialization,
         }
     }
 
@@ -805,7 +834,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         target: Type<'db>,
         work: impl FnOnce() -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
-        self.relation_visitor
+        self.context
+            .visitors
+            .relation
             .visit((source, target, self.relation), work)
     }
 
@@ -1984,9 +2015,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         EquivalenceChecker {
             constraints: self.constraints,
             given: self.given,
-            relation_visitor: self.relation_visitor,
-            disjointness_visitor: self.disjointness_visitor,
-            signature_relation_visitor: self.signature_relation_visitor,
+            context: self.context,
             materialization_visitor: self.materialization_visitor,
         }
     }
@@ -1996,9 +2025,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             constraints: self.constraints,
             inferable: self.inferable,
             given: self.given,
-            relation_visitor: self.relation_visitor,
-            disjointness_visitor: self.disjointness_visitor,
-            signature_relation_visitor: self.signature_relation_visitor,
+            context: self.context,
             materialization_visitor: self.materialization_visitor,
         }
     }
@@ -2037,13 +2064,11 @@ pub(super) struct EquivalenceChecker<'a, 'c, 'db> {
 
     // N.B. these fields are private to reduce the risk of
     // "double-visiting" a given pair of types. You should
-    // generally only ever call `self.relation_visitor.visit()`
-    // or `self.disjointness_visitor.visit()` from
+    // generally only ever call `self.context.visitors.relation.visit()`
+    // or `self.context.visitors.disjointness.visit()` from
     // `check_type_pair`, never from `check_typeddict_pair` or
     // any other more "low-level" method.
-    relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
-    disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
-    signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
+    context: &'a RelationContext<'db, 'c>,
     materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
 }
 
@@ -2058,9 +2083,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
             context_tree: ErrorContextTree::disabled(),
             given: self.given,
             inferable: InferableTypeVars::None,
-            relation_visitor: self.relation_visitor,
-            disjointness_visitor: self.disjointness_visitor,
-            signature_relation_visitor: self.signature_relation_visitor,
+            context: self.context,
             materialization_visitor,
         }
     }
@@ -2102,13 +2125,11 @@ pub(super) struct DisjointnessChecker<'a, 'c, 'db> {
 
     // N.B. these fields are private to reduce the risk of
     // "double-visiting" a given pair of types. You should
-    // generally only ever call `self.relation_visitor.visit()`
-    // or `self.disjointness_visitor.visit()` from
+    // generally only ever call `self.context.visitors.relation.visit()`
+    // or `self.context.visitors.disjointness.visit()` from
     // `check_type_pair`, never from `check_typeddict_pair` or
     // any other more "low-level" method.
-    disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
-    relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
-    signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
+    context: &'a RelationContext<'db, 'c>,
     materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
 }
 
@@ -2116,19 +2137,14 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
     pub(super) fn new(
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
-        relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
-        disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
-        signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
-        materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
+        context: &'a RelationContext<'db, 'c>,
     ) -> Self {
         Self {
             constraints,
             inferable,
             given: ConstraintSet::from_bool(constraints, false),
-            disjointness_visitor,
-            relation_visitor,
-            signature_relation_visitor,
-            materialization_visitor,
+            context,
+            materialization_visitor: &context.default_materialization,
         }
     }
 
@@ -2142,9 +2158,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             inferable: self.inferable,
             context_tree: ErrorContextTree::disabled(),
             given: self.given,
-            relation_visitor: self.relation_visitor,
-            disjointness_visitor: self.disjointness_visitor,
-            signature_relation_visitor: self.signature_relation_visitor,
+            context: self.context,
             materialization_visitor: self.materialization_visitor,
         }
     }
@@ -2153,9 +2167,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         EquivalenceChecker {
             constraints: self.constraints,
             given: self.given,
-            relation_visitor: self.relation_visitor,
-            disjointness_visitor: self.disjointness_visitor,
-            signature_relation_visitor: self.signature_relation_visitor,
+            context: self.context,
             materialization_visitor: self.materialization_visitor,
         }
     }
@@ -2166,7 +2178,10 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         target: Type<'db>,
         work: impl FnOnce() -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
-        self.disjointness_visitor.visit((source, target), work)
+        self.context
+            .visitors
+            .disjointness
+            .visit((source, target), work)
     }
 
     fn any_protocol_members_absent_or_disjoint(

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1,6 +1,7 @@
 use itertools::Itertools;
 use ruff_python_ast::name::Name;
 use rustc_hash::FxHashSet;
+use ty_python_core::definition::Definition;
 
 use crate::place::{DefinedPlace, Place};
 use crate::types::callable::CallableTypeKind;
@@ -333,6 +334,7 @@ impl<'db> Type<'db> {
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let alias_relation_visitor = AliasRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker {
             constraints,
@@ -344,6 +346,7 @@ impl<'db> Type<'db> {
             disjointness_visitor: &disjointness_visitor,
             signature_relation_visitor: &signature_relation_visitor,
             invariant_relation_visitor: &invariant_relation_visitor,
+            alias_relation_visitor: &alias_relation_visitor,
             materialization_visitor: &materialization_visitor,
         };
         checker.check_type_pair(db, self, target)
@@ -375,6 +378,7 @@ impl<'db> Type<'db> {
         let disjointness_visitor = IsDisjointVisitor::default(&builder);
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let alias_relation_visitor = AliasRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker {
             constraints: &builder,
@@ -386,6 +390,7 @@ impl<'db> Type<'db> {
             disjointness_visitor: &disjointness_visitor,
             signature_relation_visitor: &signature_relation_visitor,
             invariant_relation_visitor: &invariant_relation_visitor,
+            alias_relation_visitor: &alias_relation_visitor,
             materialization_visitor: &materialization_visitor,
         };
         checker.check_type_pair(db, self, target);
@@ -506,6 +511,7 @@ impl<'db> Type<'db> {
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let alias_relation_visitor = AliasRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker {
             constraints,
@@ -517,6 +523,7 @@ impl<'db> Type<'db> {
             disjointness_visitor: &disjointness_visitor,
             signature_relation_visitor: &signature_relation_visitor,
             invariant_relation_visitor: &invariant_relation_visitor,
+            alias_relation_visitor: &alias_relation_visitor,
             materialization_visitor: &materialization_visitor,
         };
         checker.check_type_pair(db, self, target)
@@ -580,6 +587,7 @@ impl<'db> Type<'db> {
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let alias_relation_visitor = AliasRelationVisitor::default();
         let checker = EquivalenceChecker {
             constraints,
             given: ConstraintSet::from_bool(constraints, false),
@@ -587,6 +595,7 @@ impl<'db> Type<'db> {
             disjointness_visitor: &disjointness_visitor,
             signature_relation_visitor: &signature_relation_visitor,
             invariant_relation_visitor: &invariant_relation_visitor,
+            alias_relation_visitor: &alias_relation_visitor,
             materialization_visitor,
         };
         checker.check_type_pair(db, self, other)
@@ -624,6 +633,7 @@ impl<'db> Type<'db> {
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let alias_relation_visitor = AliasRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = DisjointnessChecker {
             constraints,
@@ -633,6 +643,7 @@ impl<'db> Type<'db> {
             relation_visitor: &relation_visitor,
             signature_relation_visitor: &signature_relation_visitor,
             invariant_relation_visitor: &invariant_relation_visitor,
+            alias_relation_visitor: &alias_relation_visitor,
             materialization_visitor: &materialization_visitor,
         };
         checker.check_type_pair(db, self, other)
@@ -690,6 +701,41 @@ impl<'db> InvariantRelationGoal<'db> {
 
 pub(super) type InvariantRelationVisitor<'db> = ActiveRecursionDetector<InvariantRelationGoal<'db>>;
 
+/// Tracks recursive type-alias expansion inside relation checks.
+///
+/// The regular relation visitor is keyed by the exact pair of types, which handles recursive
+/// aliases like `type A = int | A`. It is not enough for generic aliases whose recursive reference
+/// changes specialization on each expansion, such as `type A[T] = int | A[list[T]]`. For those,
+/// keying by the alias definition plus the opposite side of the relation lets us stop unproductive
+/// expansion while still allowing productive descent into the expanded value type.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub(super) enum AliasRelationGoal<'db> {
+    /// Expanding a source alias while checking it against a fixed target.
+    Source {
+        alias: Definition<'db>,
+        target: Type<'db>,
+        relation: TypeRelation,
+    },
+    /// Expanding a target alias while checking it against a fixed source.
+    Target {
+        source: Type<'db>,
+        alias: Definition<'db>,
+        relation: TypeRelation,
+    },
+    /// Expanding a left-hand alias in a disjointness check against a fixed right-hand type.
+    DisjointLeft {
+        alias: Definition<'db>,
+        right: Type<'db>,
+    },
+    /// Expanding a right-hand alias in a disjointness check against a fixed left-hand type.
+    DisjointRight {
+        left: Type<'db>,
+        alias: Definition<'db>,
+    },
+}
+
+pub(super) type AliasRelationVisitor<'db> = ActiveRecursionDetector<AliasRelationGoal<'db>>;
+
 #[derive(Clone)]
 pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
     pub(super) constraints: &'c ConstraintSetBuilder<'db>,
@@ -708,10 +754,12 @@ pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
     disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
     pub(super) signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
     pub(super) invariant_relation_visitor: &'a InvariantRelationVisitor<'db>,
+    alias_relation_visitor: &'a AliasRelationVisitor<'db>,
     pub(super) materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
 }
 
 impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
+    #[expect(clippy::too_many_arguments)]
     pub(super) fn subtyping(
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
@@ -719,6 +767,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
         signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
         invariant_relation_visitor: &'a InvariantRelationVisitor<'db>,
+        alias_relation_visitor: &'a AliasRelationVisitor<'db>,
         materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         Self {
@@ -731,6 +780,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             disjointness_visitor,
             signature_relation_visitor,
             invariant_relation_visitor,
+            alias_relation_visitor,
             materialization_visitor,
         }
     }
@@ -741,6 +791,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
         signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
         invariant_relation_visitor: &'a InvariantRelationVisitor<'db>,
+        alias_relation_visitor: &'a AliasRelationVisitor<'db>,
         materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         Self {
@@ -753,6 +804,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             disjointness_visitor,
             signature_relation_visitor,
             invariant_relation_visitor,
+            alias_relation_visitor,
             materialization_visitor,
         }
     }
@@ -1026,11 +1078,27 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
 
             (Type::TypeAlias(source_alias), _) => self.with_recursion_guard(source, target, || {
-                self.check_type_pair(db, source_alias.value_type(db), target)
+                self.alias_relation_visitor.visit(
+                    &AliasRelationGoal::Source {
+                        alias: source_alias.definition(db),
+                        target,
+                        relation: self.relation,
+                    },
+                    || self.always(),
+                    || self.check_type_pair(db, source_alias.value_type(db), target),
+                )
             }),
 
             (_, Type::TypeAlias(target_alias)) => self.with_recursion_guard(source, target, || {
-                self.check_type_pair(db, source, target_alias.value_type(db))
+                self.alias_relation_visitor.visit(
+                    &AliasRelationGoal::Target {
+                        source,
+                        alias: target_alias.definition(db),
+                        relation: self.relation,
+                    },
+                    || self.never(),
+                    || self.check_type_pair(db, source, target_alias.value_type(db)),
+                )
             }),
 
             // Field definitions in dataclasses and dataclass-transformers can involve calls to
@@ -2036,6 +2104,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             disjointness_visitor: self.disjointness_visitor,
             signature_relation_visitor: self.signature_relation_visitor,
             invariant_relation_visitor: self.invariant_relation_visitor,
+            alias_relation_visitor: self.alias_relation_visitor,
             materialization_visitor: self.materialization_visitor,
         }
     }
@@ -2049,6 +2118,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             relation_visitor: self.relation_visitor,
             signature_relation_visitor: self.signature_relation_visitor,
             invariant_relation_visitor: self.invariant_relation_visitor,
+            alias_relation_visitor: self.alias_relation_visitor,
             materialization_visitor: self.materialization_visitor,
         }
     }
@@ -2095,6 +2165,7 @@ pub(super) struct EquivalenceChecker<'a, 'c, 'db> {
     disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
     signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
     invariant_relation_visitor: &'a InvariantRelationVisitor<'db>,
+    alias_relation_visitor: &'a AliasRelationVisitor<'db>,
     materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
 }
 
@@ -2113,6 +2184,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
             disjointness_visitor: self.disjointness_visitor,
             signature_relation_visitor: self.signature_relation_visitor,
             invariant_relation_visitor: self.invariant_relation_visitor,
+            alias_relation_visitor: self.alias_relation_visitor,
             materialization_visitor,
         }
     }
@@ -2162,10 +2234,12 @@ pub(super) struct DisjointnessChecker<'a, 'c, 'db> {
     relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
     signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
     invariant_relation_visitor: &'a InvariantRelationVisitor<'db>,
+    alias_relation_visitor: &'a AliasRelationVisitor<'db>,
     materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
 }
 
 impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
+    #[expect(clippy::too_many_arguments)]
     pub(super) fn new(
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
@@ -2173,6 +2247,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
         signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
         invariant_relation_visitor: &'a InvariantRelationVisitor<'db>,
+        alias_relation_visitor: &'a AliasRelationVisitor<'db>,
         materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         Self {
@@ -2183,6 +2258,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             relation_visitor,
             signature_relation_visitor,
             invariant_relation_visitor,
+            alias_relation_visitor,
             materialization_visitor,
         }
     }
@@ -2201,6 +2277,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             disjointness_visitor: self.disjointness_visitor,
             signature_relation_visitor: self.signature_relation_visitor,
             invariant_relation_visitor: self.invariant_relation_visitor,
+            alias_relation_visitor: self.alias_relation_visitor,
             materialization_visitor: self.materialization_visitor,
         }
     }
@@ -2213,6 +2290,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             disjointness_visitor: self.disjointness_visitor,
             signature_relation_visitor: self.signature_relation_visitor,
             invariant_relation_visitor: self.invariant_relation_visitor,
+            alias_relation_visitor: self.alias_relation_visitor,
             materialization_visitor: self.materialization_visitor,
         }
     }
@@ -2274,19 +2352,27 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             (Type::Dynamic(_), _) | (_, Type::Dynamic(_)) => self.never(),
             (Type::Divergent(_), _) | (_, Type::Divergent(_)) => self.never(),
 
-            (Type::TypeAlias(alias), _) => {
-                let left_alias_ty = alias.value_type(db);
-                self.with_recursion_guard(left, right, || {
-                    self.check_type_pair(db, left_alias_ty, right)
-                })
-            }
+            (Type::TypeAlias(left_alias), _) => self.with_recursion_guard(left, right, || {
+                self.alias_relation_visitor.visit(
+                    &AliasRelationGoal::DisjointLeft {
+                        alias: left_alias.definition(db),
+                        right,
+                    },
+                    || self.never(),
+                    || self.check_type_pair(db, left_alias.value_type(db), right),
+                )
+            }),
 
-            (_, Type::TypeAlias(alias)) => {
-                let right_alias_ty = alias.value_type(db);
-                self.with_recursion_guard(left, right, || {
-                    self.check_type_pair(db, left, right_alias_ty)
-                })
-            }
+            (_, Type::TypeAlias(right_alias)) => self.with_recursion_guard(left, right, || {
+                self.alias_relation_visitor.visit(
+                    &AliasRelationGoal::DisjointRight {
+                        left,
+                        alias: right_alias.definition(db),
+                    },
+                    || self.never(),
+                    || self.check_type_pair(db, left, right_alias.value_type(db)),
+                )
+            }),
 
             // `type[T]` is disjoint from a callable or protocol instance if its upper bound or constraints are.
             (

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -329,15 +329,22 @@ impl<'db> Type<'db> {
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let context = RelationContext::default(constraints);
+        let relation_visitor = HasRelationToVisitor::default(constraints);
+        let disjointness_visitor = IsDisjointVisitor::default(constraints);
+        let signature_relation_visitor = SignatureRelationVisitor::default();
+        let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker {
             constraints,
             inferable,
             relation: TypeRelation::SubtypingAssuming,
             context_tree: ErrorContextTree::disabled(),
             given: assuming,
-            context: &context,
-            materialization_visitor: &context.default_materialization,
+            relation_visitor: &relation_visitor,
+            disjointness_visitor: &disjointness_visitor,
+            signature_relation_visitor: &signature_relation_visitor,
+            invariant_relation_visitor: &invariant_relation_visitor,
+            materialization_visitor: &materialization_visitor,
         };
         checker.check_type_pair(db, self, target)
     }
@@ -364,15 +371,22 @@ impl<'db> Type<'db> {
         target: Type<'db>,
     ) -> ErrorContextTree<'db> {
         let builder = ConstraintSetBuilder::new();
-        let context = RelationContext::default(&builder);
+        let relation_visitor = HasRelationToVisitor::default(&builder);
+        let disjointness_visitor = IsDisjointVisitor::default(&builder);
+        let signature_relation_visitor = SignatureRelationVisitor::default();
+        let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker {
             constraints: &builder,
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             context_tree: ErrorContextTree::enabled(),
             given: ConstraintSet::from_bool(&builder, false),
-            context: &context,
-            materialization_visitor: &context.default_materialization,
+            relation_visitor: &relation_visitor,
+            disjointness_visitor: &disjointness_visitor,
+            signature_relation_visitor: &signature_relation_visitor,
+            invariant_relation_visitor: &invariant_relation_visitor,
+            materialization_visitor: &materialization_visitor,
         };
         checker.check_type_pair(db, self, target);
         checker.context_tree
@@ -488,15 +502,22 @@ impl<'db> Type<'db> {
         inferable: InferableTypeVars<'db>,
         relation: TypeRelation,
     ) -> ConstraintSet<'db, 'c> {
-        let context = RelationContext::default(constraints);
+        let relation_visitor = HasRelationToVisitor::default(constraints);
+        let disjointness_visitor = IsDisjointVisitor::default(constraints);
+        let signature_relation_visitor = SignatureRelationVisitor::default();
+        let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker {
             constraints,
             inferable,
             relation,
             context_tree: ErrorContextTree::disabled(),
             given: ConstraintSet::from_bool(constraints, false),
-            context: &context,
-            materialization_visitor: &context.default_materialization,
+            relation_visitor: &relation_visitor,
+            disjointness_visitor: &disjointness_visitor,
+            signature_relation_visitor: &signature_relation_visitor,
+            invariant_relation_visitor: &invariant_relation_visitor,
+            materialization_visitor: &materialization_visitor,
         };
         checker.check_type_pair(db, self, target)
     }
@@ -555,11 +576,17 @@ impl<'db> Type<'db> {
         constraints: &'c ConstraintSetBuilder<'db>,
         materialization_visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let context = RelationContext::default(constraints);
+        let relation_visitor = HasRelationToVisitor::default(constraints);
+        let disjointness_visitor = IsDisjointVisitor::default(constraints);
+        let signature_relation_visitor = SignatureRelationVisitor::default();
+        let invariant_relation_visitor = InvariantRelationVisitor::default();
         let checker = EquivalenceChecker {
             constraints,
             given: ConstraintSet::from_bool(constraints, false),
-            context: &context,
+            relation_visitor: &relation_visitor,
+            disjointness_visitor: &disjointness_visitor,
+            signature_relation_visitor: &signature_relation_visitor,
+            invariant_relation_visitor: &invariant_relation_visitor,
             materialization_visitor,
         };
         checker.check_type_pair(db, self, other)
@@ -593,13 +620,20 @@ impl<'db> Type<'db> {
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let context = RelationContext::default(constraints);
+        let relation_visitor = HasRelationToVisitor::default(constraints);
+        let disjointness_visitor = IsDisjointVisitor::default(constraints);
+        let signature_relation_visitor = SignatureRelationVisitor::default();
+        let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = DisjointnessChecker {
             constraints,
             inferable,
             given: ConstraintSet::from_bool(constraints, false),
-            context: &context,
-            materialization_visitor: &context.default_materialization,
+            disjointness_visitor: &disjointness_visitor,
+            relation_visitor: &relation_visitor,
+            signature_relation_visitor: &signature_relation_visitor,
+            invariant_relation_visitor: &invariant_relation_visitor,
+            materialization_visitor: &materialization_visitor,
         };
         checker.check_type_pair(db, self, other)
     }
@@ -656,38 +690,6 @@ impl<'db> InvariantRelationGoal<'db> {
 
 pub(super) type InvariantRelationVisitor<'db> = ActiveRecursionDetector<InvariantRelationGoal<'db>>;
 
-pub(super) struct RelationVisitors<'db, 'c> {
-    relation: HasRelationToVisitor<'db, 'c>,
-    disjointness: IsDisjointVisitor<'db, 'c>,
-    pub(super) signature: SignatureRelationVisitor<'db>,
-    pub(super) invariant: InvariantRelationVisitor<'db>,
-}
-
-impl<'db, 'c> RelationVisitors<'db, 'c> {
-    fn default(constraints: &'c ConstraintSetBuilder<'db>) -> Self {
-        Self {
-            relation: HasRelationToVisitor::default(constraints),
-            disjointness: IsDisjointVisitor::default(constraints),
-            signature: SignatureRelationVisitor::default(),
-            invariant: InvariantRelationVisitor::default(),
-        }
-    }
-}
-
-pub(crate) struct RelationContext<'db, 'c> {
-    pub(super) visitors: RelationVisitors<'db, 'c>,
-    pub(super) default_materialization: ApplyTypeMappingVisitor<'db>,
-}
-
-impl<'db, 'c> RelationContext<'db, 'c> {
-    pub(crate) fn default(constraints: &'c ConstraintSetBuilder<'db>) -> Self {
-        Self {
-            visitors: RelationVisitors::default(constraints),
-            default_materialization: ApplyTypeMappingVisitor::default(),
-        }
-    }
-}
-
 #[derive(Clone)]
 pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
     pub(super) constraints: &'c ConstraintSetBuilder<'db>,
@@ -698,11 +700,14 @@ pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
 
     // N.B. these fields are private to reduce the risk of
     // "double-visiting" a given pair of types. You should
-    // generally only ever call `self.context.visitors.relation.visit()`
-    // or `self.context.visitors.disjointness.visit()` from
+    // generally only ever call `self.relation_visitor.visit()`
+    // or `self.disjointness_visitor.visit()` from
     // `check_type_pair`, never from `check_typeddict_pair` or
     // any other more "low-level" method.
-    pub(super) context: &'a RelationContext<'db, 'c>,
+    relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
+    disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
+    pub(super) signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
+    pub(super) invariant_relation_visitor: &'a InvariantRelationVisitor<'db>,
     pub(super) materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
 }
 
@@ -710,7 +715,11 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     pub(super) fn subtyping(
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
-        context: &'a RelationContext<'db, 'c>,
+        relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
+        disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
+        signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
+        invariant_relation_visitor: &'a InvariantRelationVisitor<'db>,
+        materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         Self {
             constraints,
@@ -718,14 +727,21 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             relation: TypeRelation::Subtyping,
             context_tree: ErrorContextTree::disabled(),
             given: ConstraintSet::from_bool(constraints, false),
-            context,
-            materialization_visitor: &context.default_materialization,
+            relation_visitor,
+            disjointness_visitor,
+            signature_relation_visitor,
+            invariant_relation_visitor,
+            materialization_visitor,
         }
     }
 
     pub(super) fn constraint_set_assignability(
         constraints: &'c ConstraintSetBuilder<'db>,
-        context: &'a RelationContext<'db, 'c>,
+        relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
+        disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
+        signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
+        invariant_relation_visitor: &'a InvariantRelationVisitor<'db>,
+        materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         Self {
             constraints,
@@ -733,8 +749,11 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             relation: TypeRelation::ConstraintSetAssignability,
             context_tree: ErrorContextTree::disabled(),
             given: ConstraintSet::from_bool(constraints, false),
-            context,
-            materialization_visitor: &context.default_materialization,
+            relation_visitor,
+            disjointness_visitor,
+            signature_relation_visitor,
+            invariant_relation_visitor,
+            materialization_visitor,
         }
     }
 
@@ -834,9 +853,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         target: Type<'db>,
         work: impl FnOnce() -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
-        self.context
-            .visitors
-            .relation
+        self.relation_visitor
             .visit((source, target, self.relation), work)
     }
 
@@ -2015,7 +2032,10 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         EquivalenceChecker {
             constraints: self.constraints,
             given: self.given,
-            context: self.context,
+            relation_visitor: self.relation_visitor,
+            disjointness_visitor: self.disjointness_visitor,
+            signature_relation_visitor: self.signature_relation_visitor,
+            invariant_relation_visitor: self.invariant_relation_visitor,
             materialization_visitor: self.materialization_visitor,
         }
     }
@@ -2025,7 +2045,10 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             constraints: self.constraints,
             inferable: self.inferable,
             given: self.given,
-            context: self.context,
+            disjointness_visitor: self.disjointness_visitor,
+            relation_visitor: self.relation_visitor,
+            signature_relation_visitor: self.signature_relation_visitor,
+            invariant_relation_visitor: self.invariant_relation_visitor,
             materialization_visitor: self.materialization_visitor,
         }
     }
@@ -2064,11 +2087,14 @@ pub(super) struct EquivalenceChecker<'a, 'c, 'db> {
 
     // N.B. these fields are private to reduce the risk of
     // "double-visiting" a given pair of types. You should
-    // generally only ever call `self.context.visitors.relation.visit()`
-    // or `self.context.visitors.disjointness.visit()` from
+    // generally only ever call `self.relation_visitor.visit()`
+    // or `self.disjointness_visitor.visit()` from
     // `check_type_pair`, never from `check_typeddict_pair` or
     // any other more "low-level" method.
-    context: &'a RelationContext<'db, 'c>,
+    relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
+    disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
+    signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
+    invariant_relation_visitor: &'a InvariantRelationVisitor<'db>,
     materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
 }
 
@@ -2083,7 +2109,10 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
             context_tree: ErrorContextTree::disabled(),
             given: self.given,
             inferable: InferableTypeVars::None,
-            context: self.context,
+            relation_visitor: self.relation_visitor,
+            disjointness_visitor: self.disjointness_visitor,
+            signature_relation_visitor: self.signature_relation_visitor,
+            invariant_relation_visitor: self.invariant_relation_visitor,
             materialization_visitor,
         }
     }
@@ -2125,11 +2154,14 @@ pub(super) struct DisjointnessChecker<'a, 'c, 'db> {
 
     // N.B. these fields are private to reduce the risk of
     // "double-visiting" a given pair of types. You should
-    // generally only ever call `self.context.visitors.relation.visit()`
-    // or `self.context.visitors.disjointness.visit()` from
+    // generally only ever call `self.relation_visitor.visit()`
+    // or `self.disjointness_visitor.visit()` from
     // `check_type_pair`, never from `check_typeddict_pair` or
     // any other more "low-level" method.
-    context: &'a RelationContext<'db, 'c>,
+    disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
+    relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
+    signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
+    invariant_relation_visitor: &'a InvariantRelationVisitor<'db>,
     materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
 }
 
@@ -2137,14 +2169,21 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
     pub(super) fn new(
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
-        context: &'a RelationContext<'db, 'c>,
+        relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
+        disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
+        signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
+        invariant_relation_visitor: &'a InvariantRelationVisitor<'db>,
+        materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         Self {
             constraints,
             inferable,
             given: ConstraintSet::from_bool(constraints, false),
-            context,
-            materialization_visitor: &context.default_materialization,
+            disjointness_visitor,
+            relation_visitor,
+            signature_relation_visitor,
+            invariant_relation_visitor,
+            materialization_visitor,
         }
     }
 
@@ -2158,7 +2197,10 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             inferable: self.inferable,
             context_tree: ErrorContextTree::disabled(),
             given: self.given,
-            context: self.context,
+            relation_visitor: self.relation_visitor,
+            disjointness_visitor: self.disjointness_visitor,
+            signature_relation_visitor: self.signature_relation_visitor,
+            invariant_relation_visitor: self.invariant_relation_visitor,
             materialization_visitor: self.materialization_visitor,
         }
     }
@@ -2167,7 +2209,10 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         EquivalenceChecker {
             constraints: self.constraints,
             given: self.given,
-            context: self.context,
+            relation_visitor: self.relation_visitor,
+            disjointness_visitor: self.disjointness_visitor,
+            signature_relation_visitor: self.signature_relation_visitor,
+            invariant_relation_visitor: self.invariant_relation_visitor,
             materialization_visitor: self.materialization_visitor,
         }
     }
@@ -2178,10 +2223,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         target: Type<'db>,
         work: impl FnOnce() -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
-        self.context
-            .visitors
-            .disjointness
-            .visit((source, target), work)
+        self.disjointness_visitor.visit((source, target), work)
     }
 
     fn any_protocol_members_absent_or_disjoint(

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -37,9 +37,9 @@
 //! (unless exactly the same literal type), we can avoid many unnecessary redundancy checks.
 
 use super::RecursivelyDefined;
+use crate::types::cyclic::TypeAliasRecursionVisitor;
 use crate::types::enums::{enum_member_literals, enum_metadata};
 use crate::types::set_theoretic::expand_intersection_typevars_and_newtypes;
-use crate::types::type_alias::TypeAliasType;
 use crate::types::{
     ApplyTypeMappingVisitor, BytesLiteralType, ClassLiteral, EnumLiteralType, IntersectionType,
     KnownClass, LiteralValueType, LiteralValueTypeKind, NegativeIntersectionElements,
@@ -446,7 +446,7 @@ impl<'db> UnionBuilder<'db> {
         self.elements.push(UnionElement::Type(Type::object()));
     }
 
-    fn widen_literal_types(&mut self, seen_aliases: &mut Vec<Type<'db>>) {
+    fn widen_literal_types(&mut self, alias_visitor: &TypeAliasRecursionVisitor) {
         let mut replace_with = vec![];
         for elem in &self.elements {
             match elem {
@@ -467,7 +467,7 @@ impl<'db> UnionBuilder<'db> {
             }
         }
         for ty in replace_with {
-            self.add_in_place_impl(ty, seen_aliases);
+            self.add_in_place_impl(ty, alias_visitor);
         }
     }
 
@@ -479,10 +479,14 @@ impl<'db> UnionBuilder<'db> {
 
     /// Adds a type to this union.
     pub(crate) fn add_in_place(&mut self, ty: Type<'db>) {
-        self.add_in_place_impl(ty, &mut vec![]);
+        self.add_in_place_impl(ty, &TypeAliasRecursionVisitor::default());
     }
 
-    pub(crate) fn add_in_place_impl(&mut self, ty: Type<'db>, seen_aliases: &mut Vec<Type<'db>>) {
+    pub(crate) fn add_in_place_impl(
+        &mut self,
+        ty: Type<'db>,
+        alias_visitor: &TypeAliasRecursionVisitor,
+    ) {
         let cycle_recovery = self.cycle_recovery;
         let should_widen = |literals, recursively_defined: RecursivelyDefined| {
             if recursively_defined.is_yes() && cycle_recovery {
@@ -500,7 +504,7 @@ impl<'db> UnionBuilder<'db> {
                 let new_elements = union.elements(self.db);
                 self.elements.reserve(new_elements.len());
                 for element in new_elements {
-                    self.add_in_place_impl(*element, seen_aliases);
+                    self.add_in_place_impl(*element, alias_visitor);
                 }
                 self.recursively_defined = self
                     .recursively_defined
@@ -514,28 +518,28 @@ impl<'db> UnionBuilder<'db> {
                         UnionElement::Type(_) => acc,
                     });
                     if should_widen(literals, self.recursively_defined) {
-                        self.widen_literal_types(seen_aliases);
+                        self.widen_literal_types(alias_visitor);
                     }
                 }
             }
             // Adding `Never` to a union is a no-op.
             Type::Never => {}
             Type::TypeAlias(alias) if self.unpack_aliases => {
-                if seen_type_alias_definition(self.db, seen_aliases, alias) {
-                    // Union contains itself recursively via a type alias. This is an error, just
-                    // leave out the recursive alias. TODO surface this error.
-                } else {
-                    seen_aliases.push(ty);
-                    ty.visit_type_alias_value(
-                        self.db,
-                        || {
-                            // Union contains itself recursively via a type alias. This is an error, just
-                            // leave out the recursive alias. TODO surface this error.
-                        },
-                        |value_ty| self.add_in_place_impl(value_ty, seen_aliases),
-                    );
-                    seen_aliases.pop();
-                }
+                let db = self.db;
+                // Union contains itself recursively via a type alias. This is an error, just
+                // leave out the recursive alias. TODO surface this error.
+                alias_visitor.visit(
+                    db,
+                    alias,
+                    || (),
+                    || {
+                        alias.visit_value(
+                            db,
+                            || (),
+                            |value_ty| self.add_in_place_impl(value_ty, alias_visitor),
+                        );
+                    },
+                );
             }
             Type::LiteralValue(literal) => {
                 self.recursively_defined =
@@ -553,7 +557,7 @@ impl<'db> UnionBuilder<'db> {
                                 UnionElement::StringLiterals(literals) => {
                                     if should_widen(literals.len(), self.recursively_defined) {
                                         let replace_with = KnownClass::Str.to_instance(self.db);
-                                        self.add_in_place_impl(replace_with, seen_aliases);
+                                        self.add_in_place_impl(replace_with, alias_visitor);
                                         return;
                                     }
                                     found = Some(literals);
@@ -600,7 +604,7 @@ impl<'db> UnionBuilder<'db> {
                                 UnionElement::BytesLiterals(literals) => {
                                     if should_widen(literals.len(), self.recursively_defined) {
                                         let replace_with = KnownClass::Bytes.to_instance(self.db);
-                                        self.add_in_place_impl(replace_with, seen_aliases);
+                                        self.add_in_place_impl(replace_with, alias_visitor);
                                         return;
                                     }
                                     found = Some(literals);
@@ -649,7 +653,7 @@ impl<'db> UnionBuilder<'db> {
                                 UnionElement::IntLiterals(literals) => {
                                     if should_widen(literals.len(), self.recursively_defined) {
                                         let replace_with = KnownClass::Int.to_instance(self.db);
-                                        self.add_in_place_impl(replace_with, seen_aliases);
+                                        self.add_in_place_impl(replace_with, alias_visitor);
                                         return;
                                     }
                                     found = Some(literals);
@@ -698,7 +702,7 @@ impl<'db> UnionBuilder<'db> {
                         if metadata.members.len() == 1 {
                             self.add_in_place_impl(
                                 enum_member_to_add.enum_class_instance(self.db),
-                                seen_aliases,
+                                alias_visitor,
                             );
                             return;
                         }
@@ -725,7 +729,7 @@ impl<'db> UnionBuilder<'db> {
                                     if literals.len() >= enum_literals_limit {
                                         let (literal, _) = literals.first().unwrap();
                                         let replace_with = literal.enum_class_instance(self.db);
-                                        self.add_in_place_impl(replace_with, seen_aliases);
+                                        self.add_in_place_impl(replace_with, alias_visitor);
                                         return;
                                     }
                                     found = Some(literals);
@@ -759,7 +763,7 @@ impl<'db> UnionBuilder<'db> {
                                     if found.len() == metadata.members.len() {
                                         self.add_in_place_impl(
                                             enum_member_to_add.enum_class_instance(self.db),
-                                            seen_aliases,
+                                            alias_visitor,
                                         );
                                         return;
                                     }
@@ -781,16 +785,16 @@ impl<'db> UnionBuilder<'db> {
                             self.elements.swap_remove(index);
                         }
                     }
-                    _ => self.push_type(ty, seen_aliases),
+                    _ => self.push_type(ty, alias_visitor),
                 }
             }
             // Adding `object` to a union results in `object`.
             ty if ty.is_object() => self.collapse_to_object(),
-            _ => self.push_type(ty, seen_aliases),
+            _ => self.push_type(ty, alias_visitor),
         }
     }
 
-    fn push_type(&mut self, ty: Type<'db>, seen_aliases: &mut Vec<Type<'db>>) {
+    fn push_type(&mut self, ty: Type<'db>, alias_visitor: &TypeAliasRecursionVisitor) {
         let mut ty = ty;
         let bool_pair = |ty: Type<'db>| {
             if let Some(LiteralValueTypeKind::Bool(b)) = ty.as_literal_value_kind() {
@@ -850,7 +854,7 @@ impl<'db> UnionBuilder<'db> {
                 .zip(bool_pair(ty))
                 .is_some_and(|(element, pair)| element == pair)
             {
-                self.add_in_place_impl(KnownClass::Bool.to_instance(self.db), seen_aliases);
+                self.add_in_place_impl(KnownClass::Bool.to_instance(self.db), alias_visitor);
                 return;
             }
 
@@ -968,17 +972,6 @@ pub(crate) struct IntersectionBuilder<'db> {
     db: &'db dyn Db,
 }
 
-fn seen_type_alias_definition<'db>(
-    db: &'db dyn Db,
-    seen_aliases: &[Type<'db>],
-    alias: TypeAliasType<'db>,
-) -> bool {
-    let definition = alias.definition(db);
-    seen_aliases.iter().any(|seen_alias| {
-        matches!(*seen_alias, Type::TypeAlias(seen_alias) if seen_alias.definition(db) == definition)
-    })
-}
-
 impl<'db> IntersectionBuilder<'db> {
     pub(crate) fn new(db: &'db dyn Db) -> Self {
         Self {
@@ -994,40 +987,47 @@ impl<'db> IntersectionBuilder<'db> {
         }
     }
 
+    fn with_positive_alias(mut self, ty: Type<'db>) -> Self {
+        for inner in &mut self.intersections {
+            inner.positive.insert(ty);
+        }
+        self
+    }
+
+    fn with_negative_alias(mut self, ty: Type<'db>) -> Self {
+        for inner in &mut self.intersections {
+            inner.negative.insert(ty);
+        }
+        self
+    }
+
     pub(crate) fn add_positive(self, ty: Type<'db>) -> Self {
-        self.add_positive_impl(ty, &mut vec![])
+        self.add_positive_impl(ty, &TypeAliasRecursionVisitor::default())
     }
 
     pub(crate) fn add_positive_impl(
         mut self,
         ty: Type<'db>,
-        seen_aliases: &mut Vec<Type<'db>>,
+        alias_visitor: &TypeAliasRecursionVisitor,
     ) -> Self {
         match ty {
             Type::TypeAlias(alias) => {
-                if seen_type_alias_definition(self.db, seen_aliases, alias) {
-                    // Recursive alias, add it without expanding to avoid infinite recursion.
-                    for inner in &mut self.intersections {
-                        inner.positive.insert(ty);
-                    }
-                    return self;
-                }
                 let db = self.db;
-                let Some(value_type) = alias.visit_value_with_mapping_visitor(
+                let fallback = self.clone().with_positive_alias(ty);
+                let outer_fallback = fallback.clone();
+                alias_visitor.visit(
                     db,
-                    &ApplyTypeMappingVisitor::default(),
-                    || None,
-                    Some,
-                ) else {
-                    for inner in &mut self.intersections {
-                        inner.positive.insert(ty);
-                    }
-                    return self;
-                };
-                seen_aliases.push(ty);
-                let result = self.add_positive_impl(value_type, seen_aliases);
-                seen_aliases.pop();
-                result
+                    alias,
+                    || outer_fallback,
+                    || {
+                        alias.visit_value_with_mapping_visitor(
+                            db,
+                            &ApplyTypeMappingVisitor::default(),
+                            || fallback,
+                            |value_type| self.add_positive_impl(value_type, alias_visitor),
+                        )
+                    },
+                )
             }
             Type::Union(union) => {
                 // Distribute ourself over this union: for each union element, clone ourself and
@@ -1041,7 +1041,7 @@ impl<'db> IntersectionBuilder<'db> {
                 union
                     .elements(self.db)
                     .iter()
-                    .map(|elem| self.clone().add_positive_impl(*elem, seen_aliases))
+                    .map(|elem| self.clone().add_positive_impl(*elem, alias_visitor))
                     .fold(IntersectionBuilder::empty(self.db), |mut builder, sub| {
                         builder.intersections.extend(sub.intersections);
                         builder
@@ -1051,10 +1051,10 @@ impl<'db> IntersectionBuilder<'db> {
             Type::Intersection(other) => {
                 let db = self.db;
                 for pos in other.positive(db) {
-                    self = self.add_positive_impl(*pos, seen_aliases);
+                    self = self.add_positive_impl(*pos, alias_visitor);
                 }
                 for neg in other.negative(db) {
-                    self = self.add_negative_impl(*neg, seen_aliases);
+                    self = self.add_negative_impl(*neg, alias_visitor);
                 }
                 self
             }
@@ -1089,7 +1089,7 @@ impl<'db> IntersectionBuilder<'db> {
                                 .collect::<Box<[_]>>(),
                             RecursivelyDefined::No,
                         )),
-                        seen_aliases,
+                        alias_visitor,
                     )
                 } else {
                     for inner in &mut self.intersections {
@@ -1110,44 +1110,37 @@ impl<'db> IntersectionBuilder<'db> {
     }
 
     pub(crate) fn add_negative(self, ty: Type<'db>) -> Self {
-        self.add_negative_impl(ty, &mut vec![])
+        self.add_negative_impl(ty, &TypeAliasRecursionVisitor::default())
     }
 
     pub(crate) fn add_negative_impl(
         mut self,
         ty: Type<'db>,
-        seen_aliases: &mut Vec<Type<'db>>,
+        alias_visitor: &TypeAliasRecursionVisitor,
     ) -> Self {
         // See comments above in `add_positive`; this is just the negated version.
         match ty {
             Type::TypeAlias(alias) => {
-                if seen_type_alias_definition(self.db, seen_aliases, alias) {
-                    // Recursive alias, add it without expanding to avoid infinite recursion.
-                    for inner in &mut self.intersections {
-                        inner.negative.insert(ty);
-                    }
-                    return self;
-                }
                 let db = self.db;
-                let Some(value_type) = alias.visit_value_with_mapping_visitor(
+                let fallback = self.clone().with_negative_alias(ty);
+                let outer_fallback = fallback.clone();
+                alias_visitor.visit(
                     db,
-                    &ApplyTypeMappingVisitor::default(),
-                    || None,
-                    Some,
-                ) else {
-                    for inner in &mut self.intersections {
-                        inner.negative.insert(ty);
-                    }
-                    return self;
-                };
-                seen_aliases.push(ty);
-                let result = self.add_negative_impl(value_type, seen_aliases);
-                seen_aliases.pop();
-                result
+                    alias,
+                    || outer_fallback,
+                    || {
+                        alias.visit_value_with_mapping_visitor(
+                            db,
+                            &ApplyTypeMappingVisitor::default(),
+                            || fallback,
+                            |value_type| self.add_negative_impl(value_type, alias_visitor),
+                        )
+                    },
+                )
             }
             Type::Union(union) => {
                 for elem in union.elements(self.db) {
-                    self = self.add_negative_impl(*elem, seen_aliases);
+                    self = self.add_negative_impl(*elem, alias_visitor);
                 }
                 self
             }
@@ -1163,19 +1156,13 @@ impl<'db> IntersectionBuilder<'db> {
                     .positive(self.db)
                     .iter()
                     // we negate all the positive constraints while distributing
-                    .map(|elem| {
-                        self.clone()
-                            .add_negative_impl(*elem, &mut seen_aliases.clone())
-                    });
+                    .map(|elem| self.clone().add_negative_impl(*elem, alias_visitor));
 
                 let negative_side = intersection
                     .negative(self.db)
                     .iter()
                     // all negative constraints end up becoming positive constraints
-                    .map(|elem| {
-                        self.clone()
-                            .add_positive_impl(*elem, &mut seen_aliases.clone())
-                    });
+                    .map(|elem| self.clone().add_positive_impl(*elem, alias_visitor));
 
                 positive_side.chain(negative_side).fold(
                     IntersectionBuilder::empty(self.db),
@@ -1221,7 +1208,7 @@ impl<'db> IntersectionBuilder<'db> {
                             db,
                             intersections: enum_intersections,
                         }
-                        .add_positive_impl(remaining_members, seen_aliases);
+                        .add_positive_impl(remaining_members, alias_visitor);
 
                         // For non-enum intersections, just add the negative normally
                         let mut other_builder = IntersectionBuilder {

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -39,10 +39,11 @@
 use super::RecursivelyDefined;
 use crate::types::enums::{enum_member_literals, enum_metadata};
 use crate::types::set_theoretic::expand_intersection_typevars_and_newtypes;
+use crate::types::type_alias::TypeAliasType;
 use crate::types::{
-    BytesLiteralType, ClassLiteral, EnumLiteralType, IntersectionType, KnownClass,
-    LiteralValueType, LiteralValueTypeKind, NegativeIntersectionElements, StringLiteralType, Type,
-    TypeVarBoundOrConstraints, UnionType,
+    ApplyTypeMappingVisitor, BytesLiteralType, ClassLiteral, EnumLiteralType, IntersectionType,
+    KnownClass, LiteralValueType, LiteralValueTypeKind, NegativeIntersectionElements,
+    StringLiteralType, Type, TypeVarBoundOrConstraints, UnionType,
 };
 use crate::{Db, FxOrderMap, FxOrderSet};
 use smallvec::SmallVec;
@@ -520,12 +521,20 @@ impl<'db> UnionBuilder<'db> {
             // Adding `Never` to a union is a no-op.
             Type::Never => {}
             Type::TypeAlias(alias) if self.unpack_aliases => {
-                if seen_aliases.contains(&ty) {
+                if seen_type_alias_definition(self.db, seen_aliases, alias) {
                     // Union contains itself recursively via a type alias. This is an error, just
                     // leave out the recursive alias. TODO surface this error.
                 } else {
                     seen_aliases.push(ty);
-                    self.add_in_place_impl(alias.value_type(self.db), seen_aliases);
+                    ty.visit_type_alias_value(
+                        self.db,
+                        || {
+                            // Union contains itself recursively via a type alias. This is an error, just
+                            // leave out the recursive alias. TODO surface this error.
+                        },
+                        |value_ty| self.add_in_place_impl(value_ty, seen_aliases),
+                    );
+                    seen_aliases.pop();
                 }
             }
             Type::LiteralValue(literal) => {
@@ -800,7 +809,15 @@ impl<'db> UnionBuilder<'db> {
         let mut to_remove = SmallVec::<[usize; 2]>::new();
 
         for (i, element) in self.elements.iter_mut().enumerate() {
-            let element_type = match element.try_reduce(self.db, ty) {
+            let reduction = if should_simplify_full {
+                element.try_reduce(self.db, ty)
+            } else {
+                match element {
+                    UnionElement::Type(existing) => ReduceResult::Type(*existing),
+                    _ => ReduceResult::KeepIf(true),
+                }
+            };
+            let element_type = match reduction {
                 ReduceResult::KeepIf(keep) => {
                     if !keep {
                         to_remove.push(i);
@@ -951,6 +968,17 @@ pub(crate) struct IntersectionBuilder<'db> {
     db: &'db dyn Db,
 }
 
+fn seen_type_alias_definition<'db>(
+    db: &'db dyn Db,
+    seen_aliases: &[Type<'db>],
+    alias: TypeAliasType<'db>,
+) -> bool {
+    let definition = alias.definition(db);
+    seen_aliases.iter().any(|seen_alias| {
+        matches!(*seen_alias, Type::TypeAlias(seen_alias) if seen_alias.definition(db) == definition)
+    })
+}
+
 impl<'db> IntersectionBuilder<'db> {
     pub(crate) fn new(db: &'db dyn Db) -> Self {
         Self {
@@ -977,16 +1005,29 @@ impl<'db> IntersectionBuilder<'db> {
     ) -> Self {
         match ty {
             Type::TypeAlias(alias) => {
-                if seen_aliases.contains(&ty) {
+                if seen_type_alias_definition(self.db, seen_aliases, alias) {
                     // Recursive alias, add it without expanding to avoid infinite recursion.
                     for inner in &mut self.intersections {
                         inner.positive.insert(ty);
                     }
                     return self;
                 }
+                let db = self.db;
+                let Some(value_type) = alias.visit_value_with_mapping_visitor(
+                    db,
+                    &ApplyTypeMappingVisitor::default(),
+                    || None,
+                    Some,
+                ) else {
+                    for inner in &mut self.intersections {
+                        inner.positive.insert(ty);
+                    }
+                    return self;
+                };
                 seen_aliases.push(ty);
-                let value_type = alias.value_type(self.db);
-                self.add_positive_impl(value_type, seen_aliases)
+                let result = self.add_positive_impl(value_type, seen_aliases);
+                seen_aliases.pop();
+                result
             }
             Type::Union(union) => {
                 // Distribute ourself over this union: for each union element, clone ourself and
@@ -1080,16 +1121,29 @@ impl<'db> IntersectionBuilder<'db> {
         // See comments above in `add_positive`; this is just the negated version.
         match ty {
             Type::TypeAlias(alias) => {
-                if seen_aliases.contains(&ty) {
+                if seen_type_alias_definition(self.db, seen_aliases, alias) {
                     // Recursive alias, add it without expanding to avoid infinite recursion.
                     for inner in &mut self.intersections {
                         inner.negative.insert(ty);
                     }
                     return self;
                 }
+                let db = self.db;
+                let Some(value_type) = alias.visit_value_with_mapping_visitor(
+                    db,
+                    &ApplyTypeMappingVisitor::default(),
+                    || None,
+                    Some,
+                ) else {
+                    for inner in &mut self.intersections {
+                        inner.negative.insert(ty);
+                    }
+                    return self;
+                };
                 seen_aliases.push(ty);
-                let value_type = alias.value_type(self.db);
-                self.add_negative_impl(value_type, seen_aliases)
+                let result = self.add_negative_impl(value_type, seen_aliases);
+                seen_aliases.pop();
+                result
             }
             Type::Union(union) => {
                 for elem in union.elements(self.db) {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -27,7 +27,10 @@ use crate::types::generics::{
     ApplySpecialization, GenericContext, InferableTypeVars, Specialization, walk_generic_context,
 };
 use crate::types::infer::{TypeExpressionFlags, infer_deferred_types};
-use crate::types::relation::{RelationContext, TypeRelation, TypeRelationChecker};
+use crate::types::relation::{
+    HasRelationToVisitor, InvariantRelationVisitor, IsDisjointVisitor, TypeRelation,
+    TypeRelationChecker,
+};
 use crate::types::typed_dict::{
     UnpackedTypedDictKey, extract_unpacked_typed_dict_keys_from_kwargs_annotation,
     extract_unpacked_typed_dict_keys_from_value_type,
@@ -453,8 +456,19 @@ impl<'db> CallableSignature<'db> {
         other: &Self,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let context = RelationContext::default(constraints);
-        let checker = TypeRelationChecker::constraint_set_assignability(constraints, &context);
+        let relation_visitor = HasRelationToVisitor::default(constraints);
+        let disjointness_visitor = IsDisjointVisitor::default(constraints);
+        let signature_relation_visitor = SignatureRelationVisitor::default();
+        let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let materialization_visitor = ApplyTypeMappingVisitor::default();
+        let checker = TypeRelationChecker::constraint_set_assignability(
+            constraints,
+            &relation_visitor,
+            &disjointness_visitor,
+            &signature_relation_visitor,
+            &invariant_relation_visitor,
+            &materialization_visitor,
+        );
         checker.check_callable_signature_pair_inner(db, &self.overloads, &other.overloads)
     }
 }
@@ -1246,8 +1260,19 @@ impl<'db> Signature<'db> {
         other: &Self,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let context = RelationContext::default(constraints);
-        let checker = TypeRelationChecker::constraint_set_assignability(constraints, &context);
+        let relation_visitor = HasRelationToVisitor::default(constraints);
+        let disjointness_visitor = IsDisjointVisitor::default(constraints);
+        let signature_relation_visitor = SignatureRelationVisitor::default();
+        let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let materialization_visitor = ApplyTypeMappingVisitor::default();
+        let checker = TypeRelationChecker::constraint_set_assignability(
+            constraints,
+            &relation_visitor,
+            &disjointness_visitor,
+            &signature_relation_visitor,
+            &invariant_relation_visitor,
+            &materialization_visitor,
+        );
         checker.check_signature_pair(db, self, other)
     }
 
@@ -1649,9 +1674,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // Use `always` as the cycle value so valid fixed points can close; any real mismatch in
         // the finite layer still bubbles out of `work`, because only exact active revisits take
         // this branch and the result is not memoized.
-        self.context
-            .visitors
-            .signature
+        self.signature_relation_visitor
             .visit(&key, || self.always(), work)
     }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -28,8 +28,8 @@ use crate::types::generics::{
 };
 use crate::types::infer::{TypeExpressionFlags, infer_deferred_types};
 use crate::types::relation::{
-    HasRelationToVisitor, InvariantRelationVisitor, IsDisjointVisitor, TypeRelation,
-    TypeRelationChecker,
+    AliasRelationVisitor, HasRelationToVisitor, InvariantRelationVisitor, IsDisjointVisitor,
+    TypeRelation, TypeRelationChecker,
 };
 use crate::types::typed_dict::{
     UnpackedTypedDictKey, extract_unpacked_typed_dict_keys_from_kwargs_annotation,
@@ -460,6 +460,7 @@ impl<'db> CallableSignature<'db> {
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let alias_relation_visitor = AliasRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker::constraint_set_assignability(
             constraints,
@@ -467,6 +468,7 @@ impl<'db> CallableSignature<'db> {
             &disjointness_visitor,
             &signature_relation_visitor,
             &invariant_relation_visitor,
+            &alias_relation_visitor,
             &materialization_visitor,
         );
         checker.check_callable_signature_pair_inner(db, &self.overloads, &other.overloads)
@@ -1264,6 +1266,7 @@ impl<'db> Signature<'db> {
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let alias_relation_visitor = AliasRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker::constraint_set_assignability(
             constraints,
@@ -1271,6 +1274,7 @@ impl<'db> Signature<'db> {
             &disjointness_visitor,
             &signature_relation_visitor,
             &invariant_relation_visitor,
+            &alias_relation_visitor,
             &materialization_visitor,
         );
         checker.check_signature_pair(db, self, other)

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -27,9 +27,7 @@ use crate::types::generics::{
     ApplySpecialization, GenericContext, InferableTypeVars, Specialization, walk_generic_context,
 };
 use crate::types::infer::{TypeExpressionFlags, infer_deferred_types};
-use crate::types::relation::{
-    HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
-};
+use crate::types::relation::{RelationContext, TypeRelation, TypeRelationChecker};
 use crate::types::typed_dict::{
     UnpackedTypedDictKey, extract_unpacked_typed_dict_keys_from_kwargs_annotation,
     extract_unpacked_typed_dict_keys_from_value_type,
@@ -455,17 +453,8 @@ impl<'db> CallableSignature<'db> {
         other: &Self,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let relation_visitor = HasRelationToVisitor::default(constraints);
-        let disjointness_visitor = IsDisjointVisitor::default(constraints);
-        let signature_relation_visitor = SignatureRelationVisitor::default();
-        let materialization_visitor = ApplyTypeMappingVisitor::default();
-        let checker = TypeRelationChecker::constraint_set_assignability(
-            constraints,
-            &relation_visitor,
-            &disjointness_visitor,
-            &signature_relation_visitor,
-            &materialization_visitor,
-        );
+        let context = RelationContext::default(constraints);
+        let checker = TypeRelationChecker::constraint_set_assignability(constraints, &context);
         checker.check_callable_signature_pair_inner(db, &self.overloads, &other.overloads)
     }
 }
@@ -1257,17 +1246,8 @@ impl<'db> Signature<'db> {
         other: &Self,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let relation_visitor = HasRelationToVisitor::default(constraints);
-        let disjointness_visitor = IsDisjointVisitor::default(constraints);
-        let signature_relation_visitor = SignatureRelationVisitor::default();
-        let materialization_visitor = ApplyTypeMappingVisitor::default();
-        let checker = TypeRelationChecker::constraint_set_assignability(
-            constraints,
-            &relation_visitor,
-            &disjointness_visitor,
-            &signature_relation_visitor,
-            &materialization_visitor,
-        );
+        let context = RelationContext::default(constraints);
+        let checker = TypeRelationChecker::constraint_set_assignability(constraints, &context);
         checker.check_signature_pair(db, self, other)
     }
 
@@ -1669,7 +1649,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // Use `always` as the cycle value so valid fixed points can close; any real mismatch in
         // the finite layer still bubbles out of `work`, because only exact active revisits take
         // this branch and the result is not memoized.
-        self.signature_relation_visitor
+        self.context
+            .visitors
+            .signature
             .visit(&key, || self.always(), work)
     }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1152,12 +1152,16 @@ impl<'db> Signature<'db> {
         let relation_visitor = HasRelationToVisitor::default(&constraints);
         let disjointness_visitor = IsDisjointVisitor::default(&constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
+        let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let alias_relation_visitor = AliasRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker::constraint_set_assignability_with_context(
             &constraints,
             &relation_visitor,
             &disjointness_visitor,
             &signature_relation_visitor,
+            &invariant_relation_visitor,
+            &alias_relation_visitor,
             &materialization_visitor,
         );
 
@@ -1186,12 +1190,16 @@ impl<'db> Signature<'db> {
         let relation_visitor = HasRelationToVisitor::default(&constraints);
         let disjointness_visitor = IsDisjointVisitor::default(&constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
+        let invariant_relation_visitor = InvariantRelationVisitor::default();
+        let alias_relation_visitor = AliasRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker::assignability_with_context(
             &constraints,
             &relation_visitor,
             &disjointness_visitor,
             &signature_relation_visitor,
+            &invariant_relation_visitor,
+            &alias_relation_visitor,
             &materialization_visitor,
         );
 

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -526,13 +526,17 @@ impl<'db> Type<'db> {
         let inferred = match (value_ty, slice_ty) {
             (Type::Dynamic(_) | Type::Divergent(_) | Type::Never, _) => Some(Ok(value_ty)),
 
-            (Type::TypeAlias(alias), _) => {
-                Some(alias.value_type(db).subscript(db, slice_ty, expr_context))
-            }
+            (Type::TypeAlias(_), _) => Some(
+                value_ty
+                    .resolve_type_alias(db)
+                    .subscript(db, slice_ty, expr_context),
+            ),
 
-            (_, Type::TypeAlias(alias)) => {
-                Some(value_ty.subscript(db, alias.value_type(db), expr_context))
-            }
+            (_, Type::TypeAlias(_)) => Some(value_ty.subscript(
+                db,
+                slice_ty.resolve_type_alias(db),
+                expr_context,
+            )),
 
             (Type::Union(union), _) => Some(map_union_subscript(db, union, |element| {
                 element.subscript(db, slice_ty, expr_context)

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -13,7 +13,6 @@ use super::call::{Bindings, CallArguments, CallDunderError, CallErrorKind};
 use super::class::KnownClass;
 use super::class_base::ClassBase;
 use super::context::InferContext;
-use super::cyclic::ActiveRecursionDetector;
 use super::diagnostic::{
     CALL_NON_CALLABLE, INVALID_ARGUMENT_TYPE, INVALID_GENERIC_CLASS, NOT_SUBSCRIPTABLE,
     POSSIBLY_MISSING_IMPLICIT_CALL, report_index_out_of_bounds, report_invalid_key_on_typed_dict,
@@ -514,67 +513,48 @@ impl<'db> Type<'db> {
         slice_ty: Type<'db>,
         expr_context: ast::ExprContext,
     ) -> Result<Type<'db>, SubscriptError<'db>> {
-        let recursion_detector = ActiveRecursionDetector::default();
-        self.subscript_impl(db, slice_ty, expr_context, &recursion_detector)
-    }
-
-    fn subscript_impl(
-        self,
-        db: &'db dyn Db,
-        slice_ty: Type<'db>,
-        expr_context: ast::ExprContext,
-        recursion_detector: &ActiveRecursionDetector<(Type<'db>, Type<'db>)>,
-    ) -> Result<Type<'db>, SubscriptError<'db>> {
         if let Some(fallback) = self.materialized_divergent_fallback() {
-            return fallback.subscript_impl(db, slice_ty, expr_context, recursion_detector);
+            return fallback.subscript(db, slice_ty, expr_context);
         }
 
         if let Some(fallback) = slice_ty.materialized_divergent_fallback() {
-            return self.subscript_impl(db, fallback, expr_context, recursion_detector);
+            return self.subscript(db, fallback, expr_context);
         }
 
         let value_ty = self;
-        let recursion_key = (value_ty, slice_ty);
 
         let inferred = match (value_ty, slice_ty) {
             (Type::Dynamic(_) | Type::Divergent(_) | Type::Never, _) => Some(Ok(value_ty)),
 
-            (Type::TypeAlias(alias), _) => Some(recursion_detector.visit(
-                &recursion_key,
+            (Type::TypeAlias(_), _) => Some(value_ty.visit_type_alias_value(
+                db,
                 || Ok(Type::unknown()),
-                || alias.value_type(db).subscript_impl(db, slice_ty, expr_context, recursion_detector),
+                |expanded| expanded.subscript(db, slice_ty, expr_context),
             )),
 
-            (_, Type::TypeAlias(alias)) => Some(recursion_detector.visit(
-                &recursion_key,
+            (_, Type::TypeAlias(_)) => Some(slice_ty.visit_type_alias_value(
+                db,
                 || Ok(Type::unknown()),
-                || {
-                    value_ty.subscript_impl(
-                        db,
-                        alias.value_type(db),
-                        expr_context,
-                        recursion_detector,
-                    )
-                },
+                |expanded| value_ty.subscript(db, expanded, expr_context),
             )),
 
             (Type::Union(union), _) => Some(map_union_subscript(db, union, |element| {
-                element.subscript_impl(db, slice_ty, expr_context, recursion_detector)
+                element.subscript(db, slice_ty, expr_context)
             })),
 
             (_, Type::Union(union)) => Some(map_union_subscript(db, union, |element| {
-                value_ty.subscript_impl(db, element, expr_context, recursion_detector)
+                value_ty.subscript(db, element, expr_context)
             })),
 
             (Type::Intersection(intersection), _) => {
                 Some(map_intersection_subscript(db, intersection, |element| {
-                    element.subscript_impl(db, slice_ty, expr_context, recursion_detector)
+                    element.subscript(db, slice_ty, expr_context)
                 }))
             }
 
             (_, Type::Intersection(intersection)) => {
                 Some(map_intersection_subscript(db, intersection, |element| {
-                    value_ty.subscript_impl(db, element, expr_context, recursion_detector)
+                    value_ty.subscript(db, element, expr_context)
                 }))
             }
 
@@ -725,14 +705,14 @@ impl<'db> Type<'db> {
             // Ex) Given `"value"[True]`, return `"a"`
             (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal)) if (lhs_literal.is_string() || lhs_literal.is_bytes()) && rhs_literal.is_bool() => {
                 let bool = rhs_literal.as_bool().unwrap();
-                Some(value_ty.subscript_impl(db, Type::int_literal(i64::from(bool)), expr_context, recursion_detector))
+                Some(value_ty.subscript(db, Type::int_literal(i64::from(bool)), expr_context))
             }
 
             (Type::NominalInstance(nominal), Type::LiteralValue(literal))
                 if literal.is_bool() && nominal.tuple_spec(db).is_some() =>
             {
                 let bool = literal.as_bool().unwrap();
-                Some(value_ty.subscript_impl(db, Type::int_literal(i64::from(bool)), expr_context, recursion_detector))
+                Some(value_ty.subscript(db, Type::int_literal(i64::from(bool)), expr_context))
             }
 
             (Type::KnownInstance(KnownInstanceType::SubscriptedProtocol(_)), _) => {

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -233,8 +233,11 @@ impl<'db> SubscriptErrorKind<'db> {
                         "Cannot subscript non-generic type alias `{}`",
                         alias.name(db)
                     ));
-                    let value_type = alias.raw_value_type(db);
-                    if value_type.is_specialized_generic(db) {
+                    if let Some(value_type) = alias.visit_raw_value(
+                        db,
+                        || None,
+                        |value_type| value_type.is_specialized_generic(db).then_some(value_type),
+                    ) {
                         diagnostic.annotate(context.secondary(&*subscript.value).message(
                             format_args!(
                                 "Alias to `{}`, which is already specialized",

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -13,6 +13,7 @@ use super::call::{Bindings, CallArguments, CallDunderError, CallErrorKind};
 use super::class::KnownClass;
 use super::class_base::ClassBase;
 use super::context::InferContext;
+use super::cyclic::ActiveRecursionDetector;
 use super::diagnostic::{
     CALL_NON_CALLABLE, INVALID_ARGUMENT_TYPE, INVALID_GENERIC_CLASS, NOT_SUBSCRIPTABLE,
     POSSIBLY_MISSING_IMPLICIT_CALL, report_index_out_of_bounds, report_invalid_key_on_typed_dict,
@@ -513,44 +514,67 @@ impl<'db> Type<'db> {
         slice_ty: Type<'db>,
         expr_context: ast::ExprContext,
     ) -> Result<Type<'db>, SubscriptError<'db>> {
+        let recursion_detector = ActiveRecursionDetector::default();
+        self.subscript_impl(db, slice_ty, expr_context, &recursion_detector)
+    }
+
+    fn subscript_impl(
+        self,
+        db: &'db dyn Db,
+        slice_ty: Type<'db>,
+        expr_context: ast::ExprContext,
+        recursion_detector: &ActiveRecursionDetector<(Type<'db>, Type<'db>)>,
+    ) -> Result<Type<'db>, SubscriptError<'db>> {
         if let Some(fallback) = self.materialized_divergent_fallback() {
-            return fallback.subscript(db, slice_ty, expr_context);
+            return fallback.subscript_impl(db, slice_ty, expr_context, recursion_detector);
         }
 
         if let Some(fallback) = slice_ty.materialized_divergent_fallback() {
-            return self.subscript(db, fallback, expr_context);
+            return self.subscript_impl(db, fallback, expr_context, recursion_detector);
         }
 
         let value_ty = self;
+        let recursion_key = (value_ty, slice_ty);
 
         let inferred = match (value_ty, slice_ty) {
             (Type::Dynamic(_) | Type::Divergent(_) | Type::Never, _) => Some(Ok(value_ty)),
 
-            (Type::TypeAlias(alias), _) => {
-                Some(alias.value_type(db).subscript(db, slice_ty, expr_context))
-            }
+            (Type::TypeAlias(alias), _) => Some(recursion_detector.visit(
+                &recursion_key,
+                || Ok(Type::unknown()),
+                || alias.value_type(db).subscript_impl(db, slice_ty, expr_context, recursion_detector),
+            )),
 
-            (_, Type::TypeAlias(alias)) => {
-                Some(value_ty.subscript(db, alias.value_type(db), expr_context))
-            }
+            (_, Type::TypeAlias(alias)) => Some(recursion_detector.visit(
+                &recursion_key,
+                || Ok(Type::unknown()),
+                || {
+                    value_ty.subscript_impl(
+                        db,
+                        alias.value_type(db),
+                        expr_context,
+                        recursion_detector,
+                    )
+                },
+            )),
 
             (Type::Union(union), _) => Some(map_union_subscript(db, union, |element| {
-                element.subscript(db, slice_ty, expr_context)
+                element.subscript_impl(db, slice_ty, expr_context, recursion_detector)
             })),
 
             (_, Type::Union(union)) => Some(map_union_subscript(db, union, |element| {
-                value_ty.subscript(db, element, expr_context)
+                value_ty.subscript_impl(db, element, expr_context, recursion_detector)
             })),
 
             (Type::Intersection(intersection), _) => {
                 Some(map_intersection_subscript(db, intersection, |element| {
-                    element.subscript(db, slice_ty, expr_context)
+                    element.subscript_impl(db, slice_ty, expr_context, recursion_detector)
                 }))
             }
 
             (_, Type::Intersection(intersection)) => {
                 Some(map_intersection_subscript(db, intersection, |element| {
-                    value_ty.subscript(db, element, expr_context)
+                    value_ty.subscript_impl(db, element, expr_context, recursion_detector)
                 }))
             }
 
@@ -701,14 +725,14 @@ impl<'db> Type<'db> {
             // Ex) Given `"value"[True]`, return `"a"`
             (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal)) if (lhs_literal.is_string() || lhs_literal.is_bytes()) && rhs_literal.is_bool() => {
                 let bool = rhs_literal.as_bool().unwrap();
-                Some(value_ty.subscript(db, Type::int_literal(i64::from(bool)), expr_context))
+                Some(value_ty.subscript_impl(db, Type::int_literal(i64::from(bool)), expr_context, recursion_detector))
             }
 
             (Type::NominalInstance(nominal), Type::LiteralValue(literal))
                 if literal.is_bool() && nominal.tuple_spec(db).is_some() =>
             {
                 let bool = literal.as_bool().unwrap();
-                Some(value_ty.subscript(db, Type::int_literal(i64::from(bool)), expr_context))
+                Some(value_ty.subscript_impl(db, Type::int_literal(i64::from(bool)), expr_context, recursion_detector))
             }
 
             (Type::KnownInstance(KnownInstanceType::SubscriptedProtocol(_)), _) => {

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -25,7 +25,6 @@ use smallvec::{SmallVec, smallvec_inline};
 use crate::subscript::{Nth, OutOfBoundsError, PyIndex, PySlice, StepSizeZeroError};
 use crate::types::class::{ClassType, KnownClass};
 use crate::types::constraints::{ConstraintSet, IteratorConstraintsExtension};
-use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::relation::{DisjointnessChecker, TypeRelationChecker};
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::{
@@ -258,12 +257,8 @@ impl<'db> TupleType<'db> {
             .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
     }
 
-    pub(crate) fn is_single_valued_impl(
-        self,
-        db: &'db dyn Db,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) -> bool {
-        self.tuple(db).is_single_valued_impl(db, recursion_detector)
+    pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
+        self.tuple(db).is_single_valued(db)
     }
 }
 
@@ -772,14 +767,8 @@ impl<'db> FixedLengthTuple<Type<'db>> {
         }
     }
 
-    fn is_single_valued_impl(
-        &self,
-        db: &'db dyn Db,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) -> bool {
-        self.0
-            .iter()
-            .all(|ty| ty.is_single_valued_impl(db, recursion_detector))
+    fn is_single_valued(&self, db: &'db dyn Db) -> bool {
+        self.0.iter().all(|ty| ty.is_single_valued(db))
     }
 }
 
@@ -1383,13 +1372,9 @@ impl<'db> Tuple<Type<'db>> {
         }
     }
 
-    pub(crate) fn is_single_valued_impl(
-        &self,
-        db: &'db dyn Db,
-        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-    ) -> bool {
+    pub(crate) fn is_single_valued(&self, db: &'db dyn Db) -> bool {
         match self {
-            Tuple::Fixed(tuple) => tuple.is_single_valued_impl(db, recursion_detector),
+            Tuple::Fixed(tuple) => tuple.is_single_valued(db),
             Tuple::Variable(_) => false,
         }
     }

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -25,6 +25,7 @@ use smallvec::{SmallVec, smallvec_inline};
 use crate::subscript::{Nth, OutOfBoundsError, PyIndex, PySlice, StepSizeZeroError};
 use crate::types::class::{ClassType, KnownClass};
 use crate::types::constraints::{ConstraintSet, IteratorConstraintsExtension};
+use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::relation::{DisjointnessChecker, TypeRelationChecker};
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::{
@@ -257,8 +258,12 @@ impl<'db> TupleType<'db> {
             .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
     }
 
-    pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
-        self.tuple(db).is_single_valued(db)
+    pub(crate) fn is_single_valued_impl(
+        self,
+        db: &'db dyn Db,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) -> bool {
+        self.tuple(db).is_single_valued_impl(db, recursion_detector)
     }
 }
 
@@ -767,8 +772,14 @@ impl<'db> FixedLengthTuple<Type<'db>> {
         }
     }
 
-    fn is_single_valued(&self, db: &'db dyn Db) -> bool {
-        self.0.iter().all(|ty| ty.is_single_valued(db))
+    fn is_single_valued_impl(
+        &self,
+        db: &'db dyn Db,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) -> bool {
+        self.0
+            .iter()
+            .all(|ty| ty.is_single_valued_impl(db, recursion_detector))
     }
 }
 
@@ -1372,9 +1383,13 @@ impl<'db> Tuple<Type<'db>> {
         }
     }
 
-    pub(crate) fn is_single_valued(&self, db: &'db dyn Db) -> bool {
+    pub(crate) fn is_single_valued_impl(
+        &self,
+        db: &'db dyn Db,
+        recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+    ) -> bool {
         match self {
-            Tuple::Fixed(tuple) => tuple.is_single_valued(db),
+            Tuple::Fixed(tuple) => tuple.is_single_valued_impl(db, recursion_detector),
             Tuple::Variable(_) => false,
         }
     }

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -3,11 +3,9 @@ use std::fmt::Write;
 use crate::{
     Db,
     types::{
-        ApplyTypeMappingVisitor, GenericContext, Type, TypeContext, TypeMapping,
-        definition_expression_type,
-        display::qualified_name_components_from_scope,
-        generics::{ApplySpecialization, Specialization},
-        visitor,
+        ApplySpecialization, ApplyTypeMappingVisitor, GenericContext, Type, TypeContext,
+        TypeMapping, cyclic::visit_type_alias, definition_expression_type,
+        display::qualified_name_components_from_scope, generics::Specialization, visitor,
     },
 };
 use ty_python_core::{
@@ -38,7 +36,13 @@ pub(super) fn walk_pep_695_type_alias<'db, V: visitor::TypeVisitor<'db> + ?Sized
     type_alias: PEP695TypeAliasType<'db>,
     visitor: &V,
 ) {
-    visitor.visit_type(db, type_alias.value_type(db));
+    TypeAliasType::PEP695(type_alias).visit_value(
+        db,
+        || (),
+        |value_ty| {
+            visitor.visit_type(db, value_ty);
+        },
+    );
 }
 
 #[salsa::tracked]
@@ -50,7 +54,10 @@ impl<'db> PEP695TypeAliasType<'db> {
     }
 
     /// The RHS type of a PEP-695 style type alias with specialization applied.
-    pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
+    ///
+    /// This is the direct accessor used by [`TypeAliasType::visit_value`]. Recursive operations
+    /// should use the visitor wrapper so they can provide an operation-specific cycle fallback.
+    fn value_type(self, db: &'db dyn Db) -> Type<'db> {
         self.apply_function_specialization(db, self.raw_value_type(db))
     }
 
@@ -165,7 +172,13 @@ pub(super) fn walk_manual_pep_695_type_alias<'db, V: visitor::TypeVisitor<'db> +
     type_alias: ManualPEP695TypeAliasType<'db>,
     visitor: &V,
 ) {
-    visitor.visit_type(db, type_alias.value_type(db));
+    TypeAliasType::ManualPEP695(type_alias).visit_value(
+        db,
+        || (),
+        |value_ty| {
+            visitor.visit_type(db, value_ty);
+        },
+    );
 }
 
 #[salsa::tracked]
@@ -181,7 +194,7 @@ impl<'db> ManualPEP695TypeAliasType<'db> {
         },
         heap_size=ruff_memory_usage::heap_size
     )]
-    pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
+    fn value_type(self, db: &'db dyn Db) -> Type<'db> {
         let definition = self.definition(db);
         let file = definition.file(db);
         let module = parsed_module(db, file).load(db);
@@ -241,14 +254,84 @@ impl<'db> TypeAliasType<'db> {
         }
     }
 
-    pub fn value_type(self, db: &'db dyn Db) -> Type<'db> {
+    /// Direct accessor for the alias value type.
+    ///
+    /// Prefer [`TypeAliasType::visit_value`] unless the caller already owns an operation-specific
+    /// recursion guard. This direct accessor only relies on Salsa cycle recovery for the underlying
+    /// value query.
+    pub(in crate::types) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
         match self {
             TypeAliasType::PEP695(type_alias) => type_alias.value_type(db),
             TypeAliasType::ManualPEP695(type_alias) => type_alias.value_type(db),
         }
     }
 
-    pub(crate) fn raw_value_type(self, db: &'db dyn Db) -> Type<'db> {
+    /// Visits the alias value type with active-recursion tracking.
+    ///
+    /// The caller owns the fallback result because different operations need different conservative
+    /// answers when a recursive alias points back to itself.
+    pub fn visit_value<R>(
+        self,
+        db: &'db dyn Db,
+        on_cycle: impl FnOnce() -> R,
+        visit_value: impl FnOnce(Type<'db>) -> R,
+    ) -> R {
+        visit_type_alias(db, self, on_cycle, || visit_value(self.value_type(db)))
+    }
+
+    /// Visits the alias value type before applying specialization.
+    ///
+    /// Use this when the operation needs to inspect the alias definition itself rather than the
+    /// type produced by a concrete or default specialization.
+    pub fn visit_raw_value<R>(
+        self,
+        db: &'db dyn Db,
+        on_cycle: impl FnOnce() -> R,
+        visit_value: impl FnOnce(Type<'db>) -> R,
+    ) -> R {
+        visit_type_alias(db, self, on_cycle, || visit_value(self.raw_value_type(db)))
+    }
+
+    /// The alias value type with specialization applied through an existing type-mapping visitor.
+    fn value_type_with_mapping_visitor(
+        self,
+        db: &'db dyn Db,
+        visitor: &ApplyTypeMappingVisitor<'db>,
+    ) -> Type<'db> {
+        let value_type = self.raw_value_type(db);
+        let Some(generic_context) = self.generic_context(db) else {
+            return value_type;
+        };
+
+        let specialization = self
+            .specialization(db)
+            .unwrap_or_else(|| generic_context.default_specialization(db, None));
+        value_type.apply_type_mapping_impl(
+            db,
+            &TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(specialization)),
+            TypeContext::default(),
+            visitor,
+        )
+    }
+
+    /// Visits the alias value type with active-recursion tracking and applies specialization
+    /// through an existing type-mapping visitor.
+    pub(crate) fn visit_value_with_mapping_visitor<R>(
+        self,
+        db: &'db dyn Db,
+        visitor: &ApplyTypeMappingVisitor<'db>,
+        on_cycle: impl FnOnce() -> R,
+        visit_value: impl FnOnce(Type<'db>) -> R,
+    ) -> R {
+        visit_type_alias(db, self, on_cycle, || {
+            visit_value(self.value_type_with_mapping_visitor(db, visitor))
+        })
+    }
+
+    /// Direct accessor for the alias value type before applying specialization.
+    ///
+    /// Prefer [`TypeAliasType::visit_raw_value`] outside this module for recursive operations.
+    fn raw_value_type(self, db: &'db dyn Db) -> Type<'db> {
         match self {
             TypeAliasType::PEP695(type_alias) => type_alias.raw_value_type(db),
             TypeAliasType::ManualPEP695(type_alias) => type_alias.value_type(db),

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -4,8 +4,12 @@ use crate::{
     Db,
     types::{
         ApplySpecialization, ApplyTypeMappingVisitor, GenericContext, Type, TypeContext,
-        TypeMapping, cyclic::visit_type_alias, definition_expression_type,
-        display::qualified_name_components_from_scope, generics::Specialization, visitor,
+        TypeMapping,
+        cyclic::{TypeAliasRecursionVisitor, visit_type_alias},
+        definition_expression_type,
+        display::qualified_name_components_from_scope,
+        generics::Specialization,
+        visitor,
     },
 };
 use ty_python_core::{
@@ -277,6 +281,20 @@ impl<'db> TypeAliasType<'db> {
         visit_value: impl FnOnce(Type<'db>) -> R,
     ) -> R {
         visit_type_alias(db, self, on_cycle, || visit_value(self.value_type(db)))
+    }
+
+    /// Visits the alias value type with caller-owned active-recursion tracking.
+    ///
+    /// Use this when the recursive operation should share alias-recursion state across nested type
+    /// traversal, but that state should not apply to unrelated work inside the same call stack.
+    pub(crate) fn visit_value_with_recursion_visitor<R>(
+        self,
+        db: &'db dyn Db,
+        visitor: &TypeAliasRecursionVisitor,
+        on_cycle: impl FnOnce() -> R,
+        visit_value: impl FnOnce(Type<'db>) -> R,
+    ) -> R {
+        visitor.visit(db, self, on_cycle, || visit_value(self.value_type(db)))
     }
 
     /// Visits the alias value type before applying specialization.

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -26,7 +26,6 @@ use crate::types::TypeContext;
 use crate::types::TypeDefinition;
 use crate::types::class::FieldKind;
 use crate::types::constraints::{ConstraintSet, IteratorConstraintsExtension};
-use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::relation::{DisjointnessChecker, TypeRelation, TypeRelationChecker};
 use ty_python_core::definition::Definition;
 
@@ -878,15 +877,6 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
 ) -> Option<BTreeMap<Name, UnpackedTypedDictKey<'db>>> {
-    let recursion_detector = ActiveRecursionDetector::default();
-    extract_unpacked_typed_dict_keys_from_value_type_impl(db, ty, &recursion_detector)
-}
-
-fn extract_unpacked_typed_dict_keys_from_value_type_impl<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-    recursion_detector: &ActiveRecursionDetector<Type<'db>>,
-) -> Option<BTreeMap<Name, UnpackedTypedDictKey<'db>>> {
     match ty {
         Type::TypedDict(td) => {
             let keys = td
@@ -911,11 +901,7 @@ fn extract_unpacked_typed_dict_keys_from_value_type_impl<'db>(
                 .positive(db)
                 .iter()
                 .filter_map(|element| {
-                    extract_unpacked_typed_dict_keys_from_value_type_impl(
-                        db,
-                        *element,
-                        recursion_detector,
-                    )
+                    extract_unpacked_typed_dict_keys_from_value_type(db, *element)
                 })
                 .collect();
 
@@ -952,13 +938,7 @@ fn extract_unpacked_typed_dict_keys_from_value_type_impl<'db>(
             let key_maps: Vec<_> = union
                 .elements(db)
                 .iter()
-                .map(|element| {
-                    extract_unpacked_typed_dict_keys_from_value_type_impl(
-                        db,
-                        *element,
-                        recursion_detector,
-                    )
-                })
+                .map(|element| extract_unpacked_typed_dict_keys_from_value_type(db, *element))
                 .collect::<Option<_>>()?;
 
             let all_keys: OrderSet<Name> = key_maps
@@ -1003,15 +983,9 @@ fn extract_unpacked_typed_dict_keys_from_value_type_impl<'db>(
 
             Some(result)
         }
-        Type::TypeAlias(_) => {
-            ty.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
-                extract_unpacked_typed_dict_keys_from_value_type_impl(
-                    db,
-                    value_ty,
-                    recursion_detector,
-                )
-            })
-        }
+        Type::TypeAlias(_) => ty.visit_type_alias_value_or_default(db, |value_ty| {
+            extract_unpacked_typed_dict_keys_from_value_type(db, value_ty)
+        }),
         // All other types cannot contain a TypedDict
         Type::Dynamic(_)
         | Type::Divergent(_)

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -26,6 +26,7 @@ use crate::types::TypeContext;
 use crate::types::TypeDefinition;
 use crate::types::class::FieldKind;
 use crate::types::constraints::{ConstraintSet, IteratorConstraintsExtension};
+use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::relation::{DisjointnessChecker, TypeRelation, TypeRelationChecker};
 use ty_python_core::definition::Definition;
 
@@ -877,6 +878,15 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
 ) -> Option<BTreeMap<Name, UnpackedTypedDictKey<'db>>> {
+    let recursion_detector = ActiveRecursionDetector::default();
+    extract_unpacked_typed_dict_keys_from_value_type_impl(db, ty, &recursion_detector)
+}
+
+fn extract_unpacked_typed_dict_keys_from_value_type_impl<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    recursion_detector: &ActiveRecursionDetector<Type<'db>>,
+) -> Option<BTreeMap<Name, UnpackedTypedDictKey<'db>>> {
     match ty {
         Type::TypedDict(td) => {
             let keys = td
@@ -901,7 +911,11 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
                 .positive(db)
                 .iter()
                 .filter_map(|element| {
-                    extract_unpacked_typed_dict_keys_from_value_type(db, *element)
+                    extract_unpacked_typed_dict_keys_from_value_type_impl(
+                        db,
+                        *element,
+                        recursion_detector,
+                    )
                 })
                 .collect();
 
@@ -938,7 +952,13 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
             let key_maps: Vec<_> = union
                 .elements(db)
                 .iter()
-                .map(|element| extract_unpacked_typed_dict_keys_from_value_type(db, *element))
+                .map(|element| {
+                    extract_unpacked_typed_dict_keys_from_value_type_impl(
+                        db,
+                        *element,
+                        recursion_detector,
+                    )
+                })
                 .collect::<Option<_>>()?;
 
             let all_keys: OrderSet<Name> = key_maps
@@ -983,8 +1003,14 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
 
             Some(result)
         }
-        Type::TypeAlias(alias) => {
-            extract_unpacked_typed_dict_keys_from_value_type(db, alias.value_type(db))
+        Type::TypeAlias(_) => {
+            ty.visit_type_alias_value_or_default(db, recursion_detector, |value_ty| {
+                extract_unpacked_typed_dict_keys_from_value_type_impl(
+                    db,
+                    value_ty,
+                    recursion_detector,
+                )
+            })
         }
         // All other types cannot contain a TypedDict
         Type::Dynamic(_)

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -379,7 +379,11 @@ impl<'db> TypeVarInstance<'db> {
                 return false;
             }
 
-            type_is_self_referential_impl(state, type_alias.raw_value_type(state.db), self_identity)
+            type_alias.visit_raw_value(
+                state.db,
+                || false,
+                |value_ty| type_is_self_referential_impl(state, value_ty, self_identity),
+            )
         }
 
         fn type_is_self_referential_impl<'db>(


### PR DESCRIPTION
## Summary

This PR fixes a variety of panics that arise from recursive PEP 695 type aliases. (Codex estimates that it fixes 40-50 user-visible panics stemming from 8-12 underlying codepaths.)

Previously, a bunch of type operations handled aliases by directly expanding the alias RHS with `alias.value_type(db)` and then continuing the same operation on the expanded type. That works for acyclic aliases, but recursive aliases can re-enter the same alias expansion before the outer operation completes, leading to stack overflows or cycle non-convergence.

For example:

```python
type RecursiveList[T] = T | list[RecursiveList[T]]

r1: RecursiveList[int] = [1, [1, 2, 3]]
r2: RecursiveList[int] = [1, ["a"]]
```

The core fix is to make alias visitation a guarded operation. Alias expansion now goes through `Type::visit_type_alias_value(...)`, backed by an active-alias stack keyed by the alias identity. When an operation reaches the same active alias again, it stops expanding that recursive edge and returns an operation-specific conservative fallback (like `Unknown`, or a default). We have to take this into account anywhere that we try to access an alias value.

I initially implemented this by threading a visitor through all type operations (first commit). That worked, but it required adding `_impl` variants all across the API, and remembering to thread the visitor through in the correct places. So I did a second pass to use a thread-local guard, which significantly reduces the diff at the cost of some implicit magic. I am fine either approach, but figured this was much easier to review.

Closes https://github.com/astral-sh/ty/issues/3195.

Closes https://github.com/astral-sh/ty/issues/3196.

Closes https://github.com/astral-sh/ty/issues/3452.

Closes https://github.com/astral-sh/ty/issues/3960.
