### PR TITLE
Fix setting selection for multi folder workspace

### DIFF
--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -380,7 +380,7 @@ impl Index {
     fn settings_for_path(&self, path: &Path) -> Option<&WorkspaceSettings> {
         self.settings
             .range(..path.to_path_buf())
-            .next_back()
+            .rfind(|(root, _)| path.starts_with(root))
             .map(|(_, settings)| settings)
     }
 

--- a/crates/ruff_server/tests/e2e/main.rs
+++ b/crates/ruff_server/tests/e2e/main.rs
@@ -29,6 +29,7 @@ mod code_action;
 mod custom_extension;
 mod hover;
 mod notebook;
+mod workspace;
 
 use std::collections::{BTreeMap, VecDeque};
 use std::num::NonZeroUsize;

--- a/crates/ruff_server/tests/e2e/workspace.rs
+++ b/crates/ruff_server/tests/e2e/workspace.rs
@@ -16,12 +16,15 @@ ignore = ["F401"]
 "#,
         )?
         .with_file("systemtests/tests/common/fakes/wus.py", "import os\n")?
+        .with_file("external/Y/wus.py", "import os\n")?
         .build();
 
     server.open_text_document("systemtests/tests/common/fakes/wus.py", "import os\n", 1);
+    server.open_text_document("external/Y/wus.py", "import os\n", 1);
 
     let diagnostics =
         server.document_diagnostic_request("systemtests/tests/common/fakes/wus.py", None);
+    let external_diagnostics = server.document_diagnostic_request("external/Y/wus.py", None);
 
     assert_json_snapshot!(
         diagnostics,
@@ -29,6 +32,71 @@ ignore = ["F401"]
     {
       "kind": "full",
       "items": []
+    }
+    "#
+    );
+
+    assert_json_snapshot!(
+        external_diagnostics,
+        @r#"
+    {
+      "kind": "full",
+      "items": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 7
+            },
+            "end": {
+              "line": 0,
+              "character": 9
+            }
+          },
+          "severity": 2,
+          "code": "F401",
+          "codeDescription": {
+            "href": "https://docs.astral.sh/ruff/rules/unused-import"
+          },
+          "source": "Ruff",
+          "message": "`os` imported but unused",
+          "tags": [
+            1
+          ],
+          "data": {
+            "code": "F401",
+            "edits": [
+              {
+                "newText": "",
+                "range": {
+                  "end": {
+                    "character": 0,
+                    "line": 1
+                  },
+                  "start": {
+                    "character": 0,
+                    "line": 0
+                  }
+                }
+              }
+            ],
+            "noqa_edit": {
+              "newText": "  # noqa: F401\n",
+              "range": {
+                "end": {
+                  "character": 0,
+                  "line": 1
+                },
+                "start": {
+                  "character": 9,
+                  "line": 0
+                }
+              }
+            },
+            "title": "Remove unused import: `os`"
+          }
+        }
+      ]
     }
     "#
     );

--- a/crates/ruff_server/tests/e2e/workspace.rs
+++ b/crates/ruff_server/tests/e2e/workspace.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+use insta::assert_json_snapshot;
+
+use crate::TestServerBuilder;
+
+#[test]
+fn selects_the_correct_workspace_settings_for_multi_root_workspaces() -> Result<()> {
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(".")?
+        .with_workspace("external/Y")?
+        .with_file(
+            "systemtests/pyproject.toml",
+            r#"
+[tool.ruff.lint]
+ignore = ["F401"]
+"#,
+        )?
+        .with_file("systemtests/tests/common/fakes/wus.py", "import os\n")?
+        .build();
+
+    server.open_text_document("systemtests/tests/common/fakes/wus.py", "import os\n", 1);
+
+    let diagnostics =
+        server.document_diagnostic_request("systemtests/tests/common/fakes/wus.py", None);
+
+    assert_json_snapshot!(
+        diagnostics,
+        @r#"
+    {
+      "kind": "full",
+      "items": []
+    }
+    "#
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

This PR fixes an issue where the server picked the settings of the wrong workspace folder
in a multi workspace folder project:

The issue is that we used `next_back` to find the correct settings in the settings map.

There are two open workspace folders:

```
/X
/X/external/Y
```

When resolving the settings for `/X/systemtests/tests/common/fakes/wus.py`,
`range(..).next_back()` returned the settings of `/X/external/Y` instead of `/X` because 
`/X/systemtests/tests/common/fakes/wus.py` sorts after `/X/external/y`, even though 
it isn't a prefix of `/X/systemtest`.

This PR fixes the issue by using `rfind` to find the longest match with a shared prefix.

I plan to submit a similar PR for ty_server.

Fixes https://github.com/astral-sh/ruff-vscode/issues/925

## Test Plan

Added E2E test
