### PR TITLE
[ty] Remove duplicate `invalid-type-form` diagnostics for PEP-613 type alias values

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -472,14 +472,12 @@ BadTypeAlias13: TypeAlias = f"{'int'}"  # error: [invalid-type-form]
 
 # bonus ones from Alex:
 #
-# TODO should be just one error for both of these (we currently validate type-form subscripts
-# twice, once when inferring as a value expression and again when inferring as a
-# type expression in post-inference)
-#
 # error:[invalid-type-form]
 BadTypeAlias14: TypeAlias = Literal[3.14]
 # error: [invalid-type-form]
 BadTypeAlias15: TypeAlias = Literal[-3.14]
+# error: [unsupported-operator]
+BadTypeAlias16: TypeAlias = list["int" | "str"]
 ```
 
 ## No type qualifiers

--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -477,9 +477,7 @@ BadTypeAlias13: TypeAlias = f"{'int'}"  # error: [invalid-type-form]
 # type expression in post-inference)
 #
 # error:[invalid-type-form]
-# error:[invalid-type-form]
 BadTypeAlias14: TypeAlias = Literal[3.14]
-# error: [invalid-type-form]
 # error: [invalid-type-form]
 BadTypeAlias15: TypeAlias = Literal[-3.14]
 ```

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -14,7 +14,9 @@ use super::{Type, TypeCheckDiagnostics, infer_definition_types};
 use crate::diagnostic::DiagnosticGuard;
 use crate::lint::LintSource;
 use crate::reachability::is_range_reachable;
+use crate::types::diagnostic::{INVALID_TYPE_FORM, UNBOUND_TYPE_VARIABLE};
 use crate::types::function::FunctionDecorators;
+use crate::types::infer::InferenceFlags;
 use crate::{
     Db,
     lint::{LintId, LintMetadata},
@@ -42,6 +44,8 @@ pub(crate) struct InferContext<'db, 'ast> {
     module: &'ast ParsedModuleRef,
     diagnostics: std::cell::RefCell<TypeCheckDiagnostics>,
     no_type_check: InNoTypeCheck,
+    /// This field tracks various flags that control how type inference should behave in the current context.
+    pub(crate) inference_flags: InferenceFlags,
     bomb: DebugDropBomb,
 }
 
@@ -54,6 +58,7 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
             file: scope.file(db),
             diagnostics: std::cell::RefCell::new(TypeCheckDiagnostics::default()),
             no_type_check: InNoTypeCheck::default(),
+            inference_flags: InferenceFlags::empty(),
             bomb: DebugDropBomb::new(
                 "`InferContext` needs to be explicitly consumed by calling `::finish` to prevent accidental loss of diagnostics.",
             ),
@@ -448,6 +453,18 @@ impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
         range: TextRange,
     ) -> Option<LintDiagnosticGuardBuilder<'db, 'ctx>> {
         let lint_id = LintId::of(lint);
+
+        // Suppress all `invalid-type-form` errors during the first pass of
+        // inferring a PEP-613 type alias. These errors are emitted during the
+        // second pass, post-inference.
+        if (lint_id == LintId::of(&INVALID_TYPE_FORM)
+            || lint_id == LintId::of(&UNBOUND_TYPE_VARIABLE))
+            && ctx
+                .inference_flags
+                .contains(InferenceFlags::IN_PEP_613_ALIAS_FIRST_PASS)
+        {
+            return None;
+        }
 
         let (severity, source) = Self::severity_and_source(ctx, lint_id)?;
 

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1003,6 +1003,12 @@ bitflags::bitflags! {
 
         /// Whether we are currently in a context where `Concatenate` can be legal
         const IN_VALID_CONCATENATE_CONTEXT = 1 << 6;
+
+        /// Whether we're in the first pass of inferring a PEP-613 type alias.
+        ///
+        /// During this pass, `invalid-type-form` diagnostics are suppressed;
+        /// these are emitted during the second, post-inference, pass.
+        const IN_PEP_613_ALIAS_FIRST_PASS = 1 << 7;
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9117,6 +9117,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         builder.cycle_recovery = cycle_recovery;
         builder.deferred_state = deferred_state;
         builder.typevar_binding_context = typevar_binding_context;
+        builder.context.inference_flags = self.inference_flags();
         builder.expression_cache.clone_from(expression_cache);
         builder
             .return_types_and_ranges

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -284,10 +284,6 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// Whether we are in a context that binds unbound typevars.
     typevar_binding_context: Option<Definition<'db>>,
 
-    /// Type-inference is context-dependent, especially in type expressions.
-    /// This field tracks various flags that control how type inference should behave in the current context.
-    inference_flags: InferenceFlags,
-
     /// The deferred state of inferring types of certain expressions within the region.
     ///
     /// This is different from [`InferenceRegion::Deferred`] which works on the entire definition
@@ -344,7 +340,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             bindings: VecMap::default(),
             declarations: VecMap::default(),
             typevar_binding_context: None,
-            inference_flags: InferenceFlags::empty(),
             deferred: VecSet::default(),
             undecorated_type: None,
             cycle_recovery: None,
@@ -1279,12 +1274,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn infer_type_alias(&mut self, type_alias: &ast::StmtTypeAlias) {
         let previous_check_unbound_typevars = self
+            .context
             .inference_flags
             .replace(InferenceFlags::CHECK_UNBOUND_TYPEVARS, true);
-        self.inference_flags |= InferenceFlags::IN_TYPE_ALIAS;
+        self.context.inference_flags |= InferenceFlags::IN_TYPE_ALIAS;
         let value_ty = self.infer_type_expression(&type_alias.value);
-        self.inference_flags.remove(InferenceFlags::IN_TYPE_ALIAS);
-        self.inference_flags.set(
+        self.context
+            .inference_flags
+            .remove(InferenceFlags::IN_TYPE_ALIAS);
+        self.context.inference_flags.set(
             InferenceFlags::CHECK_UNBOUND_TYPEVARS,
             previous_check_unbound_typevars,
         );
@@ -3995,8 +3993,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // We defer the r.h.s. of PEP-613 `TypeAlias` assignments in stub files.
             let previous_deferred_state = self.deferred_state;
 
-            if is_pep_613_type_alias && self.in_stub() {
-                self.deferred_state = DeferredExpressionState::Deferred;
+            if is_pep_613_type_alias {
+                self.context.inference_flags |= InferenceFlags::IN_PEP_613_ALIAS_FIRST_PASS;
+                if self.in_stub() {
+                    self.deferred_state = DeferredExpressionState::Deferred;
+                }
             }
 
             // This might be a PEP-613 type alias (`OptionalList: TypeAlias = list[T] | None`). Use
@@ -4010,10 +4011,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             );
 
             self.typevar_binding_context = previous_typevar_binding_context;
-
             self.deferred_state = previous_deferred_state;
-
             self.dataclass_field_specifiers.clear();
+            self.context
+                .inference_flags
+                .remove(InferenceFlags::IN_PEP_613_ALIAS_FIRST_PASS);
 
             let inferred_ty = if target
                 .as_name_expr()
@@ -8235,7 +8237,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 db,
                                 self.scope(),
                                 self.typevar_binding_context,
-                                self.inference_flags
+                                self.inference_flags()
                             ) && !defined_type.member(db, attr_name).place.is_undefined()
                             {
                                 diag.help(format_args!(
@@ -8841,7 +8843,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // builder only state
             expression_cache: _,
             typevar_binding_context: _,
-            inference_flags: _,
             deferred_state: _,
             called_functions: _,
             index: _,
@@ -8925,7 +8926,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             dataclass_field_specifiers: _,
             undecorated_type: _,
             typevar_binding_context: _,
-            inference_flags: _,
             deferred_state: _,
             index: _,
             region: _,
@@ -8966,7 +8966,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expression_cache: _,
             dataclass_field_specifiers: _,
             typevar_binding_context: _,
-            inference_flags: _,
             deferred_state: _,
             index: _,
             region: _,
@@ -9050,7 +9049,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expression_cache: _,
             dataclass_field_specifiers: _,
             typevar_binding_context: _,
-            inference_flags: _,
             deferred_state: _,
             called_functions: _,
             index: _,
@@ -9076,6 +9074,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         ScopeInference { expressions, extra }
     }
 
+    const fn inference_flags(&self) -> InferenceFlags {
+        self.context.inference_flags
+    }
+
     /// Returns a fresh [`TypeInferenceBuilder`] for the current scope that can be used
     /// to speculatively infer expressions during multi-inference.
     ///
@@ -9087,7 +9089,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             index,
             cycle_recovery,
             deferred_state,
-            inference_flags,
             typevar_binding_context,
             ref expression_cache,
             ref return_types_and_ranges,
@@ -9116,7 +9117,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         builder.cycle_recovery = cycle_recovery;
         builder.deferred_state = deferred_state;
         builder.typevar_binding_context = typevar_binding_context;
-        builder.inference_flags = inference_flags;
         builder.expression_cache.clone_from(expression_cache);
         builder
             .return_types_and_ranges
@@ -9147,7 +9147,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // builder only state
             expression_cache: _,
             typevar_binding_context: _,
-            inference_flags: _,
             deferred_state: _,
             called_functions: _,
             index: _,

--- a/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
@@ -58,10 +58,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let previous_deferred_state = std::mem::replace(&mut self.deferred_state, state);
         let previous_check_unbound_typevars = self
+            .context
             .inference_flags
             .replace(InferenceFlags::CHECK_UNBOUND_TYPEVARS, true);
         let annotation_ty = self.infer_annotation_expression_impl(annotation, pep_613_policy);
-        self.inference_flags.set(
+        self.context.inference_flags.set(
             InferenceFlags::CHECK_UNBOUND_TYPEVARS,
             previous_check_unbound_typevars,
         );
@@ -196,13 +197,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                     self.db(),
                                     self.scope(),
                                     None,
-                                    self.inference_flags,
+                                    self.inference_flags(),
                                 )
                                 .unwrap_or_else(|err| {
                                     err.into_fallback_type(
                                         &self.context,
                                         subscript,
-                                        self.inference_flags,
+                                        self.inference_flags(),
                                     )
                                 });
                             TypeAndQualifiers::declared(in_type_expression)
@@ -324,7 +325,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         &mut self,
         string: &ast::ExprStringLiteral,
     ) -> TypeAndQualifiers<'db> {
-        match parse_string_annotation(&self.context, self.inference_flags, string) {
+        match parse_string_annotation(&self.context, self.inference_flags(), string) {
             Some(parsed) => {
                 self.string_annotations
                     .insert(ruff_python_ast::ExprRef::StringLiteral(string).into());

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -100,7 +100,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 [left_ty, right_ty],
                 self.scope(),
                 self.typevar_binding_context,
-                self.inference_flags,
+                self.inference_flags(),
             )
         }
     }
@@ -914,7 +914,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         [left_ty, right_ty],
                         self.scope(),
                         self.typevar_binding_context,
-                        self.inference_flags,
+                        self.inference_flags(),
                     ))
                 }
             }
@@ -941,7 +941,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     [left_ty, right_ty],
                     self.scope(),
                     self.typevar_binding_context,
-                    self.inference_flags,
+                    self.inference_flags(),
                 ))
             }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -497,12 +497,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn infer_return_type_annotation(&mut self, returns: Option<&ast::Expr>) {
         if let Some(returns) = returns {
-            self.inference_flags |= InferenceFlags::IN_RETURN_TYPE;
+            self.context.inference_flags |= InferenceFlags::IN_RETURN_TYPE;
             self.infer_type_expression_with_state(
                 returns,
                 DeferredExpressionState::from(self.defer_annotations()),
             );
-            self.inference_flags.remove(InferenceFlags::IN_RETURN_TYPE);
+            self.context
+                .inference_flags
+                .remove(InferenceFlags::IN_RETURN_TYPE);
         }
     }
 
@@ -532,20 +534,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             kwarg,
         } = parameters;
 
-        self.inference_flags |= InferenceFlags::IN_PARAMETER_ANNOTATION;
+        self.context.inference_flags |= InferenceFlags::IN_PARAMETER_ANNOTATION;
         for param_with_default in parameters.iter_non_variadic_params() {
             self.infer_parameter_with_default(param_with_default);
         }
         if let Some(vararg) = vararg {
-            self.inference_flags |= InferenceFlags::IN_VARARG_ANNOTATION;
+            self.context.inference_flags |= InferenceFlags::IN_VARARG_ANNOTATION;
             self.infer_parameter(vararg);
-            self.inference_flags
+            self.context
+                .inference_flags
                 .remove(InferenceFlags::IN_VARARG_ANNOTATION);
         }
         if let Some(kwarg) = kwarg {
             self.infer_parameter(kwarg);
         }
-        self.inference_flags
+        self.context
+            .inference_flags
             .remove(InferenceFlags::IN_PARAMETER_ANNOTATION);
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/pep_613_alias.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/pep_613_alias.rs
@@ -24,7 +24,7 @@ pub(crate) fn check_pep_613_alias<'db>(
     let mut speculative = builder.speculate();
 
     speculative.typevar_binding_context = Some(definition);
-    speculative.inference_flags |= InferenceFlags::IN_TYPE_ALIAS;
+    speculative.context.inference_flags |= InferenceFlags::IN_TYPE_ALIAS;
     speculative.infer_type_expression(value);
     Some(speculative.context.finish())
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -404,6 +404,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         specialize: &dyn Fn(&[Option<Type<'db>>]) -> Type<'db>,
     ) -> Type<'db> {
         let previously_allowed_paramspec = self
+            .context
             .inference_flags
             .replace(InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR, true);
         let result = self.infer_explicit_callable_specialization_impl(
@@ -412,7 +413,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             generic_context,
             specialize,
         );
-        self.inference_flags.set(
+        self.context.inference_flags.set(
             InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR,
             previously_allowed_paramspec,
         );
@@ -786,6 +787,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let mut return_todo = false;
 
                 let previously_allowed_paramspec = self
+                    .context
                     .inference_flags
                     .replace(InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR, false);
                 for param in elts {
@@ -798,7 +800,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         && matches!(param, ast::Expr::Starred(_) | ast::Expr::Subscript(_));
                     parameter_types.push(param_type);
                 }
-                self.inference_flags.set(
+                self.context.inference_flags.set(
                     InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR,
                     previously_allowed_paramspec,
                 );
@@ -838,10 +840,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
 
                 let previous_concatenate_context = self
+                    .context
                     .inference_flags
                     .replace(InferenceFlags::IN_VALID_CONCATENATE_CONTEXT, true);
                 let param_type = self.infer_type_expression(expr);
-                self.inference_flags.set(
+                self.context.inference_flags.set(
                     InferenceFlags::IN_VALID_CONCATENATE_CONTEXT,
                     previous_concatenate_context,
                 );

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -28,7 +28,7 @@ use crate::{FxOrderSet, Program, add_inferred_python_version_hint_to_diagnostic}
 /// Type expressions
 impl<'db> TypeInferenceBuilder<'db, '_> {
     pub(super) const fn type_expression_context(&self) -> &'static str {
-        self.inference_flags.type_expression_context()
+        self.inference_flags().type_expression_context()
     }
 
     /// Infer the type of a type expression.
@@ -96,10 +96,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 self.db(),
                 self.scope(),
                 self.typevar_binding_context,
-                self.inference_flags,
+                self.inference_flags(),
             )
             .unwrap_or_else(|error| {
-                error.into_fallback_type(&self.context, annotation, self.inference_flags)
+                error.into_fallback_type(&self.context, annotation, self.inference_flags())
             });
         self.check_for_unbound_type_variable(annotation, result_ty)
     }
@@ -862,7 +862,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         &mut self,
         string: &ast::ExprStringLiteral,
     ) -> Type<'db> {
-        match parse_string_annotation(&self.context, self.inference_flags, string) {
+        match parse_string_annotation(&self.context, self.inference_flags(), string) {
             Some(parsed) => {
                 self.string_annotations
                     .insert(ruff_python_ast::ExprRef::StringLiteral(string).into());
@@ -1218,7 +1218,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let scope_id = self.scope();
         let current_typevar_binding_context = self.typevar_binding_context;
-        let current_inference_flags = self.inference_flags;
+        let current_inference_flags = self.inference_flags();
 
         // TODO
         // If we explicitly specialize a recursive generic (PEP-613 or implicit) type alias,
@@ -1424,7 +1424,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                     self.db(),
                                     self.scope(),
                                     self.typevar_binding_context,
-                                    self.inference_flags,
+                                    self.inference_flags(),
                                 )
                                 .unwrap_or(Type::unknown())
                         }
@@ -1569,7 +1569,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 self.db(),
                                 self.scope(),
                                 self.typevar_binding_context,
-                                self.inference_flags,
+                                self.inference_flags(),
                             )
                             .unwrap_or(Type::unknown())
                     }
@@ -1678,11 +1678,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let first_argument = arguments.next();
 
             let previously_allowed_concatenate = builder
+                .context
                 .inference_flags
                 .replace(InferenceFlags::IN_VALID_CONCATENATE_CONTEXT, true);
             let parameters =
                 first_argument.and_then(|arg| builder.infer_callable_parameter_types(arg));
-            builder.inference_flags.set(
+            builder.context.inference_flags.set(
                 InferenceFlags::IN_VALID_CONCATENATE_CONTEXT,
                 previously_allowed_concatenate,
             );
@@ -1755,10 +1756,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // For now, we do not report unbound type variables in any `Callable` contexts, but we may
         // decide to revisit this in the future.
         let previous_check_unbound_typevars = self
+            .context
             .inference_flags
             .replace(InferenceFlags::CHECK_UNBOUND_TYPEVARS, false);
         let result = inner(self, subscript);
-        self.inference_flags.set(
+        self.context.inference_flags.set(
             InferenceFlags::CHECK_UNBOUND_TYPEVARS,
             previous_check_unbound_typevars,
         );
@@ -1779,9 +1781,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     AnnotatedExprContext::TypeExpression,
                 )
                 .inner_type()
-                .in_type_expression(self.db(), self.scope(), None, self.inference_flags)
+                .in_type_expression(self.db(), self.scope(), None, self.inference_flags())
                 .unwrap_or_else(|err| {
-                    err.into_fallback_type(&self.context, subscript, self.inference_flags)
+                    err.into_fallback_type(&self.context, subscript, self.inference_flags())
                 }),
             SpecialFormType::Literal => match self.infer_literal_parameter_type(arguments_slice) {
                 Ok(ty) => ty,
@@ -2012,7 +2014,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 self.infer_parameterized_legacy_typing_alias(subscript, alias)
             }
             SpecialFormType::TypeQualifier(qualifier) => {
-                if self.inference_flags.intersects(
+                if self.inference_flags().intersects(
                     InferenceFlags::IN_PARAMETER_ANNOTATION
                         | InferenceFlags::IN_RETURN_TYPE
                         | InferenceFlags::IN_TYPE_ALIAS,
@@ -2021,7 +2023,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         subscript,
                         format_args!(
                             "Type qualifier `{qualifier}` is not allowed in {}s",
-                            self.inference_flags.type_expression_context(),
+                            self.inference_flags().type_expression_context(),
                         ),
                     );
                 } else {
@@ -2116,19 +2118,21 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         self.store_expression_type(argument, Type::unknown());
                     } else if i < arguments.len() - 1 {
                         let previously_allowed_paramspec = self
+                            .context
                             .inference_flags
                             .replace(InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR, false);
                         self.infer_type_expression(argument);
-                        self.inference_flags.set(
+                        self.context.inference_flags.set(
                             InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR,
                             previously_allowed_paramspec,
                         );
                     } else {
                         let previously_allowed_paramspec = self
+                            .context
                             .inference_flags
                             .replace(InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR, true);
                         self.infer_type_expression(argument);
-                        self.inference_flags.set(
+                        self.context.inference_flags.set(
                             InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR,
                             previously_allowed_paramspec,
                         );
@@ -2151,7 +2155,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 // `def f(*args: Unpack[tuple[int, Unpack[tuple[str, ...]]]]): ...`,
                 // which we don't yet support.
                 if self
-                    .inference_flags
+                    .inference_flags()
                     .contains(InferenceFlags::IN_VARARG_ANNOTATION)
                     || inner_ty.exact_tuple_instance_spec(self.db()).is_none()
                 {
@@ -2446,10 +2450,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     return None;
                 }
                 let previously_allowed_paramspec = self
+                    .context
                     .inference_flags
                     .replace(InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR, true);
                 let parameters_type = self.infer_type_expression_no_store(parameters);
-                self.inference_flags.set(
+                self.context.inference_flags.set(
                     InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR,
                     previously_allowed_paramspec,
                 );
@@ -2468,7 +2473,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
             ast::Expr::StringLiteral(string) => {
                 if let Some(parsed) =
-                    parse_string_annotation(&self.context, self.inference_flags, string)
+                    parse_string_annotation(&self.context, self.inference_flags(), string)
                 {
                     self.string_annotations
                         .insert(ruff_python_ast::ExprRef::StringLiteral(string).into());
@@ -2508,6 +2513,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         subscript: &ast::ExprSubscript,
     ) -> Parameters<'db> {
         let previous_concatenate_context = self
+            .context
             .inference_flags
             .replace(InferenceFlags::IN_VALID_CONCATENATE_CONTEXT, false);
 
@@ -2541,6 +2547,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         };
 
         let previously_allowed_paramspec = self
+            .context
             .inference_flags
             .replace(InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR, false);
         let prefix_params = prefix_args
@@ -2550,7 +2557,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     .with_annotated_type(self.infer_type_expression(arg))
             })
             .collect();
-        self.inference_flags.set(
+        self.context.inference_flags.set(
             InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR,
             previously_allowed_paramspec,
         );
@@ -2567,7 +2574,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let result = parameters.unwrap_or_else(Parameters::unknown);
 
-        self.inference_flags.set(
+        self.context.inference_flags.set(
             InferenceFlags::IN_VALID_CONCATENATE_CONTEXT,
             previous_concatenate_context,
         );
@@ -2585,10 +2592,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     return None;
                 }
                 let previously_allowed_paramspec = self
+                    .context
                     .inference_flags
                     .replace(InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR, true);
                 let expr_type = self.infer_type_expression_no_store(expr);
-                self.inference_flags.set(
+                self.context.inference_flags.set(
                     InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR,
                     previously_allowed_paramspec,
                 );
@@ -2610,7 +2618,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
             ast::Expr::StringLiteral(string) => {
                 let Some(parsed) =
-                    parse_string_annotation(&self.context, self.inference_flags, string)
+                    parse_string_annotation(&self.context, self.inference_flags(), string)
                 else {
                     report_invalid_concatenate_last_arg(&self.context, expr, Type::unknown());
                     return None;
@@ -2657,7 +2665,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         ty: Type<'db>,
     ) -> Type<'db> {
         if !self
-            .inference_flags
+            .inference_flags()
             .contains(InferenceFlags::CHECK_UNBOUND_TYPEVARS)
         {
             return ty;

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -190,6 +190,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         // Detect runtime errors from e.g. `int | "bytes"` on Python <3.14 without `__future__` annotations.
                         if !self.deferred_state.is_deferred()
                             && !self.is_in_type_checking_block(self.scope(), binary)
+                            && !self
+                                .inference_flags()
+                                .contains(InferenceFlags::IN_PEP_613_ALIAS_FIRST_PASS)
                         {
                             let mut speculative_builder = self.speculate();
                             // If the left-hand side of the union is itself a PEP-604 union,

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -582,10 +582,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         paramspec_name: Option<&str>,
     ) {
         let previously_allowed_paramspec = self
+            .context
             .inference_flags
             .replace(InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR, true);
         self.infer_paramspec_default_impl(default_expr, paramspec_name);
-        self.inference_flags.set(
+        self.context.inference_flags.set(
             InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR,
             previously_allowed_paramspec,
         );
@@ -606,13 +607,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             ast::Expr::List(ast::ExprList { elts, .. }) => {
                 let previously_allowed_paramspec = self
+                    .context
                     .inference_flags
                     .replace(InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR, false);
                 let types = elts
                     .iter()
                     .map(|elt| self.infer_type_expression(elt))
                     .collect::<Vec<_>>();
-                self.inference_flags.set(
+                self.context.inference_flags.set(
                     InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR,
                     previously_allowed_paramspec,
                 );


### PR DESCRIPTION
## Summary

Set an inference flag to signal to the inference builder that we're doing first-pass inference of the right-hand side of a PEP-613 type alias. After moving storage of the `inference_flags` to an `InferContext` field rather than a field on `TypeInferenceBuilder` directly, this allows us to suppress `invalid-type-form` errors when we see that this flag has been set.

## Test Plan

mdtests updated/extended
