### PR TITLE
Color ruff success messages green to match ty (closes #24840)

### DIFF
--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -680,8 +680,7 @@ impl<'a> FormatResults<'a> {
                 }
             )
         } else if unchanged > 0 {
-            writeln!(
-                f,
+            let summary = format!(
                 "{} file{} {}",
                 unchanged,
                 if unchanged == 1 { "" } else { "s" },
@@ -689,7 +688,8 @@ impl<'a> FormatResults<'a> {
                     FormatMode::Write => "left unchanged",
                     FormatMode::Check | FormatMode::Diff => "already formatted",
                 },
-            )
+            );
+            writeln!(f, "{}", summary.green().bold())
         } else {
             Ok(())
         }

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -104,7 +104,7 @@ impl Printer {
                     let s = if remaining == 1 { "" } else { "s" };
                     writeln!(writer, "Found {remaining} error{s}.")?;
                 } else if remaining == 0 {
-                    writeln!(writer, "All checks passed!")?;
+                    writeln!(writer, "{}", "All checks passed!".green().bold())?;
                 }
 
                 if let Some(fixables) = fixables {


### PR DESCRIPTION
Closes #24840.

## Summary

Mirrors ty's \`"All checks passed!".green().bold()\` treatment for ruff's exit-without-changes messages. Two call sites:

- \`crates/ruff/src/printer.rs\`: \`ruff check\` -- "All checks passed!" when zero remaining diagnostics.
- \`crates/ruff/src/commands/format.rs\`: \`ruff format\` (write) and \`ruff format --check\` -- the pure-unchanged branch ("N files left unchanged" / "N files already formatted") when nothing needed reformatting.

I left the mixed-result format branch ("X reformatted, Y unchanged") and the \`--fix\` "Found N errors (N fixed, 0 remaining)" message uncolored, since those report changes/findings rather than a clean exit. Happy to expand if you'd prefer broader treatment.

## Verification

- \`cargo clippy --package ruff -- -D warnings\` -- clean
- \`cargo test --package ruff --test integration_test\` -- 95/95 pass (the existing tests look for the literal "All checks passed!" string and run under \`cfg!(test)\` where \`colored\` produces no ANSI codes, so they keep matching)
- Manual visual check with \`FORCE_COLOR=1\`:
  - \`ruff check clean.py\` -> \`\x1b[1;32mAll checks passed!\x1b[0m\`
  - \`ruff format --check clean.py\` -> \`\x1b[1;32m1 file already formatted\x1b[0m\`