### PR TITLE
Use `compression-level: 1` when uploading binary artifacts in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1045,7 +1045,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmarks-instrumented-ty-binary
-          compression-level: 0
+          compression-level: 1
           path: target/codspeed
           if-no-files-found: "error"
           retention-days: 1
@@ -1142,7 +1142,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmarks-walltime-binary
-          compression-level: 0
+          compression-level: 1
           path: target/codspeed
           if-no-files-found: "error"
           retention-days: 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1045,6 +1045,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmarks-instrumented-ty-binary
+          compression-level: 0
           path: target/codspeed
           if-no-files-found: "error"
           retention-days: 1
@@ -1141,6 +1142,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmarks-walltime-binary
+          compression-level: 0
           path: target/codspeed
           if-no-files-found: "error"
           retention-days: 1

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ty-builds
-          compression-level: 0
+          compression-level: 1
           path: |
             ty-base
             ty-pr

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -90,6 +90,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ty-builds
+          compression-level: 0
           path: |
             ty-base
             ty-pr


### PR DESCRIPTION
## Summary

Per https://github.com/actions/upload-artifact#altering-compressions-level-speed-v-size:

> By default, the compression level is 6, the same as GNU Gzip.

and

> Higher levels will result in better compression, but will take longer to complete. For large files that are not easily compressed, a value of 0 is recommended for significantly faster uploads.

## Test Plan

<!-- How was it tested? -->
