### PR TITLE
[ty] Emit diagnostic for invalid uses of `Unpack[...]`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -49,6 +49,71 @@ first_arg_int("not an int", "42", "42")  # TODO: should error
 first_arg_int(56, "42", 56)  # TODO: should error
 ```
 
+## Allowed `Unpack` contexts
+
+We do not yet model every `Unpack` form precisely, but we should not emit false-positive diagnostics
+in contexts where `Unpack` is allowed.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing_extensions import Callable, Generic, TypeVar, TypeVarTuple, Unpack
+
+T = TypeVar("T")
+U = TypeVar("U")
+Ts = TypeVarTuple("Ts")
+Us = TypeVarTuple("Us")
+
+class Variadic(Generic[Unpack[Ts]]): ...
+class Prefix(Generic[T, Unpack[Ts]]): ...
+class Suffix(Generic[Unpack[Ts], T]): ...
+class Pair(Generic[T, U]): ...
+class Triple(Generic[T, U, Unpack[Us]]): ...
+
+def variadic_typevartuple(*args: Unpack[Ts]) -> None:
+    reveal_type(args)  # revealed: tuple[@Todo(`Unpack[]` special form), ...]
+
+def variadic_tuple(*args: Unpack[tuple[int, str]]) -> None:
+    reveal_type(args)  # revealed: tuple[@Todo(`Unpack[]` special form), ...]
+
+def allowed(
+    tuple_fixed: tuple[int, Unpack[tuple[str, bytes]]],
+    tuple_variadic: tuple[int, Unpack[tuple[str, ...]], bytes],
+    callable_typevartuple: Callable[[int, Unpack[Ts]], None],
+    callable_tuple: Callable[[Unpack[tuple[int, str]]], None],
+    variadic: Variadic[Unpack[tuple[int, str]]],
+    prefix: Prefix[int, Unpack[tuple[str, bytes]]],
+    suffix: Suffix[Unpack[tuple[int, str]], bytes],
+    pair: Pair[Unpack[tuple[int, str]]],
+    quoted_pair_argument: Pair["Unpack[tuple[int, str]]"],
+    triple: Triple[int, Unpack[tuple[str, bytes]]],
+    quoted_tuple: "tuple[int, Unpack[tuple[str, bytes]]]",
+    quoted_pair: "Pair[Unpack[tuple[int, str]]]",
+) -> None:
+    reveal_type(tuple_fixed)  # revealed: tuple[int, str, bytes]
+    reveal_type(tuple_variadic)  # revealed: tuple[int, *tuple[str, ...], bytes]
+    reveal_type(callable_typevartuple)  # revealed: (...) -> None
+    reveal_type(callable_tuple)  # revealed: (tuple[int, str], /) -> None
+    reveal_type(pair)  # revealed: Pair[int, str]
+    reveal_type(quoted_pair_argument)  # revealed: Pair[int, str]
+    reveal_type(quoted_tuple)  # revealed: tuple[int, str, bytes]
+    reveal_type(quoted_pair)  # revealed: Pair[int, str]
+
+def invalid_parameter(invalid: Unpack[tuple[int, str]]) -> None:  # error: [invalid-type-form]
+    pass
+
+def invalid_generic(
+    non_tuple: Pair[Unpack[int], str],  # error: [invalid-type-form]
+    quoted_non_tuple: Pair["Unpack[int]", str],  # error: [invalid-type-form]
+    variadic_tuple: Pair[Unpack[tuple[int, ...]], str],  # error: [invalid-type-form]
+    quoted_variadic_tuple: Pair["Unpack[tuple[int, ...]]", str],  # error: [invalid-type-form]
+) -> None:
+    pass
+```
+
 ## Type expressions
 
 One thing that is supported is error messages for using special forms in type expressions.

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -367,6 +367,9 @@ class TwoParamSpec(Generic[P1, P2]):
 
 class TypeVarAndParamSpec(Generic[T1, P1]):
     attr: Callable[P1, T1]
+
+class ParamSpecAndTypeVar(Generic[P1, T1]):
+    attr: Callable[P1, T1]
 ```
 
 Explicit specialization of a generic class involving `ParamSpec` is done by providing either a list
@@ -423,6 +426,7 @@ reveal_type(TypeVarAndParamSpec[int, []]().attr)  # revealed: () -> int
 reveal_type(TypeVarAndParamSpec[int, [int, str]]().attr)  # revealed: (int, str, /) -> int
 reveal_type(TypeVarAndParamSpec[int, [str]]().attr)  # revealed: (str, /) -> int
 reveal_type(TypeVarAndParamSpec[int, ...]().attr)  # revealed: (...) -> int
+reveal_type(ParamSpecAndTypeVar[[int, str], str]().attr)  # revealed: (int, str, /) -> str
 
 # error: [invalid-type-arguments] "ParamSpec `P2` is unbound"
 reveal_type(TypeVarAndParamSpec[int, P2]().attr)  # revealed: (...) -> int

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -301,6 +301,9 @@ class TwoParamSpec[**P1, **P2]:
 
 class TypeVarAndParamSpec[T1, **P1]:
     attr: Callable[P1, T1]
+
+class ParamSpecAndTypeVar[**P1, T1]:
+    attr: Callable[P1, T1]
 ```
 
 Explicit specialization of a generic class involving `ParamSpec` is done by providing either a list
@@ -359,6 +362,7 @@ reveal_type(TypeVarAndParamSpec[int, []]().attr)  # revealed: () -> int
 reveal_type(TypeVarAndParamSpec[int, [int, str]]().attr)  # revealed: (int, str, /) -> int
 reveal_type(TypeVarAndParamSpec[int, [str]]().attr)  # revealed: (str, /) -> int
 reveal_type(TypeVarAndParamSpec[int, ...]().attr)  # revealed: (...) -> int
+reveal_type(ParamSpecAndTypeVar[[int, str], str]().attr)  # revealed: (int, str, /) -> str
 
 # error: [invalid-type-arguments] "ParamSpec `P2` is unbound"
 reveal_type(TypeVarAndParamSpec[int, P2]().attr)  # revealed: (...) -> int

--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -500,11 +500,18 @@ bad7: TypeAlias = ReadOnly[int]  # error: [invalid-type-form]
 bad9: TypeAlias = InitVar[int]  # error: [invalid-type-form]
 bad10: TypeAlias = InitVar  # error: [invalid-type-form]
 
-# TODO: this should cause us to emit an error (`Unpack` is not valid at the
-# top level in this context), but for different reasons to the above cases:
-# `Unpack` is not a type qualifier, and so the error message in our diagnostic
-# shouldn't say that it is.
-differently_bad: TypeAlias = Unpack[tuple[int, ...]]
+differently_bad: TypeAlias = Unpack[tuple[int, ...]]  # snapshot: invalid-type-form
+```
+
+```snapshot
+error[invalid-type-form]: `Unpack` is not allowed in type alias values
+  --> src/mdtest_snippet.py:14:30
+   |
+14 | differently_bad: TypeAlias = Unpack[tuple[int, ...]]  # snapshot: invalid-type-form
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+info: See the following page for a reference on valid type expressions:
+info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
 ```
 
 ## Recursive `TypeIs` and `TypeGuard` aliases don't stack overflow

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3224,15 +3224,13 @@ def func_nested(**kwargs: Unpack[Unpack[TD1]]) -> None:  # error: [invalid-type-
 def func_stringified_nested(**kwargs: "Unpack[Unpack[TD1]]") -> None:  # error: [invalid-type-form]
     pass
 
-# TODO: These should emit `invalid-type-form`; `Unpack` is only valid as the top-level
-# `**kwargs` annotation form, not nested inside a larger type expression.
-def func_union_nested(**kwargs: Unpack[TD1] | None) -> None:
+def func_union_nested(**kwargs: Unpack[TD1] | None) -> None:  # error: [invalid-type-form]
     pass
 
-def func_list_nested(**kwargs: list[Unpack[TD1]]) -> None:
+def func_list_nested(**kwargs: list[Unpack[TD1]]) -> None:  # error: [invalid-type-form]
     pass
 
-def func_stringified_list_nested(**kwargs: "list[Unpack[TD1]]") -> None:
+def func_stringified_list_nested(**kwargs: "list[Unpack[TD1]]") -> None:  # error: [invalid-type-form]
     pass
 
 def func_keyword_only_overlap(*, v1: int, **kwargs: Unpack[TD1]) -> None:  # error: [invalid-type-form]

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1278,6 +1278,21 @@ bitflags::bitflags! {
 
         /// Whether the visitor is currently visiting a `**kwargs` annotation.
         const IN_KWARG_ANNOTATION = 1 << 9;
+
+        /// Whether the visitor is currently visiting a `tuple[...]` type argument.
+        const IN_TUPLE_TYPE_ARGUMENT = 1 << 10;
+
+        /// Whether the visitor is currently visiting a `Callable[[...], R]` parameter type.
+        const IN_CALLABLE_PARAMETER_TYPE = 1 << 11;
+
+        /// Whether the visitor is currently visiting a type expression.
+        const IN_TYPE_EXPRESSION = 1 << 12;
+
+        /// Whether the visitor is currently visiting a nested position in a type expression.
+        const IN_NESTED_TYPE_EXPRESSION = 1 << 13;
+
+        /// Whether the visitor is currently visiting the argument to `Unpack[...]`.
+        const IN_UNPACK_TYPE_ARGUMENT = 1 << 14;
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1279,11 +1279,8 @@ bitflags::bitflags! {
         /// Whether the visitor is currently visiting a `**kwargs` annotation.
         const IN_KWARG_ANNOTATION = 1 << 9;
 
-        /// Whether the visitor is currently visiting a `tuple[...]` type argument.
-        const IN_TUPLE_TYPE_ARGUMENT = 1 << 10;
-
-        /// Whether the visitor is currently visiting a `Callable[[...], R]` parameter type.
-        const IN_CALLABLE_PARAMETER_TYPE = 1 << 11;
+        /// Whether we're in a context where `Unpack` can be legal.
+        const IN_VALID_UNPACK_CONTEXT = 1 << 10;
 
         /// Whether the visitor is currently visiting a type expression.
         const IN_TYPE_EXPRESSION = 1 << 12;

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -18,9 +18,9 @@ use crate::types::diagnostic::{
     report_not_subscriptable,
 };
 use crate::types::generics::{GenericContext, InferableTypeVars, bind_typevar};
-use crate::types::infer::InferenceFlags;
 use crate::types::infer::builder::annotation_expression::PEP613Policy;
 use crate::types::infer::builder::{ArgExpr, ArgumentsIter, MultiInferenceGuard};
+use crate::types::infer::{InferenceFlags, TypeExpressionFlags};
 use crate::types::special_form::AliasSpec;
 use crate::types::subscript::{LegacyGenericOrigin, SubscriptError, SubscriptErrorKind};
 use crate::types::tuple::{Tuple, TupleType};
@@ -456,6 +456,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             );
         }
 
+        /// A type argument after expanding any allowed `Unpack[tuple[...]]` syntax.
+        struct TypeArgument<'ast, 'db> {
+            /// The source expression used for diagnostics and deferred inference.
+            node: &'ast ast::Expr,
+            /// The already-inferred type, if this argument did not need deferred inference.
+            ty: Option<Type<'db>>,
+            /// The index of the original source argument before any `Unpack` expansion.
+            source_index: usize,
+        }
+
         let db = self.db();
         let constraints = ConstraintSetBuilder::new();
         let slice_node = subscript.slice.as_ref();
@@ -471,54 +481,151 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             _ => (std::slice::from_ref(slice_node), false),
         };
-        let mut inferred_type_arguments = Vec::with_capacity(type_arguments.len());
+        let mut inferred_type_arguments = vec![None; type_arguments.len()];
 
-        let typevars = generic_context.variables(db);
+        let typevars = generic_context.variables(db).collect::<Vec<_>>();
         let typevars_len = typevars.len();
+
+        let mut expanded_type_arguments = Vec::with_capacity(type_arguments.len());
+
+        for (source_index, expr) in type_arguments.iter().enumerate() {
+            let typevar = typevars.get(expanded_type_arguments.len()).copied();
+            if exactly_one_paramspec || typevar.is_some_and(|typevar| typevar.is_paramspec(db)) {
+                expanded_type_arguments.push(TypeArgument {
+                    node: expr,
+                    ty: None,
+                    source_index,
+                });
+                continue;
+            }
+
+            let provided_type = if typevars_len == 0 {
+                // If there are no typevars at all, this is not a generic type,
+                // so we should not infer excess arguments as type expressions.
+                // For example, `list[int][0]` — the `0` is not a type expression.
+                self.infer_expression(expr, TypeContext::default())
+            } else {
+                let previously_in_valid_unpack_context = self
+                    .context
+                    .inference_flags
+                    .replace(InferenceFlags::IN_VALID_UNPACK_CONTEXT, true);
+                let provided_type = self.infer_type_expression(expr);
+                self.context.inference_flags.set(
+                    InferenceFlags::IN_VALID_UNPACK_CONTEXT,
+                    previously_in_valid_unpack_context,
+                );
+                provided_type
+            };
+
+            inferred_type_arguments[source_index] = Some(provided_type);
+
+            let is_unpack = self
+                .type_expression_flags(expr)
+                .contains(TypeExpressionFlags::UNPACK);
+
+            if is_unpack
+                && let Some(tuple) = provided_type.exact_tuple_instance_spec(db)
+                && let Tuple::Fixed(tuple) = tuple.as_ref()
+                && expanded_type_arguments.len() <= typevars_len
+                && typevars[expanded_type_arguments.len()
+                    ..usize::min(
+                        expanded_type_arguments.len() + tuple.elements_slice().len(),
+                        typevars_len,
+                    )]
+                    .iter()
+                    .all(|typevar| !typevar.is_paramspec(db))
+            {
+                // Expand `Foo[Unpack[tuple[int, str]]]` to `Foo[int, str]`. ParamSpec arguments
+                // must still use their dedicated inference path.
+                expanded_type_arguments.extend(tuple.iter_all_elements().map(|ty| TypeArgument {
+                    node: expr,
+                    ty: Some(ty),
+                    source_index,
+                }));
+            } else {
+                if is_unpack
+                    && !self
+                        .inference_flags()
+                        .contains(InferenceFlags::IN_KWARG_ANNOTATION)
+                    && !matches!(
+                        value_ty,
+                        Type::GenericAlias(alias)
+                            if alias
+                                .specialization(db)
+                                .types(db)
+                                .contains(&Type::Dynamic(DynamicType::TodoTypeVarTuple))
+                    )
+                    && let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, expr)
+                {
+                    builder.into_diagnostic(
+                        "`Unpack` can only be used with a fixed tuple type in this context",
+                    );
+                }
+
+                expanded_type_arguments.push(TypeArgument {
+                    node: expr,
+                    ty: Some(provided_type),
+                    source_index,
+                });
+            }
+        }
 
         let mut specialization_types = Vec::with_capacity(typevars_len);
         let mut typevar_with_defaults = 0;
         let mut missing_typevars = vec![];
         let mut first_excess_type_argument_index = None;
 
-        // Helper to get the AST node corresponding to the type argument at `index`.
-        let get_node = |index| match slice_node {
-            ast::Expr::Tuple(ast::ExprTuple { elts, .. }) if !exactly_one_paramspec => &elts[index],
-            _ => slice_node,
-        };
-
         let mut error: Option<ExplicitSpecializationError> = None;
 
-        for (index, item) in typevars.zip_longest(type_arguments.iter()).enumerate() {
+        for (index, item) in typevars
+            .iter()
+            .copied()
+            .zip_longest(expanded_type_arguments.iter())
+            .enumerate()
+        {
             match item {
-                EitherOrBoth::Both(typevar, expr) => {
+                EitherOrBoth::Both(typevar, type_argument) => {
                     if typevar.default_type(db).is_some() {
                         typevar_with_defaults += 1;
                     }
 
                     let provided_type = if typevar.is_paramspec(db) {
-                        self.infer_paramspec_explicit_specialization_value(
-                            expr,
-                            exactly_one_paramspec,
-                        )
-                        .unwrap_or_else(|()| {
-                            error = Some(ExplicitSpecializationError::InvalidParamSpec);
-                            Type::paramspec_value_callable(db, Parameters::unknown())
-                        })
+                        let provided_type = self
+                            .infer_paramspec_explicit_specialization_value(
+                                type_argument.node,
+                                exactly_one_paramspec,
+                            )
+                            .unwrap_or_else(|()| {
+                                error = Some(ExplicitSpecializationError::InvalidParamSpec);
+                                Type::paramspec_value_callable(db, Parameters::unknown())
+                            });
+                        inferred_type_arguments[type_argument.source_index] = Some(provided_type);
+                        provided_type
                     } else {
-                        self.infer_type_expression(expr)
+                        type_argument.ty.unwrap_or_else(|| {
+                            let previously_in_valid_unpack_context = self
+                                .context
+                                .inference_flags
+                                .replace(InferenceFlags::IN_VALID_UNPACK_CONTEXT, true);
+                            let provided_type = self.infer_type_expression(type_argument.node);
+                            self.context.inference_flags.set(
+                                InferenceFlags::IN_VALID_UNPACK_CONTEXT,
+                                previously_in_valid_unpack_context,
+                            );
+                            inferred_type_arguments[type_argument.source_index] =
+                                Some(provided_type);
+                            provided_type
+                        })
                     };
-
-                    inferred_type_arguments.push(provided_type);
 
                     // A ParamSpec cannot be used to specialize a regular TypeVar.
                     if !typevar.is_paramspec(db)
                         && let Type::TypeVar(tv) = provided_type
                         && tv.is_paramspec(db)
                     {
-                        let node = get_node(index);
-                        if let Some(builder) =
-                            self.context.report_lint(&INVALID_TYPE_ARGUMENTS, node)
+                        if let Some(builder) = self
+                            .context
+                            .report_lint(&INVALID_TYPE_ARGUMENTS, type_argument.node)
                         {
                             let mut diagnostic = builder.into_diagnostic(format_args!(
                                 "ParamSpec `{}` cannot be used to specialize \
@@ -562,9 +669,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 )
                                 .is_never_satisfied(db)
                             {
-                                let node = get_node(index);
-                                if let Some(builder) =
-                                    self.context.report_lint(&INVALID_TYPE_ARGUMENTS, node)
+                                if let Some(builder) = self
+                                    .context
+                                    .report_lint(&INVALID_TYPE_ARGUMENTS, type_argument.node)
                                 {
                                     let mut diagnostic = builder.into_diagnostic(format_args!(
                                         "Type `{}` is not assignable to upper bound `{}` \
@@ -595,9 +702,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 )
                                 .is_never_satisfied(db)
                             {
-                                let node = get_node(index);
-                                if let Some(builder) =
-                                    self.context.report_lint(&INVALID_TYPE_ARGUMENTS, node)
+                                if let Some(builder) = self
+                                    .context
+                                    .report_lint(&INVALID_TYPE_ARGUMENTS, type_argument.node)
                                 {
                                     let mut diagnostic = builder.into_diagnostic(format_args!(
                                         "Type `{}` does not satisfy constraints `{}` \
@@ -632,16 +739,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         specialization_types.push(None);
                     }
                 }
-                EitherOrBoth::Right(expr) => {
-                    // If there are no typevars at all, this is not a generic type,
-                    // so we should not infer excess arguments as type expressions.
-                    // For example, `list[int][0]` — the `0` is not a type expression.
-                    if typevars_len == 0 {
-                        inferred_type_arguments
-                            .push(self.infer_expression(expr, TypeContext::default()));
-                    } else {
-                        inferred_type_arguments.push(self.infer_type_expression(expr));
-                    }
+                EitherOrBoth::Right(_) => {
                     first_excess_type_argument_index.get_or_insert(index);
                 }
             }
@@ -698,7 +796,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
                 error = Some(ExplicitSpecializationError::NonGeneric);
             } else {
-                let node = get_node(first_excess_type_argument_index);
+                let node = expanded_type_arguments[first_excess_type_argument_index].node;
                 if let Some(builder) = self.context.report_lint(&INVALID_TYPE_ARGUMENTS, node) {
                     let description = CallableDescription::new(db, value_ty);
                     builder.into_diagnostic(format_args!(
@@ -715,7 +813,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 typevars_len
                             )
                         },
-                        type_arguments.len(),
+                        expanded_type_arguments.len(),
                     ));
                 }
                 error = Some(ExplicitSpecializationError::TooManyArguments);
@@ -725,7 +823,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if store_inferred_type_arguments {
             self.store_expression_type(
                 slice_node,
-                Type::heterogeneous_tuple(db, inferred_type_arguments),
+                Type::heterogeneous_tuple(
+                    db,
+                    inferred_type_arguments
+                        .into_iter()
+                        .map(|ty| ty.unwrap_or(Type::unknown())),
+                ),
             );
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -981,14 +981,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             .set_primary_message("`...` cannot be used after an unpacked element");
                     }
                     self.infer_expression(ellipsis, TypeContext::default());
-                    let previously_in_tuple_type_argument = self
+                    let previously_in_valid_unpack_context = self
                         .context
                         .inference_flags
-                        .replace(InferenceFlags::IN_TUPLE_TYPE_ARGUMENT, true);
+                        .replace(InferenceFlags::IN_VALID_UNPACK_CONTEXT, true);
                     let element_ty = self.infer_type_expression(element);
                     self.context.inference_flags.set(
-                        InferenceFlags::IN_TUPLE_TYPE_ARGUMENT,
-                        previously_in_tuple_type_argument,
+                        InferenceFlags::IN_VALID_UNPACK_CONTEXT,
+                        previously_in_valid_unpack_context,
                     );
                     let result = TupleType::homogeneous(self.db(), element_ty);
                     self.store_expression_type(&tuple.slice, Type::tuple(Some(result)));
@@ -1017,14 +1017,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         element_types.push(Type::unknown());
                         continue;
                     }
-                    let previously_in_tuple_type_argument = self
+                    let previously_in_valid_unpack_context = self
                         .context
                         .inference_flags
-                        .replace(InferenceFlags::IN_TUPLE_TYPE_ARGUMENT, true);
+                        .replace(InferenceFlags::IN_VALID_UNPACK_CONTEXT, true);
                     let element_ty = self.infer_type_expression(element);
                     self.context.inference_flags.set(
-                        InferenceFlags::IN_TUPLE_TYPE_ARGUMENT,
-                        previously_in_tuple_type_argument,
+                        InferenceFlags::IN_VALID_UNPACK_CONTEXT,
+                        previously_in_valid_unpack_context,
                     );
                     return_todo |=
                         element_could_alter_type_of_whole_tuple(element, element_ty, self);
@@ -1119,14 +1119,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     self.store_expression_type(single_element, Type::unknown());
                     return TupleType::heterogeneous(self.db(), std::iter::once(Type::unknown()));
                 }
-                let previously_in_tuple_type_argument = self
+                let previously_in_valid_unpack_context = self
                     .context
                     .inference_flags
-                    .replace(InferenceFlags::IN_TUPLE_TYPE_ARGUMENT, true);
+                    .replace(InferenceFlags::IN_VALID_UNPACK_CONTEXT, true);
                 let single_element_ty = self.infer_type_expression(single_element);
                 self.context.inference_flags.set(
-                    InferenceFlags::IN_TUPLE_TYPE_ARGUMENT,
-                    previously_in_tuple_type_argument,
+                    InferenceFlags::IN_VALID_UNPACK_CONTEXT,
+                    previously_in_valid_unpack_context,
                 );
                 if element_could_alter_type_of_whole_tuple(single_element, single_element_ty, self)
                 {
@@ -2260,9 +2260,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                 if !self.inference_flags().intersects(
                     InferenceFlags::IN_VARARG_ANNOTATION
-                        | InferenceFlags::IN_PARAMETER_ANNOTATION
-                        | InferenceFlags::IN_TUPLE_TYPE_ARGUMENT
-                        | InferenceFlags::IN_CALLABLE_PARAMETER_TYPE,
+                        | InferenceFlags::IN_KWARG_ANNOTATION
+                        | InferenceFlags::IN_VALID_UNPACK_CONTEXT,
                 ) {
                     if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                         diagnostic::add_type_expression_reference_link(builder.into_diagnostic(
@@ -2288,12 +2287,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 if self
                     .inference_flags()
                     .contains(InferenceFlags::IN_KWARG_ANNOTATION)
-                    || (self
-                        .inference_flags()
-                        .contains(InferenceFlags::IN_PARAMETER_ANNOTATION)
-                        && !self
-                            .inference_flags()
-                            .contains(InferenceFlags::IN_VARARG_ANNOTATION))
                 {
                     return inner_ty;
                 }
@@ -2554,10 +2547,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 // Whether to infer `Todo` for the parameters
                 let mut return_todo = false;
 
-                let previously_in_callable_parameter_type = self
+                let previously_in_valid_unpack_context = self
                     .context
                     .inference_flags
-                    .replace(InferenceFlags::IN_CALLABLE_PARAMETER_TYPE, true);
+                    .replace(InferenceFlags::IN_VALID_UNPACK_CONTEXT, true);
                 for param in params {
                     let param_type = self.infer_type_expression(param);
                     // This is similar to what we currently do for inferring tuple type expression.
@@ -2569,8 +2562,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     parameter_types.push(param_type);
                 }
                 self.context.inference_flags.set(
-                    InferenceFlags::IN_CALLABLE_PARAMETER_TYPE,
-                    previously_in_callable_parameter_type,
+                    InferenceFlags::IN_VALID_UNPACK_CONTEXT,
+                    previously_in_valid_unpack_context,
                 );
 
                 return Some(if return_todo {

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -34,6 +34,20 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     /// Infer the type of a type expression.
     pub(super) fn infer_type_expression(&mut self, expression: &ast::Expr) -> Type<'db> {
         let previous_deferred_state = self.deferred_state;
+        let was_in_type_expression = self
+            .inference_flags()
+            .contains(InferenceFlags::IN_TYPE_EXPRESSION);
+        let was_in_nested_type_expression = self
+            .inference_flags()
+            .contains(InferenceFlags::IN_NESTED_TYPE_EXPRESSION);
+        let previously_in_nested_type_expression = self.context.inference_flags.replace(
+            InferenceFlags::IN_NESTED_TYPE_EXPRESSION,
+            was_in_type_expression || was_in_nested_type_expression,
+        );
+        let previously_in_type_expression = self
+            .context
+            .inference_flags
+            .replace(InferenceFlags::IN_TYPE_EXPRESSION, true);
 
         // `DeferredExpressionState::InStringAnnotation` takes precedence over other states.
         // However, if it's not a stringified annotation, we must still ensure that annotation expressions
@@ -49,6 +63,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let ty = self.infer_type_expression_no_store(expression);
         self.deferred_state = previous_deferred_state;
+        self.context.inference_flags.set(
+            InferenceFlags::IN_NESTED_TYPE_EXPRESSION,
+            previously_in_nested_type_expression,
+        );
+        self.context.inference_flags.set(
+            InferenceFlags::IN_TYPE_EXPRESSION,
+            previously_in_type_expression,
+        );
         self.store_expression_type(expression, ty);
         ty
     }
@@ -871,19 +893,36 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     .insert(ruff_python_ast::ExprRef::StringLiteral(string).into());
                 // String annotations are always evaluated in the deferred context.
                 let parsed_expr = parsed.expr();
+                let string_was_nested = self
+                    .inference_flags()
+                    .contains(InferenceFlags::IN_NESTED_TYPE_EXPRESSION);
+                let previously_in_type_expression = self
+                    .context
+                    .inference_flags
+                    .replace(InferenceFlags::IN_TYPE_EXPRESSION, false);
+                let previously_in_nested_type_expression = self
+                    .context
+                    .inference_flags
+                    .replace(InferenceFlags::IN_NESTED_TYPE_EXPRESSION, string_was_nested);
                 let ty = self.infer_type_expression_with_state(
                     parsed_expr,
                     DeferredExpressionState::InStringAnnotation(
                         self.enclosing_node_key(string.into()),
                     ),
                 );
-                if self
-                    .type_expression_flags(parsed_expr)
-                    .contains(TypeExpressionFlags::UNPACK)
-                {
+                self.context.inference_flags.set(
+                    InferenceFlags::IN_NESTED_TYPE_EXPRESSION,
+                    previously_in_nested_type_expression,
+                );
+                self.context.inference_flags.set(
+                    InferenceFlags::IN_TYPE_EXPRESSION,
+                    previously_in_type_expression,
+                );
+                let parsed_flags = self.type_expression_flags(parsed_expr);
+                if !parsed_flags.is_empty() {
                     self.store_type_expression_flags(
                         ruff_python_ast::ExprRef::StringLiteral(string),
-                        TypeExpressionFlags::UNPACK,
+                        parsed_flags,
                     );
                 }
                 ty
@@ -942,8 +981,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             .set_primary_message("`...` cannot be used after an unpacked element");
                     }
                     self.infer_expression(ellipsis, TypeContext::default());
-                    let result =
-                        TupleType::homogeneous(self.db(), self.infer_type_expression(element));
+                    let previously_in_tuple_type_argument = self
+                        .context
+                        .inference_flags
+                        .replace(InferenceFlags::IN_TUPLE_TYPE_ARGUMENT, true);
+                    let element_ty = self.infer_type_expression(element);
+                    self.context.inference_flags.set(
+                        InferenceFlags::IN_TUPLE_TYPE_ARGUMENT,
+                        previously_in_tuple_type_argument,
+                    );
+                    let result = TupleType::homogeneous(self.db(), element_ty);
                     self.store_expression_type(&tuple.slice, Type::tuple(Some(result)));
                     return Some(result);
                 }
@@ -970,7 +1017,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         element_types.push(Type::unknown());
                         continue;
                     }
+                    let previously_in_tuple_type_argument = self
+                        .context
+                        .inference_flags
+                        .replace(InferenceFlags::IN_TUPLE_TYPE_ARGUMENT, true);
                     let element_ty = self.infer_type_expression(element);
+                    self.context.inference_flags.set(
+                        InferenceFlags::IN_TUPLE_TYPE_ARGUMENT,
+                        previously_in_tuple_type_argument,
+                    );
                     return_todo |=
                         element_could_alter_type_of_whole_tuple(element, element_ty, self);
 
@@ -1064,7 +1119,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     self.store_expression_type(single_element, Type::unknown());
                     return TupleType::heterogeneous(self.db(), std::iter::once(Type::unknown()));
                 }
+                let previously_in_tuple_type_argument = self
+                    .context
+                    .inference_flags
+                    .replace(InferenceFlags::IN_TUPLE_TYPE_ARGUMENT, true);
                 let single_element_ty = self.infer_type_expression(single_element);
+                self.context.inference_flags.set(
+                    InferenceFlags::IN_TUPLE_TYPE_ARGUMENT,
+                    previously_in_tuple_type_argument,
+                );
                 if element_could_alter_type_of_whole_tuple(single_element, single_element_ty, self)
                 {
                     Some(TupleType::homogeneous(
@@ -2164,32 +2227,74 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     ast::ExprRef::from(subscript),
                     TypeExpressionFlags::UNPACK,
                 );
-                let inner_ty = self.infer_type_expression(arguments_slice);
 
                 if self
                     .inference_flags()
                     .contains(InferenceFlags::IN_KWARG_ANNOTATION)
+                    && self
+                        .inference_flags()
+                        .contains(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT)
                 {
-                    // TODO: Reject `Unpack` in non-top-level positions within a
-                    // `**kwargs` annotation, like `Unpack[TD] | None` or
-                    // `list[Unpack[TD]]`.
-                    if self
-                        .type_expression_flags(arguments_slice)
-                        .contains(TypeExpressionFlags::UNPACK)
-                    {
-                        if let Some(builder) = self
-                            .context
-                            .report_lint(&INVALID_TYPE_FORM, arguments_slice)
-                        {
-                            diagnostic::add_type_expression_reference_link(
-                                builder.into_diagnostic(
-                                    "`Unpack` cannot be nested in a `**kwargs` annotation",
-                                ),
-                            );
-                        }
-                        return Type::unknown();
+                    if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                        diagnostic::add_type_expression_reference_link(
+                            builder.into_diagnostic("`Unpack` cannot be nested"),
+                        );
                     }
+                    return Type::unknown();
+                }
 
+                if self
+                    .inference_flags()
+                    .contains(InferenceFlags::IN_KWARG_ANNOTATION)
+                    && self
+                        .inference_flags()
+                        .contains(InferenceFlags::IN_NESTED_TYPE_EXPRESSION)
+                {
+                    if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                        diagnostic::add_type_expression_reference_link(builder.into_diagnostic(
+                            "`Unpack` is only valid as the top-level `**kwargs` annotation form",
+                        ));
+                    }
+                    return Type::unknown();
+                }
+
+                if !self.inference_flags().intersects(
+                    InferenceFlags::IN_VARARG_ANNOTATION
+                        | InferenceFlags::IN_PARAMETER_ANNOTATION
+                        | InferenceFlags::IN_TUPLE_TYPE_ARGUMENT
+                        | InferenceFlags::IN_CALLABLE_PARAMETER_TYPE,
+                ) {
+                    if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                        diagnostic::add_type_expression_reference_link(builder.into_diagnostic(
+                            format_args!(
+                                "`Unpack` is not allowed in {}s",
+                                self.type_expression_context()
+                            ),
+                        ));
+                    }
+                    return Type::unknown();
+                }
+
+                let previously_in_unpack_type_argument = self
+                    .context
+                    .inference_flags
+                    .replace(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT, true);
+                let inner_ty = self.infer_type_expression(arguments_slice);
+                self.context.inference_flags.set(
+                    InferenceFlags::IN_UNPACK_TYPE_ARGUMENT,
+                    previously_in_unpack_type_argument,
+                );
+
+                if self
+                    .inference_flags()
+                    .contains(InferenceFlags::IN_KWARG_ANNOTATION)
+                    || (self
+                        .inference_flags()
+                        .contains(InferenceFlags::IN_PARAMETER_ANNOTATION)
+                        && !self
+                            .inference_flags()
+                            .contains(InferenceFlags::IN_VARARG_ANNOTATION))
+                {
                     return inner_ty;
                 }
 
@@ -2449,6 +2554,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 // Whether to infer `Todo` for the parameters
                 let mut return_todo = false;
 
+                let previously_in_callable_parameter_type = self
+                    .context
+                    .inference_flags
+                    .replace(InferenceFlags::IN_CALLABLE_PARAMETER_TYPE, true);
                 for param in params {
                     let param_type = self.infer_type_expression(param);
                     // This is similar to what we currently do for inferring tuple type expression.
@@ -2459,6 +2568,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         && matches!(param, ast::Expr::Starred(_) | ast::Expr::Subscript(_));
                     parameter_types.push(param_type);
                 }
+                self.context.inference_flags.set(
+                    InferenceFlags::IN_CALLABLE_PARAMETER_TYPE,
+                    previously_in_callable_parameter_type,
+                );
 
                 return Some(if return_todo {
                     // TODO: `Unpack`


### PR DESCRIPTION
## Summary

This PR adds stricter validation for uses of `Unpack[...]`, namely to ensure that we still reject `Unpack` if it's in a `**kwargs` annotation but _not_ the top-level construct (e.g., `**kwargs: list[Unpack[TD]]`, `**kwargs: Unpack[TD] | int`).