### PR TITLE
[docs] Improve rules table accessibility

### DIFF
--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -26,7 +26,7 @@ const SYMBOL_STYLE: &str = "style='width: 1em; display: inline-block;'";
 const SYMBOLS_CONTAINER: &str = "style='display: flex; gap: 0.5rem; justify-content: end;'";
 
 fn generate_table(table_out: &mut String, rules: impl IntoIterator<Item = Rule>, linter: &Linter) {
-    table_out.push_str("| Code | Name | Message |    |");
+    table_out.push_str("| Code { scope='col' } | Name { scope='col' } | Message { scope='col' } | &#8203; { scope='col' aria-label='Fix/Status' } |");
     table_out.push('\n');
     table_out.push_str("| ---- | ---- | ------- | -: |");
     table_out.push('\n');
@@ -34,27 +34,31 @@ fn generate_table(table_out: &mut String, rules: impl IntoIterator<Item = Rule>,
         let status_token = match rule.group() {
             RuleGroup::Removed { since } => {
                 format!(
-                    "<span {SYMBOL_STYLE} title='Rule was removed in {since}'>{REMOVED_SYMBOL}</span>"
+                    "<span {SYMBOL_STYLE} title='Rule was removed in {since}' aria-label='Rule was removed in {since}'>{REMOVED_SYMBOL}</span>"
                 )
             }
             RuleGroup::Deprecated { since } => {
                 format!(
-                    "<span {SYMBOL_STYLE} title='Rule has been deprecated since {since}'>{WARNING_SYMBOL}</span>"
+                    "<span {SYMBOL_STYLE} title='Rule has been deprecated since {since}' aria-label='Rule has been deprecated since {since}'>{WARNING_SYMBOL}</span>"
                 )
             }
             RuleGroup::Preview { since } => {
                 format!(
-                    "<span {SYMBOL_STYLE} title='Rule has been in preview since {since}'>{PREVIEW_SYMBOL}</span>"
+                    "<span {SYMBOL_STYLE} title='Rule has been in preview since {since}' aria-label='Rule has been in preview since {since}'>{PREVIEW_SYMBOL}</span>"
                 )
             }
             RuleGroup::Stable { since } => {
-                format!("<span {SYMBOL_STYLE} title='Rule has been stable since {since}'></span>")
+                format!(
+                    "<span {SYMBOL_STYLE} title='Rule has been stable since {since}' aria-label='Rule has been stable since {since}'></span>"
+                )
             }
         };
 
         let fix_token = match rule.fixable() {
             FixAvailability::Always | FixAvailability::Sometimes => {
-                format!("<span {SYMBOL_STYLE} title='Automatic fix available'>{FIX_SYMBOL}</span>")
+                format!(
+                    "<span {SYMBOL_STYLE} title='Automatic fix available' aria-label='Automatic fix available'>{FIX_SYMBOL}</span>"
+                )
             }
             FixAvailability::None => format!("<span {SYMBOL_STYLE}></span>"),
         };

--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -26,7 +26,7 @@ const SYMBOL_STYLE: &str = "style='width: 1em; display: inline-block;'";
 const SYMBOLS_CONTAINER: &str = "style='display: flex; gap: 0.5rem; justify-content: end;'";
 
 fn generate_table(table_out: &mut String, rules: impl IntoIterator<Item = Rule>, linter: &Linter) {
-    table_out.push_str("| Code { scope='col' } | Name { scope='col' } | Message { scope='col' } | &#8203; { scope='col' aria-label='Fix/Status' } |");
+    table_out.push_str("| Code { scope='col' } | Name { scope='col' } | Message { scope='col' } | Fix/Status { scope='col' .sr-only } |");
     table_out.push('\n');
     table_out.push_str("| ---- | ---- | ------- | -: |");
     table_out.push('\n');
@@ -34,22 +34,22 @@ fn generate_table(table_out: &mut String, rules: impl IntoIterator<Item = Rule>,
         let status_token = match rule.group() {
             RuleGroup::Removed { since } => {
                 format!(
-                    "<span {SYMBOL_STYLE} title='Rule was removed in {since}' aria-label='Rule was removed in {since}'>{REMOVED_SYMBOL}</span>"
+                    "<span aria-hidden='true' {SYMBOL_STYLE} title='Rule was removed in {since}'>{REMOVED_SYMBOL}</span><span class='sr-only'>Rule was removed in {since}</span>"
                 )
             }
             RuleGroup::Deprecated { since } => {
                 format!(
-                    "<span {SYMBOL_STYLE} title='Rule has been deprecated since {since}' aria-label='Rule has been deprecated since {since}'>{WARNING_SYMBOL}</span>"
+                    "<span aria-hidden='true' {SYMBOL_STYLE} title='Rule has been deprecated since {since}'>{WARNING_SYMBOL}</span><span class='sr-only'>Rule has been deprecated since {since}</span>"
                 )
             }
             RuleGroup::Preview { since } => {
                 format!(
-                    "<span {SYMBOL_STYLE} title='Rule has been in preview since {since}' aria-label='Rule has been in preview since {since}'>{PREVIEW_SYMBOL}</span>"
+                    "<span aria-hidden='true' {SYMBOL_STYLE} title='Rule has been in preview since {since}'>{PREVIEW_SYMBOL}</span><span class='sr-only'>Rule has been in preview since {since}</span>"
                 )
             }
             RuleGroup::Stable { since } => {
                 format!(
-                    "<span {SYMBOL_STYLE} title='Rule has been stable since {since}' aria-label='Rule has been stable since {since}'></span>"
+                    "<span aria-hidden='true' {SYMBOL_STYLE} title='Rule has been stable since {since}'></span><span class='sr-only'>Rule has been stable since {since}</span>"
                 )
             }
         };
@@ -57,7 +57,7 @@ fn generate_table(table_out: &mut String, rules: impl IntoIterator<Item = Rule>,
         let fix_token = match rule.fixable() {
             FixAvailability::Always | FixAvailability::Sometimes => {
                 format!(
-                    "<span {SYMBOL_STYLE} title='Automatic fix available' aria-label='Automatic fix available'>{FIX_SYMBOL}</span>"
+                    "<span aria-hidden='true' {SYMBOL_STYLE} title='Automatic fix available'>{FIX_SYMBOL}</span><span class='sr-only'>Automatic fix available</span>"
                 )
             }
             FixAvailability::None => format!("<span {SYMBOL_STYLE}></span>"),

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -123,3 +123,15 @@
   color: var(--md-accent-fg-color) !important;
 }
 
+/* Visually hidden but accessible to screen readers */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border-width: 0;
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Improve docs rules table accessibility, by adding scope='col' to the table headers, and aria-labels to the status and fix icons.

Resolves #13376 although I chose to go with aria-label instead of hidden spans. Willing to change if asked.

## Test Plan

I compiled the docs and verified everything displayed correctly.
