### PR TITLE
[ty] Merge same-file annotations if there is only a single line separating them

### DIFF
--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -1371,6 +1371,11 @@ pub struct DisplayDiagnosticConfig {
     /// here for now as the most "sensible" place for it to live until
     /// we had more concrete use cases. ---AG
     context: usize,
+    /// The "merge window" for annotations.
+    ///
+    /// If two annotations have fewer than this number of lines between them,
+    /// they will be merged into a single annotation.
+    merge_window: usize,
     /// Whether to use preview formatting for Ruff diagnostics.
     #[allow(
         dead_code,
@@ -1401,6 +1406,7 @@ impl DisplayDiagnosticConfig {
             format: DiagnosticFormat::default(),
             color: false,
             context: 2,
+            merge_window: 2,
             preview: false,
             hide_severity: false,
             show_fix_status: false,
@@ -1424,6 +1430,17 @@ impl DisplayDiagnosticConfig {
     pub fn context(self, lines: usize) -> DisplayDiagnosticConfig {
         DisplayDiagnosticConfig {
             context: lines,
+            ..self
+        }
+    }
+
+    /// Set the "merge window" for annotations.
+    ///
+    /// If two annotations have fewer than this number of lines between them,
+    /// they will be merged into a single annotation.
+    pub fn merge_window(self, lines: usize) -> DisplayDiagnosticConfig {
+        DisplayDiagnosticConfig {
+            merge_window: lines,
             ..self
         }
     }

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -187,12 +187,12 @@ impl<'a> Resolved<'a> {
     }
 
     /// Creates a value that is amenable to rendering directly.
-    fn to_renderable(&self, context: usize) -> Renderable<'_> {
+    fn to_renderable(&self, config: &DisplayDiagnosticConfig) -> Renderable<'_> {
         Renderable {
             diagnostics: self
                 .diagnostics
                 .iter()
-                .map(|diag| diag.to_renderable(context))
+                .map(|diag| diag.to_renderable(config))
                 .collect(),
         }
     }
@@ -304,7 +304,7 @@ impl<'a> ResolvedDiagnostic<'a> {
     ///
     /// `context` refers to the number of lines both before and after to show
     /// for each snippet.
-    fn to_renderable<'r>(&'r self, context: usize) -> RenderableDiagnostic<'r> {
+    fn to_renderable<'r>(&'r self, config: &DisplayDiagnosticConfig) -> RenderableDiagnostic<'r> {
         let mut ann_by_path: BTreeMap<&'a str, Vec<&ResolvedAnnotation<'a>>> = BTreeMap::new();
         for ann in &self.annotations {
             ann_by_path.entry(ann.path).or_default().push(ann);
@@ -317,8 +317,7 @@ impl<'a> ResolvedDiagnostic<'a> {
         // to be (in lines) to be rendered inside a single snippet.
         // This is independent of `context`, which controls how many
         // extra padding lines appear before and after each snippet.
-        const MERGE_WINDOW: usize = 2;
-        let merge_window = MERGE_WINDOW.max(context);
+        let merge_window = config.merge_window.max(config.context);
 
         let mut snippet_by_path: BTreeMap<&'a str, Vec<Vec<&ResolvedAnnotation<'a>>>> =
             BTreeMap::new();
@@ -391,7 +390,7 @@ impl<'a> ResolvedDiagnostic<'a> {
 
         let mut snippets_by_input = vec![];
         for (path, snippets) in snippet_by_path {
-            snippets_by_input.push(RenderableSnippets::new(context, path, &snippets));
+            snippets_by_input.push(RenderableSnippets::new(config.context, path, &snippets));
         }
         snippets_by_input
             .sort_by(|snips1, snips2| snips1.has_primary.cmp(&snips2.has_primary).reverse());
@@ -1572,7 +1571,9 @@ watermelon
         1 | aardvark
           | ^^^^^^^^
         2 | beetle
-        3 | canary
+          |
+         ::: animals:5:1
+          |
         4 | dog
         5 | elephant
           | ^^^^^^^^
@@ -1766,7 +1767,9 @@ watermelon
           |
         3 | beetle
           | ^^^^^^
-        4 |
+          |
+         ::: spacey-animals:5:1
+          |
         5 | canary
           | ^^^^^^
           |
@@ -2417,22 +2420,30 @@ watermelon
             env.render(&diag),
             @"
         error[test-diagnostic]: main diagnostic message
-         --> animals:1:1
+         --> animals:5:1
+          |
+        5 | elephant
+          | ^^^^^^^^ primary 5
+          |
+         ::: animals:9:1
+          |
+        9 | inchworm
+          | ^^^^^^^^ primary 9
+          |
+         ::: animals:1:1
           |
         1 | aardvark
           | -------- secondary 1
-        2 | beetle
+          |
+         ::: animals:3:1
+          |
         3 | canary
           | ------ secondary 3
-        4 | dog
-        5 | elephant
-          | ^^^^^^^^ primary 5
-        6 | finch
+          |
+         ::: animals:7:1
+          |
         7 | gorilla
           | ------- secondary 7
-        8 | hippopotamus
-        9 | inchworm
-          | ^^^^^^^^ primary 9
           |
         ",
         );
@@ -2488,23 +2499,25 @@ watermelon
             env.render(&diag),
             @"
         error[test-diagnostic]: main diagnostic message
-          --> animals:1:1
+          --> animals:11:1
+           |
+        11 | kangaroo
+           | ^^^^^^^^ primary animals 11
+           |
+          ::: animals:1:1
            |
          1 | aardvark
            | -------- secondary animals 1
-         2 | beetle
+           |
+          ::: animals:3:1
+           |
          3 | canary
            | ------ secondary animals 3
-         4 | dog
-         5 | elephant
-         6 | finch
+           |
+          ::: animals:7:1
+           |
          7 | gorilla
            | ------- secondary animals 7
-         8 | hippopotamus
-         9 | inchworm
-        10 | jackrabbit
-        11 | kangaroo
-           | ^^^^^^^^ primary animals 11
            |
           ::: fruits:10:1
            |
@@ -2532,10 +2545,14 @@ watermelon
         ///
         /// This uses the default diagnostic rendering configuration.
         pub(super) fn new() -> TestEnvironment {
-            TestEnvironment {
+            let mut env = TestEnvironment {
                 db: TestDb::new(),
                 config: DisplayDiagnosticConfig::new("ty"),
-            }
+            };
+            // Default to a merge window of 0 for testing purposes,
+            // even though this is not the default for user-facing diagnostics.
+            env.merge_window(0);
+            env
         }
 
         /// Set the number of contextual lines to include for each snippet
@@ -2547,6 +2564,15 @@ watermelon
             // configuration. So just deal with this inconvenience for now.
             let config = self.config.clone();
             self.config = config.context(lines);
+        }
+
+        /// Set the "merge window" for annotations in this test.
+        ///
+        /// If two annotations have fewer than this number of lines between them,
+        /// they will be merged into a single annotation.
+        fn merge_window(&mut self, lines: usize) {
+            let config = self.config.clone();
+            self.config = config.merge_window(lines);
         }
 
         /// Set the output format to use in diagnostic rendering.

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -1572,9 +1572,7 @@ watermelon
         1 | aardvark
           | ^^^^^^^^
         2 | beetle
-          |
-         ::: animals:5:1
-          |
+        3 | canary
         4 | dog
         5 | elephant
           | ^^^^^^^^
@@ -1768,9 +1766,7 @@ watermelon
           |
         3 | beetle
           | ^^^^^^
-          |
-         ::: spacey-animals:5:1
-          |
+        4 |
         5 | canary
           | ^^^^^^
           |
@@ -2421,30 +2417,22 @@ watermelon
             env.render(&diag),
             @"
         error[test-diagnostic]: main diagnostic message
-         --> animals:5:1
-          |
-        5 | elephant
-          | ^^^^^^^^ primary 5
-          |
-         ::: animals:9:1
-          |
-        9 | inchworm
-          | ^^^^^^^^ primary 9
-          |
-         ::: animals:1:1
+         --> animals:1:1
           |
         1 | aardvark
           | -------- secondary 1
-          |
-         ::: animals:3:1
-          |
+        2 | beetle
         3 | canary
           | ------ secondary 3
-          |
-         ::: animals:7:1
-          |
+        4 | dog
+        5 | elephant
+          | ^^^^^^^^ primary 5
+        6 | finch
         7 | gorilla
           | ------- secondary 7
+        8 | hippopotamus
+        9 | inchworm
+          | ^^^^^^^^ primary 9
           |
         ",
         );
@@ -2500,25 +2488,23 @@ watermelon
             env.render(&diag),
             @"
         error[test-diagnostic]: main diagnostic message
-          --> animals:11:1
-           |
-        11 | kangaroo
-           | ^^^^^^^^ primary animals 11
-           |
-          ::: animals:1:1
+          --> animals:1:1
            |
          1 | aardvark
            | -------- secondary animals 1
-           |
-          ::: animals:3:1
-           |
+         2 | beetle
          3 | canary
            | ------ secondary animals 3
-           |
-          ::: animals:7:1
-           |
+         4 | dog
+         5 | elephant
+         6 | finch
          7 | gorilla
            | ------- secondary animals 7
+         8 | hippopotamus
+         9 | inchworm
+        10 | jackrabbit
+        11 | kangaroo
+           | ^^^^^^^^ primary animals 11
            |
           ::: fruits:10:1
            |

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -313,6 +313,13 @@ impl<'a> ResolvedDiagnostic<'a> {
             anns.sort_by_key(|ann1| ann1.range.start());
         }
 
+        // The merge window determines how close two annotations need
+        // to be (in lines) to be rendered inside a single snippet.
+        // This is independent of `context`, which controls how many
+        // extra padding lines appear before and after each snippet.
+        const MERGE_WINDOW: usize = 2;
+        let merge_window = MERGE_WINDOW.max(context);
+
         let mut snippet_by_path: BTreeMap<&'a str, Vec<Vec<&ResolvedAnnotation<'a>>>> =
             BTreeMap::new();
         for (path, anns) in ann_by_path {
@@ -325,14 +332,14 @@ impl<'a> ResolvedDiagnostic<'a> {
 
                 let prev_context_ends = context_after(
                     &prev.diagnostic_source.as_source_code(),
-                    context,
+                    merge_window,
                     prev.line_end,
                     prev.notebook_index.as_ref(),
                 )
                 .get();
                 let this_context_begins = context_before(
                     &ann.diagnostic_source.as_source_code(),
-                    context,
+                    merge_window,
                     ann.line_start,
                     ann.notebook_index.as_ref(),
                 )

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -58,7 +58,7 @@ impl<'a> FullRenderer<'a> {
             }
 
             let resolved = Resolved::new(self.resolver, diag, self.config);
-            let renderable = resolved.to_renderable(self.config.context);
+            let renderable = resolved.to_renderable(self.config);
             for diag in renderable.diagnostics.iter() {
                 writeln!(f, "{}", renderer.render(diag.to_annotate()))?;
             }

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -646,15 +646,14 @@ class Bad(NotCallableInitSubclass):
 
 ```snapshot
 error[non-callable-init-subclass]: Invalid definition of class `Bad`
-  --> src/mdtest_snippet.py:39:7
-   |
-39 | class Bad(NotCallableInitSubclass):
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Superclass `NotCallableInitSubclass` cannot be subclassed
-   |
-  ::: src/mdtest_snippet.py:36:5
+  --> src/mdtest_snippet.py:36:5
    |
 36 |     __init_subclass__ = None
    |     ----------------- `NotCallableInitSubclass.__init_subclass__` has type `None | Unknown`, which may not be callable
+37 |
+38 | # snapshot: non-callable-init-subclass
+39 | class Bad(NotCallableInitSubclass):
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Superclass `NotCallableInitSubclass` cannot be subclassed
    |
 info: `__init_subclass__` on a superclass is implicitly called during creation of a class object
 info: See https://docs.python.org/3/reference/datamodel.html#customizing-class-creation

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -637,15 +637,13 @@ class Child(FrozenBase):
 
 ```snapshot
 error[invalid-frozen-dataclass-subclass]: Non-frozen dataclass cannot inherit from frozen dataclass
- --> src/foo.py:9:7
-  |
-9 | class Child(FrozenBase):
-  |       ^^^^^^----------^ Subclass `Child` is not frozen but base class `FrozenBase` is
-  |
- ::: src/foo.py:7:1
+ --> src/foo.py:7:1
   |
 7 | @dataclass
   | ---------- `Child` dataclass parameters
+8 | # snapshot: invalid-frozen-dataclass-subclass
+9 | class Child(FrozenBase):
+  |       ^^^^^^----------^ Subclass `Child` is not frozen but base class `FrozenBase` is
   |
 info: This causes the class creation to fail
 info: Base class definition

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -582,15 +582,14 @@ DontAssignToMe().immutable = "the properties, they are a-changing"
 
 ```snapshot
 error[invalid-assignment]: Cannot assign to read-only property `immutable` on object of type `DontAssignToMe`
- --> src/mdtest_snippet.py:6:1
-  |
-6 | DontAssignToMe().immutable = "the properties, they are a-changing"
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ Attempted assignment to `DontAssignToMe.immutable` here
-  |
- ::: src/mdtest_snippet.py:3:9
+ --> src/mdtest_snippet.py:3:9
   |
 3 |     def immutable(self): ...
   |         --------- Property `DontAssignToMe.immutable` defined here with no setter
+4 |
+5 | # snapshot: invalid-assignment
+6 | DontAssignToMe().immutable = "the properties, they are a-changing"
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ Attempted assignment to `DontAssignToMe.immutable` here
   |
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
@@ -141,9 +141,7 @@ info: Function defined here
   |
 1 | def foo(
   |     ^^^
-  |
- ::: src/mdtest_snippet.py:3:5
-  |
+2 |     x: int,
 3 |     y: int,
   |     ------ Parameter declared here
   |

--- a/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
@@ -209,15 +209,13 @@ def invalid_generator() -> Generator[int, None, None]:
 
 ```snapshot
 error[invalid-yield]: Yield expression type does not match annotation
- --> src/mdtest_snippet.py:5:11
-  |
-5 |     yield ""
-  |           ^^ expression of type `Literal[""]`, expected `int`
-  |
- ::: src/mdtest_snippet.py:3:28
+ --> src/mdtest_snippet.py:3:28
   |
 3 | def invalid_generator() -> Generator[int, None, None]:
   |                            -------------------------- Function annotated with yield type `int` here
+4 |     # snapshot: invalid-yield
+5 |     yield ""
+  |           ^^ expression of type `Literal[""]`, expected `int`
   |
 ```
 
@@ -279,15 +277,13 @@ def outer() -> Generator[int, str, None]:
 
 ```snapshot
 error[invalid-yield]: Send type does not match annotation
- --> src/mdtest_snippet.py:8:16
-  |
-8 |     yield from inner()
-  |                ^^^^^^^ generator with send type `int`, expected `str`
-  |
- ::: src/mdtest_snippet.py:6:16
+ --> src/mdtest_snippet.py:6:16
   |
 6 | def outer() -> Generator[int, str, None]:
   |                ------------------------- Function annotated with send type `str` here
+7 |     # snapshot: invalid-yield
+8 |     yield from inner()
+  |                ^^^^^^^ generator with send type `int`, expected `str`
   |
 ```
 
@@ -305,14 +301,12 @@ reveal_type(non_gen)  # revealed: def non_gen() -> Generator[int, int, None]
 
 ```snapshot
 error[invalid-return-type]: Return type does not match returned value
- --> src/mdtest_snippet.py:5:12
-  |
-5 |     return 1
-  |            ^ expected `Generator[int, int, None]`, found `Literal[1]`
-  |
- ::: src/mdtest_snippet.py:3:18
+ --> src/mdtest_snippet.py:3:18
   |
 3 | def non_gen() -> Generator[int, int, None]:
   |                  ------------------------- Expected `Generator[int, int, None]` because of return type
+4 |     # snapshot: invalid-return-type
+5 |     return 1
+  |            ^ expected `Generator[int, int, None]`, found `Literal[1]`
   |
 ```

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -228,15 +228,14 @@ class Sub16(Super2):
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `method2`
-  --> src/mdtest_snippet.pyi:46:9
-   |
-46 |     def method2(self, x, /): ...  # snapshot: invalid-method-override
-   |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super2.method2`
-   |
-  ::: src/mdtest_snippet.pyi:43:9
+  --> src/mdtest_snippet.pyi:43:9
    |
 43 |     def method2(self, x): ...
    |         ---------------- `Super2.method2` defined here
+44 |
+45 | class Sub16(Super2):
+46 |     def method2(self, x, /): ...  # snapshot: invalid-method-override
+   |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super2.method2`
    |
 info: parameter `x` is positional-only but must also accept keyword arguments
 info: This violates the Liskov Substitution Principle
@@ -251,15 +250,16 @@ class Sub17(Super2):
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `method2`
-  --> src/mdtest_snippet.pyi:48:9
-   |
-48 |     def method2(self, *, x): ...  # snapshot: invalid-method-override
-   |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super2.method2`
-   |
-  ::: src/mdtest_snippet.pyi:43:9
+  --> src/mdtest_snippet.pyi:43:9
    |
 43 |     def method2(self, x): ...
    |         ---------------- `Super2.method2` defined here
+44 |
+45 | class Sub16(Super2):
+46 |     def method2(self, x, /): ...  # snapshot: invalid-method-override
+47 | class Sub17(Super2):
+48 |     def method2(self, *, x): ...  # snapshot: invalid-method-override
+   |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super2.method2`
    |
 info: parameter `x` is keyword-only but must also accept positional arguments
 info: This violates the Liskov Substitution Principle
@@ -284,15 +284,16 @@ class Sub19(Super3):
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `method3`
-  --> src/mdtest_snippet.pyi:55:9
-   |
-55 |     def method3(self, x, /): ...  # snapshot: invalid-method-override
-   |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super3.method3`
-   |
-  ::: src/mdtest_snippet.pyi:50:9
+  --> src/mdtest_snippet.pyi:50:9
    |
 50 |     def method3(self, *, x): ...
    |         ------------------- `Super3.method3` defined here
+51 |
+52 | class Sub18(Super3):
+53 |     def method3(self, x): ...  # fine: `x` can still be used as a keyword argument
+54 | class Sub19(Super3):
+55 |     def method3(self, x, /): ...  # snapshot: invalid-method-override
+   |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super3.method3`
    |
 info: This violates the Liskov Substitution Principle
 ```
@@ -316,15 +317,16 @@ class Sub21(Super4):
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `method`
-  --> src/mdtest_snippet.pyi:62:9
-   |
-62 |     def method(self, *args): ...  # snapshot: invalid-method-override
-   |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super4.method`
-   |
-  ::: src/mdtest_snippet.pyi:57:9
+  --> src/mdtest_snippet.pyi:57:9
    |
 57 |     def method(self, *args: int, **kwargs: str): ...
    |         --------------------------------------- `Super4.method` defined here
+58 |
+59 | class Sub20(Super4):
+60 |     def method(self, *args: object, **kwargs: object): ...  # fine
+61 | class Sub21(Super4):
+62 |     def method(self, *args): ...  # snapshot: invalid-method-override
+   |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super4.method`
    |
 info: This violates the Liskov Substitution Principle
 ```
@@ -421,15 +423,14 @@ class ThirdChild(GradualParent):
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `method`
- --> src/stub.pyi:7:9
-  |
-7 |     def method(self, x: str) -> None: ...  # snapshot: invalid-method-override
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Grandparent.method`
-  |
- ::: src/stub.pyi:4:9
+ --> src/stub.pyi:4:9
   |
 4 |     def method(self, x: int) -> None: ...
   |         ---------------------------- `Grandparent.method` defined here
+5 |
+6 | class Parent(Grandparent):
+7 |     def method(self, x: str) -> None: ...  # snapshot: invalid-method-override
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Grandparent.method`
   |
 info: parameter `x` has an incompatible type: `int` is not assignable to `str`
 info: This violates the Liskov Substitution Principle
@@ -466,30 +467,30 @@ info: This violates the Liskov Substitution Principle
 
 
 error[invalid-method-override]: Invalid override of method `method`
-  --> src/stub.pyi:28:9
-   |
-28 |     def method(self) -> str: ...  # snapshot: invalid-method-override
-   |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `GrandparentWithReturnType.method`
-   |
-  ::: src/stub.pyi:25:9
+  --> src/stub.pyi:25:9
    |
 25 |     def method(self) -> int: ...
    |         ------------------- `GrandparentWithReturnType.method` defined here
+26 |
+27 | class ParentWithReturnType(GrandparentWithReturnType):
+28 |     def method(self) -> str: ...  # snapshot: invalid-method-override
+   |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `GrandparentWithReturnType.method`
    |
 info: incompatible return types: `str` is not assignable to `int`
 info: This violates the Liskov Substitution Principle
 
 
 error[invalid-method-override]: Invalid override of method `method`
-  --> src/stub.pyi:33:9
-   |
-33 |     def method(self) -> int: ...  # snapshot: invalid-method-override
-   |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `ParentWithReturnType.method`
-   |
-  ::: src/stub.pyi:28:9
+  --> src/stub.pyi:28:9
    |
 28 |     def method(self) -> str: ...  # snapshot: invalid-method-override
    |         ------------------- `ParentWithReturnType.method` defined here
+29 |
+30 | class ChildWithReturnType(ParentWithReturnType):
+31 |     # Returns `int` again -- compatible with `GrandparentWithReturnType.method`,
+32 |     # but not with `ParentWithReturnType.method`. We report against the immediate parent.
+33 |     def method(self) -> int: ...  # snapshot: invalid-method-override
+   |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `ParentWithReturnType.method`
    |
 info: incompatible return types: `int` is not assignable to `str`
 info: This violates the Liskov Substitution Principle
@@ -534,15 +535,14 @@ class D(C):
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `get`
- --> src/other_stub.pyi:5:9
-  |
-5 |     def get(self, default, /): ...  # snapshot: invalid-method-override
-  |         ^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `A.get`
-  |
- ::: src/other_stub.pyi:2:9
+ --> src/other_stub.pyi:2:9
   |
 2 |     def get(self, default): ...
   |         ------------------ `A.get` defined here
+3 |
+4 | class B(A):
+5 |     def get(self, default, /): ...  # snapshot: invalid-method-override
+  |         ^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `A.get`
   |
 info: parameter `default` is positional-only but must also accept keyword arguments
 info: This violates the Liskov Substitution Principle
@@ -820,15 +820,14 @@ class D(C):
 
 ```snapshot
 error[invalid-method-override]: Invalid override of method `x`
- --> src/bar.pyi:7:5
-  |
-7 |     x = foo.x  # snapshot: invalid-method-override
-  |     ^^^^^^^^^ Definition is incompatible with `A.x`
-  |
- ::: src/bar.pyi:4:9
+ --> src/bar.pyi:4:9
   |
 4 |     def x(self, y: int): ...
   |         --------------- `A.x` defined here
+5 |
+6 | class B(A):
+7 |     x = foo.x  # snapshot: invalid-method-override
+  |     ^^^^^^^^^ Definition is incompatible with `A.x`
   |
  ::: src/foo.pyi:1:5
   |
@@ -840,15 +839,14 @@ info: This violates the Liskov Substitution Principle
 
 
 error[invalid-method-override]: Invalid override of method `x`
-  --> src/bar.pyi:13:9
-   |
-13 |     def x(self, y: int): ...  # snapshot: invalid-method-override
-   |         ^^^^^^^^^^^^^^^ Definition is incompatible with `C.x`
-   |
-  ::: src/bar.pyi:10:5
+  --> src/bar.pyi:10:5
    |
 10 |     x = foo.x
    |     --------- `C.x` defined here
+11 |
+12 | class D(C):
+13 |     def x(self, y: int): ...  # snapshot: invalid-method-override
+   |         ^^^^^^^^^^^^^^^ Definition is incompatible with `C.x`
    |
   ::: src/foo.pyi:1:5
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(ecae0f4510696c95).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(ecae0f4510696c95).snap
@@ -49,9 +49,7 @@ error[abstract-method-in-final-class]: Final class `Abstract` has unimplemented 
   |
 6 | class Abstract(ABC):
   |       ^^^^^^^^ Abstract methods `aaaaaaaaaa`, `bbbbbbbb`, `cccccccc`, `ddddddddd`, `eeeeeeeee`, `ffffffff`, `ggggggg`, `hhhhhhhh`, `iiiiiiiii` and `kkkkkkkkkk` are unimplemented
-  |
- ::: src/mdtest_snippet.py:8:9
-  |
+7 |     @abstractmethod
 8 |     def aaaaaaaaaa(self) -> int: ...
   |         ---------- `aaaaaaaaaa` declared as abstract
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(f807ff3716d8ab0d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(f807ff3716d8ab0d).snap
@@ -49,9 +49,7 @@ error[abstract-method-in-final-class]: Final class `Abstract` has unimplemented 
   |
 6 | class Abstract(ABC):
   |       ^^^^^^^^ 10 abstract methods are unimplemented, including `aaaaaaaaaa`, `bbbbbbbb` and `cccccccc`
-  |
- ::: src/mdtest_snippet.py:8:9
-  |
+7 |     @abstractmethod
 8 |     def aaaaaaaaaa(self) -> int: ...
   |         ---------- `aaaaaaaaaa` declared as abstract
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Protocol_with_implic…_(e373f31c7a7d88e7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Protocol_with_implic…_(e373f31c7a7d88e7).snap
@@ -169,15 +169,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 
 ```
 error[abstract-method-in-final-class]: Final class `Q` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:14:7
-   |
-14 | class Q(P): ...  # error: [abstract-method-in-final-class]
-   |       ^ `still_abstractmethod` is unimplemented
-   |
-  ::: src/mdtest_snippet.py:11:9
+  --> src/mdtest_snippet.py:11:9
    |
 11 |     def still_abstractmethod(self): ...
    |         -------------------- `still_abstractmethod` declared as abstract on superclass `P`
+12 |
+13 | @final
+14 | class Q(P): ...  # error: [abstract-method-in-final-class]
+   |       ^ `still_abstractmethod` is unimplemented
    |
 info: `P.still_abstractmethod` is implicitly abstract because `P` is a `Protocol` class and `still_abstractmethod` lacks an implementation
  --> src/mdtest_snippet.py:3:7
@@ -191,15 +190,14 @@ help: Change the body of `still_abstractmethod` to `return` or `return None` if 
 
 ```
 error[abstract-method-in-final-class]: Final class `S` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:21:7
-   |
-21 | class S(R): ...  # error: [abstract-method-in-final-class]
-   |       ^ `also_still_abstractmethod` is unimplemented
-   |
-  ::: src/mdtest_snippet.py:18:9
+  --> src/mdtest_snippet.py:18:9
    |
 18 |     def also_still_abstractmethod(self) -> None: ...
    |         ------------------------- `also_still_abstractmethod` declared as abstract on superclass `R`
+19 |
+20 | @final
+21 | class S(R): ...  # error: [abstract-method-in-final-class]
+   |       ^ `also_still_abstractmethod` is unimplemented
    |
 info: `R.also_still_abstractmethod` is implicitly abstract because `R` is a `Protocol` class and `also_still_abstractmethod` lacks an implementation
   --> src/mdtest_snippet.py:16:7
@@ -276,15 +274,14 @@ info: `Strange.weird_abstractmethod` is implicitly abstract because `Strange` is
 
 ```
 error[abstract-method-in-final-class]: Final class `HasOverloadSub` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:54:7
-   |
-54 | class HasOverloadSub(HasOverloads): ...  # error: [abstract-method-in-final-class]
-   |       ^^^^^^^^^^^^^^ `foo` is unimplemented
-   |
-  ::: src/mdtest_snippet.py:51:9
+  --> src/mdtest_snippet.py:51:9
    |
 51 |     def foo(self, x: int) -> str: ...
    |         --- `foo` declared as abstract on superclass `HasOverloads`
+52 |
+53 | @final
+54 | class HasOverloadSub(HasOverloads): ...  # error: [abstract-method-in-final-class]
+   |       ^^^^^^^^^^^^^^ `foo` is unimplemented
    |
 info: `HasOverloads.foo` is implicitly abstract because `HasOverloads` is a `Protocol` class and `foo` lacks an implementation
   --> src/mdtest_snippet.py:47:7

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Cannot_override_a_me…_(338615109711a91b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Cannot_override_a_me…_(338615109711a91b).snap
@@ -169,9 +169,7 @@ info: `Parent.my_property1` is decorated with `@final`, forbidding overrides
    |
  8 |     @final
    |     ------
-   |
-  ::: src/mdtest_snippet.pyi:10:9
-   |
+ 9 |     @property
 10 |     def my_property1(self) -> int: ...
    |         ------------ `Parent.my_property1` defined here
    |
@@ -229,9 +227,7 @@ info: `Parent.class_method1` is decorated with `@final`, forbidding overrides
    |
 17 |     @final
    |     ------
-   |
-  ::: src/mdtest_snippet.pyi:19:9
-   |
+18 |     @classmethod
 19 |     def class_method1(cls) -> int: ...
    |         ------------- `Parent.class_method1` defined here
    |
@@ -261,9 +257,7 @@ info: `Parent.static_method1` is decorated with `@final`, forbidding overrides
    |
 23 |     @final
    |     ------
-   |
-  ::: src/mdtest_snippet.pyi:25:9
-   |
+24 |     @staticmethod
 25 |     def static_method1() -> int: ...
    |         -------------- `Parent.static_method1` defined here
    |
@@ -399,9 +393,7 @@ info: `Parent.my_property1` is decorated with `@final`, forbidding overrides
    |
  8 |     @final
    |     ------
-   |
-  ::: src/mdtest_snippet.pyi:10:9
-   |
+ 9 |     @property
 10 |     def my_property1(self) -> int: ...
    |         ------------ `Parent.my_property1` defined here
    |
@@ -421,9 +413,7 @@ info: `Parent.class_method1` is decorated with `@final`, forbidding overrides
    |
 17 |     @final
    |     ------
-   |
-  ::: src/mdtest_snippet.pyi:19:9
-   |
+18 |     @classmethod
 19 |     def class_method1(cls) -> int: ...
    |         ------------- `Parent.class_method1` defined here
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overloaded_methods_d…_(861757f48340ed92).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overloaded_methods_d…_(861757f48340ed92).snap
@@ -173,9 +173,7 @@ info: `Good.baz` is decorated with `@final`, forbidding overrides
    |
  9 |     @final
    |     ------
-   |
-  ::: src/stub.pyi:11:9
-   |
+10 |     @overload
 11 |     def baz(self, x: str) -> str: ...
    |         --- `Good.baz` defined here
    |
@@ -198,37 +196,32 @@ note: This is an unsafe fix and may change runtime behavior
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
-  --> src/stub.pyi:31:9
-   |
-31 |     def bar(self, x: int) -> int: ...
-   |         ^^^
-   |
-  ::: src/stub.pyi:27:9
+  --> src/stub.pyi:27:9
    |
 27 |     def bar(self, x: str) -> str: ...
    |         --- First overload defined here
-   |
-  ::: src/stub.pyi:29:5
-   |
+28 |     @overload
 29 |     @final
    |     ------
+30 |     # error: [invalid-overload]
+31 |     def bar(self, x: int) -> int: ...
+   |         ^^^
    |
 
 ```
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
-  --> src/stub.pyi:37:9
-   |
-37 |     def baz(self, x: int) -> int: ...
-   |         ^^^
-   |
-  ::: src/stub.pyi:33:9
+  --> src/stub.pyi:33:9
    |
 33 |     def baz(self, x: str) -> str: ...
    |         --- First overload defined here
 34 |     @final
    |     ------
+35 |     @overload
+36 |     # error: [invalid-overload]
+37 |     def baz(self, x: int) -> int: ...
+   |         ^^^
    |
 
 ```
@@ -335,9 +328,8 @@ error[invalid-overload]: `@final` decorator should be applied only to the overlo
    |     ------
 25 |     def f(self, x: str) -> str: ...  # error: [invalid-overload]
    |         ^
-   |
-  ::: src/main.py:28:9
-   |
+26 |     @overload
+27 |     def f(self, x: int) -> int: ...
 28 |     def f(self, x: int | str) -> int | str:
    |         - Implementation defined here
    |
@@ -346,18 +338,15 @@ error[invalid-overload]: `@final` decorator should be applied only to the overlo
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/main.py:33:9
-   |
-33 |     def g(self, x: str) -> str: ...  # error: [invalid-overload]
-   |         ^
-   |
-  ::: src/main.py:31:5
+  --> src/main.py:31:5
    |
 31 |     @final
    |     ------
-   |
-  ::: src/main.py:36:9
-   |
+32 |     @overload
+33 |     def g(self, x: str) -> str: ...  # error: [invalid-overload]
+   |         ^
+34 |     @overload
+35 |     def g(self, x: int) -> int: ...
 36 |     def g(self, x: int | str) -> int | str:
    |         - Implementation defined here
    |
@@ -380,17 +369,15 @@ error[invalid-overload]: `@final` decorator should be applied only to the overlo
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/main.py:51:9
+  --> src/main.py:49:5
    |
+49 |     @final
+   |     ------
+50 |     @overload
 51 |     def i(self, x: int) -> int: ...  # error: [invalid-overload]
    |         ^
 52 |     def i(self, x: int | str) -> int | str:
    |         - Implementation defined here
-   |
-  ::: src/main.py:49:5
-   |
-49 |     @final
-   |     ------
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_type_paramet…_-_Invalid_Order_of_Leg…_(eaa359e8d6b3031d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_type_paramet…_-_Invalid_Order_of_Leg…_(eaa359e8d6b3031d).snap
@@ -65,9 +65,7 @@ error[invalid-generic-class]: Type parameters without defaults cannot follow typ
    |
  3 | T1 = TypeVar("T1", default=int)
    | ------------------------------- `T1` defined here
-   |
-  ::: src/mdtest_snippet.py:5:1
-   |
+ 4 |
  5 | T2 = TypeVar("T2")
    | ------------------ `T2` defined here
    |
@@ -88,9 +86,8 @@ error[invalid-generic-class]: Type parameters without defaults cannot follow typ
    |
  3 | T1 = TypeVar("T1", default=int)
    | ------------------------------- `T1` defined here
-   |
-  ::: src/mdtest_snippet.py:6:1
-   |
+ 4 |
+ 5 | T2 = TypeVar("T2")
  6 | T3 = TypeVar("T3")
    | ------------------ `T3` defined here
    |
@@ -111,9 +108,7 @@ error[invalid-generic-class]: Type parameters without defaults cannot follow typ
    |
  3 | T1 = TypeVar("T1", default=int)
    | ------------------------------- `T1` defined here
-   |
-  ::: src/mdtest_snippet.py:5:1
-   |
+ 4 |
  5 | T2 = TypeVar("T2")
    | ------------------ `T2` defined here
    |
@@ -134,9 +129,7 @@ error[invalid-generic-class]: Type parameters without defaults cannot follow typ
    |
  3 | T1 = TypeVar("T1", default=int)
    | ------------------------------- `T1` defined here
-   |
-  ::: src/mdtest_snippet.py:5:1
-   |
+ 4 |
  5 | T2 = TypeVar("T2")
    | ------------------ `T2` defined here
    |
@@ -176,9 +169,7 @@ error[invalid-generic-class]: Type parameters without defaults cannot follow typ
    |
  3 | T1 = TypeVar("T1", default=int)
    | ------------------------------- `T1` defined here
-   |
-  ::: src/mdtest_snippet.py:5:1
-   |
+ 4 |
  5 | T2 = TypeVar("T2")
    | ------------------ `T2` defined here
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_lists_wi…_(ea7ebc83ec359b54).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_lists_wi…_(ea7ebc83ec359b54).snap
@@ -134,15 +134,15 @@ error[duplicate-base]: Duplicate base class `Spam`
    | |_^
    |
 info: The definition of class `Ham` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:21:5
-   |
-21 |     Spam,
-   |     ^^^^ Class `Spam` later repeated here
-   |
-  ::: src/mdtest_snippet.py:17:5
+  --> src/mdtest_snippet.py:17:5
    |
 17 |     Spam,
    |     ---- Class `Spam` first included in bases list here
+18 |     Eggs,
+19 |     Bar,
+20 |     Baz,
+21 |     Spam,
+   |     ^^^^ Class `Spam` later repeated here
    |
 
 ```
@@ -163,15 +163,15 @@ error[duplicate-base]: Duplicate base class `Eggs`
    | |_^
    |
 info: The definition of class `Ham` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:22:5
-   |
-22 |     Eggs,
-   |     ^^^^ Class `Eggs` later repeated here
-   |
-  ::: src/mdtest_snippet.py:18:5
+  --> src/mdtest_snippet.py:18:5
    |
 18 |     Eggs,
    |     ---- Class `Eggs` first included in bases list here
+19 |     Bar,
+20 |     Baz,
+21 |     Spam,
+22 |     Eggs,
+   |     ^^^^ Class `Eggs` later repeated here
    |
 
 ```
@@ -213,25 +213,21 @@ error[duplicate-base]: Duplicate base class `Eggs`
    | |_^
    |
 info: The definition of class `VeryEggyOmelette` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:41:5
-   |
-41 |     Eggs,
-   |     ^^^^ Class `Eggs` later repeated here
-   |
-  ::: src/mdtest_snippet.py:44:5
-   |
-44 |     Eggs,
-   |     ^^^^ Class `Eggs` later repeated here
-   |
-  ::: src/mdtest_snippet.py:46:5
-   |
-46 |     Eggs,
-   |     ^^^^ Class `Eggs` later repeated here
-   |
-  ::: src/mdtest_snippet.py:38:5
+  --> src/mdtest_snippet.py:38:5
    |
 38 |     Eggs,
    |     ---- Class `Eggs` first included in bases list here
+39 |     Ham,
+40 |     Spam,
+41 |     Eggs,
+   |     ^^^^ Class `Eggs` later repeated here
+42 |     Mushrooms,
+43 |     Bar,
+44 |     Eggs,
+   |     ^^^^ Class `Eggs` later repeated here
+45 |     Baz,
+46 |     Eggs,
+   |     ^^^^ Class `Eggs` later repeated here
    |
 
 ```
@@ -249,15 +245,13 @@ error[duplicate-base]: Duplicate base class `A`
    | |_^
    |
 info: The definition of class `D` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:72:5
-   |
-72 |     A,  # type: ignore[ty:duplicate-base]
-   |     ^ Class `A` later repeated here
-   |
-  ::: src/mdtest_snippet.py:70:5
+  --> src/mdtest_snippet.py:70:5
    |
 70 |     A,
    |     - Class `A` first included in bases list here
+71 |     # error: [unused-type-ignore-comment]
+72 |     A,  # type: ignore[ty:duplicate-base]
+   |     ^ Class `A` later repeated here
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_`typing.NamedTuple`_-_Definition_(bbf79630502e65e9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/named_tuple.md_-_`NamedTuple`_-_`typing.NamedTuple`_-_Definition_(bbf79630502e65e9).snap
@@ -41,30 +41,28 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/named_tuple.md
 
 ```
 error[invalid-named-tuple]: NamedTuple field without default value cannot follow field(s) with default value(s)
- --> src/mdtest_snippet.py:6:5
-  |
-6 |     latitude: float
-  |     ^^^^^^^^^^^^^^^ Field `latitude` defined here without a default value
-  |
- ::: src/mdtest_snippet.py:4:5
+ --> src/mdtest_snippet.py:4:5
   |
 4 |     altitude: float = 0.0
   |     --------------------- Earlier field `altitude` defined here with a default value
+5 |     # error: [invalid-named-tuple] "NamedTuple field without default value cannot follow field(s) with default value(s): Field `latitud…
+6 |     latitude: float
+  |     ^^^^^^^^^^^^^^^ Field `latitude` defined here without a default value
   |
 
 ```
 
 ```
 error[invalid-named-tuple]: NamedTuple field without default value cannot follow field(s) with default value(s)
- --> src/mdtest_snippet.py:8:5
-  |
-8 |     longitude: float
-  |     ^^^^^^^^^^^^^^^^ Field `longitude` defined here without a default value
-  |
- ::: src/mdtest_snippet.py:4:5
+ --> src/mdtest_snippet.py:4:5
   |
 4 |     altitude: float = 0.0
   |     --------------------- Earlier field `altitude` defined here with a default value
+5 |     # error: [invalid-named-tuple] "NamedTuple field without default value cannot follow field(s) with default value(s): Field `latitud…
+6 |     latitude: float
+7 |     # error: [invalid-named-tuple] "NamedTuple field without default value cannot follow field(s) with default value(s): Field `longitu…
+8 |     longitude: float
+  |     ^^^^^^^^^^^^^^^^ Field `longitude` defined here without a default value
   |
 
 ```
@@ -83,15 +81,13 @@ error[invalid-named-tuple]: NamedTuple field without default value cannot follow
 
 ```
 error[invalid-named-tuple]: NamedTuple field without default value cannot follow field(s) with default value(s)
-  --> src/mdtest_snippet.py:16:5
-   |
-16 |     longitude: float  # error: [invalid-named-tuple]
-   |     ^^^^^^^^^^^^^^^^ Field `longitude` defined here without a default value
-   |
-  ::: src/mdtest_snippet.py:14:5
+  --> src/mdtest_snippet.py:14:5
    |
 14 |     altitude: float = 0.0
    |     --------------------- Earlier field `altitude` defined here with a default value
+15 |     latitude: float  # error: [invalid-named-tuple]
+16 |     longitude: float  # error: [invalid-named-tuple]
+   |     ^^^^^^^^^^^^^^^^ Field `longitude` defined here without a default value
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@classmethod`_(aaa04d4cfa3adaba).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@classmethod`_(aaa04d4cfa3adaba).snap
@@ -75,15 +75,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 
 ```
 error[invalid-overload]: Overloaded function `try_from1` does not use the `@classmethod` decorator consistently
-  --> src/mdtest_snippet.py:16:9
-   |
-16 |     def try_from1(cls, x: int | str) -> CheckClassMethod | None:
-   |         ^^^^^^^^^
-   |
-  ::: src/mdtest_snippet.py:13:9
+  --> src/mdtest_snippet.py:13:9
    |
 13 |     def try_from1(cls, x: str) -> None: ...
    |         --------- Missing here
+14 |     @classmethod
+15 |     # error: [invalid-overload] "Overloaded function `try_from1` does not use the `@classmethod` decorator consistently"
+16 |     def try_from1(cls, x: int | str) -> CheckClassMethod | None:
+   |         ^^^^^^^^^
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@final`_(f8e529ec23a61665).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@final`_(f8e529ec23a61665).snap
@@ -76,18 +76,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:15:9
-   |
-15 |     def method2(self, x: int) -> int: ...
-   |         ^^^^^^^
-   |
-  ::: src/mdtest_snippet.py:13:5
+  --> src/mdtest_snippet.py:13:5
    |
 13 |     @final
    |     ------
-   |
-  ::: src/mdtest_snippet.py:18:9
-   |
+14 |     # error: [invalid-overload]
+15 |     def method2(self, x: int) -> int: ...
+   |         ^^^^^^^
+16 |     @overload
+17 |     def method2(self, x: str) -> str: ...
 18 |     def method2(self, x: int | str) -> int | str:
    |         ------- Implementation defined here
    |
@@ -96,68 +93,64 @@ error[invalid-overload]: `@final` decorator should be applied only to the overlo
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:26:9
+  --> src/mdtest_snippet.py:24:5
    |
+24 |     @final
+   |     ------
+25 |     # error: [invalid-overload]
 26 |     def method3(self, x: str) -> str: ...
    |         ^^^^^^^
 27 |     def method3(self, x: int | str) -> int | str:
    |         ------- Implementation defined here
    |
-  ::: src/mdtest_snippet.py:24:5
-   |
-24 |     @final
-   |     ------
-   |
 
 ```
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
-  --> src/mdtest_snippet.pyi:14:9
-   |
-14 |     def method2(self, x: str) -> str: ...
-   |         ^^^^^^^
-   |
-  ::: src/mdtest_snippet.pyi:10:9
+  --> src/mdtest_snippet.pyi:10:9
    |
 10 |     def method2(self, x: int) -> int: ...
    |         ------- First overload defined here
 11 |     @final
    |     ------
+12 |     @overload
+13 |     # error: [invalid-overload]
+14 |     def method2(self, x: str) -> str: ...
+   |         ^^^^^^^
    |
 
 ```
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
-  --> src/mdtest_snippet.pyi:19:9
-   |
-19 |     def method3(self, x: str) -> int: ...  # error: [invalid-overload]
-   |         ^^^^^^^
-   |
-  ::: src/mdtest_snippet.pyi:16:9
+  --> src/mdtest_snippet.pyi:16:9
    |
 16 |     def method3(self, x: int) -> int: ...
    |         ------- First overload defined here
 17 |     @final
    |     ------
+18 |     @overload
+19 |     def method3(self, x: str) -> int: ...  # error: [invalid-overload]
+   |         ^^^^^^^
    |
 
 ```
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
-  --> src/mdtest_snippet.pyi:21:5
+  --> src/mdtest_snippet.pyi:16:9
    |
+16 |     def method3(self, x: int) -> int: ...
+   |         ------- First overload defined here
+17 |     @final
+18 |     @overload
+19 |     def method3(self, x: str) -> int: ...  # error: [invalid-overload]
+20 |     @overload
 21 |     @final
    |     ------
 22 |     def method3(self, x: bytes) -> bytes: ...  # error: [invalid-overload]
    |         ^^^^^^^
-   |
-  ::: src/mdtest_snippet.pyi:16:9
-   |
-16 |     def method3(self, x: int) -> int: ...
-   |         ------- First overload defined here
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@override`_(2df210735ca532f9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@override`_(2df210735ca532f9).snap
@@ -84,35 +84,30 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 
 ```
 error[invalid-overload]: `@override` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:26:9
+  --> src/mdtest_snippet.py:24:5
    |
+24 |     @override
+   |     ---------
+25 |     # error: [invalid-overload]
 26 |     def method(self, x: str) -> str: ...
    |         ^^^^^^
 27 |     def method(self, x: int | str) -> int | str:
    |         ------ Implementation defined here
-   |
-  ::: src/mdtest_snippet.py:24:5
-   |
-24 |     @override
-   |     ---------
    |
 
 ```
 
 ```
 error[invalid-overload]: `@override` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:34:9
-   |
-34 |     def method(self, x: int) -> int: ...
-   |         ^^^^^^
-   |
-  ::: src/mdtest_snippet.py:32:5
+  --> src/mdtest_snippet.py:32:5
    |
 32 |     @override
    |     ---------
-   |
-  ::: src/mdtest_snippet.py:37:9
-   |
+33 |     # error: [invalid-overload]
+34 |     def method(self, x: int) -> int: ...
+   |         ^^^^^^
+35 |     @overload
+36 |     def method(self, x: str) -> str: ...
 37 |     def method(self, x: int | str) -> int | str:
    |         ------ Implementation defined here
    |
@@ -121,20 +116,16 @@ error[invalid-overload]: `@override` decorator should be applied only to the ove
 
 ```
 error[invalid-overload]: `@override` decorator should be applied only to the first overload
-  --> src/mdtest_snippet.pyi:22:9
-   |
-22 |     def method(self, x: str) -> str: ...
-   |         ^^^^^^
-   |
-  ::: src/mdtest_snippet.pyi:18:9
+  --> src/mdtest_snippet.pyi:18:9
    |
 18 |     def method(self, x: int) -> int: ...
    |         ------ First overload defined here
-   |
-  ::: src/mdtest_snippet.pyi:20:5
-   |
+19 |     @overload
 20 |     @override
    |     ---------
+21 |     # error: [invalid-overload]
+22 |     def method(self, x: str) -> str: ...
+   |         ^^^^^^
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/override.md_-_`typing.override`_-_Basics_(b7c220f8171f11f0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/override.md_-_`typing.override`_-_Basics_(b7c220f8171f11f0).snap
@@ -206,15 +206,13 @@ info: No `___reprrr__` definitions were found on any superclasses of `Invalid`
 
 ```
 error[invalid-explicit-override]: Method `foo` is decorated with `@override` but does not override anything
-   --> src/mdtest_snippet.pyi:101:9
-    |
-101 |     def foo(self): ...  # error: [invalid-explicit-override]
-    |         ^^^
-    |
-   ::: src/mdtest_snippet.pyi:99:5
+   --> src/mdtest_snippet.pyi:99:5
     |
  99 |     @override
     |     ---------
+100 |     @classmethod
+101 |     def foo(self): ...  # error: [invalid-explicit-override]
+    |         ^^^
     |
 info: No `foo` definitions were found on any superclasses of `Invalid`
 
@@ -248,15 +246,13 @@ info: No `baz` definitions were found on any superclasses of `Invalid`
 
 ```
 error[invalid-explicit-override]: Method `eggs` is decorated with `@override` but does not override anything
-   --> src/mdtest_snippet.pyi:110:9
-    |
-110 |     def eggs(): ...  # error: [invalid-explicit-override]
-    |         ^^^^
-    |
-   ::: src/mdtest_snippet.pyi:108:5
+   --> src/mdtest_snippet.pyi:108:5
     |
 108 |     @override
     |     ---------
+109 |     @staticmethod
+110 |     def eggs(): ...  # error: [invalid-explicit-override]
+    |         ^^^^
     |
 info: No `eggs` definitions were found on any superclasses of `Invalid`
 
@@ -277,15 +273,13 @@ info: No `bad_property1` definitions were found on any superclasses of `Invalid`
 
 ```
 error[invalid-explicit-override]: Method `bad_property2` is decorated with `@override` but does not override anything
-   --> src/mdtest_snippet.pyi:116:9
-    |
-116 |     def bad_property2(self) -> int: ...  # error: [invalid-explicit-override]
-    |         ^^^^^^^^^^^^^
-    |
-   ::: src/mdtest_snippet.pyi:114:5
+   --> src/mdtest_snippet.pyi:114:5
     |
 114 |     @override
     |     ---------
+115 |     @property
+116 |     def bad_property2(self) -> int: ...  # error: [invalid-explicit-override]
+    |         ^^^^^^^^^^^^^
     |
 info: No `bad_property2` definitions were found on any superclasses of `Invalid`
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/paramspec.md_-_PEP_695_`ParamSpec`_-_`ParamSpec`_cannot_s…_(8243f67799c93e3c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/paramspec.md_-_PEP_695_`ParamSpec`_-_`ParamSpec`_cannot_s…_(8243f67799c93e3c).snap
@@ -48,8 +48,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspe
 
 ```
 error[invalid-type-arguments]: ParamSpec `P` cannot be used to specialize type variable `T`
-  --> src/mdtest_snippet.py:11:20
+  --> src/mdtest_snippet.py:9:9
    |
+ 9 | def f[**P, T]():
+   |         - ParamSpec `P` defined here
+10 |     # error: [invalid-type-arguments] "ParamSpec `P` cannot be used to specialize type variable `T`"
 11 |     a: OnlyTypeVar[P]
    |                    ^
    |
@@ -57,11 +60,6 @@ error[invalid-type-arguments]: ParamSpec `P` cannot be used to specialize type v
    |
  3 | class OnlyTypeVar[T]:
    |                   - Type variable `T` defined here
-   |
-  ::: src/mdtest_snippet.py:9:9
-   |
- 9 | def f[**P, T]():
-   |         - ParamSpec `P` defined here
    |
 
 ```
@@ -77,9 +75,8 @@ error[invalid-type-arguments]: ParamSpec `P` cannot be used to specialize type v
    |
  6 | class TypeVarAndParamSpec[T, **P]:
    |                           - Type variable `T` defined here
-   |
-  ::: src/mdtest_snippet.py:9:9
-   |
+ 7 |     attr: Callable[P, T]
+ 8 |
  9 | def f[**P, T]():
    |         - ParamSpec `P` defined here
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions_-_Synchronous_(6a32ec69d15117b8).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Generator_functions_-_Synchronous_(6a32ec69d15117b8).snap
@@ -67,30 +67,26 @@ info: See https://docs.python.org/3/glossary.html#term-generator for more detail
 
 ```
 error[invalid-return-type]: Return type does not match returned value
-  --> src/mdtest_snippet.py:24:12
-   |
-24 |     return ""  # error: [invalid-return-type]
-   |            ^^ expected `None`, found `Literal[""]`
-   |
-  ::: src/mdtest_snippet.py:22:30
+  --> src/mdtest_snippet.py:22:30
    |
 22 | def invalid_return_type() -> typing.Generator[None, None, None]:
    |                              ---------------------------------- Expected `None` because of return type
+23 |     yield
+24 |     return ""  # error: [invalid-return-type]
+   |            ^^ expected `None`, found `Literal[""]`
    |
 
 ```
 
 ```
 error[invalid-return-type]: Return type does not match returned value
-  --> src/mdtest_snippet.py:27:12
-   |
-27 |     return ""  # error: [invalid-return-type]
-   |            ^^ expected `int`, found `Literal[""]`
-   |
-  ::: src/mdtest_snippet.py:25:23
+  --> src/mdtest_snippet.py:25:23
    |
 25 | def wrong_return() -> typing.Generator[int, int, int]:
    |                       ------------------------------- Expected `int` because of return type
+26 |     yield 1
+27 |     return ""  # error: [invalid-return-type]
+   |            ^^ expected `int`, found `Literal[""]`
    |
 
 ```
@@ -108,15 +104,14 @@ info: Consider changing the return annotation to `-> None` or adding a `return` 
 
 ```
 error[invalid-return-type]: Return type does not match returned value
-  --> src/mdtest_snippet.py:36:12
-   |
-36 |     return "foo"
-   |            ^^^^^ expected `None`, found `Literal["foo"]`
-   |
-  ::: src/mdtest_snippet.py:33:35
+  --> src/mdtest_snippet.py:33:35
    |
 33 | def iterator_must_not_return() -> typing.Iterator[int]:
    |                                   -------------------- Expected `None` because of return type
+34 |     yield 2
+35 |     # error: [invalid-return-type]
+36 |     return "foo"
+   |            ^^^^^ expected `None`, found `Literal["foo"]`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_…_(94c036c5d3803ab2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_conditional_…_(94c036c5d3803ab2).snap
@@ -33,30 +33,30 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 
 ```
 error[invalid-return-type]: Return type does not match returned value
- --> src/mdtest_snippet.py:6:16
-  |
-6 |         return 1
-  |                ^ expected `str`, found `Literal[1]`
-  |
- ::: src/mdtest_snippet.py:1:22
+ --> src/mdtest_snippet.py:1:22
   |
 1 | def f(cond: bool) -> str:
   |                      --- Expected `str` because of return type
+2 |     if cond:
+3 |         return "a"
+4 |     else:
+5 |         # error: [invalid-return-type]
+6 |         return 1
+  |                ^ expected `str`, found `Literal[1]`
   |
 
 ```
 
 ```
 error[invalid-return-type]: Return type does not match returned value
-  --> src/mdtest_snippet.py:11:16
-   |
-11 |         return 1
-   |                ^ expected `str`, found `Literal[1]`
-   |
-  ::: src/mdtest_snippet.py:8:22
+  --> src/mdtest_snippet.py:8:22
    |
  8 | def f(cond: bool) -> str:
    |                      --- Expected `str` because of return type
+ 9 |     if cond:
+10 |         # error: [invalid-return-type]
+11 |         return 1
+   |                ^ expected `str`, found `Literal[1]`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_(a91e0c67519cd77f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_(a91e0c67519cd77f).snap
@@ -60,30 +60,26 @@ info: Consider changing the return annotation to `-> None` or adding a `return` 
 
 ```
 error[invalid-return-type]: Return type does not match returned value
- --> src/mdtest_snippet.py:7:12
-  |
-7 |     return 1
-  |            ^ expected `str`, found `Literal[1]`
-  |
- ::: src/mdtest_snippet.py:5:12
+ --> src/mdtest_snippet.py:5:12
   |
 5 | def f() -> str:
   |            --- Expected `str` because of return type
+6 |     # error: [invalid-return-type]
+7 |     return 1
+  |            ^ expected `str`, found `Literal[1]`
   |
 
 ```
 
 ```
 error[invalid-return-type]: Return type does not match returned value
-  --> src/mdtest_snippet.py:11:5
-   |
-11 |     return
-   |     ^^^^^^ expected `int`, found `None`
-   |
-  ::: src/mdtest_snippet.py:9:12
+  --> src/mdtest_snippet.py:9:12
    |
  9 | def f() -> int:
    |            --- Expected `int` because of return type
+10 |     # error: [invalid-return-type]
+11 |     return
+   |     ^^^^^^ expected `int`, found `None`
    |
 
 ```
@@ -106,30 +102,26 @@ info:  - or as `@abstractmethod`-decorated methods on abstract classes
 
 ```
 error[invalid-return-type]: Return type does not match returned value
-  --> src/mdtest_snippet.py:24:12
-   |
-24 |     return A[int]()  # error: [invalid-return-type]
-   |            ^^^^^^^^ expected `mdtest_snippet.A[int]`, found `mdtest_snippet.<locals of function 'f'>.A[int]`
-   |
-  ::: src/mdtest_snippet.py:22:12
+  --> src/mdtest_snippet.py:22:12
    |
 22 | def f() -> A[int]:
    |            ------ Expected `mdtest_snippet.A[int]` because of return type
+23 |     class A[T]: ...
+24 |     return A[int]()  # error: [invalid-return-type]
+   |            ^^^^^^^^ expected `mdtest_snippet.A[int]`, found `mdtest_snippet.<locals of function 'f'>.A[int]`
    |
 
 ```
 
 ```
 error[invalid-return-type]: Return type does not match returned value
-  --> src/mdtest_snippet.py:30:12
-   |
-30 |     return B()  # error: [invalid-return-type]
-   |            ^^^ expected `mdtest_snippet.B`, found `mdtest_snippet.<locals of function 'g'>.B`
-   |
-  ::: src/mdtest_snippet.py:28:12
+  --> src/mdtest_snippet.py:28:12
    |
 28 | def g() -> B:
    |            - Expected `mdtest_snippet.B` because of return type
+29 |     class B: ...
+30 |     return B()  # error: [invalid-return-type]
+   |            ^^^ expected `mdtest_snippet.B`, found `mdtest_snippet.<locals of function 'g'>.B`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_…_(c3a523878447af6b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/return_type.md_-_Function_return_type_-_Invalid_return_type_…_(c3a523878447af6b).snap
@@ -32,15 +32,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/function/return_type.md
 
 ```
 error[invalid-return-type]: Return type does not match returned value
- --> src/mdtest_snippet.pyi:3:12
-  |
-3 |     return ...
-  |            ^^^ expected `int`, found `EllipsisType`
-  |
- ::: src/mdtest_snippet.pyi:1:12
+ --> src/mdtest_snippet.pyi:1:12
   |
 1 | def f() -> int:
   |            --- Expected `int` because of return type
+2 |     # error: [invalid-return-type]
+3 |     return ...
+  |            ^^^ expected `int`, found `EllipsisType`
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Nested_formal_typeva…_-_Generic_class_within…_(3259718bf20b45a2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Nested_formal_typeva…_-_Generic_class_within…_(3259718bf20b45a2).snap
@@ -27,30 +27,30 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[shadowed-type-variable]: Generic class `Bad1` uses type variable `T` already bound by an enclosing scope
- --> src/mdtest_snippet.py:6:11
-  |
-6 |     class Bad1[T]: ...
-  |           ^^^^ `T` used in class definition here
-  |
- ::: src/mdtest_snippet.py:3:5
+ --> src/mdtest_snippet.py:3:5
   |
 3 | def f[T](x: T, y: T) -> None:
   |     ------------------------ Type variable `T` is bound in this enclosing scope
+4 |     class Ok[S]: ...
+5 |     # error: [shadowed-type-variable]
+6 |     class Bad1[T]: ...
+  |           ^^^^ `T` used in class definition here
   |
 
 ```
 
 ```
 error[shadowed-type-variable]: Generic class `Bad2` uses type variable `T` already bound by an enclosing scope
- --> src/mdtest_snippet.py:8:11
-  |
-8 |     class Bad2(Iterable[T]): ...
-  |           ^^^^^^^^^^^^^^^^^ `T` used in class definition here
-  |
- ::: src/mdtest_snippet.py:3:5
+ --> src/mdtest_snippet.py:3:5
   |
 3 | def f[T](x: T, y: T) -> None:
   |     ------------------------ Type variable `T` is bound in this enclosing scope
+4 |     class Ok[S]: ...
+5 |     # error: [shadowed-type-variable]
+6 |     class Bad1[T]: ...
+7 |     # error: [shadowed-type-variable]
+8 |     class Bad2(Iterable[T]): ...
+  |           ^^^^^^^^^^^^^^^^^ `T` used in class definition here
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Nested_formal_typeva…_-_Generic_class_within…_(711fb86287c4d87b).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Nested_formal_typeva…_-_Generic_class_within…_(711fb86287c4d87b).snap
@@ -27,30 +27,30 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[shadowed-type-variable]: Generic class `Bad1` uses type variable `T` already bound by an enclosing scope
- --> src/mdtest_snippet.py:6:11
-  |
-6 |     class Bad1[T]: ...
-  |           ^^^^ `T` used in class definition here
-  |
- ::: src/mdtest_snippet.py:3:7
+ --> src/mdtest_snippet.py:3:7
   |
 3 | class C[T]:
   |       - Type variable `T` is bound in this enclosing scope
+4 |     class Ok1[S]: ...
+5 |     # error: [shadowed-type-variable]
+6 |     class Bad1[T]: ...
+  |           ^^^^ `T` used in class definition here
   |
 
 ```
 
 ```
 error[shadowed-type-variable]: Generic class `Bad2` uses type variable `T` already bound by an enclosing scope
- --> src/mdtest_snippet.py:8:11
-  |
-8 |     class Bad2(Iterable[T]): ...
-  |           ^^^^^^^^^^^^^^^^^ `T` used in class definition here
-  |
- ::: src/mdtest_snippet.py:3:7
+ --> src/mdtest_snippet.py:3:7
   |
 3 | class C[T]:
   |       - Type variable `T` is bound in this enclosing scope
+4 |     class Ok1[S]: ...
+5 |     # error: [shadowed-type-variable]
+6 |     class Bad1[T]: ...
+7 |     # error: [shadowed-type-variable]
+8 |     class Bad2(Iterable[T]): ...
+  |           ^^^^^^^^^^^^^^^^^ `T` used in class definition here
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Function_nested_in_c…_(1a50b4ccb10b95dd).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Function_nested_in_c…_(1a50b4ccb10b95dd).snap
@@ -23,15 +23,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[invalid-type-variable-default]: Invalid default for type parameter `U`
- --> src/mdtest_snippet.py:3:15
-  |
-3 |     def f[U = T](self): ...
-  |               ^ `T` is a type parameter bound in an outer scope
-  |
- ::: src/mdtest_snippet.py:1:9
+ --> src/mdtest_snippet.py:1:9
   |
 1 | class C[T]:
   |         - `T` defined here
+2 |     # error: [invalid-type-variable-default]
+3 |     def f[U = T](self): ...
+  |               ^ `T` is a type parameter bound in an outer scope
   |
 info: See https://typing.python.org/en/latest/spec/generics.html#scoping-rules
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Legacy_TypeVar_in_me…_(2ed4c18a38ed9090).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Legacy_TypeVar_in_me…_(2ed4c18a38ed9090).snap
@@ -28,15 +28,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[invalid-type-variable-default]: Invalid use of type variable `T2`
- --> src/mdtest_snippet.py:8:25
-  |
-8 |     def method(self, x: T2) -> T2:
-  |                         ^^ Default of `T2` references out-of-scope type variable `T1`
-  |
- ::: src/mdtest_snippet.py:4:1
+ --> src/mdtest_snippet.py:4:1
   |
 4 | T2 = TypeVar("T2", default=T1)
   | ------------------------------ `T2` defined here
+5 |
+6 | class Foo(Generic[T1]):
+7 |     # error: [invalid-type-variable-default] "Invalid use of type variable `T2`: default of `T2` refers to out-of-scope type variable `…
+8 |     def method(self, x: T2) -> T2:
+  |                         ^^ Default of `T2` references out-of-scope type variable `T1`
   |
 info: See https://typing.python.org/en/latest/spec/generics.html#scoping-rules
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Legacy_TypeVar_in_ne…_(a1aca17ea750ffdd).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Legacy_TypeVar_in_ne…_(a1aca17ea750ffdd).snap
@@ -29,15 +29,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[invalid-type-variable-default]: Invalid use of type variable `U`
- --> src/mdtest_snippet.py:8:18
-  |
-8 |     def inner(y: U) -> U:
-  |                  ^ Default of `U` references out-of-scope type variable `T`
-  |
- ::: src/mdtest_snippet.py:4:1
+ --> src/mdtest_snippet.py:4:1
   |
 4 | U = TypeVar("U", default=T)
   | --------------------------- `U` defined here
+5 |
+6 | def outer(x: T) -> T:
+7 |     # error: [invalid-type-variable-default]
+8 |     def inner(y: U) -> U:
+  |                  ^ Default of `U` references out-of-scope type variable `T`
   |
 info: See https://typing.python.org/en/latest/spec/generics.html#scoping-rules
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Legacy_TypeVar_order…_(d075a45828c9dbc5).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Legacy_TypeVar_order…_(d075a45828c9dbc5).snap
@@ -73,9 +73,7 @@ error[invalid-type-variable-default]: Type parameters without defaults cannot fo
    |
  3 | T1 = TypeVar("T1", default=int)
    | ------------------------------- `T1` defined here
-   |
-  ::: src/mdtest_snippet.py:5:1
-   |
+ 4 | T2 = TypeVar("T2")
  5 | T3 = TypeVar("T3")
    | ------------------ `T3` defined here
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Legacy_TypeVar_with_…_(ce8defbeaf54e06c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Legacy_TypeVar_with_…_(ce8defbeaf54e06c).snap
@@ -31,15 +31,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[invalid-type-variable-default]: Invalid use of type variable `U`
- --> src/mdtest_snippet.py:7:12
-  |
-7 | def bad(y: U, z: T) -> tuple[U, T]:
-  |            ^ Default of `U` references later type parameter `T`
-  |
- ::: src/mdtest_snippet.py:4:1
+ --> src/mdtest_snippet.py:4:1
   |
 4 | U = TypeVar("U", default=T)
   | --------------------------- `U` defined here
+5 |
+6 | # error: [invalid-type-variable-default]
+7 | def bad(y: U, z: T) -> tuple[U, T]:
+  |            ^ Default of `U` references later type parameter `T`
   |
 info: See https://typing.python.org/en/latest/spec/generics.html#scoping-rules
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Nested_functions_(3f2ee9fa81da0177).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Nested_functions_(3f2ee9fa81da0177).snap
@@ -23,15 +23,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[invalid-type-variable-default]: Invalid default for type parameter `U`
- --> src/mdtest_snippet.py:3:19
-  |
-3 |     def inner[U = T](): ...
-  |                   ^ `T` is a type parameter bound in an outer scope
-  |
- ::: src/mdtest_snippet.py:1:11
+ --> src/mdtest_snippet.py:1:11
   |
 1 | def outer[T]():
   |           - `T` defined here
+2 |     # error: [invalid-type-variable-default] "Type parameter `U` cannot use outer-scope type parameter `T` as its default"
+3 |     def inner[U = T](): ...
+  |                   ^ `T` is a type parameter bound in an outer scope
   |
 info: See https://typing.python.org/en/latest/spec/generics.html#scoping-rules
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Type_alias_nested_in…_(de027dcc5360f252).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/scoping.md_-_Scoping_rules_for_ty…_-_Type_parameter_defau…_-_Type_alias_nested_in…_(de027dcc5360f252).snap
@@ -24,15 +24,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/scoping.md
 
 ```
 error[invalid-type-variable-default]: Invalid default for type parameter `U`
- --> src/mdtest_snippet.py:3:20
-  |
-3 |     type Alias[U = T] = list[U]
-  |                    ^ `T` is a type parameter bound in an outer scope
-  |
- ::: src/mdtest_snippet.py:1:9
+ --> src/mdtest_snippet.py:1:9
   |
 1 | class C[T]:
   |         - `T` defined here
+2 |     # error: [invalid-type-variable-default]
+3 |     type Alias[U = T] = list[U]
+  |                    ^ `T` is a type parameter bound in an outer scope
   |
 info: See https://typing.python.org/en/latest/spec/generics.html#scoping-rules
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_An_unbounded_default…_(a2759fd9d2731a7d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_An_unbounded_default…_(a2759fd9d2731a7d).snap
@@ -25,17 +25,16 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/variable
 
 ```
 error[invalid-type-variable-default]: TypeVar default is not assignable to the TypeVar's upper bound
- --> src/mdtest_snippet.py:6:26
+ --> src/mdtest_snippet.py:3:1
   |
+3 | T1 = TypeVar("T1")
+  | ------------------ `T1` defined here
+4 |
+5 | # error: [invalid-type-variable-default] "Default `T1` of TypeVar `S` is not assignable to upper bound `int` of `S` because its upper b…
 6 | S = TypeVar("S", default=T1, bound=int)
   |                          ^^        --- Upper bound of `S`
   |                          |
   |                          Upper bound `object` of default `T1` is not assignable to upper bound of `S`
-  |
- ::: src/mdtest_snippet.py:3:1
-  |
-3 | T1 = TypeVar("T1")
-  | ------------------ `T1` defined here
   |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Shadowing_checks_use…_(7e6bb178099059fe).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Shadowing_checks_use…_(7e6bb178099059fe).snap
@@ -43,30 +43,30 @@ warning[mismatched-type-name]: The name passed to `TypeVar` must match the varia
 
 ```
 error[shadowed-type-variable]: Generic class `Bad` uses type variable `Q` already bound by an enclosing scope
-  --> src/mdtest_snippet.py:14:11
-   |
-14 |     class Bad(Generic[Q]): ...
-   |           ^^^^^^^^^^^^^^^ `Q` used in class definition here
-   |
-  ::: src/mdtest_snippet.py:10:7
+  --> src/mdtest_snippet.py:10:7
    |
 10 | class Outer(Generic[Q]):
    |       ----------------- Type variable `Q` is bound in this enclosing scope
+11 |     class Ok(Generic[S]): ...
+12 |     # error: [shadowed-type-variable]
+13 |     # error: [shadowed-type-variable]
+14 |     class Bad(Generic[Q]): ...
+   |           ^^^^^^^^^^^^^^^ `Q` used in class definition here
    |
 
 ```
 
 ```
 error[shadowed-type-variable]: Generic class `Bad` uses type variable `Q` already bound by an enclosing scope
-  --> src/mdtest_snippet.py:14:11
-   |
-14 |     class Bad(Generic[Q]): ...
-   |           ^^^^^^^^^^^^^^^ `Q` used in class definition here
-   |
-  ::: src/mdtest_snippet.py:10:7
+  --> src/mdtest_snippet.py:10:7
    |
 10 | class Outer(Generic[Q]):
    |       ----------------- Type variable `Q` is bound in this enclosing scope
+11 |     class Ok(Generic[S]): ...
+12 |     # error: [shadowed-type-variable]
+13 |     # error: [shadowed-type-variable]
+14 |     class Bad(Generic[Q]): ...
+   |           ^^^^^^^^^^^^^^^ `Q` used in class definition here
    |
 
 ```


### PR DESCRIPTION
## Summary

Following https://github.com/astral-sh/ruff/pull/24689, two annotations are rendered with separate code frames even if they are very close to each other. For example, on this snippet:

```py
from dataclasses import dataclass

@dataclass(frozen=True)
# check out this dataclass
class Parent: ...

@dataclass
# and its subclass
class Child(Parent): ...
```

we currently render this diagnostic:

<img width="1848" height="900" alt="image" src="https://github.com/user-attachments/assets/37198ac5-23a0-4e1d-83fe-6ad0fdb2b5cf" />

On this PR branch, we merge the two context frames if two annotations are very close together, so that the diagnostic changes to this:

<img width="1828" height="728" alt="image" src="https://github.com/user-attachments/assets/6564f332-52cc-4db7-ba66-9c5f912e5193" />

which feels much more sensible

## Test Plan

Snapshots updated
