### PR TITLE
[ty] Treat `[*xs]` as an irrefutable pattern

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1352,6 +1352,17 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     ClassPatternKind::Refutable
                 })
             }
+            ast::Pattern::MatchSequence(pattern) => {
+                // `case [*rest]` matches every sequence, while all other sequence patterns
+                // are refutable because they impose a minimum and/or exact length.
+                PatternPredicateKind::Sequence(
+                    if matches!(pattern.patterns.as_slice(), [ast::Pattern::MatchStar(_)]) {
+                        ClassPatternKind::Irrefutable
+                    } else {
+                        ClassPatternKind::Refutable
+                    },
+                )
+            }
             ast::Pattern::MatchOr(pattern) => {
                 let predicates = pattern
                     .patterns
@@ -1367,7 +1378,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     .map(|p| Box::new(self.predicate_kind(p))),
                 pattern.name.as_ref().map(|name| name.id.clone()),
             ),
-            _ => PatternPredicateKind::Unsupported,
+            ast::Pattern::MatchStar(_) => PatternPredicateKind::Unsupported,
         }
     }
 

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -153,6 +153,7 @@ pub enum PatternPredicateKind<'db> {
     Or(Vec<PatternPredicateKind<'db>>),
     Class(Expression<'db>, ClassPatternKind),
     Mapping(ClassPatternKind),
+    Sequence(ClassPatternKind),
     As(Option<Box<PatternPredicateKind<'db>>>, Option<Name>),
     Unsupported,
 }

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -40,40 +40,33 @@ from collections.abc import Sequence
 
 def sequence_star_pattern_is_exhaustive(paths: list[int]) -> None:
     match paths:
-        case []:
-            value = 0
-        case [_first]:
-            value = 1
-        case [_first, _second]:
-            value = 2
         case [*_paths]:
             raise ValueError
 
-    print(value)
+    reveal_type(paths)  # revealed: Never
 
 def sequence_star_pattern_is_not_exhaustive_for_text(paths: Sequence[str]) -> None:
     match paths:
-        case []:
-            value = 0
-        case [_first]:
-            value = 1
-        case [_first, _second]:
-            value = 2
         case [*_paths]:
             raise ValueError
 
-    print(value)  # error: [possibly-unresolved-reference]
+    # `str`, `bytes`, and `bytearray` are subtypes of `Sequence`, but sequence
+    # patterns explicitly do not match them.
+    # TODO: After https://github.com/astral-sh/ty/issues/3314 is fixed, the
+    # `Sequence[str] & bytes` and `Sequence[str] & bytearray` intersections
+    # should simplify to `Never`.
+    reveal_type(paths)  # revealed: str | (Sequence[str] & bytes) | (Sequence[str] & bytearray)
 
 def sequence_prefix_star_pattern_is_not_catch_all(paths: Sequence[str]) -> None:
     match paths:
         case []:
-            value = 0
+            raise ValueError
         case [_first]:
-            value = 1
+            raise ValueError
         case [_first, _second, *_paths]:
             raise ValueError
 
-    print(value)  # error: [possibly-unresolved-reference]
+    reveal_type(paths)  # revealed: Sequence[str]
 ```
 
 ## Basic match

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -33,6 +33,49 @@ def _(target: int):
     reveal_type(y)
 ```
 
+## With sequence wildcard
+
+```py
+from collections.abc import Sequence
+
+def sequence_star_pattern_is_exhaustive(paths: list[int]) -> None:
+    match paths:
+        case []:
+            value = 0
+        case [_first]:
+            value = 1
+        case [_first, _second]:
+            value = 2
+        case [*_paths]:
+            raise ValueError
+
+    print(value)
+
+def sequence_star_pattern_is_not_exhaustive_for_text(paths: Sequence[str]) -> None:
+    match paths:
+        case []:
+            value = 0
+        case [_first]:
+            value = 1
+        case [_first, _second]:
+            value = 2
+        case [*_paths]:
+            raise ValueError
+
+    print(value)  # error: [possibly-unresolved-reference]
+
+def sequence_prefix_star_pattern_is_not_catch_all(paths: Sequence[str]) -> None:
+    match paths:
+        case []:
+            value = 0
+        case [_first]:
+            value = 1
+        case [_first, _second, *_paths]:
+            raise ValueError
+
+    print(value)  # error: [possibly-unresolved-reference]
+```
+
 ## Basic match
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/import/star.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/star.md
@@ -188,9 +188,9 @@ def get_object() -> object:
 match get_object():
     case {"something": M}:
         pass
-    case [*N]:
-        pass
     case [O]:
+        pass
+    case [*N]:
         pass
     case I(foo=R):
         pass
@@ -243,7 +243,7 @@ print((
     L,
     M,  # error: [possibly-unresolved-reference]
     N,  # error: [possibly-unresolved-reference]
-    O,  # error: [unresolved-reference]
+    O,  # error: [possibly-unresolved-reference]
     P,  # error: [possibly-unresolved-reference]
     Q,  # error: [possibly-unresolved-reference]
     R,  # error: [possibly-unresolved-reference]

--- a/crates/ty_python_semantic/resources/mdtest/import/star.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/star.md
@@ -243,7 +243,7 @@ print((
     L,
     M,  # error: [possibly-unresolved-reference]
     N,  # error: [possibly-unresolved-reference]
-    O,  # error: [possibly-unresolved-reference]
+    O,  # error: [unresolved-reference]
     P,  # error: [possibly-unresolved-reference]
     Q,  # error: [possibly-unresolved-reference]
     R,  # error: [possibly-unresolved-reference]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -151,6 +151,26 @@ def test_match_refutable(x: dict | int) -> None:
             reveal_type(x)  # revealed: dict[Unknown, Unknown] | int
 ```
 
+## Sequence patterns
+
+```py
+from collections.abc import Sequence
+
+def test_match_star(x: Sequence[int] | int) -> None:
+    match x:
+        case [*rest]:
+            reveal_type(x)  # revealed: (Sequence[int] & ~str & ~bytes & ~bytearray) | (int & Sequence[object])
+        case _:
+            reveal_type(x)  # revealed: (int & ~Sequence[object]) | (Sequence[int] & str) | bytes | bytearray
+
+def test_match_star_excludes_text_and_bytes(x: str | bytes | bytearray | list[int]) -> None:
+    match x:
+        case [*rest]:
+            reveal_type(x)  # revealed: list[int]
+        case _:
+            reveal_type(x)  # revealed: str | bytes | bytearray
+```
+
 ## Value patterns
 
 Value patterns are evaluated by equality, which is overridable. Therefore successfully matching on

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -161,6 +161,12 @@ def test_match_star(x: Sequence[int] | int) -> None:
         case [*rest]:
             reveal_type(x)  # revealed: (Sequence[int] & ~str & ~bytes & ~bytearray) | (int & Sequence[object])
         case _:
+            # `str`, `bytes`, and `bytearray` are subtypes of `Sequence`, but
+            # sequence patterns explicitly do not match them. `bytes` and
+            # `bytearray` are possible inhabitants of `Sequence[int]`.
+            # TODO: After https://github.com/astral-sh/ty/issues/3314 is
+            # fixed, the `Sequence[int] & str` intersection should simplify to
+            # `Never`.
             reveal_type(x)  # revealed: (int & ~Sequence[object]) | (Sequence[int] & str) | bytes | bytearray
 
 def test_match_star_excludes_text_and_bytes(x: str | bytes | bytearray | list[int]) -> None:

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -230,6 +230,17 @@ fn mapping_pattern_type(db: &dyn Db) -> Type<'_> {
     KnownClass::Mapping.to_instance(db).top_materialization(db)
 }
 
+pub(crate) fn sequence_pattern_type(db: &dyn Db) -> Type<'_> {
+    IntersectionBuilder::new(db)
+        .add_positive(KnownClass::Sequence.to_instance(db).top_materialization(db))
+        // `str`, `bytes`, and `bytearray` are sequences, but Python sequence
+        // patterns explicitly do not match them or their subclasses.
+        .add_negative(KnownClass::Str.to_instance(db))
+        .add_negative(KnownClass::Bytes.to_instance(db))
+        .add_negative(KnownClass::Bytearray.to_instance(db))
+        .build()
+}
+
 /// Turn a `match` pattern kind into a type that represents the set of all values that would definitely
 /// match that pattern.
 fn pattern_kind_to_type<'db>(db: &'db dyn Db, kind: &PatternPredicateKind<'db>) -> Type<'db> {
@@ -259,6 +270,13 @@ fn pattern_kind_to_type<'db>(db: &'db dyn Db, kind: &PatternPredicateKind<'db>) 
         PatternPredicateKind::Mapping(kind) => {
             if kind.is_irrefutable() {
                 mapping_pattern_type(db)
+            } else {
+                Type::Never
+            }
+        }
+        PatternPredicateKind::Sequence(kind) => {
+            if kind.is_irrefutable() {
+                sequence_pattern_type(db)
             } else {
                 Type::Never
             }
@@ -660,6 +678,20 @@ fn analyze_single_pattern_predicate_kind<'db>(
                     Truthiness::Ambiguous
                 }
             } else if subject_ty.is_disjoint_from(db, mapping_ty) {
+                Truthiness::AlwaysFalse
+            } else {
+                Truthiness::Ambiguous
+            }
+        }
+        PatternPredicateKind::Sequence(kind) => {
+            let sequence_ty = sequence_pattern_type(db);
+            if subject_ty.is_subtype_of(db, sequence_ty) {
+                if kind.is_irrefutable() {
+                    Truthiness::AlwaysTrue
+                } else {
+                    Truthiness::Ambiguous
+                }
+            } else if subject_ty.is_disjoint_from(db, sequence_ty) {
                 Truthiness::AlwaysFalse
             } else {
                 Truthiness::Ambiguous

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1,5 +1,5 @@
 use crate::Db;
-use crate::reachability::ReachabilityConstraintsExtension;
+use crate::reachability::{ReachabilityConstraintsExtension, sequence_pattern_type};
 use crate::subscript::PyIndex;
 use crate::types::enums::{enum_member_literals, enum_metadata};
 use crate::types::function::KnownFunction;
@@ -728,6 +728,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             }
             PatternPredicateKind::Mapping(kind) => {
                 self.evaluate_match_pattern_mapping(subject, *kind, is_positive)
+            }
+            PatternPredicateKind::Sequence(kind) => {
+                self.evaluate_match_pattern_sequence(subject, *kind, is_positive)
             }
             PatternPredicateKind::Value(expr) => {
                 self.evaluate_match_pattern_value(subject, *expr, is_positive)
@@ -1727,6 +1730,27 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         Some(NarrowingConstraints::from_iter([(
             place,
             NarrowingConstraint::intersection(mapping_type),
+        )]))
+    }
+
+    fn evaluate_match_pattern_sequence(
+        &mut self,
+        subject: Expression<'db>,
+        kind: ClassPatternKind,
+        is_positive: bool,
+    ) -> Option<NarrowingConstraints<'db>> {
+        if !kind.is_irrefutable() && !is_positive {
+            return None;
+        }
+
+        let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
+        let place = self.expect_place(&subject);
+
+        let sequence_type = sequence_pattern_type(self.db).negate_if(self.db, !is_positive);
+
+        Some(NarrowingConstraints::from_iter([(
+            place,
+            NarrowingConstraint::intersection(sequence_type),
         )]))
     }
 


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ty/issues/3304.
