### PR TITLE
Drop deprecated license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",  # for compatibility with tooling such as pip-licenses
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
## Summary

Per https://github.com/astral-sh/ruff/pull/19599#issuecomment-3151993900, maturin now supports PEP 639 fully. Consequently we should drop the license classifier, as it's legally ambiguous.

See also https://github.com/astral-sh/uv/pull/19130 for where we're doing the same for uv.

## Test Plan

NFC.