### PR TITLE
[flake8-use-pathlib] Avoid bytes-path false positives in PTH rules

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/bytes_paths.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/bytes_paths.py
@@ -1,0 +1,35 @@
+import glob
+import os
+import os.path
+
+bytes_path = b"file.py"
+bytes_dir = b"directory"
+bytes_src = b"src"
+bytes_dst = b"dst"
+
+open(bytes_path)
+os.chmod(bytes_path, 0o444)
+os.mkdir(bytes_dir)
+os.makedirs(bytes_dir)
+os.rename(bytes_src, bytes_dst)
+os.replace(bytes_src, bytes_dst)
+os.rmdir(bytes_dir)
+os.remove(bytes_path)
+os.unlink(bytes_path)
+os.readlink(bytes_path)
+os.stat(bytes_path)
+os.path.exists(bytes_path)
+os.path.expanduser(bytes_path)
+os.path.isdir(bytes_dir)
+os.path.isfile(bytes_path)
+os.path.islink(bytes_path)
+os.path.isabs(bytes_path)
+os.path.join(bytes_dir, bytes_path)
+os.path.basename(bytes_path)
+os.path.dirname(bytes_path)
+os.path.samefile(bytes_src, bytes_dst)
+os.path.splitext(bytes_path)
+os.listdir(bytes_dir)
+os.symlink(bytes_src, bytes_dst)
+glob.glob(bytes_path)
+glob.iglob(bytes_path)

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/helpers.rs
@@ -67,6 +67,10 @@ pub(crate) fn check_os_pathlib_single_arg_calls(
         return;
     };
 
+    if is_bytes_path(arg, checker.semantic()) {
+        return;
+    }
+
     let arg_code = checker.locator().slice(arg.range());
     let range = call.range();
 
@@ -134,6 +138,23 @@ pub(crate) fn is_file_descriptor(expr: &Expr, semantic: &SemanticModel) -> bool 
     typing::is_int(binding, semantic)
 }
 
+/// Returns `true` if the given expression looks like a bytes path.
+pub(crate) fn is_bytes_path(expr: &Expr, semantic: &SemanticModel) -> bool {
+    if matches!(expr, Expr::BytesLiteral(_)) {
+        return true;
+    }
+
+    let Some(name) = get_name_expr(expr) else {
+        return false;
+    };
+
+    let Some(binding) = semantic.only_binding(name).map(|id| semantic.binding(id)) else {
+        return false;
+    };
+
+    typing::is_bytes(binding, semantic)
+}
+
 #[expect(clippy::too_many_arguments)]
 pub(crate) fn check_os_pathlib_two_arg_calls(
     checker: &Checker,
@@ -145,6 +166,17 @@ pub(crate) fn check_os_pathlib_two_arg_calls(
     violation: impl Violation,
     applicability: Applicability,
 ) {
+    if let (Some(path_expr), Some(second_expr)) = (
+        call.arguments.find_argument_value(path_arg, 0),
+        call.arguments.find_argument_value(second_arg, 1),
+    ) {
+        if is_bytes_path(path_expr, checker.semantic())
+            || is_bytes_path(second_expr, checker.semantic())
+        {
+            return;
+        }
+    }
+
     let range = call.range();
     let mut diagnostic = checker.report_diagnostic(violation, call.func.range());
 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
@@ -18,6 +18,7 @@ mod tests {
     use crate::{assert_diagnostics, assert_diagnostics_diff};
 
     #[test_case(Path::new("full_name.py"))]
+    #[test_case(Path::new("bytes_paths.py"))]
     #[test_case(Path::new("import_as.py"))]
     #[test_case(Path::new("import_from_as.py"))]
     #[test_case(Path::new("import_from.py"))]
@@ -106,6 +107,7 @@ mod tests {
     }
 
     #[test_case(Path::new("full_name.py"))]
+    #[test_case(Path::new("bytes_paths.py"))]
     #[test_case(Path::new("import_as.py"))]
     #[test_case(Path::new("import_from_as.py"))]
     #[test_case(Path::new("import_from.py"))]

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/builtin_open.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/builtin_open.rs
@@ -7,8 +7,8 @@ use crate::checkers::ast::Checker;
 use crate::importer::ImportRequest;
 use crate::preview::is_fix_builtin_open_enabled;
 use crate::rules::flake8_use_pathlib::helpers::{
-    has_unknown_keywords_or_starred_expr, is_argument_non_default, is_file_descriptor,
-    is_pathlib_path_call,
+    has_unknown_keywords_or_starred_expr, is_argument_non_default, is_bytes_path,
+    is_file_descriptor, is_pathlib_path_call,
 };
 use crate::{FixAvailability, Violation};
 
@@ -100,7 +100,9 @@ pub(crate) fn builtin_open(checker: &Checker, call: &ExprCall, segments: &[&str]
             )
         })
         || is_argument_non_default(&call.arguments, "opener", 7)
-        || file_arg.is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
+        || file_arg.is_some_and(|expr| {
+            is_file_descriptor(expr, checker.semantic()) || is_bytes_path(expr, checker.semantic())
+        })
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_chmod.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_chmod.rs
@@ -7,8 +7,8 @@ use crate::checkers::ast::Checker;
 use crate::importer::ImportRequest;
 use crate::preview::is_fix_os_chmod_enabled;
 use crate::rules::flake8_use_pathlib::helpers::{
-    has_unknown_keywords_or_starred_expr, is_file_descriptor, is_keyword_only_argument_non_default,
-    is_pathlib_path_call,
+    has_unknown_keywords_or_starred_expr, is_bytes_path, is_file_descriptor,
+    is_keyword_only_argument_non_default, is_pathlib_path_call,
 };
 use crate::{FixAvailability, Violation};
 
@@ -81,8 +81,9 @@ pub(crate) fn os_chmod(checker: &Checker, call: &ExprCall, segments: &[&str]) {
     // ```
     let path_arg = call.arguments.find_argument_value("path", 0);
 
-    if path_arg.is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
-        || is_keyword_only_argument_non_default(&call.arguments, "dir_fd")
+    if path_arg.is_some_and(|expr| {
+        is_file_descriptor(expr, checker.semantic()) || is_bytes_path(expr, checker.semantic())
+    }) || is_keyword_only_argument_non_default(&call.arguments, "dir_fd")
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_makedirs.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_makedirs.rs
@@ -7,7 +7,7 @@ use crate::checkers::ast::Checker;
 use crate::importer::ImportRequest;
 use crate::preview::is_fix_os_makedirs_enabled;
 use crate::rules::flake8_use_pathlib::helpers::{
-    has_unknown_keywords_or_starred_expr, is_pathlib_path_call,
+    has_unknown_keywords_or_starred_expr, is_bytes_path, is_pathlib_path_call,
 };
 use crate::{FixAvailability, Violation};
 
@@ -72,12 +72,16 @@ pub(crate) fn os_makedirs(checker: &Checker, call: &ExprCall, segments: &[&str])
         return;
     }
 
-    let range = call.range();
-    let mut diagnostic = checker.report_diagnostic(OsMakedirs, call.func.range());
-
     let Some(name) = call.arguments.find_argument_value("name", 0) else {
         return;
     };
+
+    if is_bytes_path(name, checker.semantic()) {
+        return;
+    }
+
+    let range = call.range();
+    let mut diagnostic = checker.report_diagnostic(OsMakedirs, call.func.range());
 
     if !is_fix_os_makedirs_enabled(checker.settings()) {
         return;

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_mkdir.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_mkdir.rs
@@ -7,7 +7,7 @@ use crate::checkers::ast::Checker;
 use crate::importer::ImportRequest;
 use crate::preview::is_fix_os_mkdir_enabled;
 use crate::rules::flake8_use_pathlib::helpers::{
-    has_unknown_keywords_or_starred_expr, is_keyword_only_argument_non_default,
+    has_unknown_keywords_or_starred_expr, is_bytes_path, is_keyword_only_argument_non_default,
     is_pathlib_path_call,
 };
 use crate::{FixAvailability, Violation};
@@ -82,12 +82,16 @@ pub(crate) fn os_mkdir(checker: &Checker, call: &ExprCall, segments: &[&str]) {
         return;
     }
 
-    let range = call.range();
-    let mut diagnostic = checker.report_diagnostic(OsMkdir, call.func.range());
-
     let Some(path) = call.arguments.find_argument_value("path", 0) else {
         return;
     };
+
+    if is_bytes_path(path, checker.semantic()) {
+        return;
+    }
+
+    let range = call.range();
+    let mut diagnostic = checker.report_diagnostic(OsMkdir, call.func.range());
 
     if !is_fix_os_mkdir_enabled(checker.settings()) {
         return;

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_symlink.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_symlink.rs
@@ -7,7 +7,7 @@ use crate::checkers::ast::Checker;
 use crate::importer::ImportRequest;
 use crate::preview::is_fix_os_symlink_enabled;
 use crate::rules::flake8_use_pathlib::helpers::{
-    has_unknown_keywords_or_starred_expr, is_keyword_only_argument_non_default,
+    has_unknown_keywords_or_starred_expr, is_bytes_path, is_keyword_only_argument_non_default,
     is_pathlib_path_call,
 };
 use crate::{FixAvailability, Violation};
@@ -80,6 +80,17 @@ pub(crate) fn os_symlink(checker: &Checker, call: &ExprCall, segments: &[&str]) 
         return;
     }
 
+    let (Some(src), Some(dst)) = (
+        call.arguments.find_argument_value("src", 0),
+        call.arguments.find_argument_value("dst", 1),
+    ) else {
+        return;
+    };
+
+    if is_bytes_path(src, checker.semantic()) || is_bytes_path(dst, checker.semantic()) {
+        return;
+    }
+
     let range = call.range();
     let mut diagnostic = checker.report_diagnostic(OsSymlink, call.func.range());
 
@@ -97,13 +108,6 @@ pub(crate) fn os_symlink(checker: &Checker, call: &ExprCall, segments: &[&str]) 
     ) {
         return;
     }
-
-    let (Some(src), Some(dst)) = (
-        call.arguments.find_argument_value("src", 0),
-        call.arguments.find_argument_value("dst", 1),
-    ) else {
-        return;
-    };
 
     diagnostic.try_set_fix(|| {
         let (import_edit, binding) = checker.importer().get_or_import_symbol(

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
@@ -3,7 +3,7 @@ use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
 use crate::rules::flake8_use_pathlib::helpers::{
-    is_file_descriptor, is_keyword_only_argument_non_default,
+    is_bytes_path, is_file_descriptor, is_keyword_only_argument_non_default,
 };
 use crate::rules::flake8_use_pathlib::{
     rules::Glob,
@@ -28,7 +28,10 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             if call
                 .arguments
                 .find_argument_value("path", 0)
-                .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
+                .is_some_and(|expr| {
+                    is_file_descriptor(expr, checker.semantic())
+                        || is_bytes_path(expr, checker.semantic())
+                })
                 || is_keyword_only_argument_non_default(&call.arguments, "dir_fd")
             {
                 return;
@@ -36,17 +39,27 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             checker.report_diagnostic_if_enabled(OsStat, range)
         }
         // PTH118
-        ["os", "path", "join"] => checker.report_diagnostic_if_enabled(
-            OsPathJoin {
-                module: "path".to_string(),
-                joiner: if call.arguments.args.iter().any(Expr::is_starred_expr) {
-                    Joiner::Joinpath
-                } else {
-                    Joiner::Slash
+        ["os", "path", "join"] => {
+            if call
+                .arguments
+                .args
+                .iter()
+                .any(|expr| is_bytes_path(expr, checker.semantic()))
+            {
+                return;
+            }
+            checker.report_diagnostic_if_enabled(
+                OsPathJoin {
+                    module: "path".to_string(),
+                    joiner: if call.arguments.args.iter().any(Expr::is_starred_expr) {
+                        Joiner::Joinpath
+                    } else {
+                        Joiner::Slash
+                    },
                 },
-            },
-            range,
-        ),
+                range,
+            )
+        }
         ["os", "sep", "join"] => checker.report_diagnostic_if_enabled(
             OsPathJoin {
                 module: "sep".to_string(),
@@ -59,7 +72,16 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             range,
         ),
         // PTH122
-        ["os", "path", "splitext"] => checker.report_diagnostic_if_enabled(OsPathSplitext, range),
+        ["os", "path", "splitext"] => {
+            if call
+                .arguments
+                .find_argument_value("p", 0)
+                .is_some_and(|expr| is_bytes_path(expr, checker.semantic()))
+            {
+                return;
+            }
+            checker.report_diagnostic_if_enabled(OsPathSplitext, range)
+        }
         // PTH124
         ["py", "path", "local"] => checker.report_diagnostic_if_enabled(PyPath, range),
         // PTH207
@@ -71,6 +93,13 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             // glob.glob(pathname, *, root_dir=None, dir_fd=None, recursive=False, include_hidden=False)
             // ```
             if is_keyword_only_argument_non_default(&call.arguments, "dir_fd") {
+                return;
+            }
+            if call
+                .arguments
+                .find_argument_value("pathname", 0)
+                .is_some_and(|expr| is_bytes_path(expr, checker.semantic()))
+            {
                 return;
             }
 
@@ -92,6 +121,13 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             if is_keyword_only_argument_non_default(&call.arguments, "dir_fd") {
                 return;
             }
+            if call
+                .arguments
+                .find_argument_value("pathname", 0)
+                .is_some_and(|expr| is_bytes_path(expr, checker.semantic()))
+            {
+                return;
+            }
 
             checker.report_diagnostic_if_enabled(
                 Glob {
@@ -105,7 +141,10 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             if call
                 .arguments
                 .find_argument_value("path", 0)
-                .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
+                .is_some_and(|expr| {
+                    is_file_descriptor(expr, checker.semantic())
+                        || is_bytes_path(expr, checker.semantic())
+                })
             {
                 return;
             }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH202_PTH202.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH202_PTH202.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+assertion_line: 82
 ---
 PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
   --> PTH202.py:10:1
@@ -8,17 +9,6 @@ PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
    | ^^^^^^^^^^^^^^^
 11 | os.path.getsize(b"filename")
 12 | os.path.getsize(Path("filename"))
-   |
-help: Replace with `Path(...).stat().st_size`
-
-PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
-  --> PTH202.py:11:1
-   |
-10 | os.path.getsize("filename")
-11 | os.path.getsize(b"filename")
-   | ^^^^^^^^^^^^^^^
-12 | os.path.getsize(Path("filename"))
-13 | os.path.getsize(__file__)
    |
 help: Replace with `Path(...).stat().st_size`
 
@@ -92,17 +82,6 @@ PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
 help: Replace with `Path(...).stat().st_size`
 
 PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
-  --> PTH202.py:20:1
-   |
-19 | os.path.getsize(filename="filename")
-20 | os.path.getsize(filename=b"filename")
-   | ^^^^^^^^^^^^^^^
-21 | os.path.getsize(filename=Path("filename"))
-22 | os.path.getsize(filename=__file__)
-   |
-help: Replace with `Path(...).stat().st_size`
-
-PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
   --> PTH202.py:21:1
    |
 19 | os.path.getsize(filename="filename")
@@ -138,17 +117,6 @@ PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
 help: Replace with `Path(...).stat().st_size`
 
 PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
-  --> PTH202.py:25:1
-   |
-24 | getsize("filename")
-25 | getsize(b"filename")
-   | ^^^^^^^
-26 | getsize(Path("filename"))
-27 | getsize(__file__)
-   |
-help: Replace with `Path(...).stat().st_size`
-
-PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
   --> PTH202.py:26:1
    |
 24 | getsize("filename")
@@ -180,17 +148,6 @@ PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
    | ^^^^^^^
 30 | getsize(filename=b"filename")
 31 | getsize(filename=Path("filename"))
-   |
-help: Replace with `Path(...).stat().st_size`
-
-PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
-  --> PTH202.py:30:1
-   |
-29 | getsize(filename="filename")
-30 | getsize(filename=b"filename")
-   | ^^^^^^^
-31 | getsize(filename=Path("filename"))
-32 | getsize(filename=__file__)
    |
 help: Replace with `Path(...).stat().st_size`
 
@@ -272,18 +229,6 @@ PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
 help: Replace with `Path(...).stat().st_size`
 
 PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
-  --> PTH202.py:50:1
-   |
-48 | )
-49 |
-50 | os.path.getsize(
-   | ^^^^^^^^^^^^^^^
-51 |     # comment
-52 |     b"filename"
-   |
-help: Replace with `Path(...).stat().st_size`
-
-PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
   --> PTH202.py:56:1
    |
 54 | )
@@ -303,18 +248,6 @@ PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
 61 | getsize( # comment
    | ^^^^^^^
 62 |     "filename")
-   |
-help: Replace with `Path(...).stat().st_size`
-
-PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
-  --> PTH202.py:64:1
-   |
-62 |     "filename")
-63 |
-64 | getsize( # comment
-   | ^^^^^^^
-65 |     b"filename",
-66 |     #comment
    |
 help: Replace with `Path(...).stat().st_size`
 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH202_PTH202_2.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH202_PTH202_2.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+assertion_line: 82
 ---
 PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
  --> PTH202_2.py:3:1
@@ -9,16 +10,6 @@ PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
 3 | os.path.getsize(filename="filename")
   | ^^^^^^^^^^^^^^^
 4 | os.path.getsize(filename=b"filename")
-5 | os.path.getsize(filename=__file__)
-  |
-help: Replace with `Path(...).stat().st_size`
-
-PTH202 `os.path.getsize` should be replaced by `Path.stat().st_size`
- --> PTH202_2.py:4:1
-  |
-3 | os.path.getsize(filename="filename")
-4 | os.path.getsize(filename=b"filename")
-  | ^^^^^^^^^^^^^^^
 5 | os.path.getsize(filename=__file__)
   |
 help: Replace with `Path(...).stat().st_size`

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH203_PTH203.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH203_PTH203.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+assertion_line: 82
 ---
 PTH203 `os.path.getatime` should be replaced by `Path.stat().st_atime`
  --> PTH203.py:5:1
@@ -9,16 +10,6 @@ PTH203 `os.path.getatime` should be replaced by `Path.stat().st_atime`
 5 | os.path.getatime("filename")
   | ^^^^^^^^^^^^^^^^
 6 | os.path.getatime(b"filename")
-7 | os.path.getatime(Path("filename"))
-  |
-help: Replace with `Path.stat(...).st_atime`
-
-PTH203 `os.path.getatime` should be replaced by `Path.stat().st_atime`
- --> PTH203.py:6:1
-  |
-5 | os.path.getatime("filename")
-6 | os.path.getatime(b"filename")
-  | ^^^^^^^^^^^^^^^^
 7 | os.path.getatime(Path("filename"))
   |
 help: Replace with `Path.stat(...).st_atime`
@@ -39,16 +30,6 @@ PTH203 `os.path.getatime` should be replaced by `Path.stat().st_atime`
 10 | getatime("filename")
    | ^^^^^^^^
 11 | getatime(b"filename")
-12 | getatime(Path("filename"))
-   |
-help: Replace with `Path.stat(...).st_atime`
-
-PTH203 `os.path.getatime` should be replaced by `Path.stat().st_atime`
-  --> PTH203.py:11:1
-   |
-10 | getatime("filename")
-11 | getatime(b"filename")
-   | ^^^^^^^^
 12 | getatime(Path("filename"))
    |
 help: Replace with `Path.stat(...).st_atime`

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH204_PTH204.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH204_PTH204.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+assertion_line: 82
 ---
 PTH204 `os.path.getmtime` should be replaced by `Path.stat().st_mtime`
  --> PTH204.py:6:1
@@ -7,16 +8,6 @@ PTH204 `os.path.getmtime` should be replaced by `Path.stat().st_mtime`
 6 | os.path.getmtime("filename")
   | ^^^^^^^^^^^^^^^^
 7 | os.path.getmtime(b"filename")
-8 | os.path.getmtime(Path("filename"))
-  |
-help: Replace with `Path.stat(...).st_mtime`
-
-PTH204 `os.path.getmtime` should be replaced by `Path.stat().st_mtime`
- --> PTH204.py:7:1
-  |
-6 | os.path.getmtime("filename")
-7 | os.path.getmtime(b"filename")
-  | ^^^^^^^^^^^^^^^^
 8 | os.path.getmtime(Path("filename"))
   |
 help: Replace with `Path.stat(...).st_mtime`
@@ -37,16 +28,6 @@ PTH204 `os.path.getmtime` should be replaced by `Path.stat().st_mtime`
 11 | getmtime("filename")
    | ^^^^^^^^
 12 | getmtime(b"filename")
-13 | getmtime(Path("filename"))
-   |
-help: Replace with `Path.stat(...).st_mtime`
-
-PTH204 `os.path.getmtime` should be replaced by `Path.stat().st_mtime`
-  --> PTH204.py:12:1
-   |
-11 | getmtime("filename")
-12 | getmtime(b"filename")
-   | ^^^^^^^^
 13 | getmtime(Path("filename"))
    |
 help: Replace with `Path.stat(...).st_mtime`

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH205_PTH205.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH205_PTH205.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+assertion_line: 82
 ---
 PTH205 `os.path.getctime` should be replaced by `Path.stat().st_ctime`
  --> PTH205.py:6:1
@@ -7,16 +8,6 @@ PTH205 `os.path.getctime` should be replaced by `Path.stat().st_ctime`
 6 | os.path.getctime("filename")
   | ^^^^^^^^^^^^^^^^
 7 | os.path.getctime(b"filename")
-8 | os.path.getctime(Path("filename"))
-  |
-help: Replace with `Path.stat(...).st_ctime`
-
-PTH205 `os.path.getctime` should be replaced by `Path.stat().st_ctime`
- --> PTH205.py:7:1
-  |
-6 | os.path.getctime("filename")
-7 | os.path.getctime(b"filename")
-  | ^^^^^^^^^^^^^^^^
 8 | os.path.getctime(Path("filename"))
   |
 help: Replace with `Path.stat(...).st_ctime`
@@ -41,16 +32,6 @@ PTH205 `os.path.getctime` should be replaced by `Path.stat().st_ctime`
 10 | getctime("filename")
    | ^^^^^^^^
 11 | getctime(b"filename")
-12 | getctime(Path("filename"))
-   |
-help: Replace with `Path.stat(...).st_ctime`
-
-PTH205 `os.path.getctime` should be replaced by `Path.stat().st_ctime`
-  --> PTH205.py:11:1
-   |
-10 | getctime("filename")
-11 | getctime(b"filename")
-   | ^^^^^^^^
 12 | getctime(Path("filename"))
    |
 help: Replace with `Path.stat(...).st_ctime`

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH208_PTH208.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH208_PTH208.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+assertion_line: 82
 ---
 PTH208 Use `pathlib.Path.iterdir()` instead.
  --> PTH208.py:3:1
@@ -12,16 +13,6 @@ PTH208 Use `pathlib.Path.iterdir()` instead.
   |
 
 PTH208 Use `pathlib.Path.iterdir()` instead.
- --> PTH208.py:4:1
-  |
-3 | os.listdir('.')
-4 | os.listdir(b'.')
-  | ^^^^^^^^^^
-5 |
-6 | string_path = '.'
-  |
-
-PTH208 Use `pathlib.Path.iterdir()` instead.
  --> PTH208.py:7:1
   |
 6 | string_path = '.'
@@ -30,14 +21,6 @@ PTH208 Use `pathlib.Path.iterdir()` instead.
 8 |
 9 | bytes_path = b'.'
   |
-
-PTH208 Use `pathlib.Path.iterdir()` instead.
-  --> PTH208.py:10:1
-   |
- 9 | bytes_path = b'.'
-10 | os.listdir(bytes_path)
-   | ^^^^^^^^^^
-   |
 
 PTH208 Use `pathlib.Path.iterdir()` instead.
   --> PTH208.py:16:1

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH211_PTH211.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH211_PTH211.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+assertion_line: 82
 ---
 PTH211 `os.symlink` should be replaced by `Path.symlink_to`
  --> PTH211.py:5:1
@@ -12,16 +13,6 @@ PTH211 `os.symlink` should be replaced by `Path.symlink_to`
 help: Replace with `Path(...).symlink_to(...)`
 
 PTH211 `os.symlink` should be replaced by `Path.symlink_to`
- --> PTH211.py:6:1
-  |
-5 | os.symlink("usr/bin/python", "tmp/python")
-6 | os.symlink(b"usr/bin/python", b"tmp/python")
-  | ^^^^^^^^^^
-7 | Path("tmp/python").symlink_to("usr/bin/python")  # Ok
-  |
-help: Replace with `Path(...).symlink_to(...)`
-
-PTH211 `os.symlink` should be replaced by `Path.symlink_to`
   --> PTH211.py:9:1
    |
  7 | Path("tmp/python").symlink_to("usr/bin/python")  # Ok
@@ -29,16 +20,6 @@ PTH211 `os.symlink` should be replaced by `Path.symlink_to`
  9 | os.symlink("usr/bin/python", "tmp/python", target_is_directory=True)
    | ^^^^^^^^^^
 10 | os.symlink(b"usr/bin/python", b"tmp/python", target_is_directory=True)
-11 | Path("tmp/python").symlink_to("usr/bin/python", target_is_directory=True)  # Ok
-   |
-help: Replace with `Path(...).symlink_to(...)`
-
-PTH211 `os.symlink` should be replaced by `Path.symlink_to`
-  --> PTH211.py:10:1
-   |
- 9 | os.symlink("usr/bin/python", "tmp/python", target_is_directory=True)
-10 | os.symlink(b"usr/bin/python", b"tmp/python", target_is_directory=True)
-   | ^^^^^^^^^^
 11 | Path("tmp/python").symlink_to("usr/bin/python", target_is_directory=True)  # Ok
    |
 help: Replace with `Path(...).symlink_to(...)`

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__bytes_paths.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__bytes_paths.py.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+assertion_line: 57
+---
+

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__full_name.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__full_name.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+assertion_line: 57
 ---
 PTH100 `os.path.abspath()` should be replaced by `Path.resolve()`
  --> full_name.py:7:5
@@ -372,42 +373,6 @@ PTH123 `open()` should be replaced by `Path.open()`
 47 | open(p, 'r', - 1, None, None, None, True, None)
    | ^^^^
 48 | open(p, 'r', - 1, None, None, None, False, opener)
-   |
-help: Replace with `Path.open()`
-
-PTH123 `open()` should be replaced by `Path.open()`
-  --> full_name.py:65:1
-   |
-63 | open(f())
-64 |
-65 | open(b"foo")
-   | ^^^^
-66 | byte_str = b"bar"
-67 | open(byte_str)
-   |
-help: Replace with `Path.open()`
-
-PTH123 `open()` should be replaced by `Path.open()`
-  --> full_name.py:67:1
-   |
-65 | open(b"foo")
-66 | byte_str = b"bar"
-67 | open(byte_str)
-   | ^^^^
-68 |
-69 | def bytes_str_func() -> bytes:
-   |
-help: Replace with `Path.open()`
-
-PTH123 `open()` should be replaced by `Path.open()`
-  --> full_name.py:71:1
-   |
-69 | def bytes_str_func() -> bytes:
-70 |     return b"foo"
-71 | open(bytes_str_func())
-   | ^^^^
-72 |
-73 | # https://github.com/astral-sh/ruff/issues/17693
    |
 help: Replace with `Path.open()`
 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview__PTH202_PTH202.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview__PTH202_PTH202.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+assertion_line: 172
 ---
 PTH202 [*] `os.path.getsize` should be replaced by `Path.stat().st_size`
   --> PTH202.py:10:1
@@ -18,25 +19,6 @@ help: Replace with `Path(...).stat().st_size`
 11 | os.path.getsize(b"filename")
 12 | os.path.getsize(Path("filename"))
 13 | os.path.getsize(__file__)
-
-PTH202 [*] `os.path.getsize` should be replaced by `Path.stat().st_size`
-  --> PTH202.py:11:1
-   |
-10 | os.path.getsize("filename")
-11 | os.path.getsize(b"filename")
-   | ^^^^^^^^^^^^^^^
-12 | os.path.getsize(Path("filename"))
-13 | os.path.getsize(__file__)
-   |
-help: Replace with `Path(...).stat().st_size`
-8  |
-9  |
-10 | os.path.getsize("filename")
-   - os.path.getsize(b"filename")
-11 + Path(b"filename").stat().st_size
-12 | os.path.getsize(Path("filename"))
-13 | os.path.getsize(__file__)
-14 |
 
 PTH202 [*] `os.path.getsize` should be replaced by `Path.stat().st_size`
   --> PTH202.py:12:1
@@ -156,25 +138,6 @@ help: Replace with `Path(...).stat().st_size`
 22 | os.path.getsize(filename=__file__)
 
 PTH202 [*] `os.path.getsize` should be replaced by `Path.stat().st_size`
-  --> PTH202.py:20:1
-   |
-19 | os.path.getsize(filename="filename")
-20 | os.path.getsize(filename=b"filename")
-   | ^^^^^^^^^^^^^^^
-21 | os.path.getsize(filename=Path("filename"))
-22 | os.path.getsize(filename=__file__)
-   |
-help: Replace with `Path(...).stat().st_size`
-17 | os.path.getsize(filename2)
-18 |
-19 | os.path.getsize(filename="filename")
-   - os.path.getsize(filename=b"filename")
-20 + Path(b"filename").stat().st_size
-21 | os.path.getsize(filename=Path("filename"))
-22 | os.path.getsize(filename=__file__)
-23 |
-
-PTH202 [*] `os.path.getsize` should be replaced by `Path.stat().st_size`
   --> PTH202.py:21:1
    |
 19 | os.path.getsize(filename="filename")
@@ -234,25 +197,6 @@ help: Replace with `Path(...).stat().st_size`
 27 | getsize(__file__)
 
 PTH202 [*] `os.path.getsize` should be replaced by `Path.stat().st_size`
-  --> PTH202.py:25:1
-   |
-24 | getsize("filename")
-25 | getsize(b"filename")
-   | ^^^^^^^
-26 | getsize(Path("filename"))
-27 | getsize(__file__)
-   |
-help: Replace with `Path(...).stat().st_size`
-22 | os.path.getsize(filename=__file__)
-23 |
-24 | getsize("filename")
-   - getsize(b"filename")
-25 + Path(b"filename").stat().st_size
-26 | getsize(Path("filename"))
-27 | getsize(__file__)
-28 |
-
-PTH202 [*] `os.path.getsize` should be replaced by `Path.stat().st_size`
   --> PTH202.py:26:1
    |
 24 | getsize("filename")
@@ -310,25 +254,6 @@ help: Replace with `Path(...).stat().st_size`
 30 | getsize(filename=b"filename")
 31 | getsize(filename=Path("filename"))
 32 | getsize(filename=__file__)
-
-PTH202 [*] `os.path.getsize` should be replaced by `Path.stat().st_size`
-  --> PTH202.py:30:1
-   |
-29 | getsize(filename="filename")
-30 | getsize(filename=b"filename")
-   | ^^^^^^^
-31 | getsize(filename=Path("filename"))
-32 | getsize(filename=__file__)
-   |
-help: Replace with `Path(...).stat().st_size`
-27 | getsize(__file__)
-28 |
-29 | getsize(filename="filename")
-   - getsize(filename=b"filename")
-30 + Path(b"filename").stat().st_size
-31 | getsize(filename=Path("filename"))
-32 | getsize(filename=__file__)
-33 |
 
 PTH202 [*] `os.path.getsize` should be replaced by `Path.stat().st_size`
   --> PTH202.py:31:1
@@ -473,31 +398,6 @@ help: Replace with `Path(...).stat().st_size`
 note: This is an unsafe fix and may change runtime behavior
 
 PTH202 [*] `os.path.getsize` should be replaced by `Path.stat().st_size`
-  --> PTH202.py:50:1
-   |
-48 | )
-49 |
-50 | os.path.getsize(
-   | ^^^^^^^^^^^^^^^
-51 |     # comment
-52 |     b"filename"
-   |
-help: Replace with `Path(...).stat().st_size`
-47 |     # comment
-48 | )
-49 |
-   - os.path.getsize(
-   -     # comment
-   -     b"filename"
-   -     # comment
-   - )
-50 + Path(b"filename").stat().st_size
-51 |
-52 | os.path.getsize( # comment
-53 |     Path(__file__)
-note: This is an unsafe fix and may change runtime behavior
-
-PTH202 [*] `os.path.getsize` should be replaced by `Path.stat().st_size`
   --> PTH202.py:56:1
    |
 54 | )
@@ -540,30 +440,6 @@ help: Replace with `Path(...).stat().st_size`
 62 |
 63 | getsize( # comment
 64 |     b"filename",
-note: This is an unsafe fix and may change runtime behavior
-
-PTH202 [*] `os.path.getsize` should be replaced by `Path.stat().st_size`
-  --> PTH202.py:64:1
-   |
-62 |     "filename")
-63 |
-64 | getsize( # comment
-   | ^^^^^^^
-65 |     b"filename",
-66 |     #comment
-   |
-help: Replace with `Path(...).stat().st_size`
-61 | getsize( # comment
-62 |     "filename")
-63 |
-   - getsize( # comment
-   -     b"filename",
-   -     #comment
-   - )
-64 + Path(b"filename").stat().st_size
-65 |
-66 | os.path.getsize("file" + "name")
-67 |
 note: This is an unsafe fix and may change runtime behavior
 
 PTH202 [*] `os.path.getsize` should be replaced by `Path.stat().st_size`

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview__PTH202_PTH202_2.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview__PTH202_PTH202_2.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+assertion_line: 172
 ---
 PTH202 [*] `os.path.getsize` should be replaced by `Path.stat().st_size`
  --> PTH202_2.py:3:1
@@ -18,23 +19,6 @@ help: Replace with `Path(...).stat().st_size`
   - os.path.getsize(filename="filename")
 4 + pathlib.Path("filename").stat().st_size
 5 | os.path.getsize(filename=b"filename")
-6 | os.path.getsize(filename=__file__)
-
-PTH202 [*] `os.path.getsize` should be replaced by `Path.stat().st_size`
- --> PTH202_2.py:4:1
-  |
-3 | os.path.getsize(filename="filename")
-4 | os.path.getsize(filename=b"filename")
-  | ^^^^^^^^^^^^^^^
-5 | os.path.getsize(filename=__file__)
-  |
-help: Replace with `Path(...).stat().st_size`
-1 | import os
-2 + import pathlib
-3 |
-4 | os.path.getsize(filename="filename")
-  - os.path.getsize(filename=b"filename")
-5 + pathlib.Path(b"filename").stat().st_size
 6 | os.path.getsize(filename=__file__)
 
 PTH202 [*] `os.path.getsize` should be replaced by `Path.stat().st_size`

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview__PTH203_PTH203.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview__PTH203_PTH203.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+assertion_line: 172
 ---
 PTH203 [*] `os.path.getatime` should be replaced by `Path.stat().st_atime`
  --> PTH203.py:5:1
@@ -20,24 +21,6 @@ help: Replace with `Path.stat(...).st_atime`
 6 | os.path.getatime(b"filename")
 7 | os.path.getatime(Path("filename"))
 8 |
-
-PTH203 [*] `os.path.getatime` should be replaced by `Path.stat().st_atime`
- --> PTH203.py:6:1
-  |
-5 | os.path.getatime("filename")
-6 | os.path.getatime(b"filename")
-  | ^^^^^^^^^^^^^^^^
-7 | os.path.getatime(Path("filename"))
-  |
-help: Replace with `Path.stat(...).st_atime`
-3 | from os.path import getatime
-4 |
-5 | os.path.getatime("filename")
-  - os.path.getatime(b"filename")
-6 + Path(b"filename").stat().st_atime
-7 | os.path.getatime(Path("filename"))
-8 |
-9 |
 
 PTH203 [*] `os.path.getatime` should be replaced by `Path.stat().st_atime`
  --> PTH203.py:7:1
@@ -74,24 +57,6 @@ help: Replace with `Path.stat(...).st_atime`
 11 | getatime(b"filename")
 12 | getatime(Path("filename"))
 13 |
-
-PTH203 [*] `os.path.getatime` should be replaced by `Path.stat().st_atime`
-  --> PTH203.py:11:1
-   |
-10 | getatime("filename")
-11 | getatime(b"filename")
-   | ^^^^^^^^
-12 | getatime(Path("filename"))
-   |
-help: Replace with `Path.stat(...).st_atime`
-8  |
-9  |
-10 | getatime("filename")
-   - getatime(b"filename")
-11 + Path(b"filename").stat().st_atime
-12 | getatime(Path("filename"))
-13 |
-14 |
 
 PTH203 [*] `os.path.getatime` should be replaced by `Path.stat().st_atime`
   --> PTH203.py:12:1

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview__PTH204_PTH204.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview__PTH204_PTH204.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+assertion_line: 172
 ---
 PTH204 [*] `os.path.getmtime` should be replaced by `Path.stat().st_mtime`
  --> PTH204.py:6:1
@@ -18,24 +19,6 @@ help: Replace with `Path.stat(...).st_mtime`
 7 | os.path.getmtime(b"filename")
 8 | os.path.getmtime(Path("filename"))
 9 |
-
-PTH204 [*] `os.path.getmtime` should be replaced by `Path.stat().st_mtime`
- --> PTH204.py:7:1
-  |
-6 | os.path.getmtime("filename")
-7 | os.path.getmtime(b"filename")
-  | ^^^^^^^^^^^^^^^^
-8 | os.path.getmtime(Path("filename"))
-  |
-help: Replace with `Path.stat(...).st_mtime`
-4  |
-5  |
-6  | os.path.getmtime("filename")
-   - os.path.getmtime(b"filename")
-7  + Path(b"filename").stat().st_mtime
-8  | os.path.getmtime(Path("filename"))
-9  |
-10 |
 
 PTH204 [*] `os.path.getmtime` should be replaced by `Path.stat().st_mtime`
  --> PTH204.py:8:1
@@ -70,22 +53,6 @@ help: Replace with `Path.stat(...).st_mtime`
    - getmtime("filename")
 11 + Path("filename").stat().st_mtime
 12 | getmtime(b"filename")
-13 | getmtime(Path("filename"))
-
-PTH204 [*] `os.path.getmtime` should be replaced by `Path.stat().st_mtime`
-  --> PTH204.py:12:1
-   |
-11 | getmtime("filename")
-12 | getmtime(b"filename")
-   | ^^^^^^^^
-13 | getmtime(Path("filename"))
-   |
-help: Replace with `Path.stat(...).st_mtime`
-9  |
-10 |
-11 | getmtime("filename")
-   - getmtime(b"filename")
-12 + Path(b"filename").stat().st_mtime
 13 | getmtime(Path("filename"))
 
 PTH204 [*] `os.path.getmtime` should be replaced by `Path.stat().st_mtime`

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview__PTH205_PTH205.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview__PTH205_PTH205.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+assertion_line: 172
 ---
 PTH205 [*] `os.path.getctime` should be replaced by `Path.stat().st_ctime`
  --> PTH205.py:6:1
@@ -18,24 +19,6 @@ help: Replace with `Path.stat(...).st_ctime`
 7 | os.path.getctime(b"filename")
 8 | os.path.getctime(Path("filename"))
 9 |
-
-PTH205 [*] `os.path.getctime` should be replaced by `Path.stat().st_ctime`
- --> PTH205.py:7:1
-  |
-6 | os.path.getctime("filename")
-7 | os.path.getctime(b"filename")
-  | ^^^^^^^^^^^^^^^^
-8 | os.path.getctime(Path("filename"))
-  |
-help: Replace with `Path.stat(...).st_ctime`
-4  |
-5  |
-6  | os.path.getctime("filename")
-   - os.path.getctime(b"filename")
-7  + Path(b"filename").stat().st_ctime
-8  | os.path.getctime(Path("filename"))
-9  |
-10 | getctime("filename")
 
 PTH205 [*] `os.path.getctime` should be replaced by `Path.stat().st_ctime`
   --> PTH205.py:8:1
@@ -74,22 +57,6 @@ help: Replace with `Path.stat(...).st_ctime`
    - getctime("filename")
 10 + Path("filename").stat().st_ctime
 11 | getctime(b"filename")
-12 | getctime(Path("filename"))
-
-PTH205 [*] `os.path.getctime` should be replaced by `Path.stat().st_ctime`
-  --> PTH205.py:11:1
-   |
-10 | getctime("filename")
-11 | getctime(b"filename")
-   | ^^^^^^^^
-12 | getctime(Path("filename"))
-   |
-help: Replace with `Path.stat(...).st_ctime`
-8  | os.path.getctime(Path("filename"))
-9  |
-10 | getctime("filename")
-   - getctime(b"filename")
-11 + Path(b"filename").stat().st_ctime
 12 | getctime(Path("filename"))
 
 PTH205 [*] `os.path.getctime` should be replaced by `Path.stat().st_ctime`

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview_bytes_paths.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview_bytes_paths.py.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+assertion_line: 148
+---
+

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview_full_name.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview_full_name.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+assertion_line: 148
 ---
 PTH100 [*] `os.path.abspath()` should be replaced by `Path.resolve()`
  --> full_name.py:7:5
@@ -659,87 +660,6 @@ help: Replace with `Path.open()`
 49 | open(p, 'r', - 1, None, None, None, False, opener)
 50 |
 51 | # Cannot be upgraded `pathlib.Open` does not support fds
-
-PTH123 [*] `open()` should be replaced by `Path.open()`
-  --> full_name.py:65:1
-   |
-63 | open(f())
-64 |
-65 | open(b"foo")
-   | ^^^^
-66 | byte_str = b"bar"
-67 | open(byte_str)
-   |
-help: Replace with `Path.open()`
-1  | import os
-2  | import os.path
-3  + import pathlib
-4  |
-5  | p = "/foo"
-6  | q = "bar"
---------------------------------------------------------------------------------
-63 |     return 1
-64 | open(f())
-65 |
-   - open(b"foo")
-66 + pathlib.Path(b"foo").open()
-67 | byte_str = b"bar"
-68 | open(byte_str)
-69 |
-
-PTH123 [*] `open()` should be replaced by `Path.open()`
-  --> full_name.py:67:1
-   |
-65 | open(b"foo")
-66 | byte_str = b"bar"
-67 | open(byte_str)
-   | ^^^^
-68 |
-69 | def bytes_str_func() -> bytes:
-   |
-help: Replace with `Path.open()`
-1  | import os
-2  | import os.path
-3  + import pathlib
-4  |
-5  | p = "/foo"
-6  | q = "bar"
---------------------------------------------------------------------------------
-65 |
-66 | open(b"foo")
-67 | byte_str = b"bar"
-   - open(byte_str)
-68 + pathlib.Path(byte_str).open()
-69 |
-70 | def bytes_str_func() -> bytes:
-71 |     return b"foo"
-
-PTH123 [*] `open()` should be replaced by `Path.open()`
-  --> full_name.py:71:1
-   |
-69 | def bytes_str_func() -> bytes:
-70 |     return b"foo"
-71 | open(bytes_str_func())
-   | ^^^^
-72 |
-73 | # https://github.com/astral-sh/ruff/issues/17693
-   |
-help: Replace with `Path.open()`
-1  | import os
-2  | import os.path
-3  + import pathlib
-4  |
-5  | p = "/foo"
-6  | q = "bar"
---------------------------------------------------------------------------------
-69 |
-70 | def bytes_str_func() -> bytes:
-71 |     return b"foo"
-   - open(bytes_str_func())
-72 + pathlib.Path(bytes_str_func()).open()
-73 |
-74 | # https://github.com/astral-sh/ruff/issues/17693
-75 | os.stat(1)
 
 PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
    --> full_name.py:108:1


### PR DESCRIPTION
## Summary

- suppress `flake8-use-pathlib` diagnostics when the relevant operand is bytes-backed
- apply the bytes-path guard in both the shared replacement helpers and the custom rule handlers that bypass them
- add a dedicated `bytes_paths.py` fixture and refresh the affected snapshots

This addresses #17699.

## Testing

```bash
cargo test -p ruff_linter flake8_use_pathlib
cargo fmt --check
cargo clippy -p ruff_linter --all-targets -- -D warnings
target/debug/ruff check --isolated --select PTH208 - <<'PY'
import os
os.listdir(b'.')
PY
target/debug/ruff check --isolated --select PTH208 - <<'PY'
import os
os.listdir('.')
PY
target/debug/ruff check --isolated --select PTH123 - <<'PY'
open(b'foo')
PY
target/debug/ruff check --isolated --select PTH121 - <<'PY'
import os
os.path.samefile(b'a', 'a')
PY
```