### PR TITLE
Update Renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,7 @@
   suppressNotifications: ["prEditedNotification"],
   extends: ["github>astral-sh/renovate-config"],
   labels: ["internal"],
-  schedule: ["before 4am on Monday"],
+  schedule: ["before 0am on Wednesday"],
   semanticCommits: "disabled",
   separateMajorMinor: false,
   enabledManagers: ["github-actions", "pre-commit", "cargo", "pep621", "pip_requirements", "npm"],
@@ -85,6 +85,12 @@
       matchManagers: ["npm"],
       matchDepTypes: ["devDependencies"],
       description: "Weekly update of NPM development dependencies",
+    },
+    {
+      groupName: "ESLint dependencies",
+      matchManagers: ["npm"],
+      matchPackageNames: ["@eslint/js", "eslint"],
+      description: "Weekly update of ESLint dependencies",
     },
     {
       groupName: "Monaco",


### PR DESCRIPTION
## Summary

* Run the update on Wednesday instead of Monday to avoid adding to the weekend backlog
* Running it at 0 am UTC ensures the review load is not exclusive on folks in Europe
* Extract ESLint into its own group. The ESlint 10 upgrade is blocked on `eslint-plugin-react`'s ESLint 10 support

## Test Plan

`npx --yes --package renovate -- renovate-config-validator --no-global .github/renovate.json5`
