### PR TITLE
Improve diagnostics for implicit calls to a possibly unbound unary operator.

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/unary/custom.md
+++ b/crates/ty_python_semantic/resources/mdtest/unary/custom.md
@@ -135,6 +135,62 @@ reveal_type(-no())  # revealed: Unknown
 reveal_type(~no())  # revealed: Unknown
 ```
 
+## Union where one member lacks the dunder
+
+```py
+class Yes:
+    def __pos__(self) -> bool:
+        return False
+
+    def __neg__(self) -> str:
+        return "negative"
+
+    def __invert__(self) -> int:
+        return 17
+
+class No: ...
+
+def _(flag: bool):
+    x = Yes() if flag else No()
+
+    # snapshot: unsupported-operator
+    reveal_type(+x)  # revealed: bool
+
+    # snapshot: unsupported-operator
+    reveal_type(-x)  # revealed: str
+
+    # snapshot: unsupported-operator
+    reveal_type(~x)  # revealed: int
+```
+
+```snapshot
+error[unsupported-operator]: Unary operator `+` is not supported for object of type `Yes | No`
+  --> src/mdtest_snippet.py:17:17
+   |
+17 |     reveal_type(+x)  # revealed: bool
+   |                 ^^
+   |
+info: `No` does not implement `__pos__`
+
+
+error[unsupported-operator]: Unary operator `-` is not supported for object of type `Yes | No`
+  --> src/mdtest_snippet.py:20:17
+   |
+20 |     reveal_type(-x)  # revealed: str
+   |                 ^^
+   |
+info: `No` does not implement `__neg__`
+
+
+error[unsupported-operator]: Unary operator `~` is not supported for object of type `Yes | No`
+  --> src/mdtest_snippet.py:23:17
+   |
+23 |     reveal_type(~x)  # revealed: int
+   |                 ^^
+   |
+info: `No` does not implement `__invert__`
+```
+
 ## Metaclass
 
 ```py

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8524,6 +8524,37 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
+    fn report_unsupported_unary_operator(
+        &self,
+        unary: &ast::ExprUnaryOp,
+        op: ast::UnaryOp,
+        operand_type: Type<'db>,
+        unary_dunder_method: &str,
+        error: Option<&CallDunderError<'db>>,
+    ) {
+        let Some(builder) = self.context.report_lint(&UNSUPPORTED_OPERATOR, unary) else {
+            return;
+        };
+
+        let mut diagnostic = builder.into_diagnostic(format_args!(
+            "Unary operator `{op}` is not supported for object of type `{}`",
+            operand_type.display(self.db()),
+        ));
+
+        if let Some(CallDunderError::PossiblyUnbound {
+            unbound_on: Some(unbound_on),
+            ..
+        }) = error
+        {
+            for ty in unbound_on.iter().copied() {
+                diagnostic.info(format_args!(
+                    "`{}` does not implement `{unary_dunder_method}`",
+                    ty.display(self.db())
+                ));
+            }
+        }
+    }
+
     fn infer_unary_expression(&mut self, unary: &ast::ExprUnaryOp) -> Type<'db> {
         let ast::ExprUnaryOp {
             range: _,
@@ -8561,12 +8592,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ) {
                 Ok(outcome) => outcome.return_type(self.db()),
                 Err(e) => {
-                    if let Some(builder) = self.context.report_lint(&UNSUPPORTED_OPERATOR, unary) {
-                        builder.into_diagnostic(format_args!(
-                            "Unary operator `{op}` is not supported for object of type `{}`",
-                            operand_type.display(self.db()),
-                        ));
-                    }
+                    self.report_unsupported_unary_operator(
+                        unary,
+                        op,
+                        operand_type,
+                        unary_dunder_method,
+                        Some(&e),
+                    );
                     e.fallback_return_type(self.db())
                 }
             }
@@ -8659,14 +8691,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             Some(ty) => ty,
                             None => {
                                 // At least one constraint failed; report error.
-                                if let Some(builder) =
-                                    self.context.report_lint(&UNSUPPORTED_OPERATOR, unary)
-                                {
-                                    builder.into_diagnostic(format_args!(
-                                        "Unary operator `{op}` is not supported for object of type `{}`",
-                                        operand_type.display(db),
-                                    ));
-                                }
+                                self.report_unsupported_unary_operator(
+                                    unary,
+                                    op,
+                                    operand_type,
+                                    unary_dunder_method,
+                                    None,
+                                );
                                 operand_type
                                     .try_call_dunder(
                                         db,
@@ -8695,14 +8726,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     ) {
                         Ok(outcome) => outcome.return_type(self.db()),
                         Err(e) => {
-                            if let Some(builder) =
-                                self.context.report_lint(&UNSUPPORTED_OPERATOR, unary)
-                            {
-                                builder.into_diagnostic(format_args!(
-                                    "Unary operator `{op}` is not supported for object of type `{}`",
-                                    operand_type.display(self.db()),
-                                ));
-                            }
+                            self.report_unsupported_unary_operator(
+                                unary,
+                                op,
+                                operand_type,
+                                unary_dunder_method,
+                                Some(&e),
+                            );
                             e.fallback_return_type(self.db())
                         }
                     },


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Building on https://github.com/astral-sh/ruff/pull/24662, and similarly to https://github.com/astral-sh/ruff/pull/24676, this adds more "info" sub-diagnostics to possibly unbound method error messages that occur when a dunder is called implicitly against a union type. The implicit dunder calls covered here are for unary operators (e.g. `__pos__`).

Closes https://github.com/astral-sh/ty/issues/940.

## Test Plan

Please see new/updated mdtests and related snapshots.
<!-- How was it tested? -->
