### PR TITLE
[`pylint`] Fix `PLR0124` description not to claim self-comparison always returns the same value

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
@@ -12,8 +12,8 @@ use crate::fix::snippet::SourceCodeSnippet;
 /// Checks for operations that compare a name to itself.
 ///
 /// ## Why is this bad?
-/// Comparing a name to itself always results in the same value, and is likely
-/// a mistake.
+/// Comparing a name to itself typically results in a truthy value, and is
+/// likely a mistake.
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
Closes #22160

## Summary
PLR0124 documentation previously stated that comparing a name to itself "always results in the same value". This is incorrect because `__eq__` can be overridden (e.g., `float('nan') == float('nan')` returns `False`).

Updated to match the suggestion in the issue: `Comparing a name to itself typically results in a truthy value, and is likely a mistake.`