### PR TITLE
Revert preview changes to displayed diagnostic severity in LSP

### DIFF
--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -19,8 +19,7 @@ use ruff_linter::{
     linter::check_path,
     package::PackageRoot,
     packaging::detect_package_root,
-    preview::is_warning_severity_enabled,
-    settings::{flags, types::PreviewMode},
+    settings::flags,
     source_kind::SourceKind,
     suppression::Suppressions,
 };
@@ -187,7 +186,6 @@ pub(crate) fn check(
                         &source_kind,
                         locator.to_index(),
                         encoding,
-                        settings.linter.preview,
                     ))
                 }
             });
@@ -249,7 +247,6 @@ fn to_lsp_diagnostic(
     source_kind: &SourceKind,
     index: &LineIndex,
     encoding: PositionEncoding,
-    preview: PreviewMode,
 ) -> (usize, lsp_types::Diagnostic) {
     let diagnostic_range = diagnostic.range().unwrap_or_default();
     let name = diagnostic.name();
@@ -300,9 +297,7 @@ fn to_lsp_diagnostic(
         range = diagnostic_range.to_range(source_kind.source_code(), index, encoding);
     }
 
-    let (severity, code) = if let Some(code) = code
-        && !is_warning_severity_enabled(preview)
-    {
+    let (severity, code) = if let Some(code) = code {
         (severity(code), code.to_string())
     } else {
         (


### PR DESCRIPTION
Since it may take a little more time to support user-configured severities, it makes sense to revert this change for now as it is disruptive to users and there is no workaround.

(I don't think it's necessary to change the preview behavior in the CLI since both the displayed color and the exit-code behavior is unchanged.)

Closes #24069

## Screenshots

Before: 
<img width="1074" height="342" alt="Screenshot 2026-04-22 at 10 29 51 AM" src="https://github.com/user-attachments/assets/32c1cb87-601a-4f7c-be9d-8662a2cb4e1e" />

After:
<img width="1074" height="348" alt="Screenshot 2026-04-22 at 10 30 46 AM" src="https://github.com/user-attachments/assets/f19fdb1e-77ad-4dcf-8f2f-458f88d6c4b4" />
