### PR TITLE
[ty] Fine-tune diagnostic range of `unresolved-cast`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/cast.md
@@ -31,13 +31,13 @@ cast(str, b"ar", "foo")
 def function_returning_int() -> int:
     return 10
 
-# error: [redundant-cast] "Value is already of type `int`"
+# error: [redundant-cast] "Redundant cast: value is already of type `int`"
 cast(int, function_returning_int())
 
 def function_returning_any() -> Any:
     return "blah"
 
-# error: [redundant-cast] "Value is already of type `Any`"
+# error: [redundant-cast] "Redundant cast: value is already of type `Any`"
 cast(Any, function_returning_any())
 ```
 
@@ -108,11 +108,11 @@ cast(int, secrets.randbelow(10))
 ```
 
 ```snapshot
-warning[redundant-cast]: Value is already of type `int`
- --> src/mdtest_snippet.py:5:1
+warning[redundant-cast]: Redundant cast to type `int`
+ --> src/mdtest_snippet.py:5:11
   |
 5 | cast(int, secrets.randbelow(10))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |           ^^^^^^^^^^^^^^^^^^^^^ Value is already of type `int`
   |
 ```
 
@@ -122,10 +122,10 @@ cast(val=secrets.randbelow(10), typ=int)
 ```
 
 ```snapshot
-warning[redundant-cast]: Value is already of type `int`
- --> src/mdtest_snippet.py:7:1
+warning[redundant-cast]: Redundant cast to type `int`
+ --> src/mdtest_snippet.py:7:10
   |
 7 | cast(val=secrets.randbelow(10), typ=int)
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |          ^^^^^^^^^^^^^^^^^^^^^ Value is already of type `int`
   |
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Redundant_cast_warni…_(75ac240a2d1f7108).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Redundant_cast_warni…_(75ac240a2d1f7108).snap
@@ -29,21 +29,21 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/typed_dict.md
 # Diagnostics
 
 ```
-warning[redundant-cast]: Value is already of type `Foo2`
-  --> src/mdtest_snippet.py:10:5
+warning[redundant-cast]: Redundant cast to type `Foo2`
+  --> src/mdtest_snippet.py:10:16
    |
 10 | _ = cast(Foo2, foo)  # error: [redundant-cast]
-   |     ^^^^^^^^^^^^^^^
+   |                ^^^ Value is already of type `Foo2`
    |
 
 ```
 
 ```
-warning[redundant-cast]: Value is already of type `Bar2`
-  --> src/mdtest_snippet.py:11:5
+warning[redundant-cast]: Redundant cast to type `Bar2`
+  --> src/mdtest_snippet.py:11:16
    |
 11 | _ = cast(Bar2, foo)  # error: [redundant-cast]
-   |     ^^^^^^^^^^^^^^^
+   |                ^^^ Value is already of type `Bar2`
    |
 info: `Bar2` is equivalent to `Foo2`
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -55,7 +55,7 @@ use bitflags::bitflags;
 use ruff_db::diagnostic::{Annotation, DiagnosticId, Severity, Span};
 use ruff_db::files::{File, FileRange};
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
-use ruff_python_ast::{self as ast, ParameterWithDefault};
+use ruff_python_ast::{self as ast, AnyNodeRef, ParameterWithDefault};
 use ruff_text_size::Ranged;
 use ty_module_resolver::{KnownModule, ModuleName, file_to_module, resolve_module};
 
@@ -2060,11 +2060,21 @@ impl KnownFunction {
                     && !any_over_type(db, *source_type, true, contains_unknown_or_todo)
                     && !any_over_type(db, *casted_type, true, contains_unknown_or_todo)
                 {
-                    if let Some(builder) = context.report_lint(&REDUNDANT_CAST, call_expression) {
+                    let value_arg = call_expression.arguments.find_argument_value("val", 1);
+                    let node = value_arg
+                        .map(AnyNodeRef::from)
+                        .unwrap_or(AnyNodeRef::from(call_expression));
+                    if let Some(builder) = context.report_lint(&REDUNDANT_CAST, node) {
                         let source_display = source_type.display(db).to_string();
                         let casted_display = casted_type.display(db).to_string();
                         let mut diagnostic = builder.into_diagnostic(format_args!(
-                            "Value is already of type `{casted_display}`",
+                            "Redundant cast to type `{casted_display}`",
+                        ));
+                        diagnostic.set_primary_message(format_args!(
+                            "Value is already of type `{casted_display}`"
+                        ));
+                        diagnostic.set_concise_message(format_args!(
+                            "Redundant cast: value is already of type `{casted_display}`",
                         ));
                         if source_display != casted_display {
                             diagnostic.info(format_args!(


### PR DESCRIPTION
## Summary

Better diagnostic messages and source annotation range for `redundant-cast` diagnostics.

Before:

<img width="478" height="134" alt="image" src="https://github.com/user-attachments/assets/d5ff83b2-c7f9-4eaf-bca1-3ca594d654de" />

After:

<img width="606" height="134" alt="image" src="https://github.com/user-attachments/assets/8e51d446-ee42-48e6-855d-90f1189aaa33" />


## Test Plan

Updated snapshot tests