### PR TITLE
[ty] Fix attribute access on Callable-bounded TypeVars

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -673,6 +673,27 @@ def decorated(t: T) -> None:
     reveal_type(cast(T, t))  # revealed: T@decorated
 ```
 
+## Attribute access on `Callable`-bounded TypeVars
+
+```py
+from typing import Callable, Generic, TypeVar
+
+F = TypeVar("F", bound=Callable)
+
+def my_decorator(f: F) -> None:
+    # error: [unresolved-attribute]
+    f.whatever
+    # error: [unresolved-attribute]
+    f.whatever = 1
+
+class Box(Generic[F]):
+    cls: type[F]
+
+def specialized(box: Box[Callable]) -> None:
+    # error: [unresolved-attribute]
+    box.cls.whatever
+```
+
 ## Solving TypeVars with upper bounds in unions
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -741,6 +741,25 @@ def decorated[T](t: T) -> None:
     reveal_type(cast(T, t))  # revealed: T@decorated
 ```
 
+## Attribute access on `Callable`-bounded TypeVars
+
+```py
+from typing import Callable
+
+def my_decorator[T: Callable](f: T) -> None:
+    # error: [unresolved-attribute]
+    f.whatever
+    # error: [unresolved-attribute]
+    f.whatever = 1
+
+class Box[T: Callable]:
+    cls: type[T]
+
+def specialized(box: Box[Callable]) -> None:
+    # error: [unresolved-attribute]
+    box.cls.whatever
+```
+
 ## Solving TypeVars with upper bounds in unions
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -331,8 +331,7 @@ def f2[T](x: T) -> type[T]:
 reveal_type(f2(int(1)))  # revealed: type[int]
 reveal_type(f2(object()))  # revealed: type
 
-# TODO: This should reveal `type[Literal[1]]`.
-reveal_type(f2(1))  # revealed: type[Unknown]
+reveal_type(f2(1))  # revealed: <class 'int'>
 
 def f3[T](x: type[T]) -> T:
     return x()

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -319,6 +319,8 @@ def _[T](x: X[type[T]]):
 ## Generic Type Inference
 
 ```py
+from typing import Callable
+
 def f1[T](x: type[T]) -> type[T]:
     return x
 
@@ -332,6 +334,29 @@ reveal_type(f2(int(1)))  # revealed: type[int]
 reveal_type(f2(object()))  # revealed: type
 
 reveal_type(f2(1))  # revealed: <class 'int'>
+reveal_type(f2(type))  # revealed: <class 'type'>
+
+def foo() -> int:
+    return 1
+
+reveal_type(f2(foo))  # revealed: <class 'FunctionType'>
+
+def _(x: Callable[[int], int]):
+    reveal_type(f2(x))  # revealed: type
+
+class Meta(type): ...
+class Base(metaclass=Meta): ...
+
+reveal_type(f2(Base))  # revealed: <class 'Meta'>
+reveal_type(type(Base))  # revealed: <class 'Meta'>
+
+class MetaWithAttr(type):
+    meta_attr: int
+
+class BaseWithAttr(metaclass=MetaWithAttr): ...
+
+def _[T: type[BaseWithAttr]](x: type[T]) -> None:
+    reveal_type(x.meta_attr)  # revealed: int
 
 def f3[T](x: type[T]) -> T:
     return x()

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -163,8 +163,7 @@ impl<'db> SubclassOfType<'db> {
                 if mapped.is_never() {
                     Type::Never
                 } else {
-                    SubclassOfType::try_from_instance(db, mapped)
-                        .unwrap_or(SubclassOfType::subclass_of_unknown())
+                    mapped.to_meta_type(db)
                 }
             }
         }
@@ -460,16 +459,12 @@ impl<'db> SubclassOfInner<'db> {
                         .unwrap_or(SubclassOfType::subclass_of_unknown()),
                 ),
                 Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                    TypeVarBoundOrConstraints::UpperBound(
-                        SubclassOfType::try_from_instance(db, bound)
-                            .unwrap_or(SubclassOfType::subclass_of_unknown()),
-                    )
+                    TypeVarBoundOrConstraints::UpperBound(bound.to_meta_type(db))
                 }
                 Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                    TypeVarBoundOrConstraints::Constraints(constraints.map(db, |constraint| {
-                        SubclassOfType::try_from_instance(db, *constraint)
-                            .unwrap_or(SubclassOfType::subclass_of_unknown())
-                    }))
+                    TypeVarBoundOrConstraints::Constraints(
+                        constraints.map(db, |constraint| constraint.to_meta_type(db)),
+                    )
                 }
             })
         });

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -160,11 +160,7 @@ impl<'db> SubclassOfType<'db> {
             },
             SubclassOfInner::TypeVar(typevar) => {
                 let mapped = typevar.apply_type_mapping_impl(db, type_mapping, visitor);
-                if mapped.is_never() {
-                    Type::Never
-                } else {
-                    mapped.to_meta_type(db)
-                }
+                mapped.to_meta_type(db)
             }
         }
     }
@@ -439,11 +435,19 @@ impl<'db> SubclassOfInner<'db> {
         })
     }
 
-    /// Transposes `type[T]` with a type variable `T` into `T: type[...]`.
+    /// Converts `type[T]` with a type variable `T` into a type variable whose bound or
+    /// constraints describe the runtime classes of `T`'s possible inhabitants.
+    ///
+    /// For ordinary nominal bounds, this looks like transposing `type[T]` into
+    /// `T: type[...]`. The conversion intentionally goes through [`Type::to_meta_type`],
+    /// though, so bounds such as function-like callables and custom metaclasses keep the
+    /// richer meta-type that callers need instead of collapsing to `type[Unknown]`.
     ///
     /// In particular:
-    /// - If `T` has an upper bound of `T: Bound`, this returns `T: type[Bound]`.
-    /// - If `T` has constraints `T: (A, B)`, this returns `T: (type[A], type[B])`.
+    /// - If `T` has an upper bound of `T: Bound`, this returns `T` with the meta-type of
+    ///   `Bound` as its upper bound.
+    /// - If `T` has constraints `T: (A, B)`, this returns `T` constrained by the meta-types
+    ///   of `A` and `B`.
     /// - Otherwise, for an unbounded type variable, this returns `type[object]`.
     ///
     /// If this is type of a concrete type `C`, returns the type unchanged.


### PR DESCRIPTION
When converting `type[T]` into the metatype for a concrete `T`, we were doing `SubclassOfType::try_from_instance(...)`. But that method only handles a subset of types: nominal types, `TypedDict`, etc., and falls back to `type[Unknown]` for `Callable`, allowing arbitrary attribute access.

We now use `Type::to_meta_type(...)`, which is more general and knows how to handle `Callable`, etc.

I'm not yet certain why we weren't using this from the start.

Closes https://github.com/astral-sh/ty/issues/3303.
