### PR TITLE
Use mimalloc v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ lsp-types = { git = "https://github.com/astral-sh/lsp-types.git", rev = "e15db05
 ] }
 matchit = { version = "0.9.0" }
 memchr = { version = "2.7.1" }
-mimalloc = { version = "0.1.39" }
+mimalloc = { version = "0.1.49", features = ["v2"] }
 natord = { version = "1.0.9" }
 notify = { version = "8.0.0" }
 ordermap = { version = "1.0.0" }


### PR DESCRIPTION
v3 causes Ruff to crash on Windows arm64: https://github.com/purpleprotocol/mimalloc_rust/issues/159

## Test plan

Run `ruff format` on a smol codebase.