### PR TITLE
[ty] Validate unpacked `TypedDict` `**kwargs` arguments

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3060,6 +3060,16 @@ func(v1=1, v3="ok", v4=1)
 
 # error: [invalid-argument-type]
 func(v1=1, v3=1)
+
+td2 = TD2(v1=1, v3="ok")
+func(**td2)
+
+untyped_dict: dict[str, str] = {}
+# error: [invalid-argument-type]
+func(**untyped_dict)
+
+# error: [parameter-already-assigned]
+func(v1=1, **td2)
 ```
 
 ### Extra keyword arguments
@@ -3305,6 +3315,114 @@ def stringified(**kwargs: "Unpack[StringifiedTD]") -> None:
 stringified(a=1)
 ```
 
+### Non-string-keyed mappings are rejected
+
+Only string-keyed mappings can be unpacked into named keyword parameters.
+
+```py
+def takes_name(*, name: str) -> None: ...
+def _(int_key_dict: dict[int, str]) -> None:
+    # snapshot: invalid-argument-type
+    takes_name(**int_key_dict)
+```
+
+```snapshot
+error[invalid-argument-type]: Argument expression after ** must be a mapping with `str` key type
+ --> src/mdtest_snippet.py:4:16
+  |
+4 |     takes_name(**int_key_dict)
+  |                ^^^^^^^^^^^^^^ Found `int`
+  |
+```
+
+### Explicit keywords still conflict with maybe-present unpacked keys
+
+If a partial `TypedDict` may provide a key, passing that key explicitly still counts as a duplicate.
+
+```py
+from typing_extensions import TypedDict
+
+class MaybeX(TypedDict, total=False):
+    x: int
+
+def takes_x(*, x: int) -> None: ...
+def _(maybe_x: MaybeX) -> None:
+    # error: [parameter-already-assigned]
+    takes_x(x=1, **maybe_x)
+```
+
+### Partial `TypedDict`s do not satisfy required unpacked keys
+
+When a `TypedDict` key is not required, unpacking it does not prove that the corresponding required
+parameter is present.
+
+```py
+from typing_extensions import TypedDict, Unpack
+
+class MaybeX(TypedDict, total=False):
+    x: int
+
+class HasX(TypedDict):
+    x: int
+
+def takes_required_x(**kwargs: Unpack[HasX]) -> None: ...
+def _(maybe_x: MaybeX, has_x: HasX) -> None:
+    # snapshot: missing-argument
+    takes_required_x(**maybe_x)
+
+    takes_required_x(**has_x)
+```
+
+```snapshot
+error[missing-argument]: No argument provided for required parameter `x` of function `takes_required_x`
+  --> src/mdtest_snippet.py:12:5
+   |
+12 |     takes_required_x(**maybe_x)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+info: Parameter declared here
+ --> src/mdtest_snippet.py:9:22
+  |
+9 | def takes_required_x(**kwargs: Unpack[HasX]) -> None: ...
+  |                      ^^^^^^^^^^^^^^^^^^^^^^
+  |
+```
+
+### Partial `TypedDict`s can still contribute unknown keys
+
+If a partial `TypedDict` only offers unrelated keys, the call can fail both because a required key
+is missing and because the provided key is unknown.
+
+```py
+from typing_extensions import TypedDict
+
+class MaybeExtra(TypedDict, total=False):
+    extra: int
+
+def takes_y(*, y: int) -> None: ...
+def _(maybe_extra: MaybeExtra) -> None:
+    # error: [missing-argument]
+    # error: [unknown-argument]
+    takes_y(**maybe_extra)
+```
+
+### Legacy dunder-style positional-only parameters still coexist with unpacked keys
+
+Legacy stub-style positional-only parameter names like `__x` should not conflict with unpacked
+`TypedDict` keys of the same name.
+
+```py
+from typing_extensions import TypedDict, Unpack
+
+LegacyPositionalOnlyKwargs = TypedDict("LegacyPositionalOnlyKwargs", {"__x": int})
+
+def legacy(__x: int, **kwargs: Unpack[LegacyPositionalOnlyKwargs]) -> None:
+    reveal_type(kwargs)  # revealed: LegacyPositionalOnlyKwargs
+
+def _(legacy_kwargs: LegacyPositionalOnlyKwargs) -> None:
+    legacy(1, **legacy_kwargs)
+```
+
 ## Bare `TypedDict` annotations in `**kwargs`
 
 A bare `TypedDict` annotation on `**kwargs` still means “arbitrary keyword names whose values have
@@ -3338,6 +3456,37 @@ explicit_a_bad: ExplicitAProtocol = plain
 
 def unrelated_named_parameter(x: int, **kwargs: BareKwargs) -> None:
     reveal_type(kwargs)  # revealed: dict[str, BareKwargs]
+```
+
+## `dict[str, T]` remains permissive
+
+When the unpacked mapping is a string-keyed mapping like `dict[str, T]`, ty should optimistically
+assume that the right keys may be present. It should still require the mapping's value type `T` to
+be assignable to each parameter exposed by the unpacked `TypedDict`.
+
+```py
+from typing_extensions import TypedDict, Unpack
+
+class NameKwargs(TypedDict, total=False):
+    name: int
+
+def accepts_name_kwargs(**kwargs: Unpack[NameKwargs]) -> None: ...
+
+class AcceptsNameKwargs:
+    def __init__(self, **kwargs: Unpack[NameKwargs]) -> None:
+        pass
+
+class ForwardingWrapper(AcceptsNameKwargs):
+    def __init__(self, **kwargs: int) -> None:
+        super().__init__(**kwargs)
+
+def _(good_kwargs: dict[str, int], bad_kwargs: dict[str, str]) -> None:
+    accepts_name_kwargs(**good_kwargs)
+    AcceptsNameKwargs(**good_kwargs)
+    ForwardingWrapper(**good_kwargs)
+
+    # error: [invalid-argument-type]
+    accepts_name_kwargs(**bad_kwargs)
 ```
 
 ## Recursive functional `TypedDict` (unstringified forward reference)

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3320,19 +3320,49 @@ stringified(a=1)
 Only string-keyed mappings can be unpacked into named keyword parameters.
 
 ```py
-def takes_name(*, name: str) -> None: ...
+from typing_extensions import TypedDict, Unpack
+
+class HasNameKwargs(TypedDict):
+    name: str
+
+def takes_name_kwargs(**kwargs: Unpack[HasNameKwargs]) -> None: ...
 def _(int_key_dict: dict[int, str]) -> None:
     # snapshot: invalid-argument-type
-    takes_name(**int_key_dict)
+    takes_name_kwargs(**int_key_dict)
 ```
 
 ```snapshot
 error[invalid-argument-type]: Argument expression after ** must be a mapping with `str` key type
- --> src/mdtest_snippet.py:4:16
+ --> src/mdtest_snippet.py:9:23
   |
-4 |     takes_name(**int_key_dict)
-  |                ^^^^^^^^^^^^^^ Found `int`
+9 |     takes_name_kwargs(**int_key_dict)
+  |                       ^^^^^^^^^^^^^^ Found `int`
   |
+```
+
+### Non-mapping values are rejected without missing-argument cascades
+
+```py
+from typing_extensions import TypedDict, Unpack
+
+class HasNameKwargs(TypedDict):
+    name: str
+
+class NotAMapping: ...
+
+def takes_name_kwargs(**kwargs: Unpack[HasNameKwargs]) -> None: ...
+def _(bad: NotAMapping) -> None:
+    # snapshot: invalid-argument-type
+    takes_name_kwargs(**bad)
+```
+
+```snapshot
+error[invalid-argument-type]: Argument expression after ** must be a mapping type
+  --> src/mdtest_snippet.py:11:25
+   |
+11 |     takes_name_kwargs(**bad)
+   |                         ^^^ Found `NotAMapping`
+   |
 ```
 
 ### Explicit keywords still conflict with maybe-present unpacked keys
@@ -3470,10 +3500,19 @@ from typing_extensions import TypedDict, Unpack
 class NameKwargs(TypedDict, total=False):
     name: int
 
+class MixedKwargs(TypedDict, total=False):
+    name: int
+    label: str
+
 def accepts_name_kwargs(**kwargs: Unpack[NameKwargs]) -> None: ...
+def accepts_mixed_kwargs(**kwargs: Unpack[MixedKwargs]) -> None: ...
 
 class AcceptsNameKwargs:
     def __init__(self, **kwargs: Unpack[NameKwargs]) -> None:
+        pass
+
+class AcceptsMixedKwargs:
+    def __init__(self, **kwargs: Unpack[MixedKwargs]) -> None:
         pass
 
 class ForwardingWrapper(AcceptsNameKwargs):
@@ -3487,6 +3526,12 @@ def _(good_kwargs: dict[str, int], bad_kwargs: dict[str, str]) -> None:
 
     # error: [invalid-argument-type]
     accepts_name_kwargs(**bad_kwargs)
+
+    # error: [invalid-argument-type]
+    accepts_mixed_kwargs(**good_kwargs)
+
+    # error: [invalid-argument-type]
+    AcceptsMixedKwargs(**good_kwargs)
 ```
 
 ## Recursive functional `TypedDict` (unstringified forward reference)

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4126,30 +4126,10 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             return;
         }
 
-        if let Some((parameter_index, parameter)) = self.parameters.unpacked() {
-            let permissive_string_mapping = argument_type.is_some_and(|argument_type| {
-                let Some((key_ty, _value_ty)) = argument_type.unpack_keys_and_items(db) else {
-                    return false;
-                };
-
-                key_ty.is_assignable_to(db, KnownClass::Str.to_instance(db))
-            });
-
-            if !permissive_string_mapping {
-                self.errors.push(BindingError::InvalidArgumentType {
-                    parameter: ParameterContext {
-                        name: Some(parameter.display_name()),
-                        index: parameter_index,
-                        positional: false,
-                    },
-                    argument_index: self.get_argument_index(argument_index),
-                    expected_ty: parameter.annotated_type(),
-                    provided_ty: argument_type.unwrap_or_else(Type::unknown),
-                });
-                return;
-            }
-        }
-
+        // Fall back to ordinary `**kwargs` binding when the unpacked value is not TypedDict-shaped.
+        // This mirrors the non-`Unpack[TypedDict]` path: later validation still reports invalid
+        // `**` arguments, while binding here suppresses redundant missing-argument cascades and
+        // preserves per-parameter value checking for string-keyed mappings.
         for (parameter_index, parameter) in self.parameters.iter().enumerate() {
             if self.parameter_info[parameter_index]
                 .match_state
@@ -5004,6 +4984,14 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             .iter()
             .any(Option::is_some)
         {
+            // The binding phase already matched this `**` argument against one or more parameters.
+            // For example, `dict[str, int]` can optimistically match
+            // `**kwargs: Unpack[TypedDict("Kwargs", {"name": int}, total=False)]`: the mapping may
+            // contain the right key, and the value type can be checked below against `name`.
+            //
+            // We still need to validate the unpacked mapping's key type here. A `dict[int, str]`
+            // may also have matched a parameter by value type, but it is not valid after `**`
+            // because keyword argument names must be strings.
             if extract_unpacked_typed_dict_keys_from_value_type(self.db, argument_type).is_none()
                 && argument_type.as_paramspec_typevar(self.db).is_none()
             {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -49,6 +49,7 @@ use crate::types::signatures::{
     CallableSignature, Parameter, ParameterForm, ParameterKind, Parameters, ParametersKind,
 };
 use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
+use crate::types::typed_dict::extract_unpacked_typed_dict_keys_from_value_type;
 use crate::types::typevar::BoundTypeVarIdentity;
 use crate::types::{
     BoundMethodType, BoundTypeVarInstance, CallableType, ClassLiteral, DATACLASS_FLAGS,
@@ -3624,10 +3625,56 @@ impl ArgumentForms {
     }
 }
 
+/// Per-parameter binding state accumulated while matching call arguments.
 #[derive(Default, Clone, Copy)]
 struct ParameterInfo {
-    matched: bool,
+    /// Whether the parameter is unmatched, provisionally matched, or definitively matched.
+    match_state: ParameterMatchState,
+    /// Suppresses a later missing-argument error after a more specific binding error has already
+    /// been reported for this parameter.
     suppress_missing_error: bool,
+}
+
+/// The accumulated match state for a parameter after considering some subset of call arguments.
+#[derive(Default, Clone, Copy)]
+enum ParameterMatchState {
+    /// No argument has matched this parameter yet.
+    #[default]
+    Unmatched,
+    /// The parameter is matched only through a conditionally-present source, such as a
+    /// `NotRequired` key from `**kwargs: Unpack[TypedDict]`.
+    ///
+    /// Provisional matches still participate in duplicate and type checking, but they do not
+    /// satisfy required-argument handling.
+    Provisional,
+    /// The parameter is definitely satisfied by an argument at this call site.
+    Definitive,
+}
+
+impl ParameterMatchState {
+    const fn is_matched(self) -> bool {
+        !matches!(self, Self::Unmatched)
+    }
+
+    const fn is_definitive(self) -> bool {
+        matches!(self, Self::Definitive)
+    }
+
+    const fn with_match_kind(self, match_kind: ParameterMatchKind) -> Self {
+        match (self, match_kind) {
+            (Self::Definitive, _) | (_, ParameterMatchKind::Definitive) => Self::Definitive,
+            (Self::Provisional, _) | (_, ParameterMatchKind::Provisional) => Self::Provisional,
+        }
+    }
+}
+
+/// Whether a successful parameter match is definitely or only conditionally present.
+#[derive(Clone, Copy)]
+enum ParameterMatchKind {
+    /// The argument definitely binds this parameter.
+    Definitive,
+    /// The argument may bind this parameter at runtime, but does not guarantee its presence.
+    Provisional,
 }
 
 struct ArgumentMatcher<'a, 'db> {
@@ -3717,6 +3764,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         parameter: &Parameter<'db>,
         positional: bool,
         variable_argument_length: bool,
+        match_kind: ParameterMatchKind,
     ) {
         if !matches!(argument, Argument::Synthetic) {
             let adjusted_argument_index = argument_index - self.num_synthetic_args;
@@ -3729,7 +3777,10 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                 }
             }
         }
-        if self.parameter_info[parameter_index].matched {
+        if self.parameter_info[parameter_index]
+            .match_state
+            .is_matched()
+        {
             if !parameter.is_variadic() && !parameter.is_keyword_variadic() {
                 self.errors.push(BindingError::ParameterAlreadyAssigned {
                     argument_index: self.get_argument_index(argument_index),
@@ -3750,7 +3801,9 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         matched_argument.parameters.push(parameter_index);
         matched_argument.types.push(argument_type);
         matched_argument.matched = true;
-        self.parameter_info[parameter_index].matched = true;
+        self.parameter_info[parameter_index].match_state = self.parameter_info[parameter_index]
+            .match_state
+            .with_match_kind(match_kind);
     }
 
     fn match_positional(
@@ -3782,6 +3835,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             parameter,
             !parameter.is_variadic(),
             variable_argument_length,
+            ParameterMatchKind::Definitive,
         );
         Ok(())
     }
@@ -3792,11 +3846,9 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         argument: Argument<'a>,
         argument_type: Option<Type<'db>>,
         name: &str,
+        match_kind: ParameterMatchKind,
     ) -> Result<(), ()> {
-        let Some((parameter_index, parameter)) = self
-            .parameters
-            .keyword_by_name(name)
-            .or_else(|| self.parameters.keyword_variadic())
+        let Some((parameter_index, parameter)) = self.parameters.bindable_keyword_by_name(name)
         else {
             if let Some((parameter_index, parameter)) =
                 self.parameters.positional_only_by_name(name)
@@ -3823,6 +3875,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             parameter,
             false,
             false,
+            match_kind,
         );
         Ok(())
     }
@@ -4054,53 +4107,88 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         argument_index: usize,
         argument_type: Option<Type<'db>>,
     ) {
-        if let Some(Type::TypedDict(typed_dict)) = argument_type {
-            // Special case TypedDict because we know which keys are present.
-            for (name, field) in typed_dict.items(db) {
+        if let Some(unpacked_keys) = argument_type.and_then(|argument_type| {
+            extract_unpacked_typed_dict_keys_from_value_type(db, argument_type)
+        }) {
+            for (name, unpacked_key) in unpacked_keys {
                 let _ = self.match_keyword(
                     argument_index,
                     Argument::Keywords,
-                    Some(field.declared_ty),
+                    Some(unpacked_key.value_ty),
                     name.as_str(),
+                    if unpacked_key.is_required {
+                        ParameterMatchKind::Definitive
+                    } else {
+                        ParameterMatchKind::Provisional
+                    },
                 );
             }
-        } else {
-            for (parameter_index, parameter) in self.parameters.iter().enumerate() {
-                if self.parameter_info[parameter_index].matched && !parameter.is_keyword_variadic()
-                {
-                    continue;
-                }
+            return;
+        }
 
-                if matches!(
-                    parameter.kind(),
-                    ParameterKind::PositionalOnly { .. } | ParameterKind::Variadic { .. }
-                ) {
-                    continue;
-                }
-
-                let parameter_name = self.parameters[parameter_index]
-                    .keyword_name()
-                    .map(Name::as_str);
-
-                let value_type = match argument_type {
-                    Some(argument_type) => argument_type
-                        .as_paramspec_typevar(db)
-                        .or_else(|| argument_type.getitem_dunder_call(db, parameter_name))
-                        .unwrap_or(Type::unknown()),
-
-                    None => Type::unknown(),
+        if let Some((parameter_index, parameter)) = self.parameters.unpacked() {
+            let permissive_string_mapping = argument_type.is_some_and(|argument_type| {
+                let Some((key_ty, _value_ty)) = argument_type.unpack_keys_and_items(db) else {
+                    return false;
                 };
 
-                self.assign_argument(
-                    argument_index,
-                    Argument::Keywords,
-                    Some(value_type),
-                    parameter_index,
-                    parameter,
-                    false,
-                    true,
-                );
+                key_ty.is_assignable_to(db, KnownClass::Str.to_instance(db))
+            });
+
+            if !permissive_string_mapping {
+                self.errors.push(BindingError::InvalidArgumentType {
+                    parameter: ParameterContext {
+                        name: Some(parameter.display_name()),
+                        index: parameter_index,
+                        positional: false,
+                    },
+                    argument_index: self.get_argument_index(argument_index),
+                    expected_ty: parameter.annotated_type(),
+                    provided_ty: argument_type.unwrap_or_else(Type::unknown),
+                });
+                return;
             }
+        }
+
+        for (parameter_index, parameter) in self.parameters.iter().enumerate() {
+            if self.parameter_info[parameter_index]
+                .match_state
+                .is_definitive()
+                && !parameter.is_keyword_variadic()
+            {
+                continue;
+            }
+
+            if matches!(
+                parameter.kind(),
+                ParameterKind::PositionalOnly { .. } | ParameterKind::Variadic { .. }
+            ) {
+                continue;
+            }
+
+            let parameter_name = self.parameters[parameter_index]
+                .keyword_name()
+                .map(Name::as_str);
+
+            let value_type = match argument_type {
+                Some(argument_type) => argument_type
+                    .as_paramspec_typevar(db)
+                    .or_else(|| argument_type.getitem_dunder_call(db, parameter_name))
+                    .unwrap_or(Type::unknown()),
+
+                None => Type::unknown(),
+            };
+
+            self.assign_argument(
+                argument_index,
+                Argument::Keywords,
+                Some(value_type),
+                parameter_index,
+                parameter,
+                false,
+                true,
+                ParameterMatchKind::Definitive,
+            );
         }
     }
 
@@ -4122,12 +4210,12 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         for (
             index,
             ParameterInfo {
-                matched,
+                match_state,
                 suppress_missing_error,
             },
         ) in self.parameter_info.iter().copied().enumerate()
         {
-            if !matched {
+            if !match_state.is_definitive() {
                 if suppress_missing_error {
                     continue;
                 }
@@ -4911,20 +4999,46 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         argument: Argument<'a>,
         argument_type: Type<'db>,
     ) {
-        if let Type::TypedDict(typed_dict) = argument_type {
-            for (argument_type, parameter_index) in typed_dict
-                .items(self.db)
-                .values()
-                .map(|field| field.declared_ty)
-                .zip(&self.argument_matches[argument_index].parameters)
+        if self.argument_matches[argument_index]
+            .types
+            .iter()
+            .any(Option::is_some)
+        {
+            if extract_unpacked_typed_dict_keys_from_value_type(self.db, argument_type).is_none()
+                && argument_type.as_paramspec_typevar(self.db).is_none()
             {
+                let Some((key_type, _)) = argument_type.unpack_keys_and_items(self.db) else {
+                    return;
+                };
+
+                if !key_type
+                    .when_assignable_to(
+                        self.db,
+                        KnownClass::Str.to_instance(self.db),
+                        constraints,
+                        self.inferable_typevars,
+                    )
+                    .is_always_satisfied(self.db)
+                {
+                    self.errors.push(BindingError::InvalidKeyType {
+                        argument_index: adjusted_argument_index,
+                        provided_ty: key_type,
+                    });
+                }
+            }
+
+            for (parameter_index, argument_type) in self.argument_matches[argument_index].iter() {
+                let Some(argument_type) = argument_type else {
+                    continue;
+                };
+
                 self.check_argument_type(
                     constraints,
                     argument_index,
                     adjusted_argument_index,
                     argument,
                     argument_type,
-                    *parameter_index,
+                    parameter_index,
                 );
             }
 
@@ -5125,7 +5239,13 @@ impl<'db> Binding<'db> {
                     let _ = matcher.match_positional(argument_index, argument, None, false);
                 }
                 Argument::Keyword(name) => {
-                    let _ = matcher.match_keyword(argument_index, argument, None, name);
+                    let _ = matcher.match_keyword(
+                        argument_index,
+                        argument,
+                        None,
+                        name,
+                        ParameterMatchKind::Definitive,
+                    );
                 }
                 Argument::Variadic => {
                     let _ = matcher.match_variadic(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2525,66 +2525,7 @@ pub(crate) enum ParametersKind<'db> {
 pub(crate) struct Parameters<'db> {
     // TODO: use SmallVec here once invariance bug is fixed
     value: Vec<Parameter<'db>>,
-    unpacked: Option<Unpacked<'db>>,
     kind: ParametersKind<'db>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
-pub(crate) struct Unpacked<'db> {
-    name: Name,
-    annotated_type: Type<'db>,
-}
-
-impl<'db> Unpacked<'db> {
-    fn from_parameter(db: &'db dyn Db, parameter: &Parameter<'db>) -> Self {
-        debug_assert!(parameter.is_unpacked(db));
-        Self {
-            name: parameter
-                .name()
-                .expect("keyword variadic parameter always has a name")
-                .clone(),
-            annotated_type: parameter.annotated_type(),
-        }
-    }
-
-    pub(crate) fn display_name(&self) -> Name {
-        Name::new(format!("**{}", self.name))
-    }
-
-    pub(crate) fn annotated_type(&self) -> Type<'db> {
-        self.annotated_type
-    }
-
-    fn apply_type_mapping_impl<'a>(
-        &self,
-        db: &'db dyn Db,
-        type_mapping: &TypeMapping<'a, 'db>,
-        tcx: TypeContext<'db>,
-        visitor: &ApplyTypeMappingVisitor<'db>,
-    ) -> Self {
-        Self {
-            name: self.name.clone(),
-            annotated_type: self.annotated_type.apply_type_mapping_impl(
-                db,
-                type_mapping,
-                tcx,
-                visitor,
-            ),
-        }
-    }
-
-    fn to_parameter(&self) -> Parameter<'db> {
-        Parameter {
-            annotated_type: self.annotated_type,
-            inferred_annotation: false,
-            has_starred_annotation: false,
-            has_unpacked_kwargs_annotation: true,
-            kind: ParameterKind::KeywordVariadic {
-                name: self.name.clone(),
-            },
-            form: ParameterForm::Value,
-        }
-    }
 }
 
 impl<'db> Parameters<'db> {
@@ -2602,7 +2543,6 @@ impl<'db> Parameters<'db> {
     ) -> Self {
         let parameters = parameters.into_iter();
         let mut value: Vec<Parameter<'db>> = Vec::with_capacity(parameters.size_hint().0);
-        let mut unpacked = None;
 
         for parameter in parameters {
             if let Some(unpacked_keys) = parameter.unpacked_typed_dict_keys(db) {
@@ -2633,7 +2573,6 @@ impl<'db> Parameters<'db> {
                 value.push(
                     Parameter::keyword_variadic(kwargs_name).with_annotated_type(Type::object()),
                 );
-                unpacked = Some(Unpacked::from_parameter(db, &parameter));
             } else {
                 value.push(parameter);
             }
@@ -2714,18 +2653,13 @@ impl<'db> Parameters<'db> {
             }
         }
 
-        Parameters {
-            value,
-            unpacked,
-            kind,
-        }
+        Parameters { value, kind }
     }
 
     /// Create an empty parameter list.
     pub(crate) fn empty() -> Self {
         Self {
             value: Vec::new(),
-            unpacked: None,
             kind: ParametersKind::Standard,
         }
     }
@@ -2796,7 +2730,6 @@ impl<'db> Parameters<'db> {
                 Parameter::keyword_variadic(Name::new_static("kwargs"))
                     .with_annotated_type(todo_type!("todo signature **kwargs")),
             ],
-            unpacked: None,
             kind: ParametersKind::Gradual,
         }
     }
@@ -2814,7 +2747,6 @@ impl<'db> Parameters<'db> {
                 Parameter::keyword_variadic(Name::new_static("kwargs"))
                     .with_annotated_type(Type::Dynamic(DynamicType::Any)),
             ],
-            unpacked: None,
             kind: ParametersKind::Gradual,
         }
     }
@@ -2829,7 +2761,6 @@ impl<'db> Parameters<'db> {
                     Type::TypeVar(typevar.with_paramspec_attr(db, ParamSpecAttrKind::Kwargs)),
                 ),
             ],
-            unpacked: None,
             kind: ParametersKind::ParamSpec(typevar),
         }
     }
@@ -2859,7 +2790,6 @@ impl<'db> Parameters<'db> {
         ]);
         Self {
             value: prefix_params,
-            unpacked: None,
             kind: ParametersKind::Concatenate(concatenate_tail),
         }
     }
@@ -2878,7 +2808,6 @@ impl<'db> Parameters<'db> {
                 Parameter::keyword_variadic(Name::new_static("kwargs"))
                     .with_annotated_type(Type::Dynamic(DynamicType::Unknown)),
             ],
-            unpacked: None,
             kind: ParametersKind::Gradual,
         }
     }
@@ -2892,7 +2821,6 @@ impl<'db> Parameters<'db> {
                 Parameter::keyword_variadic(Name::new_static("kwargs"))
                     .with_annotated_type(Type::object()),
             ],
-            unpacked: None,
             kind: ParametersKind::Standard,
         }
     }
@@ -2912,7 +2840,6 @@ impl<'db> Parameters<'db> {
                 Parameter::keyword_variadic(Name::new_static("kwargs"))
                     .with_annotated_type(Type::object()),
             ],
-            unpacked: None,
             kind: ParametersKind::Top,
         }
     }
@@ -3067,10 +2994,6 @@ impl<'db> Parameters<'db> {
                 .iter()
                 .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor))
                 .collect(),
-            unpacked: self
-                .unpacked
-                .as_ref()
-                .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor)),
             kind: self.kind,
         }
     }
@@ -3147,13 +3070,6 @@ impl<'db> Parameters<'db> {
         self.iter()
             .enumerate()
             .rfind(|(_, parameter)| parameter.is_keyword_variadic())
-    }
-
-    /// Return the retained `**kwargs: Unpack[TypedDict]` metadata and its index, if any.
-    pub(crate) fn unpacked(&self) -> Option<(usize, &Unpacked<'db>)> {
-        self.unpacked
-            .as_ref()
-            .map(|parameter| (self.value.len(), parameter))
     }
 }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2525,7 +2525,66 @@ pub(crate) enum ParametersKind<'db> {
 pub(crate) struct Parameters<'db> {
     // TODO: use SmallVec here once invariance bug is fixed
     value: Vec<Parameter<'db>>,
+    unpacked: Option<Unpacked<'db>>,
     kind: ParametersKind<'db>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+pub(crate) struct Unpacked<'db> {
+    name: Name,
+    annotated_type: Type<'db>,
+}
+
+impl<'db> Unpacked<'db> {
+    fn from_parameter(db: &'db dyn Db, parameter: &Parameter<'db>) -> Self {
+        debug_assert!(parameter.is_unpacked(db));
+        Self {
+            name: parameter
+                .name()
+                .expect("keyword variadic parameter always has a name")
+                .clone(),
+            annotated_type: parameter.annotated_type(),
+        }
+    }
+
+    pub(crate) fn display_name(&self) -> Name {
+        Name::new(format!("**{}", self.name))
+    }
+
+    pub(crate) fn annotated_type(&self) -> Type<'db> {
+        self.annotated_type
+    }
+
+    fn apply_type_mapping_impl<'a>(
+        &self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'a, 'db>,
+        tcx: TypeContext<'db>,
+        visitor: &ApplyTypeMappingVisitor<'db>,
+    ) -> Self {
+        Self {
+            name: self.name.clone(),
+            annotated_type: self.annotated_type.apply_type_mapping_impl(
+                db,
+                type_mapping,
+                tcx,
+                visitor,
+            ),
+        }
+    }
+
+    fn to_parameter(&self) -> Parameter<'db> {
+        Parameter {
+            annotated_type: self.annotated_type,
+            inferred_annotation: false,
+            has_starred_annotation: false,
+            has_unpacked_kwargs_annotation: true,
+            kind: ParameterKind::KeywordVariadic {
+                name: self.name.clone(),
+            },
+            form: ParameterForm::Value,
+        }
+    }
 }
 
 impl<'db> Parameters<'db> {
@@ -2543,6 +2602,7 @@ impl<'db> Parameters<'db> {
     ) -> Self {
         let parameters = parameters.into_iter();
         let mut value: Vec<Parameter<'db>> = Vec::with_capacity(parameters.size_hint().0);
+        let mut unpacked = None;
 
         for parameter in parameters {
             if let Some(unpacked_keys) = parameter.unpacked_typed_dict_keys(db) {
@@ -2573,6 +2633,7 @@ impl<'db> Parameters<'db> {
                 value.push(
                     Parameter::keyword_variadic(kwargs_name).with_annotated_type(Type::object()),
                 );
+                unpacked = Some(Unpacked::from_parameter(db, &parameter));
             } else {
                 value.push(parameter);
             }
@@ -2653,13 +2714,18 @@ impl<'db> Parameters<'db> {
             }
         }
 
-        Parameters { value, kind }
+        Parameters {
+            value,
+            unpacked,
+            kind,
+        }
     }
 
     /// Create an empty parameter list.
     pub(crate) fn empty() -> Self {
         Self {
             value: Vec::new(),
+            unpacked: None,
             kind: ParametersKind::Standard,
         }
     }
@@ -2730,6 +2796,7 @@ impl<'db> Parameters<'db> {
                 Parameter::keyword_variadic(Name::new_static("kwargs"))
                     .with_annotated_type(todo_type!("todo signature **kwargs")),
             ],
+            unpacked: None,
             kind: ParametersKind::Gradual,
         }
     }
@@ -2747,6 +2814,7 @@ impl<'db> Parameters<'db> {
                 Parameter::keyword_variadic(Name::new_static("kwargs"))
                     .with_annotated_type(Type::Dynamic(DynamicType::Any)),
             ],
+            unpacked: None,
             kind: ParametersKind::Gradual,
         }
     }
@@ -2761,6 +2829,7 @@ impl<'db> Parameters<'db> {
                     Type::TypeVar(typevar.with_paramspec_attr(db, ParamSpecAttrKind::Kwargs)),
                 ),
             ],
+            unpacked: None,
             kind: ParametersKind::ParamSpec(typevar),
         }
     }
@@ -2790,6 +2859,7 @@ impl<'db> Parameters<'db> {
         ]);
         Self {
             value: prefix_params,
+            unpacked: None,
             kind: ParametersKind::Concatenate(concatenate_tail),
         }
     }
@@ -2808,6 +2878,7 @@ impl<'db> Parameters<'db> {
                 Parameter::keyword_variadic(Name::new_static("kwargs"))
                     .with_annotated_type(Type::Dynamic(DynamicType::Unknown)),
             ],
+            unpacked: None,
             kind: ParametersKind::Gradual,
         }
     }
@@ -2821,6 +2892,7 @@ impl<'db> Parameters<'db> {
                 Parameter::keyword_variadic(Name::new_static("kwargs"))
                     .with_annotated_type(Type::object()),
             ],
+            unpacked: None,
             kind: ParametersKind::Standard,
         }
     }
@@ -2840,6 +2912,7 @@ impl<'db> Parameters<'db> {
                 Parameter::keyword_variadic(Name::new_static("kwargs"))
                     .with_annotated_type(Type::object()),
             ],
+            unpacked: None,
             kind: ParametersKind::Top,
         }
     }
@@ -2994,6 +3067,10 @@ impl<'db> Parameters<'db> {
                 .iter()
                 .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor))
                 .collect(),
+            unpacked: self
+                .unpacked
+                .as_ref()
+                .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor)),
             kind: self.kind,
         }
     }
@@ -3058,11 +3135,25 @@ impl<'db> Parameters<'db> {
             .find(|(_, parameter)| parameter.callable_by_name(name))
     }
 
+    /// Return parameter (with index) for given keyword name, including fallback to an ordinary
+    /// `**kwargs` parameter that accepts arbitrary keyword names.
+    pub(crate) fn bindable_keyword_by_name(&self, name: &str) -> Option<(usize, &Parameter<'db>)> {
+        self.keyword_by_name(name)
+            .or_else(|| self.keyword_variadic())
+    }
+
     /// Return the keywords parameter (`**kwargs`), if any, and its index, or `None`.
     pub(crate) fn keyword_variadic(&self) -> Option<(usize, &Parameter<'db>)> {
         self.iter()
             .enumerate()
             .rfind(|(_, parameter)| parameter.is_keyword_variadic())
+    }
+
+    /// Return the retained `**kwargs: Unpack[TypedDict]` metadata and its index, if any.
+    pub(crate) fn unpacked(&self) -> Option<(usize, &Unpacked<'db>)> {
+        self.unpacked
+            .as_ref()
+            .map(|parameter| (self.value.len(), parameter))
     }
 }
 


### PR DESCRIPTION
## Summary

This PR improves validation of `**kwargs` unpacking against `Unpack[TypedDict]` at call sites.

In particular, we now distinguish definitely-present keys from maybe-present keys, so required parameters are no
longer treated as satisfied by optional `TypedDict` entries, duplicate explicit keywords are diagnosed correctly, etc.

Comparing our behavior before and after:

```python
from typing import TypedDict, Unpack

class MaybeX(TypedDict, total=False):
    x: int

class HasX(TypedDict):
    x: int

def takes_required_x(**kwargs: Unpack[HasX]) -> None: ...
def takes_x(*, x: int) -> None: ...

maybe_x: MaybeX = {}

# Before: accepted
# After: error[missing-argument]
takes_required_x(**maybe_x)
                 
# Before: accepted
# After: error[parameter-already-assigned]
takes_x(x=1, **maybe_x)
```