### PR TITLE
[ty] Remove `InNoTypeCheck` enum

### DIFF
--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -43,7 +43,6 @@ pub(crate) struct InferContext<'db, 'ast> {
     file: File,
     module: &'ast ParsedModuleRef,
     diagnostics: std::cell::RefCell<TypeCheckDiagnostics>,
-    no_type_check: InNoTypeCheck,
     /// This field tracks various flags that control how type inference should behave in the current context.
     pub(crate) inference_flags: InferenceFlags,
     bomb: DebugDropBomb,
@@ -57,7 +56,6 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
             module,
             file: scope.file(db),
             diagnostics: std::cell::RefCell::new(TypeCheckDiagnostics::default()),
-            no_type_check: InNoTypeCheck::default(),
             inference_flags: InferenceFlags::empty(),
             bomb: DebugDropBomb::new(
                 "`InferContext` needs to be explicitly consumed by calling `::finish` to prevent accidental loss of diagnostics.",
@@ -167,38 +165,36 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
         DiagnosticGuardBuilder::new(self, id, severity)
     }
 
-    pub(super) fn set_in_no_type_check(&mut self, no_type_check: InNoTypeCheck) -> InNoTypeCheck {
-        std::mem::replace(&mut self.no_type_check, no_type_check)
-    }
-
     fn is_in_no_type_check(&self) -> bool {
-        match self.no_type_check {
-            InNoTypeCheck::Possibly => {
-                // Accessing the semantic index here is fine because
-                // the index belongs to the same file as for which we emit the diagnostic.
-                let index = semantic_index(self.db, self.file);
-
-                let scope_id = self.scope.file_scope_id(self.db);
-
-                // Inspect all ancestor function scopes by walking bottom up and check
-                // if any is decorated with `@no_type_check`. We use the undecorated type
-                // rather than the binding type because other decorators (e.g. unknown ones)
-                // may transform the function type into a non-`FunctionLiteral`.
-                // `undecorated_type()` can be `None` during cycle recovery.
-                index
-                    .ancestor_scopes(scope_id)
-                    .filter_map(|(_, scope)| scope.node().as_function())
-                    .filter_map(|node| {
-                        infer_definition_types(self.db, index.expect_single_definition(node))
-                            .undecorated_type()
-                            .and_then(Type::as_function_literal)
-                    })
-                    .any(|function_ty| {
-                        function_ty.has_known_decorator(self.db, FunctionDecorators::NO_TYPE_CHECK)
-                    })
-            }
-            InNoTypeCheck::Yes => true,
+        if self
+            .inference_flags
+            .contains(InferenceFlags::IN_NO_TYPE_CHECK)
+        {
+            return true;
         }
+
+        // Accessing the semantic index here is fine because
+        // the index belongs to the same file as for which we emit the diagnostic.
+        let index = semantic_index(self.db, self.file);
+
+        let scope_id = self.scope.file_scope_id(self.db);
+
+        // Inspect all ancestor function scopes by walking bottom up and check
+        // if any is decorated with `@no_type_check`. We use the undecorated type
+        // rather than the binding type because other decorators (e.g. unknown ones)
+        // may transform the function type into a non-`FunctionLiteral`.
+        // `undecorated_type()` can be `None` during cycle recovery.
+        index
+            .ancestor_scopes(scope_id)
+            .filter_map(|(_, scope)| scope.node().as_function())
+            .filter_map(|node| {
+                infer_definition_types(self.db, index.expect_single_definition(node))
+                    .undecorated_type()
+                    .and_then(Type::as_function_literal)
+            })
+            .any(|function_ty| {
+                function_ty.has_known_decorator(self.db, FunctionDecorators::NO_TYPE_CHECK)
+            })
     }
 
     /// Check whether a diagnostic emitted at `range` is in reachable code.
@@ -237,17 +233,6 @@ impl fmt::Debug for InferContext<'_, '_> {
             .field("defused", &self.bomb)
             .finish()
     }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
-pub(crate) enum InNoTypeCheck {
-    /// The inference might be in a `no_type_check` block but only if any
-    /// ancestor function is decorated with `@no_type_check`.
-    #[default]
-    Possibly,
-
-    /// The inference is known to be in an `@no_type_check` decorated function.
-    Yes,
 }
 
 /// An abstraction for mutating a diagnostic through the lense of a lint.

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -974,7 +974,7 @@ impl<'db> ExpressionInference<'db> {
 
 bitflags::bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub(crate) struct InferenceFlags: u8 {
+    pub(crate) struct InferenceFlags: u16 {
         /// Whether to allow `ParamSpec` in type expressions.
         ///
         /// In most contexts inside type expressions, bare `ParamSpec`s are not allowed.
@@ -1009,6 +1009,8 @@ bitflags::bitflags! {
         /// During this pass, `invalid-type-form` diagnostics are suppressed;
         /// these are emitted during the second, post-inference, pass.
         const IN_PEP_613_ALIAS_FIRST_PASS = 1 << 7;
+
+        const IN_NO_TYPE_CHECK = 1 << 8;
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -42,7 +42,6 @@ use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorK
 use crate::types::callable::CallableTypeKind;
 use crate::types::class::{ClassLiteral, CodeGeneratorKind, MethodDecorator};
 use crate::types::constraints::{ConstraintSetBuilder, PathBounds, Solutions};
-use crate::types::context::InNoTypeCheck;
 use crate::types::context::InferContext;
 use crate::types::diagnostic::{
     self, CALL_NON_CALLABLE, CONFLICTING_DECLARATIONS, CYCLIC_TYPE_ALIAS_DEFINITION,
@@ -871,7 +870,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             {
                 // Match `infer_function_definition`: suppress diagnostics that follow
                 // `@no_type_check`, including later decorators.
-                self.context.set_in_no_type_check(InNoTypeCheck::Yes);
+                self.context.inference_flags |= InferenceFlags::IN_NO_TYPE_CHECK;
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -4,7 +4,6 @@ use crate::{
     types::{
         KnownClass, KnownInstanceType, ParamSpecAttrKind, SubclassOfInner, SubclassOfType, Type,
         TypeContext, UnionType,
-        context::InNoTypeCheck,
         diagnostic::{
             FINAL_ON_NON_METHOD, INVALID_PARAMETER_DEFAULT, INVALID_PARAMSPEC, INVALID_TYPE_FORM,
             USELESS_OVERLOAD_BODY, add_type_expression_reference_link,
@@ -261,7 +260,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     Some(KnownFunction::NoTypeCheck) => {
                         // If the function is decorated with the `no_type_check` decorator,
                         // we need to suppress any errors that come after the decorators.
-                        self.context.set_in_no_type_check(InNoTypeCheck::Yes);
+                        self.context.inference_flags |= InferenceFlags::IN_NO_TYPE_CHECK;
                         continue;
                     }
                     Some(KnownFunction::Final) => {
@@ -415,7 +414,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         function: &ast::StmtFunctionDef,
     ) {
         let db = self.db();
-        let mut prev_in_no_type_check = self.context.set_in_no_type_check(InNoTypeCheck::Yes);
+        let mut prev_in_no_type_check = self
+            .context
+            .inference_flags
+            .replace(InferenceFlags::IN_NO_TYPE_CHECK, true);
         for decorator in &function.decorator_list {
             let decorator_type = self.infer_decorator(decorator);
             if let Type::FunctionLiteral(function) = decorator_type
@@ -423,11 +425,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             {
                 // If the function is decorated with the `no_type_check` decorator,
                 // we need to suppress any errors that come after the decorators.
-                prev_in_no_type_check = InNoTypeCheck::Yes;
+                prev_in_no_type_check = true;
                 break;
             }
         }
-        self.context.set_in_no_type_check(prev_in_no_type_check);
+        self.context
+            .inference_flags
+            .set(InferenceFlags::IN_NO_TYPE_CHECK, prev_in_no_type_check);
 
         let has_type_params = function.type_params.is_some();
         let has_defaults = function


### PR DESCRIPTION
## Summary

A minor simplification. Following https://github.com/astral-sh/ruff/commit/be5736e24017562522259dc197e9ed9475c1fab2, `InferenceFlags` are stored directly on `InferContext`, so we may as well use this bitflag for tracking whether we're currently visiting a `@no_type_check`-decorated region as well, rather than having a separate enum for that.

## Test Plan

existing tests
