### PR TITLE
[ty] Add contextual secondary annotations in more places

### DIFF
--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -8,7 +8,7 @@
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22abstract-method-in-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2441" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2443" target="_blank">View source</a>
 </small>
 
 
@@ -49,7 +49,7 @@ class Derived(Base):  # Error: `Derived` does not implement `method`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-protocol-member%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L658" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L660" target="_blank">View source</a>
 </small>
 
 
@@ -90,7 +90,7 @@ class SubProto(BaseProto, Protocol):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22assert-type-unspellable-subtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2577" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2579" target="_blank">View source</a>
 </small>
 
 
@@ -126,7 +126,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Preview (since <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a>) ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-abstract-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2476" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2478" target="_blank">View source</a>
 </small>
 
 
@@ -175,7 +175,7 @@ Foo.method()  # Error: cannot call abstract classmethod
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-non-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L174" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L176" target="_blank">View source</a>
 </small>
 
 
@@ -199,7 +199,7 @@ Calling a non-callable object will raise a `TypeError` at runtime.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.7">0.0.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-top-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L192" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L194" target="_blank">View source</a>
 </small>
 
 
@@ -230,7 +230,7 @@ def f(x: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-argument-forms%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L243" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L245" target="_blank">View source</a>
 </small>
 
 
@@ -262,7 +262,7 @@ f(int)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-declarations%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L269" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L271" target="_blank">View source</a>
 </small>
 
 
@@ -293,7 +293,7 @@ a = 1
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L294" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L296" target="_blank">View source</a>
 </small>
 
 
@@ -325,7 +325,7 @@ class C(A, B): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-class-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L320" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L322" target="_blank">View source</a>
 </small>
 
 
@@ -357,7 +357,7 @@ class B(A): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-type-alias-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L346" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L348" target="_blank">View source</a>
 </small>
 
 
@@ -385,7 +385,7 @@ type B = A
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22dataclass-field-order%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L464" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L466" target="_blank">View source</a>
 </small>
 
 
@@ -417,7 +417,7 @@ class Example:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.16">0.0.1-alpha.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22deprecated%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L390" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L392" target="_blank">View source</a>
 </small>
 
 
@@ -444,7 +444,7 @@ old_func()  # emits [deprecated] diagnostic
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22division-by-zero%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L368" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L370" target="_blank">View source</a>
 </small>
 
 
@@ -473,7 +473,7 @@ false positives it can produce.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L411" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L413" target="_blank">View source</a>
 </small>
 
 
@@ -500,7 +500,7 @@ class B(A, A): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-kw-only%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L432" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L434" target="_blank">View source</a>
 </small>
 
 
@@ -538,7 +538,7 @@ class A:  # Crash at runtime
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22empty-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1006" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1008" target="_blank">View source</a>
 </small>
 
 
@@ -609,7 +609,7 @@ def foo() -> "intt\b": ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-on-non-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2388" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2390" target="_blank">View source</a>
 </small>
 
 
@@ -641,7 +641,7 @@ def my_function() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-without-value%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2414" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2416" target="_blank">View source</a>
 </small>
 
 
@@ -736,7 +736,7 @@ def test(): -> "Literal[5]":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22inconsistent-mro%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L775" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L777" target="_blank">View source</a>
 </small>
 
 
@@ -766,7 +766,7 @@ class C(A, B): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22index-out-of-bounds%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L799" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L801" target="_blank">View source</a>
 </small>
 
 
@@ -792,7 +792,7 @@ t[3]  # IndexError: tuple index out of range
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.33">0.0.1-alpha.33</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ineffective-final%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2360" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2362" target="_blank">View source</a>
 </small>
 
 
@@ -826,7 +826,7 @@ class MyClass: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22instance-layout-conflict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L547" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L549" target="_blank">View source</a>
 </small>
 
 
@@ -915,7 +915,7 @@ an atypical memory layout.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-argument-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L937" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L939" target="_blank">View source</a>
 </small>
 
 
@@ -942,7 +942,7 @@ func("foo")  # error: [invalid-argument-type]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-assignment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1046" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1048" target="_blank">View source</a>
 </small>
 
 
@@ -970,7 +970,7 @@ a: int = ''
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-attribute-access%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2906" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2908" target="_blank">View source</a>
 </small>
 
 
@@ -1004,7 +1004,7 @@ C.instance_var = 3  # error: Cannot assign to instance variable
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-await%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1068" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1070" target="_blank">View source</a>
 </small>
 
 
@@ -1040,7 +1040,7 @@ asyncio.run(main())
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1098" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1100" target="_blank">View source</a>
 </small>
 
 
@@ -1064,7 +1064,7 @@ class A(42): ...  # error: [invalid-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-context-manager%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1182" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1184" target="_blank">View source</a>
 </small>
 
 
@@ -1091,7 +1091,7 @@ with 1:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L516" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L518" target="_blank">View source</a>
 </small>
 
 
@@ -1128,7 +1128,7 @@ class Foo(NamedTuple):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L490" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L492" target="_blank">View source</a>
 </small>
 
 
@@ -1160,7 +1160,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-declaration%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1203" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1205" target="_blank">View source</a>
 </small>
 
 
@@ -1189,7 +1189,7 @@ a: str
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-enum-member-annotation%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1262" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1264" target="_blank">View source</a>
 </small>
 
 
@@ -1238,7 +1238,7 @@ class Pet(Enum):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-exception-caught%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1226" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1228" target="_blank">View source</a>
 </small>
 
 
@@ -1282,7 +1282,7 @@ except ZeroDivisionError:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.28">0.0.1-alpha.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-explicit-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2519" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2521" target="_blank">View source</a>
 </small>
 
 
@@ -1324,7 +1324,7 @@ class D(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.35">0.0.1-alpha.35</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-frozen-dataclass-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3264" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3266" target="_blank">View source</a>
 </small>
 
 
@@ -1368,7 +1368,7 @@ class NonFrozenChild(FrozenBase):  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1346" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1348" target="_blank">View source</a>
 </small>
 
 
@@ -1406,7 +1406,7 @@ class D(Generic[U, T]): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-enum%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1304" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1306" target="_blank">View source</a>
 </small>
 
 
@@ -1485,7 +1485,7 @@ a = 20 / 0  # type: ignore
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.17">0.0.1-alpha.17</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L820" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L822" target="_blank">View source</a>
 </small>
 
 
@@ -1524,7 +1524,7 @@ carol = Person(name="Carol", aeg=25)  # typo!
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-positional-parameter%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3342" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3344" target="_blank">View source</a>
 </small>
 
 
@@ -1585,7 +1585,7 @@ def f(x, y, /):  # Python 3.8+ syntax
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1403" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1405" target="_blank">View source</a>
 </small>
 
 
@@ -1620,7 +1620,7 @@ def f(t: TypeVar("U")): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-match-pattern%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1807" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1809" target="_blank">View source</a>
 </small>
 
 
@@ -1648,7 +1648,7 @@ match x:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1531" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1533" target="_blank">View source</a>
 </small>
 
 
@@ -1682,7 +1682,7 @@ class B(metaclass=f): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-method-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3166" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3168" target="_blank">View source</a>
 </small>
 
 
@@ -1789,7 +1789,7 @@ Correct use of `@override` is enforced by ty's [`invalid-explicit-override`](#in
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-named-tuple%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L693" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L695" target="_blank">View source</a>
 </small>
 
 
@@ -1843,7 +1843,7 @@ AttributeError: Cannot overwrite NamedTuple attribute _asdict
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.31">0.0.31</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-named-tuple-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L741" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L743" target="_blank">View source</a>
 </small>
 
 
@@ -1884,7 +1884,7 @@ admin[0]  # "Alice"
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.27">0.0.1-alpha.27</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-newtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1476" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1478" target="_blank">View source</a>
 </small>
 
 
@@ -1914,7 +1914,7 @@ Baz = NewType("Baz", int | str)  # error: invalid base for `typing.NewType`
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1558" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1560" target="_blank">View source</a>
 </small>
 
 
@@ -1964,7 +1964,7 @@ def foo(x: int) -> int: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-parameter-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1657" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1659" target="_blank">View source</a>
 </small>
 
 
@@ -1990,7 +1990,7 @@ def f(a: int = ''): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-paramspec%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1431" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1433" target="_blank">View source</a>
 </small>
 
 
@@ -2021,7 +2021,7 @@ P2 = ParamSpec("S2")  # error: ParamSpec name must match the variable it's assig
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L629" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L631" target="_blank">View source</a>
 </small>
 
 
@@ -2055,7 +2055,7 @@ TypeError: Protocols can only inherit from other protocols, got <class 'int'>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-raise%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1677" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1679" target="_blank">View source</a>
 </small>
 
 
@@ -2104,7 +2104,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-return-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L958" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L960" target="_blank">View source</a>
 </small>
 
 
@@ -2133,7 +2133,7 @@ def func() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-super-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1720" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1722" target="_blank">View source</a>
 </small>
 
 
@@ -2229,7 +2229,7 @@ class C: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.10">0.0.10</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-total-ordering%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3302" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3304" target="_blank">View source</a>
 </small>
 
 
@@ -2275,7 +2275,7 @@ class MyClass:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.6">0.0.1-alpha.6</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-alias-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1455" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1457" target="_blank">View source</a>
 </small>
 
 
@@ -2302,7 +2302,7 @@ NewAlias = TypeAliasType(get_name(), int)        # error: TypeAliasType name mus
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2067" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2069" target="_blank">View source</a>
 </small>
 
 
@@ -2349,7 +2349,7 @@ Bar[int]  # error: too few arguments
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-checking-constant%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1759" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1761" target="_blank">View source</a>
 </small>
 
 
@@ -2379,7 +2379,7 @@ TYPE_CHECKING = ''
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-form%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1783" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1785" target="_blank">View source</a>
 </small>
 
 
@@ -2409,7 +2409,7 @@ b: Annotated[int]  # `Annotated` expects at least two arguments
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-guard-call%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1857" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1859" target="_blank">View source</a>
 </small>
 
 
@@ -2443,7 +2443,7 @@ f(10)  # Error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-guard-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1829" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1831" target="_blank">View source</a>
 </small>
 
 
@@ -2477,7 +2477,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-bound%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1926" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1928" target="_blank">View source</a>
 </small>
 
 
@@ -2508,7 +2508,7 @@ def g[U, T: U](): ...  # error: [invalid-type-variable-bound]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-constraints%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1885" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1887" target="_blank">View source</a>
 </small>
 
 
@@ -2555,7 +2555,7 @@ U = TypeVar('U', list[int], int)  # valid constrained Type
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1951" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1953" target="_blank">View source</a>
 </small>
 
 
@@ -2587,7 +2587,7 @@ U = TypeVar("U", int, str, default=bytes)  # error: [invalid-type-variable-defau
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.28">0.0.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-field%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3112" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3114" target="_blank">View source</a>
 </small>
 
 
@@ -2618,7 +2618,7 @@ class Child(Base):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-header%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3137" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3139" target="_blank">View source</a>
 </small>
 
 
@@ -2653,7 +2653,7 @@ def f(x: dict):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.9">0.0.9</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-statement%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3087" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3089" target="_blank">View source</a>
 </small>
 
 
@@ -2684,7 +2684,7 @@ class Foo(TypedDict):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.25">0.0.25</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-yield%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L981" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L983" target="_blank">View source</a>
 </small>
 
 
@@ -2715,7 +2715,7 @@ def gen() -> Iterator[int]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L853" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L855" target="_blank">View source</a>
 </small>
 
 
@@ -2770,7 +2770,7 @@ def h(arg2: type):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-typed-dict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L901" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L903" target="_blank">View source</a>
 </small>
 
 
@@ -2813,7 +2813,7 @@ def g(arg: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22mismatched-type-name%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1500" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1502" target="_blank">View source</a>
 </small>
 
 
@@ -2851,7 +2851,7 @@ Movie = TypedDict("Film", {"title": str})  # error: [mismatched-type-name]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2007" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2009" target="_blank">View source</a>
 </small>
 
 
@@ -2876,7 +2876,7 @@ func()  # TypeError: func() missing 1 required positional argument: 'x'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-typed-dict-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3060" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3062" target="_blank">View source</a>
 </small>
 
 
@@ -2909,7 +2909,7 @@ alice["age"]  # KeyError
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22no-matching-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2026" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2028" target="_blank">View source</a>
 </small>
 
 
@@ -2938,7 +2938,7 @@ func("string")  # error: [no-matching-overload]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22non-callable-init-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1377" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1379" target="_blank">View source</a>
 </small>
 
 
@@ -2971,7 +2971,7 @@ class Sub(Super): ...  # error: [non-callable-init-subclass]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-iterable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2108" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2110" target="_blank">View source</a>
 </small>
 
 
@@ -2997,7 +2997,7 @@ for i in 34:  # TypeError: 'int' object is not iterable
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-subscriptable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2049" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2051" target="_blank">View source</a>
 </small>
 
 
@@ -3021,7 +3021,7 @@ Subscripting an object that does not support it will raise a `TypeError` at runt
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2306" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2308" target="_blank">View source</a>
 </small>
 
 
@@ -3054,7 +3054,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2333" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2335" target="_blank">View source</a>
 </small>
 
 
@@ -3087,7 +3087,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22parameter-already-assigned%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2159" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2161" target="_blank">View source</a>
 </small>
 
 
@@ -3114,7 +3114,7 @@ f(1, x=2)  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22positional-only-parameter-as-kwarg%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2733" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2735" target="_blank">View source</a>
 </small>
 
 
@@ -3141,7 +3141,7 @@ f(x=1)  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2180" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2182" target="_blank">View source</a>
 </small>
 
 
@@ -3174,7 +3174,7 @@ A.c  # AttributeError: type object 'A' has no attribute 'c'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-implicit-call%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L217" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L219" target="_blank">View source</a>
 </small>
 
 
@@ -3206,7 +3206,7 @@ A()[0]  # TypeError: 'A' object is not subscriptable
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2227" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2229" target="_blank">View source</a>
 </small>
 
 
@@ -3243,7 +3243,7 @@ from module import a  # ImportError: cannot import name 'a' from 'module'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.23">0.0.23</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-submodule%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2206" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2208" target="_blank">View source</a>
 </small>
 
 
@@ -3270,7 +3270,7 @@ html.parser  # AttributeError: module 'html' has no attribute 'parser'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2257" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2259" target="_blank">View source</a>
 </small>
 
 
@@ -3334,7 +3334,7 @@ def test(): -> "int":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-cast%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2934" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2936" target="_blank">View source</a>
 </small>
 
 
@@ -3361,7 +3361,7 @@ cast(int, f())  # Redundant
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-final-classvar%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2955" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2957" target="_blank">View source</a>
 </small>
 
 
@@ -3393,7 +3393,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22shadowed-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2981" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2983" target="_blank">View source</a>
 </small>
 
 
@@ -3427,7 +3427,7 @@ class Outer[T]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22static-assert-error%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2882" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2884" target="_blank">View source</a>
 </small>
 
 
@@ -3457,7 +3457,7 @@ static_assert(int(2.0 * 3.0) == 6)  # error: does not have a statically known tr
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2283" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2285" target="_blank">View source</a>
 </small>
 
 
@@ -3486,7 +3486,7 @@ class B(A): ...  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.30">0.0.1-alpha.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22super-call-in-named-tuple-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2667" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2669" target="_blank">View source</a>
 </small>
 
 
@@ -3520,7 +3520,7 @@ class F(NamedTuple):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22too-many-positional-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2607" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2609" target="_blank">View source</a>
 </small>
 
 
@@ -3547,7 +3547,7 @@ f("foo")  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22type-assertion-failure%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2555" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2557" target="_blank">View source</a>
 </small>
 
 
@@ -3575,7 +3575,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unavailable-implicit-super-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2628" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2630" target="_blank">View source</a>
 </small>
 
 
@@ -3621,7 +3621,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unbound-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1977" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1979" target="_blank">View source</a>
 </small>
 
 
@@ -3658,7 +3658,7 @@ class C(Generic[T]):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22undefined-reveal%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2694" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2696" target="_blank">View source</a>
 </small>
 
 
@@ -3682,7 +3682,7 @@ reveal_type(1)  # NameError: name 'reveal_type' is not defined
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unknown-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2712" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2714" target="_blank">View source</a>
 </small>
 
 
@@ -3709,7 +3709,7 @@ f(x=1, y=2)  # Error raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2754" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2756" target="_blank">View source</a>
 </small>
 
 
@@ -3737,7 +3737,7 @@ A().foo  # AttributeError: 'A' object has no attribute 'foo'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.15">0.0.1-alpha.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-global%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3008" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3010" target="_blank">View source</a>
 </small>
 
 
@@ -3795,7 +3795,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2776" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2778" target="_blank">View source</a>
 </small>
 
 
@@ -3820,7 +3820,7 @@ import foo  # ModuleNotFoundError: No module named 'foo'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2795" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2797" target="_blank">View source</a>
 </small>
 
 
@@ -3845,7 +3845,7 @@ print(x)  # NameError: name 'x' is not defined
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.7">0.0.1-alpha.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1116" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1118" target="_blank">View source</a>
 </small>
 
 
@@ -3884,7 +3884,7 @@ class D(C): ...  # error: [unsupported-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-bool-conversion%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2128" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2130" target="_blank">View source</a>
 </small>
 
 
@@ -3921,7 +3921,7 @@ b1 < b2 < b1  # exception raised here
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-dynamic-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1149" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1151" target="_blank">View source</a>
 </small>
 
 
@@ -3961,7 +3961,7 @@ def factory(base: type[Base]) -> type:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-operator%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2814" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2816" target="_blank">View source</a>
 </small>
 
 
@@ -3989,7 +3989,7 @@ A() + A()  # TypeError: unsupported operand type(s) for +: 'A' and 'A'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Preview (since <a href="https://github.com/astral-sh/ty/releases/tag/0.0.21">0.0.21</a>) ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-awaitable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2836" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2838" target="_blank">View source</a>
 </small>
 
 
@@ -4095,7 +4095,7 @@ to `false`.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22useless-overload-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1601" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1603" target="_blank">View source</a>
 </small>
 
 
@@ -4158,7 +4158,7 @@ def foo(x: int | str) -> int | str:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22zero-stepsize-in-slice%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2863" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L2865" target="_blank">View source</a>
 </small>
 
 

--- a/crates/ty/tests/cli/rule_selection.rs
+++ b/crates/ty/tests/cli/rule_selection.rs
@@ -1105,15 +1105,18 @@ fn configuration_all_rules_with_rule_sorting_before_all() -> anyhow::Result<()> 
     exit_code: 1
     ----- stdout -----
     error[abstract-method-in-final-class]: Final class `Derived` has unimplemented abstract methods
-      --> test.py:11:7
+      --> test.py:6:5
        |
-    11 | class Derived(Base):
-       |       ^^^^^^^ `foo` is unimplemented
-       |
-      ::: test.py:7:9
-       |
+     6 |     @abstractmethod
+       |     ---------------
      7 |     def foo(self) -> int:
        |         --- `foo` declared as abstract on superclass `Base`
+     8 |         raise NotImplementedError
+     9 |
+    10 | @final
+       | ------
+    11 | class Derived(Base):
+       |       ^^^^^^^ `foo` is unimplemented
        |
     info: rule `abstract-method-in-final-class` was selected in the configuration file
 
@@ -1166,15 +1169,18 @@ fn overrides_all_rules_with_rule_sorting_before_all() -> anyhow::Result<()> {
     exit_code: 1
     ----- stdout -----
     error[abstract-method-in-final-class]: Final class `Derived` has unimplemented abstract methods
-      --> src/test.py:11:7
+      --> src/test.py:6:5
        |
-    11 | class Derived(Base):
-       |       ^^^^^^^ `foo` is unimplemented
-       |
-      ::: src/test.py:7:9
-       |
+     6 |     @abstractmethod
+       |     ---------------
      7 |     def foo(self) -> int:
        |         --- `foo` declared as abstract on superclass `Base`
+     8 |         raise NotImplementedError
+     9 |
+    10 | @final
+       | ------
+    11 | class Derived(Base):
+       |       ^^^^^^^ `foo` is unimplemented
        |
     info: rule `abstract-method-in-final-class` was selected in the configuration file
 

--- a/crates/ty/tests/cli/rule_selection.rs
+++ b/crates/ty/tests/cli/rule_selection.rs
@@ -1107,16 +1107,15 @@ fn configuration_all_rules_with_rule_sorting_before_all() -> anyhow::Result<()> 
     error[abstract-method-in-final-class]: Final class `Derived` has unimplemented abstract methods
       --> test.py:6:5
        |
-     6 |     @abstractmethod
-       |     ---------------
-     7 |     def foo(self) -> int:
-       |         --- `foo` declared as abstract on superclass `Base`
-     8 |         raise NotImplementedError
+     6 | /     @abstractmethod
+     7 | |     def foo(self) -> int:
+       | |________________________- `foo` declared as abstract on superclass `Base`
+     8 |           raise NotImplementedError
      9 |
-    10 | @final
-       | ------
-    11 | class Derived(Base):
-       |       ^^^^^^^ `foo` is unimplemented
+    10 |   @final
+       |   ------
+    11 |   class Derived(Base):
+       |         ^^^^^^^ `foo` is unimplemented
        |
     info: rule `abstract-method-in-final-class` was selected in the configuration file
 
@@ -1171,16 +1170,15 @@ fn overrides_all_rules_with_rule_sorting_before_all() -> anyhow::Result<()> {
     error[abstract-method-in-final-class]: Final class `Derived` has unimplemented abstract methods
       --> src/test.py:6:5
        |
-     6 |     @abstractmethod
-       |     ---------------
-     7 |     def foo(self) -> int:
-       |         --- `foo` declared as abstract on superclass `Base`
-     8 |         raise NotImplementedError
+     6 | /     @abstractmethod
+     7 | |     def foo(self) -> int:
+       | |________________________- `foo` declared as abstract on superclass `Base`
+     8 |           raise NotImplementedError
      9 |
-    10 | @final
-       | ------
-    11 | class Derived(Base):
-       |       ^^^^^^^ `foo` is unimplemented
+    10 |   @final
+       |   ------
+    11 |   class Derived(Base):
+       |         ^^^^^^^ `foo` is unimplemented
        |
     info: rule `abstract-method-in-final-class` was selected in the configuration file
 

--- a/crates/ty_python_semantic/resources/mdtest/call/abstract_method.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/abstract_method.md
@@ -18,16 +18,16 @@ Foo.method()
 
 ```snapshot
 error[call-abstract-method]: Cannot call `method` on class object
- --> src/mdtest_snippet.py:5:5
+ --> src/mdtest_snippet.py:4:5
   |
-5 |     @abstractmethod
-  |     ---------------
-6 |     def method(cls) -> int: ...
-  |         ----------------------- Method `method` defined here
+4 | /     @classmethod
+5 | |     @abstractmethod
+6 | |     def method(cls) -> int: ...
+  | |_______________________________- Method `method` defined here
 7 |
-8 | # snapshot: call-abstract-method
-9 | Foo.method()
-  | ^^^^^^^^^^^^ `method` is an abstract classmethod with a trivial body
+8 |   # snapshot: call-abstract-method
+9 |   Foo.method()
+  |   ^^^^^^^^^^^^ `method` is an abstract classmethod with a trivial body
   |
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/call/abstract_method.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/abstract_method.md
@@ -23,7 +23,7 @@ error[call-abstract-method]: Cannot call `method` on class object
 5 |     @abstractmethod
   |     ---------------
 6 |     def method(cls) -> int: ...
-  |         ------ Method `method` defined here
+  |         ----------------------- Method `method` defined here
 7 |
 8 | # snapshot: call-abstract-method
 9 | Foo.method()

--- a/crates/ty_python_semantic/resources/mdtest/call/abstract_method.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/abstract_method.md
@@ -18,16 +18,16 @@ Foo.method()
 
 ```snapshot
 error[call-abstract-method]: Cannot call `method` on class object
- --> src/mdtest_snippet.py:9:1
+ --> src/mdtest_snippet.py:5:5
   |
+5 |     @abstractmethod
+  |     ---------------
+6 |     def method(cls) -> int: ...
+  |         ------ Method `method` defined here
+7 |
+8 | # snapshot: call-abstract-method
 9 | Foo.method()
   | ^^^^^^^^^^^^ `method` is an abstract classmethod with a trivial body
-  |
-info: Method `method` defined here
- --> src/mdtest_snippet.py:6:9
-  |
-6 |     def method(cls) -> int: ...
-  |         ^^^^^^
   |
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -956,8 +956,10 @@ error[no-matching-overload]: No overload of function `f` matches arguments
    |
 info: Limit of argument type expansion reached at argument 9
 info: First overload defined here
- --> src/overloaded.pyi:8:5
+ --> src/overloaded.pyi:7:1
   |
+7 | @overload
+  | ---------
 8 | def f() -> None: ...
   |     ^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -958,10 +958,9 @@ info: Limit of argument type expansion reached at argument 9
 info: First overload defined here
  --> src/overloaded.pyi:7:1
   |
-7 | @overload
-  | ---------
-8 | def f() -> None: ...
-  |     ^^^^^^^^^^^
+7 | / @overload
+8 | | def f() -> None: ...
+  | |____________________^ First overload defined here
   |
 info: Possible overloads for function `f`:
 info:   () -> None

--- a/crates/ty_python_semantic/resources/mdtest/del.md
+++ b/crates/ty_python_semantic/resources/mdtest/del.md
@@ -450,10 +450,15 @@ error[invalid-argument-type]: Cannot delete required key "name" from TypedDict `
    |       ^^^^^^
    |
 info: Field defined here
- --> src/mdtest_snippet.py:4:5
+ --> src/mdtest_snippet.py:3:7
   |
+3 | class Movie(TypedDict):
+  |       ---------------- `Movie` defined here
 4 |     name: str
-  |     --------- `name` declared as required here; consider making it `NotRequired`
+  |     ---------
+  |     |
+  |     `name` declared as required here
+  |     Consider making it `NotRequired`
   |
 info: Only keys marked as `NotRequired` (or in a TypedDict with `total=False`) can be deleted
 ```
@@ -485,10 +490,15 @@ error[invalid-argument-type]: Cannot delete required key "name" from TypedDict `
    |           ^^^^^^
    |
 info: Field defined here
-  --> src/mdtest_snippet.py:12:5
+  --> src/mdtest_snippet.py:11:7
    |
+11 | class MixedMovie(TypedDict):
+   |       --------------------- `MixedMovie` defined here
 12 |     name: str
-   |     --------- `name` declared as required here; consider making it `NotRequired`
+   |     ---------
+   |     |
+   |     `name` declared as required here
+   |     Consider making it `NotRequired`
    |
 info: Only keys marked as `NotRequired` (or in a TypedDict with `total=False`) can be deleted
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Abstract_method_in_g…_(6d8b024dda7ced11).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Abstract_method_in_g…_(6d8b024dda7ced11).snap
@@ -34,18 +34,17 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 error[abstract-method-in-final-class]: Final class `Child` has unimplemented abstract methods
   --> src/mdtest_snippet.py:5:5
    |
- 5 |     @abstractmethod
-   |     ---------------
- 6 |     def method(self) -> int: ...
-   |         ------ `method` declared as abstract on superclass `GrandParent`
+ 5 | /     @abstractmethod
+ 6 | |     def method(self) -> int: ...
+   | |________________________________- `method` declared as abstract on superclass `GrandParent`
  7 |
- 8 | class Parent(GrandParent):
- 9 |     pass
+ 8 |   class Parent(GrandParent):
+ 9 |       pass
 10 |
-11 | @final
-   | ------
-12 | class Child(Parent):  # error: [abstract-method-in-final-class]
-   |       ^^^^^ `method` is unimplemented
+11 |   @final
+   |   ------
+12 |   class Child(Parent):  # error: [abstract-method-in-final-class]
+   |         ^^^^^ `method` is unimplemented
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Abstract_method_in_g…_(6d8b024dda7ced11).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Abstract_method_in_g…_(6d8b024dda7ced11).snap
@@ -32,15 +32,20 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 
 ```
 error[abstract-method-in-final-class]: Final class `Child` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:12:7
+  --> src/mdtest_snippet.py:5:5
    |
-12 | class Child(Parent):  # error: [abstract-method-in-final-class]
-   |       ^^^^^ `method` is unimplemented
-   |
-  ::: src/mdtest_snippet.py:6:9
-   |
+ 5 |     @abstractmethod
+   |     ---------------
  6 |     def method(self) -> int: ...
    |         ------ `method` declared as abstract on superclass `GrandParent`
+ 7 |
+ 8 | class Parent(GrandParent):
+ 9 |     pass
+10 |
+11 | @final
+   | ------
+12 | class Child(Parent):  # error: [abstract-method-in-final-class]
+   |       ^^^^^ `method` is unimplemented
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Basic_case_with_ABC_(21e412599c45972a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Basic_case_with_ABC_(21e412599c45972a).snap
@@ -32,16 +32,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 error[abstract-method-in-final-class]: Final class `Derived` has unimplemented abstract methods
   --> src/mdtest_snippet.py:5:5
    |
- 5 |     @abstractmethod
-   |     ---------------
- 6 |     def foo(self) -> int:
-   |         --- `foo` declared as abstract on superclass `Base`
- 7 |         raise NotImplementedError
+ 5 | /     @abstractmethod
+ 6 | |     def foo(self) -> int:
+   | |________________________- `foo` declared as abstract on superclass `Base`
+ 7 |           raise NotImplementedError
  8 |
- 9 | @final
-   | ------
-10 | class Derived(Base):  # error: [abstract-method-in-final-class] "Final class `Derived` has unimplemented abstract method `foo`"
-   |       ^^^^^^^ `foo` is unimplemented
+ 9 |   @final
+   |   ------
+10 |   class Derived(Base):  # error: [abstract-method-in-final-class] "Final class `Derived` has unimplemented abstract method `foo`"
+   |         ^^^^^^^ `foo` is unimplemented
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Basic_case_with_ABC_(21e412599c45972a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Basic_case_with_ABC_(21e412599c45972a).snap
@@ -30,15 +30,18 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 
 ```
 error[abstract-method-in-final-class]: Final class `Derived` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:10:7
+  --> src/mdtest_snippet.py:5:5
    |
-10 | class Derived(Base):  # error: [abstract-method-in-final-class] "Final class `Derived` has unimplemented abstract method `foo`"
-   |       ^^^^^^^ `foo` is unimplemented
-   |
-  ::: src/mdtest_snippet.py:6:9
-   |
+ 5 |     @abstractmethod
+   |     ---------------
  6 |     def foo(self) -> int:
    |         --- `foo` declared as abstract on superclass `Base`
+ 7 |         raise NotImplementedError
+ 8 |
+ 9 | @final
+   | ------
+10 | class Derived(Base):  # error: [abstract-method-in-final-class] "Final class `Derived` has unimplemented abstract method `foo`"
+   |       ^^^^^^^ `foo` is unimplemented
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(ecae0f4510696c95).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(ecae0f4510696c95).snap
@@ -47,15 +47,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 error[abstract-method-in-final-class]: Final class `Abstract` has unimplemented abstract methods
  --> src/mdtest_snippet.py:4:1
   |
-4 | @final
-  | ------
-5 | # error: [abstract-method-in-final-class] "Final class `Abstract` has unimplemented abstract methods `aaaaaaaaaa`, `bbbbbbbb`, `ccccccc…
-6 | class Abstract(ABC):
-  |       ^^^^^^^^ Abstract methods `aaaaaaaaaa`, `bbbbbbbb`, `cccccccc`, `ddddddddd`, `eeeeeeeee`, `ffffffff`, `ggggggg`, `hhhhhhhh`, `iiiiiiiii` and `kkkkkkkkkk` are unimplemented
-7 |     @abstractmethod
-  |     ---------------
-8 |     def aaaaaaaaaa(self) -> int: ...
-  |         ---------- `aaaaaaaaaa` declared as abstract
+4 |   @final
+  |   ------
+5 |   # error: [abstract-method-in-final-class] "Final class `Abstract` has unimplemented abstract methods `aaaaaaaaaa`, `bbbbbbbb`, `ccccccc…
+6 |   class Abstract(ABC):
+  |         ^^^^^^^^ Abstract methods `aaaaaaaaaa`, `bbbbbbbb`, `cccccccc`, `ddddddddd`, `eeeeeeeee`, `ffffffff`, `ggggggg`, `hhhhhhhh`, `iiiiiiiii` and `kkkkkkkkkk` are unimplemented
+7 | /     @abstractmethod
+8 | |     def aaaaaaaaaa(self) -> int: ...
+  | |____________________________________- `aaaaaaaaaa` declared as abstract
   |
 info: rule `abstract-method-in-final-class` is enabled by default
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(ecae0f4510696c95).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(ecae0f4510696c95).snap
@@ -45,11 +45,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 
 ```
 error[abstract-method-in-final-class]: Final class `Abstract` has unimplemented abstract methods
- --> src/mdtest_snippet.py:6:7
+ --> src/mdtest_snippet.py:4:1
   |
+4 | @final
+  | ------
+5 | # error: [abstract-method-in-final-class] "Final class `Abstract` has unimplemented abstract methods `aaaaaaaaaa`, `bbbbbbbb`, `ccccccc…
 6 | class Abstract(ABC):
   |       ^^^^^^^^ Abstract methods `aaaaaaaaaa`, `bbbbbbbb`, `cccccccc`, `ddddddddd`, `eeeeeeeee`, `ffffffff`, `ggggggg`, `hhhhhhhh`, `iiiiiiiii` and `kkkkkkkkkk` are unimplemented
 7 |     @abstractmethod
+  |     ---------------
 8 |     def aaaaaaaaaa(self) -> int: ...
   |         ---------- `aaaaaaaaaa` declared as abstract
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(f807ff3716d8ab0d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(f807ff3716d8ab0d).snap
@@ -45,11 +45,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 
 ```
 error[abstract-method-in-final-class]: Final class `Abstract` has unimplemented abstract methods
- --> src/mdtest_snippet.py:6:7
+ --> src/mdtest_snippet.py:4:1
   |
+4 | @final
+  | ------
+5 | # error: [abstract-method-in-final-class] "Final class `Abstract` has 10 unimplemented abstract methods, including `aaaaaaaaaa`, `bbbbb…
 6 | class Abstract(ABC):
   |       ^^^^^^^^ 10 abstract methods are unimplemented, including `aaaaaaaaaa`, `bbbbbbbb` and `cccccccc`
 7 |     @abstractmethod
+  |     ---------------
 8 |     def aaaaaaaaaa(self) -> int: ...
   |         ---------- `aaaaaaaaaa` declared as abstract
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(f807ff3716d8ab0d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Diagnostic_when_ther…_(f807ff3716d8ab0d).snap
@@ -47,15 +47,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 error[abstract-method-in-final-class]: Final class `Abstract` has unimplemented abstract methods
  --> src/mdtest_snippet.py:4:1
   |
-4 | @final
-  | ------
-5 | # error: [abstract-method-in-final-class] "Final class `Abstract` has 10 unimplemented abstract methods, including `aaaaaaaaaa`, `bbbbb…
-6 | class Abstract(ABC):
-  |       ^^^^^^^^ 10 abstract methods are unimplemented, including `aaaaaaaaaa`, `bbbbbbbb` and `cccccccc`
-7 |     @abstractmethod
-  |     ---------------
-8 |     def aaaaaaaaaa(self) -> int: ...
-  |         ---------- `aaaaaaaaaa` declared as abstract
+4 |   @final
+  |   ------
+5 |   # error: [abstract-method-in-final-class] "Final class `Abstract` has 10 unimplemented abstract methods, including `aaaaaaaaaa`, `bbbbb…
+6 |   class Abstract(ABC):
+  |         ^^^^^^^^ 10 abstract methods are unimplemented, including `aaaaaaaaaa`, `bbbbbbbb` and `cccccccc`
+7 | /     @abstractmethod
+8 | |     def aaaaaaaaaa(self) -> int: ...
+  | |____________________________________- `aaaaaaaaaa` declared as abstract
   |
 info: Use `--verbose` to see all 10 unimplemented abstract methods
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Multiple_abstract_me…_(feafee9a4abbe8d1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Multiple_abstract_me…_(feafee9a4abbe8d1).snap
@@ -41,13 +41,17 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 
 ```
 error[abstract-method-in-final-class]: Final class `MissingAll` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:13:7
+  --> src/mdtest_snippet.py:12:1
    |
+12 | @final
+   | ------
 13 | class MissingAll(Base):  # error: [abstract-method-in-final-class]
    |       ^^^^^^^^^^ Abstract methods `foo`, `bar` and `baz` are unimplemented
    |
-  ::: src/mdtest_snippet.py:6:9
+  ::: src/mdtest_snippet.py:5:5
    |
+ 5 |     @abstractmethod
+   |     ---------------
  6 |     def foo(self) -> int: ...
    |         --- `foo` declared as abstract on superclass `Base`
    |
@@ -56,13 +60,17 @@ error[abstract-method-in-final-class]: Final class `MissingAll` has unimplemente
 
 ```
 error[abstract-method-in-final-class]: Final class `PartiallyImplemented` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:17:7
+  --> src/mdtest_snippet.py:16:1
    |
+16 | @final
+   | ------
 17 | class PartiallyImplemented(Base):  # error: [abstract-method-in-final-class]
    |       ^^^^^^^^^^^^^^^^^^^^ `baz` is unimplemented
    |
-  ::: src/mdtest_snippet.py:10:9
+  ::: src/mdtest_snippet.py:9:5
    |
+ 9 |     @abstractmethod
+   |     ---------------
 10 |     def baz(self) -> None: ...
    |         --- `baz` declared as abstract on superclass `Base`
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Multiple_abstract_me…_(feafee9a4abbe8d1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Multiple_abstract_me…_(feafee9a4abbe8d1).snap
@@ -43,17 +43,16 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 error[abstract-method-in-final-class]: Final class `MissingAll` has unimplemented abstract methods
   --> src/mdtest_snippet.py:12:1
    |
-12 | @final
-   | ------
-13 | class MissingAll(Base):  # error: [abstract-method-in-final-class]
-   |       ^^^^^^^^^^ Abstract methods `foo`, `bar` and `baz` are unimplemented
+12 |   @final
+   |   ------
+13 |   class MissingAll(Base):  # error: [abstract-method-in-final-class]
+   |         ^^^^^^^^^^ Abstract methods `foo`, `bar` and `baz` are unimplemented
    |
   ::: src/mdtest_snippet.py:5:5
    |
- 5 |     @abstractmethod
-   |     ---------------
- 6 |     def foo(self) -> int: ...
-   |         --- `foo` declared as abstract on superclass `Base`
+ 5 | /     @abstractmethod
+ 6 | |     def foo(self) -> int: ...
+   | |_____________________________- `foo` declared as abstract on superclass `Base`
    |
 
 ```
@@ -62,17 +61,16 @@ error[abstract-method-in-final-class]: Final class `MissingAll` has unimplemente
 error[abstract-method-in-final-class]: Final class `PartiallyImplemented` has unimplemented abstract methods
   --> src/mdtest_snippet.py:16:1
    |
-16 | @final
-   | ------
-17 | class PartiallyImplemented(Base):  # error: [abstract-method-in-final-class]
-   |       ^^^^^^^^^^^^^^^^^^^^ `baz` is unimplemented
+16 |   @final
+   |   ------
+17 |   class PartiallyImplemented(Base):  # error: [abstract-method-in-final-class]
+   |         ^^^^^^^^^^^^^^^^^^^^ `baz` is unimplemented
    |
   ::: src/mdtest_snippet.py:9:5
    |
- 9 |     @abstractmethod
-   |     ---------------
-10 |     def baz(self) -> None: ...
-   |         --- `baz` declared as abstract on superclass `Base`
+ 9 | /     @abstractmethod
+10 | |     def baz(self) -> None: ...
+   | |______________________________- `baz` declared as abstract on superclass `Base`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Protocol_with_implic…_(e373f31c7a7d88e7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Protocol_with_implic…_(e373f31c7a7d88e7).snap
@@ -169,10 +169,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/final.md
 
 ```
 error[abstract-method-in-final-class]: Final class `Q` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:11:9
+  --> src/mdtest_snippet.py:11:5
    |
 11 |     def still_abstractmethod(self): ...
-   |         ------------------------------- `still_abstractmethod` declared as abstract on superclass `P`
+   |     ----------------------------------- `still_abstractmethod` declared as abstract on superclass `P`
 12 |
 13 | @final
    | ------
@@ -191,10 +191,10 @@ help: Change the body of `still_abstractmethod` to `return` or `return None` if 
 
 ```
 error[abstract-method-in-final-class]: Final class `S` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:18:9
+  --> src/mdtest_snippet.py:18:5
    |
 18 |     def also_still_abstractmethod(self) -> None: ...
-   |         -------------------------------------------- `also_still_abstractmethod` declared as abstract on superclass `R`
+   |     ------------------------------------------------ `also_still_abstractmethod` declared as abstract on superclass `R`
 19 |
 20 | @final
    | ------
@@ -213,17 +213,16 @@ help: Change the body of `also_still_abstractmethod` to `return` or `return None
 
 ```
 error[abstract-method-in-final-class]: Final class `RaisesSub` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:24:9
+  --> src/mdtest_snippet.py:24:5
    |
-24 |     def even_this_is_abstract(self):
-   |         --------------------- `even_this_is_abstract` declared as abstract on superclass `Raises`
-25 |         raise NotImplementedError
-   |         -------------------------
+24 | /     def even_this_is_abstract(self):
+25 | |         raise NotImplementedError
+   | |_________________________________- `even_this_is_abstract` declared as abstract on superclass `Raises`
 26 |
-27 | @final
-   | ------
-28 | class RaisesSub(Raises): ...  # error: [abstract-method-in-final-class]
-   |       ^^^^^^^^^ `even_this_is_abstract` is unimplemented
+27 |   @final
+   |   ------
+28 |   class RaisesSub(Raises): ...  # error: [abstract-method-in-final-class]
+   |         ^^^^^^^^^ `even_this_is_abstract` is unimplemented
    |
 info: `Raises.even_this_is_abstract` is implicitly abstract because `Raises` is a `Protocol` class and `even_this_is_abstract` lacks an implementation
   --> src/mdtest_snippet.py:23:7
@@ -236,17 +235,16 @@ info: `Raises.even_this_is_abstract` is implicitly abstract because `Raises` is 
 
 ```
 error[abstract-method-in-final-class]: Final class `AlsoRaisesSub` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:31:9
+  --> src/mdtest_snippet.py:31:5
    |
-31 |     def also_abstractmethod(self) -> Never:
-   |         ------------------- `also_abstractmethod` declared as abstract on superclass `AlsoRaises`
-32 |         raise NotImplementedError
-   |         -------------------------
+31 | /     def also_abstractmethod(self) -> Never:
+32 | |         raise NotImplementedError
+   | |_________________________________- `also_abstractmethod` declared as abstract on superclass `AlsoRaises`
 33 |
-34 | @final
-   | ------
-35 | class AlsoRaisesSub(AlsoRaises): ...  # error: [abstract-method-in-final-class]
-   |       ^^^^^^^^^^^^^ `also_abstractmethod` is unimplemented
+34 |   @final
+   |   ------
+35 |   class AlsoRaisesSub(AlsoRaises): ...  # error: [abstract-method-in-final-class]
+   |         ^^^^^^^^^^^^^ `also_abstractmethod` is unimplemented
    |
 info: `AlsoRaises.also_abstractmethod` is implicitly abstract because `AlsoRaises` is a `Protocol` class and `also_abstractmethod` lacks an implementation
   --> src/mdtest_snippet.py:30:7
@@ -259,17 +257,16 @@ info: `AlsoRaises.also_abstractmethod` is implicitly abstract because `AlsoRaise
 
 ```
 error[abstract-method-in-final-class]: Final class `StrangeSub` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:41:13
+  --> src/mdtest_snippet.py:41:9
    |
-41 |         def weird_abstractmethod(self):
-   |             -------------------- `weird_abstractmethod` declared as abstract on superclass `Strange`
-42 |             raise x
-   |             -------
+41 | /         def weird_abstractmethod(self):
+42 | |             raise x
+   | |___________________- `weird_abstractmethod` declared as abstract on superclass `Strange`
 43 |
-44 |     @final
-   |     ------
-45 |     class StrangeSub(Strange): ...  # error: [abstract-method-in-final-class]
-   |           ^^^^^^^^^^ `weird_abstractmethod` is unimplemented
+44 |       @final
+   |       ------
+45 |       class StrangeSub(Strange): ...  # error: [abstract-method-in-final-class]
+   |             ^^^^^^^^^^ `weird_abstractmethod` is unimplemented
    |
 info: `Strange.weird_abstractmethod` is implicitly abstract because `Strange` is a `Protocol` class and `weird_abstractmethod` lacks an implementation
   --> src/mdtest_snippet.py:40:11
@@ -310,10 +307,10 @@ error[abstract-method-in-final-class]: Final class `HasAbstractSub` has unimplem
 123 | class HasAbstractSub(HasAbstract): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^ `a` is unimplemented
     |
-   ::: src/mdtest_snippet.py:72:9
+   ::: src/mdtest_snippet.py:72:5
     |
  72 |     def a(self) -> int: ...
-    |         ------------------- `a` declared as abstract on superclass `HasAbstract`
+    |     ----------------------- `a` declared as abstract on superclass `HasAbstract`
     |
 info: `HasAbstract.a` is implicitly abstract because `HasAbstract` is a `Protocol` class and `a` lacks an implementation
   --> src/mdtest_snippet.py:71:7
@@ -328,17 +325,16 @@ info: `HasAbstract.a` is implicitly abstract because `HasAbstract` is a `Protoco
 error[abstract-method-in-final-class]: Final class `HasAbstract2Sub` has unimplemented abstract methods
    --> src/mdtest_snippet.py:125:1
     |
-125 | @final
-    | ------
-126 | class HasAbstract2Sub(HasAbstract2): ...  # error: [abstract-method-in-final-class]
-    |       ^^^^^^^^^^^^^^^ `a` is unimplemented
+125 |   @final
+    |   ------
+126 |   class HasAbstract2Sub(HasAbstract2): ...  # error: [abstract-method-in-final-class]
+    |         ^^^^^^^^^^^^^^^ `a` is unimplemented
     |
-   ::: src/mdtest_snippet.py:75:9
+   ::: src/mdtest_snippet.py:75:5
     |
- 75 |     def a(self) -> int:
-    |         - `a` declared as abstract on superclass `HasAbstract2`
- 76 |         pass
-    |         ----
+ 75 | /     def a(self) -> int:
+ 76 | |         pass
+    | |____________- `a` declared as abstract on superclass `HasAbstract2`
     |
 info: `HasAbstract2.a` is implicitly abstract because `HasAbstract2` is a `Protocol` class and `a` lacks an implementation
   --> src/mdtest_snippet.py:74:7
@@ -358,10 +354,10 @@ error[abstract-method-in-final-class]: Final class `HasAbstract3Sub` has unimple
 129 | class HasAbstract3Sub(HasAbstract4): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
     |
-   ::: src/mdtest_snippet.py:83:9
+   ::: src/mdtest_snippet.py:83:5
     |
  83 |     def a(self) -> int:
-    |         - `a` declared as abstract on superclass `HasAbstract4`
+    |     ------------------ `a` declared as abstract on superclass `HasAbstract4`
     |
 info: `HasAbstract4.a` is implicitly abstract because `HasAbstract4` is a `Protocol` class and `a` lacks an implementation
   --> src/mdtest_snippet.py:82:7
@@ -381,10 +377,10 @@ error[abstract-method-in-final-class]: Final class `HasAbstract4Sub` has unimple
 132 | class HasAbstract4Sub(HasAbstract4): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
     |
-   ::: src/mdtest_snippet.py:83:9
+   ::: src/mdtest_snippet.py:83:5
     |
  83 |     def a(self) -> int:
-    |         - `a` declared as abstract on superclass `HasAbstract4`
+    |     ------------------ `a` declared as abstract on superclass `HasAbstract4`
     |
 info: `HasAbstract4.a` is implicitly abstract because `HasAbstract4` is a `Protocol` class and `a` lacks an implementation
   --> src/mdtest_snippet.py:82:7
@@ -404,10 +400,10 @@ error[abstract-method-in-final-class]: Final class `HasAbstract5Sub` has unimple
 135 | class HasAbstract5Sub(HasAbstract5): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
     |
-   ::: src/mdtest_snippet.py:88:9
+   ::: src/mdtest_snippet.py:88:5
     |
  88 |     def a(self) -> int:
-    |         - `a` declared as abstract on superclass `HasAbstract5`
+    |     ------------------ `a` declared as abstract on superclass `HasAbstract5`
     |
 info: `HasAbstract5.a` is implicitly abstract because `HasAbstract5` is a `Protocol` class and `a` lacks an implementation
   --> src/mdtest_snippet.py:87:7
@@ -427,10 +423,10 @@ error[abstract-method-in-final-class]: Final class `HasAbstract6Sub` has unimple
 138 | class HasAbstract6Sub(HasAbstract6): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
     |
-   ::: src/mdtest_snippet.py:93:9
+   ::: src/mdtest_snippet.py:93:5
     |
  93 |     def a(self) -> int:
-    |         - `a` declared as abstract on superclass `HasAbstract6`
+    |     ------------------ `a` declared as abstract on superclass `HasAbstract6`
     |
 info: `HasAbstract6.a` is implicitly abstract because `HasAbstract6` is a `Protocol` class and `a` lacks an implementation
   --> src/mdtest_snippet.py:92:7
@@ -445,17 +441,16 @@ info: `HasAbstract6.a` is implicitly abstract because `HasAbstract6` is a `Proto
 error[abstract-method-in-final-class]: Final class `HasAbstract7Sub` has unimplemented abstract methods
    --> src/mdtest_snippet.py:140:1
     |
-140 | @final
-    | ------
-141 | class HasAbstract7Sub(HasAbstract7): ...  # error: [abstract-method-in-final-class]
-    |       ^^^^^^^^^^^^^^^ `a` is unimplemented
+140 |   @final
+    |   ------
+141 |   class HasAbstract7Sub(HasAbstract7): ...  # error: [abstract-method-in-final-class]
+    |         ^^^^^^^^^^^^^^^ `a` is unimplemented
     |
-   ::: src/mdtest_snippet.py:105:9
+   ::: src/mdtest_snippet.py:105:5
     |
-105 |     def a(self) -> int:
-    |         - `a` declared as abstract on superclass `HasAbstract7`
-106 |         raise NotImplementedError
-    |         -------------------------
+105 | /     def a(self) -> int:
+106 | |         raise NotImplementedError
+    | |_________________________________- `a` declared as abstract on superclass `HasAbstract7`
     |
 info: `HasAbstract7.a` is implicitly abstract because `HasAbstract7` is a `Protocol` class and `a` lacks an implementation
    --> src/mdtest_snippet.py:104:7
@@ -470,17 +465,16 @@ info: `HasAbstract7.a` is implicitly abstract because `HasAbstract7` is a `Proto
 error[abstract-method-in-final-class]: Final class `HasAbstract8Sub` has unimplemented abstract methods
    --> src/mdtest_snippet.py:143:1
     |
-143 | @final
-    | ------
-144 | class HasAbstract8Sub(HasAbstract8): ...  # error: [abstract-method-in-final-class]
-    |       ^^^^^^^^^^^^^^^ `a` is unimplemented
+143 |   @final
+    |   ------
+144 |   class HasAbstract8Sub(HasAbstract8): ...  # error: [abstract-method-in-final-class]
+    |         ^^^^^^^^^^^^^^^ `a` is unimplemented
     |
-   ::: src/mdtest_snippet.py:109:9
+   ::: src/mdtest_snippet.py:109:5
     |
-109 |     def a(self) -> int:
-    |         - `a` declared as abstract on superclass `HasAbstract8`
-110 |         raise NotImplementedError()
-    |         ---------------------------
+109 | /     def a(self) -> int:
+110 | |         raise NotImplementedError()
+    | |___________________________________- `a` declared as abstract on superclass `HasAbstract8`
     |
 info: `HasAbstract8.a` is implicitly abstract because `HasAbstract8` is a `Protocol` class and `a` lacks an implementation
    --> src/mdtest_snippet.py:108:7
@@ -500,10 +494,10 @@ error[abstract-method-in-final-class]: Final class `HasAbstract9Sub` has unimple
 147 | class HasAbstract9Sub(HasAbstract9): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
     |
-   ::: src/mdtest_snippet.py:113:9
+   ::: src/mdtest_snippet.py:113:5
     |
 113 |     def a(self) -> int:
-    |         - `a` declared as abstract on superclass `HasAbstract9`
+    |     ------------------ `a` declared as abstract on superclass `HasAbstract9`
     |
 info: `HasAbstract9.a` is implicitly abstract because `HasAbstract9` is a `Protocol` class and `a` lacks an implementation
    --> src/mdtest_snippet.py:112:7
@@ -523,10 +517,10 @@ error[abstract-method-in-final-class]: Final class `HasAbstract10Sub` has unimpl
 150 | class HasAbstract10Sub(HasAbstract10): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^^ `a` is unimplemented
     |
-   ::: src/mdtest_snippet.py:118:9
+   ::: src/mdtest_snippet.py:118:5
     |
 118 |     def a(self) -> int:
-    |         - `a` declared as abstract on superclass `HasAbstract10`
+    |     ------------------ `a` declared as abstract on superclass `HasAbstract10`
     |
 info: `HasAbstract10.a` is implicitly abstract because `HasAbstract10` is a `Protocol` class and `a` lacks an implementation
    --> src/mdtest_snippet.py:117:7

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Protocol_with_implic…_(e373f31c7a7d88e7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Protocol_with_implic…_(e373f31c7a7d88e7).snap
@@ -172,7 +172,7 @@ error[abstract-method-in-final-class]: Final class `Q` has unimplemented abstrac
   --> src/mdtest_snippet.py:11:9
    |
 11 |     def still_abstractmethod(self): ...
-   |         -------------------- `still_abstractmethod` declared as abstract on superclass `P`
+   |         ------------------------------- `still_abstractmethod` declared as abstract on superclass `P`
 12 |
 13 | @final
    | ------
@@ -194,7 +194,7 @@ error[abstract-method-in-final-class]: Final class `S` has unimplemented abstrac
   --> src/mdtest_snippet.py:18:9
    |
 18 |     def also_still_abstractmethod(self) -> None: ...
-   |         ------------------------- `also_still_abstractmethod` declared as abstract on superclass `R`
+   |         -------------------------------------------- `also_still_abstractmethod` declared as abstract on superclass `R`
 19 |
 20 | @final
    | ------
@@ -218,6 +218,7 @@ error[abstract-method-in-final-class]: Final class `RaisesSub` has unimplemented
 24 |     def even_this_is_abstract(self):
    |         --------------------- `even_this_is_abstract` declared as abstract on superclass `Raises`
 25 |         raise NotImplementedError
+   |         -------------------------
 26 |
 27 | @final
    | ------
@@ -240,6 +241,7 @@ error[abstract-method-in-final-class]: Final class `AlsoRaisesSub` has unimpleme
 31 |     def also_abstractmethod(self) -> Never:
    |         ------------------- `also_abstractmethod` declared as abstract on superclass `AlsoRaises`
 32 |         raise NotImplementedError
+   |         -------------------------
 33 |
 34 | @final
    | ------
@@ -262,6 +264,7 @@ error[abstract-method-in-final-class]: Final class `StrangeSub` has unimplemente
 41 |         def weird_abstractmethod(self):
    |             -------------------- `weird_abstractmethod` declared as abstract on superclass `Strange`
 42 |             raise x
+   |             -------
 43 |
 44 |     @final
    |     ------
@@ -310,7 +313,7 @@ error[abstract-method-in-final-class]: Final class `HasAbstractSub` has unimplem
    ::: src/mdtest_snippet.py:72:9
     |
  72 |     def a(self) -> int: ...
-    |         - `a` declared as abstract on superclass `HasAbstract`
+    |         ------------------- `a` declared as abstract on superclass `HasAbstract`
     |
 info: `HasAbstract.a` is implicitly abstract because `HasAbstract` is a `Protocol` class and `a` lacks an implementation
   --> src/mdtest_snippet.py:71:7
@@ -334,6 +337,8 @@ error[abstract-method-in-final-class]: Final class `HasAbstract2Sub` has unimple
     |
  75 |     def a(self) -> int:
     |         - `a` declared as abstract on superclass `HasAbstract2`
+ 76 |         pass
+    |         ----
     |
 info: `HasAbstract2.a` is implicitly abstract because `HasAbstract2` is a `Protocol` class and `a` lacks an implementation
   --> src/mdtest_snippet.py:74:7
@@ -449,6 +454,8 @@ error[abstract-method-in-final-class]: Final class `HasAbstract7Sub` has unimple
     |
 105 |     def a(self) -> int:
     |         - `a` declared as abstract on superclass `HasAbstract7`
+106 |         raise NotImplementedError
+    |         -------------------------
     |
 info: `HasAbstract7.a` is implicitly abstract because `HasAbstract7` is a `Protocol` class and `a` lacks an implementation
    --> src/mdtest_snippet.py:104:7
@@ -472,6 +479,8 @@ error[abstract-method-in-final-class]: Final class `HasAbstract8Sub` has unimple
     |
 109 |     def a(self) -> int:
     |         - `a` declared as abstract on superclass `HasAbstract8`
+110 |         raise NotImplementedError()
+    |         ---------------------------
     |
 info: `HasAbstract8.a` is implicitly abstract because `HasAbstract8` is a `Protocol` class and `a` lacks an implementation
    --> src/mdtest_snippet.py:108:7

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Protocol_with_implic…_(e373f31c7a7d88e7).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_A_`@final`_class_mus…_-_Protocol_with_implic…_(e373f31c7a7d88e7).snap
@@ -175,6 +175,7 @@ error[abstract-method-in-final-class]: Final class `Q` has unimplemented abstrac
    |         -------------------- `still_abstractmethod` declared as abstract on superclass `P`
 12 |
 13 | @final
+   | ------
 14 | class Q(P): ...  # error: [abstract-method-in-final-class]
    |       ^ `still_abstractmethod` is unimplemented
    |
@@ -196,6 +197,7 @@ error[abstract-method-in-final-class]: Final class `S` has unimplemented abstrac
    |         ------------------------- `also_still_abstractmethod` declared as abstract on superclass `R`
 19 |
 20 | @final
+   | ------
 21 | class S(R): ...  # error: [abstract-method-in-final-class]
    |       ^ `also_still_abstractmethod` is unimplemented
    |
@@ -211,15 +213,16 @@ help: Change the body of `also_still_abstractmethod` to `return` or `return None
 
 ```
 error[abstract-method-in-final-class]: Final class `RaisesSub` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:28:7
-   |
-28 | class RaisesSub(Raises): ...  # error: [abstract-method-in-final-class]
-   |       ^^^^^^^^^ `even_this_is_abstract` is unimplemented
-   |
-  ::: src/mdtest_snippet.py:24:9
+  --> src/mdtest_snippet.py:24:9
    |
 24 |     def even_this_is_abstract(self):
    |         --------------------- `even_this_is_abstract` declared as abstract on superclass `Raises`
+25 |         raise NotImplementedError
+26 |
+27 | @final
+   | ------
+28 | class RaisesSub(Raises): ...  # error: [abstract-method-in-final-class]
+   |       ^^^^^^^^^ `even_this_is_abstract` is unimplemented
    |
 info: `Raises.even_this_is_abstract` is implicitly abstract because `Raises` is a `Protocol` class and `even_this_is_abstract` lacks an implementation
   --> src/mdtest_snippet.py:23:7
@@ -232,15 +235,16 @@ info: `Raises.even_this_is_abstract` is implicitly abstract because `Raises` is 
 
 ```
 error[abstract-method-in-final-class]: Final class `AlsoRaisesSub` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:35:7
-   |
-35 | class AlsoRaisesSub(AlsoRaises): ...  # error: [abstract-method-in-final-class]
-   |       ^^^^^^^^^^^^^ `also_abstractmethod` is unimplemented
-   |
-  ::: src/mdtest_snippet.py:31:9
+  --> src/mdtest_snippet.py:31:9
    |
 31 |     def also_abstractmethod(self) -> Never:
    |         ------------------- `also_abstractmethod` declared as abstract on superclass `AlsoRaises`
+32 |         raise NotImplementedError
+33 |
+34 | @final
+   | ------
+35 | class AlsoRaisesSub(AlsoRaises): ...  # error: [abstract-method-in-final-class]
+   |       ^^^^^^^^^^^^^ `also_abstractmethod` is unimplemented
    |
 info: `AlsoRaises.also_abstractmethod` is implicitly abstract because `AlsoRaises` is a `Protocol` class and `also_abstractmethod` lacks an implementation
   --> src/mdtest_snippet.py:30:7
@@ -253,15 +257,16 @@ info: `AlsoRaises.also_abstractmethod` is implicitly abstract because `AlsoRaise
 
 ```
 error[abstract-method-in-final-class]: Final class `StrangeSub` has unimplemented abstract methods
-  --> src/mdtest_snippet.py:45:11
-   |
-45 |     class StrangeSub(Strange): ...  # error: [abstract-method-in-final-class]
-   |           ^^^^^^^^^^ `weird_abstractmethod` is unimplemented
-   |
-  ::: src/mdtest_snippet.py:41:13
+  --> src/mdtest_snippet.py:41:13
    |
 41 |         def weird_abstractmethod(self):
    |             -------------------- `weird_abstractmethod` declared as abstract on superclass `Strange`
+42 |             raise x
+43 |
+44 |     @final
+   |     ------
+45 |     class StrangeSub(Strange): ...  # error: [abstract-method-in-final-class]
+   |           ^^^^^^^^^^ `weird_abstractmethod` is unimplemented
    |
 info: `Strange.weird_abstractmethod` is implicitly abstract because `Strange` is a `Protocol` class and `weird_abstractmethod` lacks an implementation
   --> src/mdtest_snippet.py:40:11
@@ -280,6 +285,7 @@ error[abstract-method-in-final-class]: Final class `HasOverloadSub` has unimplem
    |         --- `foo` declared as abstract on superclass `HasOverloads`
 52 |
 53 | @final
+   | ------
 54 | class HasOverloadSub(HasOverloads): ...  # error: [abstract-method-in-final-class]
    |       ^^^^^^^^^^^^^^ `foo` is unimplemented
    |
@@ -294,8 +300,10 @@ info: `HasOverloads.foo` is implicitly abstract because `HasOverloads` is a `Pro
 
 ```
 error[abstract-method-in-final-class]: Final class `HasAbstractSub` has unimplemented abstract methods
-   --> src/mdtest_snippet.py:123:7
+   --> src/mdtest_snippet.py:122:1
     |
+122 | @final
+    | ------
 123 | class HasAbstractSub(HasAbstract): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^ `a` is unimplemented
     |
@@ -315,8 +323,10 @@ info: `HasAbstract.a` is implicitly abstract because `HasAbstract` is a `Protoco
 
 ```
 error[abstract-method-in-final-class]: Final class `HasAbstract2Sub` has unimplemented abstract methods
-   --> src/mdtest_snippet.py:126:7
+   --> src/mdtest_snippet.py:125:1
     |
+125 | @final
+    | ------
 126 | class HasAbstract2Sub(HasAbstract2): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
     |
@@ -336,8 +346,10 @@ info: `HasAbstract2.a` is implicitly abstract because `HasAbstract2` is a `Proto
 
 ```
 error[abstract-method-in-final-class]: Final class `HasAbstract3Sub` has unimplemented abstract methods
-   --> src/mdtest_snippet.py:129:7
+   --> src/mdtest_snippet.py:128:1
     |
+128 | @final
+    | ------
 129 | class HasAbstract3Sub(HasAbstract4): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
     |
@@ -357,8 +369,10 @@ info: `HasAbstract4.a` is implicitly abstract because `HasAbstract4` is a `Proto
 
 ```
 error[abstract-method-in-final-class]: Final class `HasAbstract4Sub` has unimplemented abstract methods
-   --> src/mdtest_snippet.py:132:7
+   --> src/mdtest_snippet.py:131:1
     |
+131 | @final
+    | ------
 132 | class HasAbstract4Sub(HasAbstract4): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
     |
@@ -378,8 +392,10 @@ info: `HasAbstract4.a` is implicitly abstract because `HasAbstract4` is a `Proto
 
 ```
 error[abstract-method-in-final-class]: Final class `HasAbstract5Sub` has unimplemented abstract methods
-   --> src/mdtest_snippet.py:135:7
+   --> src/mdtest_snippet.py:134:1
     |
+134 | @final
+    | ------
 135 | class HasAbstract5Sub(HasAbstract5): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
     |
@@ -399,8 +415,10 @@ info: `HasAbstract5.a` is implicitly abstract because `HasAbstract5` is a `Proto
 
 ```
 error[abstract-method-in-final-class]: Final class `HasAbstract6Sub` has unimplemented abstract methods
-   --> src/mdtest_snippet.py:138:7
+   --> src/mdtest_snippet.py:137:1
     |
+137 | @final
+    | ------
 138 | class HasAbstract6Sub(HasAbstract6): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
     |
@@ -420,8 +438,10 @@ info: `HasAbstract6.a` is implicitly abstract because `HasAbstract6` is a `Proto
 
 ```
 error[abstract-method-in-final-class]: Final class `HasAbstract7Sub` has unimplemented abstract methods
-   --> src/mdtest_snippet.py:141:7
+   --> src/mdtest_snippet.py:140:1
     |
+140 | @final
+    | ------
 141 | class HasAbstract7Sub(HasAbstract7): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
     |
@@ -441,8 +461,10 @@ info: `HasAbstract7.a` is implicitly abstract because `HasAbstract7` is a `Proto
 
 ```
 error[abstract-method-in-final-class]: Final class `HasAbstract8Sub` has unimplemented abstract methods
-   --> src/mdtest_snippet.py:144:7
+   --> src/mdtest_snippet.py:143:1
     |
+143 | @final
+    | ------
 144 | class HasAbstract8Sub(HasAbstract8): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
     |
@@ -462,8 +484,10 @@ info: `HasAbstract8.a` is implicitly abstract because `HasAbstract8` is a `Proto
 
 ```
 error[abstract-method-in-final-class]: Final class `HasAbstract9Sub` has unimplemented abstract methods
-   --> src/mdtest_snippet.py:147:7
+   --> src/mdtest_snippet.py:146:1
     |
+146 | @final
+    | ------
 147 | class HasAbstract9Sub(HasAbstract9): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^ `a` is unimplemented
     |
@@ -483,8 +507,10 @@ info: `HasAbstract9.a` is implicitly abstract because `HasAbstract9` is a `Proto
 
 ```
 error[abstract-method-in-final-class]: Final class `HasAbstract10Sub` has unimplemented abstract methods
-   --> src/mdtest_snippet.py:150:7
+   --> src/mdtest_snippet.py:149:1
     |
+149 | @final
+    | ------
 150 | class HasAbstract10Sub(HasAbstract10): ...  # error: [abstract-method-in-final-class]
     |       ^^^^^^^^^^^^^^^^ `a` is unimplemented
     |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overloaded_methods_d…_(861757f48340ed92).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overloaded_methods_d…_(861757f48340ed92).snap
@@ -198,16 +198,15 @@ note: This is an unsafe fix and may change runtime behavior
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
   --> src/stub.pyi:26:5
    |
-26 |     @overload
-   |     ---------
-27 |     def bar(self, x: str) -> str: ...
-   |         --- First overload defined here
-28 |     @overload
-29 |     @final
-   |     ------
-30 |     # error: [invalid-overload]
-31 |     def bar(self, x: int) -> int: ...
-   |         ^^^
+26 | /     @overload
+27 | |     def bar(self, x: str) -> str: ...
+   | |_____________________________________- First overload defined here
+28 |       @overload
+29 |       @final
+   |       ------
+30 |       # error: [invalid-overload]
+31 |       def bar(self, x: int) -> int: ...
+   |           ^^^
    |
 
 ```
@@ -216,16 +215,15 @@ error[invalid-overload]: `@final` decorator should be applied only to the first 
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
   --> src/stub.pyi:32:5
    |
-32 |     @overload
-   |     ---------
-33 |     def baz(self, x: str) -> str: ...
-   |         --- First overload defined here
-34 |     @final
-   |     ------
-35 |     @overload
-36 |     # error: [invalid-overload]
-37 |     def baz(self, x: int) -> int: ...
-   |         ^^^
+32 | /     @overload
+33 | |     def baz(self, x: str) -> str: ...
+   | |_____________________________________- First overload defined here
+34 |       @final
+   |       ------
+35 |       @overload
+36 |       # error: [invalid-overload]
+37 |       def baz(self, x: int) -> int: ...
+   |           ^^^
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overloaded_methods_d…_(861757f48340ed92).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/final.md_-_Tests_for_the_`@typi…_-_Overloaded_methods_d…_(861757f48340ed92).snap
@@ -196,8 +196,10 @@ note: This is an unsafe fix and may change runtime behavior
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
-  --> src/stub.pyi:27:9
+  --> src/stub.pyi:26:5
    |
+26 |     @overload
+   |     ---------
 27 |     def bar(self, x: str) -> str: ...
    |         --- First overload defined here
 28 |     @overload
@@ -212,8 +214,10 @@ error[invalid-overload]: `@final` decorator should be applied only to the first 
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
-  --> src/stub.pyi:33:9
+  --> src/stub.pyi:32:5
    |
+32 |     @overload
+   |     ---------
 33 |     def baz(self, x: str) -> str: ...
    |         --- First overload defined here
 34 |     @final
@@ -322,8 +326,10 @@ note: This is an unsafe fix and may change runtime behavior
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/main.py:24:5
+  --> src/main.py:23:5
    |
+23 |     @overload
+   |     ---------
 24 |     @final
    |     ------
 25 |     def f(self, x: str) -> str: ...  # error: [invalid-overload]
@@ -343,6 +349,7 @@ error[invalid-overload]: `@final` decorator should be applied only to the overlo
 31 |     @final
    |     ------
 32 |     @overload
+   |     ---------
 33 |     def g(self, x: str) -> str: ...  # error: [invalid-overload]
    |         ^
 34 |     @overload
@@ -355,8 +362,10 @@ error[invalid-overload]: `@final` decorator should be applied only to the overlo
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/main.py:42:5
+  --> src/main.py:41:5
    |
+41 |     @overload
+   |     ---------
 42 |     @final
    |     ------
 43 |     def h(self, x: int) -> int: ...  # error: [invalid-overload]
@@ -374,6 +383,7 @@ error[invalid-overload]: `@final` decorator should be applied only to the overlo
 49 |     @final
    |     ------
 50 |     @overload
+   |     ---------
 51 |     def i(self, x: int) -> int: ...  # error: [invalid-overload]
    |         ^
 52 |     def i(self, x: int | str) -> int | str:

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_A_method_call_with_u…_(31cb5f881221158e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_A_method_call_with_u…_(31cb5f881221158e).snap
@@ -39,10 +39,9 @@ error[no-matching-overload]: No overload of bound method `Foo.bar` matches argum
 info: First overload defined here
  --> src/mdtest_snippet.py:4:5
   |
-4 |     @overload
-  |     ---------
-5 |     def bar(self, x: int) -> int: ...
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^
+4 | /     @overload
+5 | |     def bar(self, x: int) -> int: ...
+  | |_____________________________________^ First overload defined here
   |
 info: Possible overloads for bound method `bar`:
 info:   (self, x: int) -> int

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_A_method_call_with_u…_(31cb5f881221158e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_A_method_call_with_u…_(31cb5f881221158e).snap
@@ -37,8 +37,10 @@ error[no-matching-overload]: No overload of bound method `Foo.bar` matches argum
    | ^^^^^^^^^^^^^^^
    |
 info: First overload defined here
- --> src/mdtest_snippet.py:5:9
+ --> src/mdtest_snippet.py:4:5
   |
+4 |     @overload
+  |     ---------
 5 |     def bar(self, x: int) -> int: ...
   |         ^^^^^^^^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Call_to_function_wit…_(dd80c593d9136f35).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Call_to_function_wit…_(dd80c593d9136f35).snap
@@ -74,8 +74,10 @@ error[no-matching-overload]: No overload of function `foo` matches arguments
    | ^^^^^^^^^^^^^^^^^
    |
 info: First overload defined here
- --> src/mdtest_snippet.py:6:5
+ --> src/mdtest_snippet.py:5:1
   |
+5 | @overload
+  | ---------
 6 | def foo(a: int, b: int, c: int): ...
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Call_to_function_wit…_(dd80c593d9136f35).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Call_to_function_wit…_(dd80c593d9136f35).snap
@@ -76,10 +76,9 @@ error[no-matching-overload]: No overload of function `foo` matches arguments
 info: First overload defined here
  --> src/mdtest_snippet.py:5:1
   |
-5 | @overload
-  | ---------
-6 | def foo(a: int, b: int, c: int): ...
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | / @overload
+6 | | def foo(a: int, b: int, c: int): ...
+  | |____________________________________^ First overload defined here
   |
 info: Possible overloads for function `foo`:
 info:   (a: int, b: int, c: int) -> Unknown

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Call_to_function_wit…_(f66e3a8a3977c472).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Call_to_function_wit…_(f66e3a8a3977c472).snap
@@ -154,8 +154,10 @@ error[no-matching-overload]: No overload of function `foo` matches arguments
     | ^^^^^^^^^^^^^^^^^
     |
 info: First overload defined here
- --> src/mdtest_snippet.py:6:5
+ --> src/mdtest_snippet.py:5:1
   |
+5 | @overload
+  | ---------
 6 | def foo(a: int, b: int, c: int): ...
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Call_to_function_wit…_(f66e3a8a3977c472).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Call_to_function_wit…_(f66e3a8a3977c472).snap
@@ -156,10 +156,9 @@ error[no-matching-overload]: No overload of function `foo` matches arguments
 info: First overload defined here
  --> src/mdtest_snippet.py:5:1
   |
-5 | @overload
-  | ---------
-6 | def foo(a: int, b: int, c: int): ...
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 | / @overload
+6 | | def foo(a: int, b: int, c: int): ...
+  | |____________________________________^ First overload defined here
   |
 info: Possible overloads for function `foo`:
 info:   (a: int, b: int, c: int) -> Unknown

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Calls_to_overloaded_…_(3553d085684e16a0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Calls_to_overloaded_…_(3553d085684e16a0).snap
@@ -37,10 +37,9 @@ error[no-matching-overload]: No overload of function `f` matches arguments
 info: First overload defined here
  --> src/mdtest_snippet.py:3:1
   |
-3 | @overload
-  | ---------
-4 | def f(x: int) -> int: ...
-  |     ^^^^^^^^^^^^^^^^
+3 | / @overload
+4 | | def f(x: int) -> int: ...
+  | |_________________________^ First overload defined here
   |
 info: Possible overloads for function `f`:
 info:   (x: int) -> int

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Calls_to_overloaded_…_(3553d085684e16a0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Calls_to_overloaded_…_(3553d085684e16a0).snap
@@ -35,8 +35,10 @@ error[no-matching-overload]: No overload of function `f` matches arguments
    | ^^^^^^^^^
    |
 info: First overload defined here
- --> src/mdtest_snippet.py:4:5
+ --> src/mdtest_snippet.py:3:1
   |
+3 | @overload
+  | ---------
 4 | def f(x: int) -> int: ...
   |     ^^^^^^^^^^^^^^^^
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Calls_to_overloaded_…_(36814b28492c01d2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Calls_to_overloaded_…_(36814b28492c01d2).snap
@@ -86,8 +86,10 @@ error[no-matching-overload]: No overload of function `f` matches arguments
    | ^^^^^^^^^
    |
 info: First overload defined here
-  --> src/mdtest_snippet.py:4:5
+  --> src/mdtest_snippet.py:3:1
    |
+ 3 |   @overload
+   |   ---------
  4 |   def f(
    |  _____^
  5 | |     lion: int,

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Calls_to_overloaded_…_(36814b28492c01d2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Calls_to_overloaded_…_(36814b28492c01d2).snap
@@ -88,10 +88,8 @@ error[no-matching-overload]: No overload of function `f` matches arguments
 info: First overload defined here
   --> src/mdtest_snippet.py:3:1
    |
- 3 |   @overload
-   |   ---------
- 4 |   def f(
-   |  _____^
+ 3 | / @overload
+ 4 | | def f(
  5 | |     lion: int,
  6 | |     turtle: int,
  7 | |     tortoise: int,
@@ -109,7 +107,7 @@ info: First overload defined here
 19 | |     leopard: int,
 20 | |     hyena: int,
 21 | | ) -> int: ...
-   | |________^
+   | |_____________^ First overload defined here
    |
 info: Possible overloads for function `f`:
 info:   (lion: int, turtle: int, tortoise: int, goat: int, capybara: int, chicken: int, ostrich: int, gorilla: int, giraffe: int, condor: int, kangaroo: int, anaconda: int, tarantula: int, millipede: int, leopard: int, hyena: int) -> int

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloa…_(84dadf8abd8f2f2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_At_least_two_overloa…_(84dadf8abd8f2f2).snap
@@ -36,8 +36,11 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 
 ```
 error[invalid-overload]: Overloaded function `func` requires at least two overloads
- --> src/mdtest_snippet.py:5:5
+ --> src/mdtest_snippet.py:3:1
   |
+3 | @overload
+  | ---------
+4 | # error: [invalid-overload]
 5 | def func(x: int) -> int: ...
   |     ^^^^ Only one overload defined here
   |
@@ -46,8 +49,11 @@ error[invalid-overload]: Overloaded function `func` requires at least two overlo
 
 ```
 error[invalid-overload]: Overloaded function `func` requires at least two overloads
- --> src/mdtest_snippet.pyi:5:5
+ --> src/mdtest_snippet.pyi:3:1
   |
+3 | @overload
+  | ---------
+4 | # error: [invalid-overload]
 5 | def func(x: int) -> int: ...
   |     ^^^^ Only one overload defined here
   |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@classmethod`_(aaa04d4cfa3adaba).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@classmethod`_(aaa04d4cfa3adaba).snap
@@ -75,8 +75,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 
 ```
 error[invalid-overload]: Overloaded function `try_from1` does not use the `@classmethod` decorator consistently
-  --> src/mdtest_snippet.py:13:9
+  --> src/mdtest_snippet.py:12:5
    |
+12 |     @overload
+   |     ---------
 13 |     def try_from1(cls, x: str) -> None: ...
    |         --------- Missing here
 14 |     @classmethod
@@ -94,8 +96,10 @@ error[invalid-overload]: Overloaded function `try_from2` does not use the `@clas
 28 |     def try_from2(cls, x: int | str) -> CheckClassMethod | None:
    |         ^^^^^^^^^
    |
-  ::: src/mdtest_snippet.py:22:9
+  ::: src/mdtest_snippet.py:21:5
    |
+21 |     @overload
+   |     ---------
 22 |     def try_from2(cls, x: int) -> CheckClassMethod: ...
    |         --------- Missing here
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@final`_(f8e529ec23a61665).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@final`_(f8e529ec23a61665).snap
@@ -114,16 +114,15 @@ error[invalid-overload]: `@final` decorator should be applied only to the overlo
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
   --> src/mdtest_snippet.pyi:9:5
    |
- 9 |     @overload
-   |     ---------
-10 |     def method2(self, x: int) -> int: ...
-   |         ------- First overload defined here
-11 |     @final
-   |     ------
-12 |     @overload
-13 |     # error: [invalid-overload]
-14 |     def method2(self, x: str) -> str: ...
-   |         ^^^^^^^
+ 9 | /     @overload
+10 | |     def method2(self, x: int) -> int: ...
+   | |_________________________________________- First overload defined here
+11 |       @final
+   |       ------
+12 |       @overload
+13 |       # error: [invalid-overload]
+14 |       def method2(self, x: str) -> str: ...
+   |           ^^^^^^^
    |
 
 ```
@@ -132,15 +131,14 @@ error[invalid-overload]: `@final` decorator should be applied only to the first 
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
   --> src/mdtest_snippet.pyi:15:5
    |
-15 |     @overload
-   |     ---------
-16 |     def method3(self, x: int) -> int: ...
-   |         ------- First overload defined here
-17 |     @final
-   |     ------
-18 |     @overload
-19 |     def method3(self, x: str) -> int: ...  # error: [invalid-overload]
-   |         ^^^^^^^
+15 | /     @overload
+16 | |     def method3(self, x: int) -> int: ...
+   | |_________________________________________- First overload defined here
+17 |       @final
+   |       ------
+18 |       @overload
+19 |       def method3(self, x: str) -> int: ...  # error: [invalid-overload]
+   |           ^^^^^^^
    |
 
 ```
@@ -149,18 +147,17 @@ error[invalid-overload]: `@final` decorator should be applied only to the first 
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
   --> src/mdtest_snippet.pyi:15:5
    |
-15 |     @overload
-   |     ---------
-16 |     def method3(self, x: int) -> int: ...
-   |         ------- First overload defined here
-17 |     @final
-18 |     @overload
-19 |     def method3(self, x: str) -> int: ...  # error: [invalid-overload]
-20 |     @overload
-21 |     @final
-   |     ------
-22 |     def method3(self, x: bytes) -> bytes: ...  # error: [invalid-overload]
-   |         ^^^^^^^
+15 | /     @overload
+16 | |     def method3(self, x: int) -> int: ...
+   | |_________________________________________- First overload defined here
+17 |       @final
+18 |       @overload
+19 |       def method3(self, x: str) -> int: ...  # error: [invalid-overload]
+20 |       @overload
+21 |       @final
+   |       ------
+22 |       def method3(self, x: bytes) -> bytes: ...  # error: [invalid-overload]
+   |           ^^^^^^^
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@final`_(f8e529ec23a61665).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@final`_(f8e529ec23a61665).snap
@@ -76,8 +76,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:13:5
+  --> src/mdtest_snippet.py:12:5
    |
+12 |     @overload
+   |     ---------
 13 |     @final
    |     ------
 14 |     # error: [invalid-overload]
@@ -93,8 +95,10 @@ error[invalid-overload]: `@final` decorator should be applied only to the overlo
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:24:5
+  --> src/mdtest_snippet.py:23:5
    |
+23 |     @overload
+   |     ---------
 24 |     @final
    |     ------
 25 |     # error: [invalid-overload]
@@ -108,8 +112,10 @@ error[invalid-overload]: `@final` decorator should be applied only to the overlo
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
-  --> src/mdtest_snippet.pyi:10:9
+  --> src/mdtest_snippet.pyi:9:5
    |
+ 9 |     @overload
+   |     ---------
 10 |     def method2(self, x: int) -> int: ...
    |         ------- First overload defined here
 11 |     @final
@@ -124,8 +130,10 @@ error[invalid-overload]: `@final` decorator should be applied only to the first 
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
-  --> src/mdtest_snippet.pyi:16:9
+  --> src/mdtest_snippet.pyi:15:5
    |
+15 |     @overload
+   |     ---------
 16 |     def method3(self, x: int) -> int: ...
    |         ------- First overload defined here
 17 |     @final
@@ -139,8 +147,10 @@ error[invalid-overload]: `@final` decorator should be applied only to the first 
 
 ```
 error[invalid-overload]: `@final` decorator should be applied only to the first overload
-  --> src/mdtest_snippet.pyi:16:9
+  --> src/mdtest_snippet.pyi:15:5
    |
+15 |     @overload
+   |     ---------
 16 |     def method3(self, x: int) -> int: ...
    |         ------- First overload defined here
 17 |     @final

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@override`_(2df210735ca532f9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@override`_(2df210735ca532f9).snap
@@ -122,16 +122,15 @@ error[invalid-overload]: `@override` decorator should be applied only to the ove
 error[invalid-overload]: `@override` decorator should be applied only to the first overload
   --> src/mdtest_snippet.pyi:17:5
    |
-17 |     @overload
-   |     ---------
-18 |     def method(self, x: int) -> int: ...
-   |         ------ First overload defined here
-19 |     @overload
-20 |     @override
-   |     ---------
-21 |     # error: [invalid-overload]
-22 |     def method(self, x: str) -> str: ...
-   |         ^^^^^^
+17 | /     @overload
+18 | |     def method(self, x: int) -> int: ...
+   | |________________________________________- First overload defined here
+19 |       @overload
+20 |       @override
+   |       ---------
+21 |       # error: [invalid-overload]
+22 |       def method(self, x: str) -> str: ...
+   |           ^^^^^^
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@override`_(2df210735ca532f9).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@override`_(2df210735ca532f9).snap
@@ -84,8 +84,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 
 ```
 error[invalid-overload]: `@override` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:24:5
+  --> src/mdtest_snippet.py:23:5
    |
+23 |     @overload
+   |     ---------
 24 |     @override
    |     ---------
 25 |     # error: [invalid-overload]
@@ -99,8 +101,10 @@ error[invalid-overload]: `@override` decorator should be applied only to the ove
 
 ```
 error[invalid-overload]: `@override` decorator should be applied only to the overload implementation
-  --> src/mdtest_snippet.py:32:5
+  --> src/mdtest_snippet.py:31:5
    |
+31 |     @overload
+   |     ---------
 32 |     @override
    |     ---------
 33 |     # error: [invalid-overload]
@@ -116,8 +120,10 @@ error[invalid-overload]: `@override` decorator should be applied only to the ove
 
 ```
 error[invalid-overload]: `@override` decorator should be applied only to the first overload
-  --> src/mdtest_snippet.pyi:18:9
+  --> src/mdtest_snippet.pyi:17:5
    |
+17 |     @overload
+   |     ---------
 18 |     def method(self, x: int) -> int: ...
    |         ------ First overload defined here
 19 |     @overload

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Cover_non-keyword_re…_(707b284610419a54).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Cover_non-keyword_re…_(707b284610419a54).snap
@@ -123,10 +123,9 @@ error[no-matching-overload]: No overload of function `f6` matches arguments
 info: First overload defined here
   --> src/mdtest_snippet.py:23:1
    |
-23 | @overload
-   | ---------
-24 | def f6() -> None: ...
-   |     ^^^^^^^^^^^^
+23 | / @overload
+24 | | def f6() -> None: ...
+   | |_____________________^ First overload defined here
    |
 info: Possible overloads for function `f6`:
 info:   () -> None

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Cover_non-keyword_re…_(707b284610419a54).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Cover_non-keyword_re…_(707b284610419a54).snap
@@ -121,8 +121,10 @@ error[no-matching-overload]: No overload of function `f6` matches arguments
    |         ^^^^
    |
 info: First overload defined here
-  --> src/mdtest_snippet.py:24:5
+  --> src/mdtest_snippet.py:23:1
    |
+23 | @overload
+   | ---------
 24 | def f6() -> None: ...
    |     ^^^^^^^^^^^^
    |

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -58,7 +58,7 @@ use crate::types::{
     TypeVarVariance, UnionBuilder, UnionType, WrapperDescriptorKind, enums, list_members,
 };
 use crate::{DisplaySettings, FxOrderSet, Program};
-use ruff_db::diagnostic::{Annotation, Diagnostic, SubDiagnostic, SubDiagnosticSeverity};
+use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity};
 use ruff_python_ast::{self as ast, AnyNodeRef, ArgOrKeyword, PythonVersion};
 use ty_module_resolver::KnownModule;
 use ty_python_core::scope::NodeWithScopeKind;
@@ -3518,12 +3518,25 @@ impl<'db> CallableBinding<'db> {
                             SubDiagnosticSeverity::Info,
                             "First overload defined here",
                         );
-                        sub.annotate(Annotation::primary(overload.spans(context.db()).signature));
-                        if let Some(decorator) = overload
-                            .find_known_decorator_span(context.db(), KnownFunction::Overload)
-                        {
-                            sub.annotate(Annotation::secondary(decorator));
-                        }
+                        let file = function.file(context.db());
+                        let module = parsed_module(context.db(), file).load(context.db());
+                        let node =
+                            overload.node(context.db(), function.file(context.db()), &module);
+                        let range = if node.body.len() == 1 {
+                            node.range()
+                        } else {
+                            TextRange::new(
+                                node.start(),
+                                node.returns
+                                    .as_deref()
+                                    .map(Ranged::end)
+                                    .unwrap_or_else(|| node.parameters.end()),
+                            )
+                        };
+                        sub.annotate(
+                            Annotation::primary(Span::from(file).with_range(range))
+                                .message("First overload defined here"),
+                        );
                         diag.sub(sub);
                     }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3519,6 +3519,11 @@ impl<'db> CallableBinding<'db> {
                             "First overload defined here",
                         );
                         sub.annotate(Annotation::primary(overload.spans(context.db()).signature));
+                        if let Some(decorator) = overload
+                            .find_known_decorator_span(context.db(), KnownFunction::Overload)
+                        {
+                            sub.annotate(Annotation::secondary(decorator));
+                        }
                         diag.sub(sub);
                     }
 

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -33,6 +33,7 @@ use crate::types::{
 use crate::types::{KnownInstanceType, MemberLookupPolicy, TypedDictType, UnionType};
 use crate::{Db, DisplaySettings, FxIndexMap, Program, declare_lint};
 use itertools::Itertools;
+use ruff_db::source::source_text;
 use ruff_db::{
     diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity},
     parsed::parsed_module,
@@ -41,6 +42,7 @@ use ruff_diagnostics::{Edit, Fix, IsolationLevel};
 use ruff_python_ast::name::Name;
 use ruff_python_ast::token::parentheses_iterator;
 use ruff_python_ast::{self as ast, AnyNodeRef, HasNodeIndex, PythonVersion, StringFlags};
+use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
 use std::fmt::{self, Formatter};
@@ -4833,16 +4835,64 @@ pub(crate) fn report_call_to_abstract_method(
     diag.set_primary_message(format_args!(
         "`{name}` is an abstract {method_kind} with a trivial body"
     ));
-    let spans = function.spans(db);
-    diag.annotate(
-        Annotation::secondary(spans.name).message(format_args!("Method `{name}` defined here")),
-    );
-    if let (_, Some(implementation)) = function.overloads_and_implementation(db)
+
+    let annotation = Annotation::secondary(abstract_method_span(
+        db,
+        &mut diag,
+        function,
+        AbstractMethodAnnotationPolicy::IncludeBody,
+    ))
+    .message(format_args!("Method `{name}` defined here"));
+
+    diag.annotate(annotation);
+}
+
+pub(super) fn abstract_method_span<'db>(
+    db: &'db dyn Db,
+    diagnostic: &mut Diagnostic,
+    function: FunctionType<'db>,
+    policy: AbstractMethodAnnotationPolicy,
+) -> Span {
+    let (_, implementation) = function.overloads_and_implementation(db);
+
+    if let Some(implementation) = implementation
         && let Some(span) =
             implementation.find_known_decorator_span(db, KnownFunction::AbstractMethod)
     {
-        diag.annotate(Annotation::secondary(span));
+        diagnostic.annotate(Annotation::secondary(span));
     }
+
+    if policy == AbstractMethodAnnotationPolicy::ExcludeBody {
+        return function.spans(db).name;
+    }
+
+    let file = function.file(db);
+    let module = parsed_module(db, file).load(db);
+    let node = implementation.map(|implementation| implementation.node(db, file, &module));
+
+    if let Some(node) = node
+        && let [single_stmt] = &*node.body
+        && let source_text = source_text(db, file)
+        && source_text.line_start(node.name.end()) == source_text.line_start(single_stmt.start())
+    {
+        Span::from(file).with_range(TextRange::new(node.name.start(), single_stmt.end()))
+    } else {
+        if let Some(node) = node
+            && let [single_stmt] = &*node.body
+        {
+            diagnostic.annotate(Annotation::secondary(
+                Span::from(file).with_range(single_stmt.range()),
+            ));
+        }
+
+        function.spans(db).name
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(super) enum AbstractMethodAnnotationPolicy {
+    IncludeBody,
+    ExcludeBody,
 }
 
 pub(crate) fn report_undeclared_protocol_member(

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4835,64 +4835,61 @@ pub(crate) fn report_call_to_abstract_method(
     diag.set_primary_message(format_args!(
         "`{name}` is an abstract {method_kind} with a trivial body"
     ));
-
-    let annotation = Annotation::secondary(abstract_method_span(
+    let span = abstract_method_span(
         db,
-        &mut diag,
         function,
-        AbstractMethodAnnotationPolicy::IncludeBody,
-    ))
-    .message(format_args!("Method `{name}` defined here"));
-
-    diag.annotate(annotation);
+        AbstractMethodAnnotationPolicy::AlwaysIncludeBody,
+    );
+    diag.annotate(
+        Annotation::secondary(span).message(format_args!("Method `{name}` defined here")),
+    );
 }
 
 pub(super) fn abstract_method_span<'db>(
     db: &'db dyn Db,
-    diagnostic: &mut Diagnostic,
     function: FunctionType<'db>,
     policy: AbstractMethodAnnotationPolicy,
 ) -> Span {
     let (_, implementation) = function.overloads_and_implementation(db);
 
-    if let Some(implementation) = implementation
-        && let Some(span) =
-            implementation.find_known_decorator_span(db, KnownFunction::AbstractMethod)
-    {
-        diagnostic.annotate(Annotation::secondary(span));
-    }
-
-    if policy == AbstractMethodAnnotationPolicy::ExcludeBody {
+    let Some(implementation) = implementation else {
         return function.spans(db).name;
-    }
+    };
 
     let file = function.file(db);
     let module = parsed_module(db, file).load(db);
-    let node = implementation.map(|implementation| implementation.node(db, file, &module));
+    let node = implementation.node(db, file, &module);
+    let source_text = source_text(db, file);
 
-    if let Some(node) = node
-        && let [single_stmt] = &*node.body
-        && let source_text = source_text(db, file)
-        && source_text.line_start(node.name.end()) == source_text.line_start(single_stmt.start())
+    let decorators_and_parameters = || {
+        Span::from(file).with_range(TextRange::new(
+            node.start(),
+            node.returns
+                .as_deref()
+                .map(Ranged::end)
+                .unwrap_or_else(|| node.parameters.end()),
+        ))
+    };
+
+    if policy == AbstractMethodAnnotationPolicy::ExcludeVerboseBody
+        && source_text.line_start(node.name.end()) != source_text.line_start(node.end())
     {
-        Span::from(file).with_range(TextRange::new(node.name.start(), single_stmt.end()))
-    } else {
-        if let Some(node) = node
-            && let [single_stmt] = &*node.body
-        {
-            diagnostic.annotate(Annotation::secondary(
-                Span::from(file).with_range(single_stmt.range()),
-            ));
-        }
+        return decorators_and_parameters();
+    }
 
-        function.spans(db).name
+    if let [single_stmt] = &*node.body
+        && source_text.line_start(single_stmt.start()) == source_text.line_start(single_stmt.end())
+    {
+        Span::from(file).with_range(node.range())
+    } else {
+        decorators_and_parameters()
     }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(super) enum AbstractMethodAnnotationPolicy {
-    IncludeBody,
-    ExcludeBody,
+    AlwaysIncludeBody,
+    ExcludeVerboseBody,
 }
 
 pub(crate) fn report_undeclared_protocol_member(

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -30,7 +30,7 @@ use crate::types::{
     ProtocolInstanceType, SpecialFormType, SubclassOfInner, Type, TypeContext, TypeVarVariance,
     binding_type, protocol_class::ProtocolClass,
 };
-use crate::types::{KnownInstanceType, MemberLookupPolicy, UnionType};
+use crate::types::{KnownInstanceType, MemberLookupPolicy, TypedDictType, UnionType};
 use crate::{Db, DisplaySettings, FxIndexMap, Program, declare_lint};
 use itertools::Itertools;
 use ruff_db::{
@@ -4834,12 +4834,15 @@ pub(crate) fn report_call_to_abstract_method(
         "`{name}` is an abstract {method_kind} with a trivial body"
     ));
     let spans = function.spans(db);
-    let mut sub = SubDiagnostic::new(
-        SubDiagnosticSeverity::Info,
-        format_args!("Method `{name}` defined here"),
+    diag.annotate(
+        Annotation::secondary(spans.name).message(format_args!("Method `{name}` defined here")),
     );
-    sub.annotate(Annotation::primary(spans.name));
-    diag.sub(sub);
+    if let (_, Some(implementation)) = function.overloads_and_implementation(db)
+        && let Some(span) =
+            implementation.find_known_decorator_span(db, KnownFunction::AbstractMethod)
+    {
+        diag.annotate(Annotation::secondary(span));
+    }
 }
 
 pub(crate) fn report_undeclared_protocol_member(
@@ -5344,7 +5347,7 @@ pub(crate) enum TypedDictDeleteErrorKind {
 pub(crate) fn report_cannot_delete_typed_dict_key<'db>(
     context: &InferContext<'db, '_>,
     key_node: AnyNodeRef,
-    typed_dict_ty: Type<'db>,
+    typed_dict_ty: TypedDictType<'db>,
     field_name: &str,
     field: Option<&crate::types::typed_dict::TypedDictField<'db>>,
     error_kind: TypedDictDeleteErrorKind,
@@ -5354,7 +5357,7 @@ pub(crate) fn report_cannot_delete_typed_dict_key<'db>(
         return;
     };
 
-    let typed_dict_name = typed_dict_ty.display(db);
+    let typed_dict_name = Type::TypedDict(typed_dict_ty).display(db);
 
     let mut diagnostic = match error_kind {
         TypedDictDeleteErrorKind::RequiredKey => builder.into_diagnostic(format_args!(
@@ -5373,14 +5376,27 @@ pub(crate) fn report_cannot_delete_typed_dict_key<'db>(
         let module = parsed_module(db, file).load(db);
 
         let mut sub = SubDiagnostic::new(SubDiagnosticSeverity::Info, "Field defined here");
-        sub.annotate(
-            Annotation::secondary(
-                Span::from(file).with_range(declaration.full_range(db, &module).range()),
-            )
-            .message(format_args!(
-                "`{field_name}` declared as required here; consider making it `NotRequired`"
-            )),
-        );
+        for message in [
+            format_args!("`{field_name}` declared as required here"),
+            format_args!("Consider making it `NotRequired`"),
+        ] {
+            sub.annotate(
+                Annotation::secondary(
+                    Span::from(file).with_range(declaration.full_range(db, &module).range()),
+                )
+                .message(message),
+            );
+        }
+
+        if let Some(class) = typed_dict_ty.defining_class() {
+            sub.annotate(
+                Annotation::secondary(
+                    Span::from(file).with_range(class.class_literal(db).header_range(db)),
+                )
+                .message(format_args!("`{}` defined here", class.name(db))),
+            );
+        }
+
         diagnostic.sub(sub);
     }
 
@@ -6329,6 +6345,7 @@ pub(super) fn report_invalid_total_ordering(
         "`{}` does not define `__lt__`, `__le__`, `__gt__`, or `__ge__`",
         class.name(db)
     ));
+    diagnostic.annotate(context.secondary(class.header_range(db)));
     diagnostic.info("The decorator will raise `ValueError` at runtime");
 }
 

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4861,20 +4861,10 @@ pub(super) fn abstract_method_span<'db>(
     let node = implementation.node(db, file, &module);
     let source_text = source_text(db, file);
 
-    let decorators_and_parameters = || {
-        Span::from(file).with_range(TextRange::new(
-            node.start(),
-            node.returns
-                .as_deref()
-                .map(Ranged::end)
-                .unwrap_or_else(|| node.parameters.end()),
-        ))
-    };
-
     if policy == AbstractMethodAnnotationPolicy::ExcludeVerboseBody
         && source_text.line_start(node.name.end()) != source_text.line_start(node.end())
     {
-        return decorators_and_parameters();
+        return implementation.spans(db).decorators_and_header;
     }
 
     if let [single_stmt] = &*node.body
@@ -4882,7 +4872,7 @@ pub(super) fn abstract_method_span<'db>(
     {
         Span::from(file).with_range(node.range())
     } else {
-        decorators_and_parameters()
+        implementation.spans(db).decorators_and_header
     }
 }
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -109,6 +109,10 @@ pub(crate) struct FunctionSpans {
     pub(crate) parameters: Span,
     /// The span of the annotated return type, if present.
     pub(crate) return_type: Option<Span>,
+    /// A span that starts at the beginning of the first decorator (if any),
+    /// and ends at the end of the function signature (either the last parameter,
+    /// or the return type if present).
+    pub(crate) decorators_and_header: Span,
 }
 
 bitflags! {
@@ -642,6 +646,7 @@ impl<'db> OverloadLiteral<'db> {
             name: span.clone().with_range(func_def.name.range),
             parameters: span.clone().with_range(func_def.parameters.range),
             return_type: return_type_range.map(|range| span.clone().with_range(range)),
+            decorators_and_header: span.with_range(signature.cover_offset(func_def.start())),
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -92,6 +92,11 @@ pub(crate) fn check_overloaded_function<'db>(
                 &function_node.name
             ));
             diagnostic.set_primary_message("Only one overload defined here");
+            if let Some(decorator) =
+                single_overload.find_known_decorator_span(db, KnownFunction::Overload)
+            {
+                diagnostic.annotate(Annotation::secondary(decorator));
+            }
         }
     }
 
@@ -130,9 +135,10 @@ pub(crate) fn check_overloaded_function<'db>(
             let function_node = overloads[0].node(db, context.file(), context.module());
             if let Some(builder) = context.report_lint(&INVALID_OVERLOAD, &function_node.name) {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
-                            "Overloads for function `{}` must be followed by a non-`@overload`-decorated implementation function",
-                            &function_node.name
-                        ));
+                    "Overloads for function `{}` must be followed by a \
+                    non-`@overload`-decorated implementation function",
+                    &function_node.name
+                ));
                 diagnostic.info(format_args!(
                     "Attempting to call `{}` will raise `TypeError` at runtime",
                     &function_node.name
@@ -178,7 +184,7 @@ pub(crate) fn check_overloaded_function<'db>(
         if let Some(builder) = context.report_lint(&INVALID_OVERLOAD, &function_node.name) {
             let mut diagnostic = builder.into_diagnostic(format_args!(
                 "Overloaded function `{}` does not use the `@{name}` decorator \
-                         consistently",
+                    consistently",
                 &function_node.name
             ));
             for function in decorator_missing {
@@ -187,6 +193,11 @@ pub(crate) fn check_overloaded_function<'db>(
                         .secondary(function.focus_range(db, context.module()))
                         .message(format_args!("Missing here")),
                 );
+                if let Some(decorator) =
+                    function.find_known_decorator_span(db, KnownFunction::Overload)
+                {
+                    diagnostic.annotate(Annotation::secondary(decorator));
+                }
             }
         }
     }
@@ -207,11 +218,13 @@ pub(crate) fn check_overloaded_function<'db>(
                 };
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "`@{name}` decorator should be applied only to the \
-                            overload implementation",
+                        overload implementation",
                     name = function.name()
                 ));
-                if let Some(decorator) = overload.find_known_decorator_span(db, function) {
-                    diagnostic.annotate(Annotation::secondary(decorator));
+                for function in [function, KnownFunction::Overload] {
+                    if let Some(decorator) = overload.find_known_decorator_span(db, function) {
+                        diagnostic.annotate(Annotation::secondary(decorator));
+                    }
                 }
                 diagnostic.annotate(
                     context
@@ -235,7 +248,7 @@ pub(crate) fn check_overloaded_function<'db>(
                 };
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "`@{name}` decorator should be applied only to the \
-                                first overload",
+                        first overload",
                     name = function.name()
                 ));
                 if let Some(decorator) = overload.find_known_decorator_span(db, function) {
@@ -246,6 +259,11 @@ pub(crate) fn check_overloaded_function<'db>(
                         .secondary(first_overload.focus_range(db, context.module()))
                         .message(format_args!("First overload defined here")),
                 );
+                if let Some(decorator) =
+                    first_overload.find_known_decorator_span(db, KnownFunction::Overload)
+                {
+                    diagnostic.annotate(Annotation::secondary(decorator));
+                }
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -1,5 +1,8 @@
-use ruff_db::{diagnostic::Annotation, parsed::parsed_module};
-use ruff_text_size::{Ranged, TextRange};
+use ruff_db::{
+    diagnostic::{Annotation, Span},
+    parsed::parsed_module,
+};
+use ruff_text_size::Ranged;
 use rustc_hash::FxHashSet;
 
 use crate::{
@@ -258,20 +261,13 @@ pub(crate) fn check_overloaded_function<'db>(
                 let file = function.file(db);
                 let module = parsed_module(db, file).load(db);
                 let node = first_overload.node(db, file, &module);
-                let range = if node.body.len() == 1 {
-                    node.range()
+                let span = if node.body.len() == 1 {
+                    Span::from(file).with_range(node.range())
                 } else {
-                    TextRange::new(
-                        node.start(),
-                        node.returns
-                            .as_deref()
-                            .map(Ranged::end)
-                            .unwrap_or_else(|| node.parameters.end()),
-                    )
+                    first_overload.spans(db).decorators_and_header
                 };
                 diagnostic.annotate(
-                    context
-                        .secondary(range)
+                    Annotation::secondary(span)
                         .message(format_args!("First overload defined here")),
                 );
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -1,5 +1,5 @@
-use ruff_db::diagnostic::Annotation;
-use ruff_text_size::Ranged;
+use ruff_db::{diagnostic::Annotation, parsed::parsed_module};
+use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
 
 use crate::{
@@ -202,7 +202,7 @@ pub(crate) fn check_overloaded_function<'db>(
         }
     }
 
-    for (function, decorator) in [
+    for (known_function, decorator) in [
         (KnownFunction::Final, FunctionDecorators::FINAL),
         (KnownFunction::Override, FunctionDecorators::OVERRIDE),
     ] {
@@ -219,10 +219,11 @@ pub(crate) fn check_overloaded_function<'db>(
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "`@{name}` decorator should be applied only to the \
                         overload implementation",
-                    name = function.name()
+                    name = known_function.name()
                 ));
-                for function in [function, KnownFunction::Overload] {
-                    if let Some(decorator) = overload.find_known_decorator_span(db, function) {
+                for known_function in [known_function, KnownFunction::Overload] {
+                    if let Some(decorator) = overload.find_known_decorator_span(db, known_function)
+                    {
                         diagnostic.annotate(Annotation::secondary(decorator));
                     }
                 }
@@ -249,21 +250,30 @@ pub(crate) fn check_overloaded_function<'db>(
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "`@{name}` decorator should be applied only to the \
                         first overload",
-                    name = function.name()
+                    name = known_function.name()
                 ));
-                if let Some(decorator) = overload.find_known_decorator_span(db, function) {
+                if let Some(decorator) = overload.find_known_decorator_span(db, known_function) {
                     diagnostic.annotate(Annotation::secondary(decorator));
                 }
+                let file = function.file(db);
+                let module = parsed_module(db, file).load(db);
+                let node = first_overload.node(db, file, &module);
+                let range = if node.body.len() == 1 {
+                    node.range()
+                } else {
+                    TextRange::new(
+                        node.start(),
+                        node.returns
+                            .as_deref()
+                            .map(Ranged::end)
+                            .unwrap_or_else(|| node.parameters.end()),
+                    )
+                };
                 diagnostic.annotate(
                     context
-                        .secondary(first_overload.focus_range(db, context.module()))
+                        .secondary(range)
                         .message(format_args!("First overload defined here")),
                 );
-                if let Some(decorator) =
-                    first_overload.find_known_decorator_span(db, KnownFunction::Overload)
-                {
-                    diagnostic.annotate(Annotation::secondary(decorator));
-                }
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -1159,11 +1159,11 @@ fn check_final_class_abstract_methods<'db>(
 
     if let Type::FunctionLiteral(function) = binding_type(db, *definition) {
         let policy = if kind.is_explicit() {
-            AbstractMethodAnnotationPolicy::ExcludeBody
+            AbstractMethodAnnotationPolicy::ExcludeVerboseBody
         } else {
-            AbstractMethodAnnotationPolicy::IncludeBody
+            AbstractMethodAnnotationPolicy::AlwaysIncludeBody
         };
-        let secondary_span = abstract_method_span(db, &mut diagnostic, function, policy);
+        let secondary_span = abstract_method_span(db, function, policy);
         let mut secondary_annotation = Annotation::secondary(secondary_span);
         secondary_annotation = if defining_class.class_literal(db) == ClassLiteral::Static(class) {
             secondary_annotation.message(format_args!("`{first_method_name}` declared as abstract"))

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -17,7 +17,7 @@ use crate::{
     types::{
         CallArguments, ClassBase, ClassLiteral, ClassType, GenericAlias, KnownInstanceType,
         MemberLookupPolicy, MetaclassCandidate, Parameters, Signature, SpecialFormType,
-        StaticClassLiteral, Type,
+        StaticClassLiteral, Type, binding_type,
         call::Argument,
         class::{
             AbstractMethod, CodeGeneratorKind, FieldKind, MetaclassErrorKind,
@@ -1095,6 +1095,23 @@ fn check_final_class_abstract_methods<'db>(
         "Final class `{class_name}` has unimplemented abstract methods",
     ));
 
+    let definition_types = infer_definition_types(db, class.definition(db));
+
+    if let Some(class_node) = class.body_scope(db).node(db).as_class()
+        && let Some(decorator) = class_node
+            .node(context.module())
+            .decorator_list
+            .iter()
+            .find(|decorator| {
+                definition_types
+                    .expression_type(&decorator.expression)
+                    .as_function_literal()
+                    .is_some_and(|function| function.is_known(db, KnownFunction::Final))
+            })
+    {
+        diagnostic.annotate(context.secondary(decorator));
+    }
+
     let num_abstract_methods = abstract_methods.len();
 
     if num_abstract_methods == 1 {
@@ -1152,6 +1169,13 @@ fn check_final_class_abstract_methods<'db>(
         ))
     };
     diagnostic.annotate(secondary_annotation);
+
+    if let Type::FunctionLiteral(function) = binding_type(db, *definition)
+        && let (_, Some(function)) = function.overloads_and_implementation(db)
+        && let Some(span) = function.find_known_decorator_span(db, KnownFunction::AbstractMethod)
+    {
+        diagnostic.annotate(Annotation::secondary(span));
+    }
 
     if !kind.is_explicit() {
         let mut sub = SubDiagnostic::new(

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -1,7 +1,6 @@
 use itertools::Itertools;
 use ruff_db::{
-    diagnostic::{Annotation, Span, SubDiagnostic, SubDiagnosticSeverity},
-    parsed::parsed_module,
+    diagnostic::{Annotation, SubDiagnostic, SubDiagnosticSeverity},
     source::source_text,
 };
 use ruff_diagnostics::{Edit, Fix};
@@ -9,7 +8,6 @@ use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use rustc_hash::FxHashMap;
 
-use crate::attribute_assignments;
 use crate::{
     TypeQualifiers,
     diagnostic::format_enumeration,
@@ -26,12 +24,12 @@ use crate::{
         context::InferContext,
         definition_expression_type,
         diagnostic::{
-            ABSTRACT_METHOD_IN_FINAL_CLASS, CONFLICTING_METACLASS, CYCLIC_CLASS_DEFINITION,
-            DATACLASS_FIELD_ORDER, DUPLICATE_KW_ONLY, FINAL_WITHOUT_VALUE, INCONSISTENT_MRO,
-            INVALID_ARGUMENT_TYPE, INVALID_BASE, INVALID_DATACLASS, INVALID_GENERIC_CLASS,
-            INVALID_GENERIC_ENUM, INVALID_METACLASS, INVALID_NAMED_TUPLE, INVALID_PROTOCOL,
-            INVALID_TYPED_DICT_HEADER, IncompatibleBases, SUBCLASS_OF_FINAL_CLASS,
-            UNKNOWN_ARGUMENT, report_bad_frozen_dataclass_inheritance,
+            ABSTRACT_METHOD_IN_FINAL_CLASS, AbstractMethodAnnotationPolicy, CONFLICTING_METACLASS,
+            CYCLIC_CLASS_DEFINITION, DATACLASS_FIELD_ORDER, DUPLICATE_KW_ONLY, FINAL_WITHOUT_VALUE,
+            INCONSISTENT_MRO, INVALID_ARGUMENT_TYPE, INVALID_BASE, INVALID_DATACLASS,
+            INVALID_GENERIC_CLASS, INVALID_GENERIC_ENUM, INVALID_METACLASS, INVALID_NAMED_TUPLE,
+            INVALID_PROTOCOL, INVALID_TYPED_DICT_HEADER, IncompatibleBases,
+            SUBCLASS_OF_FINAL_CLASS, UNKNOWN_ARGUMENT, report_bad_frozen_dataclass_inheritance,
             report_conflicting_metaclass_from_bases, report_duplicate_bases,
             report_instance_layout_conflict, report_invalid_or_unsupported_base,
             report_invalid_total_ordering, report_invalid_type_param_order,
@@ -53,6 +51,7 @@ use crate::{
         visitor::find_over_type,
     },
 };
+use crate::{attribute_assignments, types::diagnostic::abstract_method_span};
 use ty_python_core::{SemanticIndex, definition::DefinitionKind, scope::ScopeId};
 
 /// Iterate over all static class definitions (created using `class` statements) to check that
@@ -1156,25 +1155,24 @@ fn check_final_class_abstract_methods<'db>(
         kind,
     } = abstract_method;
 
-    let module = parsed_module(db, definition.file(db)).load(db);
-    let span = Span::from(definition.focus_range(db, &module));
     let defining_class_name = defining_class.name(db);
 
-    let mut secondary_annotation = Annotation::secondary(span);
-    secondary_annotation = if defining_class.class_literal(db) == ClassLiteral::Static(class) {
-        secondary_annotation.message(format_args!("`{first_method_name}` declared as abstract"))
-    } else {
-        secondary_annotation.message(format_args!(
-            "`{first_method_name}` declared as abstract on superclass `{defining_class_name}`",
-        ))
-    };
-    diagnostic.annotate(secondary_annotation);
-
-    if let Type::FunctionLiteral(function) = binding_type(db, *definition)
-        && let (_, Some(function)) = function.overloads_and_implementation(db)
-        && let Some(span) = function.find_known_decorator_span(db, KnownFunction::AbstractMethod)
-    {
-        diagnostic.annotate(Annotation::secondary(span));
+    if let Type::FunctionLiteral(function) = binding_type(db, *definition) {
+        let policy = if kind.is_explicit() {
+            AbstractMethodAnnotationPolicy::ExcludeBody
+        } else {
+            AbstractMethodAnnotationPolicy::IncludeBody
+        };
+        let secondary_span = abstract_method_span(db, &mut diagnostic, function, policy);
+        let mut secondary_annotation = Annotation::secondary(secondary_span);
+        secondary_annotation = if defining_class.class_literal(db) == ClassLiteral::Static(class) {
+            secondary_annotation.message(format_args!("`{first_method_name}` declared as abstract"))
+        } else {
+            secondary_annotation.message(format_args!(
+                "`{first_method_name}` declared as abstract on superclass `{defining_class_name}`",
+            ))
+        };
+        diagnostic.annotate(secondary_annotation);
     }
 
     if !kind.is_explicit() {

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -1599,7 +1599,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                                 report_cannot_delete_typed_dict_key(
                                                     &self.context,
                                                     (&*target.slice).into(),
-                                                    object_ty,
+                                                    typed_dict,
                                                     key,
                                                     Some(field),
                                                     TypedDictDeleteErrorKind::RequiredKey,
@@ -1609,7 +1609,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                                 report_cannot_delete_typed_dict_key(
                                                     &self.context,
                                                     (&*target.slice).into(),
-                                                    object_ty,
+                                                    typed_dict,
                                                     key,
                                                     None,
                                                     TypedDictDeleteErrorKind::UnknownKey,


### PR DESCRIPTION
## Summary

Following https://github.com/astral-sh/ruff/pull/24689, it's now much more likely that a diagnostic regarding an invalid `@final`, for example, will not include the `@final` decorator in the code frame.

This was already a pre-existing issue, because there's nothing to stop a class from having multiple decorators, so `@final` was really only "accidentally" in the context window most of the time. E.g. for this class, `@final` would not have been in the context window even with our old context margin of 2:

```py
from typing import final
from abc import abstractmethod
from dataclasses import dataclass
from functools import total_ordering

@final
@dataclass
@total_ordering
class Foo:
    @abstractmethod
    def __lt__(self, other): ...
```

Our diagnostic on the latest release of ty for that was:

<img width="1678" height="442" alt="image" src="https://github.com/user-attachments/assets/a87e4040-82fb-48c2-896f-27d398a83059" />

But #24689 makes this problem much likelier to occur. This PR therefore adds secondary annotations to several diagnostics that ensure that relevant decorators are included in the diagnostic frames rendered to the user

## Test plan

snapshots updated