### PR TITLE
[ty] Improve TypedDict -> dict assignment error diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -473,7 +473,8 @@ error[invalid-assignment]: Object of type `Person` is not assignable to `dict[st
    |             |
    |             Declared type
    |
-info: `TypedDict` types are not assignable to `dict` (consider using `Mapping` instead)
+info: TypedDict `Person` is not assignable to `dict`
+help: Generally, TypedDict types are not assignable to any specialization of `dict[..]`, since dictionary types allow destructive operations like `clear()`. Consider using `Mapping[..]` instead of `dict[..]`.
 ```
 
 ## Protocols

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -474,7 +474,8 @@ error[invalid-assignment]: Object of type `Person` is not assignable to `dict[st
    |             Declared type
    |
 info: TypedDict `Person` is not assignable to `dict`
-help: Generally, TypedDict types are not assignable to any specialization of `dict[..]`, since dictionary types allow destructive operations like `clear()`. Consider using `Mapping[..]` instead of `dict[..]`.
+help: A TypedDict is not usually assignable to any `dict[..]` type; `dict` types allow destructive operations like `clear()`.
+help: Consider using `Mapping[..]` instead of `dict[..]`.
 ```
 
 ## Protocols

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5815,9 +5815,7 @@ impl<'db> BindingError<'db> {
 
                 let error_context =
                     provided_ty.assignability_error_context(context.db(), *expected_ty);
-                for message in error_context.info_messages(context.db()) {
-                    diag.info(message);
-                }
+                error_context.attach_to(context.db(), &mut diag);
 
                 if let Some(matching_overload) = matching_overload {
                     if let Some(overload_literal) = matching_overload.get(context.db()) {

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3800,9 +3800,7 @@ pub(super) fn report_invalid_assignment<'db>(
         ));
 
         let error_context = value_ty.assignability_error_context(context.db(), target_ty);
-        for message in error_context.info_messages(context.db()) {
-            diag.info(message);
-        }
+        error_context.attach_to(context.db(), &mut diag);
 
         // Overwrite the concise message to avoid showing the value type twice
         let message = diag.primary_message().to_string();
@@ -5693,9 +5691,7 @@ pub(super) fn report_invalid_method_override<'db>(
         ));
     }
 
-    for message in error_context().info_messages(context.db()) {
-        diagnostic.info(message);
-    }
+    error_context().attach_to(context.db(), &mut diagnostic);
 
     diagnostic.info("This violates the Liskov Substitution Principle");
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1436,7 +1436,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // compatible `Mapping`s. `extra_items` could also allow for some assignments to `dict`, as
             // long as `total=False`. (But then again, does anyone want a non-total `TypedDict` where all
             // key types are a supertype of the extra items type?)
-            (Type::TypedDict(_), _) => self.with_recursion_guard(source, target, || {
+            (Type::TypedDict(typed_dict), _) => self.with_recursion_guard(source, target, || {
                 let spec = &[KnownClass::Str.to_instance(db), Type::object()];
                 let str_object_map = KnownClass::Mapping.to_specialized_instance(db, spec);
                 let result = self.check_type_pair(db, str_object_map, target);
@@ -1444,7 +1444,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     if let Type::NominalInstance(instance) = target
                         && instance.class(db).is_known(db, KnownClass::Dict)
                     {
-                        self.provide_context(|| ErrorContext::TypedDictNotAssignableToDict);
+                        self.provide_context(|| {
+                            ErrorContext::TypedDictNotAssignableToDict(typed_dict)
+                        });
                     }
                 }
                 result

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -100,7 +100,11 @@ pub(crate) enum ErrorContext<'db> {
 }
 
 impl<'db> ErrorContext<'db> {
-    fn render(&self, db: &'db dyn Db) -> Option<String> {
+    fn render(
+        &self,
+        db: &'db dyn Db,
+        help_messages: &mut FxOrderSet<HelpMessages>,
+    ) -> Option<String> {
         Some(match self {
             Self::Empty => {
                 return None;
@@ -125,6 +129,9 @@ impl<'db> ErrorContext<'db> {
                 if *n == 1 { "" } else { "s" }
             ),
             Self::TypedDictNotAssignableToDict(typed_dict) => {
+                help_messages.insert(HelpMessages::TypedDictNotAssignableToDict);
+                help_messages.insert(HelpMessages::ConsiderUsingMappingInsteadOfDict);
+
                 let name = match typed_dict {
                     TypedDictType::Class(class) => format!("TypedDict `{}`", class.name(db)),
                     TypedDictType::Synthesized(_) => "TypedDict".to_string(),
@@ -219,29 +226,22 @@ impl<'db> ErrorContext<'db> {
             }
         })
     }
-
-    fn help_message(&self) -> Option<HelpMessages> {
-        match self {
-            Self::TypedDictNotAssignableToDict(_) => {
-                Some(HelpMessages::TypedDictNotAssignableToDict)
-            }
-            _ => None,
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum HelpMessages {
     TypedDictNotAssignableToDict,
+    ConsiderUsingMappingInsteadOfDict,
 }
 
 impl std::fmt::Display for HelpMessages {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             HelpMessages::TypedDictNotAssignableToDict => {
-                f.write_str("Generally, TypedDict types are not assignable to any specialization of `dict[..]`, \
-                             since dictionary types allow destructive operations like `clear()`. \
-                             Consider using `Mapping[..]` instead of `dict[..]`.")
+                f.write_str("A TypedDict is not usually assignable to any `dict[..]` type; `dict` types allow destructive operations like `clear()`.")
+            }
+            HelpMessages::ConsiderUsingMappingInsteadOfDict => {
+                f.write_str("Consider using `Mapping[..]` instead of `dict[..]`.")
             }
         }
     }
@@ -276,11 +276,8 @@ impl<'db> ErrorContextNode<'db> {
         prefix: &str,
         continuation: &str,
     ) {
-        if let Some(line) = self.context.render(db) {
+        if let Some(line) = self.context.render(db, help_messages) {
             output_lines.push(format!("{prefix}{line}"));
-        }
-        if let Some(help_message) = self.context.help_message() {
-            help_messages.insert(help_message);
         }
 
         let num_children = self.children.len();

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -5,9 +5,10 @@ use std::rc::Rc;
 
 use ruff_python_ast::name::Name;
 
-use crate::Db;
-use crate::types::Type;
+use crate::types::context::LintDiagnosticGuard;
 use crate::types::tuple::TupleLength;
+use crate::types::{Type, TypedDictType};
+use crate::{Db, FxOrderSet};
 
 /// Identifies a parameter, either by name or by position.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -54,7 +55,7 @@ pub(crate) enum ErrorContext<'db> {
     NotAssignableToNOtherUnionElements {
         n: usize,
     },
-    TypedDictNotAssignableToDict,
+    TypedDictNotAssignableToDict(TypedDictType<'db>),
     IncompatibleReturnTypes {
         source: Type<'db>,
         target: Type<'db>,
@@ -123,9 +124,12 @@ impl<'db> ErrorContext<'db> {
                 "... omitted {n} union element{} without additional context",
                 if *n == 1 { "" } else { "s" }
             ),
-            Self::TypedDictNotAssignableToDict => {
-                "`TypedDict` types are not assignable to `dict` (consider using `Mapping` instead)"
-                    .to_string()
+            Self::TypedDictNotAssignableToDict(typed_dict) => {
+                let name = match typed_dict {
+                    TypedDictType::Class(class) => format!("TypedDict `{}`", class.name(db)),
+                    TypedDictType::Synthesized(_) => "TypedDict".to_string(),
+                };
+                format!("{name} is not assignable to `dict`")
             }
             Self::IncompatibleReturnTypes { source, target } => format!(
                 "incompatible return types: `{source}` is not assignable to `{target}`",
@@ -215,6 +219,32 @@ impl<'db> ErrorContext<'db> {
             }
         })
     }
+
+    fn help_message(&self) -> Option<HelpMessages> {
+        match self {
+            Self::TypedDictNotAssignableToDict(_) => {
+                Some(HelpMessages::TypedDictNotAssignableToDict)
+            }
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum HelpMessages {
+    TypedDictNotAssignableToDict,
+}
+
+impl std::fmt::Display for HelpMessages {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HelpMessages::TypedDictNotAssignableToDict => {
+                f.write_str("Generally, TypedDict types are not assignable to any specialization of `dict[..]`, \
+                             since dictionary types allow destructive operations like `clear()`. \
+                             Consider using `Mapping[..]` instead of `dict[..]`.")
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -238,15 +268,19 @@ impl<'db> ErrorContextNode<'db> {
         matches!(self.context, ErrorContext::Empty) && self.children.is_empty()
     }
 
-    fn render_messages(
+    fn render_tree(
         &self,
         db: &'db dyn Db,
-        messages: &mut Vec<String>,
+        output_lines: &mut Vec<String>,
+        help_messages: &mut FxOrderSet<HelpMessages>,
         prefix: &str,
         continuation: &str,
     ) {
-        if let Some(message) = self.context.render(db) {
-            messages.push(format!("{prefix}{message}"));
+        if let Some(line) = self.context.render(db) {
+            output_lines.push(format!("{prefix}{line}"));
+        }
+        if let Some(help_message) = self.context.help_message() {
+            help_messages.insert(help_message);
         }
 
         let num_children = self.children.len();
@@ -257,7 +291,13 @@ impl<'db> ErrorContextNode<'db> {
             } else {
                 (format!("{continuation}├── "), format!("{continuation}│   "))
             };
-            child.render_messages(db, messages, &child_prefix, &child_continuation);
+            child.render_tree(
+                db,
+                output_lines,
+                help_messages,
+                &child_prefix,
+                &child_continuation,
+            );
         }
     }
 }
@@ -356,12 +396,22 @@ impl<'db> ErrorContextTree<'db> {
         }
     }
 
-    /// Render the tree as a list of messages, with child nodes rendered as indented sub-messages.
-    pub(crate) fn info_messages(&self, db: &'db dyn Db) -> impl Iterator<Item = String> {
-        let mut messages = Vec::new();
+    /// Render the error context tree as info sub-diagnostics on `diag`.
+    pub(in crate::types) fn attach_to(
+        &self,
+        db: &'db dyn Db,
+        diag: &mut LintDiagnosticGuard<'_, '_>,
+    ) {
+        let mut output_lines = Vec::new();
+        let mut help_messages = FxOrderSet::default();
         self.root
             .borrow()
-            .render_messages(db, &mut messages, "", "");
-        messages.into_iter()
+            .render_tree(db, &mut output_lines, &mut help_messages, "", "");
+        for line in output_lines {
+            diag.info(line);
+        }
+        for help_message in help_messages {
+            diag.help(help_message.to_string());
+        }
     }
 }


### PR DESCRIPTION
## Summary

Improve the error message(s) that we show for a failing `TypedDict` to `dict` assignment.

<img width="1028" height="330" alt="image" src="https://github.com/user-attachments/assets/58a96d5e-b13f-467b-b6ba-71a62431078f" />



closes https://github.com/astral-sh/ty/issues/1646

## Test Plan

Updated snapshot
