### PR TITLE
Fix: silent StopIteration leaving repo in inconsistent state in add_p…

### DIFF
--- a/scripts/add_plugin.py
+++ b/scripts/add_plugin.py
@@ -96,11 +96,15 @@ mod tests {
 
     text = ""
     with (ROOT_DIR / "crates/ruff_linter/src/codes.rs").open("r") as fp:
-        while (line := next(fp)).strip() != "// ruff":
+        for line in fp:
+            if line.strip() == "// ruff":
+                text += " " * 8 + f"// {plugin}\n\n"
+                text += line
+                text += fp.read()
+                break
             text += line
-        text += " " * 8 + f"// {plugin}\n\n"
-        text += line
-        text += fp.read()
+        else:
+            raise RuntimeError("Marker '// ruff' not found in codes.rs")
 
     with (ROOT_DIR / "crates/ruff_linter/src/codes.rs").open("w") as fp:
         fp.write(text)


### PR DESCRIPTION
Replace while next(fp) loop with a for/else construct that raises a clear RuntimeError when the // ruff marker is missing from codes.rs, preventing partial file writes that leave registry.rs modified while codes.rs is untouched.