### PR TITLE
[ty] Fix unbounded type growth in nested-typevar substitutions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/regression/derived_constraint_cycles.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/derived_constraint_cycles.md
@@ -5,6 +5,8 @@
 python-version = "3.13"
 ```
 
+## Initial repeated-substitution cycle
+
 Before [ty#24660], this example would never complete, because we would repeatedly try to substitute
 one of the typevars in a constraint over and over, creating increasingly large types in the lower or
 upper bound of the constraint.
@@ -23,6 +25,46 @@ def reduce[T](function: Callable[[T, T], T]) -> T:
     raise NotImplementedError
 
 reduce(add)
+```
+
+## Repeated substitutions across derived constraints
+
+The repeat-guard introduced in [ty#24660] only suppressed a follow-up substitution when the second
+attempt was into the same constraint id it had already substituted into. Every substitution produces
+a new derived constraint, so chains that alternate between two typevars as each other's bounds kept
+generating ever-deeper replacement types — for instance by alternating between substituting
+`T1 → Iterable[T2]` and `T2 → T1` into the upper bound of a third constraint, each round adding
+another `Iterable[...]` layer.
+
+Keying the repeat-guard by the constrained typevar (which stays stable across the chain) caps each
+substitution shape to at most one application per BDD path, preventing unbounded growth.
+
+This pattern shows up in real code via `itertools.accumulate` combined with a builtin like `min`,
+whose overloaded signature provides the cross-typevar constraints that drive the chain:
+
+```py
+from itertools import accumulate
+
+def running_min(iterable):
+    iterator = iter(iterable)
+    return accumulate(iterator, func=min)
+```
+
+This is a version that more exaggerates the performance degradation. Even in the release build, it
+took tens of seconds to complete.
+
+```py
+from itertools import accumulate
+
+def nested_running_min(iterable):
+    it = iter(iterable)
+    return accumulate(
+        accumulate(
+            accumulate(accumulate(accumulate(it, func=min), func=min), func=min),
+            func=min,
+        ),
+        func=min,
+    )
 ```
 
 [ty#24660]: https://github.com/astral-sh/ruff/pull/24660

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -885,15 +885,18 @@ enum NestedSubstitutionSide {
 /// Identifies one nested-typevar substitution that has been applied while saturating a single
 /// BDD path.
 ///
-/// We intentionally key this by the constraint that we substitute _into_ and the typevar that we
-/// substitute _for_, but not by the replacement type. For the pathological cases that matter for
-/// performance, the same nested substitution shape can keep producing ever-deeper replacement
-/// types (for instance, repeated `Iterable[...]` wrapping). Recording only the substitution site
-/// lets [`PathAssignments`] apply that substitution at most once per path, which preserves the
-/// initial cross-typevar relationship without repeatedly unfolding the same pattern.
+/// We key this by the typevar of the constrained constraint (which stays the same across an
+/// entire chain of derivations against a single root constraint), the typevar that we substitute
+/// _for_, and the side. We deliberately do _not_ key by the constraint id we substitute into,
+/// because each nested substitution produces a new derived constraint, and if we keyed by that
+/// id the next derivation step would have a different id and the repeat-guard would never fire.
+/// The pathological cases that matter for performance involve repeated wrapping (e.g.
+/// `Iterable[...]` layers) that keeps producing ever-deeper replacement types while targeting
+/// the same constrained typevar; keying by the constrained typevar plus the substituted typevar
+/// lets [`PathAssignments`] apply each substitution shape at most once per path.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
 struct NestedSubstitution {
-    substituted_into: ConstraintId,
+    constrained_typevar: TypeVarId,
     substituted_typevar: TypeVarId,
     side: NestedSubstitutionSide,
 }
@@ -909,12 +912,12 @@ struct DerivedConstraint {
 fn nested_substitution<'db>(
     db: &'db dyn Db,
     builder: &ConstraintSetBuilder<'db>,
-    substituted_into: ConstraintId,
+    constrained_typevar: BoundTypeVarInstance<'db>,
     substituted_typevar: BoundTypeVarInstance<'db>,
     side: NestedSubstitutionSide,
 ) -> NestedSubstitution {
     NestedSubstitution {
-        substituted_into,
+        constrained_typevar: builder.typevar_id(db, constrained_typevar),
         substituted_typevar: builder.typevar_id(db, substituted_typevar),
         side,
     }
@@ -4870,7 +4873,7 @@ impl SequentMap {
                             Some(nested_substitution(
                                 db,
                                 builder,
-                                constrained_constraint,
+                                constrained_typevar,
                                 bound_typevar,
                                 NestedSubstitutionSide::Upper,
                             )),
@@ -4934,7 +4937,7 @@ impl SequentMap {
                             Some(nested_substitution(
                                 db,
                                 builder,
-                                constrained_constraint,
+                                constrained_typevar,
                                 bound_typevar,
                                 NestedSubstitutionSide::Lower,
                             )),
@@ -5030,7 +5033,7 @@ impl SequentMap {
                                 Some(nested_substitution(
                                     db,
                                     builder,
-                                    constrained_constraint,
+                                    constrained_typevar,
                                     nested_typevar,
                                     NestedSubstitutionSide::Upper,
                                 )),
@@ -5074,7 +5077,7 @@ impl SequentMap {
                                 Some(nested_substitution(
                                     db,
                                     builder,
-                                    constrained_constraint,
+                                    constrained_typevar,
                                     nested_typevar,
                                     NestedSubstitutionSide::Lower,
                                 )),

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -896,6 +896,10 @@ enum NestedSubstitutionSide {
 /// lets [`PathAssignments`] apply each substitution shape at most once per path.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
 struct NestedSubstitution {
+    /// NOTE: Keying `NestedSubstitution` by `constrained_typevar` instead of the specific constrained `ConstraintId` makes
+    /// deduplication apply across all constraints on that typevar.
+    /// This provides a performance benefit, but may weaken sequent saturation and can miss contradictions (or other implications) that depend on keeping both substitutions.
+    /// However, at present, there don't seem to be any cases where this is a problem (see ruff#24803 for details).
     constrained_typevar: TypeVarId,
     substituted_typevar: TypeVarId,
     side: NestedSubstitutionSide,


### PR DESCRIPTION
## Summary

This was discovered while working on https://github.com/astral-sh/ruff/pull/24773.

The fix implemented in https://github.com/astral-sh/ruff/pull/24660 to address performance degradations appear to have been insufficient. Here's an example of significantly poor performance in main:

```py
from itertools import accumulate

def nested_running_min(iterable):
    it = iter(iterable)
    return accumulate(
        accumulate(
            accumulate(accumulate(accumulate(it, func=min), func=min), func=min),
            func=min,
        ),
        func=min,
    )
```

This takes tens of seconds to complete, even in a release build.

The problem was that the cache key used to avoid repeated substitutions was constructed using a `ConstraintId` instead of a `TypeVarId`. As a result, duplicates were not being eliminated sufficiently.

## Test Plan

mdtest updated (regression test)
