### PR TITLE
[ty] Fix receiver coloring for aliased decorators

### DIFF
--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -547,14 +547,11 @@ impl<'db> SemanticTokenVisitor<'db> {
         if is_first && self.in_class_scope {
             let method_decorator = func
                 .inferred_type(self.model)
-                .and_then(|ty| match ty {
-                    Type::FunctionLiteral(function_ty) => Some(function_ty),
-                    _ => None,
-                })
+                .and_then(Type::as_function_literal)
                 .and_then(|function_ty| {
-                    MethodDecorator::try_from_fn_type(self.model.db(), function_ty).ok()
+                    MethodDecorator::try_from_fn_type(self.model.db(), function_ty)
                 })
-                .unwrap_or(MethodDecorator::None);
+                .unwrap_or_default();
 
             match method_decorator {
                 MethodDecorator::StaticMethod => SemanticTokenType::Parameter,

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -50,7 +50,7 @@ use ty_python_semantic::{
         CallArgumentForm, call_argument_forms, definition_for_name,
         static_member_type_for_attribute,
     },
-    types::{SpecialFormType, Type, TypeVarKind},
+    types::{MethodDecorator, SpecialFormType, Type, TypeVarKind},
 };
 
 /// Semantic token types supported by the language server.
@@ -545,37 +545,21 @@ impl<'db> SemanticTokenVisitor<'db> {
         func: &ast::StmtFunctionDef,
     ) -> SemanticTokenType {
         if is_first && self.in_class_scope {
-            // Check if this is a classmethod (has @classmethod decorator)
-            // TODO - replace with a more robust way to check whether this is a classmethod
-            let is_classmethod =
-                func.decorator_list
-                    .iter()
-                    .any(|decorator| match &decorator.expression {
-                        ast::Expr::Name(name) => name.id.as_str() == "classmethod",
-                        ast::Expr::Attribute(attr) => attr.attr.id.as_str() == "classmethod",
-                        _ => false,
-                    });
+            let method_decorator = func
+                .inferred_type(self.model)
+                .and_then(|ty| match ty {
+                    Type::FunctionLiteral(function_ty) => Some(function_ty),
+                    _ => None,
+                })
+                .and_then(|function_ty| {
+                    MethodDecorator::try_from_fn_type(self.model.db(), function_ty).ok()
+                })
+                .unwrap_or(MethodDecorator::None);
 
-            // Check if this is a staticmethod (has @staticmethod decorator)
-            // TODO - replace with a more robust way to check whether this is a staticmethod
-            let is_staticmethod =
-                func.decorator_list
-                    .iter()
-                    .any(|decorator| match &decorator.expression {
-                        ast::Expr::Name(name) => name.id.as_str() == "staticmethod",
-                        ast::Expr::Attribute(attr) => attr.attr.id.as_str() == "staticmethod",
-                        _ => false,
-                    });
-
-            if is_staticmethod {
-                // Static methods don't have self/cls parameters
-                SemanticTokenType::Parameter
-            } else if is_classmethod {
-                // First parameter of a classmethod is cls parameter
-                SemanticTokenType::ClsParameter
-            } else {
-                // First parameter of an instance method is self parameter
-                SemanticTokenType::SelfParameter
+            match method_decorator {
+                MethodDecorator::StaticMethod => SemanticTokenType::Parameter,
+                MethodDecorator::ClassMethod => SemanticTokenType::ClsParameter,
+                MethodDecorator::None => SemanticTokenType::SelfParameter,
             }
         } else {
             SemanticTokenType::Parameter
@@ -1411,6 +1395,56 @@ class MyClass:
         "method" @ 42..48: Method [definition]
         "x" @ 49..50: Parameter [definition]
         "y" @ 52..53: Parameter [definition]
+        "#);
+    }
+
+    #[test]
+    fn semantic_tokens_aliased_staticmethod_parameter() {
+        let test = SemanticTokenTest::new(
+            "
+sm = staticmethod
+
+class MyClass:
+    @sm
+    def method(x, y): pass
+",
+        );
+
+        let tokens = test.highlight_file();
+
+        assert_snapshot!(test.to_snapshot(&tokens), @r#"
+        "sm" @ 1..3: Class [definition]
+        "staticmethod" @ 6..18: Class
+        "MyClass" @ 26..33: Class [definition]
+        "sm" @ 40..42: Decorator
+        "method" @ 51..57: Method [definition]
+        "x" @ 58..59: Parameter [definition]
+        "y" @ 61..62: Parameter [definition]
+        "#);
+    }
+
+    #[test]
+    fn semantic_tokens_aliased_classmethod_parameter() {
+        let test = SemanticTokenTest::new(
+            "
+cm = classmethod
+
+class MyClass:
+    @cm
+    def method(cls, x): pass
+",
+        );
+
+        let tokens = test.highlight_file();
+
+        assert_snapshot!(test.to_snapshot(&tokens), @r#"
+        "cm" @ 1..3: Class [definition]
+        "classmethod" @ 6..17: Class
+        "MyClass" @ 25..32: Class [definition]
+        "cm" @ 39..41: Decorator
+        "method" @ 50..56: Method [definition]
+        "cls" @ 57..60: ClsParameter [definition]
+        "x" @ 62..63: Parameter [definition]
         "#);
     }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1535,7 +1535,7 @@ impl<'db> Type<'db> {
         }
     }
 
-    pub(crate) const fn as_function_literal(self) -> Option<FunctionType<'db>> {
+    pub const fn as_function_literal(self) -> Option<FunctionType<'db>> {
         match self {
             Type::FunctionLiteral(function_type) => Some(function_type),
             _ => None,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -85,8 +85,8 @@ pub use crate::types::variance::TypeVarVariance;
 use crate::types::variance::VarianceInferable;
 use crate::types::visitor::any_over_type;
 use crate::{Db, FxOrderSet, Program};
-pub use class::KnownClass;
 pub(crate) use class::{ClassLiteral, ClassType, GenericAlias, StaticClassLiteral};
+pub use class::{KnownClass, MethodDecorator};
 use instance::Protocol;
 pub use instance::{NominalInstanceType, ProtocolInstanceType};
 pub(crate) use literal::{

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2112,9 +2112,10 @@ pub(super) struct AbstractMethod<'db> {
 }
 
 /// The decorator category for a method-like function.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum MethodDecorator {
     /// An instance method with an implicit instance receiver, conventionally named `self`.
+    #[default]
     None,
     /// A classmethod with an implicit class receiver, conventionally named `cls`.
     ClassMethod,
@@ -2122,23 +2123,14 @@ pub enum MethodDecorator {
     StaticMethod,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum MethodDecoratorError {
-    /// A method can't be static and a class method at the same time.
-    ConflictingDecorators,
-}
-
 impl MethodDecorator {
     /// Returns the decorator category for a function type.
-    pub fn try_from_fn_type(
-        db: &dyn Db,
-        fn_type: FunctionType,
-    ) -> Result<Self, MethodDecoratorError> {
+    pub fn try_from_fn_type(db: &dyn Db, fn_type: FunctionType) -> Option<Self> {
         match (fn_type.is_classmethod(db), fn_type.is_staticmethod(db)) {
-            (true, true) => Err(MethodDecoratorError::ConflictingDecorators),
-            (true, false) => Ok(Self::ClassMethod),
-            (false, true) => Ok(Self::StaticMethod),
-            (false, false) => Ok(Self::None),
+            (true, true) => None,
+            (true, false) => Some(Self::ClassMethod),
+            (false, true) => Some(Self::StaticMethod),
+            (false, false) => Some(Self::None),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2111,25 +2111,38 @@ pub(super) struct AbstractMethod<'db> {
     pub(super) kind: AbstractMethodKind,
 }
 
-/// A filter that describes which methods are considered when looking for implicit attribute assignments
-/// in [`StaticClassLiteral::implicit_attribute`].
+/// The decorator category for a method-like function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(super) enum MethodDecorator {
+pub enum MethodDecorator {
+    /// An instance method with an implicit instance receiver, conventionally named `self`.
     None,
+    /// A classmethod with an implicit class receiver, conventionally named `cls`.
     ClassMethod,
+    /// A staticmethod with no implicit receiver.
     StaticMethod,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MethodDecoratorError {
+    /// A method can't be static and a class method at the same time.
+    ConflictingDecorators,
+}
+
 impl MethodDecorator {
-    pub(crate) fn try_from_fn_type(db: &dyn Db, fn_type: FunctionType) -> Result<Self, ()> {
+    /// Returns the decorator category for a function type.
+    pub fn try_from_fn_type(
+        db: &dyn Db,
+        fn_type: FunctionType,
+    ) -> Result<Self, MethodDecoratorError> {
         match (fn_type.is_classmethod(db), fn_type.is_staticmethod(db)) {
-            (true, true) => Err(()), // A method can't be static and class method at the same time.
+            (true, true) => Err(MethodDecoratorError::ConflictingDecorators),
             (true, false) => Ok(Self::ClassMethod),
             (false, true) => Ok(Self::StaticMethod),
             (false, false) => Ok(Self::None),
         }
     }
 
+    /// Returns a concise description of this decorator category.
     pub(crate) const fn description(self) -> &'static str {
         match self {
             MethodDecorator::None => "an instance method",

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2127,7 +2127,7 @@ impl MethodDecorator {
     /// Returns the decorator category for a function type.
     pub fn try_from_fn_type(db: &dyn Db, fn_type: FunctionType) -> Option<Self> {
         match (fn_type.is_classmethod(db), fn_type.is_staticmethod(db)) {
-            (true, true) => None,  // A method can't be static and class method at the same time.
+            (true, true) => None, // A method can't be static and class method at the same time.
             (true, false) => Some(Self::ClassMethod),
             (false, true) => Some(Self::StaticMethod),
             (false, false) => Some(Self::None),

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2127,7 +2127,7 @@ impl MethodDecorator {
     /// Returns the decorator category for a function type.
     pub fn try_from_fn_type(db: &dyn Db, fn_type: FunctionType) -> Option<Self> {
         match (fn_type.is_classmethod(db), fn_type.is_staticmethod(db)) {
-            (true, true) => None,
+            (true, true) => None,  // A method can't be static and class method at the same time.
             (true, false) => Some(Self::ClassMethod),
             (false, true) => Some(Self::StaticMethod),
             (false, false) => Some(Self::None),

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -5744,9 +5744,10 @@ pub(super) fn report_invalid_method_override<'db>(
             ty: Type::FunctionLiteral(superclass_function),
             ..
         }) = class_member(superclass)
-        && let Ok(superclass_function_kind) =
+        && let Some(superclass_function_kind) =
             MethodDecorator::try_from_fn_type(db, superclass_function)
-        && let Ok(subclass_function_kind) = MethodDecorator::try_from_fn_type(db, subclass_function)
+        && let Some(subclass_function_kind) =
+            MethodDecorator::try_from_fn_type(db, subclass_function)
         && superclass_function_kind != subclass_function_kind
     {
         diagnostic.info(format_args!(

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8187,7 +8187,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .member(self.db(), id)
                 .place
                 .is_undefined(),
-            Ok(MethodDecorator::StaticMethod) | Err(()) => false,
+            Ok(MethodDecorator::StaticMethod) | Err(_) => false,
         };
 
         if attribute_exists {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8179,15 +8179,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         let attribute_exists = match MethodDecorator::try_from_fn_type(self.db(), function_type) {
-            Ok(MethodDecorator::ClassMethod) => !Type::instance(self.db(), class)
+            Some(MethodDecorator::ClassMethod) => !Type::instance(self.db(), class)
                 .class_member(self.db(), id.clone())
                 .place
                 .is_undefined(),
-            Ok(MethodDecorator::None) => !Type::instance(self.db(), class)
+            Some(MethodDecorator::None) => !Type::instance(self.db(), class)
                 .member(self.db(), id)
                 .place
                 .is_undefined(),
-            Ok(MethodDecorator::StaticMethod) | Err(_) => false,
+            Some(MethodDecorator::StaticMethod) | None => false,
         };
 
         if attribute_exists {


### PR DESCRIPTION
## Summary

We already expose `is_classmethod`, etc., on function type, and those methods already support aliasing, so the LSP just uses those directly now.

Closes https://github.com/astral-sh/ty/issues/3358.
