### PR TITLE
Factor out more mdtest helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4780,7 +4780,6 @@ dependencies = [
  "camino",
  "colored 3.1.1",
  "dunce",
- "insta",
  "mdtest",
  "ruff_db",
  "ruff_diagnostics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4778,7 +4778,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "camino",
- "colored 3.1.1",
  "dunce",
  "mdtest",
  "ruff_db",

--- a/crates/mdtest/Cargo.toml
+++ b/crates/mdtest/Cargo.toml
@@ -26,7 +26,7 @@ anyhow = { workspace = true }
 camino = { workspace = true }
 colored = { workspace = true }
 indexmap = { workspace = true }
-insta = { workspace = true }
+insta = { workspace = true, features = ["filters"] }
 memchr = { workspace = true }
 path-slash = { workspace = true }
 regex = { workspace = true }

--- a/crates/mdtest/src/lib.rs
+++ b/crates/mdtest/src/lib.rs
@@ -165,7 +165,7 @@ pub enum OutputFormat {
 }
 
 impl OutputFormat {
-    pub const fn is_cli(self) -> bool {
+    const fn is_cli(self) -> bool {
         matches!(self, OutputFormat::Cli)
     }
 
@@ -178,7 +178,7 @@ impl OutputFormat {
     /// Actions can detect them as workflow commands. Workflow commands must
     /// appear at the beginning of a line in stdout to be parsed by GitHub.
     #[expect(clippy::print_stdout)]
-    pub fn write_error(
+    fn write_error(
         self,
         assertion_buf: &mut String,
         file: &str,

--- a/crates/mdtest/src/lib.rs
+++ b/crates/mdtest/src/lib.rs
@@ -1,10 +1,14 @@
+use std::backtrace::BacktraceStatus;
 use std::fmt::{Display, Write};
 
 use camino::Utf8Path;
 use colored::Colorize;
 use similar::{ChangeTag, TextDiff};
 
+use ruff_db::Db;
 use ruff_db::diagnostic::{Diagnostic, DisplayDiagnosticConfig, FileResolver};
+use ruff_db::files::File;
+use ruff_db::panic::{PanicError, catch_unwind};
 use ruff_db::source::line_index;
 use ruff_diagnostics::Applicability;
 use ruff_source_file::OneIndexed;
@@ -460,6 +464,87 @@ pub fn create_diagnostic_snapshot<'d, C>(
 pub struct MarkdownEdit {
     pub(crate) range: TextRange,
     pub(crate) replacement: String,
+}
+
+/// Run a function over an embedded test file, catching any panics that occur in the process.
+///
+/// If no panic occurs, the result of the function is returned as an `Ok()` variant.
+///
+/// If a panic occurs, a nicely formatted [`FileFailures`] is returned as an `Err()` variant to
+/// be formatted into a diagnostic message by callers.
+pub fn attempt_test<'a, T, F>(
+    test_fn: F,
+    test_file: &'a TestFile<'a>,
+) -> Result<T, AttemptTestError<'a>>
+where
+    F: FnOnce(File) -> T + std::panic::UnwindSafe,
+{
+    catch_unwind(|| test_fn(test_file.file)).map_err(|info| AttemptTestError { info, test_file })
+}
+
+pub struct AttemptTestError<'a> {
+    pub info: PanicError,
+    test_file: &'a TestFile<'a>,
+}
+
+impl AttemptTestError<'_> {
+    pub fn into_file_failures(
+        self,
+        db: &dyn Db,
+        action: &str,
+        clarification: Option<&str>,
+    ) -> FileFailures {
+        let info = self.info;
+
+        let mut by_line = matcher::FailuresByLine::default();
+        let mut messages = vec![];
+        match info.location {
+            Some(location) => messages.push(Failure::new(format_args!(
+                "Attempting to {action} caused a panic at {location}"
+            ))),
+            None => messages.push(Failure::new(format_args!(
+                "Attempting to {action} caused a panic at an unknown location",
+            ))),
+        }
+        if let Some(clarification) = clarification {
+            messages.push(Failure::new(clarification));
+        }
+        messages.push(Failure::new(""));
+        match info.payload.as_str() {
+            Some(message) => messages.push(Failure::new(message)),
+            // Mimic the default panic hook's rendering of the panic payload if it's
+            // not a string.
+            None => messages.push(Failure::new("Box<dyn Any>")),
+        }
+        messages.push(Failure::new(""));
+
+        if let Some(backtrace) = info.backtrace {
+            match backtrace.status() {
+                BacktraceStatus::Disabled => {
+                    let msg = "run with `RUST_BACKTRACE=1` environment variable to \
+                         a backtrace";
+                    messages.push(Failure::new(msg));
+                }
+                BacktraceStatus::Captured => {
+                    messages.extend(backtrace.to_string().split('\n').map(Failure::new));
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(backtrace) = info.salsa_backtrace {
+            salsa::attach(db, || {
+                messages.extend(format!("{backtrace:#}").split('\n').map(Failure::new));
+            });
+        }
+
+        by_line.push(OneIndexed::from_zero_indexed(0), messages);
+
+        FileFailures {
+            backtick_offsets: self.test_file.to_code_block_backtick_offsets(),
+            by_line,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/mdtest/src/lib.rs
+++ b/crates/mdtest/src/lib.rs
@@ -20,7 +20,7 @@ use crate::parser::{BacktickOffsets, EmbeddedFileSourceMap};
 /// Filter which tests to run in mdtest.
 ///
 /// Only tests whose names contain this filter string will be executed.
-pub const MDTEST_TEST_FILTER: &str = "MDTEST_TEST_FILTER";
+const MDTEST_TEST_FILTER: &str = "MDTEST_TEST_FILTER";
 
 /// If set to a value other than "0", updates the content of inline snapshots.
 const MDTEST_UPDATE_SNAPSHOTS: &str = "MDTEST_UPDATE_SNAPSHOTS";
@@ -146,7 +146,7 @@ pub fn run<C>(
 }
 
 /// Determine the output format from the `MDTEST_GITHUB_ANNOTATIONS_FORMAT` environment variable.
-pub fn output_format() -> OutputFormat {
+fn output_format() -> OutputFormat {
     if std::env::var(MDTEST_GITHUB_ANNOTATIONS_FORMAT).is_ok() {
         OutputFormat::GitHub
     } else {
@@ -496,7 +496,7 @@ fn render_diff(f: &mut dyn std::fmt::Write, expected: &str, actual: &str) -> std
     Ok(())
 }
 
-pub fn try_apply_markdown_edits(
+fn try_apply_markdown_edits(
     absolute_fixture_path: &Utf8Path,
     source: &str,
     mut edits: Vec<MarkdownEdit>,

--- a/crates/mdtest/src/lib.rs
+++ b/crates/mdtest/src/lib.rs
@@ -178,7 +178,7 @@ impl OutputFormat {
     /// Actions can detect them as workflow commands. Workflow commands must
     /// appear at the beginning of a line in stdout to be parsed by GitHub.
     #[expect(clippy::print_stdout)]
-    fn write_error(
+    pub fn write_error(
         self,
         assertion_buf: &mut String,
         file: &str,

--- a/crates/mdtest/src/lib.rs
+++ b/crates/mdtest/src/lib.rs
@@ -547,6 +547,12 @@ impl AttemptTestError<'_> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TestOutcome {
+    Success,
+    Skipped,
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use ruff_db::Db;

--- a/crates/mdtest/src/lib.rs
+++ b/crates/mdtest/src/lib.rs
@@ -9,7 +9,6 @@ use ruff_db::Db;
 use ruff_db::diagnostic::{Diagnostic, DisplayDiagnosticConfig, FileResolver};
 use ruff_db::files::File;
 use ruff_db::panic::{PanicError, catch_unwind};
-use ruff_db::source::line_index;
 use ruff_diagnostics::Applicability;
 use ruff_source_file::{LineIndex, OneIndexed};
 use ruff_text_size::{Ranged, TextRange};
@@ -354,14 +353,15 @@ pub(crate) fn apply_snapshot_filters(rendered: &str) -> std::borrow::Cow<'_, str
 }
 
 pub fn validate_inline_snapshot(
-    db: &dyn ruff_db::Db,
+    resolver: &dyn FileResolver,
     tool_name: &'static str,
     test_file: &TestFile<'_>,
     inline_diagnostics: &[Diagnostic],
     markdown_edits: &mut Vec<MarkdownEdit>,
 ) -> Result<(), matcher::FailuresByLine> {
     let update_snapshots = is_update_inline_snapshots_enabled();
-    let line_index = line_index(db, test_file.file);
+    let input = resolver.input(test_file.file);
+    let line_index = input.line_index();
     let mut failures = matcher::FailuresByLine::default();
     let mut inline_diagnostics = inline_diagnostics;
 
@@ -415,8 +415,9 @@ pub fn validate_inline_snapshot(
             continue;
         };
 
-        let actual = apply_snapshot_filters(&render_diagnostics(&db, tool_name, block_diagnostics))
-            .into_owned();
+        let actual =
+            apply_snapshot_filters(&render_diagnostics(resolver, tool_name, block_diagnostics))
+                .into_owned();
 
         let Some(snapshot_code_block) = code_block.inline_snapshot_block() else {
             if update_snapshots {

--- a/crates/mdtest/src/lib.rs
+++ b/crates/mdtest/src/lib.rs
@@ -11,11 +11,11 @@ use ruff_db::files::File;
 use ruff_db::panic::{PanicError, catch_unwind};
 use ruff_db::source::line_index;
 use ruff_diagnostics::Applicability;
-use ruff_source_file::OneIndexed;
+use ruff_source_file::{LineIndex, OneIndexed};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::matcher::Failure;
-use crate::parser::BacktickOffsets;
+use crate::parser::{BacktickOffsets, EmbeddedFileSourceMap};
 
 /// Filter which tests to run in mdtest.
 ///
@@ -34,6 +34,116 @@ mod assertion;
 mod diagnostic;
 pub mod matcher;
 pub mod parser;
+
+/// Run `path` as a markdown test suite with given `title`.
+///
+/// Panic on test failure, and print failure details.
+pub fn run<C>(
+    absolute_fixture_path: &Utf8Path,
+    relative_fixture_path: &Utf8Path,
+    source: &str,
+    test_name: &str,
+    crate_name: &str,
+    suite: &parser::MarkdownTestSuite<'_, C>,
+    mut run_test: impl FnMut(
+        &parser::MarkdownTest<'_, '_, C>,
+        &mut String,
+        OutputFormat,
+    ) -> Result<(TestOutcome, Vec<MarkdownEdit>), Failures>,
+) -> anyhow::Result<()> {
+    let output_format = output_format();
+
+    let mut markdown_edits = vec![];
+
+    let filter = std::env::var(MDTEST_TEST_FILTER).ok();
+    let mut any_failures = false;
+    let mut assertion = String::new();
+    for test in suite.tests() {
+        if filter
+            .as_ref()
+            .is_some_and(|f| !(test.uncontracted_name().contains(f) || test.name() == *f))
+        {
+            continue;
+        }
+
+        let result = run_test(&test, &mut assertion, output_format);
+
+        let this_test_failed = result.is_err();
+        any_failures = any_failures || this_test_failed;
+
+        if this_test_failed && output_format.is_cli() {
+            let _ = writeln!(assertion, "\n\n{}\n", test.name().bold().underline());
+        }
+
+        match result {
+            Ok((_, edits)) => markdown_edits.extend(edits),
+            Err(failures) => {
+                let md_index = LineIndex::from_source_text(source);
+
+                for test_failures in failures {
+                    let source_map =
+                        EmbeddedFileSourceMap::new(&md_index, test_failures.backtick_offsets);
+
+                    for (relative_line_number, failures) in test_failures.by_line.iter() {
+                        let file = relative_fixture_path.as_str();
+
+                        let absolute_line_number =
+                            match source_map.to_absolute_line_number(relative_line_number) {
+                                Ok(line_number) => line_number,
+                                Err(last_line_number) => {
+                                    output_format.write_error(
+                                        &mut assertion,
+                                        file,
+                                        last_line_number,
+                                        &Failure::new(
+                                            "Found a trailing assertion comment \
+                                            (e.g., `# revealed:` or `# error:`) \
+                                            not followed by any statement.",
+                                        ),
+                                    );
+
+                                    continue;
+                                }
+                            };
+
+                        for failure in failures {
+                            output_format.write_error(
+                                &mut assertion,
+                                file,
+                                absolute_line_number,
+                                failure,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        if this_test_failed && output_format.is_cli() {
+            let escaped_test_name = test.name().replace('\'', "\\'");
+            let _ = writeln!(
+                assertion,
+                "\nTo rerun this specific test, \
+                set the environment variable: {MDTEST_TEST_FILTER}='{escaped_test_name}'",
+            );
+            let _ = writeln!(
+                assertion,
+                "{MDTEST_TEST_FILTER}='{escaped_test_name}' cargo test -p {crate_name} \
+                --test mdtest -- {test_name}",
+            );
+
+            let _ = writeln!(assertion, "\n{}", "-".repeat(50));
+        }
+    }
+
+    if !markdown_edits.is_empty() {
+        try_apply_markdown_edits(absolute_fixture_path, source, markdown_edits);
+    }
+
+    assert!(!any_failures, "{}", &assertion);
+
+    Ok(())
+}
 
 /// Determine the output format from the `MDTEST_GITHUB_ANNOTATIONS_FORMAT` environment variable.
 pub fn output_format() -> OutputFormat {

--- a/crates/mdtest/src/lib.rs
+++ b/crates/mdtest/src/lib.rs
@@ -65,7 +65,9 @@ pub fn run<C>(
             continue;
         }
 
-        let result = run_test(&test, &mut assertion, output_format);
+        // Buffer any immediate output from the test to emit after the header has been printed.
+        let mut test_assertion = String::new();
+        let result = run_test(&test, &mut test_assertion, output_format);
 
         let this_test_failed = result.is_err();
         any_failures = any_failures || this_test_failed;
@@ -119,6 +121,8 @@ pub fn run<C>(
         }
 
         if this_test_failed && output_format.is_cli() {
+            assertion.push_str(&test_assertion);
+
             let escaped_test_name = test.name().replace('\'', "\\'");
             let _ = writeln!(
                 assertion,

--- a/crates/mdtest/src/lib.rs
+++ b/crates/mdtest/src/lib.rs
@@ -14,7 +14,7 @@ use ruff_source_file::{LineIndex, OneIndexed};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::matcher::Failure;
-use crate::parser::{BacktickOffsets, EmbeddedFileSourceMap};
+use crate::parser::{BacktickOffsets, EmbeddedFileSourceMap, MarkdownTest};
 
 /// Filter which tests to run in mdtest.
 ///
@@ -661,6 +661,75 @@ impl AttemptTestError<'_> {
 pub enum TestOutcome {
     Success,
     Skipped,
+}
+
+pub fn check_panic<C>(test: &MarkdownTest<'_, '_, C>, panic_info: Option<PanicError>) {
+    match panic_info {
+        Some(panic_info) => {
+            let expected_message = test
+                .should_expect_panic()
+                .expect("panic_info is only set when `should_expect_panic` is `Ok`");
+
+            if let Some(expected_message) = expected_message {
+                let message = panic_info.payload.to_string();
+                assert!(
+                    message.contains(expected_message),
+                    "Test `{}` is expected to panic with `{expected_message}`, but panicked with `{message}` instead.",
+                    test.name(),
+                );
+            }
+        }
+        None => {
+            if let Ok(message) = test.should_expect_panic() {
+                if let Some(message) = message {
+                    panic!(
+                        "Test `{}` is expected to panic with `{message}`, but it didn't.",
+                        test.name()
+                    );
+                }
+                panic!("Test `{}` is expected to panic but it didn't.", test.name());
+            }
+        }
+    }
+}
+
+pub fn snapshot_diagnostics<C>(
+    test: &MarkdownTest<'_, '_, C>,
+    resolver: &dyn FileResolver,
+    tool_name: &'static str,
+    relative_fixture_path: &Utf8Path,
+    snapshot_path: &Utf8Path,
+    diagnostics: &[Diagnostic],
+    mut snapshot_filter: impl FnMut(&Diagnostic) -> bool,
+) {
+    if test.should_snapshot_diagnostics() {
+        assert!(
+            !diagnostics.is_empty(),
+            "Test `{}` requested snapshotting diagnostics but it didn't produce any.",
+            test.name()
+        );
+
+        let snapshot = crate::create_diagnostic_snapshot(
+            resolver,
+            tool_name,
+            relative_fixture_path,
+            test,
+            diagnostics
+                .iter()
+                .filter(|diagnostic| snapshot_filter(diagnostic)),
+        );
+
+        let name = test.name().replace(' ', "_").replace(':', "__");
+        insta::with_settings!(
+            {
+                snapshot_path => snapshot_path,
+                input_file => name.clone(),
+                filters => vec![(r"\\", "/")],
+                prepend_module_to_snapshot => false,
+            },
+            { insta::assert_snapshot!(name, snapshot) }
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/mdtest/src/lib.rs
+++ b/crates/mdtest/src/lib.rs
@@ -542,6 +542,12 @@ impl AttemptTestError<'_> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TestOutcome {
+    Success,
+    Skipped,
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use ruff_db::Db;

--- a/crates/mdtest/src/lib.rs
+++ b/crates/mdtest/src/lib.rs
@@ -1,10 +1,14 @@
+use std::backtrace::BacktraceStatus;
 use std::fmt::{Display, Write};
 
 use camino::Utf8Path;
 use colored::Colorize;
 use similar::{ChangeTag, TextDiff};
 
+use ruff_db::Db;
 use ruff_db::diagnostic::{Diagnostic, DisplayDiagnosticConfig, FileResolver};
+use ruff_db::files::File;
+use ruff_db::panic::{PanicError, catch_unwind};
 use ruff_db::source::line_index;
 use ruff_diagnostics::Applicability;
 use ruff_source_file::OneIndexed;
@@ -460,6 +464,82 @@ pub fn create_diagnostic_snapshot<'d, C>(
 pub struct MarkdownEdit {
     pub(crate) range: TextRange,
     pub(crate) replacement: String,
+}
+
+/// Run a function over an embedded test file, catching any panics that occur in the process.
+///
+/// If no panic occurs, the result of the function is returned as an `Ok()` variant.
+///
+/// If a panic occurs, a nicely formatted [`FileFailures`] is returned as an `Err()` variant to
+/// be formatted into a diagnostic message by callers.
+pub fn attempt_test<'a, T, F>(
+    test_fn: F,
+    test_file: &'a TestFile<'a>,
+) -> Result<T, AttemptTestError<'a>>
+where
+    F: FnOnce(File) -> T + std::panic::UnwindSafe,
+{
+    catch_unwind(|| test_fn(test_file.file)).map_err(|info| AttemptTestError { info, test_file })
+}
+
+pub struct AttemptTestError<'a> {
+    pub info: PanicError,
+    test_file: &'a TestFile<'a>,
+}
+
+impl AttemptTestError<'_> {
+    pub fn into_file_failures(
+        self,
+        db: &dyn Db,
+        action: &str,
+        clarification: Option<&str>,
+    ) -> FileFailures {
+        let info = self.info;
+
+        let mut by_line = matcher::FailuresByLine::default();
+        let mut messages = vec![];
+        match info.location {
+            Some(location) => messages.push(Failure::new(format_args!(
+                "Attempting to {action} caused a panic at {location}"
+            ))),
+            None => messages.push(Failure::new(format_args!(
+                "Attempting to {action} caused a panic at an unknown location",
+            ))),
+        }
+        if let Some(clarification) = clarification {
+            messages.push(Failure::new(clarification));
+        }
+        messages.push(Failure::new(""));
+        messages.push(Failure::new(info.payload));
+        messages.push(Failure::new(""));
+
+        if let Some(backtrace) = info.backtrace {
+            match backtrace.status() {
+                BacktraceStatus::Disabled => {
+                    let msg = "run with `RUST_BACKTRACE=1` environment variable to \
+                         a backtrace";
+                    messages.push(Failure::new(msg));
+                }
+                BacktraceStatus::Captured => {
+                    messages.extend(backtrace.to_string().split('\n').map(Failure::new));
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(backtrace) = info.salsa_backtrace {
+            salsa::attach(db, || {
+                messages.extend(format!("{backtrace:#}").split('\n').map(Failure::new));
+            });
+        }
+
+        by_line.push(OneIndexed::from_zero_indexed(0), messages);
+
+        FileFailures {
+            backtick_offsets: self.test_file.to_code_block_backtick_offsets(),
+            by_line,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/mdtest/src/parser.rs
+++ b/crates/mdtest/src/parser.rs
@@ -291,7 +291,7 @@ struct SectionId;
 /// [`MarkdownTest`]), or it may contain nested sections (headers with more `#` characters), but
 /// not both.
 #[derive(Debug)]
-struct Section<'s, C> {
+pub struct Section<'s, C> {
     title: &'s str,
     level: u8,
     parent_id: Option<SectionId>,

--- a/crates/mdtest/src/parser.rs
+++ b/crates/mdtest/src/parser.rs
@@ -52,7 +52,7 @@ pub struct MarkdownTestSuite<'s, C> {
 }
 
 impl<'s, C> MarkdownTestSuite<'s, C> {
-    pub fn tests(&self) -> MarkdownTestIterator<'_, 's, C> {
+    pub(crate) fn tests(&self) -> MarkdownTestIterator<'_, 's, C> {
         MarkdownTestIterator {
             suite: self,
             current_file_index: 0,
@@ -141,11 +141,11 @@ impl<'m, 's, C> MarkdownTest<'m, 's, C> {
         contracted_name
     }
 
-    pub fn uncontracted_name(&self) -> String {
+    pub(crate) fn uncontracted_name(&self) -> String {
         self.joined_name(false)
     }
 
-    pub fn name(&self) -> String {
+    pub(crate) fn name(&self) -> String {
         self.joined_name(true)
     }
 
@@ -157,7 +157,7 @@ impl<'m, 's, C> MarkdownTest<'m, 's, C> {
         &self.section.config
     }
 
-    pub fn should_snapshot_diagnostics(&self) -> bool {
+    fn should_snapshot_diagnostics(&self) -> bool {
         self.section
             .directives
             .has_directive_set(MdtestDirective::SnapshotDiagnostics)
@@ -291,7 +291,7 @@ struct SectionId;
 /// [`MarkdownTest`]), or it may contain nested sections (headers with more `#` characters), but
 /// not both.
 #[derive(Debug)]
-pub struct Section<'s, C> {
+struct Section<'s, C> {
     title: &'s str,
     level: u8,
     parent_id: Option<SectionId>,

--- a/crates/mdtest/src/parser.rs
+++ b/crates/mdtest/src/parser.rs
@@ -6,7 +6,10 @@ use std::{
 
 use anyhow::{Context, bail};
 use indexmap::{IndexMap, map::Entry};
-use ruff_db::system::{SystemPath, SystemPathBuf};
+use ruff_db::{
+    panic::PanicError,
+    system::{SystemPath, SystemPathBuf},
+};
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use ruff_index::{IndexVec, newtype_index};
@@ -167,6 +170,41 @@ impl<'m, 's, C> MarkdownTest<'m, 's, C> {
         self.section
             .directives
             .has_directive_set(MdtestDirective::PullTypesSkip)
+    }
+
+    pub fn check_panic(&self, panic_info: Option<PanicError>) {
+        match panic_info {
+            Some(panic_info) => {
+                let expected_message = self
+                    .should_expect_panic()
+                    .expect("panic_info is only set when `should_expect_panic` is `Ok`");
+
+                let message = panic_info
+                    .payload
+                    .as_str()
+                    .unwrap_or("Box<dyn Any>")
+                    .to_string();
+
+                if let Some(expected_message) = expected_message {
+                    assert!(
+                        message.contains(expected_message),
+                        "Test `{}` is expected to panic with `{expected_message}`, but panicked with `{message}` instead.",
+                        self.name()
+                    );
+                }
+            }
+            None => {
+                if let Ok(message) = self.should_expect_panic() {
+                    if let Some(message) = message {
+                        panic!(
+                            "Test `{}` is expected to panic with `{message}`, but it didn't.",
+                            self.name()
+                        );
+                    }
+                    panic!("Test `{}` is expected to panic but it didn't.", self.name());
+                }
+            }
+        }
     }
 }
 

--- a/crates/mdtest/src/parser.rs
+++ b/crates/mdtest/src/parser.rs
@@ -363,12 +363,12 @@ impl Ranged for InlineSnapshotBlock<'_> {
 /// count of the first block, and then add the new relative line number (1)
 /// to the absolute start line of the second block (12), resulting in an
 /// absolute line number of 13.
-pub struct EmbeddedFileSourceMap {
+pub(crate) struct EmbeddedFileSourceMap {
     start_line_and_line_count: Vec<(usize, usize)>,
 }
 
 impl EmbeddedFileSourceMap {
-    pub fn new(
+    pub(crate) fn new(
         md_index: &LineIndex,
         dimensions: impl IntoIterator<Item = BacktickOffsets>,
     ) -> EmbeddedFileSourceMap {
@@ -393,7 +393,7 @@ impl EmbeddedFileSourceMap {
     ///
     /// # Panics
     ///  If called when the markdown file has no code blocks.
-    pub fn to_absolute_line_number(
+    pub(crate) fn to_absolute_line_number(
         &self,
         relative_line_number: OneIndexed,
     ) -> std::result::Result<OneIndexed, OneIndexed> {

--- a/crates/mdtest/src/parser.rs
+++ b/crates/mdtest/src/parser.rs
@@ -5,8 +5,10 @@ use std::{
 };
 
 use anyhow::{Context, bail};
+use camino::Utf8Path;
 use indexmap::{IndexMap, map::Entry};
 use ruff_db::{
+    diagnostic::{Diagnostic, FileResolver},
     panic::PanicError,
     system::{SystemPath, SystemPathBuf},
 };
@@ -204,6 +206,45 @@ impl<'m, 's, C> MarkdownTest<'m, 's, C> {
                     panic!("Test `{}` is expected to panic but it didn't.", self.name());
                 }
             }
+        }
+    }
+
+    pub fn snapshot_diagnostics(
+        &self,
+        resolver: &dyn FileResolver,
+        tool_name: &'static str,
+        relative_fixture_path: &Utf8Path,
+        snapshot_path: &Utf8Path,
+        diagnostics: &[Diagnostic],
+        mut snapshot_filter: impl FnMut(&Diagnostic) -> bool,
+    ) {
+        if self.should_snapshot_diagnostics() {
+            assert!(
+                !diagnostics.is_empty(),
+                "Test `{}` requested snapshotting diagnostics but it didn't produce any.",
+                self.name()
+            );
+
+            let snapshot = crate::create_diagnostic_snapshot(
+                resolver,
+                tool_name,
+                relative_fixture_path,
+                self,
+                diagnostics
+                    .iter()
+                    .filter(|diagnostic| snapshot_filter(diagnostic)),
+            );
+
+            let name = self.name().replace(' ', "_").replace(':', "__");
+            insta::with_settings!(
+                {
+                    snapshot_path => snapshot_path,
+                    input_file => name.clone(),
+                    filters => vec![(r"\\", "/")],
+                    prepend_module_to_snapshot => false,
+                },
+                { insta::assert_snapshot!(name, snapshot) }
+            );
         }
     }
 }

--- a/crates/mdtest/src/parser.rs
+++ b/crates/mdtest/src/parser.rs
@@ -6,7 +6,10 @@ use std::{
 
 use anyhow::{Context, bail};
 use indexmap::{IndexMap, map::Entry};
-use ruff_db::system::{SystemPath, SystemPathBuf};
+use ruff_db::{
+    panic::PanicError,
+    system::{SystemPath, SystemPathBuf},
+};
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use ruff_index::{IndexVec, newtype_index};
@@ -167,6 +170,36 @@ impl<'m, 's, C> MarkdownTest<'m, 's, C> {
         self.section
             .directives
             .has_directive_set(MdtestDirective::PullTypesSkip)
+    }
+
+    pub fn check_panic(&self, panic_info: Option<PanicError>) {
+        match panic_info {
+            Some(panic_info) => {
+                let expected_message = self
+                    .should_expect_panic()
+                    .expect("panic_info is only set when `should_expect_panic` is `Ok`");
+
+                if let Some(expected_message) = expected_message {
+                    let message = panic_info.payload.to_string();
+                    assert!(
+                        message.contains(expected_message),
+                        "Test `{}` is expected to panic with `{expected_message}`, but panicked with `{message}` instead.",
+                        self.name(),
+                    );
+                }
+            }
+            None => {
+                if let Ok(message) = self.should_expect_panic() {
+                    if let Some(message) = message {
+                        panic!(
+                            "Test `{}` is expected to panic with `{message}`, but it didn't.",
+                            self.name()
+                        );
+                    }
+                    panic!("Test `{}` is expected to panic but it didn't.", self.name());
+                }
+            }
+        }
     }
 }
 

--- a/crates/mdtest/src/parser.rs
+++ b/crates/mdtest/src/parser.rs
@@ -5,8 +5,10 @@ use std::{
 };
 
 use anyhow::{Context, bail};
+use camino::Utf8Path;
 use indexmap::{IndexMap, map::Entry};
 use ruff_db::{
+    diagnostic::{Diagnostic, FileResolver},
     panic::PanicError,
     system::{SystemPath, SystemPathBuf},
 };
@@ -199,6 +201,45 @@ impl<'m, 's, C> MarkdownTest<'m, 's, C> {
                     panic!("Test `{}` is expected to panic but it didn't.", self.name());
                 }
             }
+        }
+    }
+
+    pub fn snapshot_diagnostics(
+        &self,
+        resolver: &dyn FileResolver,
+        tool_name: &'static str,
+        relative_fixture_path: &Utf8Path,
+        snapshot_path: &Utf8Path,
+        diagnostics: &[Diagnostic],
+        mut snapshot_filter: impl FnMut(&Diagnostic) -> bool,
+    ) {
+        if self.should_snapshot_diagnostics() {
+            assert!(
+                !diagnostics.is_empty(),
+                "Test `{}` requested snapshotting diagnostics but it didn't produce any.",
+                self.name()
+            );
+
+            let snapshot = crate::create_diagnostic_snapshot(
+                resolver,
+                tool_name,
+                relative_fixture_path,
+                self,
+                diagnostics
+                    .iter()
+                    .filter(|diagnostic| snapshot_filter(diagnostic)),
+            );
+
+            let name = self.name().replace(' ', "_").replace(':', "__");
+            insta::with_settings!(
+                {
+                    snapshot_path => snapshot_path,
+                    input_file => name.clone(),
+                    filters => vec![(r"\\", "/")],
+                    prepend_module_to_snapshot => false,
+                },
+                { insta::assert_snapshot!(name, snapshot) }
+            );
         }
     }
 }

--- a/crates/mdtest/src/parser.rs
+++ b/crates/mdtest/src/parser.rs
@@ -5,13 +5,8 @@ use std::{
 };
 
 use anyhow::{Context, bail};
-use camino::Utf8Path;
 use indexmap::{IndexMap, map::Entry};
-use ruff_db::{
-    diagnostic::{Diagnostic, FileResolver},
-    panic::PanicError,
-    system::{SystemPath, SystemPathBuf},
-};
+use ruff_db::system::{SystemPath, SystemPathBuf};
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use ruff_index::{IndexVec, newtype_index};
@@ -157,7 +152,7 @@ impl<'m, 's, C> MarkdownTest<'m, 's, C> {
         &self.section.config
     }
 
-    fn should_snapshot_diagnostics(&self) -> bool {
+    pub(crate) fn should_snapshot_diagnostics(&self) -> bool {
         self.section
             .directives
             .has_directive_set(MdtestDirective::SnapshotDiagnostics)
@@ -172,75 +167,6 @@ impl<'m, 's, C> MarkdownTest<'m, 's, C> {
         self.section
             .directives
             .has_directive_set(MdtestDirective::PullTypesSkip)
-    }
-
-    pub fn check_panic(&self, panic_info: Option<PanicError>) {
-        match panic_info {
-            Some(panic_info) => {
-                let expected_message = self
-                    .should_expect_panic()
-                    .expect("panic_info is only set when `should_expect_panic` is `Ok`");
-
-                if let Some(expected_message) = expected_message {
-                    let message = panic_info.payload.to_string();
-                    assert!(
-                        message.contains(expected_message),
-                        "Test `{}` is expected to panic with `{expected_message}`, but panicked with `{message}` instead.",
-                        self.name(),
-                    );
-                }
-            }
-            None => {
-                if let Ok(message) = self.should_expect_panic() {
-                    if let Some(message) = message {
-                        panic!(
-                            "Test `{}` is expected to panic with `{message}`, but it didn't.",
-                            self.name()
-                        );
-                    }
-                    panic!("Test `{}` is expected to panic but it didn't.", self.name());
-                }
-            }
-        }
-    }
-
-    pub fn snapshot_diagnostics(
-        &self,
-        resolver: &dyn FileResolver,
-        tool_name: &'static str,
-        relative_fixture_path: &Utf8Path,
-        snapshot_path: &Utf8Path,
-        diagnostics: &[Diagnostic],
-        mut snapshot_filter: impl FnMut(&Diagnostic) -> bool,
-    ) {
-        if self.should_snapshot_diagnostics() {
-            assert!(
-                !diagnostics.is_empty(),
-                "Test `{}` requested snapshotting diagnostics but it didn't produce any.",
-                self.name()
-            );
-
-            let snapshot = crate::create_diagnostic_snapshot(
-                resolver,
-                tool_name,
-                relative_fixture_path,
-                self,
-                diagnostics
-                    .iter()
-                    .filter(|diagnostic| snapshot_filter(diagnostic)),
-            );
-
-            let name = self.name().replace(' ', "_").replace(':', "__");
-            insta::with_settings!(
-                {
-                    snapshot_path => snapshot_path,
-                    input_file => name.clone(),
-                    filters => vec![(r"\\", "/")],
-                    prepend_module_to_snapshot => false,
-                },
-                { insta::assert_snapshot!(name, snapshot) }
-            );
-        }
     }
 }
 

--- a/crates/mdtest/src/parser.rs
+++ b/crates/mdtest/src/parser.rs
@@ -286,7 +286,7 @@ struct SectionId;
 /// [`MarkdownTest`]), or it may contain nested sections (headers with more `#` characters), but
 /// not both.
 #[derive(Debug)]
-struct Section<'s, C> {
+pub struct Section<'s, C> {
     title: &'s str,
     level: u8,
     parent_id: Option<SectionId>,

--- a/crates/mdtest/src/parser.rs
+++ b/crates/mdtest/src/parser.rs
@@ -358,12 +358,12 @@ impl Ranged for InlineSnapshotBlock<'_> {
 /// count of the first block, and then add the new relative line number (1)
 /// to the absolute start line of the second block (12), resulting in an
 /// absolute line number of 13.
-pub struct EmbeddedFileSourceMap {
+pub(crate) struct EmbeddedFileSourceMap {
     start_line_and_line_count: Vec<(usize, usize)>,
 }
 
 impl EmbeddedFileSourceMap {
-    pub fn new(
+    pub(crate) fn new(
         md_index: &LineIndex,
         dimensions: impl IntoIterator<Item = BacktickOffsets>,
     ) -> EmbeddedFileSourceMap {
@@ -388,7 +388,7 @@ impl EmbeddedFileSourceMap {
     ///
     /// # Panics
     ///  If called when the markdown file has no code blocks.
-    pub fn to_absolute_line_number(
+    pub(crate) fn to_absolute_line_number(
         &self,
         relative_line_number: OneIndexed,
     ) -> std::result::Result<OneIndexed, OneIndexed> {

--- a/crates/mdtest/src/parser.rs
+++ b/crates/mdtest/src/parser.rs
@@ -52,7 +52,7 @@ pub struct MarkdownTestSuite<'s, C> {
 }
 
 impl<'s, C> MarkdownTestSuite<'s, C> {
-    pub fn tests(&self) -> MarkdownTestIterator<'_, 's, C> {
+    pub(crate) fn tests(&self) -> MarkdownTestIterator<'_, 's, C> {
         MarkdownTestIterator {
             suite: self,
             current_file_index: 0,
@@ -141,11 +141,11 @@ impl<'m, 's, C> MarkdownTest<'m, 's, C> {
         contracted_name
     }
 
-    pub fn uncontracted_name(&self) -> String {
+    pub(crate) fn uncontracted_name(&self) -> String {
         self.joined_name(false)
     }
 
-    pub fn name(&self) -> String {
+    pub(crate) fn name(&self) -> String {
         self.joined_name(true)
     }
 
@@ -157,7 +157,7 @@ impl<'m, 's, C> MarkdownTest<'m, 's, C> {
         &self.section.config
     }
 
-    pub fn should_snapshot_diagnostics(&self) -> bool {
+    fn should_snapshot_diagnostics(&self) -> bool {
         self.section
             .directives
             .has_directive_set(MdtestDirective::SnapshotDiagnostics)
@@ -286,7 +286,7 @@ struct SectionId;
 /// [`MarkdownTest`]), or it may contain nested sections (headers with more `#` characters), but
 /// not both.
 #[derive(Debug)]
-pub struct Section<'s, C> {
+struct Section<'s, C> {
     title: &'s str,
     level: u8,
     parent_id: Option<SectionId>,

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -907,6 +907,12 @@ pub struct Input {
     pub(crate) line_index: LineIndex,
 }
 
+impl Input {
+    pub fn line_index(&self) -> &LineIndex {
+        &self.line_index
+    }
+}
+
 /// Returns the line number accounting for the given `len`
 /// number of preceding context lines.
 ///

--- a/crates/ty_test/Cargo.toml
+++ b/crates/ty_test/Cargo.toml
@@ -29,7 +29,6 @@ anyhow = { workspace = true }
 camino = { workspace = true }
 colored = { workspace = true }
 dunce = { workspace = true }
-insta = { workspace = true, features = ["filters"] }
 salsa = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tempfile = { workspace = true }

--- a/crates/ty_test/Cargo.toml
+++ b/crates/ty_test/Cargo.toml
@@ -27,7 +27,6 @@ ty_vendored = { workspace = true }
 
 anyhow = { workspace = true }
 camino = { workspace = true }
-colored = { workspace = true }
 dunce = { workspace = true }
 salsa = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -477,37 +477,19 @@ fn run_test(
         failures.push(failure);
     }
 
-    if test.should_snapshot_diagnostics() {
-        assert!(
-            !all_diagnostics.is_empty(),
-            "Test `{}` requested snapshotting diagnostics but it didn't produce any.",
-            test.name()
-        );
-
-        // Filter out `revealed-type` and `undefined-reveal` diagnostics from snapshots,
-        // since they make snapshots very noisy!
-        let snapshot = mdtest::create_diagnostic_snapshot(
-            db,
-            "ty",
-            relative_fixture_path,
-            test,
-            all_diagnostics.iter().filter(|diagnostic| {
-                diagnostic.id() != DiagnosticId::RevealedType
-                    && !diagnostic.id().is_lint_named(&UNDEFINED_REVEAL.name())
-            }),
-        );
-
-        let name = test.name().replace(' ', "_").replace(':', "__");
-        insta::with_settings!(
-            {
-                snapshot_path => snapshot_path,
-                input_file => name.clone(),
-                filters => vec![(r"\\", "/")],
-                prepend_module_to_snapshot => false,
-            },
-            { insta::assert_snapshot!(name, snapshot) }
-        );
-    }
+    // Filter out `revealed-type` and `undefined-reveal` diagnostics from snapshots,
+    // since they make snapshots very noisy!
+    test.snapshot_diagnostics(
+        db,
+        "ty",
+        relative_fixture_path,
+        snapshot_path,
+        &all_diagnostics,
+        |diagnostic| {
+            diagnostic.id() != DiagnosticId::RevealedType
+                && !diagnostic.id().is_lint_named(&UNDEFINED_REVEAL.name())
+        },
+    );
 
     // Test to fix all fixable diagnostics and verify that they don't introduce any syntax errors.
     // But don't try to run fixes for tests that are expected to panic.

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -1,12 +1,10 @@
 use crate::config::{Log, MarkdownTestConfig, SystemKind};
 use anyhow::{anyhow, bail};
 use camino::Utf8Path;
-use colored::Colorize;
 use mdtest::matcher::{self, Failure};
-use mdtest::parser::{self, EmbeddedFileSourceMap};
+use mdtest::parser::{self};
 use mdtest::{
-    Failures, FileFailures, MDTEST_TEST_FILTER, MarkdownEdit, OutputFormat, TestFile, TestOutcome,
-    attempt_test, output_format,
+    Failures, FileFailures, MarkdownEdit, OutputFormat, TestFile, TestOutcome, attempt_test,
 };
 use ruff_db::Db;
 use ruff_db::cancellation::CancellationTokenSource;
@@ -15,7 +13,7 @@ use ruff_db::files::{FileRootKind, system_path_to_file};
 use ruff_db::system::{DbWithWritableSystem as _, SystemPath, SystemPathBuf};
 use ruff_db::testing::{setup_logging, setup_logging_with_filter};
 use ruff_diagnostics::Applicability;
-use ruff_source_file::{LineIndex, OneIndexed};
+use ruff_source_file::OneIndexed;
 use std::fmt::Write;
 use ty_module_resolver::{
     Module, SearchPath, SearchPathSettings, list_modules, resolve_module_confident,
@@ -39,116 +37,6 @@ const MDTEST_EXTERNAL: &str = "MDTEST_EXTERNAL";
 /// Run `path` as a markdown test suite with given `title`.
 ///
 /// Panic on test failure, and print failure details.
-pub fn run_<C>(
-    absolute_fixture_path: &Utf8Path,
-    relative_fixture_path: &Utf8Path,
-    source: &str,
-    test_name: &str,
-    crate_name: &str,
-    suite: &parser::MarkdownTestSuite<'_, C>,
-    mut run_test: impl FnMut(
-        &parser::MarkdownTest<'_, '_, C>,
-        &mut String,
-        OutputFormat,
-    ) -> Result<(TestOutcome, Vec<MarkdownEdit>), Failures>,
-) -> anyhow::Result<()> {
-    let output_format = output_format();
-
-    let mut markdown_edits = vec![];
-
-    let filter = std::env::var(MDTEST_TEST_FILTER).ok();
-    let mut any_failures = false;
-    let mut assertion = String::new();
-    for test in suite.tests() {
-        if filter
-            .as_ref()
-            .is_some_and(|f| !(test.uncontracted_name().contains(f) || test.name() == *f))
-        {
-            continue;
-        }
-
-        let result = run_test(&test, &mut assertion, output_format);
-
-        let this_test_failed = result.is_err();
-        any_failures = any_failures || this_test_failed;
-
-        if this_test_failed && output_format.is_cli() {
-            let _ = writeln!(assertion, "\n\n{}\n", test.name().bold().underline());
-        }
-
-        match result {
-            Ok((_, edits)) => markdown_edits.extend(edits),
-            Err(failures) => {
-                let md_index = LineIndex::from_source_text(source);
-
-                for test_failures in failures {
-                    let source_map =
-                        EmbeddedFileSourceMap::new(&md_index, test_failures.backtick_offsets);
-
-                    for (relative_line_number, failures) in test_failures.by_line.iter() {
-                        let file = relative_fixture_path.as_str();
-
-                        let absolute_line_number =
-                            match source_map.to_absolute_line_number(relative_line_number) {
-                                Ok(line_number) => line_number,
-                                Err(last_line_number) => {
-                                    output_format.write_error(
-                                        &mut assertion,
-                                        file,
-                                        last_line_number,
-                                        &Failure::new(
-                                            "Found a trailing assertion comment \
-                                            (e.g., `# revealed:` or `# error:`) \
-                                            not followed by any statement.",
-                                        ),
-                                    );
-
-                                    continue;
-                                }
-                            };
-
-                        for failure in failures {
-                            output_format.write_error(
-                                &mut assertion,
-                                file,
-                                absolute_line_number,
-                                failure,
-                            );
-                        }
-                    }
-                }
-            }
-        }
-
-        if this_test_failed && output_format.is_cli() {
-            let escaped_test_name = test.name().replace('\'', "\\'");
-            let _ = writeln!(
-                assertion,
-                "\nTo rerun this specific test, \
-                set the environment variable: {MDTEST_TEST_FILTER}='{escaped_test_name}'",
-            );
-            let _ = writeln!(
-                assertion,
-                "{MDTEST_TEST_FILTER}='{escaped_test_name}' cargo test -p {crate_name} \
-                --test mdtest -- {test_name}",
-            );
-
-            let _ = writeln!(assertion, "\n{}", "-".repeat(50));
-        }
-    }
-
-    if !markdown_edits.is_empty() {
-        mdtest::try_apply_markdown_edits(absolute_fixture_path, source, markdown_edits);
-    }
-
-    assert!(!any_failures, "{}", &assertion);
-
-    Ok(())
-}
-
-/// Run `path` as a markdown test suite with given `title`.
-///
-/// Panic on test failure, and print failure details.
 pub fn run(
     absolute_fixture_path: &Utf8Path,
     relative_fixture_path: &Utf8Path,
@@ -162,7 +50,7 @@ pub fn run(
     let suite =
         parse(short_title, source).map_err(|err| anyhow!("Failed to parse fixture: {err}"))?;
 
-    run_(
+    mdtest::run(
         absolute_fixture_path,
         relative_fixture_path,
         source,

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -39,20 +39,21 @@ const MDTEST_EXTERNAL: &str = "MDTEST_EXTERNAL";
 /// Run `path` as a markdown test suite with given `title`.
 ///
 /// Panic on test failure, and print failure details.
-pub fn run(
+pub fn run_<C>(
     absolute_fixture_path: &Utf8Path,
     relative_fixture_path: &Utf8Path,
     source: &str,
-    snapshot_path: &Utf8Path,
-    short_title: &str,
     test_name: &str,
+    crate_name: &str,
+    suite: &parser::MarkdownTestSuite<'_, C>,
+    mut run_test: impl FnMut(
+        &parser::MarkdownTest<'_, '_, C>,
+        &mut String,
+        OutputFormat,
+    ) -> Result<(TestOutcome, Vec<MarkdownEdit>), Failures>,
 ) -> anyhow::Result<()> {
     let output_format = output_format();
 
-    let suite =
-        parse(short_title, source).map_err(|err| anyhow!("Failed to parse fixture: {err}"))?;
-
-    let mut db = db::Db::setup();
     let mut markdown_edits = vec![];
 
     let filter = std::env::var(MDTEST_TEST_FILTER).ok();
@@ -66,15 +67,7 @@ pub fn run(
             continue;
         }
 
-        let result = run_test(
-            &mut db,
-            absolute_fixture_path,
-            relative_fixture_path,
-            snapshot_path,
-            &test,
-            &mut assertion,
-            output_format,
-        );
+        let result = run_test(&test, &mut assertion, output_format);
 
         let this_test_failed = result.is_err();
         any_failures = any_failures || this_test_failed;
@@ -136,7 +129,7 @@ pub fn run(
             );
             let _ = writeln!(
                 assertion,
-                "{MDTEST_TEST_FILTER}='{escaped_test_name}' cargo test -p ty_python_semantic \
+                "{MDTEST_TEST_FILTER}='{escaped_test_name}' cargo test -p {crate_name} \
                 --test mdtest -- {test_name}",
             );
 
@@ -151,6 +144,43 @@ pub fn run(
     assert!(!any_failures, "{}", &assertion);
 
     Ok(())
+}
+
+/// Run `path` as a markdown test suite with given `title`.
+///
+/// Panic on test failure, and print failure details.
+pub fn run(
+    absolute_fixture_path: &Utf8Path,
+    relative_fixture_path: &Utf8Path,
+    source: &str,
+    snapshot_path: &Utf8Path,
+    short_title: &str,
+    test_name: &str,
+) -> anyhow::Result<()> {
+    let mut db = db::Db::setup();
+
+    let suite =
+        parse(short_title, source).map_err(|err| anyhow!("Failed to parse fixture: {err}"))?;
+
+    run_(
+        absolute_fixture_path,
+        relative_fixture_path,
+        source,
+        test_name,
+        "ty_python_semantic",
+        &suite,
+        |test, assertion, output_format| {
+            run_test(
+                &mut db,
+                absolute_fixture_path,
+                relative_fixture_path,
+                snapshot_path,
+                test,
+                assertion,
+                output_format,
+            )
+        },
+    )
 }
 
 fn run_test(

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -459,38 +459,7 @@ fn run_test(
         })
         .collect();
 
-    match panic_info {
-        Some(panic_info) => {
-            let expected_message = test
-                .should_expect_panic()
-                .expect("panic_info is only set when `should_expect_panic` is `Ok`");
-
-            let message = panic_info
-                .payload
-                .as_str()
-                .unwrap_or("Box<dyn Any>")
-                .to_string();
-
-            if let Some(expected_message) = expected_message {
-                assert!(
-                    message.contains(expected_message),
-                    "Test `{}` is expected to panic with `{expected_message}`, but panicked with `{message}` instead.",
-                    test.name()
-                );
-            }
-        }
-        None => {
-            if let Ok(message) = test.should_expect_panic() {
-                if let Some(message) = message {
-                    panic!(
-                        "Test `{}` is expected to panic with `{message}`, but it didn't.",
-                        test.name()
-                    );
-                }
-                panic!("Test `{}` is expected to panic but it didn't.", test.name());
-            }
-        }
-    }
+    test.check_panic(panic_info);
 
     if test.should_skip_pulling_types() && !any_pull_types_failures {
         let mut by_line = matcher::FailuresByLine::default();

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -5,8 +5,8 @@ use colored::Colorize;
 use mdtest::matcher::{self, Failure};
 use mdtest::parser::{self, EmbeddedFileSourceMap};
 use mdtest::{
-    Failures, FileFailures, MDTEST_TEST_FILTER, MarkdownEdit, OutputFormat, TestFile, attempt_test,
-    output_format,
+    Failures, FileFailures, MDTEST_TEST_FILTER, MarkdownEdit, OutputFormat, TestFile, TestOutcome,
+    attempt_test, output_format,
 };
 use ruff_db::Db;
 use ruff_db::cancellation::CancellationTokenSource;
@@ -151,12 +151,6 @@ pub fn run(
     assert!(!any_failures, "{}", &assertion);
 
     Ok(())
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TestOutcome {
-    Success,
-    Skipped,
 }
 
 fn run_test(

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -5,18 +5,17 @@ use colored::Colorize;
 use mdtest::matcher::{self, Failure};
 use mdtest::parser::{self, EmbeddedFileSourceMap};
 use mdtest::{
-    Failures, FileFailures, MDTEST_TEST_FILTER, MarkdownEdit, OutputFormat, TestFile, output_format,
+    Failures, FileFailures, MDTEST_TEST_FILTER, MarkdownEdit, OutputFormat, TestFile, attempt_test,
+    output_format,
 };
 use ruff_db::Db;
 use ruff_db::cancellation::CancellationTokenSource;
 use ruff_db::diagnostic::DiagnosticId;
-use ruff_db::files::{File, FileRootKind, system_path_to_file};
-use ruff_db::panic::{PanicError, catch_unwind};
+use ruff_db::files::{FileRootKind, system_path_to_file};
 use ruff_db::system::{DbWithWritableSystem as _, SystemPath, SystemPathBuf};
 use ruff_db::testing::{setup_logging, setup_logging_with_filter};
 use ruff_diagnostics::Applicability;
 use ruff_source_file::{LineIndex, OneIndexed};
-use std::backtrace::BacktraceStatus;
 use std::fmt::Write;
 use ty_module_resolver::{
     Module, SearchPath, SearchPathSettings, list_modules, resolve_module_confident,
@@ -682,87 +681,6 @@ impl std::fmt::Display for ModuleInconsistency<'_> {
             }
         }
         Ok(())
-    }
-}
-
-/// Run a function over an embedded test file, catching any panics that occur in the process.
-///
-/// If no panic occurs, the result of the function is returned as an `Ok()` variant.
-///
-/// If a panic occurs, a nicely formatted [`FileFailures`] is returned as an `Err()` variant to
-/// be formatted into a diagnostic message by callers.
-pub fn attempt_test<'a, T, F>(
-    test_fn: F,
-    test_file: &'a TestFile<'a>,
-) -> Result<T, AttemptTestError<'a>>
-where
-    F: FnOnce(File) -> T + std::panic::UnwindSafe,
-{
-    catch_unwind(|| test_fn(test_file.file)).map_err(|info| AttemptTestError { info, test_file })
-}
-
-pub struct AttemptTestError<'a> {
-    pub info: PanicError,
-    test_file: &'a TestFile<'a>,
-}
-
-impl AttemptTestError<'_> {
-    pub fn into_file_failures(
-        self,
-        db: &dyn Db,
-        action: &str,
-        clarification: Option<&str>,
-    ) -> FileFailures {
-        let info = self.info;
-
-        let mut by_line = matcher::FailuresByLine::default();
-        let mut messages = vec![];
-        match info.location {
-            Some(location) => messages.push(Failure::new(format_args!(
-                "Attempting to {action} caused a panic at {location}"
-            ))),
-            None => messages.push(Failure::new(format_args!(
-                "Attempting to {action} caused a panic at an unknown location",
-            ))),
-        }
-        if let Some(clarification) = clarification {
-            messages.push(Failure::new(clarification));
-        }
-        messages.push(Failure::new(""));
-        match info.payload.as_str() {
-            Some(message) => messages.push(Failure::new(message)),
-            // Mimic the default panic hook's rendering of the panic payload if it's
-            // not a string.
-            None => messages.push(Failure::new("Box<dyn Any>")),
-        }
-        messages.push(Failure::new(""));
-
-        if let Some(backtrace) = info.backtrace {
-            match backtrace.status() {
-                BacktraceStatus::Disabled => {
-                    let msg = "run with `RUST_BACKTRACE=1` environment variable to \
-                         a backtrace";
-                    messages.push(Failure::new(msg));
-                }
-                BacktraceStatus::Captured => {
-                    messages.extend(backtrace.to_string().split('\n').map(Failure::new));
-                }
-                _ => {}
-            }
-        }
-
-        if let Some(backtrace) = info.salsa_backtrace {
-            salsa::attach(db, || {
-                messages.extend(format!("{backtrace:#}").split('\n').map(Failure::new));
-            });
-        }
-
-        by_line.push(OneIndexed::from_zero_indexed(0), messages);
-
-        FileFailures {
-            backtick_offsets: self.test_file.to_code_block_backtick_offsets(),
-            by_line,
-        }
     }
 }
 

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -1,5 +1,4 @@
 use crate::config::{Log, MarkdownTestConfig, SystemKind};
-use crate::db::Db;
 use anyhow::{anyhow, bail};
 use camino::Utf8Path;
 use colored::Colorize;
@@ -8,7 +7,7 @@ use mdtest::parser::{self, EmbeddedFileSourceMap};
 use mdtest::{
     Failures, FileFailures, MDTEST_TEST_FILTER, MarkdownEdit, OutputFormat, TestFile, output_format,
 };
-use ruff_db::Db as _;
+use ruff_db::Db;
 use ruff_db::cancellation::CancellationTokenSource;
 use ruff_db::diagnostic::DiagnosticId;
 use ruff_db::files::{File, FileRootKind, system_path_to_file};
@@ -54,7 +53,7 @@ pub fn run(
     let suite =
         parse(short_title, source).map_err(|err| anyhow!("Failed to parse fixture: {err}"))?;
 
-    let mut db = Db::setup();
+    let mut db = db::Db::setup();
     let mut markdown_edits = vec![];
 
     let filter = std::env::var(MDTEST_TEST_FILTER).ok();
@@ -403,7 +402,10 @@ fn run_test(
     let mut failures: Failures = test_files
         .iter()
         .filter_map(|test_file| {
-            let mdtest_result = attempt_test(db, ty_python_semantic::Db::check_file, test_file);
+            let mdtest_result = attempt_test(
+                |file| ty_python_semantic::Db::check_file(db, file),
+                test_file,
+            );
             let diagnostics = match mdtest_result {
                 Ok(diagnostics) => diagnostics,
                 Err(failures) => {
@@ -436,7 +438,7 @@ fn run_test(
 
             all_diagnostics.extend(diagnostics);
 
-            let pull_types_result = attempt_test(db, pull_types, test_file);
+            let pull_types_result = attempt_test(|file| pull_types(db, file), test_file);
             match pull_types_result {
                 Ok(()) => {}
                 Err(failures) => {
@@ -687,29 +689,27 @@ impl std::fmt::Display for ModuleInconsistency<'_> {
 ///
 /// If no panic occurs, the result of the function is returned as an `Ok()` variant.
 ///
-/// If a panic occurs, a nicely formatted [`FileFailures`] is returned as an `Err()` variant.
-/// This will be formatted into a diagnostic message by `ty_test`.
-fn attempt_test<'db, 'a, T, F>(
-    db: &'db Db,
+/// If a panic occurs, a nicely formatted [`FileFailures`] is returned as an `Err()` variant to
+/// be formatted into a diagnostic message by callers.
+pub fn attempt_test<'a, T, F>(
     test_fn: F,
     test_file: &'a TestFile<'a>,
 ) -> Result<T, AttemptTestError<'a>>
 where
-    F: FnOnce(&'db dyn ty_python_semantic::Db, File) -> T + std::panic::UnwindSafe,
+    F: FnOnce(File) -> T + std::panic::UnwindSafe,
 {
-    catch_unwind(|| test_fn(db, test_file.file))
-        .map_err(|info| AttemptTestError { info, test_file })
+    catch_unwind(|| test_fn(test_file.file)).map_err(|info| AttemptTestError { info, test_file })
 }
 
-struct AttemptTestError<'a> {
-    info: PanicError,
+pub struct AttemptTestError<'a> {
+    pub info: PanicError,
     test_file: &'a TestFile<'a>,
 }
 
 impl AttemptTestError<'_> {
-    fn into_file_failures(
+    pub fn into_file_failures(
         self,
-        db: &Db,
+        db: &dyn Db,
         action: &str,
         clarification: Option<&str>,
     ) -> FileFailures {

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -5,7 +5,9 @@ use camino::Utf8Path;
 use colored::Colorize;
 use mdtest::matcher::{self, Failure};
 use mdtest::parser::{self, EmbeddedFileSourceMap};
-use mdtest::{Failures, FileFailures, MDTEST_TEST_FILTER, MarkdownEdit, TestFile, output_format};
+use mdtest::{
+    Failures, FileFailures, MDTEST_TEST_FILTER, MarkdownEdit, OutputFormat, TestFile, output_format,
+};
 use ruff_db::Db as _;
 use ruff_db::cancellation::CancellationTokenSource;
 use ruff_db::diagnostic::DiagnosticId;
@@ -66,29 +68,17 @@ pub fn run(
             continue;
         }
 
-        let _tracing = test.configuration().log.as_ref().and_then(|log| match log {
-            Log::Bool(enabled) => enabled.then(setup_logging),
-            Log::Filter(filter) => setup_logging_with_filter(filter),
-        });
-
         let result = run_test(
             &mut db,
             absolute_fixture_path,
             relative_fixture_path,
             snapshot_path,
             &test,
+            &mut assertion,
+            output_format,
         );
 
-        let inconsistencies = if result
-            .as_ref()
-            .is_ok_and(|(outcome, _)| outcome.has_been_skipped())
-        {
-            Ok(())
-        } else {
-            run_module_resolution_consistency_test(&db)
-        };
-
-        let this_test_failed = result.is_err() || inconsistencies.is_err();
+        let this_test_failed = result.is_err();
         any_failures = any_failures || this_test_failed;
 
         if this_test_failed && output_format.is_cli() {
@@ -138,16 +128,6 @@ pub fn run(
                 }
             }
         }
-        if let Err(inconsistencies) = inconsistencies {
-            any_failures = true;
-            for inconsistency in inconsistencies {
-                output_format.write_inconsistency(
-                    &mut assertion,
-                    relative_fixture_path,
-                    &inconsistency,
-                );
-            }
-        }
 
         if this_test_failed && output_format.is_cli() {
             let escaped_test_name = test.name().replace('\'', "\\'");
@@ -181,19 +161,20 @@ enum TestOutcome {
     Skipped,
 }
 
-impl TestOutcome {
-    const fn has_been_skipped(self) -> bool {
-        matches!(self, TestOutcome::Skipped)
-    }
-}
-
 fn run_test(
     db: &mut db::Db,
     absolute_fixture_path: &Utf8Path,
     relative_fixture_path: &Utf8Path,
     snapshot_path: &Utf8Path,
     test: &parser::MarkdownTest<'_, '_, MarkdownTestConfig>,
+    assertion: &mut String,
+    output_format: OutputFormat,
 ) -> Result<(TestOutcome, Vec<MarkdownEdit>), Failures> {
+    let _tracing = test.configuration().log.as_ref().and_then(|log| match log {
+        Log::Bool(enabled) => enabled.then(setup_logging),
+        Log::Filter(filter) => setup_logging_with_filter(filter),
+    });
+
     // Initialize the system and remove all files and directories to reset the system to a clean state.
     match test.configuration().system.unwrap_or_default() {
         SystemKind::InMemory => {
@@ -599,7 +580,15 @@ fn run_test(
         }
     }
 
-    if failures.is_empty() {
+    let inconsistencies = run_module_resolution_consistency_test(db);
+
+    if let Err(inconsistencies) = &inconsistencies {
+        for inconsistency in inconsistencies {
+            output_format.write_inconsistency(assertion, relative_fixture_path, &inconsistency);
+        }
+    }
+
+    if failures.is_empty() && inconsistencies.is_ok() {
         Ok((TestOutcome::Success, markdown_edits))
     } else {
         Err(failures)

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -5,7 +5,9 @@ use camino::Utf8Path;
 use colored::Colorize;
 use mdtest::matcher::{self, Failure};
 use mdtest::parser::{self, EmbeddedFileSourceMap};
-use mdtest::{Failures, FileFailures, MDTEST_TEST_FILTER, MarkdownEdit, TestFile, output_format};
+use mdtest::{
+    Failures, FileFailures, MDTEST_TEST_FILTER, MarkdownEdit, OutputFormat, TestFile, output_format,
+};
 use ruff_db::Db as _;
 use ruff_db::cancellation::CancellationTokenSource;
 use ruff_db::diagnostic::DiagnosticId;
@@ -66,29 +68,17 @@ pub fn run(
             continue;
         }
 
-        let _tracing = test.configuration().log.as_ref().and_then(|log| match log {
-            Log::Bool(enabled) => enabled.then(setup_logging),
-            Log::Filter(filter) => setup_logging_with_filter(filter),
-        });
-
         let result = run_test(
             &mut db,
             absolute_fixture_path,
             relative_fixture_path,
             snapshot_path,
             &test,
+            &mut assertion,
+            output_format,
         );
 
-        let inconsistencies = if result
-            .as_ref()
-            .is_ok_and(|(outcome, _)| outcome.has_been_skipped())
-        {
-            Ok(())
-        } else {
-            run_module_resolution_consistency_test(&db)
-        };
-
-        let this_test_failed = result.is_err() || inconsistencies.is_err();
+        let this_test_failed = result.is_err();
         any_failures = any_failures || this_test_failed;
 
         if this_test_failed && output_format.is_cli() {
@@ -138,16 +128,6 @@ pub fn run(
                 }
             }
         }
-        if let Err(inconsistencies) = inconsistencies {
-            any_failures = true;
-            for inconsistency in inconsistencies {
-                output_format.write_inconsistency(
-                    &mut assertion,
-                    relative_fixture_path,
-                    &inconsistency,
-                );
-            }
-        }
 
         if this_test_failed && output_format.is_cli() {
             let escaped_test_name = test.name().replace('\'', "\\'");
@@ -181,19 +161,20 @@ enum TestOutcome {
     Skipped,
 }
 
-impl TestOutcome {
-    const fn has_been_skipped(self) -> bool {
-        matches!(self, TestOutcome::Skipped)
-    }
-}
-
 fn run_test(
     db: &mut db::Db,
     absolute_fixture_path: &Utf8Path,
     relative_fixture_path: &Utf8Path,
     snapshot_path: &Utf8Path,
     test: &parser::MarkdownTest<'_, '_, MarkdownTestConfig>,
+    assertion: &mut String,
+    output_format: OutputFormat,
 ) -> Result<(TestOutcome, Vec<MarkdownEdit>), Failures> {
+    let _tracing = test.configuration().log.as_ref().and_then(|log| match log {
+        Log::Bool(enabled) => enabled.then(setup_logging),
+        Log::Filter(filter) => setup_logging_with_filter(filter),
+    });
+
     // Initialize the system and remove all files and directories to reset the system to a clean state.
     match test.configuration().system.unwrap_or_default() {
         SystemKind::InMemory => {
@@ -594,7 +575,15 @@ fn run_test(
         }
     }
 
-    if failures.is_empty() {
+    let inconsistencies = run_module_resolution_consistency_test(db);
+
+    if let Err(inconsistencies) = &inconsistencies {
+        for inconsistency in inconsistencies {
+            output_format.write_inconsistency(assertion, relative_fixture_path, &inconsistency);
+        }
+    }
+
+    if failures.is_empty() && inconsistencies.is_ok() {
         Ok((TestOutcome::Success, markdown_edits))
     } else {
         Err(failures)

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -5,18 +5,17 @@ use colored::Colorize;
 use mdtest::matcher::{self, Failure};
 use mdtest::parser::{self, EmbeddedFileSourceMap};
 use mdtest::{
-    Failures, FileFailures, MDTEST_TEST_FILTER, MarkdownEdit, OutputFormat, TestFile, output_format,
+    Failures, FileFailures, MDTEST_TEST_FILTER, MarkdownEdit, OutputFormat, TestFile, attempt_test,
+    output_format,
 };
 use ruff_db::Db;
 use ruff_db::cancellation::CancellationTokenSource;
 use ruff_db::diagnostic::DiagnosticId;
-use ruff_db::files::{File, FileRootKind, system_path_to_file};
-use ruff_db::panic::{PanicError, catch_unwind};
+use ruff_db::files::{FileRootKind, system_path_to_file};
 use ruff_db::system::{DbWithWritableSystem as _, SystemPath, SystemPathBuf};
 use ruff_db::testing::{setup_logging, setup_logging_with_filter};
 use ruff_diagnostics::Applicability;
 use ruff_source_file::{LineIndex, OneIndexed};
-use std::backtrace::BacktraceStatus;
 use std::fmt::Write;
 use ty_module_resolver::{
     Module, SearchPath, SearchPathSettings, list_modules, resolve_module_confident,
@@ -677,82 +676,6 @@ impl std::fmt::Display for ModuleInconsistency<'_> {
             }
         }
         Ok(())
-    }
-}
-
-/// Run a function over an embedded test file, catching any panics that occur in the process.
-///
-/// If no panic occurs, the result of the function is returned as an `Ok()` variant.
-///
-/// If a panic occurs, a nicely formatted [`FileFailures`] is returned as an `Err()` variant to
-/// be formatted into a diagnostic message by callers.
-pub fn attempt_test<'a, T, F>(
-    test_fn: F,
-    test_file: &'a TestFile<'a>,
-) -> Result<T, AttemptTestError<'a>>
-where
-    F: FnOnce(File) -> T + std::panic::UnwindSafe,
-{
-    catch_unwind(|| test_fn(test_file.file)).map_err(|info| AttemptTestError { info, test_file })
-}
-
-pub struct AttemptTestError<'a> {
-    pub info: PanicError,
-    test_file: &'a TestFile<'a>,
-}
-
-impl AttemptTestError<'_> {
-    pub fn into_file_failures(
-        self,
-        db: &dyn Db,
-        action: &str,
-        clarification: Option<&str>,
-    ) -> FileFailures {
-        let info = self.info;
-
-        let mut by_line = matcher::FailuresByLine::default();
-        let mut messages = vec![];
-        match info.location {
-            Some(location) => messages.push(Failure::new(format_args!(
-                "Attempting to {action} caused a panic at {location}"
-            ))),
-            None => messages.push(Failure::new(format_args!(
-                "Attempting to {action} caused a panic at an unknown location",
-            ))),
-        }
-        if let Some(clarification) = clarification {
-            messages.push(Failure::new(clarification));
-        }
-        messages.push(Failure::new(""));
-        messages.push(Failure::new(info.payload));
-        messages.push(Failure::new(""));
-
-        if let Some(backtrace) = info.backtrace {
-            match backtrace.status() {
-                BacktraceStatus::Disabled => {
-                    let msg = "run with `RUST_BACKTRACE=1` environment variable to \
-                         a backtrace";
-                    messages.push(Failure::new(msg));
-                }
-                BacktraceStatus::Captured => {
-                    messages.extend(backtrace.to_string().split('\n').map(Failure::new));
-                }
-                _ => {}
-            }
-        }
-
-        if let Some(backtrace) = info.salsa_backtrace {
-            salsa::attach(db, || {
-                messages.extend(format!("{backtrace:#}").split('\n').map(Failure::new));
-            });
-        }
-
-        by_line.push(OneIndexed::from_zero_indexed(0), messages);
-
-        FileFailures {
-            backtick_offsets: self.test_file.to_code_block_backtick_offsets(),
-            by_line,
-        }
     }
 }
 

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -459,33 +459,7 @@ fn run_test(
         })
         .collect();
 
-    match panic_info {
-        Some(panic_info) => {
-            let expected_message = test
-                .should_expect_panic()
-                .expect("panic_info is only set when `should_expect_panic` is `Ok`");
-
-            if let Some(expected_message) = expected_message {
-                let message = panic_info.payload.to_string();
-                assert!(
-                    message.contains(expected_message),
-                    "Test `{}` is expected to panic with `{expected_message}`, but panicked with `{message}` instead.",
-                    test.name(),
-                );
-            }
-        }
-        None => {
-            if let Ok(message) = test.should_expect_panic() {
-                if let Some(message) = message {
-                    panic!(
-                        "Test `{}` is expected to panic with `{message}`, but it didn't.",
-                        test.name()
-                    );
-                }
-                panic!("Test `{}` is expected to panic but it didn't.", test.name());
-            }
-        }
-    }
+    test.check_panic(panic_info);
 
     if test.should_skip_pulling_types() && !any_pull_types_failures {
         let mut by_line = matcher::FailuresByLine::default();

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -1,5 +1,4 @@
 use crate::config::{Log, MarkdownTestConfig, SystemKind};
-use crate::db::Db;
 use anyhow::{anyhow, bail};
 use camino::Utf8Path;
 use colored::Colorize;
@@ -8,7 +7,7 @@ use mdtest::parser::{self, EmbeddedFileSourceMap};
 use mdtest::{
     Failures, FileFailures, MDTEST_TEST_FILTER, MarkdownEdit, OutputFormat, TestFile, output_format,
 };
-use ruff_db::Db as _;
+use ruff_db::Db;
 use ruff_db::cancellation::CancellationTokenSource;
 use ruff_db::diagnostic::DiagnosticId;
 use ruff_db::files::{File, FileRootKind, system_path_to_file};
@@ -54,7 +53,7 @@ pub fn run(
     let suite =
         parse(short_title, source).map_err(|err| anyhow!("Failed to parse fixture: {err}"))?;
 
-    let mut db = Db::setup();
+    let mut db = db::Db::setup();
     let mut markdown_edits = vec![];
 
     let filter = std::env::var(MDTEST_TEST_FILTER).ok();
@@ -403,7 +402,10 @@ fn run_test(
     let mut failures: Failures = test_files
         .iter()
         .filter_map(|test_file| {
-            let mdtest_result = attempt_test(db, ty_python_semantic::Db::check_file, test_file);
+            let mdtest_result = attempt_test(
+                |file| ty_python_semantic::Db::check_file(db, file),
+                test_file,
+            );
             let diagnostics = match mdtest_result {
                 Ok(diagnostics) => diagnostics,
                 Err(failures) => {
@@ -436,7 +438,7 @@ fn run_test(
 
             all_diagnostics.extend(diagnostics);
 
-            let pull_types_result = attempt_test(db, pull_types, test_file);
+            let pull_types_result = attempt_test(|file| pull_types(db, file), test_file);
             match pull_types_result {
                 Ok(()) => {}
                 Err(failures) => {
@@ -682,29 +684,27 @@ impl std::fmt::Display for ModuleInconsistency<'_> {
 ///
 /// If no panic occurs, the result of the function is returned as an `Ok()` variant.
 ///
-/// If a panic occurs, a nicely formatted [`FileFailures`] is returned as an `Err()` variant.
-/// This will be formatted into a diagnostic message by `ty_test`.
-fn attempt_test<'db, 'a, T, F>(
-    db: &'db Db,
+/// If a panic occurs, a nicely formatted [`FileFailures`] is returned as an `Err()` variant to
+/// be formatted into a diagnostic message by callers.
+pub fn attempt_test<'a, T, F>(
     test_fn: F,
     test_file: &'a TestFile<'a>,
 ) -> Result<T, AttemptTestError<'a>>
 where
-    F: FnOnce(&'db dyn ty_python_semantic::Db, File) -> T + std::panic::UnwindSafe,
+    F: FnOnce(File) -> T + std::panic::UnwindSafe,
 {
-    catch_unwind(|| test_fn(db, test_file.file))
-        .map_err(|info| AttemptTestError { info, test_file })
+    catch_unwind(|| test_fn(test_file.file)).map_err(|info| AttemptTestError { info, test_file })
 }
 
-struct AttemptTestError<'a> {
-    info: PanicError,
+pub struct AttemptTestError<'a> {
+    pub info: PanicError,
     test_file: &'a TestFile<'a>,
 }
 
 impl AttemptTestError<'_> {
-    fn into_file_failures(
+    pub fn into_file_failures(
         self,
-        db: &Db,
+        db: &dyn Db,
         action: &str,
         clarification: Option<&str>,
     ) -> FileFailures {

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -371,7 +371,7 @@ fn run_test(
         })
         .collect();
 
-    test.check_panic(panic_info);
+    mdtest::check_panic(test, panic_info);
 
     if test.should_skip_pulling_types() && !any_pull_types_failures {
         let mut by_line = matcher::FailuresByLine::default();
@@ -391,7 +391,8 @@ fn run_test(
 
     // Filter out `revealed-type` and `undefined-reveal` diagnostics from snapshots,
     // since they make snapshots very noisy!
-    test.snapshot_diagnostics(
+    mdtest::snapshot_diagnostics(
+        test,
         db,
         "ty",
         relative_fixture_path,


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/astral-sh/ruff/pull/24616 to share a bit more infrastructure between `ty_test` and the `ruff_test` crate introduced in https://github.com/astral-sh/ruff/pull/24617. In particular, the primary `run` function has moved into `mdtest`, along with the `attempt_test`, `check_panic` and `snapshot_diagnostics` helpers.

You should be able to review commit-by-commit, but the first commit is probably the most important to look at since it moves the `tracing` setup and inconsistency checks from `ty_test::run` into `ty_test::run_test`. I think that narrows the span of the `tracing` logs a bit, but the important section should still be covered.

The other commits should be pretty straightforward and reviewable as one diff.

## Test Plan

Existing tests, as well as rebasing #24617 onto this branch.
