### PR TITLE
[ty] Make block folding ranges returned by the language server character-precise.

### DIFF
--- a/crates/ty_ide/src/folding_range.rs
+++ b/crates/ty_ide/src/folding_range.rs
@@ -47,6 +47,40 @@ impl From<TextRange> for FoldingRange {
     }
 }
 
+/// Represents the range of source that should remain visible above a folding range.
+///
+/// EXAMPLES:
+///
+/// ```text
+/// def foo(bar: int, baz: str) -> str:
+/// ^---------------------------------^
+///
+/// async def foo(bar: int, baz: str) -> str:
+/// ^---------------------------------------^
+///
+/// class Foo(Bar):
+/// ^-------------^
+///
+/// if (foo && bar):
+/// ^--------------^
+/// ```
+#[derive(Debug, Clone, Copy)]
+struct BlockHeader {
+    /// The full range of the header, from the block's keyword to the colon.
+    range: TextRange,
+    /// The optional header subrange to fold, and the grouped range that surrounds it.
+    ///
+    /// For example, when a function definition has a multi-line parameter list, this range
+    /// covers the ellipsis in `def f(...):`.
+    sub_range: Option<BlockHeaderSubRange>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BlockHeaderSubRange {
+    wrapper_range: TextRange,
+    sub_range: TextRange,
+}
+
 /// Returns a list of folding ranges for the given file.
 pub fn folding_ranges(
     db: &dyn Db,
@@ -59,10 +93,15 @@ pub fn folding_ranges(
     let mut visitor = FoldingRangeVisitor {
         source: source.as_str(),
         ranges: vec![],
+        active_block_header_sub_ranges: vec![],
         tokens: parsed.tokens(),
         range_filter,
     };
     walk_node(&mut visitor, AnyNodeRef::from(parsed.syntax()));
+    debug_assert!(
+        visitor.active_block_header_sub_ranges.is_empty(),
+        "all active block header subranges should be cleared after traversal"
+    );
 
     // Add remaining ranges not covered by the AST visitor.
     let own_line_comment_ranges: Vec<_> = parsed
@@ -90,8 +129,15 @@ pub fn folding_ranges(
 struct FoldingRangeVisitor<'a> {
     source: &'a str,
     ranges: Vec<FoldingRange>,
+    active_block_header_sub_ranges: Vec<ActiveBlockHeaderSubRange>,
     tokens: &'a Tokens,
     range_filter: Option<TextRange>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ActiveBlockHeaderSubRange {
+    owner: TextRange,
+    wrapper_range: TextRange,
 }
 
 impl FoldingRangeVisitor<'_> {
@@ -132,6 +178,19 @@ impl FoldingRangeVisitor<'_> {
 
     fn is_multiline(&self, range: TextRange) -> bool {
         self.source[range].contains('\n') || self.source[range].contains('\r')
+    }
+
+    fn is_redundant_block_header_ast_range(&self, range: TextRange) -> bool {
+        self.active_block_header_sub_ranges
+            .iter()
+            .any(|block_header_sub_range| range == block_header_sub_range.wrapper_range)
+    }
+
+    /// Adds a generic multiline AST-node range, skipping redundant ranges for block headers.
+    fn add_multiline_node_range(&mut self, range: TextRange) {
+        if !self.is_redundant_block_header_ast_range(range) {
+            self.add_range(range);
+        }
     }
 
     /// Compute folding ranges for consecutive import statements.
@@ -299,44 +358,151 @@ impl FoldingRangeVisitor<'_> {
         self.add_range(FoldingRange::from(first_stmt.range()).with_kind(FoldingRangeKind::Comment));
     }
 
-    /// Add a folding range for the function or class definition.
-    ///
-    /// `target` is checked for in `search_range`, and is used as the start if found.
-    fn add_def_range(&mut self, target: TokenKind, search_range: TextRange, end: TextSize) {
-        let target_token = self
-            .tokens
+    /// Attempts to find the starting position of the given token in the given range.
+    fn find_token_start(&self, target: TokenKind, search_range: TextRange) -> Option<TextSize> {
+        self.tokens
             .in_range(search_range)
             .iter()
-            .find(|tok| tok.kind() == target);
-        if let Some(tok) = target_token {
-            let range = TextRange::new(tok.start(), end);
-            self.add_range(range);
+            .find(|tok| tok.kind() == target)
+            .map(Ranged::start)
+    }
+
+    /// Attempts to find a [`BlockHeader`] within the given range.
+    fn block_header(&self, start: TextSize, body_start: TextSize) -> Option<BlockHeader> {
+        let mut open_groups = Vec::new();
+        let mut sub_range = None;
+        let mut colon_end = None;
+
+        for token in self.tokens.in_range(TextRange::new(start, body_start)) {
+            match token.kind() {
+                TokenKind::Lpar | TokenKind::Lsqb | TokenKind::Lbrace => {
+                    open_groups.push((token.start(), token.end()));
+                }
+                TokenKind::Rpar | TokenKind::Rsqb | TokenKind::Rbrace => {
+                    if let Some((wrapper_start, sub_range_start)) = open_groups.pop()
+                        && open_groups.is_empty()
+                        && sub_range.is_none()
+                    {
+                        let range = TextRange::new(sub_range_start, token.start());
+                        if self.is_multiline(range) {
+                            sub_range = Some(BlockHeaderSubRange {
+                                wrapper_range: TextRange::new(wrapper_start, token.end()),
+                                sub_range: range,
+                            });
+                        }
+                    }
+                }
+                TokenKind::Colon if open_groups.is_empty() => {
+                    colon_end = Some(token.end());
+                }
+                _ => {}
+            }
+        }
+
+        Some(BlockHeader {
+            range: TextRange::new(start, colon_end?),
+            sub_range,
+        })
+    }
+
+    /// Adds folding ranges for the given block of code:
+    ///
+    /// 1. A folding range for the body of the block (always present).
+    /// 2. An optional folding range for a multi-line block header.
+    fn add_block_ranges<T: Ranged>(
+        &mut self,
+        owner: TextRange,
+        header_start: TextSize,
+        body: &[T],
+    ) {
+        let (Some(first), Some(last)) = (body.first(), body.last()) else {
+            return;
+        };
+        let Some(header) = self.block_header(header_start, first.start()) else {
+            return;
+        };
+        if let Some(sub_range) = header.sub_range {
+            self.active_block_header_sub_ranges
+                .push(ActiveBlockHeaderSubRange {
+                    owner,
+                    wrapper_range: sub_range.wrapper_range,
+                });
+        }
+
+        // Optionally add a folding range for the text between grouping tokens in a multi-line block header.
+        if let Some(sub_range) = header.sub_range {
+            self.add_range(sub_range.sub_range);
+        }
+
+        // Add a folding range for the body of the block, keeping the full header line visible.
+        let body_fold_start = self.source.line_end(header.range.end());
+        if body_fold_start <= last.end() {
+            self.add_range(TextRange::new(body_fold_start, last.end()));
+        }
+    }
+
+    /// Searches for a given keyword (e.g. `else`) and, if present, adds folding ranges for the block it defines.
+    fn add_block_ranges_from_keyword(
+        &mut self,
+        owner: TextRange,
+        keyword: TokenKind,
+        search_range: TextRange,
+        body: &[impl Ranged],
+    ) {
+        if let Some(header_start) = self.find_token_start(keyword, search_range) {
+            self.add_block_ranges(owner, header_start, body);
+        }
+    }
+
+    /// Adds folding ranges for a given block while leaving decorators unfolded.
+    fn add_block_ranges_omitting_decorators(
+        &mut self,
+        owner: TextRange,
+        statement_start: TextSize,
+        last_decorator_end: Option<TextSize>,
+        keyword: TokenKind,
+        keyword_search_end: TextSize,
+        body: &[impl Ranged],
+    ) {
+        if let Some(decorator_end) = last_decorator_end {
+            self.add_block_ranges_from_keyword(
+                owner,
+                keyword,
+                TextRange::new(decorator_end, keyword_search_end),
+                body,
+            );
+        } else {
+            self.add_block_ranges(owner, statement_start, body);
         }
     }
 
     /// Add a folding range for function definitions, excluding decorators.
     fn add_function_def_range(&mut self, func: &StmtFunctionDef) {
-        if let Some(decorator) = func.decorator_list.last() {
-            let target = if func.is_async {
-                TokenKind::Async
-            } else {
-                TokenKind::Def
-            };
-            let search_range = TextRange::new(decorator.end(), func.name.start());
-            self.add_def_range(target, search_range, func.end());
+        let keyword = if func.is_async {
+            TokenKind::Async
         } else {
-            self.add_range(func.range());
-        }
+            TokenKind::Def
+        };
+        self.add_block_ranges_omitting_decorators(
+            func.range(),
+            func.start(),
+            func.decorator_list.last().map(Ranged::end),
+            keyword,
+            func.name.start(),
+            &func.body,
+        );
     }
 
     /// Add a folding range for class definitions, excluding decorators.
     fn add_class_def_range(&mut self, class: &StmtClassDef) {
-        if let Some(decorator) = class.decorator_list.last() {
-            let search_range = TextRange::new(decorator.end(), class.name.start());
-            self.add_def_range(TokenKind::Class, search_range, class.end());
-        } else {
-            self.add_range(class.range());
-        }
+        self.add_block_ranges_omitting_decorators(
+            class.range(),
+            class.start(),
+            class.decorator_list.last().map(Ranged::end),
+            TokenKind::Class,
+            class.name.start(),
+            &class.body,
+        );
     }
 }
 
@@ -371,127 +537,162 @@ impl SourceOrderVisitor<'_> for FoldingRangeVisitor<'_> {
             }
             AnyNodeRef::StmtIf(if_stmt) => {
                 // Fold each branch individually rather than the entire if block.
-                // The if clause range is from the start of the if to the end of its body.
-                if let Some(last_stmt) = if_stmt.body.last() {
-                    self.add_range(TextRange::new(if_stmt.start(), last_stmt.end()));
-                }
+                self.add_block_ranges(if_stmt.range(), if_stmt.start(), &if_stmt.body);
+            }
+            AnyNodeRef::ElifElseClause(clause) => {
                 // Each elif/else clause has its own range.
-                for clause in &if_stmt.elif_else_clauses {
-                    self.add_range(clause.range());
-                }
+                self.add_block_ranges(clause.range(), clause.start(), &clause.body);
             }
             AnyNodeRef::StmtFor(for_stmt) => {
                 // Fold the for body separately from the else block.
-                if let Some(last_stmt) = for_stmt.body.last() {
-                    self.add_range(TextRange::new(for_stmt.start(), last_stmt.end()));
-                }
-                if let (Some(first), Some(last)) = (for_stmt.orelse.first(), for_stmt.orelse.last())
+                self.add_block_ranges(for_stmt.range(), for_stmt.start(), &for_stmt.body);
+                if let (Some(body_last), Some(orelse_first)) =
+                    (for_stmt.body.last(), for_stmt.orelse.first())
                 {
-                    self.add_range(TextRange::new(first.start(), last.end()));
+                    self.add_block_ranges_from_keyword(
+                        for_stmt.range(),
+                        TokenKind::Else,
+                        TextRange::new(body_last.end(), orelse_first.start()),
+                        &for_stmt.orelse,
+                    );
                 }
             }
             AnyNodeRef::StmtWhile(while_stmt) => {
                 // Fold the while body separately from the else block.
-                if let Some(last_stmt) = while_stmt.body.last() {
-                    self.add_range(TextRange::new(while_stmt.start(), last_stmt.end()));
-                }
-                if let (Some(first), Some(last)) =
-                    (while_stmt.orelse.first(), while_stmt.orelse.last())
+                self.add_block_ranges(while_stmt.range(), while_stmt.start(), &while_stmt.body);
+                if let (Some(body_last), Some(orelse_first)) =
+                    (while_stmt.body.last(), while_stmt.orelse.first())
                 {
-                    self.add_range(TextRange::new(first.start(), last.end()));
+                    self.add_block_ranges_from_keyword(
+                        while_stmt.range(),
+                        TokenKind::Else,
+                        TextRange::new(body_last.end(), orelse_first.start()),
+                        &while_stmt.orelse,
+                    );
                 }
             }
             AnyNodeRef::StmtWith(with_stmt) => {
-                self.add_range(with_stmt.range());
+                self.add_block_ranges(with_stmt.range(), with_stmt.start(), &with_stmt.body);
             }
             AnyNodeRef::StmtTry(try_stmt) => {
                 // Fold the try body separately from handlers, else, and finally.
-                if let Some(last_stmt) = try_stmt.body.last() {
-                    self.add_range(TextRange::new(try_stmt.start(), last_stmt.end()));
-                }
+                self.add_block_ranges(try_stmt.range(), try_stmt.start(), &try_stmt.body);
                 // Exception handlers are folded via ExceptHandlerExceptHandler.
                 // Fold the else block if present.
-                if let (Some(first), Some(last)) = (try_stmt.orelse.first(), try_stmt.orelse.last())
-                {
-                    self.force_add_range(TextRange::new(first.start(), last.end()));
+                if let Some(orelse_first) = try_stmt.orelse.first() {
+                    let previous_end = try_stmt
+                        .handlers
+                        .last()
+                        .map(Ranged::end)
+                        .or_else(|| try_stmt.body.last().map(Ranged::end));
+                    if let Some(previous_end) = previous_end {
+                        self.add_block_ranges_from_keyword(
+                            try_stmt.range(),
+                            TokenKind::Else,
+                            TextRange::new(previous_end, orelse_first.start()),
+                            &try_stmt.orelse,
+                        );
+                    }
                 }
                 // Fold the finally block if present.
-                if let (Some(first), Some(last)) =
-                    (try_stmt.finalbody.first(), try_stmt.finalbody.last())
-                {
-                    self.force_add_range(TextRange::new(first.start(), last.end()));
+                if let Some(finally_first) = try_stmt.finalbody.first() {
+                    let previous_end = try_stmt
+                        .orelse
+                        .last()
+                        .map(Ranged::end)
+                        .or_else(|| try_stmt.handlers.last().map(Ranged::end))
+                        .or_else(|| try_stmt.body.last().map(Ranged::end));
+                    if let Some(previous_end) = previous_end {
+                        self.add_block_ranges_from_keyword(
+                            try_stmt.range(),
+                            TokenKind::Finally,
+                            TextRange::new(previous_end, finally_first.start()),
+                            &try_stmt.finalbody,
+                        );
+                    }
                 }
             }
             AnyNodeRef::StmtMatch(match_stmt) => {
-                self.add_range(match_stmt.range());
+                self.add_block_ranges(match_stmt.range(), match_stmt.start(), &match_stmt.cases);
             }
 
             // Match cases within match statements
             AnyNodeRef::MatchCase(case) => {
-                self.add_range(case.range());
+                self.add_block_ranges(case.range(), case.start(), &case.body);
             }
 
             // Exception handlers
             AnyNodeRef::ExceptHandlerExceptHandler(handler) => {
-                self.add_range(handler.range());
+                self.add_block_ranges(handler.range(), handler.start(), &handler.body);
             }
 
             // Multiline expressions
             AnyNodeRef::ExprList(list) => {
-                self.add_range(list.range());
+                self.add_multiline_node_range(list.range());
             }
             AnyNodeRef::ExprTuple(tuple)
                 // Only fold parenthesized tuples.
                 if tuple.parenthesized => {
-                    self.add_range(tuple.range());
+                    self.add_multiline_node_range(tuple.range());
                 }
             AnyNodeRef::ExprDict(dict) => {
-                self.add_range(dict.range());
+                self.add_multiline_node_range(dict.range());
             }
             AnyNodeRef::ExprSet(set) => {
-                self.add_range(set.range());
+                self.add_multiline_node_range(set.range());
             }
             AnyNodeRef::ExprListComp(listcomp) => {
-                self.add_range(listcomp.range());
+                self.add_multiline_node_range(listcomp.range());
             }
             AnyNodeRef::ExprSetComp(setcomp) => {
-                self.add_range(setcomp.range());
+                self.add_multiline_node_range(setcomp.range());
             }
             AnyNodeRef::ExprDictComp(dictcomp) => {
-                self.add_range(dictcomp.range());
+                self.add_multiline_node_range(dictcomp.range());
             }
             AnyNodeRef::ExprGenerator(generator) => {
-                self.add_range(generator.range());
+                self.add_multiline_node_range(generator.range());
             }
 
             // Function calls with arguments spanning multiple lines
             AnyNodeRef::ExprCall(call) => {
-                self.add_range(call.range());
+                self.add_multiline_node_range(call.range());
             }
 
             // String and bytes literals
             AnyNodeRef::ExprStringLiteral(string) => {
-                self.add_range(string.range());
+                self.add_multiline_node_range(string.range());
             }
             AnyNodeRef::ExprBytesLiteral(bytes) => {
-                self.add_range(bytes.range());
+                self.add_multiline_node_range(bytes.range());
             }
             AnyNodeRef::ExprFString(fstring) => {
-                self.add_range(fstring.range());
+                self.add_multiline_node_range(fstring.range());
             }
             AnyNodeRef::ExprTString(tstring) => {
-                self.add_range(tstring.range());
+                self.add_multiline_node_range(tstring.range());
             }
 
             // Type parameter lists
             AnyNodeRef::TypeParams(params) => {
-                self.add_range(params.range());
+                self.add_multiline_node_range(params.range());
             }
 
             _ => {}
         }
 
         TraversalSignal::Traverse
+    }
+
+    fn leave_node(&mut self, node: AnyNodeRef<'_>) {
+        let node_range = node.range();
+        while self
+            .active_block_header_sub_ranges
+            .last()
+            .is_some_and(|sub_range| sub_range.owner == node_range)
+        {
+            self.active_block_header_sub_ranges.pop();
+        }
     }
 
     fn visit_body(&mut self, body: &'_ [Stmt]) {
@@ -527,9 +728,10 @@ class MyClass:
 
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-         --> main.py:2:1
+         --> main.py:2:15
           |
-        2 | / class MyClass:
+        2 |   class MyClass:
+          |  _______________^
         3 | |     def __init__(self):
         4 | |         self.value = 1
         5 | |
@@ -539,17 +741,19 @@ class MyClass:
           |
 
         info[folding-range]: Folding Range
-         --> main.py:3:5
+         --> main.py:3:24
           |
-        3 | /     def __init__(self):
+        3 |       def __init__(self):
+          |  ________________________^
         4 | |         self.value = 1
           | |______________________^
           |
 
         info[folding-range]: Folding Range
-         --> main.py:6:5
+         --> main.py:6:22
           |
-        6 | /     def method(self):
+        6 |       def method(self):
+          |  ______________________^
         7 | |         return self.value
           | |_________________________^
           |
@@ -576,9 +780,10 @@ class MyClass:
 
         assert_snapshot!(test.folding_ranges(), @r#"
         info[folding-range]: Folding Range
-         --> main.py:2:1
+         --> main.py:2:15
           |
-        2 | / class MyClass:
+        2 |   class MyClass:
+          |  _______________^
         3 | |     def __init__(self):
         4 | |         self.value = 1
         5 | |         """
@@ -589,9 +794,10 @@ class MyClass:
           |
 
         info[folding-range]: Folding Range
-         --> main.py:3:5
+         --> main.py:3:24
           |
-        3 | /     def __init__(self):
+        3 |       def __init__(self):
+          |  ________________________^
         4 | |         self.value = 1
         5 | |         """
         6 | |         This is an
@@ -639,9 +845,10 @@ def main():
           |
 
         info[folding-range]: Folding Range
-         --> main.py:6:1
+         --> main.py:6:12
           |
-        6 | / def main():
+        6 |   def main():
+          |  ____________^
         7 | |     pass
           | |________^
           |
@@ -728,9 +935,10 @@ from fastapi import FastAPI
            |
 
         info[folding-range]: Folding Range
-         --> main.py:5:1
+         --> main.py:5:5
           |
-        5 | / try:
+        5 |   try:
+          |  _____^
         6 | |     import foo
         7 | |     import bar
           | |______________^
@@ -745,9 +953,10 @@ from fastapi import FastAPI
           |
 
         info[folding-range]: Folding Range
-          --> main.py:8:1
+          --> main.py:8:20
            |
-         8 | / except ImportError:
+         8 |   except ImportError:
+           |  ____________________^
          9 | |     first = None
         10 | |     bar = None
            | |______________^
@@ -781,9 +990,10 @@ class MyClass:
 
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-         --> main.py:2:1
+         --> main.py:2:19
           |
-        2 | / def my_function():
+        2 |   def my_function():
+          |  ___________________^
         3 | |     import os
         4 | |     import sys
         5 | |
@@ -811,9 +1021,10 @@ class MyClass:
           |
 
         info[folding-range]: Folding Range
-          --> main.py:12:1
+          --> main.py:12:15
            |
-        12 | / class MyClass:
+        12 |   class MyClass:
+           |  _______________^
         13 | |     import typing
         14 | |     import collections
            | |______________________^
@@ -859,44 +1070,92 @@ else:
 
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-         --> main.py:2:1
+         --> main.py:2:14
           |
-        2 | / if condition:
+        2 |   if condition:
+          |  ______________^
         3 | |     do_something()
           | |__________________^
           |
 
         info[folding-range]: Folding Range
-         --> main.py:4:1
+         --> main.py:4:12
           |
-        4 | / elif other:
+        4 |   elif other:
+          |  ____________^
         5 | |     do_other()
           | |______________^
           |
 
         info[folding-range]: Folding Range
-         --> main.py:6:1
+         --> main.py:6:6
           |
-        6 | / else:
+        6 |   else:
+          |  ______^
         7 | |     default()
           | |_____________^
           |
 
         info[folding-range]: Folding Range
-          --> main.py:9:1
+          --> main.py:9:19
            |
-         9 | / for item in items:
+         9 |   for item in items:
+           |  ___________________^
         10 | |     process(item)
            | |_________________^
            |
 
         info[folding-range]: Folding Range
-          --> main.py:14:1
+          --> main.py:11:6
            |
-        14 | / while running:
+        11 |   else:
+           |  ______^
+        12 | |     okay()
+           | |__________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:14:15
+           |
+        14 |   while running:
+           |  _______________^
         15 | |     continue_work()
            | |___________________^
            |
+
+        info[folding-range]: Folding Range
+          --> main.py:16:6
+           |
+        16 |   else:
+           |  ______^
+        17 | |     doit()
+           | |__________^
+           |
+        ");
+    }
+
+    #[test]
+    fn test_folding_range_preserves_inline_block_header_comment() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+if condition:  # why
+    do_work()
+<CURSOR>
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.folding_ranges(), @"
+        info[folding-range]: Folding Range
+         --> main.py:2:21
+          |
+        2 |   if condition:  # why
+          |  _____________________^
+        3 | |     do_work()
+          | |_____________^
+          |
         ");
     }
 
@@ -923,9 +1182,10 @@ if condition:
 
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-          --> main.py:2:1
+          --> main.py:2:14
            |
-         2 | / if condition:
+         2 |   if condition:
+           |  ______________^
          3 | |     while running:
          4 | |         do_this()
          5 | |         and_that()
@@ -938,9 +1198,10 @@ if condition:
            |
 
         info[folding-range]: Folding Range
-          --> main.py:3:5
+          --> main.py:3:19
            |
-         3 | /     while running:
+         3 |       while running:
+           |  ___________________^
          4 | |         do_this()
          5 | |         and_that()
          6 | |         if maybe:
@@ -952,9 +1213,10 @@ if condition:
            |
 
         info[folding-range]: Folding Range
-          --> main.py:6:9
+          --> main.py:6:18
            |
-         6 | /         if maybe:
+         6 |           if maybe:
+           |  __________________^
          7 | |             and_maybe_this()
          8 | |             and_maybe_this()
          9 | |             and_maybe_this()
@@ -990,35 +1252,41 @@ else:
 
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-         --> main.py:2:1
+         --> main.py:2:19
           |
-        2 | / for item in items:
+        2 |   for item in items:
+          |  ___________________^
         3 | |     process(item)
         4 | |     validate(item)
           | |__________________^
           |
 
         info[folding-range]: Folding Range
-         --> main.py:6:5
+         --> main.py:5:6
           |
-        6 | /     log_success()
+        5 |   else:
+          |  ______^
+        6 | |     log_success()
         7 | |     notify_complete()
           | |_____________________^
           |
 
         info[folding-range]: Folding Range
-          --> main.py:9:1
+          --> main.py:9:17
            |
-         9 | / while condition:
+         9 |   while condition:
+           |  _________________^
         10 | |     do_work()
         11 | |     check_status()
            | |__________________^
            |
 
         info[folding-range]: Folding Range
-          --> main.py:13:5
+          --> main.py:12:6
            |
-        13 | /     handle_done()
+        12 |   else:
+           |  ______^
+        13 | |     handle_done()
         14 | |     cleanup_resources()
            | |_______________________^
            |
@@ -1048,39 +1316,46 @@ finally:
 
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-         --> main.py:2:1
+         --> main.py:2:5
           |
-        2 | / try:
+        2 |   try:
+          |  _____^
         3 | |     risky_operation()
           | |_____________________^
           |
 
         info[folding-range]: Folding Range
-         --> main.py:9:5
+         --> main.py:8:6
           |
-        9 |     success_action()
-          |     ^^^^^^^^^^^^^^^^
+        8 |   else:
+          |  ______^
+        9 | |     success_action()
+          | |____________________^
           |
 
         info[folding-range]: Folding Range
-          --> main.py:11:5
+          --> main.py:10:9
            |
-        11 |     cleanup()
-           |     ^^^^^^^^^
+        10 |   finally:
+           |  _________^
+        11 | |     cleanup()
+           | |_____________^
            |
 
         info[folding-range]: Folding Range
-         --> main.py:4:1
+         --> main.py:4:19
           |
-        4 | / except ValueError:
+        4 |   except ValueError:
+          |  ___________________^
         5 | |     handle_value_error()
           | |________________________^
           |
 
         info[folding-range]: Folding Range
-         --> main.py:6:1
+         --> main.py:6:18
           |
-        6 | / except TypeError:
+        6 |   except TypeError:
+          |  __________________^
         7 | |     handle_type_error()
           | |_______________________^
           |
@@ -1231,9 +1506,10 @@ match value:
 
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-         --> main.py:2:1
+         --> main.py:2:13
           |
-        2 | / match value:
+        2 |   match value:
+          |  _____________^
         3 | |     case 1:
         4 | |         one()
         5 | |     case 2:
@@ -1244,25 +1520,28 @@ match value:
           |
 
         info[folding-range]: Folding Range
-         --> main.py:3:5
+         --> main.py:3:12
           |
-        3 | /     case 1:
+        3 |       case 1:
+          |  ____________^
         4 | |         one()
           | |_____________^
           |
 
         info[folding-range]: Folding Range
-         --> main.py:5:5
+         --> main.py:5:12
           |
-        5 | /     case 2:
+        5 |       case 2:
+          |  ____________^
         6 | |         two()
           | |_____________^
           |
 
         info[folding-range]: Folding Range
-         --> main.py:7:5
+         --> main.py:7:12
           |
-        7 | /     case _:
+        7 |       case _:
+          |  ____________^
         8 | |         default()
           | |_________________^
           |
@@ -1299,9 +1578,10 @@ def main():
           |
 
         info[folding-range]: Folding Range
-         --> main.py:8:1
+         --> main.py:8:12
           |
-        8 | / def main():
+        8 |   def main():
+          |  ____________^
         9 | |     pass
           | |________^
           |
@@ -1378,9 +1658,10 @@ def my_function():
 
         assert_snapshot!(test.folding_ranges(), @r#"
         info[folding-range]: Folding Range
-         --> main.py:2:1
+         --> main.py:2:19
           |
-        2 | / def my_function():
+        2 |   def my_function():
+          |  ___________________^
         3 | |     """
         4 | |     This is a multiline
         5 | |     docstring.
@@ -1407,6 +1688,194 @@ def my_function():
         5 | |     docstring.
         6 | |     """
           | |_______^
+          |
+        "#);
+    }
+
+    #[test]
+    fn test_folding_range_multiline_function_header() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+def combine(
+    first,
+    second,
+):
+    return first + second
+<CURSOR>
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.folding_ranges(), @"
+        info[folding-range]: Folding Range
+         --> main.py:2:13
+          |
+        2 |   def combine(
+          |  _____________^
+        3 | |     first,
+        4 | |     second,
+          | |____________^
+          |
+
+        info[folding-range]: Folding Range
+         --> main.py:5:3
+          |
+        5 |   ):
+          |  ___^
+        6 | |     return first + second
+          | |_________________________^
+          |
+        ");
+    }
+
+    #[test]
+    fn test_folding_range_multiline_class_header() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+class Derived(
+    Base,
+    metaclass=Meta,
+):
+    value = 1
+<CURSOR>
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.folding_ranges(), @"
+        info[folding-range]: Folding Range
+         --> main.py:2:15
+          |
+        2 |   class Derived(
+          |  _______________^
+        3 | |     Base,
+        4 | |     metaclass=Meta,
+          | |____________________^
+          |
+
+        info[folding-range]: Folding Range
+         --> main.py:5:3
+          |
+        5 |   ):
+          |  ___^
+        6 | |     value = 1
+          | |_____________^
+          |
+        ");
+    }
+
+    #[test]
+    fn test_folding_range_multiline_parenthesized_if_header() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+if (
+    first
+    and second
+):
+    handle()
+<CURSOR>
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.folding_ranges(), @"
+        info[folding-range]: Folding Range
+         --> main.py:2:5
+          |
+        2 |   if (
+          |  _____^
+        3 | |     first
+        4 | |     and second
+          | |_______________^
+          |
+
+        info[folding-range]: Folding Range
+         --> main.py:5:3
+          |
+        5 |   ):
+          |  ___^
+        6 | |     handle()
+          | |____________^
+          |
+        ");
+    }
+
+    #[test]
+    fn test_folding_range_multiline_square_bracket_header() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+class Repository[
+    Model,
+    Id,
+]:
+    value = 1
+<CURSOR>
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.folding_ranges(), @"
+        info[folding-range]: Folding Range
+         --> main.py:2:18
+          |
+        2 |   class Repository[
+          |  __________________^
+        3 | |     Model,
+        4 | |     Id,
+          | |________^
+          |
+
+        info[folding-range]: Folding Range
+         --> main.py:5:3
+          |
+        5 |   ]:
+          |  ___^
+        6 | |     value = 1
+          | |_____________^
+          |
+        ");
+    }
+
+    #[test]
+    fn test_folding_range_multiline_brace_header() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+if {
+    "enabled": feature_flag,
+}["enabled"]:
+    handle()
+<CURSOR>
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.folding_ranges(), @r#"
+        info[folding-range]: Folding Range
+         --> main.py:2:5
+          |
+        2 |   if {
+          |  _____^
+        3 | |     "enabled": feature_flag,
+          | |_____________________________^
+          |
+
+        info[folding-range]: Folding Range
+         --> main.py:4:14
+          |
+        4 |   }["enabled"]:
+          |  ______________^
+        5 | |     handle()
+          | |____________^
           |
         "#);
     }
@@ -1447,9 +1916,10 @@ def with_rawstring_doc():
 
         assert_snapshot!(test.folding_ranges(), @r#"
         info[folding-range]: Folding Range
-         --> main.py:2:1
+         --> main.py:2:24
           |
-        2 | / def with_fstring_doc():
+        2 |   def with_fstring_doc():
+          |  ________________________^
         3 | |     f"""
         4 | |     This is an f-string
         5 | |     used as a docstring.
@@ -1479,9 +1949,10 @@ def with_rawstring_doc():
           |
 
         info[folding-range]: Folding Range
-          --> main.py:10:1
+          --> main.py:10:24
            |
-        10 | / def with_tstring_doc():
+        10 |   def with_tstring_doc():
+           |  ________________________^
         11 | |     t"""
         12 | |     This is a t-string
         13 | |     used as a docstring.
@@ -1511,9 +1982,10 @@ def with_rawstring_doc():
            |
 
         info[folding-range]: Folding Range
-          --> main.py:18:1
+          --> main.py:18:26
            |
-        18 | / def with_rawstring_doc():
+        18 |   def with_rawstring_doc():
+           |  __________________________^
         19 | |     r"""
         20 | |     This is a raw string
         21 | |     used as a docstring.
@@ -1568,9 +2040,10 @@ def foo():
             test.folding_ranges(),
             @"
         info[folding-range]: Folding Range
-         --> main.py:6:1
+         --> main.py:6:11
           |
-        6 | / def foo():
+        6 |   def foo():
+          |  ___________^
         7 | |     pass
           | |________^
           |
@@ -1611,9 +2084,10 @@ with open("file.txt") as f:
 
         assert_snapshot!(test.folding_ranges(), @r#"
         info[folding-range]: Folding Range
-         --> main.py:2:1
+         --> main.py:2:28
           |
-        2 | / with open("file.txt") as f:
+        2 |   with open("file.txt") as f:
+          |  ____________________________^
         3 | |     content = f.read()
         4 | |     process(content)
           | |____________________^
@@ -1651,9 +2125,10 @@ with open("file.txt") as f:
 
         assert_snapshot!(test.folding_ranges(), @r#"
         info[folding-range]: Folding Range
-          --> main.py:2:17
+          --> main.py:2:40
            |
-         2 | /                 def chunk_date_range():
+         2 |                   def chunk_date_range():
+           |  ________________________________________^
          3 | |                     """Split a date range into chunks respecting the maximum days limit.
          4 | |
          5 | |                     The API has a 1-month limit, so this function splits larger ranges
@@ -1695,9 +2170,10 @@ with open("file.txt") as f:
           |
 
         info[folding-range]: Folding Range
-          --> main.py:11:21
+          --> main.py:11:42
            |
-        11 | /                     while current <= end:
+        11 |                       while current <= end:
+           |  __________________________________________^
         12 | |                         # Calculate the end of the current chunk
         13 | |                         # Go to the last day of the current month
         14 | |                         b = 20
@@ -1732,9 +2208,10 @@ with open("file.txt") as f:
             .build();
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-         --> main.py:1:1
+         --> main.py:1:15
           |
-        1 | / class MyClass:
+        1 |   class MyClass:
+          |  _______________^
         2 | |     pass
           | |________^
           |
@@ -1746,9 +2223,10 @@ with open("file.txt") as f:
             .build();
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-         --> main.py:1:1
+         --> main.py:1:15
           |
-        1 | / class MyClass:
+        1 |   class MyClass:
+          |  _______________^
         2 | |     pass
           | |________^
           |
@@ -1760,9 +2238,10 @@ with open("file.txt") as f:
             .build();
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-         --> main.py:1:1
+         --> main.py:1:15
           |
-        1 | / class MyClass:
+        1 |   class MyClass:
+          |  _______________^
         2 | |     pass
           | |________^
           |
@@ -1802,9 +2281,10 @@ def my_function():
 
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-         --> main.py:3:1
+         --> main.py:3:19
           |
-        3 | / def my_function():
+        3 |   def my_function():
+          |  ___________________^
         4 | |     pass
           | |________^
           |
@@ -1829,9 +2309,10 @@ def my_function():
 
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-         --> main.py:5:1
+         --> main.py:5:19
           |
-        5 | / def my_function():
+        5 |   def my_function():
+          |  ___________________^
         6 | |     pass
           | |________^
           |
@@ -1856,9 +2337,10 @@ class MyClass:
         // Single decorator is one line, so no decorator folding range is emitted.
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-         --> main.py:3:1
+         --> main.py:3:15
           |
-        3 | / class MyClass:
+        3 |   class MyClass:
+          |  _______________^
         4 | |     value: int
         5 | |     name: str
           | |_____________^
@@ -1883,9 +2365,10 @@ class MyClass:
 
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-         --> main.py:4:1
+         --> main.py:4:15
           |
-        4 | / class MyClass:
+        4 |   class MyClass:
+          |  _______________^
         5 | |     value: int
           | |______________^
           |
@@ -1908,9 +2391,10 @@ async def my_async_function():
 
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-         --> main.py:3:1
+         --> main.py:3:31
           |
-        3 | / async def my_async_function():
+        3 |   async def my_async_function():
+          |  _______________________________^
         4 | |     pass
           | |________^
           |
@@ -1934,9 +2418,10 @@ def outer_function():
 
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-         --> main.py:2:1
+         --> main.py:2:22
           |
-        2 | / def outer_function():
+        2 |   def outer_function():
+          |  ______________________^
         3 | |     @decorator
         4 | |     def inner_function():
         5 | |         pass
@@ -1944,9 +2429,10 @@ def outer_function():
           |
 
         info[folding-range]: Folding Range
-         --> main.py:4:5
+         --> main.py:4:26
           |
-        4 | /     def inner_function():
+        4 |       def inner_function():
+          |  __________________________^
         5 | |         pass
           | |____________^
           |
@@ -1970,9 +2456,10 @@ class MyClass:
 
         assert_snapshot!(test.folding_ranges(), @"
         info[folding-range]: Folding Range
-         --> main.py:2:1
+         --> main.py:2:15
           |
-        2 | / class MyClass:
+        2 |   class MyClass:
+          |  _______________^
         3 | |     @decorator
         4 | |     async def my_async_method(self):
         5 | |         pass
@@ -1980,9 +2467,10 @@ class MyClass:
           |
 
         info[folding-range]: Folding Range
-         --> main.py:4:5
+         --> main.py:4:37
           |
-        4 | /     async def my_async_method(self):
+        4 |       async def my_async_method(self):
+          |  _____________________________________^
         5 | |         pass
           | |____________^
           |

--- a/crates/ty_server/tests/e2e/folding_range.rs
+++ b/crates/ty_server/tests/e2e/folding_range.rs
@@ -14,6 +14,24 @@ fn folding_range_basic_functionality() -> Result<()> {
 
     def method(self):
         return self.value
+
+    def combine(
+        first,
+        second,
+    ):
+        return first + second
+
+    class Derived(
+        Base,
+        metaclass=Meta,
+    ):
+        value = 1
+
+    if (
+        first
+        and second
+    ):
+        handle()
 "#;
 
     let mut server = TestServerBuilder::new()?

--- a/crates/ty_server/tests/e2e/snapshots/e2e__folding_range__folding_range_basic_functionality.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__folding_range__folding_range_basic_functionality.snap
@@ -5,20 +5,56 @@ expression: ranges
 [
   {
     "startLine": 0,
-    "startCharacter": 0,
-    "endLine": 5,
-    "endCharacter": 25
+    "startCharacter": 14,
+    "endLine": 23,
+    "endCharacter": 16
   },
   {
     "startLine": 1,
-    "startCharacter": 4,
+    "startCharacter": 23,
     "endLine": 2,
     "endCharacter": 22
   },
   {
     "startLine": 4,
-    "startCharacter": 4,
+    "startCharacter": 21,
     "endLine": 5,
     "endCharacter": 25
+  },
+  {
+    "startLine": 7,
+    "startCharacter": 16,
+    "endLine": 10,
+    "endCharacter": 4
+  },
+  {
+    "startLine": 10,
+    "startCharacter": 6,
+    "endLine": 11,
+    "endCharacter": 29
+  },
+  {
+    "startLine": 13,
+    "startCharacter": 18,
+    "endLine": 16,
+    "endCharacter": 4
+  },
+  {
+    "startLine": 16,
+    "startCharacter": 6,
+    "endLine": 17,
+    "endCharacter": 17
+  },
+  {
+    "startLine": 19,
+    "startCharacter": 8,
+    "endLine": 22,
+    "endCharacter": 4
+  },
+  {
+    "startLine": 22,
+    "startCharacter": 6,
+    "endLine": 23,
+    "endCharacter": 16
   }
 ]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__folding_range__folding_range_notebook_cells_are_filtered_to_the_requested_cell.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__folding_range__folding_range_notebook_cells_are_filtered_to_the_requested_cell.snap
@@ -13,31 +13,31 @@ expression: "[first_cell_ranges, second_cell_ranges]"
     },
     {
       "startLine": 6,
-      "startCharacter": 0,
+      "startCharacter": 46,
       "endLine": 13,
       "endCharacter": 20
     },
     {
       "startLine": 7,
-      "startCharacter": 4,
+      "startCharacter": 40,
       "endLine": 13,
       "endCharacter": 20
     },
     {
       "startLine": 9,
-      "startCharacter": 8,
+      "startCharacter": 36,
       "endLine": 10,
       "endCharacter": 16
     },
     {
       "startLine": 11,
-      "startCharacter": 8,
+      "startCharacter": 13,
       "endLine": 13,
       "endCharacter": 20
     },
     {
       "startLine": 12,
-      "startCharacter": 12,
+      "startCharacter": 40,
       "endLine": 13,
       "endCharacter": 20
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This changes how we emit folding ranges from the language server such that the new ranges are character-precise for block headers[^1]. This improves code folding in character-precise clients like Zed by keeping the block header visible above the fold.

[^1]: Where a block header is a statement like `def foo():`, `class Foo():`, an `if foo:` condition, and so on.

Previously, we would begin folding a block from the beginning of the header line:

```text
/ def main():
|     work()
|__________^
```

Now, we fold that block starting after the colon that marks the end of the block header, thus preserving the block header:

```text
  def main():
 ____________^
|     work()
|__________^
```

For multi-line block headers, we emit a folding range that covers the parenthesized region and another for the block body. So rather than this:

```text
/ def combine(
|     first,
|     second,
| ):
|     return first + second
|_________________________^
```

We emit this:

```text
  def combine(
 _____________^
|     first,
|     second,
|____________^
```

```text
  ):
 ___^
|     return first + second
|_________________________^
```

With the result that the folded code looks like:

```text
def combined(...):
   ...
```

Closes https://github.com/astral-sh/ty/issues/3320.

## Test Plan

Please see updated and added tests in `folding_range.rs`.

<!-- How was it tested? -->
