### PR TITLE
[ty] Allow ParamSpec specialization through unioned generic classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -326,6 +326,21 @@ reveal_type(OnlyParamSpec[P2]().attr)  # revealed: (...) -> None
 reveal_type(OnlyParamSpec[()]().attr)  # revealed: (...) -> None
 ```
 
+Specializing a union of generic classes supports the same `ParamSpec` argument forms.
+
+```py
+if input():
+    class ConditionalParamSpec[**P]:
+        attr: Callable[P, None]
+
+else:
+    class ConditionalParamSpec[**P]:
+        attr: Callable[P, None]
+
+def conditional_class_paramspec[**P](_: ConditionalParamSpec[P]) -> None: ...
+def conditional_class_paramspec_list(_: ConditionalParamSpec[[int, str]]) -> None: ...
+```
+
 An explicit tuple expression (unlike an implicit one that omits the parentheses) is also accepted
 when the `ParamSpec` is the only type variable. But, this isn't recommended is mainly a fallout of
 it having the same AST as the one without the parentheses. Both mypy and Pyright also allow this.

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1675,14 +1675,23 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 todo_type!("string literal subscripted in type expression")
             }
             Type::Union(union) => {
-                self.infer_type_expression(slice);
-                union.map(self.db(), |element| {
+                let db = self.db();
+                let mut union_builder =
+                    UnionBuilder::new(db).recursively_defined(union.recursively_defined(db));
+
+                for (index, element) in union.elements(db).iter().enumerate() {
                     let mut speculative_builder = self.speculate();
                     let subscript_ty =
                         speculative_builder.infer_subscript_type_expression(subscript, *element);
-                    self.context.extend(&speculative_builder.context.finish());
-                    subscript_ty
-                })
+                    if index == 0 {
+                        self.extend(speculative_builder);
+                    } else {
+                        self.context.extend(&speculative_builder.context.finish());
+                    }
+                    union_builder = union_builder.add(subscript_ty);
+                }
+
+                union_builder.build()
             }
             _ => {
                 if !self.in_string_annotation() {


### PR DESCRIPTION
## Summary

Previously, given something like:

```python
from typing import Callable

if flag:
    class A[**P]:
        f: Callable[P, None]
else:
    class A[**P]:
        f: Callable[P, None]

def foo[**P](x: A[P]) -> None: ...
```

Where `A` is a union, `A[P]` was considered invalid -- we inferred `P` as a standalone type expression before specializing each union element (and a bare `ParamSpec` is not valid as a standalone annotation).

Now, each union element is specialized in context. (We use one speculative specialization to preserve expressions for the shared AST nodes, but the rest just add diagnostics.)

Closes https://github.com/astral-sh/ty/issues/3332.
