### PR TITLE
[ty] handle finally blocks where all try/except are terminal

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1498,6 +1498,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.current_use_def_map_mut().mark_unreachable();
     }
 
+    /// Records that the current state can enter any active `finally` suites before the current
+    /// terminal control-flow transfer reaches its destination.
+    fn record_terminal_finally_entry(&mut self) {
+        let mut try_node_stack_manager = std::mem::take(&mut self.try_node_context_stack_manager);
+        try_node_stack_manager.record_terminal_finally_entry(self);
+        self.try_node_context_stack_manager = try_node_stack_manager;
+    }
+
     /// Records a reachability constraint that always evaluates to "ambiguous".
     fn record_ambiguous_reachability(&mut self) {
         self.current_use_def_map_mut()
@@ -3108,8 +3116,12 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 let mut post_except_states = vec![];
 
                 // Take a record also of all the intermediate states we encountered
-                // while visiting the `try` block
-                let try_block_snapshots = self.try_node_context_stack_manager.pop_context();
+                // while visiting the `try` block. Keep the context itself on the stack so that
+                // terminal statements in `except` and `else` suites can still be recorded as
+                // entries to the associated `finally` suite.
+                let try_block_snapshots = self
+                    .try_node_context_stack_manager
+                    .take_try_suite_snapshots();
 
                 if !handlers.is_empty() {
                     // Save the state immediately *after* visiting the `try` block
@@ -3188,6 +3200,12 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     self.flow_merge(post_except_state);
                 }
 
+                let normal_pre_finally_state = self.flow_snapshot();
+                let terminal_finally_entry_snapshots = self
+                    .try_node_context_stack_manager
+                    .pop_context()
+                    .into_terminal_finally_entry_snapshots();
+
                 // TODO: there's lots of complexity here that isn't yet handled by our model.
                 // In order to accurately model the semantics of `finally` suites, we in fact need to visit
                 // the suite twice: once under the (current) assumption that either the `try + else` suite
@@ -3198,12 +3216,31 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 // For more details, see:
                 // - https://astral-sh.notion.site/Exception-handler-control-flow-11348797e1ca80bb8ce1e9aedbbe439d
                 // - https://github.com/astral-sh/ruff/pull/13633#discussion_r1788626702
-                self.visit_body(finalbody);
+                if normal_pre_finally_state.is_always_unreachable()
+                    && !terminal_finally_entry_snapshots.is_empty()
+                {
+                    let mut snapshots = terminal_finally_entry_snapshots.into_iter();
+                    let first_snapshot = snapshots.next().expect("checked non-empty snapshots");
+                    self.flow_restore(first_snapshot);
+                    for snapshot in snapshots {
+                        self.flow_merge(snapshot);
+                    }
+                    self.visit_body(finalbody);
+                    if !self.flow_snapshot().is_always_unreachable() {
+                        self.record_terminal_finally_entry();
+                    }
+                    self.mark_unreachable();
+                } else {
+                    // Mixed normal and terminal entry states are still handled by the normal path
+                    // only. See the corresponding TODO tests in `terminal_statements.md`.
+                    self.visit_body(finalbody);
+                }
                 self.in_try = was_in_try;
             }
 
             ast::Stmt::Raise(_) | ast::Stmt::Return(_) => {
                 walk_stmt(self, stmt);
+                self.record_terminal_finally_entry();
                 // Everything in the current block after a terminal statement is unreachable.
                 self.mark_unreachable();
             }
@@ -3213,6 +3250,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 if let Some(current_loop) = self.current_loop_mut() {
                     current_loop.push_continue(snapshot);
                 }
+                self.record_terminal_finally_entry();
                 // Everything in the current block after a terminal statement is unreachable.
                 self.mark_unreachable();
             }
@@ -3222,6 +3260,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 if let Some(current_loop) = self.current_loop_mut() {
                     current_loop.push_break(snapshot);
                 }
+                self.record_terminal_finally_entry();
                 // Everything in the current block after a terminal statement is unreachable.
                 self.mark_unreachable();
             }

--- a/crates/ty_python_core/src/builder/except_handlers.rs
+++ b/crates/ty_python_core/src/builder/except_handlers.rs
@@ -32,17 +32,29 @@ impl TryNodeContextStackManager {
         self.current_try_context_stack().push_context();
     }
 
-    /// Pop a [`TryNodeContext`] off the [`TryNodeContextStack`]
-    /// at the top of our stack of stacks. Return the Vec of [`FlowSnapshot`]s
-    /// recorded while we were visiting the `try` suite.
-    pub(super) fn pop_context(&mut self) -> Vec<FlowSnapshot> {
+    /// Pop a [`TryNodeContext`] off the [`TryNodeContextStack`] at the top of our stack of stacks.
+    pub(super) fn pop_context(&mut self) -> TryNodeContext {
         self.current_try_context_stack().pop_context()
+    }
+
+    /// Retrieve the [`TryNodeContext`] that is currently at the top of the stack, and take all
+    /// snapshots recorded while visiting the `try` suite.
+    pub(super) fn take_try_suite_snapshots(&mut self) -> Vec<FlowSnapshot> {
+        self.current_try_context_stack().take_try_suite_snapshots()
     }
 
     /// Retrieve the stack that is at the top of our stack of stacks.
     /// For each `try` block on that stack, push the snapshot onto the `try` block
     pub(super) fn record_definition(&mut self, builder: &SemanticIndexBuilder) {
         self.current_try_context_stack().record_definition(builder);
+    }
+
+    /// Retrieve the stack that is at the top of our stack of stacks.
+    /// Push the snapshot onto the innermost `try` block's terminal-entry snapshots for its
+    /// `finally` suite.
+    pub(super) fn record_terminal_finally_entry(&mut self, builder: &SemanticIndexBuilder) {
+        self.current_try_context_stack()
+            .record_terminal_finally_entry(builder);
     }
 
     /// Retrieve the [`TryNodeContextStack`] that is relevant for the current scope.
@@ -64,22 +76,36 @@ impl TryNodeContextStack {
         self.0.push(TryNodeContext::default());
     }
 
-    /// Pop a [`TryNodeContext`] off the stack. Return the Vec of [`FlowSnapshot`]s
-    /// recorded while we were visiting the `try` suite.
-    fn pop_context(&mut self) -> Vec<FlowSnapshot> {
-        let TryNodeContext {
-            try_suite_snapshots,
-        } = self
-            .0
+    /// Pop a [`TryNodeContext`] off the stack.
+    fn pop_context(&mut self) -> TryNodeContext {
+        self.0
             .pop()
-            .expect("Cannot pop a `try` block off an empty `TryBlockContexts` stack");
-        try_suite_snapshots
+            .expect("Cannot pop a `try` block off an empty `TryBlockContexts` stack")
+    }
+
+    /// Take all snapshots recorded while visiting the `try` suite.
+    fn take_try_suite_snapshots(&mut self) -> Vec<FlowSnapshot> {
+        std::mem::take(
+            &mut self
+                .0
+                .last_mut()
+                .expect("Cannot take snapshots from an empty `TryBlockContexts` stack")
+                .try_suite_snapshots,
+        )
     }
 
     /// For each `try` block on the stack, push the snapshot onto the `try` block
     fn record_definition(&mut self, builder: &SemanticIndexBuilder) {
         for context in &mut self.0 {
             context.record_definition(builder.flow_snapshot());
+        }
+    }
+
+    /// Push the snapshot onto the innermost `try` block's terminal-entry snapshots for its
+    /// `finally` suite.
+    fn record_terminal_finally_entry(&mut self, builder: &SemanticIndexBuilder) {
+        if let Some(context) = self.0.last_mut() {
+            context.record_terminal_finally_entry(builder.flow_snapshot());
         }
     }
 }
@@ -90,13 +116,24 @@ impl TryNodeContextStack {
 /// It will likely be necessary to add more fields to this struct in the future
 /// when we add more advanced handling of `finally` branches.
 #[derive(Debug, Default)]
-struct TryNodeContext {
+pub(super) struct TryNodeContext {
     try_suite_snapshots: Vec<FlowSnapshot>,
+    terminal_finally_entry_snapshots: Vec<FlowSnapshot>,
 }
 
 impl TryNodeContext {
+    pub(super) fn into_terminal_finally_entry_snapshots(self) -> Vec<FlowSnapshot> {
+        self.terminal_finally_entry_snapshots
+    }
+
     /// Take a record of what the internal state looked like after a definition
     fn record_definition(&mut self, snapshot: FlowSnapshot) {
         self.try_suite_snapshots.push(snapshot);
+    }
+
+    /// Take a record of what the internal state looked like before a terminal control-flow
+    /// transfer that will pass through the `finally` suite.
+    fn record_terminal_finally_entry(&mut self, snapshot: FlowSnapshot) {
+        self.terminal_finally_entry_snapshots.push(snapshot);
     }
 }

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -900,6 +900,12 @@ pub(super) struct FlowSnapshot {
     reachability: ScopedReachabilityConstraintId,
 }
 
+impl FlowSnapshot {
+    pub(super) fn is_always_unreachable(&self) -> bool {
+        self.reachability == ScopedReachabilityConstraintId::ALWAYS_FALSE
+    }
+}
+
 /// A snapshot of the state of a single symbol (e.g. `obj`) and all of its associated members
 /// (e.g. `obj.attr`, `obj["key"]`).
 pub(super) struct SingleSymbolSnapshot {

--- a/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
+++ b/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
@@ -545,11 +545,132 @@ def raise_in_both_nested_branches(cond1: bool, cond2: bool):
 
 ## Terminal in `try` with `finally` clause
 
-TODO: we don't yet model that a `break` or `continue` in a `try` block will jump to a `finally`
-clause before it jumps to end/start of the loop.
+TODO: we don't yet model that terminal control flow in a `try`, `except`, or `else` block will jump
+to a `finally` clause before it terminates the current scope or jumps to its final destination.
 
 ```py
-def f():
+def finally_runs_after_return():
+    x = "before"
+    try:
+        x = "return"
+        return
+    finally:
+        # TODO: should include `Literal["return"]`
+        reveal_type(x)  # revealed: Never
+
+def finally_runs_after_try_and_except_are_terminal(cond: bool):
+    x = "before"
+    try:
+        if cond:
+            x = "try-return"
+            return
+        else:
+            x = "try-raise"
+            raise ValueError
+    except ValueError:
+        x = "except-return"
+        return
+    finally:
+        # TODO: should include terminal states from both the `try` and `except` blocks
+        reveal_type(x)  # revealed: Never
+
+def finally_runs_after_except_and_else_are_terminal():
+    x = "before"
+    try:
+        x = "try-normal"
+    except ValueError:
+        x = "except-return"
+        return
+    else:
+        x = "else-return"
+        return
+    finally:
+        # TODO: should include terminal states from both the `except` and `else` blocks
+        reveal_type(x)  # revealed: Never
+
+def finally_runs_after_mixed_except_paths(cond: bool):
+    x = "before"
+    try:
+        raise ValueError
+    except ValueError:
+        if cond:
+            x = "except-return"
+            return
+        x = "except-normal"
+    finally:
+        # TODO: should also include `Literal["except-return"]`
+        reveal_type(x)  # revealed: Literal["except-normal"]
+
+def finally_runs_after_mixed_try_paths(cond: bool):
+    x = "before"
+    try:
+        if cond:
+            x = "try-return"
+            return
+        x = "try-normal"
+    finally:
+        # TODO: should also include `Literal["try-return"]`
+        reveal_type(x)  # revealed: Literal["try-normal"]
+
+def finally_runs_after_mixed_break_paths(cond: bool):
+    x = "before"
+    while True:
+        try:
+            if cond:
+                x = "break"
+                break
+            x = "normal"
+        finally:
+            # TODO: should also include `Literal["break"]`
+            reveal_type(x)  # revealed: Literal["normal"]
+        break
+
+def finally_runs_before_break():
+    x = "before"
+    while True:
+        try:
+            x = "break"
+            break
+        finally:
+            # TODO: should include `Literal["break"]`
+            reveal_type(x)  # revealed: Never
+
+def finally_runs_before_continue(cond: bool):
+    while cond:
+        x = "before"
+        try:
+            x = "continue"
+            continue
+        finally:
+            # TODO: should include `Literal["continue"]`
+            reveal_type(x)  # revealed: Never
+
+def nested_finally_runs_after_return():
+    x = "before"
+    try:
+        try:
+            x = "return"
+            return
+        finally:
+            # TODO: should include `Literal["return"]`
+            reveal_type(x)  # revealed: Never
+    finally:
+        # TODO: should include `Literal["return"]`
+        reveal_type(x)  # revealed: Never
+
+def nested_outer_finally_sees_inner_finally_assignments():
+    x = "before"
+    try:
+        try:
+            x = "return"
+            return
+        finally:
+            x = "inner-finally"
+    finally:
+        # TODO: should include `Literal["inner-finally"]`
+        reveal_type(x)  # revealed: Never
+
+def finally_assignment_runs_before_break():
     x = 1
     while True:
         try:

--- a/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
+++ b/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
@@ -545,8 +545,12 @@ def raise_in_both_nested_branches(cond1: bool, cond2: bool):
 
 ## Terminal in `try` with `finally` clause
 
-TODO: we don't yet model that terminal control flow in a `try`, `except`, or `else` block will jump
-to a `finally` clause before it terminates the current scope or jumps to its final destination.
+We model terminal control flow in a `try`, `except`, or `else` block as jumping to a `finally`
+clause before it terminates the current scope or jumps to its final destination when there are no
+normal paths into the `finally` block.
+
+TODO: we don't yet consider both normal and terminal entry states when checking a `finally` block
+that has a mix of normal and terminal entry paths.
 
 ```py
 def finally_runs_after_return():
@@ -555,8 +559,7 @@ def finally_runs_after_return():
         x = "return"
         return
     finally:
-        # TODO: should include `Literal["return"]`
-        reveal_type(x)  # revealed: Never
+        reveal_type(x)  # revealed: Literal["return"]
 
 def finally_runs_after_try_and_except_are_terminal(cond: bool):
     x = "before"
@@ -571,8 +574,7 @@ def finally_runs_after_try_and_except_are_terminal(cond: bool):
         x = "except-return"
         return
     finally:
-        # TODO: should include terminal states from both the `try` and `except` blocks
-        reveal_type(x)  # revealed: Never
+        reveal_type(x)  # revealed: Literal["try-return", "try-raise", "except-return"]
 
 def finally_runs_after_except_and_else_are_terminal():
     x = "before"
@@ -585,8 +587,7 @@ def finally_runs_after_except_and_else_are_terminal():
         x = "else-return"
         return
     finally:
-        # TODO: should include terminal states from both the `except` and `else` blocks
-        reveal_type(x)  # revealed: Never
+        reveal_type(x)  # revealed: Literal["except-return", "else-return"]
 
 def finally_runs_after_mixed_except_paths(cond: bool):
     x = "before"
@@ -632,8 +633,7 @@ def finally_runs_before_break():
             x = "break"
             break
         finally:
-            # TODO: should include `Literal["break"]`
-            reveal_type(x)  # revealed: Never
+            reveal_type(x)  # revealed: Literal["break"]
 
 def finally_runs_before_continue(cond: bool):
     while cond:
@@ -642,8 +642,7 @@ def finally_runs_before_continue(cond: bool):
             x = "continue"
             continue
         finally:
-            # TODO: should include `Literal["continue"]`
-            reveal_type(x)  # revealed: Never
+            reveal_type(x)  # revealed: Literal["continue"]
 
 def nested_finally_runs_after_return():
     x = "before"
@@ -652,11 +651,9 @@ def nested_finally_runs_after_return():
             x = "return"
             return
         finally:
-            # TODO: should include `Literal["return"]`
-            reveal_type(x)  # revealed: Never
+            reveal_type(x)  # revealed: Literal["return"]
     finally:
-        # TODO: should include `Literal["return"]`
-        reveal_type(x)  # revealed: Never
+        reveal_type(x)  # revealed: Literal["return"]
 
 def nested_outer_finally_sees_inner_finally_assignments():
     x = "before"
@@ -667,8 +664,7 @@ def nested_outer_finally_sees_inner_finally_assignments():
         finally:
             x = "inner-finally"
     finally:
-        # TODO: should include `Literal["inner-finally"]`
-        reveal_type(x)  # revealed: Never
+        reveal_type(x)  # revealed: Literal["inner-finally"]
 
 def finally_assignment_runs_before_break():
     x = 1


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/3308.
Partial steps towards https://github.com/astral-sh/ty/issues/233.

Today we model only the "normal flow" entry path into a finally suite (that is, control flow reaches the end of one of its associated try/except/else suites). We don't model entry into the finally suite from terminal statements or arbitrary exceptions in the try/except/else suites.

The most pressing symptom of this is that if all try/except/else suites are terminal, we currently wrongly mark the finally block as unreachable.

This PR fixes that symptom, and puts some pieces in place towards a complete fix for finally-suite control flow, by a) tracking all flow states that can enter finally blocks via terminal statements in try/except/else, and then b) using those flow states as the entry state for the finally suite, if the normal-flow entry state is unreachable. In this case we also mark the exit state of the finally suite as unreachable. (If the finally suite is entered via a terminal path, control flow will leave the scope at the end of the finally suite, not continue to subsequent code.)

This only modifies the scenario where all try/except/else suites are terminal. In mixed cases (where control flow can enter the finally suite either via terminal or normal flow), we continue to model only the normal flow, as before. The mixed cases will be trickier, because we need to check the finally suite accounting for all entry paths, but reset its final flow state to one that accounts only for the normal-flow entry path. This will likely require building a speculative-visit mode for `SemanticIndexBuilder`.

We also don't yet model that control flow can jump from a try/except/else to a finally suite via an arbitrary exception raised by any code, not solely via an explicitly terminal statement.

The remaining gaps are reasonably well covered with TODO tests.

## Test Plan

Added mdtests.

Ecosystem results look as expected; we now check finally suites that we previously considered unreachable, where all try/except/else are terminal. All new diagnostics otherwise look expected / known unrelated limitations.