### PR TITLE
[ty] fix goto definition for generic classes

### DIFF
--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -2335,7 +2335,7 @@ for x in range(10):
         ");
     }
 
-    /// Go-to-definition on super() should not lookup on the super class itself
+    /// Go-to-definition on `super()` should not lookup on the super class itself
     #[test]
     fn goto_definition_does_not_lookup_on_bound_super() {
         let test = CursorTest::builder()

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -2335,6 +2335,43 @@ for x in range(10):
         ");
     }
 
+    /// Go-to-definition on super() should not lookup on the super class itself
+    #[test]
+    fn goto_definition_does_not_lookup_on_bound_super() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                "
+class Foo:
+    def __init__(self, x: int) -> None:
+        self.x = x
+
+class Bar(Foo):
+    def __init__(self):
+        super().__init<CURSOR>__(x)
+",
+            )
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @r"
+        info[goto-definition]: Go to definition
+         --> main.py:8:17
+          |
+        6 | class Bar(Foo):
+        7 |     def __init__(self):
+        8 |         super().__init__(x)
+          |                 ^^^^^^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:3:9
+          |
+        2 | class Foo:
+        3 |     def __init__(self, x: int) -> None:
+          |         --------
+        4 |         self.x = x
+          |
+        ");
+    }
     impl CursorTest {
         fn goto_definition(&self) -> String {
             let Some(targets) = salsa::attach(&self.db, || {

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -2372,6 +2372,47 @@ class Bar(Foo):
           |
         ");
     }
+
+    /// Go-to-definition should resolve to the parent class
+    #[test]
+    fn goto_definition_resolves_super_for_generic_class() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                "
+class Base:
+    def __init__(self, x: int) -> None:
+        self.x = x
+
+class GenericFoo[T](Base):
+    def __init__(self, x: int, y: T):
+        super().__init<CURSOR>__(x)
+        self.y = y
+",
+            )
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @r"
+        info[goto-definition]: Go to definition
+         --> main.py:8:17
+          |
+        6 | class GenericFoo[T](Base):
+        7 |     def __init__(self, x: int, y: T):
+        8 |         super().__init__(x)
+          |                 ^^^^^^^^ Clicking here
+        9 |         self.y = y
+          |
+        info: Found 1 definition
+         --> main.py:3:9
+          |
+        2 | class Base:
+        3 |     def __init__(self, x: int) -> None:
+          |         --------
+        4 |         self.x = x
+          |
+        ");
+    }
+
     impl CursorTest {
         fn goto_definition(&self) -> String {
             let Some(targets) = salsa::attach(&self.db, || {

--- a/crates/ty_python_semantic/resources/mdtest/class/super.md
+++ b/crates/ty_python_semantic/resources/mdtest/class/super.md
@@ -811,7 +811,7 @@ class MyProtocol(Protocol, Generic[_T_co]):
     def __class_getitem__(cls, item):
         # Accessing parent's __class_getitem__ through super()
         reveal_type(super())  # revealed: <super: <class 'MyProtocol'>, type[Self@__class_getitem__]>
-        parent_method = super().__class_getitem__  # error: [unresolved-attribute] "Object of type `<super: <class 'MyProtocol'>, type[Self@__class_getitem__]>` has no attribute `__class_getitem__`"
-        reveal_type(parent_method)  # revealed: Unknown
+        parent_method = super().__class_getitem__
+        reveal_type(parent_method)  # revealed: (item: Unknown, /) -> type[Self@__class_getitem__]
         return parent_method(item)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/class/super.md
+++ b/crates/ty_python_semantic/resources/mdtest/class/super.md
@@ -811,7 +811,7 @@ class MyProtocol(Protocol, Generic[_T_co]):
     def __class_getitem__(cls, item):
         # Accessing parent's __class_getitem__ through super()
         reveal_type(super())  # revealed: <super: <class 'MyProtocol'>, type[Self@__class_getitem__]>
-        parent_method = super().__class_getitem__
-        reveal_type(parent_method)  # revealed: @Todo(super in generic class)
+        parent_method = super().__class_getitem__  # error: [unresolved-attribute] "Object of type `<super: <class 'MyProtocol'>, type[Self@__class_getitem__]>` has no attribute `__class_getitem__`"
+        reveal_type(parent_method)  # revealed: Unknown
         return parent_method(item)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -1855,7 +1855,7 @@ class ConcreteChild(GenericBase[str]):
 class GenericChild(GenericBase[T]):
     def __new__(cls, x: T) -> Self:
         instance = super().__new__(cls, x)
-        reveal_type(instance)  # revealed: @Todo(super in generic class)
+        reveal_type(instance)  # revealed: Self@__new__
         return instance
 
 reveal_type(GenericChild(x=3.14))  # revealed: GenericChild[int | float]

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -913,27 +913,6 @@ impl<'db> BoundSuperType<'db> {
         };
 
         let class_literal = class.class_literal(db);
-        // TODO properly support super() with generic types
-        // * requires a fix for https://github.com/astral-sh/ruff/issues/17432
-        // * also requires understanding how we should handle cases like this:
-        //  ```python
-        //  b_int: B[int]
-        //  b_unknown: B
-        //
-        //  super(B, b_int)
-        //  super(B[int], b_unknown)
-        //  ```
-
-        // NOTE: disable this because we are now handling generic classes
-        // match class_literal.generic_context(db) {
-        //     Some(_) => Place::bound(todo_type!("super in generic class")).into(),
-        //     None => class_literal.class_member_from_mro(
-        //         db,
-        //         name,
-        //         policy,
-        //         self.skip_until_after_pivot(db, owner.iter_mro(db)),
-        //     ),
-        // }
         class_literal.class_member_from_mro(
             db,
             name,

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -2,11 +2,11 @@
 
 use itertools::{Either, Itertools};
 use ruff_db::diagnostic::Diagnostic;
-use ruff_python_ast::AnyNodeRef;
+use ruff_python_ast::{AnyNodeRef, name::Name};
 
 use crate::{
     Db, DisplaySettings,
-    place::PlaceAndQualifiers,
+    place::{Place, PlaceAndQualifiers},
     types::{
         BoundTypeVarInstance, ClassBase, ClassType, DivergentType, DynamicType,
         IntersectionBuilder, KnownClass, MemberLookupPolicy, SpecialFormType, SubclassOfInner,
@@ -15,6 +15,7 @@ use crate::{
         context::InferContext,
         diagnostic::{INVALID_SUPER_ARGUMENT, UNAVAILABLE_IMPLICIT_SUPER_ARGUMENTS},
         relation::EquivalenceChecker,
+        signatures::{Parameter, Parameters, Signature},
         typevar::{TypeVarConstraints, TypeVarInstance},
         visitor,
     },
@@ -310,7 +311,7 @@ impl<'db> SuperOwnerKind<'db> {
         }
     }
 
-    fn iter_mro(&self, db: &'db dyn Db) -> impl Iterator<Item = ClassBase<'db>> {
+    fn iter_mro(&self, db: &'db dyn Db) -> impl Iterator<Item = ClassBase<'db>> + Clone {
         match self {
             SuperOwnerKind::Dynamic(dynamic) => {
                 Either::Left(ClassBase::Dynamic(*dynamic).mro(db, None))
@@ -854,8 +855,8 @@ impl<'db> BoundSuperType<'db> {
     fn skip_until_after_pivot(
         self,
         db: &'db dyn Db,
-        mro_iter: impl Iterator<Item = ClassBase<'db>>,
-    ) -> impl Iterator<Item = ClassBase<'db>> {
+        mro_iter: impl Iterator<Item = ClassBase<'db>> + Clone,
+    ) -> impl Iterator<Item = ClassBase<'db>> + Clone {
         let Some(pivot_class) = self.pivot_class(db).into_class() else {
             return Either::Left(ClassBase::Dynamic(DynamicType::Unknown).mro(db, None));
         };
@@ -912,13 +913,28 @@ impl<'db> BoundSuperType<'db> {
             SuperOwnerKind::Resolved(resolved_owner) => resolved_owner.lookup_anchor,
         };
 
+        let mut mro_after_pivot = self.skip_until_after_pivot(db, owner.iter_mro(db));
         let class_literal = class.class_literal(db);
-        class_literal.class_member_from_mro(
-            db,
-            name,
-            policy,
-            self.skip_until_after_pivot(db, owner.iter_mro(db)),
-        )
+        let result = class_literal.class_member_from_mro(db, name, policy, mro_after_pivot.clone());
+
+        // TODO: Here we are hard-coding that __class_getitem__ is the only member defined in
+        // typing._Generic in the typeshed, and we are hard-coding its signature. Ideally we would
+        // look that up from the typeshed class, but that would require threading through the
+        // static class literal through the SpecialForm and KnownInstance types that we create.
+        if result.place.is_undefined()
+            && name == "__class_getitem__"
+            && mro_after_pivot
+                .any(|superclass| matches!(superclass, ClassBase::Generic | ClassBase::Protocol))
+        {
+            let item_parameter = Parameter::positional_only(Some(Name::new_static("item")))
+                .with_annotated_type(Type::unknown());
+            let parameters = Parameters::new(db, [item_parameter]);
+            let return_type = self.owner(db).owner_type();
+            let class_getitem = Type::single_callable(db, Signature::new(parameters, return_type));
+            return Place::bound(class_getitem).into();
+        }
+
+        result
     }
 
     pub(super) fn recursive_type_normalized_impl(

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -866,8 +866,10 @@ impl<'db> BoundSuperType<'db> {
         Either::Right(mro_iter.skip_while(move |superclass| {
             if pivot_found {
                 false
-            } else if Some(pivot_class) == superclass.into_class() {
-                pivot_found = true;
+            } else if let Some(superclass_type) = superclass.into_class() {
+                if superclass_type.class_literal(db) == pivot_class.class_literal(db) {
+                    pivot_found = true;
+                };
                 true
             } else {
                 true
@@ -922,15 +924,23 @@ impl<'db> BoundSuperType<'db> {
         //  super(B, b_int)
         //  super(B[int], b_unknown)
         //  ```
-        match class_literal.generic_context(db) {
-            Some(_) => Place::bound(todo_type!("super in generic class")).into(),
-            None => class_literal.class_member_from_mro(
-                db,
-                name,
-                policy,
-                self.skip_until_after_pivot(db, owner.iter_mro(db)),
-            ),
-        }
+
+        // NOTE: disable this because we are now handling generic classes
+        // match class_literal.generic_context(db) {
+        //     Some(_) => Place::bound(todo_type!("super in generic class")).into(),
+        //     None => class_literal.class_member_from_mro(
+        //         db,
+        //         name,
+        //         policy,
+        //         self.skip_until_after_pivot(db, owner.iter_mro(db)),
+        //     ),
+        // }
+        class_literal.class_member_from_mro(
+            db,
+            name,
+            policy,
+            self.skip_until_after_pivot(db, owner.iter_mro(db)),
+        )
     }
 
     pub(super) fn recursive_type_normalized_impl(

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -6,7 +6,7 @@ use ruff_python_ast::AnyNodeRef;
 
 use crate::{
     Db, DisplaySettings,
-    place::{Place, PlaceAndQualifiers},
+    place::{PlaceAndQualifiers},
     types::{
         BoundTypeVarInstance, ClassBase, ClassType, DivergentType, DynamicType,
         IntersectionBuilder, KnownClass, MemberLookupPolicy, SpecialFormType, SubclassOfInner,
@@ -15,7 +15,6 @@ use crate::{
         context::InferContext,
         diagnostic::{INVALID_SUPER_ARGUMENT, UNAVAILABLE_IMPLICIT_SUPER_ARGUMENTS},
         relation::EquivalenceChecker,
-        todo_type,
         typevar::{TypeVarConstraints, TypeVarInstance},
         visitor,
     },

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -865,15 +865,15 @@ impl<'db> BoundSuperType<'db> {
 
         Either::Right(mro_iter.skip_while(move |superclass| {
             if pivot_found {
-                false
-            } else if let Some(superclass_type) = superclass.into_class() {
-                if superclass_type.class_literal(db) == pivot_class.class_literal(db) {
-                    pivot_found = true;
-                }
-                true
-            } else {
-                true
+                return false;
             }
+
+            if let Some(superclass_type) = superclass.into_class()
+                && superclass_type.class_literal(db) == pivot_class.class_literal(db)
+            {
+                pivot_found = true;
+            }
+            true
         }))
     }
 

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -6,7 +6,7 @@ use ruff_python_ast::AnyNodeRef;
 
 use crate::{
     Db, DisplaySettings,
-    place::{PlaceAndQualifiers},
+    place::PlaceAndQualifiers,
     types::{
         BoundTypeVarInstance, ClassBase, ClassType, DivergentType, DynamicType,
         IntersectionBuilder, KnownClass, MemberLookupPolicy, SpecialFormType, SubclassOfInner,
@@ -868,7 +868,7 @@ impl<'db> BoundSuperType<'db> {
             } else if let Some(superclass_type) = superclass.into_class() {
                 if superclass_type.class_literal(db) == pivot_class.class_literal(db) {
                     pivot_found = true;
-                };
+                }
                 true
             } else {
                 true

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -379,7 +379,7 @@ impl<'db> ClassBase<'db> {
         self,
         db: &'db dyn Db,
         additional_specialization: Option<Specialization<'db>>,
-    ) -> impl Iterator<Item = ClassBase<'db>> {
+    ) -> impl Iterator<Item = ClassBase<'db>> + Clone {
         match self {
             ClassBase::Protocol => ClassBaseMroIterator::length_3(db, self, ClassBase::Generic),
             ClassBase::Dynamic(_)
@@ -456,6 +456,7 @@ impl<'db> From<&ClassBase<'db>> for Type<'db> {
 }
 
 /// An iterator over the MRO of a class base.
+#[derive(Clone)]
 enum ClassBaseMroIterator<'db> {
     Length2(core::array::IntoIter<ClassBase<'db>, 2>),
     Length3(core::array::IntoIter<ClassBase<'db>, 3>),

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -261,6 +261,11 @@ pub fn definitions_for_attribute<'db>(
             continue;
         }
 
+        // Prevent lookup on BoundSuper proxy object
+        if matches!(ty, Type::BoundSuper(_)) {
+            continue;
+        }
+
         let meta_type = ty.to_meta_type(db);
 
         // Look up the attribute first on the meta-type, unless it's already a class-like type.

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -560,6 +560,7 @@ impl<'db> FromIterator<ClassBase<'db>> for Mro<'db> {
 /// Even for first-party code, where we will have to resolve the MRO for every class we encounter,
 /// loading the cached MRO comes with a certain amount of overhead, so it's best to avoid calling the
 /// Salsa-tracked [`StaticClassLiteral::try_mro`] method unless it's absolutely necessary.
+#[derive(Clone)]
 pub(crate) struct MroIterator<'db> {
     db: &'db dyn Db,
 


### PR DESCRIPTION
Hi, this fixes https://github.com/astral-sh/ty/issues/2854

## Summary

Compare class literals instead of class bases for the purposes of skipping the MRO until the pivot class.
Also skip `BoundSuperType` when looking up definitions since we probably do not want to look up definitions on the `super` class itself.

## Test Plan
Added snapshot tests