### PR TITLE
Speed up CI workflows by setting `line-tables-only` for debug info

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,11 +21,6 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
-  # Trim debug info to line tables only across the dev and `profiling` profiles
-  # used by CI. Panic backtraces still report file:line, but compilation and
-  # linking are significantly faster than with the default `debug = "full"`.
-  CARGO_PROFILE_DEV_DEBUG: line-tables-only
-  CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
   PACKAGE_NAME: ruff
   PYTHON_VERSION: "3.14"
   NEXTEST_PROFILE: ci
@@ -273,6 +268,9 @@ jobs:
     needs: determine_changes
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     timeout-minutes: 20
+    env:
+      # Line-tables-only debug info: faster builds, backtraces still work.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -339,6 +337,9 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'no-test') &&
       (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main')
     timeout-minutes: 20
+    env:
+      # Line-tables-only debug info: faster builds, backtraces still work.
+      CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -375,6 +376,9 @@ jobs:
     needs: determine_changes
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     timeout-minutes: 20
+    env:
+      # Line-tables-only debug info: faster builds, backtraces still work.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -436,6 +440,9 @@ jobs:
     needs: determine_changes
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     timeout-minutes: 20
+    env:
+      # Line-tables-only debug info: faster builds, backtraces still work.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -505,7 +512,12 @@ jobs:
           save-if: false
       - name: "Install Rust toolchain"
         run: rustup show
+      - name: "Install mold"
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - name: Build Ruff binary
+        env:
+          # Line-tables-only debug info: faster builds, backtraces still work.
+          CARGO_PROFILE_DEV_DEBUG: line-tables-only
         run: cargo build --bin ruff
       - name: Fuzz
         run: |
@@ -569,6 +581,9 @@ jobs:
         needs.determine_changes.outputs.formatter == 'true'
       )
     timeout-minutes: 20
+    env:
+      # Line-tables-only debug info: faster builds, backtraces still work.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -702,6 +717,8 @@ jobs:
       - name: Fuzz
         env:
           FORCE_COLOR: 1
+          # Line-tables-only debug info: faster builds, backtraces still work.
+          CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
         run: |
           echo "new commit"
           git rev-list --format=%s --max-count=1 "$GITHUB_SHA"
@@ -746,6 +763,9 @@ jobs:
     runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.ty == 'true' || github.ref == 'refs/heads/main' }}
+    env:
+      # Line-tables-only debug info: faster builds, backtraces still work.
+      CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -883,6 +903,9 @@ jobs:
     timeout-minutes: 5
     needs: determine_changes
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
+    env:
+      # Line-tables-only debug info: faster builds, backtraces still work.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
     steps:
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
         env:
@@ -900,6 +923,9 @@ jobs:
 
       - name: "Install Rust toolchain"
         run: rustup show
+
+      - name: "Install mold"
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Build Ruff binary
         run: cargo build -p ruff --bin ruff

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,11 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
+  # Trim debug info to line tables only across the dev and `profiling` profiles
+  # used by CI. Panic backtraces still report file:line, but compilation and
+  # linking are significantly faster than with the default `debug = "full"`.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
   PACKAGE_NAME: ruff
   PYTHON_VERSION: "3.14"
   NEXTEST_PROFILE: ci

--- a/.github/workflows/daily_fuzz.yaml
+++ b/.github/workflows/daily_fuzz.yaml
@@ -20,6 +20,10 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
+  # The fuzzer only runs the binary; we don't need full debug info. Keep line
+  # tables so panic backtraces (which the fuzzer specifically hunts for) still
+  # report file:line.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
   PACKAGE_NAME: ruff
   FORCE_COLOR: 1
 

--- a/.github/workflows/daily_fuzz.yaml
+++ b/.github/workflows/daily_fuzz.yaml
@@ -20,9 +20,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
-  # The fuzzer only runs the binary; we don't need full debug info. Keep line
-  # tables so panic backtraces (which the fuzzer specifically hunts for) still
-  # report file:line.
+  # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
   PACKAGE_NAME: ruff
   FORCE_COLOR: 1

--- a/.github/workflows/memory_report.yaml
+++ b/.github/workflows/memory_report.yaml
@@ -34,6 +34,10 @@ env:
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
   RUST_BACKTRACE: 1
+  # The memory report only consumes JSON output from the binary, so override
+  # the `profiling` profile's `debug = "full"` to speed up compilation and
+  # linking. Line tables are kept so panic backtraces still report file:line.
+  CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
   PYTHON_VERSION: 3.14
 
 jobs:

--- a/.github/workflows/memory_report.yaml
+++ b/.github/workflows/memory_report.yaml
@@ -34,9 +34,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
   RUST_BACKTRACE: 1
-  # The memory report only consumes JSON output from the binary, so override
-  # the `profiling` profile's `debug = "full"` to speed up compilation and
-  # linking. Line tables are kept so panic backtraces still report file:line.
+  # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
   PYTHON_VERSION: 3.14
 
@@ -62,6 +60,9 @@ jobs:
 
       - name: Install Rust toolchain
         run: rustup show
+
+      - name: "Install mold"
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Compute memory usage diff
         shell: bash

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -35,9 +35,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
   RUST_BACKTRACE: 1
-  # The ecosystem-analyzer doesn't need full debug symbols, but we keep line
-  # tables so panic backtraces still report file:line. This is significantly
-  # cheaper than the `profiling` profile's default `debug = "full"`.
+  # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
   ECOSYSTEM_ANALYZER_COMMIT: e7576e66e8f992b057ea92c820c04313dceda755
 
@@ -63,6 +61,9 @@ jobs:
 
       - name: Install Rust toolchain
         run: rustup show
+
+      - name: "Install mold"
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Build ty for both commits
         id: build

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -35,6 +35,10 @@ env:
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
   RUST_BACKTRACE: 1
+  # The ecosystem-analyzer doesn't need full debug symbols, but we keep line
+  # tables so panic backtraces still report file:line. This is significantly
+  # cheaper than the `profiling` profile's default `debug = "full"`.
+  CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
   ECOSYSTEM_ANALYZER_COMMIT: e7576e66e8f992b057ea92c820c04313dceda755
 
 jobs:

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -18,9 +18,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
   RUST_BACKTRACE: 1
-  # The ecosystem-analyzer doesn't need full debug symbols, but we keep line
-  # tables so panic backtraces still report file:line. This is significantly
-  # cheaper than the `profiling` profile's default `debug = "full"`.
+  # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
 
 jobs:
@@ -48,6 +46,9 @@ jobs:
 
       - name: Install Rust toolchain
         run: rustup show
+
+      - name: "Install mold"
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Create report
         shell: bash

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -18,6 +18,10 @@ env:
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
   RUST_BACKTRACE: 1
+  # The ecosystem-analyzer doesn't need full debug symbols, but we keep line
+  # tables so panic backtraces still report file:line. This is significantly
+  # cheaper than the `profiling` profile's default `debug = "full"`.
+  CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
 
 jobs:
   ty-ecosystem-report:

--- a/.github/workflows/typing_conformance.yaml
+++ b/.github/workflows/typing_conformance.yaml
@@ -34,6 +34,9 @@ env:
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
   RUST_BACKTRACE: 1
+  # The conformance suite only runs the binary; it doesn't need full debug
+  # info. Keep line tables so panic backtraces still report file:line.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
   CONFORMANCE_SUITE_COMMIT: 5a701a037b5243df1f39622b642893d865f06205
   PYTHON_VERSION: 3.12
 

--- a/.github/workflows/typing_conformance.yaml
+++ b/.github/workflows/typing_conformance.yaml
@@ -34,8 +34,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
   RUST_BACKTRACE: 1
-  # The conformance suite only runs the binary; it doesn't need full debug
-  # info. Keep line tables so panic backtraces still report file:line.
+  # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
   CONFORMANCE_SUITE_COMMIT: 5a701a037b5243df1f39622b642893d865f06205
   PYTHON_VERSION: 3.12
@@ -69,6 +68,9 @@ jobs:
 
       - name: Install Rust toolchain
         run: rustup show
+
+      - name: "Install mold"
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Compute diagnostic diff
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,28 +4,28 @@ This repository contains both Ruff (a Python linter and formatter) and ty (a Pyt
 
 ## Running Tests
 
-Run all tests (using `nextest` for faster execution, setting `CARGO_PROFILE_DEV_OPT_LEVEL=1` to enable optimizations while retaining debug info, and setting `INSTA_FORCE_PASS=1 INSTA_UPDATE=always` to ensure all snapshots are updated):
+Run all tests (using `nextest` for faster execution, setting `CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_DEBUG="line-tables-only"` to enable optimizations while retaining some debug info, and setting `INSTA_FORCE_PASS=1 INSTA_UPDATE=always MDTEST_UPDATE_SNAPSHOTS=1` to ensure all snapshots are updated):
 
 ```sh
-CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always cargo nextest run
+CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run
 ```
 
 Run tests for a specific crate:
 
 ```sh
-CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always cargo nextest run -p ty_python_semantic
+CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic
 ```
 
 Run a single mdtest file. The path to the mdtest file should be relative to the `crates/ty_python_semantic/resources/mdtest` folder:
 
 ```sh
-CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always cargo nextest run -p ty_python_semantic -- mdtest::<path/to/mdtest_file.md>
+CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic -- mdtest::<path/to/mdtest_file.md>
 ```
 
 To run a specific mdtest within a file, use a substring of the Markdown header text as `MDTEST_TEST_FILTER`. Only use this if it's necessary to isolate a single test case:
 
 ```sh
-MDTEST_TEST_FILTER="<filter>" CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always cargo nextest run -p ty_python_semantic -- mdtest::<path/to/mdtest_file.md>
+MDTEST_TEST_FILTER="<filter>" CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic -- mdtest::<path/to/mdtest_file.md>
 ```
 
 After running the tests, always review the contents of any snapshots that have been added or updated.

--- a/crates/ty_python_semantic/mdtest.py
+++ b/crates/ty_python_semantic/mdtest.py
@@ -77,6 +77,7 @@ class MDTestRunner:
                 os.environ,
                 CLI_COLOR="1",
                 CARGO_PROFILE_DEV_OPT_LEVEL="0" if self.filters else "1",
+                CARGO_PROFILE_DEV_DEBUG="line-tables-only",
             ),
             stderr=subprocess.STDOUT,
             text=True,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -161,7 +161,7 @@ pub fn check_types(db: &dyn Db, file: File) -> Vec<Diagnostic> {
     for scope_id in index.scope_ids() {
         // Scopes that may require type context are inferred during the inference of
         // their outer scope.
-        if !scope_id.accepts_type_context(db) {
+        if scope_id.accepts_type_context(db) {
             continue;
         }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -161,7 +161,7 @@ pub fn check_types(db: &dyn Db, file: File) -> Vec<Diagnostic> {
     for scope_id in index.scope_ids() {
         // Scopes that may require type context are inferred during the inference of
         // their outer scope.
-        if scope_id.accepts_type_context(db) {
+        if !scope_id.accepts_type_context(db) {
             continue;
         }
 


### PR DESCRIPTION
This appears to cut around 30s off the time it takes to build ty in CI for ecosystem-analyzer. (For a fair comparison with builds on recent ty PRs, I pushed a [temporary commit](https://github.com/astral-sh/ruff/pull/24833/changes/404e37e71404ea7013feeed4dfb1d4019654f9e7) to make sure that the second build of ty was actually doing some work during the test run rather than just instantly completing. The speedup was still very evident.)