### PR TITLE
[ty] Improve generic inference with non-inferable typevars

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -386,6 +386,23 @@ reveal_type(union_and_nonunion_params(3, 1))  # revealed: Literal[1]
 reveal_type(union_and_nonunion_params("a", 1))  # revealed: Literal["a", 1]
 ```
 
+```py
+def _[T](t: T):
+    def union_with_non_inferable_t[U](x: T | U) -> U:
+        raise NotImplementedError
+
+    reveal_type(union_with_non_inferable_t("a"))  # revealed: Literal["a"]
+    reveal_type(union_with_non_inferable_t(1))  # revealed: Literal[1]
+    reveal_type(union_with_non_inferable_t(t))  # revealed: Unknown
+
+    def _(x: int | T):
+        # TODO: This should reveal `int`.
+        reveal_type(union_with_non_inferable_t(x))  # revealed: Unknown
+
+    def _(x: int | None):
+        reveal_type(union_with_non_inferable_t(x))  # revealed: int | None
+```
+
 This also works if the typevar has a bound:
 
 ```py

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2032,9 +2032,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             // common cases specially:
             (Type::Union(formal_union), Type::Union(actual_union)) => {
                 // First, if both formal and actual are unions, and precisely one formal union
-                // element _is_ a typevar (not _contains_ a typevar), then we remove any actual
-                // union elements that are a subtype of the formal (as a whole), and map the formal
-                // typevar to any remaining actual union elements.
+                // element _is_ an inferable typevar (not _contains_ a typevar), then we remove any
+                // actual union elements that are a subtype of the formal (as a whole), and map the
+                // formal typevar to any remaining actual union elements.
                 //
                 // In particular, this handles cases like
                 //
@@ -2051,10 +2051,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 // We do not handle cases where the `formal` types contain other types that contain type variables
                 // to prevent incorrect specialization: e.g. `T = int | list[int]` for `formal: T | list[T], actual: int | list[int]`
                 // (the correct specialization is `T = int`).
-                let types_have_typevars = formal_union
-                    .elements(self.db)
-                    .iter()
-                    .filter(|ty| ty.has_typevar(self.db));
+                let types_have_typevars = formal_union.elements(self.db).iter().filter(|ty| {
+                    ty.as_typevar()
+                        .is_some_and(|typevar| typevar.is_inferable(self.db, self.inferable))
+                });
                 let Ok(Type::TypeVar(formal_bound_typevar)) = types_have_typevars.exactly_one()
                 else {
                     return Ok(());
@@ -2112,10 +2112,11 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 let mut bound_typevars = union_formal
                     .elements(self.db)
                     .iter()
-                    .filter_map(|ty| ty.as_typevar());
+                    .filter_map(|ty| ty.as_typevar())
+                    .filter(|typevar| typevar.is_inferable(self.db, self.inferable));
 
                 // TODO:
-                // Handling more than one bare typevar is something that we can't handle yet.
+                // Handling more than one bare inferable typevar is something that we can't handle yet.
                 if bound_typevars.nth(1).is_some() {
                     return Ok(());
                 }


### PR DESCRIPTION
There are a couple cases where we special-case the generic solver based on the number of typevars in a union. These should only consider *inferable* typevars, as non-inferable typevars are no different than any other concrete type for the purposes of the constraint solver.