### PR TITLE
[ty] Fix notifications about watched changes for entities outside any workspace

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -162,7 +162,7 @@ fn benchmark_incremental(criterion: &mut Criterion) {
         let Case { db, .. } = case;
 
         db.apply_changes(
-            vec![ChangeEvent::Changed {
+            &[ChangeEvent::Changed {
                 path: case.file_path.clone(),
                 kind: ChangedKind::FileContent,
             }],

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -456,7 +456,7 @@ impl MainLoop {
 
                     revision += 1;
                     // Automatically cancels any pending queries and waits for them to complete.
-                    db.apply_changes(changes, Some(&self.project_options_overrides));
+                    db.apply_changes(&changes, Some(&self.project_options_overrides));
                     if let Some(watcher) = self.watcher.as_mut() {
                         watcher.update(db);
                     }

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -175,7 +175,7 @@ impl TestCase {
 
     fn apply_changes(
         &mut self,
-        changes: Vec<ChangeEvent>,
+        changes: &[ChangeEvent],
         project_options_overrides: Option<&ProjectOptionsOverrides>,
     ) {
         self.db.apply_changes(changes, project_options_overrides);
@@ -193,7 +193,7 @@ impl TestCase {
         .context("Failed to write configuration")?;
 
         let changes = self.take_watch_changes(event_for_file("pyproject.toml"));
-        self.apply_changes(changes, None);
+        self.apply_changes(&changes, None);
 
         if let Some(watcher) = &mut self.watcher {
             watcher.update(&self.db);
@@ -521,7 +521,7 @@ fn new_file() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("foo.py"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     let foo = case.system_file(&foo_path).expect("foo.py to exist.");
 
@@ -544,7 +544,7 @@ fn new_ignored_file() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("foo.py"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     assert!(case.system_file(&foo_path).is_ok());
     case.assert_indexed_project_files([bar_file]);
@@ -580,7 +580,7 @@ fn new_non_project_file() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("black.py"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     assert!(case.system_file(&black_path).is_ok());
 
@@ -621,7 +621,7 @@ fn new_files_with_explicit_included_paths() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("test2.py"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     let sub_a_file = case.system_file(&sub_a_path).expect("sub/a.py to exist");
 
@@ -666,7 +666,7 @@ fn new_file_in_included_out_of_project_directory() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("script2.py"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     let src_a_file = case.system_file(&src_a).unwrap();
     let outside_b_file = case.system_file(&outside_b_path).unwrap();
@@ -693,7 +693,7 @@ fn changed_file() -> anyhow::Result<()> {
 
     assert!(!changes.is_empty());
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     assert_eq!(source_text(case.db(), foo).as_str(), "print('Version 2')");
     case.assert_indexed_project_files([foo]);
@@ -716,7 +716,7 @@ fn deleted_file() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("foo.py"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     assert!(!foo.exists(case.db()));
     case.assert_indexed_project_files([]);
@@ -748,7 +748,7 @@ fn move_file_to_trash() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("foo.py"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     assert!(!foo.exists(case.db()));
     case.assert_indexed_project_files([]);
@@ -775,7 +775,7 @@ fn move_file_to_project() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("foo.py"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     let foo_in_project = case.system_file(&foo_in_project)?;
 
@@ -800,7 +800,7 @@ fn rename_file() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("bar.py"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     assert!(!foo.exists(case.db()));
 
@@ -839,7 +839,7 @@ fn directory_moved_to_project() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("sub"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     let init_file = case
         .system_file(sub_new_path.join("__init__.py"))
@@ -888,7 +888,7 @@ fn directory_moved_to_trash() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("sub"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     // `import sub.a` should no longer resolve
     assert!(
@@ -939,7 +939,7 @@ fn directory_renamed() -> anyhow::Result<()> {
     // Linux and windows only emit an event for the newly created root directory, but not for every new component.
     let changes = case.stop_watch(event_for_file("sub"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     // `import sub.a` should no longer resolve
     assert!(
@@ -1000,7 +1000,7 @@ fn directory_deleted() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("sub"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     // `import sub.a` should no longer resolve
     assert!(
@@ -1042,7 +1042,7 @@ fn search_path() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("a.py"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     assert!(resolve_module_confident(case.db(), &ModuleName::new_static("a").unwrap()).is_some());
     case.assert_indexed_project_files([case.system_file(case.project_path("bar.py")).unwrap()]);
@@ -1073,7 +1073,7 @@ fn add_search_path() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("a.py"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     assert!(resolve_module_confident(case.db(), &ModuleName::new_static("a").unwrap()).is_some());
 
@@ -1220,7 +1220,7 @@ fn changed_versions_file() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("VERSIONS"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     assert!(resolve_module_confident(case.db(), &ModuleName::new_static("os").unwrap()).is_some());
 
@@ -1274,7 +1274,7 @@ fn hard_links_in_project() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("foo.py"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     assert_eq!(source_text(case.db(), foo).as_str(), "print('Version 2')");
 
@@ -1345,7 +1345,7 @@ fn hard_links_to_target_outside_project() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(ChangeEvent::is_changed);
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     assert_eq!(source_text(case.db(), bar).as_str(), "print('Version 2')");
 
@@ -1384,7 +1384,7 @@ mod unix {
 
         let changes = case.stop_watch(event_for_file("foo.py"));
 
-        case.apply_changes(changes, None);
+        case.apply_changes(&changes, None);
 
         assert_eq!(
             foo.permissions(case.db()),
@@ -1464,7 +1464,7 @@ mod unix {
 
         let changes = case.take_watch_changes(event_for_file("baz.py"));
 
-        case.apply_changes(changes, None);
+        case.apply_changes(&changes, None);
 
         assert_eq!(
             source_text(case.db(), baz_file).as_str(),
@@ -1477,7 +1477,7 @@ mod unix {
 
         let changes = case.stop_watch(event_for_file("baz.py"));
 
-        case.apply_changes(changes, None);
+        case.apply_changes(&changes, None);
 
         assert_eq!(
             source_text(case.db(), baz_file).as_str(),
@@ -1545,7 +1545,7 @@ mod unix {
 
         let changes = case.stop_watch(event_for_file("baz.py"));
 
-        case.apply_changes(changes, None);
+        case.apply_changes(&changes, None);
 
         // The file watcher is guaranteed to emit one event for the changed file, but it isn't specified
         // if the event is emitted for the "original" or linked path because both paths are watched.
@@ -1659,7 +1659,7 @@ mod unix {
 
         let changes = case.stop_watch(event_for_file("baz.py"));
 
-        case.apply_changes(changes, None);
+        case.apply_changes(&changes, None);
 
         assert_eq!(
             source_text(case.db(), baz_original_file).as_str(),
@@ -1716,7 +1716,7 @@ fn nested_projects_delete_root() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(ChangeEvent::is_deleted);
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     // It should now pick up the outer project.
     assert_eq!(case.db().project().root(case.db()), case.root_path());
@@ -1782,7 +1782,7 @@ fn changes_to_user_configuration() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("ty.toml"));
 
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     let diagnostics = case.db().check_file(foo);
 
@@ -1843,7 +1843,7 @@ fn changes_to_config_file_override() -> anyhow::Result<()> {
     let changes = case.stop_watch(event_for_file("ty-override.toml"));
 
     case.apply_changes(
-        changes,
+        &changes,
         Some(&ProjectOptionsOverrides::new(
             Some(case.project_path("ty-override.toml")),
             Options::default(),
@@ -1922,7 +1922,7 @@ fn rename_files_casing_only() -> anyhow::Result<()> {
     }
 
     let changes = case.stop_watch(event_for_file("Lib.py"));
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     // Resolving `lib` should now fail but `Lib` should now succeed
     assert_eq!(
@@ -1952,7 +1952,7 @@ fn submodule_cache_invalidation_created() -> anyhow::Result<()> {
 
     std::fs::write(case.project_path("bar/wazoo.py").as_std_path(), "")?;
     let changes = case.stop_watch(event_for_file("wazoo.py"));
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     insta::assert_snapshot!(
         case.sorted_submodule_names("bar").join("\n"),
@@ -1986,7 +1986,7 @@ fn submodule_cache_invalidation_deleted() -> anyhow::Result<()> {
 
     std::fs::remove_file(case.project_path("bar/wazoo.py").as_std_path())?;
     let changes = case.stop_watch(event_for_file("wazoo.py"));
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     insta::assert_snapshot!(
         case.sorted_submodule_names("bar").join("\n"),
@@ -2009,11 +2009,11 @@ fn submodule_cache_invalidation_created_then_deleted() -> anyhow::Result<()> {
 
     std::fs::write(case.project_path("bar/wazoo.py").as_std_path(), "")?;
     let changes = case.take_watch_changes(event_for_file("wazoo.py"));
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     std::fs::remove_file(case.project_path("bar/wazoo.py").as_std_path())?;
     let changes = case.stop_watch(event_for_file("wazoo.py"));
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     insta::assert_snapshot!(
         case.sorted_submodule_names("bar").join("\n"),
@@ -2039,7 +2039,7 @@ fn submodule_cache_invalidation_after_pyproject_created() -> anyhow::Result<()> 
 
     std::fs::write(case.project_path("bar/wazoo.py").as_std_path(), "")?;
     let changes = case.take_watch_changes(event_for_file("wazoo.py"));
-    case.apply_changes(changes, None);
+    case.apply_changes(&changes, None);
 
     insta::assert_snapshot!(
         case.sorted_submodule_names("bar").join("\n"),

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -35,7 +35,7 @@ impl ProjectDatabase {
     #[tracing::instrument(level = "debug", skip(self, changes, project_options_overrides))]
     pub fn apply_changes(
         &mut self,
-        changes: Vec<ChangeEvent>,
+        changes: &[ChangeEvent],
         project_options_overrides: Option<&ProjectOptionsOverrides>,
     ) -> ChangeResult {
         let project = self.project();
@@ -91,7 +91,7 @@ impl ProjectDatabase {
                 ChangeEvent::Changed { path, kind: _ } | ChangeEvent::Opened(path) => {
                     if synced_files.insert(path.to_path_buf()) {
                         let absolute =
-                            SystemPath::absolute(&path, self.system().current_directory());
+                            SystemPath::absolute(path, self.system().current_directory());
                         File::sync_path_only(self, &absolute);
                         if let Some(root) = self.files().root(self, &absolute) {
                             match root.kind_at_time_of_creation(self) {
@@ -129,7 +129,7 @@ impl ProjectDatabase {
                     match kind {
                         CreatedKind::File => {
                             if synced_files.insert(path.to_path_buf()) {
-                                File::sync_path(self, &path);
+                                File::sync_path(self, path);
                             }
                         }
                         CreatedKind::Directory | CreatedKind::Any => {
@@ -147,15 +147,15 @@ impl ProjectDatabase {
                     // paths that aren't part of the project or shouldn't be included
                     // when checking the project.
 
-                    if self.system().is_file(&path) {
-                        if project.is_file_included(self, &path) {
+                    if self.system().is_file(path) {
+                        if project.is_file_included(self, path) {
                             // Add the parent directory because `walkdir`
                             // always visits explicitly passed files even if
                             // they match an exclude filter.
                             added_paths.insert(path.parent().unwrap().to_path_buf());
                         }
-                    } else if project.is_directory_included(self, &path) {
-                        added_paths.insert(path);
+                    } else if project.is_directory_included(self, path) {
+                        added_paths.insert(path.clone());
                     }
                 }
 
@@ -168,16 +168,16 @@ impl ProjectDatabase {
                         }
                         DeletedKind::Any => self
                             .files
-                            .try_system(self, &path)
+                            .try_system(self, path)
                             .is_some_and(|file| file.exists(self)),
                     };
 
                     if is_file {
                         if synced_files.insert(path.to_path_buf()) {
-                            File::sync_path(self, &path);
+                            File::sync_path(self, path);
                         }
 
-                        if let Some(file) = self.files().try_system(self, &path) {
+                        if let Some(file) = self.files().try_system(self, path) {
                             project.remove_file(self, file);
                         }
                     } else {
@@ -185,14 +185,14 @@ impl ProjectDatabase {
 
                         if custom_stdlib_versions_path
                             .as_ref()
-                            .is_some_and(|versions_path| versions_path.starts_with(&path))
+                            .is_some_and(|versions_path| versions_path.starts_with(path))
                         {
                             result.custom_stdlib_changed = true;
                         }
 
-                        let directory_included = project.is_directory_included(self, &path);
+                        let directory_included = project.is_directory_included(self, path);
 
-                        if directory_included || path == project_root {
+                        if directory_included || path == &project_root {
                             // TODO: Shouldn't it be enough to simply traverse the project files and remove all
                             // that start with the given path?
                             tracing::debug!(
@@ -213,11 +213,11 @@ impl ProjectDatabase {
                 }
 
                 ChangeEvent::CreatedVirtual(path) | ChangeEvent::ChangedVirtual(path) => {
-                    File::sync_virtual_path(self, &path);
+                    File::sync_virtual_path(self, path);
                 }
 
                 ChangeEvent::DeletedVirtual(path) => {
-                    if let Some(virtual_file) = self.files().try_virtual_file(&path) {
+                    if let Some(virtual_file) = self.files().try_virtual_file(path) {
                         virtual_file.close(self);
                     }
                 }

--- a/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
@@ -80,7 +80,7 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
         for (root, changes) in events_by_db {
             tracing::debug!("Applying changes to `{root}`");
 
-            session.apply_changes(&AnySystemPath::System(root.clone()), changes);
+            session.apply_changes(&AnySystemPath::System(root.clone()), &changes);
             publish_settings_diagnostics(session, client, root);
         }
 

--- a/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
@@ -9,7 +9,7 @@ use crate::session::client::Client;
 use crate::system::AnySystemPath;
 use lsp_types as types;
 use lsp_types::{FileChangeType, notification as notif};
-use rustc_hash::FxHashMap;
+use ruff_db::system::SystemPathBuf;
 use ty_project::Db as _;
 use ty_project::watch::{ChangeEvent, ChangedKind, CreatedKind, DeletedKind};
 
@@ -25,7 +25,7 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
         client: &Client,
         params: types::DidChangeWatchedFilesParams,
     ) -> Result<()> {
-        let mut events_by_db: FxHashMap<_, Vec<ChangeEvent>> = FxHashMap::default();
+        let mut changes = Vec::new();
 
         for change in params.changes {
             let path = DocumentKey::from_url(&change.uri).into_file_path();
@@ -36,13 +36,6 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
                     tracing::debug!("Ignoring virtual path from change event: `{path}`");
                     continue;
                 }
-            };
-
-            let Some(db) = session.project_db_for_path(&system_path) else {
-                tracing::trace!(
-                    "Ignoring change event for `{system_path}` because it's not in any workspace"
-                );
-                continue;
             };
 
             let change_event = match change.typ {
@@ -67,17 +60,19 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
                 }
             };
 
-            events_by_db
-                .entry(db.project().root(db).to_path_buf())
-                .or_default()
-                .push(change_event);
+            changes.push(change_event);
         }
 
-        if events_by_db.is_empty() {
+        if changes.is_empty() {
             return Ok(());
         }
 
-        for (root, changes) in events_by_db {
+        let roots: Vec<SystemPathBuf> = session
+            .project_dbs()
+            .map(|db| db.project().root(db).to_owned())
+            .collect();
+
+        for root in roots {
             tracing::debug!("Applying changes to `{root}`");
 
             session.apply_changes(&AnySystemPath::System(root.clone()), &changes);

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -406,7 +406,7 @@ impl Session {
     pub(crate) fn apply_changes(
         &mut self,
         path: &AnySystemPath,
-        changes: Vec<ChangeEvent>,
+        changes: &[ChangeEvent],
     ) -> ChangeResult {
         let overrides = path.as_system().and_then(|root| {
             self.workspaces()
@@ -1215,7 +1215,7 @@ impl Session {
                 } else {
                     ChangeEvent::Opened(system_path.clone())
                 };
-                self.apply_changes(path, vec![event]);
+                self.apply_changes(path, &[event]);
 
                 if is_not_python {
                     return;
@@ -1844,14 +1844,14 @@ impl DocumentHandle {
         let path = self.notebook_or_file_path();
         let changes = match path {
             AnySystemPath::System(system_path) => {
-                vec![ChangeEvent::file_content_changed(system_path.clone())]
+                [ChangeEvent::file_content_changed(system_path.clone())]
             }
             AnySystemPath::SystemVirtual(virtual_path) => {
-                vec![ChangeEvent::ChangedVirtual(virtual_path.clone())]
+                [ChangeEvent::ChangedVirtual(virtual_path.clone())]
             }
         };
 
-        session.apply_changes(path, changes);
+        session.apply_changes(path, &changes);
     }
 
     fn set_version(&mut self, version: DocumentVersion) {

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -325,15 +325,6 @@ impl Session {
         &mut self.project_state_mut(path).db
     }
 
-    /// Returns a reference to the project's [`ProjectDatabase`] corresponding to the given path, if
-    /// any.
-    pub(crate) fn project_db_for_path(
-        &self,
-        path: impl AsRef<SystemPath>,
-    ) -> Option<&ProjectDatabase> {
-        self.project_state_for_path(path).map(|state| &state.db)
-    }
-
     /// Returns a reference to the project's [`ProjectState`] in which the given `path` belongs.
     ///
     /// If the path is a system path, it will return the project database that is closest to the

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -184,7 +184,7 @@ impl Workspace {
             .map_err(into_error)?;
 
         self.db.apply_changes(
-            vec![ChangeEvent::Created {
+            &[ChangeEvent::Created {
                 path: path.clone(),
                 kind: CreatedKind::File,
             }],
@@ -217,7 +217,7 @@ impl Workspace {
             .map_err(into_error)?;
 
         self.db.apply_changes(
-            vec![
+            &[
                 ChangeEvent::Changed {
                     path: system_path.to_path_buf(),
                     kind: ChangedKind::FileContent,
@@ -251,7 +251,7 @@ impl Workspace {
                 .map_err(into_error)?;
 
             self.db.apply_changes(
-                vec![ChangeEvent::Deleted {
+                &[ChangeEvent::Deleted {
                     path: system_path.to_path_buf(),
                     kind: DeletedKind::File,
                 }],


### PR DESCRIPTION
## Summary

Distribute watched file change events generated by the LSP client to all dbs.

This simplifies the filtering logic to be handled by each db, and also fixes venvs which are outside the workspace (which can happen for symlinked environments).

## Test Plan

Neovim, and a custom test harness (let me know if there is a way to test this in ty itself, Micha made it sound like it wasn't so easy.
