### PR TITLE
[ty] Increase the number of ecosystem-analyzer shards to 4

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -166,7 +166,7 @@ jobs:
   generate-report:
     name: Generate diagnostic diff report
     needs: [analyze-shards]
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Install the latest version of uv

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -111,7 +111,7 @@ jobs:
     needs: [build-ty]
     strategy:
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2, 3, 4, 5]
     runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-22.04-32' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
@@ -152,7 +152,7 @@ jobs:
             --new "${GITHUB_SHA}" \
             --exclude-newer "${EXCLUDE_NEWER}" \
             --shard "${SHARD}" \
-            --num-shards 4 \
+            --num-shards 6 \
             --output-old "diagnostics-base-${SHARD}.json" \
             --output-new "diagnostics-PR-${SHARD}.json"
 
@@ -196,6 +196,16 @@ jobs:
         with:
           name: diagnostics-shard-3
 
+      - name: Download shard 4 diagnostics
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: diagnostics-shard-4
+
+      - name: Download shard 5 diagnostics
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: diagnostics-shard-5
+
       - name: Generate reports
         id: generate-reports
         shell: bash
@@ -203,8 +213,8 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           # Merge shard diagnostics
-          jq -s '{ outputs: [.[].outputs[]] }' diagnostics-base-0.json diagnostics-base-1.json diagnostics-base-2.json diagnostics-base-3.json > diagnostics-base.json
-          jq -s '{ outputs: [.[].outputs[]] }' diagnostics-PR-0.json   diagnostics-PR-1.json   diagnostics-PR-2.json   diagnostics-PR-3.json   > diagnostics-PR.json
+          jq -s '{ outputs: [.[].outputs[]] }' diagnostics-base-0.json diagnostics-base-1.json diagnostics-base-2.json diagnostics-base-3.json diagnostics-base-4.json diagnostics-base-5.json > diagnostics-base.json
+          jq -s '{ outputs: [.[].outputs[]] }' diagnostics-PR-0.json   diagnostics-PR-1.json   diagnostics-PR-2.json   diagnostics-PR-3.json   diagnostics-PR-4.json   diagnostics-PR-5.json   > diagnostics-PR.json
 
           uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@$ECOSYSTEM_ANALYZER_COMMIT"
 

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -177,25 +177,11 @@ jobs:
           enable-cache: true
           version: "0.11.7"
 
-      - name: Download shard 0 diagnostics
+      - name: Download shard diagnostics
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: diagnostics-shard-0
-
-      - name: Download shard 1 diagnostics
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: diagnostics-shard-1
-
-      - name: Download shard 2 diagnostics
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: diagnostics-shard-2
-
-      - name: Download shard 3 diagnostics
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: diagnostics-shard-3
+          pattern: diagnostics-shard-*
+          merge-multiple: true
 
       - name: Generate reports
         id: generate-reports
@@ -203,8 +189,8 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           # Merge shard diagnostics
-          jq -s '{ outputs: [.[].outputs[]] }' diagnostics-base-0.json diagnostics-base-1.json diagnostics-base-2.json diagnostics-base-3.json > diagnostics-base.json
-          jq -s '{ outputs: [.[].outputs[]] }' diagnostics-PR-0.json   diagnostics-PR-1.json   diagnostics-PR-2.json   diagnostics-PR-3.json   > diagnostics-PR.json
+          jq -s '{ outputs: [.[].outputs[]] }' diagnostics-base-*.json > diagnostics-base.json
+          jq -s '{ outputs: [.[].outputs[]] }' diagnostics-PR-*.json   > diagnostics-PR.json
 
           uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@$ECOSYSTEM_ANALYZER_COMMIT"
 

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -53,10 +53,6 @@ jobs:
           path: ruff
           persist-credentials: false
 
-      # Faster to do this separately than to use `fetch-depth: 0` with `actions/checkout`
-      - name: Fetch full history without tags
-        run: git -C ruff fetch --no-tags --filter=blob:none --unshallow origin
-
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "ruff"
@@ -74,6 +70,9 @@ jobs:
         shell: bash
         run: |
           echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+          # Faster to do this separately than to use `fetch-depth: 0` with `actions/checkout`
+          git fetch --no-tags --filter=blob:none --unshallow origin
 
           MERGE_BASE="$(git merge-base "${GITHUB_SHA}" "origin/${GITHUB_BASE_REF}")"
           echo "merge-base=${MERGE_BASE}" >> "$GITHUB_OUTPUT"
@@ -167,7 +166,7 @@ jobs:
   generate-report:
     name: Generate diagnostic diff report
     needs: [analyze-shards]
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 5
     steps:
       - name: Install the latest version of uv

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -29,6 +29,10 @@ concurrency:
   group: ty-ecosystem-analyzer-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+defaults:
+  run:
+    shell: bash
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
@@ -67,7 +71,6 @@ jobs:
       - name: Build ty for both commits
         id: build
         working-directory: ruff
-        shell: bash
         run: |
           echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
@@ -126,7 +129,6 @@ jobs:
           name: ty-builds
 
       - name: Analyze shard ${{ matrix.shard }}
-        shell: bash
         env:
           SHARD: ${{ matrix.shard }}
           EXCLUDE_NEWER: ${{ needs.build-ty.outputs.timestamp }}
@@ -197,7 +199,6 @@ jobs:
 
       - name: Generate reports
         id: generate-reports
-        shell: bash
         env:
           REF_NAME: ${{ github.ref_name }}
         run: |

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -37,7 +37,7 @@ env:
   RUST_BACKTRACE: 1
   # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
-  ECOSYSTEM_ANALYZER_COMMIT: e7576e66e8f992b057ea92c820c04313dceda755
+  ECOSYSTEM_ANALYZER_COMMIT: 702b757c63622c7ea3cc3a271050eeab15d83aa7
 
 jobs:
   build-ty:

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -54,12 +54,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          path: ruff
           persist-credentials: false
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          workspaces: "ruff"
           lookup-only: false
 
       - name: Install Rust toolchain
@@ -70,7 +68,6 @@ jobs:
 
       - name: Build ty for both commits
         id: build
-        working-directory: ruff
         run: |
           echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
@@ -84,17 +81,17 @@ jobs:
 
           git checkout "${MERGE_BASE}"
           cargo build --package ty --profile profiling
-          cp target/profiling/ty ../ty-base
+          cp target/profiling/ty ty-base
 
           git checkout "${GITHUB_SHA}"
           cargo build --package ty --profile profiling
-          cp target/profiling/ty ../ty-pr
+          cp target/profiling/ty ty-pr
 
           # Extract project lists and config for the shard jobs
-          git show "${MERGE_BASE}:crates/ty_python_semantic/resources/primer/good.txt" > ../projects_old.txt
-          git show "${GITHUB_SHA}:crates/ty_python_semantic/resources/primer/good.txt" > ../projects_new.txt
-          cp crates/ty_python_semantic/resources/primer/flaky.txt ../projects_flaky.txt
-          cp .github/ty-ecosystem.toml ../ty-ecosystem.toml
+          git show "${MERGE_BASE}:crates/ty_python_semantic/resources/primer/good.txt" > projects_old.txt
+          cp crates/ty_python_semantic/resources/primer/good.txt projects_new.txt
+          cp crates/ty_python_semantic/resources/primer/flaky.txt projects_flaky.txt
+          cp .github/ty-ecosystem.toml ty-ecosystem.toml
 
       - name: Upload ty binaries, project lists, and config
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -111,7 +111,7 @@ jobs:
     needs: [build-ty]
     strategy:
       matrix:
-        shard: [0, 1]
+        shard: [0, 1, 2, 3]
     runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-22.04-32' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
@@ -152,7 +152,7 @@ jobs:
             --new "${GITHUB_SHA}" \
             --exclude-newer "${EXCLUDE_NEWER}" \
             --shard "${SHARD}" \
-            --num-shards 2 \
+            --num-shards 4 \
             --output-old "diagnostics-base-${SHARD}.json" \
             --output-new "diagnostics-PR-${SHARD}.json"
 
@@ -186,11 +186,15 @@ jobs:
         with:
           name: diagnostics-shard-1
 
-      - name: Merge shard diagnostics
-        shell: bash
-        run: |
-          jq -s '{ outputs: [.[].outputs[]] }' diagnostics-base-0.json diagnostics-base-1.json > diagnostics-base.json
-          jq -s '{ outputs: [.[].outputs[]] }' diagnostics-PR-0.json   diagnostics-PR-1.json   > diagnostics-PR.json
+      - name: Download shard 2 diagnostics
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: diagnostics-shard-2
+
+      - name: Download shard 3 diagnostics
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: diagnostics-shard-3
 
       - name: Generate reports
         id: generate-reports
@@ -198,6 +202,10 @@ jobs:
         env:
           REF_NAME: ${{ github.ref_name }}
         run: |
+          # Merge shard diagnostics
+          jq -s '{ outputs: [.[].outputs[]] }' diagnostics-base-0.json diagnostics-base-1.json diagnostics-base-2.json diagnostics-base-3.json > diagnostics-base.json
+          jq -s '{ outputs: [.[].outputs[]] }' diagnostics-PR-0.json   diagnostics-PR-1.json   diagnostics-PR-2.json   diagnostics-PR-3.json   > diagnostics-PR.json
+
           uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@$ECOSYSTEM_ANALYZER_COMMIT"
 
           mkdir dist

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -110,7 +110,7 @@ jobs:
     needs: [build-ty]
     strategy:
       matrix:
-        shard: [0, 1, 2, 3, 4, 5]
+        shard: [0, 1, 2, 3]
     runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-22.04-32' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
@@ -151,7 +151,7 @@ jobs:
             --new "${GITHUB_SHA}" \
             --exclude-newer "${EXCLUDE_NEWER}" \
             --shard "${SHARD}" \
-            --num-shards 6 \
+            --num-shards 4 \
             --output-old "diagnostics-base-${SHARD}.json" \
             --output-new "diagnostics-PR-${SHARD}.json"
 
@@ -195,16 +195,6 @@ jobs:
         with:
           name: diagnostics-shard-3
 
-      - name: Download shard 4 diagnostics
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: diagnostics-shard-4
-
-      - name: Download shard 5 diagnostics
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: diagnostics-shard-5
-
       - name: Generate reports
         id: generate-reports
         shell: bash
@@ -212,8 +202,8 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           # Merge shard diagnostics
-          jq -s '{ outputs: [.[].outputs[]] }' diagnostics-base-0.json diagnostics-base-1.json diagnostics-base-2.json diagnostics-base-3.json diagnostics-base-4.json diagnostics-base-5.json > diagnostics-base.json
-          jq -s '{ outputs: [.[].outputs[]] }' diagnostics-PR-0.json   diagnostics-PR-1.json   diagnostics-PR-2.json   diagnostics-PR-3.json   diagnostics-PR-4.json   diagnostics-PR-5.json   > diagnostics-PR.json
+          jq -s '{ outputs: [.[].outputs[]] }' diagnostics-base-0.json diagnostics-base-1.json diagnostics-base-2.json diagnostics-base-3.json > diagnostics-base.json
+          jq -s '{ outputs: [.[].outputs[]] }' diagnostics-PR-0.json   diagnostics-PR-1.json   diagnostics-PR-2.json   diagnostics-PR-3.json   > diagnostics-PR.json
 
           uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@$ECOSYSTEM_ANALYZER_COMMIT"
 

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -29,12 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          path: ruff
           persist-credentials: false
-
-      # Faster to do this separately than to use `fetch-depth: 0` with `actions/checkout`
-      - name: Fetch full history without tags
-        run: git -C ruff fetch --no-tags --filter=blob:none --unshallow origin
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -44,7 +39,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          workspaces: "ruff"
           lookup-only: false
 
       - name: Install Rust toolchain
@@ -56,23 +50,22 @@ jobs:
       - name: Create report
         shell: bash
         run: |
-          cd ruff
+          # Faster to do this separately than to use `fetch-depth: 0` with `actions/checkout`
+          git fetch --no-tags --filter=blob:none --unshallow origin
 
           echo "Enabling configuration overloads (see .github/ty-ecosystem.toml)"
           mkdir -p ~/.config/ty
           cp .github/ty-ecosystem.toml ~/.config/ty/ty.toml
 
-          cd ..
-
           uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@702b757c63622c7ea3cc3a271050eeab15d83aa7"
 
           ecosystem-analyzer \
             --verbose \
-            --repository ruff \
+            --repository . \
             --flaky-runs 20 \
             analyze \
             --profile=profiling \
-            --projects ruff/crates/ty_python_semantic/resources/primer/good.txt \
+            --projects crates/ty_python_semantic/resources/primer/good.txt \
             --output ecosystem-diagnostics.json
 
           mkdir dist

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -64,7 +64,7 @@ jobs:
 
           cd ..
 
-          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@e7576e66e8f992b057ea92c820c04313dceda755"
+          uv tool install "git+https://github.com/astral-sh/ecosystem-analyzer@702b757c63622c7ea3cc3a271050eeab15d83aa7"
 
           ecosystem-analyzer \
             --verbose \


### PR DESCRIPTION
## Summary

This leads to the longest-running shard going from taking >2m10s to taking 1m34s.

Increasing the number of shards _even more_ (to 6, say) cuts even more time off the workflow. But each increase in the number of shards has diminishing marginal returns, and also comes at a cost: I believe we have a fixed pool of depot runners across the organisation, so if multiple ty PRs are leading to ecosystem-analyzer being run simultaneously, that could mean there are fewer depot runners for folks working on uv or python-build-standalone. I think that's just something we'll have to monitor?

FWIW, typeshed shards mypy_primer between 4 workers in its CI, and mypy shards it between 5.

## Test Plan

CI on this PR.
