### PR TITLE
another desperate attempt to try to reduce the time it takes to checkout Ruff in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,8 +54,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
           persist-credentials: false
+
+      # Faster to do this separately than to use `fetch-depth: 0` with `actions/checkout`
+      - name: Fetch full history without tags
+        run: git fetch --no-tags --filter=blob:none --unshallow origin
 
       - name: Determine merge base
         id: merge_base
@@ -702,8 +705,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
           persist-credentials: false
+      # Faster to do this separately than to use `fetch-depth: 0` with `actions/checkout`
+      - name: Fetch full history without tags
+        run: git fetch --no-tags --filter=blob:none --unshallow origin
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.11.7"

--- a/.github/workflows/memory_report.yaml
+++ b/.github/workflows/memory_report.yaml
@@ -47,8 +47,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: ruff
-          fetch-depth: 0
           persist-credentials: false
+
+      # Faster to do this separately than to use `fetch-depth: 0` with `actions/checkout`
+      - name: Fetch full history without tags
+        run: git -C ruff fetch --no-tags --filter=blob:none --unshallow origin
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -51,8 +51,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: ruff
-          fetch-depth: 0
           persist-credentials: false
+
+      # Faster to do this separately than to use `fetch-depth: 0` with `actions/checkout`
+      - name: Fetch full history without tags
+        run: git -C ruff fetch --no-tags --filter=blob:none --unshallow origin
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -30,8 +30,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: ruff
-          fetch-depth: 0
           persist-credentials: false
+
+      # Faster to do this separately than to use `fetch-depth: 0` with `actions/checkout`
+      - name: Fetch full history without tags
+        run: git -C ruff fetch --no-tags --filter=blob:none --unshallow origin
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/typing_conformance.yaml
+++ b/.github/workflows/typing_conformance.yaml
@@ -48,8 +48,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: ruff
-          fetch-depth: 0
           persist-credentials: false
+
+      # Faster to do this separately than to use `fetch-depth: 0` with `actions/checkout`
+      - name: Fetch full history without tags
+        run: git -C ruff fetch --no-tags --filter=blob:none --unshallow origin
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -161,7 +161,7 @@ pub fn check_types(db: &dyn Db, file: File) -> Vec<Diagnostic> {
     for scope_id in index.scope_ids() {
         // Scopes that may require type context are inferred during the inference of
         // their outer scope.
-        if !scope_id.accepts_type_context(db) {
+        if scope_id.accepts_type_context(db) {
             continue;
         }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -161,7 +161,7 @@ pub fn check_types(db: &dyn Db, file: File) -> Vec<Diagnostic> {
     for scope_id in index.scope_ids() {
         // Scopes that may require type context are inferred during the inference of
         // their outer scope.
-        if scope_id.accepts_type_context(db) {
+        if !scope_id.accepts_type_context(db) {
             continue;
         }
 


### PR DESCRIPTION
## Summary

This appears to cut 5-10s off the CI time for the memory-report job in CI, for example.

Unlike https://github.com/astral-sh/ruff/pull/24846, this retains the use of `actions/checkout` for the initial clone, which takes care of subtle details like whether we're checking out the correct ref for the merge commit between the PR branch and the target branch, etc. etc. Claude is happy with this approach, whereas it kept on finding issues with the previous one.

## Test Plan

CI on this PR. I temporarily pushed a spurious semantic change to ensure that we were getting a fair timing comparison; otherwise, the second incremental build would be much faster than for a typical PR run.
