### PR TITLE
[ty] Lazily allocate parameter type builders

### DIFF
--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4232,8 +4232,6 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         return_ty: Type<'db>,
         errors: &'a mut Vec<BindingError<'db>>,
     ) -> Self {
-        let parameter_count = parameter_tys.len();
-
         Self {
             db,
             signature_type,
@@ -4241,9 +4239,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             arguments,
             argument_matches,
             parameter_tys,
-            parameter_ty_builders: std::iter::repeat_with(|| None)
-                .take(parameter_count)
-                .collect(),
+            parameter_ty_builders: Vec::new(),
             call_expression_tcx,
             return_ty,
             errors,
@@ -4606,12 +4602,21 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         }
         // We still update the actual type of the parameter in this binding to match the argument,
         // even if the argument type is not assignable to the expected parameter type.
-        if let Some(builder) = &mut self.parameter_ty_builders[parameter_index] {
+        if let Some(builder) = self
+            .parameter_ty_builders
+            .get_mut(parameter_index)
+            .and_then(Option::as_mut)
+        {
             builder.add_in_place(argument_type);
         } else if let Some(existing) = self.parameter_tys[parameter_index] {
             let mut builder = UnionBuilder::new(self.db);
             builder.add_in_place(existing);
             builder.add_in_place(argument_type);
+            if self.parameter_ty_builders.is_empty() {
+                self.parameter_ty_builders = std::iter::repeat_with(|| None)
+                    .take(self.parameter_tys.len())
+                    .collect();
+            }
             self.parameter_ty_builders[parameter_index] = Some(builder);
         } else {
             self.parameter_tys[parameter_index] = Some(argument_type);


### PR DESCRIPTION
## Summary

I added these in #24756, but we only need this vector when there is more than one match for at least one argument (which is rare).
