### PR TITLE
Always include panic payload in panic diagnostic message

### DIFF
--- a/crates/ruff_db/src/panic.rs
+++ b/crates/ruff_db/src/panic.rs
@@ -16,18 +16,22 @@ pub struct PanicError {
 pub struct Payload(Box<dyn std::any::Any + Send>);
 
 impl Payload {
-    pub fn as_str(&self) -> Option<&str> {
-        if let Some(s) = self.0.downcast_ref::<String>() {
-            Some(s)
-        } else if let Some(s) = self.0.downcast_ref::<&str>() {
-            Some(s)
-        } else {
-            None
-        }
-    }
-
     pub fn downcast_ref<R: Any>(&self) -> Option<&R> {
         self.0.downcast_ref::<R>()
+    }
+}
+
+impl std::fmt::Display for Payload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(s) = self.0.downcast_ref::<String>() {
+            f.write_str(s)
+        } else if let Some(s) = self.0.downcast_ref::<&str>() {
+            f.write_str(s)
+        } else if let Some(s) = self.0.downcast_ref::<salsa::Cancelled>() {
+            write!(f, "{s}")
+        } else {
+            f.write_str("Box<dyn Any>")
+        }
     }
 }
 
@@ -50,9 +54,7 @@ impl PanicError {
             let _ = write!(&mut message, " when checking `{path}`");
         }
 
-        if let Some(payload) = self.payload.as_str() {
-            let _ = write!(&mut message, ": `{payload}`");
-        }
+        let _ = write!(&mut message, ": `{payload}`", payload = self.payload);
 
         message
     }
@@ -64,9 +66,9 @@ impl std::fmt::Display for PanicError {
         if let Some(location) = &self.location {
             write!(f, " {location}")?;
         }
-        if let Some(payload) = self.payload.as_str() {
-            write!(f, ":\n{payload}")?;
-        }
+
+        write!(f, ":\n{payload}", payload = self.payload)?;
+
         if let Some(query_trace) = self.salsa_backtrace.as_ref() {
             let _ = writeln!(f, "{query_trace}");
         }

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -483,17 +483,12 @@ fn run_test(
                 .should_expect_panic()
                 .expect("panic_info is only set when `should_expect_panic` is `Ok`");
 
-            let message = panic_info
-                .payload
-                .as_str()
-                .unwrap_or("Box<dyn Any>")
-                .to_string();
-
             if let Some(expected_message) = expected_message {
+                let message = panic_info.payload.to_string();
                 assert!(
                     message.contains(expected_message),
                     "Test `{}` is expected to panic with `{expected_message}`, but panicked with `{message}` instead.",
-                    test.name()
+                    test.name(),
                 );
             }
         }
@@ -740,12 +735,7 @@ impl AttemptTestError<'_> {
             messages.push(Failure::new(clarification));
         }
         messages.push(Failure::new(""));
-        match info.payload.as_str() {
-            Some(message) => messages.push(Failure::new(message)),
-            // Mimic the default panic hook's rendering of the panic payload if it's
-            // not a string.
-            None => messages.push(Failure::new("Box<dyn Any>")),
-        }
+        messages.push(Failure::new(info.payload));
         messages.push(Failure::new(""));
 
         if let Some(backtrace) = info.backtrace {


### PR DESCRIPTION
Our panic handler omits the panic payload if it is neither a `str` or `String` today. This can be confusing because it appears the user's report misses the crucial message, when in fact it's simply that the panic body is a non-string value (see https://github.com/astral-sh/ty/issues/3339).

This PR changes the diagnostic rendering to always include the panic payload, even if it's just a `Box<dyn Any>`. While that isn't terribly useful on its own, it at least indicates that the panic body isn't a string value. This PR also adds special handling for `salsa::Cancelled`, as these are the most likely non-stringish panic bodies in ty.

This aligns the behavior with what we use in mdtests.