### PR TITLE
docs: fix PLR0124 description to acknowledge __eq__ can be overridden

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
@@ -12,8 +12,8 @@ use crate::fix::snippet::SourceCodeSnippet;
 /// Checks for operations that compare a name to itself.
 ///
 /// ## Why is this bad?
-/// Comparing a name to itself always results in the same value, and is likely
-/// a mistake.
+/// Comparing a name to itself is likely a mistake, as `__eq__` may be
+/// overridden to return a non-trivial value.
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
## Summary

Fixes the documentation for `comparison-with-itself` (PLR0124) to acknowledge that `__eq__` may be overridden to return a non-trivial value, making self-comparisons not always redundant.

The previous wording stated that "Comparing a name to itself always results in the same value", which is incorrect when `__eq__` is overridden.

Closes #22160

## Test Plan

Documentation-only change. The rule logic is unchanged.