### PR TITLE
[ty] Avoid bookkeeping for unannotated functions

### DIFF
--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -337,9 +337,7 @@ impl<'db> GenericContext<'db> {
             NodeWithScopeKind::Function(function) => {
                 let definition = index.expect_single_definition(function);
                 infer_definition_types(db, definition)
-                    .undecorated_type()
-                    .expect("function should have undecorated type")
-                    .as_function_literal()?
+                    .function_type(definition)?
                     .last_definition_signature(db)
                     .generic_context
             }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -639,11 +639,7 @@ pub(crate) fn nearest_enclosing_function<'db>(
         .find_map(|(_, ancestor_scope)| {
             let func = ancestor_scope.node().as_function()?;
             let definition = semantic.expect_single_definition(func);
-            let inference = infer_definition_types(db, definition);
-            inference
-                .undecorated_type()
-                .unwrap_or_else(|| inference.declaration_type(definition).inner_type())
-                .as_function_literal()
+            infer_definition_types(db, definition).function_type(definition)
         })
 }
 
@@ -943,6 +939,12 @@ impl<'db> DefinitionInference<'db> {
 
     pub(crate) fn undecorated_type(&self) -> Option<Type<'db>> {
         self.extra.as_ref().and_then(|extra| extra.undecorated_type)
+    }
+
+    pub(crate) fn function_type(&self, definition: Definition<'db>) -> Option<FunctionType<'db>> {
+        self.undecorated_type()
+            .unwrap_or_else(|| self.declaration_type(definition).inner_type())
+            .as_function_literal()
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -36,6 +36,20 @@ use ty_python_core::{
 use ruff_python_ast as ast;
 use ruff_text_size::Ranged;
 
+fn parameters_have_annotations(parameters: &ast::Parameters) -> bool {
+    parameters
+        .iter_non_variadic_params()
+        .any(|param| param.parameter.annotation.is_some())
+        || parameters
+            .vararg
+            .as_deref()
+            .is_some_and(|param| param.annotation.is_some())
+        || parameters
+            .kwarg
+            .as_deref()
+            .is_some_and(|param| param.annotation.is_some())
+}
+
 impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     pub(super) fn infer_function_body(&mut self, function: &ast::StmtFunctionDef) {
         fn can_implicitly_return_none<'db>(db: &'db dyn Db, use_def: &UseDefMap<'db>) -> bool {
@@ -313,12 +327,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .any(|param| param.default.is_some());
 
         // If there are type params, parameters and returns are evaluated in that scope. Otherwise,
-        // we always defer the inference of the parameters and returns. That ensures that we do not
-        // add any spurious salsa cycles when applying decorators below. (Applying a decorator
+        // we defer the inference of any parameter and return annotations. That ensures that we do
+        // not add any spurious salsa cycles when applying decorators below. (Applying a decorator
         // requires getting the signature of this function definition, which in turn requires
         // (lazily) inferring the parameter and return types.) If defaults exist, we also defer so
         // they can be inferred once with type context in the enclosing scope.
-        if type_params.is_none() || has_defaults {
+        let has_signature_annotations =
+            function.returns.is_some() || parameters_have_annotations(parameters);
+        if (type_params.is_none() && has_signature_annotations) || has_defaults {
             self.deferred.insert(definition);
         }
 
@@ -349,7 +365,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let mut inferred_ty =
             Type::FunctionLiteral(FunctionType::new(db, function_literal, None, None));
-        self.undecorated_type = Some(inferred_ty);
+        if !decorator_list.is_empty() {
+            self.undecorated_type = Some(inferred_ty);
+        }
 
         // Check that the function's own type parameters don't shadow
         // type variables from enclosing scopes (by name).

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -26,8 +26,7 @@ pub(crate) fn check_function_definition<'db>(
 ) {
     let db = context.db();
 
-    let Some(Type::FunctionLiteral(function_type)) =
-        infer_definition_types(db, definition).undecorated_type()
+    let Some(function_type) = infer_definition_types(db, definition).function_type(definition)
     else {
         return;
     };


### PR DESCRIPTION
## Summary

If a function doesn't contain any annotations or default arguments, we don't need to do deferred inference for the signature; and if the function isn't decorated, we don't need to store a separate `undecorated_type`. This avoids a deferred-definition entry, an empty deferred inference query, and (oftena) an `DefinitionInferenceExtra` allocation.
