### PR TITLE
 [ty] Add error context to `invalid-return-type` diagnostics 

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -1082,3 +1082,24 @@ def _(source: frozenset[bool]):
 def _(source: tuple[bool, bool]):
     target: tuple[int, int] = source
 ```
+
+## Error context in other scenarios
+
+### In `invalid-return-type` diagnostics
+
+```py
+def f() -> tuple[int, str]:
+    return 1, b""  # snapshot: invalid-return-type
+```
+
+```snapshot
+error[invalid-return-type]: Return type does not match returned value
+ --> src/mdtest_snippet.py:1:12
+  |
+1 | def f() -> tuple[int, str]:
+  |            --------------- Expected `tuple[int, str]` because of return type
+2 |     return 1, b""  # snapshot: invalid-return-type
+  |            ^^^^^^ expected `tuple[int, str]`, found `tuple[Literal[1], Literal[b""]]`
+  |
+info: the second tuple element is not compatible: `Literal[b""]` is not assignable to `str`
+```

--- a/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
@@ -309,4 +309,6 @@ error[invalid-return-type]: Return type does not match returned value
 5 |     return 1
   |            ^ expected `Generator[int, int, None]`, found `Literal[1]`
   |
+info: type `Literal[1]` is not assignable to protocol `Generator[int, int, None]`
+info: └── protocol member `__iter__` is not defined on type `Literal[1]`
 ```

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3967,6 +3967,9 @@ pub(super) fn report_invalid_return_type(
             expected_ty = expected_ty.display_with(context.db(), settings),
         )),
     );
+
+    let error_context = actual_ty.assignability_error_context(context.db(), expected_ty);
+    error_context.attach_to(context.db(), &mut diag);
 }
 
 pub(super) fn report_invalid_generator_function_return_type(


### PR DESCRIPTION
## Summary

Add error context to `invalid-return-type` diagnostics as well.

## Test Plan

New snapshot test
