### PR TITLE
[ty] Store call argument data together

### DIFF
--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -43,8 +43,13 @@ pub(crate) enum Argument<'a> {
 /// Arguments for a single call, in source order, along with inferred types for each argument.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct CallArguments<'a, 'db> {
-    arguments: Vec<Argument<'a>>,
-    types: Vec<CallArgumentTypes<'db>>,
+    items: Vec<CallArgument<'a, 'db>>,
+}
+
+#[derive(Clone, Debug)]
+struct CallArgument<'a, 'db> {
+    argument: Argument<'a>,
+    types: CallArgumentTypes<'db>,
 }
 
 /// Inferred types for a given argument.
@@ -109,11 +114,6 @@ impl<'db> CallArgumentTypes<'db> {
 }
 
 impl<'a, 'db> CallArguments<'a, 'db> {
-    fn new(arguments: Vec<Argument<'a>>, types: Vec<CallArgumentTypes<'db>>) -> Self {
-        debug_assert!(arguments.len() == types.len());
-        Self { arguments, types }
-    }
-
     /// Create `CallArguments` from AST arguments. We will use the provided callback to obtain the
     /// type of each splatted argument, so that we can determine its length. All other arguments
     /// will remain uninitialized as `Unknown`.
@@ -121,9 +121,12 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         arguments: &'a ast::Arguments,
         mut infer_argument_type: impl FnMut(&ast::ArgOrKeyword, &ast::Expr) -> Type<'db>,
     ) -> Self {
-        arguments
-            .iter_source_order()
-            .map(|arg_or_keyword| match arg_or_keyword {
+        let mut call_arguments = Self {
+            items: Vec::with_capacity(arguments.len()),
+        };
+
+        for arg_or_keyword in arguments.iter_source_order() {
+            let (argument, ty) = match arg_or_keyword {
                 ast::ArgOrKeyword::Arg(arg) => match arg {
                     ast::Expr::Starred(ast::ExprStarred { value, .. }) => {
                         let ty = infer_argument_type(&arg_or_keyword, value);
@@ -139,8 +142,14 @@ impl<'a, 'db> CallArguments<'a, 'db> {
                         (Argument::Keywords, Some(ty))
                     }
                 }
-            })
-            .collect()
+            };
+            call_arguments.items.push(CallArgument {
+                argument,
+                types: CallArgumentTypes::new(ty),
+            });
+        }
+
+        call_arguments
     }
 
     /// Like [`Self::from_arguments`] but fills as much typing info in as possible.
@@ -183,21 +192,22 @@ impl<'a, 'db> CallArguments<'a, 'db> {
 
     /// Create a [`CallArguments`] from an iterator over non-variadic positional argument types.
     pub(crate) fn positional(positional_tys: impl IntoIterator<Item = Type<'db>>) -> Self {
-        let types: Vec<_> = positional_tys
+        positional_tys
             .into_iter()
-            .map(Some)
-            .map(CallArgumentTypes::new)
-            .collect();
-        let arguments = vec![Argument::Positional; types.len()];
-        Self { arguments, types }
+            .map(|ty| (Argument::Positional, Some(ty)))
+            .collect()
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.arguments.len()
+        self.items.len()
     }
 
-    pub(crate) fn types(&self) -> &[CallArgumentTypes<'db>] {
-        &self.types
+    pub(crate) fn argument_types(&self, index: usize) -> Option<&CallArgumentTypes<'db>> {
+        self.items.get(index).map(|item| &item.types)
+    }
+
+    pub(crate) fn iter_types(&self) -> impl Iterator<Item = &CallArgumentTypes<'db>> + '_ {
+        self.items.iter().map(|item| &item.types)
     }
 
     /// Prepend an optional extra synthetic argument (for a `self` or `cls` parameter) to the front
@@ -205,13 +215,13 @@ impl<'a, 'db> CallArguments<'a, 'db> {
     /// unmodified.)
     pub(crate) fn with_self(&self, bound_self: Option<Type<'db>>) -> Cow<'_, Self> {
         if bound_self.is_some() {
-            let arguments = std::iter::once(Argument::Synthetic)
-                .chain(self.arguments.iter().copied())
-                .collect();
-            let types = std::iter::once(CallArgumentTypes::new(bound_self))
-                .chain(self.types.iter().cloned())
-                .collect();
-            Cow::Owned(CallArguments { arguments, types })
+            let mut items = Vec::with_capacity(self.items.len() + 1);
+            items.push(CallArgument {
+                argument: Argument::Synthetic,
+                types: CallArgumentTypes::new(bound_self),
+            });
+            items.extend(self.items.iter().cloned());
+            Cow::Owned(CallArguments { items })
         } else {
             Cow::Borrowed(self)
         }
@@ -220,20 +230,21 @@ impl<'a, 'db> CallArguments<'a, 'db> {
     pub(crate) fn iter(
         &self,
     ) -> impl Iterator<Item = (Argument<'a>, &CallArgumentTypes<'db>)> + '_ {
-        (self.arguments.iter().copied()).zip(self.types.iter())
+        self.items.iter().map(|item| (item.argument, &item.types))
     }
 
     pub(crate) fn iter_mut(
         &mut self,
     ) -> impl Iterator<Item = (Argument<'a>, &mut CallArgumentTypes<'db>)> + '_ {
-        (self.arguments.iter().copied()).zip(self.types.iter_mut())
+        self.items
+            .iter_mut()
+            .map(|item| (item.argument, &mut item.types))
     }
 
     /// Create a new [`CallArguments`] starting from the specified index.
     pub(super) fn start_from(&self, index: usize) -> Self {
         Self {
-            arguments: self.arguments[index..].to_vec(),
-            types: self.types[index..].to_vec(),
+            items: self.items[index..].to_vec(),
         }
     }
 
@@ -245,36 +256,35 @@ impl<'a, 'db> CallArguments<'a, 'db> {
     /// [argument type expansion]: https://typing.python.org/en/latest/spec/overload.html#argument-type-expansion
     pub(super) fn expand(&self, db: &'db dyn Db) -> impl Iterator<Item = Expansion<'a, 'db>> + '_ {
         /// Represents the state of the expansion process.
-        enum State<'a, 'b, 'db> {
+        enum State<'a, 'db> {
             LimitReached(usize),
-            Expanding(ExpandingState<'a, 'b, 'db>),
+            Expanding(ExpandingState<'a, 'db>),
         }
 
         /// Represents the expanding state with either the initial types or the expanded types.
         ///
         /// This is useful to avoid cloning the initial types vector if none of the types can be
         /// expanded.
-        enum ExpandingState<'a, 'b, 'db> {
-            Initial(&'b Vec<CallArgumentTypes<'db>>),
+        enum ExpandingState<'a, 'db> {
+            Initial,
             Expanded(Vec<CallArguments<'a, 'db>>),
         }
 
-        impl<'db> ExpandingState<'_, '_, 'db> {
+        impl<'a, 'db> ExpandingState<'a, 'db> {
             fn len(&self) -> usize {
                 match self {
-                    ExpandingState::Initial(_) => 1,
+                    ExpandingState::Initial => 1,
                     ExpandingState::Expanded(expanded) => expanded.len(),
                 }
             }
 
-            fn iter(&self) -> impl Iterator<Item = &[CallArgumentTypes<'db>]> + '_ {
+            fn iter<'s>(
+                &'s self,
+                initial: &'s CallArguments<'a, 'db>,
+            ) -> impl Iterator<Item = &'s CallArguments<'a, 'db>> {
                 match self {
-                    ExpandingState::Initial(types) => {
-                        Either::Left(std::iter::once(types.as_slice()))
-                    }
-                    ExpandingState::Expanded(expanded) => {
-                        Either::Right(expanded.iter().map(CallArguments::types))
-                    }
+                    ExpandingState::Initial => Either::Left(std::iter::once(initial)),
+                    ExpandingState::Expanded(expanded) => Either::Right(expanded.iter()),
                 }
             }
         }
@@ -282,7 +292,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         let mut index = 0;
 
         std::iter::successors(
-            Some(State::Expanding(ExpandingState::Initial(&self.types))),
+            Some(State::Expanding(ExpandingState::Initial)),
             move |previous| {
                 let state = match previous {
                     State::LimitReached(index) => return Some(State::LimitReached(*index)),
@@ -291,7 +301,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
 
                 // Find the next type that can be expanded.
                 let expanded_types = loop {
-                    let arg_type = self.types.get(index)?;
+                    let arg_type = self.argument_types(index)?;
                     // TODO: For types inferred multiple times with distinct type context, we currently only
                     // expand the default inference. Note that direct expansion of a type inferred against a
                     // given declared type would not likely be assignable to other declared types without
@@ -318,14 +328,12 @@ impl<'a, 'db> CallArguments<'a, 'db> {
 
                 let mut expanded_arguments = Vec::with_capacity(expansion_size);
 
-                for pre_expanded_types in state.iter() {
+                for pre_expanded_types in state.iter(self) {
                     for subtype in &expanded_types {
-                        let mut new_expanded_types = pre_expanded_types.to_vec();
-                        new_expanded_types[index] = CallArgumentTypes::new(Some(*subtype));
-                        expanded_arguments.push(CallArguments::new(
-                            self.arguments.clone(),
-                            new_expanded_types,
-                        ));
+                        let mut expanded_argument = pre_expanded_types.clone();
+                        expanded_argument.items[index].types =
+                            CallArgumentTypes::new(Some(*subtype));
+                        expanded_arguments.push(expanded_argument);
                     }
                 }
 
@@ -340,7 +348,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         .skip(1) // Skip the initial state, which has no expanded types.
         .map(|state| match state {
             State::LimitReached(index) => Expansion::LimitReached(index),
-            State::Expanding(ExpandingState::Initial(_)) => {
+            State::Expanding(ExpandingState::Initial) => {
                 unreachable!("initial state should be skipped")
             }
             State::Expanding(ExpandingState::Expanded(expanded)) => Expansion::Expanded(expanded),
@@ -435,11 +443,18 @@ impl<'a, 'db> FromIterator<(Argument<'a>, Option<Type<'db>>)> for CallArguments<
     where
         T: IntoIterator<Item = (Argument<'a>, Option<Type<'db>>)>,
     {
-        let (arguments, types) = iter
-            .into_iter()
-            .map(|(arg, ty)| (arg, CallArgumentTypes::new(ty)))
-            .unzip();
-        Self { arguments, types }
+        let iter = iter.into_iter();
+        let (lower, upper) = iter.size_hint();
+        let mut items = Vec::with_capacity(upper.unwrap_or(lower));
+
+        for (argument, ty) in iter {
+            items.push(CallArgument {
+                argument,
+                types: CallArgumentTypes::new(ty),
+            });
+        }
+
+        Self { items }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -880,7 +880,9 @@ impl<'db> Bindings<'db> {
         call_arguments: &'a CallArguments<'a, 'db>,
         argument_index: usize,
     ) -> Type<'db> {
-        let argument_types = &call_arguments.types()[argument_index];
+        let argument_types = call_arguments
+            .argument_types(argument_index)
+            .expect("argument index should be valid");
 
         // If there is a single matching parameter, return the argument type inferred against
         // its declared type.
@@ -3034,7 +3036,7 @@ impl<'db> CallableBinding<'db> {
                 let slots = overload
                     .argument_matches
                     .iter()
-                    .zip(arguments.types())
+                    .zip(arguments.iter_types())
                     .flat_map(move |(matched_argument, argument_types)| {
                         matched_argument.iter().map(
                             move |(parameter_index, variadic_argument_type)| {


### PR DESCRIPTION
## Summary

These values are typically accessed together (e.g., `ArgumentMatcher::new`), and the construction now halves the number of vector allocations.
