### PR TITLE
Set `filter: blob:none` for `actions/checkout` when using `fetch-depth: 0`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,7 @@ jobs:
         run: |
           git clone --filter=blob:none https://github.com/astral-sh/ruff .
           git fetch origin "${GITHUB_REF}"
+          git checkout FETCH_HEAD
 
       - name: Determine merge base
         id: merge_base
@@ -709,6 +710,7 @@ jobs:
         run: |
           git clone --filter=blob:none https://github.com/astral-sh/ruff .
           git fetch origin "${GITHUB_REF}"
+          git checkout FETCH_HEAD
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.11.7"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,10 +52,12 @@ jobs:
       # Flag that is set to "true" when code related to the benchmarks changes.
       benchmarks: ${{ steps.check_benchmarks.outputs.changed }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
+      # Avoid `actions/checkout` because we'd need `fetch-depth: 0`,
+      # which is really slow on this repo.
+      - name: Clone repository (blobless)
+        run: |
+          git clone --filter=blob:none https://github.com/astral-sh/ruff .
+          git fetch origin "${GITHUB_REF}"
 
       - name: Determine merge base
         id: merge_base
@@ -700,10 +702,13 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') && github.event_name == 'pull_request' && (needs.determine_changes.outputs.ty == 'true' || needs.determine_changes.outputs.py-fuzzer == 'true') }}
     timeout-minutes: ${{ github.repository == 'astral-sh/ruff' && 10 || 20 }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
+      # Clone before rust-cache so it can find Cargo.lock
+      # Avoid `actions/checkout` because we'd need `fetch-depth: 0`,
+      # which is really slow on this repo.
+      - name: Clone repository (blobless)
+        run: |
+          git clone --filter=blob:none https://github.com/astral-sh/ruff .
+          git fetch origin "${GITHUB_REF}"
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.11.7"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,13 +52,12 @@ jobs:
       # Flag that is set to "true" when code related to the benchmarks changes.
       benchmarks: ${{ steps.check_benchmarks.outputs.changed }}
     steps:
-      # Avoid `actions/checkout` because we'd need `fetch-depth: 0`,
-      # which is really slow on this repo.
-      - name: Clone repository (blobless)
-        run: |
-          git clone --filter=blob:none https://github.com/astral-sh/ruff .
-          git fetch origin "${GITHUB_REF}"
-          git checkout FETCH_HEAD
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          # Speeds up the full-history fetch significantly.
+          filter: blob:none
+          persist-credentials: false
 
       - name: Determine merge base
         id: merge_base
@@ -703,14 +702,12 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') && github.event_name == 'pull_request' && (needs.determine_changes.outputs.ty == 'true' || needs.determine_changes.outputs.py-fuzzer == 'true') }}
     timeout-minutes: ${{ github.repository == 'astral-sh/ruff' && 10 || 20 }}
     steps:
-      # Clone before rust-cache so it can find Cargo.lock
-      # Avoid `actions/checkout` because we'd need `fetch-depth: 0`,
-      # which is really slow on this repo.
-      - name: Clone repository (blobless)
-        run: |
-          git clone --filter=blob:none https://github.com/astral-sh/ruff .
-          git fetch origin "${GITHUB_REF}"
-          git checkout FETCH_HEAD
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          # Speeds up the full-history fetch significantly.
+          filter: blob:none
+          persist-credentials: false
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.11.7"

--- a/.github/workflows/memory_report.yaml
+++ b/.github/workflows/memory_report.yaml
@@ -44,11 +44,13 @@ jobs:
     runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-22.04-32' || 'ubuntu-latest' }}
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          path: ruff
-          fetch-depth: 0
-          persist-credentials: false
+      # Clone before rust-cache so it can find Cargo.lock
+      # Avoid `actions/checkout` because we'd need `fetch-depth: 0`,
+      # which is really slow on this repo.
+      - name: Clone repository (blobless)
+        run: |
+          git clone --filter=blob:none https://github.com/astral-sh/ruff ruff
+          git -C ruff fetch origin "${GITHUB_REF}"
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:

--- a/.github/workflows/memory_report.yaml
+++ b/.github/workflows/memory_report.yaml
@@ -51,6 +51,7 @@ jobs:
         run: |
           git clone --filter=blob:none https://github.com/astral-sh/ruff ruff
           git -C ruff fetch origin "${GITHUB_REF}"
+          git -C ruff checkout FETCH_HEAD
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:

--- a/.github/workflows/memory_report.yaml
+++ b/.github/workflows/memory_report.yaml
@@ -44,14 +44,13 @@ jobs:
     runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-22.04-32' || 'ubuntu-latest' }}
     timeout-minutes: 20
     steps:
-      # Clone before rust-cache so it can find Cargo.lock
-      # Avoid `actions/checkout` because we'd need `fetch-depth: 0`,
-      # which is really slow on this repo.
-      - name: Clone repository (blobless)
-        run: |
-          git clone --filter=blob:none https://github.com/astral-sh/ruff ruff
-          git -C ruff fetch origin "${GITHUB_REF}"
-          git -C ruff checkout FETCH_HEAD
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: ruff
+          fetch-depth: 0
+          # Speeds up the full-history fetch significantly.
+          filter: blob:none
+          persist-credentials: false
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -55,6 +55,7 @@ jobs:
         run: |
           git clone --filter=blob:none https://github.com/astral-sh/ruff ruff
           git -C ruff fetch origin "${GITHUB_REF}"
+          git -C ruff checkout FETCH_HEAD
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -48,11 +48,11 @@ jobs:
       timestamp: ${{ steps.build.outputs.timestamp }}
       merge-base: ${{ steps.build.outputs.merge-base }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          path: ruff
-          fetch-depth: 0
-          persist-credentials: false
+      # Clone before rust-cache so it can find Cargo.lock
+      - name: Clone repository (blobless)
+        run: |
+          git clone --filter=blob:none https://github.com/astral-sh/ruff ruff
+          git -C ruff fetch origin "${GITHUB_REF}"
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -48,14 +48,13 @@ jobs:
       timestamp: ${{ steps.build.outputs.timestamp }}
       merge-base: ${{ steps.build.outputs.merge-base }}
     steps:
-      # Clone before rust-cache so it can find Cargo.lock.
-      # Avoid `actions/checkout` because we'd need `fetch-depth: 0`,
-      # which is really slow on this repo.
-      - name: Clone repository (blobless)
-        run: |
-          git clone --filter=blob:none https://github.com/astral-sh/ruff ruff
-          git -C ruff fetch origin "${GITHUB_REF}"
-          git -C ruff checkout FETCH_HEAD
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: ruff
+          fetch-depth: 0
+          # Speeds up the full-history fetch significantly.
+          filter: blob:none
+          persist-credentials: false
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -48,7 +48,9 @@ jobs:
       timestamp: ${{ steps.build.outputs.timestamp }}
       merge-base: ${{ steps.build.outputs.merge-base }}
     steps:
-      # Clone before rust-cache so it can find Cargo.lock
+      # Clone before rust-cache so it can find Cargo.lock.
+      # Avoid `actions/checkout` because we'd need `fetch-depth: 0`,
+      # which is really slow on this repo.
       - name: Clone repository (blobless)
         run: |
           git clone --filter=blob:none https://github.com/astral-sh/ruff ruff

--- a/.github/workflows/typing_conformance.yaml
+++ b/.github/workflows/typing_conformance.yaml
@@ -52,6 +52,7 @@ jobs:
         run: |
           git clone --filter=blob:none https://github.com/astral-sh/ruff ruff
           git -C ruff fetch origin "${GITHUB_REF}"
+          git -C ruff checkout FETCH_HEAD
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/typing_conformance.yaml
+++ b/.github/workflows/typing_conformance.yaml
@@ -45,11 +45,13 @@ jobs:
     runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-22.04-32' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          path: ruff
-          fetch-depth: 0
-          persist-credentials: false
+      # Clone before rust-cache so it can find Cargo.lock
+      # Avoid `actions/checkout` because we'd need `fetch-depth: 0`,
+      # which is really slow on this repo.
+      - name: Clone repository (blobless)
+        run: |
+          git clone --filter=blob:none https://github.com/astral-sh/ruff ruff
+          git -C ruff fetch origin "${GITHUB_REF}"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/typing_conformance.yaml
+++ b/.github/workflows/typing_conformance.yaml
@@ -45,14 +45,13 @@ jobs:
     runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-22.04-32' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
-      # Clone before rust-cache so it can find Cargo.lock
-      # Avoid `actions/checkout` because we'd need `fetch-depth: 0`,
-      # which is really slow on this repo.
-      - name: Clone repository (blobless)
-        run: |
-          git clone --filter=blob:none https://github.com/astral-sh/ruff ruff
-          git -C ruff fetch origin "${GITHUB_REF}"
-          git -C ruff checkout FETCH_HEAD
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: ruff
+          fetch-depth: 0
+          # Speeds up the full-history fetch significantly.
+          filter: blob:none
+          persist-credentials: false
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary

`fetch-depth: 0` fetches all history for all branches and all tags on the upstream repository. For a repo like Ruff with many upstream branches and many upstream tags, this is really slow. We can speed it up by ~~avoiding `actions/checkout` altogether and just using `git clone` directly~~ setting `filter: blob:none` to fetch content lazily. This cuts about 5-6s off the time a CI workflow takes.

## Test Plan

CI on this PR.
