### PR TITLE
[ty] Add error context for TypedDict assignments

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -2,7 +2,7 @@
 
 ```toml
 [environment]
-python-version = "3.12"
+python-version = "3.13"
 ```
 
 A lot of ty's diagnostics are emitted as a direct result of a type-to-type assignability check
@@ -409,7 +409,7 @@ info: This violates the Liskov Substitution Principle
 Incompatible field types:
 
 ```py
-from typing import Any, TypedDict
+from typing import Any, TypedDict, NotRequired, ReadOnly
 
 class Person(TypedDict):
     name: str
@@ -430,6 +430,7 @@ error[invalid-assignment]: Object of type `Person` is not assignable to `Other`
    |             |
    |             Declared type
    |
+info: field "name" on TypedDict `Person` has type `str` which is not assignable to type `bytes` expected by TypedDict `Other`
 ```
 
 Missing required fields:
@@ -452,23 +453,86 @@ error[invalid-assignment]: Object of type `Person` is not assignable to `PersonW
    |             |
    |             Declared type
    |
+info: required field "age" is not present in source TypedDict `Person`
+```
+
+Non-required fields that are required in the target:
+
+```py
+class PersonWithOptionalAge(TypedDict):
+    name: str
+    age: NotRequired[int]
+
+def _(source: PersonWithOptionalAge):
+    target: PersonWithAge = source  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `PersonWithOptionalAge` is not assignable to `PersonWithAge`
+  --> src/mdtest_snippet.py:22:13
+   |
+22 |     target: PersonWithAge = source  # snapshot
+   |             -------------   ^^^^^^ Incompatible value of type `PersonWithOptionalAge`
+   |             |
+   |             Declared type
+   |
+info: field "age" is required in TypedDict `PersonWithAge` but not required in TypedDict `PersonWithOptionalAge`
+```
+
+Read-only fields that are mutable in the target:
+
+```py
+class PersonWithReadOnlyName(TypedDict):
+    name: ReadOnly[str]
+
+def _(source: PersonWithReadOnlyName):
+    target: Person = source  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `PersonWithReadOnlyName` is not assignable to `Person`
+  --> src/mdtest_snippet.py:27:13
+   |
+27 |     target: Person = source  # snapshot
+   |             ------   ^^^^^^ Incompatible value of type `PersonWithReadOnlyName`
+   |             |
+   |             Declared type
+   |
+info: field "name" is read-only in TypedDict `PersonWithReadOnlyName` but mutable in TypedDict `Person`
+```
+
+Required fields that are not required and mutable in the target:
+
+```py
+def _(source: PersonWithAge):
+    target: PersonWithOptionalAge = source  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `PersonWithAge` is not assignable to `PersonWithOptionalAge`
+  --> src/mdtest_snippet.py:29:13
+   |
+29 |     target: PersonWithOptionalAge = source  # snapshot
+   |             ---------------------   ^^^^^^ Incompatible value of type `PersonWithAge`
+   |             |
+   |             Declared type
+   |
+info: field "age" is required in TypedDict `PersonWithAge` but not required and mutable in TypedDict `PersonWithOptionalAge`
+help: The required field could be removed through a destructive operation like `del` on the target.
 ```
 
 Assigning a `TypedDict` to a `dict`
 
 ```py
-class Person(TypedDict):
-    name: str
-
 def _(source: Person):
     target: dict[str, Any] = source  # snapshot
 ```
 
 ```snapshot
 error[invalid-assignment]: Object of type `Person` is not assignable to `dict[str, Any]`
-  --> src/mdtest_snippet.py:21:13
+  --> src/mdtest_snippet.py:31:13
    |
-21 |     target: dict[str, Any] = source  # snapshot
+31 |     target: dict[str, Any] = source  # snapshot
    |             --------------   ^^^^^^ Incompatible value of type `Person`
    |             |
    |             Declared type

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -55,6 +55,32 @@ pub(crate) enum ErrorContext<'db> {
     NotAssignableToNOtherUnionElements {
         n: usize,
     },
+    TypedDictFieldMissing {
+        field_name: Name,
+        source: TypedDictType<'db>,
+    },
+    TypedDictFieldNotRequiredInSource {
+        source: TypedDictType<'db>,
+        target: TypedDictType<'db>,
+        field_name: Name,
+    },
+    TypedDictFieldNotRequiredAndMutableInTarget {
+        source: TypedDictType<'db>,
+        target: TypedDictType<'db>,
+        field_name: Name,
+    },
+    TypedDictFieldReadOnlyInSource {
+        field_name: Name,
+        source: TypedDictType<'db>,
+        target: TypedDictType<'db>,
+    },
+    TypedDictFieldIncompatible {
+        field_name: Name,
+        source: TypedDictType<'db>,
+        target: TypedDictType<'db>,
+        source_field: Type<'db>,
+        target_field: Type<'db>,
+    },
     TypedDictNotAssignableToDict(TypedDictType<'db>),
     IncompatibleReturnTypes {
         source: Type<'db>,
@@ -105,6 +131,11 @@ impl<'db> ErrorContext<'db> {
         db: &'db dyn Db,
         help_messages: &mut FxOrderSet<HelpMessages>,
     ) -> Option<String> {
+        let typed_dict_name = |typed_dict: &TypedDictType<'db>| match typed_dict {
+            TypedDictType::Class(class) => format!("TypedDict `{}`", class.name(db)),
+            TypedDictType::Synthesized(_) => Type::TypedDict(*typed_dict).display(db).to_string(),
+        };
+
         Some(match self {
             Self::Empty => {
                 return None;
@@ -128,15 +159,67 @@ impl<'db> ErrorContext<'db> {
                 "... omitted {n} union element{} without additional context",
                 if *n == 1 { "" } else { "s" }
             ),
+            Self::TypedDictFieldMissing { field_name, source } => {
+                format!(
+                    "required field \"{field_name}\" is not present in source {source}",
+                    source = typed_dict_name(source)
+                )
+            }
+            Self::TypedDictFieldNotRequiredInSource {
+                field_name,
+                source,
+                target,
+            } => {
+                format!(
+                    "field \"{field_name}\" is required in {target} but not required in {source}",
+                    source = typed_dict_name(source),
+                    target = typed_dict_name(target)
+                )
+            }
+            Self::TypedDictFieldNotRequiredAndMutableInTarget {
+                field_name,
+                source,
+                target,
+            } => {
+                help_messages.insert(HelpMessages::RequiredFieldCouldBeRemoved);
+                format!(
+                    "field \"{field_name}\" is required in {source} but not required and mutable in {target}",
+                    source = typed_dict_name(source),
+                    target = typed_dict_name(target)
+                )
+            }
+            Self::TypedDictFieldReadOnlyInSource {
+                field_name,
+                source,
+                target,
+            } => {
+                format!(
+                    "field \"{field_name}\" is read-only in {source} but mutable in {target}",
+                    source = typed_dict_name(source),
+                    target = typed_dict_name(target)
+                )
+            }
+            Self::TypedDictFieldIncompatible {
+                field_name,
+                source,
+                target,
+                source_field,
+                target_field,
+            } => format!(
+                "field \"{field_name}\" on {source} has type `{source_field}` which is not assignable to type `{target_field}` expected by {target}",
+                source = typed_dict_name(source),
+                target = typed_dict_name(target),
+                source_field = source_field.display(db),
+                target_field = target_field.display(db),
+            ),
             Self::TypedDictNotAssignableToDict(typed_dict) => {
                 help_messages.insert(HelpMessages::TypedDictNotAssignableToDict);
                 help_messages.insert(HelpMessages::ConsiderUsingMappingInsteadOfDict);
 
-                let name = match typed_dict {
-                    TypedDictType::Class(class) => format!("TypedDict `{}`", class.name(db)),
-                    TypedDictType::Synthesized(_) => "TypedDict".to_string(),
-                };
-                format!("{name} is not assignable to `dict`")
+                format!(
+                    "{source} is not assignable to `dict`",
+                    source = typed_dict_name(typed_dict)
+                )
             }
             Self::IncompatibleReturnTypes { source, target } => format!(
                 "incompatible return types: `{source}` is not assignable to `{target}`",
@@ -230,6 +313,7 @@ impl<'db> ErrorContext<'db> {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum HelpMessages {
+    RequiredFieldCouldBeRemoved,
     TypedDictNotAssignableToDict,
     ConsiderUsingMappingInsteadOfDict,
 }
@@ -237,6 +321,9 @@ enum HelpMessages {
 impl std::fmt::Display for HelpMessages {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            HelpMessages::RequiredFieldCouldBeRemoved => {
+                f.write_str("The required field could be removed through a destructive operation like `del` on the target.")
+            }
             HelpMessages::TypedDictNotAssignableToDict => {
                 f.write_str("A TypedDict is not usually assignable to any `dict[..]` type; `dict` types allow destructive operations like `clear()`.")
             }

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -18,8 +18,8 @@ use super::diagnostic::{
 };
 use super::infer::infer_deferred_types;
 use super::{
-    ApplyTypeMappingVisitor, IntersectionType, Type, TypeMapping, TypeQualifiers, UnionBuilder,
-    definition_expression_type, visitor,
+    ApplyTypeMappingVisitor, ErrorContext, IntersectionType, Type, TypeMapping, TypeQualifiers,
+    UnionBuilder, definition_expression_type, visitor,
 };
 use crate::Db;
 use crate::types::TypeContext;
@@ -275,10 +275,19 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // required target fields
                 let Some(source_item_field) = source_items.get(target_item_name) else {
                     // Self is missing a required field.
+                    self.provide_context(|| ErrorContext::TypedDictFieldMissing {
+                        field_name: target_item_name.clone(),
+                        source,
+                    });
                     return self.never();
                 };
                 if !source_item_field.is_required() {
                     // A required field is not required in self.
+                    self.provide_context(|| ErrorContext::TypedDictFieldNotRequiredInSource {
+                        field_name: target_item_name.clone(),
+                        source,
+                        target,
+                    });
                     return self.never();
                 }
                 if target_item_field.is_read_only() {
@@ -294,6 +303,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 } else {
                     if source_item_field.is_read_only() {
                         // A read-only field can't be assigned to a mutable target.
+                        self.provide_context(|| ErrorContext::TypedDictFieldReadOnlyInSource {
+                            field_name: target_item_name.clone(),
+                            source,
+                            target,
+                        });
                         return self.never();
                     }
                     // For mutable fields in the target, the relation needs to apply both
@@ -350,11 +364,23 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     if let Some(source_item_field) = source_items.get(target_item_name) {
                         if source_item_field.is_read_only() {
                             // A read-only field can't be assigned to a mutable target.
+                            self.provide_context(|| ErrorContext::TypedDictFieldReadOnlyInSource {
+                                field_name: target_item_name.clone(),
+                                source,
+                                target,
+                            });
                             return self.never();
                         }
                         if source_item_field.is_required() {
                             // A required field can't be assigned to a not-required, mutable field
                             // in the target, because `del` is allowed on the target field.
+                            self.provide_context(|| {
+                                ErrorContext::TypedDictFieldNotRequiredAndMutableInTarget {
+                                    field_name: target_item_name.clone(),
+                                    source,
+                                    target,
+                                }
+                            });
                             return self.never();
                         }
 
@@ -386,6 +412,15 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             };
             result.intersect(db, self.constraints, field_constraints);
             if result.is_never_satisfied(db) {
+                if let Some(source_item_field) = source_items.get(target_item_name) {
+                    self.provide_context(|| ErrorContext::TypedDictFieldIncompatible {
+                        field_name: target_item_name.clone(),
+                        source,
+                        target,
+                        source_field: source_item_field.declared_ty,
+                        target_field: target_item_field.declared_ty,
+                    });
+                }
                 return result;
             }
         }


### PR DESCRIPTION
## Summary

Add error context for `TypedDict` to `TypedDict` assignments

<img width="1095" height="145" alt="image" src="https://github.com/user-attachments/assets/1ed5e877-3ca3-4f37-964f-87ebbcada56e" />

## Test Plan

Adapted and new Markdown tests.
