### PR TITLE
[ty] Add error context for intersection types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -94,60 +94,89 @@ Assigning an intersection to a non-intersection:
 
 ```py
 from ty_extensions import Intersection
+from typing import Protocol
 
-class P: ...
-class Q: ...
-class R: ...
+class SupportsFoo(Protocol):
+    def foo(self) -> None: ...
 
-def _(source: Intersection[P, Q]):
-    target: int = source  # snapshot
+class SupportsBar(Protocol):
+    def bar(self) -> None: ...
+
+class SupportsFooAndBar(Protocol):
+    def foo(self) -> None: ...
+    def bar(self) -> None: ...
+
+class HasFoo:
+    def foo(self) -> None: ...
+
+class HasBar:
+    def bar(self) -> None: ...
+
+class HasNeither: ...
+
+def _(source: Intersection[HasBar, HasNeither]):
+    target: SupportsFooAndBar = source  # snapshot
 ```
 
 ```snapshot
-error[invalid-assignment]: Object of type `P & Q` is not assignable to `int`
- --> src/mdtest_snippet.py:8:13
-  |
-8 |     target: int = source  # snapshot
-  |             ---   ^^^^^^ Incompatible value of type `P & Q`
-  |             |
-  |             Declared type
-  |
+error[invalid-assignment]: Object of type `HasBar & HasNeither` is not assignable to `SupportsFooAndBar`
+  --> src/mdtest_snippet.py:23:13
+   |
+23 |     target: SupportsFooAndBar = source  # snapshot
+   |             -----------------   ^^^^^^ Incompatible value of type `HasBar & HasNeither`
+   |             |
+   |             Declared type
+   |
+info: no element of intersection `HasBar & HasNeither` is assignable to `SupportsFooAndBar`
+info: ├── type `HasBar` is not assignable to protocol `SupportsFooAndBar`
+info: │   └── protocol member `foo` is not defined on type `HasBar`
+info: └── type `HasNeither` is not assignable to protocol `SupportsFooAndBar`
+info:     └── protocol member `bar` is not defined on type `HasNeither`
 ```
 
 Assigning a non-intersection to an intersection:
 
 ```py
-def _(source: P):
-    target: Intersection[P, Q] = source  # snapshot
+def _(source: HasFoo):
+    target: Intersection[SupportsFoo, SupportsBar] = source  # snapshot
 ```
 
 ```snapshot
-error[invalid-assignment]: Object of type `P` is not assignable to `P & Q`
-  --> src/mdtest_snippet.py:10:13
+error[invalid-assignment]: Object of type `HasFoo` is not assignable to `SupportsFoo & SupportsBar`
+  --> src/mdtest_snippet.py:25:13
    |
-10 |     target: Intersection[P, Q] = source  # snapshot
-   |             ------------------   ^^^^^^ Incompatible value of type `P`
+25 |     target: Intersection[SupportsFoo, SupportsBar] = source  # snapshot
+   |             --------------------------------------   ^^^^^^ Incompatible value of type `HasFoo`
    |             |
    |             Declared type
    |
+info: type `HasFoo` is not assignable to element `SupportsBar` of intersection `SupportsFoo & SupportsBar`
+info: └── type `HasFoo` is not assignable to protocol `SupportsBar`
+info:     └── protocol member `bar` is not defined on type `HasFoo`
 ```
 
 Assigning an intersection to an intersection:
 
 ```py
-def _(source: Intersection[P, R]):
-    target: Intersection[P, Q] = source  # snapshot
+def _(source: Intersection[HasFoo, HasNeither]):
+    target: Intersection[SupportsFoo, SupportsBar] = source  # snapshot
 ```
 
 ```snapshot
-error[invalid-assignment]: Object of type `P & R` is not assignable to `P & Q`
-  --> src/mdtest_snippet.py:12:13
+error[invalid-assignment]: Object of type `HasFoo & HasNeither` is not assignable to `SupportsFoo & SupportsBar`
+  --> src/mdtest_snippet.py:27:13
    |
-12 |     target: Intersection[P, Q] = source  # snapshot
-   |             ------------------   ^^^^^^ Incompatible value of type `P & R`
+27 |     target: Intersection[SupportsFoo, SupportsBar] = source  # snapshot
+   |             --------------------------------------   ^^^^^^ Incompatible value of type `HasFoo & HasNeither`
    |             |
    |             Declared type
    |
+info: type `HasFoo & HasNeither` is not assignable to element `SupportsBar` of intersection `SupportsFoo & SupportsBar`
+info: └── no element of intersection `HasFoo & HasNeither` is assignable to `SupportsBar`
+info:     ├── type `HasFoo` is not assignable to protocol `SupportsBar`
+info:     │   └── protocol member `bar` is not defined on type `HasFoo`
+info:     └── type `HasNeither` is not assignable to protocol `SupportsBar`
+info:         └── protocol member `bar` is not defined on type `HasNeither`
 ```
 
 ## Tuples
@@ -725,6 +754,11 @@ error[invalid-assignment]: Object of type `DoesNotSupportFoo1 & DoesNotSupportFo
    |             |
    |             Declared type
    |
+info: no element of intersection `DoesNotSupportFoo1 & DoesNotSupportFoo2` is assignable to `SupportsFoo`
+info: ├── type `DoesNotSupportFoo1` is not assignable to protocol `SupportsFoo`
+info: │   └── protocol member `foo` is not defined on type `DoesNotSupportFoo1`
+info: └── type `DoesNotSupportFoo2` is not assignable to protocol `SupportsFoo`
+info:     └── protocol member `foo` is not defined on type `DoesNotSupportFoo2`
 ```
 
 ## Assigning an overload set

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -94,60 +94,89 @@ Assigning an intersection to a non-intersection:
 
 ```py
 from ty_extensions import Intersection
+from typing import Protocol
 
-class P: ...
-class Q: ...
-class R: ...
+class SupportsFoo(Protocol):
+    def foo(self) -> None: ...
 
-def _(source: Intersection[P, Q]):
-    target: int = source  # snapshot
+class SupportsBar(Protocol):
+    def bar(self) -> None: ...
+
+class SupportsFooAndBar(Protocol):
+    def foo(self) -> None: ...
+    def bar(self) -> None: ...
+
+class HasFoo:
+    def foo(self) -> None: ...
+
+class HasBar:
+    def bar(self) -> None: ...
+
+class HasNeither: ...
+
+def _(source: Intersection[HasBar, HasNeither]):
+    target: SupportsFooAndBar = source  # snapshot
 ```
 
 ```snapshot
-error[invalid-assignment]: Object of type `P & Q` is not assignable to `int`
- --> src/mdtest_snippet.py:8:13
-  |
-8 |     target: int = source  # snapshot
-  |             ---   ^^^^^^ Incompatible value of type `P & Q`
-  |             |
-  |             Declared type
-  |
+error[invalid-assignment]: Object of type `HasBar & HasNeither` is not assignable to `SupportsFooAndBar`
+  --> src/mdtest_snippet.py:23:13
+   |
+23 |     target: SupportsFooAndBar = source  # snapshot
+   |             -----------------   ^^^^^^ Incompatible value of type `HasBar & HasNeither`
+   |             |
+   |             Declared type
+   |
+info: no element of intersection `HasBar & HasNeither` is assignable to `SupportsFooAndBar`
+info: ├── type `HasBar` is not assignable to protocol `SupportsFooAndBar`
+info: │   └── protocol member `foo` is not defined on type `HasBar`
+info: └── type `HasNeither` is not assignable to protocol `SupportsFooAndBar`
+info:     └── protocol member `bar` is not defined on type `HasNeither`
 ```
 
 Assigning a non-intersection to an intersection:
 
 ```py
-def _(source: P):
-    target: Intersection[P, Q] = source  # snapshot
+def _(source: HasFoo):
+    target: Intersection[SupportsFoo, SupportsBar] = source  # snapshot
 ```
 
 ```snapshot
-error[invalid-assignment]: Object of type `P` is not assignable to `P & Q`
-  --> src/mdtest_snippet.py:10:13
+error[invalid-assignment]: Object of type `HasFoo` is not assignable to `SupportsFoo & SupportsBar`
+  --> src/mdtest_snippet.py:25:13
    |
-10 |     target: Intersection[P, Q] = source  # snapshot
-   |             ------------------   ^^^^^^ Incompatible value of type `P`
+25 |     target: Intersection[SupportsFoo, SupportsBar] = source  # snapshot
+   |             --------------------------------------   ^^^^^^ Incompatible value of type `HasFoo`
    |             |
    |             Declared type
    |
+info: type `HasFoo` is not assignable to element `SupportsBar` of intersection `SupportsFoo & SupportsBar`
+info: └── type `HasFoo` is not assignable to protocol `SupportsBar`
+info:     └── protocol member `bar` is not defined on type `HasFoo`
 ```
 
 Assigning an intersection to an intersection:
 
 ```py
-def _(source: Intersection[P, R]):
-    target: Intersection[P, Q] = source  # snapshot
+def _(source: Intersection[HasFoo, HasNeither]):
+    target: Intersection[SupportsFoo, SupportsBar] = source  # snapshot
 ```
 
 ```snapshot
-error[invalid-assignment]: Object of type `P & R` is not assignable to `P & Q`
-  --> src/mdtest_snippet.py:12:13
+error[invalid-assignment]: Object of type `HasFoo & HasNeither` is not assignable to `SupportsFoo & SupportsBar`
+  --> src/mdtest_snippet.py:27:13
    |
-12 |     target: Intersection[P, Q] = source  # snapshot
-   |             ------------------   ^^^^^^ Incompatible value of type `P & R`
+27 |     target: Intersection[SupportsFoo, SupportsBar] = source  # snapshot
+   |             --------------------------------------   ^^^^^^ Incompatible value of type `HasFoo & HasNeither`
    |             |
    |             Declared type
    |
+info: type `HasFoo & HasNeither` is not assignable to element `SupportsBar` of intersection `SupportsFoo & SupportsBar`
+info: └── no element of intersection `HasFoo & HasNeither` is assignable to `SupportsBar`
+info:     ├── type `HasFoo` is not assignable to protocol `SupportsBar`
+info:     │   └── protocol member `bar` is not defined on type `HasFoo`
+info:     └── type `HasNeither` is not assignable to protocol `SupportsBar`
+info:         └── protocol member `bar` is not defined on type `HasNeither`
 ```
 
 ## Tuples
@@ -789,6 +818,11 @@ error[invalid-assignment]: Object of type `DoesNotSupportFoo1 & DoesNotSupportFo
    |             |
    |             Declared type
    |
+info: no element of intersection `DoesNotSupportFoo1 & DoesNotSupportFoo2` is assignable to `SupportsFoo`
+info: ├── type `DoesNotSupportFoo1` is not assignable to protocol `SupportsFoo`
+info: │   └── protocol member `foo` is not defined on type `DoesNotSupportFoo1`
+info: └── type `DoesNotSupportFoo2` is not assignable to protocol `SupportsFoo`
+info:     └── protocol member `foo` is not defined on type `DoesNotSupportFoo2`
 ```
 
 ## Assigning an overload set

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1211,7 +1211,15 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 .positive(db)
                 .iter()
                 .when_all(db, self.constraints, |&pos_ty| {
-                    self.check_type_pair(db, source, pos_ty)
+                    let constraint_set = self.check_type_pair(db, source, pos_ty);
+                    if constraint_set.is_never_satisfied(db) {
+                        self.provide_context(|| ErrorContext::NotAssignableToIntersectionElement {
+                            source,
+                            element: pos_ty,
+                            intersection: target,
+                        });
+                    }
+                    constraint_set
                 })
                 .and(db, self.constraints, || {
                     // For subtyping, we would want to check whether the *top materialization* of `source`
@@ -1258,27 +1266,48 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 // positive elements is a subtype of that type. If there are no positive elements,
                 // we treat `object` as the implicit positive element (e.g., `~str` is semantically
                 // `object & ~str`).
-                // TODO: Similar to how we do this for unions, we should collect error
-                // context for all elements and report it if *all* checks fail.
 
-                self.without_context_collection(|| {
-                    intersection
-                        .positive_elements_or_object(db)
-                        .when_any(db, self.constraints, |elem_ty| {
-                            self.check_type_pair(db, elem_ty, target)
-                        })
-                        .or(db, self.constraints, || {
-                            if should_expand_intersection(intersection) {
-                                self.check_type_pair(
-                                    db,
-                                    intersection.with_expanded_typevars_and_newtypes(db),
-                                    target,
-                                )
-                            } else {
-                                self.never()
+                let mut elements_context = vec![];
+                let context_collection_enabled = self.is_context_collection_enabled();
+
+                let result = intersection
+                    .positive_elements_or_object(db)
+                    .when_any(db, self.constraints, |elem_ty| {
+                        let result = self.check_type_pair(db, elem_ty, target);
+                        if context_collection_enabled {
+                            let ctx = self.context_tree.take();
+                            if !ctx.is_empty() {
+                                elements_context.push(ctx);
                             }
-                        })
-                })
+                        }
+                        result
+                    })
+                    .or(db, self.constraints, || {
+                        if should_expand_intersection(intersection) {
+                            self.check_type_pair(
+                                db,
+                                intersection.with_expanded_typevars_and_newtypes(db),
+                                target,
+                            )
+                        } else {
+                            self.never()
+                        }
+                    });
+
+                if context_collection_enabled
+                    && !elements_context.is_empty()
+                    && result.is_never_satisfied(db)
+                {
+                    self.set_context(
+                        ErrorContext::NoIntersectionElementAssignableToTarget {
+                            intersection: source,
+                            target,
+                        },
+                        elements_context,
+                    );
+                }
+
+                result
             }
 
             // `Never` is the bottom type, the empty set.

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -55,6 +55,15 @@ pub(crate) enum ErrorContext<'db> {
     NotAssignableToNOtherUnionElements {
         n: usize,
     },
+    NotAssignableToIntersectionElement {
+        source: Type<'db>,
+        element: Type<'db>,
+        intersection: Type<'db>,
+    },
+    NoIntersectionElementAssignableToTarget {
+        intersection: Type<'db>,
+        target: Type<'db>,
+    },
     TypedDictNotAssignableToDict(TypedDictType<'db>),
     IncompatibleReturnTypes {
         source: Type<'db>,
@@ -127,6 +136,24 @@ impl<'db> ErrorContext<'db> {
             Self::NotAssignableToNOtherUnionElements { n } => format!(
                 "... omitted {n} union element{} without additional context",
                 if *n == 1 { "" } else { "s" }
+            ),
+            Self::NotAssignableToIntersectionElement {
+                source,
+                element,
+                intersection,
+            } => format!(
+                "type `{}` is not assignable to element `{}` of intersection `{}`",
+                source.display(db),
+                element.display(db),
+                intersection.display(db),
+            ),
+            Self::NoIntersectionElementAssignableToTarget {
+                intersection,
+                target,
+            } => format!(
+                "no element of intersection `{}` is assignable to `{}`",
+                intersection.display(db),
+                target.display(db),
             ),
             Self::TypedDictNotAssignableToDict(typed_dict) => {
                 help_messages.insert(HelpMessages::TypedDictNotAssignableToDict);

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -55,6 +55,15 @@ pub(crate) enum ErrorContext<'db> {
     NotAssignableToNOtherUnionElements {
         n: usize,
     },
+    NotAssignableToIntersectionElement {
+        source: Type<'db>,
+        element: Type<'db>,
+        intersection: Type<'db>,
+    },
+    NoIntersectionElementAssignableToTarget {
+        intersection: Type<'db>,
+        target: Type<'db>,
+    },
     TypedDictFieldMissing {
         field_name: Name,
         source: TypedDictType<'db>,
@@ -158,6 +167,24 @@ impl<'db> ErrorContext<'db> {
             Self::NotAssignableToNOtherUnionElements { n } => format!(
                 "... omitted {n} union element{} without additional context",
                 if *n == 1 { "" } else { "s" }
+            ),
+            Self::NotAssignableToIntersectionElement {
+                source,
+                element,
+                intersection,
+            } => format!(
+                "type `{}` is not assignable to element `{}` of intersection `{}`",
+                source.display(db),
+                element.display(db),
+                intersection.display(db),
+            ),
+            Self::NoIntersectionElementAssignableToTarget {
+                intersection,
+                target,
+            } => format!(
+                "no element of intersection `{}` is assignable to `{}`",
+                intersection.display(db),
+                target.display(db),
             ),
             Self::TypedDictFieldMissing { field_name, source } => {
                 format!(


### PR DESCRIPTION
## Summary

This implementation is basically the dual of what we do for unions (with the assignability direction flipped).

## Test Plan

Updated mdtests.
