### PR TITLE
Switch to `gen-lsp-types` to provide LSP types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,6 +1243,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "gen-lsp-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0af56ad77049db9a3ccf0ec5605561d71c674688b467c429175df54ea5886151"
+dependencies = [
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1978,18 +1989,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
-]
-
-[[package]]
-name = "lsp-types"
-version = "0.95.1"
-source = "git+https://github.com/astral-sh/lsp-types.git?rev=e15db0593f0ecbbd80599c3f5880e4bf5da1ca0c#e15db0593f0ecbbd80599c3f5880e4bf5da1ca0c"
-dependencies = [
- "bitflags 1.3.2",
- "serde",
- "serde_json",
- "serde_repr",
- "url",
 ]
 
 [[package]]
@@ -3515,12 +3514,12 @@ dependencies = [
  "anyhow",
  "crossbeam",
  "dunce",
+ "gen-lsp-types",
  "ignore",
  "insta",
  "jod-thread",
  "libc",
  "lsp-server",
- "lsp-types",
  "regex",
  "ruff_db",
  "ruff_diagnostics",
@@ -3836,26 +3835,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4742,11 +4730,11 @@ dependencies = [
  "bitflags 2.11.1",
  "crossbeam",
  "dunce",
+ "gen-lsp-types",
  "insta",
  "jod-thread",
  "libc",
  "lsp-server",
- "lsp-types",
  "regex",
  "ruff_db",
  "ruff_diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,9 +131,7 @@ libc = { version = "0.2.153" }
 libcst = { version = "1.8.4", default-features = false }
 log = { version = "0.4.17" }
 lsp-server = { version = "0.7.6" }
-lsp-types = { git = "https://github.com/astral-sh/lsp-types.git", rev = "e15db0593f0ecbbd80599c3f5880e4bf5da1ca0c", features = [
-    "proposed",
-] }
+lsp-types = { package = "gen-lsp-types", version = "0.8.0", features = ["url"] }
 matchit = { version = "0.9.0" }
 memchr = { version = "2.7.1" }
 mimalloc = { version = "0.1.49", features = ["v2"] }

--- a/crates/ruff_server/src/edit.rs
+++ b/crates/ruff_server/src/edit.rs
@@ -7,7 +7,7 @@ mod text_document;
 
 use std::collections::HashMap;
 
-use lsp_types::{PositionEncodingKind, Url};
+use lsp_types::{DocumentChange, PositionEncodingKind, TextDocumentIdentifier, Uri};
 pub(crate) use notebook::NotebookDocument;
 pub(crate) use range::{NotebookRange, RangeExt, ToRangeExt};
 pub(crate) use replacement::Replacement;
@@ -41,22 +41,22 @@ impl From<PositionEncoding> for ruff_source_file::PositionEncoding {
     }
 }
 
-/// A unique document ID, derived from a URL passed as part of an LSP request.
+/// A unique document ID, derived from a URI passed as part of an LSP request.
 /// This document ID can point to either be a standalone Python file, a full notebook, or a cell within a notebook.
 #[derive(Clone, Debug)]
 pub(crate) enum DocumentKey {
-    Notebook(Url),
-    NotebookCell(Url),
-    Text(Url),
+    Notebook(Uri),
+    NotebookCell(Uri),
+    Text(Uri),
 }
 
 impl DocumentKey {
-    /// Converts the key back into its original URL.
-    pub(crate) fn into_url(self) -> Url {
+    /// Converts the key back into its original URI.
+    pub(crate) fn into_uri(self) -> Uri {
         match self {
-            DocumentKey::NotebookCell(url)
-            | DocumentKey::Notebook(url)
-            | DocumentKey::Text(url) => url,
+            DocumentKey::NotebookCell(uri)
+            | DocumentKey::Notebook(uri)
+            | DocumentKey::Text(uri) => uri,
         }
     }
 }
@@ -64,7 +64,7 @@ impl DocumentKey {
 impl std::fmt::Display for DocumentKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::NotebookCell(url) | Self::Notebook(url) | Self::Text(url) => url.fmt(f),
+            Self::NotebookCell(uri) | Self::Notebook(uri) | Self::Text(uri) => uri.fmt(f),
         }
     }
 }
@@ -74,7 +74,7 @@ impl std::fmt::Display for DocumentKey {
 #[derive(Debug)]
 pub(crate) enum WorkspaceEditTracker {
     DocumentChanges(Vec<lsp_types::TextDocumentEdit>),
-    Changes(HashMap<Url, Vec<lsp_types::TextEdit>>),
+    Changes(HashMap<Uri, Vec<lsp_types::TextEdit>>),
 }
 
 impl From<PositionEncoding> for lsp_types::PositionEncodingKind {
@@ -129,7 +129,7 @@ impl WorkspaceEditTracker {
     /// multiple times.
     pub(crate) fn set_edits_for_document(
         &mut self,
-        uri: Url,
+        uri: Uri,
         _version: DocumentVersion,
         edits: Vec<lsp_types::TextEdit>,
     ) -> crate::Result<()> {
@@ -137,7 +137,7 @@ impl WorkspaceEditTracker {
             Self::DocumentChanges(document_edits) => {
                 if document_edits
                     .iter()
-                    .any(|document| document.text_document.uri == uri)
+                    .any(|document| document.text_document.text_document_identifier.uri == uri)
                 {
                     return Err(anyhow::anyhow!(
                         "Attempted to add edits for a document that was already edited"
@@ -145,11 +145,11 @@ impl WorkspaceEditTracker {
                 }
                 document_edits.push(lsp_types::TextDocumentEdit {
                     text_document: lsp_types::OptionalVersionedTextDocumentIdentifier {
-                        uri,
+                        text_document_identifier: TextDocumentIdentifier { uri },
                         // TODO(jane): Re-enable versioned edits after investigating whether it could work with notebook cells
                         version: None,
                     },
-                    edits: edits.into_iter().map(lsp_types::OneOf::Left).collect(),
+                    edits: edits.into_iter().map(lsp_types::Edit::TextEdit).collect(),
                 });
                 Ok(())
             }
@@ -175,10 +175,15 @@ impl WorkspaceEditTracker {
     pub(crate) fn into_workspace_edit(self) -> lsp_types::WorkspaceEdit {
         match self {
             Self::DocumentChanges(document_edits) => lsp_types::WorkspaceEdit {
-                document_changes: Some(lsp_types::DocumentChanges::Edits(document_edits)),
+                document_changes: Some(
+                    document_edits
+                        .into_iter()
+                        .map(DocumentChange::TextDocumentEdit)
+                        .collect(),
+                ),
                 ..Default::default()
             },
-            Self::Changes(changes) => lsp_types::WorkspaceEdit::new(changes),
+            Self::Changes(changes) => lsp_types::WorkspaceEdit::new(Some(changes), None, None),
         }
     }
 }

--- a/crates/ruff_server/src/edit/notebook.rs
+++ b/crates/ruff_server/src/edit/notebook.rs
@@ -2,6 +2,7 @@ use anyhow::Ok;
 use lsp_types::NotebookCellKind;
 use ruff_notebook::CellMetadata;
 use rustc_hash::{FxBuildHasher, FxHashMap};
+use serde_json::Map;
 
 use crate::{PositionEncoding, TextDocument};
 
@@ -16,14 +17,14 @@ pub(crate) struct NotebookDocument {
     cells: Vec<NotebookCell>,
     metadata: ruff_notebook::RawNotebookMetadata,
     version: DocumentVersion,
-    // Used to quickly find the index of a cell for a given URL.
-    cell_index: FxHashMap<lsp_types::Url, CellId>,
+    // Used to quickly find the index of a cell for a given URI.
+    cell_index: FxHashMap<lsp_types::Uri, CellId>,
 }
 
 /// A single cell within a notebook, which has text contents represented as a `TextDocument`.
 #[derive(Clone, Debug)]
 struct NotebookCell {
-    url: lsp_types::Url,
+    uri: lsp_types::Uri,
     kind: NotebookCellKind,
     document: TextDocument,
 }
@@ -32,7 +33,7 @@ impl NotebookDocument {
     pub(crate) fn new(
         version: DocumentVersion,
         cells: Vec<lsp_types::NotebookCell>,
-        metadata: serde_json::Map<String, serde_json::Value>,
+        metadata: Map<String, serde_json::Value>,
         cell_documents: Vec<lsp_types::TextDocumentItem>,
     ) -> crate::Result<Self> {
         let mut cell_contents: FxHashMap<_, _> = cell_documents
@@ -97,14 +98,14 @@ impl NotebookDocument {
 
     pub(crate) fn update(
         &mut self,
-        cells: Option<lsp_types::NotebookDocumentCellChange>,
-        metadata_change: Option<serde_json::Map<String, serde_json::Value>>,
+        cells: Option<lsp_types::NotebookDocumentCellChanges>,
+        metadata_change: Option<Map<String, serde_json::Value>>,
         version: DocumentVersion,
         encoding: PositionEncoding,
     ) -> crate::Result<()> {
         self.version = version;
 
-        if let Some(lsp_types::NotebookDocumentCellChange {
+        if let Some(lsp_types::NotebookDocumentCellChanges {
             structure,
             data,
             text_content,
@@ -127,8 +128,8 @@ impl NotebookDocument {
                 // First, delete the cells and remove them from the index.
                 if delete > 0 {
                     for cell in self.cells.drain(start..start + delete) {
-                        self.cell_index.remove(&cell.url);
-                        deleted_cells.insert(cell.url, cell.document);
+                        self.cell_index.remove(&cell.uri);
+                        deleted_cells.insert(cell.uri, cell.document);
                     }
                 }
 
@@ -150,7 +151,7 @@ impl NotebookDocument {
                 // Third, register the new cells in the index and update existing ones that came
                 // after the insertion.
                 for (index, cell) in self.cells.iter().enumerate().skip(start) {
-                    self.cell_index.insert(cell.url.clone(), index);
+                    self.cell_index.insert(cell.uri.clone(), index);
                 }
 
                 // Finally, update the text document that represents the cell with the actual
@@ -178,7 +179,9 @@ impl NotebookDocument {
 
             if let Some(content_changes) = text_content {
                 for content_change in content_changes {
-                    if let Some(cell) = self.cell_by_uri_mut(&content_change.document.uri) {
+                    if let Some(cell) =
+                        self.cell_by_uri_mut(&content_change.document.text_document_identifier.uri)
+                    {
                         cell.document
                             .apply_changes(content_change.changes, version, encoding);
                     }
@@ -187,7 +190,7 @@ impl NotebookDocument {
         }
 
         if let Some(metadata_change) = metadata_change {
-            self.metadata = serde_json::from_value(serde_json::Value::Object(metadata_change))?;
+            self.metadata = serde_json::from_value(serde_json::to_value(metadata_change)?)?;
         }
 
         Ok(())
@@ -199,30 +202,30 @@ impl NotebookDocument {
     }
 
     /// Get the URI for a cell by its index within the cell array.
-    pub(crate) fn cell_uri_by_index(&self, index: CellId) -> Option<&lsp_types::Url> {
-        self.cells.get(index).map(|cell| &cell.url)
+    pub(crate) fn cell_uri_by_index(&self, index: CellId) -> Option<&lsp_types::Uri> {
+        self.cells.get(index).map(|cell| &cell.uri)
     }
 
     /// Get the text document representing the contents of a cell by the cell URI.
-    pub(crate) fn cell_document_by_uri(&self, uri: &lsp_types::Url) -> Option<&TextDocument> {
+    pub(crate) fn cell_document_by_uri(&self, uri: &lsp_types::Uri) -> Option<&TextDocument> {
         self.cells
             .get(*self.cell_index.get(uri)?)
             .map(|cell| &cell.document)
     }
 
     /// Returns a list of cell URIs in the order they appear in the array.
-    pub(crate) fn urls(&self) -> impl Iterator<Item = &lsp_types::Url> {
-        self.cells.iter().map(|cell| &cell.url)
+    pub(crate) fn uris(&self) -> impl Iterator<Item = &lsp_types::Uri> {
+        self.cells.iter().map(|cell| &cell.uri)
     }
 
-    fn cell_by_uri_mut(&mut self, uri: &lsp_types::Url) -> Option<&mut NotebookCell> {
+    fn cell_by_uri_mut(&mut self, uri: &lsp_types::Uri) -> Option<&mut NotebookCell> {
         self.cells.get_mut(*self.cell_index.get(uri)?)
     }
 
-    fn make_cell_index(cells: &[NotebookCell]) -> FxHashMap<lsp_types::Url, CellId> {
+    fn make_cell_index(cells: &[NotebookCell]) -> FxHashMap<lsp_types::Uri, CellId> {
         let mut index = FxHashMap::with_capacity_and_hasher(cells.len(), FxBuildHasher);
         for (i, cell) in cells.iter().enumerate() {
-            index.insert(cell.url.clone(), i);
+            index.insert(cell.uri.clone(), i);
         }
         index
     }
@@ -235,7 +238,7 @@ impl NotebookCell {
         version: DocumentVersion,
     ) -> Self {
         Self {
-            url: cell.document,
+            uri: cell.document,
             kind: cell.kind,
             document: TextDocument::new(contents, version),
         }
@@ -244,6 +247,10 @@ impl NotebookCell {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::Map;
+
+    use lsp_types::LanguageKind;
+
     use super::NotebookDocument;
 
     enum TestCellContent {
@@ -252,8 +259,8 @@ mod tests {
         Code(String),
     }
 
-    fn create_test_url(index: usize) -> lsp_types::Url {
-        lsp_types::Url::parse(&format!("cell:/test.ipynb#{index}")).unwrap()
+    fn create_test_uri(index: usize) -> lsp_types::Uri {
+        lsp_types::Uri::parse(&format!("cell:/test.ipynb#{index}")).unwrap()
     }
 
     fn create_test_notebook(test_cells: Vec<TestCellContent>) -> NotebookDocument {
@@ -261,18 +268,18 @@ mod tests {
         let mut cell_documents = Vec::with_capacity(test_cells.len());
 
         for (index, test_cell) in test_cells.into_iter().enumerate() {
-            let url = create_test_url(index);
+            let uri = create_test_uri(index);
             match test_cell {
                 TestCellContent::Markup(content) => {
                     cells.push(lsp_types::NotebookCell {
                         kind: lsp_types::NotebookCellKind::Markup,
-                        document: url.clone(),
+                        document: uri.clone(),
                         metadata: None,
                         execution_summary: None,
                     });
                     cell_documents.push(lsp_types::TextDocumentItem {
-                        uri: url,
-                        language_id: "markdown".to_owned(),
+                        uri,
+                        language_id: LanguageKind::new("markdown"),
                         version: 0,
                         text: content,
                     });
@@ -280,13 +287,13 @@ mod tests {
                 TestCellContent::Code(content) => {
                     cells.push(lsp_types::NotebookCell {
                         kind: lsp_types::NotebookCellKind::Code,
-                        document: url.clone(),
+                        document: uri.clone(),
                         metadata: None,
                         execution_summary: None,
                     });
                     cell_documents.push(lsp_types::TextDocumentItem {
-                        uri: url,
-                        language_id: "python".to_owned(),
+                        uri,
+                        language_id: LanguageKind::new("python"),
                         version: 0,
                         text: content,
                     });
@@ -294,7 +301,7 @@ mod tests {
             }
         }
 
-        NotebookDocument::new(0, cells, serde_json::Map::default(), cell_documents).unwrap()
+        NotebookDocument::new(0, cells, Map::default(), cell_documents).unwrap()
     }
 
     /// This test case checks that for a notebook with three code cells, when the client sends a
@@ -312,7 +319,7 @@ mod tests {
 
         notebook
             .update(
-                Some(lsp_types::NotebookDocumentCellChange {
+                Some(lsp_types::NotebookDocumentCellChanges {
                     structure: Some(lsp_types::NotebookDocumentCellChangeStructure {
                         array: lsp_types::NotebookCellArrayChange {
                             start: 0,
@@ -320,13 +327,13 @@ mod tests {
                             cells: Some(vec![
                                 lsp_types::NotebookCell {
                                     kind: lsp_types::NotebookCellKind::Code,
-                                    document: create_test_url(1),
+                                    document: create_test_uri(1),
                                     metadata: None,
                                     execution_summary: None,
                                 },
                                 lsp_types::NotebookCell {
                                     kind: lsp_types::NotebookCellKind::Code,
-                                    document: create_test_url(0),
+                                    document: create_test_uri(0),
                                     metadata: None,
                                     execution_summary: None,
                                 },

--- a/crates/ruff_server/src/edit/text_document.rs
+++ b/crates/ruff_server/src/edit/text_document.rs
@@ -1,4 +1,7 @@
-use lsp_types::TextDocumentContentChangeEvent;
+use lsp_types::{
+    LanguageKind, TextDocumentContentChangeEvent, TextDocumentContentChangePartial,
+    TextDocumentContentChangeWholeDocument,
+};
 use ruff_source_file::LineIndex;
 
 use crate::PositionEncoding;
@@ -31,11 +34,11 @@ pub enum LanguageId {
     Other,
 }
 
-impl From<&str> for LanguageId {
-    fn from(language_id: &str) -> Self {
+impl From<LanguageKind> for LanguageId {
+    fn from(language_id: LanguageKind) -> Self {
         match language_id {
-            "python" => Self::Python,
-            "markdown" => Self::Markdown,
+            LanguageKind::Python => Self::Python,
+            LanguageKind::Markdown => Self::Markdown,
             _ => Self::Other,
         }
     }
@@ -53,7 +56,7 @@ impl TextDocument {
     }
 
     #[must_use]
-    pub fn with_language_id(mut self, language_id: &str) -> Self {
+    pub fn with_language_id(mut self, language_id: LanguageKind) -> Self {
         self.language_id = Some(LanguageId::from(language_id));
         self
     }
@@ -85,9 +88,9 @@ impl TextDocument {
         encoding: PositionEncoding,
     ) {
         if let [
-            lsp_types::TextDocumentContentChangeEvent {
-                range: None, text, ..
-            },
+            TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument { text },
+            ),
         ] = changes.as_slice()
         {
             tracing::debug!("Fast path - replacing entire document");
@@ -101,21 +104,21 @@ impl TextDocument {
         let mut new_contents = self.contents().to_string();
         let mut active_index = self.index().clone();
 
-        for TextDocumentContentChangeEvent {
-            range,
-            text: change,
-            ..
-        } in changes
-        {
-            if let Some(range) = range {
-                let range = range.to_text_range(&new_contents, &active_index, encoding);
+        for change in changes {
+            match change {
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial { range, text, .. },
+                ) => {
+                    let range = range.to_text_range(&new_contents, &active_index, encoding);
 
-                new_contents.replace_range(
-                    usize::from(range.start())..usize::from(range.end()),
-                    &change,
-                );
-            } else {
-                new_contents = change;
+                    new_contents
+                        .replace_range(usize::from(range.start())..usize::from(range.end()), &text);
+                }
+                TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                    TextDocumentContentChangeWholeDocument { text },
+                ) => {
+                    new_contents = text;
+                }
             }
 
             active_index = LineIndex::from_source_text(&new_contents);
@@ -156,7 +159,7 @@ impl TextDocument {
 #[cfg(test)]
 mod tests {
     use crate::{PositionEncoding, TextDocument};
-    use lsp_types::{Position, TextDocumentContentChangeEvent};
+    use lsp_types::{Position, TextDocumentContentChangeEvent, TextDocumentContentChangePartial};
 
     #[test]
     fn redo_edit() {
@@ -179,30 +182,27 @@ def interface():
         // Add an `s`, remove it again (back to the original code), and then re-add the `s`
         document.apply_changes(
             vec![
-                TextDocumentContentChangeEvent {
-                    range: Some(lsp_types::Range::new(
-                        Position::new(9, 7),
-                        Position::new(9, 7),
-                    )),
-                    range_length: Some(0),
-                    text: "s".to_string(),
-                },
-                TextDocumentContentChangeEvent {
-                    range: Some(lsp_types::Range::new(
-                        Position::new(9, 7),
-                        Position::new(9, 8),
-                    )),
-                    range_length: Some(1),
-                    text: String::new(),
-                },
-                TextDocumentContentChangeEvent {
-                    range: Some(lsp_types::Range::new(
-                        Position::new(9, 7),
-                        Position::new(9, 7),
-                    )),
-                    range_length: Some(0),
-                    text: "s".to_string(),
-                },
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial {
+                        range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 7)),
+                        text: "s".to_string(),
+                        ..Default::default()
+                    },
+                ),
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial {
+                        range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 8)),
+                        text: String::new(),
+                        ..Default::default()
+                    },
+                ),
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial {
+                        range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 7)),
+                        text: "s".to_string(),
+                        ..Default::default()
+                    },
+                ),
             ],
             1,
             PositionEncoding::UTF16,

--- a/crates/ruff_server/src/fix.rs
+++ b/crates/ruff_server/src/fix.rs
@@ -20,7 +20,7 @@ use ruff_source_file::LineIndex;
 
 /// A simultaneous fix made across a single text document or among an arbitrary
 /// number of notebook cells.
-pub(crate) type Fixes = FxHashMap<lsp_types::Url, Vec<lsp_types::TextEdit>>;
+pub(crate) type Fixes = FxHashMap<lsp_types::Uri, Vec<lsp_types::TextEdit>>;
 
 pub(crate) fn fix_all(
     query: &DocumentQuery,
@@ -102,12 +102,12 @@ pub(crate) fn fix_all(
             anyhow::bail!("Notebook document expected from notebook source kind");
         };
         let mut fixes = Fixes::default();
-        for ((source, modified), url) in source_notebook
+        for ((source, modified), uri) in source_notebook
             .cells()
             .iter()
             .map(cell_source)
             .zip(modified_notebook.cells().iter().map(cell_source))
-            .zip(notebook.urls())
+            .zip(notebook.uris())
         {
             let source_index = LineIndex::from_source_text(&source);
             let modified_index = LineIndex::from_source_text(&modified);
@@ -123,7 +123,7 @@ pub(crate) fn fix_all(
             );
 
             fixes.insert(
-                url.clone(),
+                uri.clone(),
                 vec![lsp_types::TextEdit {
                     range: source_range.to_range(&source, &source_index, encoding),
                     new_text: modified[modified_range].to_owned(),
@@ -147,7 +147,7 @@ pub(crate) fn fix_all(
             modified_index.line_starts(),
         );
         Ok([(
-            query.make_key().into_url(),
+            query.make_key().into_uri(),
             vec![lsp_types::TextEdit {
                 range: source_range.to_range(source_kind.source_code(), &source_index, encoding),
                 new_text: modified[modified_range].to_owned(),

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -62,7 +62,7 @@ pub(crate) struct DiagnosticFix {
 }
 
 /// A series of diagnostics across a single text document or an arbitrary number of notebook cells.
-pub(crate) type DiagnosticsMap = FxHashMap<lsp_types::Url, Vec<lsp_types::Diagnostic>>;
+pub(crate) type DiagnosticsMap = FxHashMap<lsp_types::Uri, Vec<lsp_types::Diagnostic>>;
 
 pub(crate) fn check(
     query: &DocumentQuery,
@@ -163,12 +163,12 @@ pub(crate) fn check(
     // Populates all relevant URLs with an empty diagnostic list.
     // This ensures that documents without diagnostics still get updated.
     if let Some(notebook) = query.as_notebook() {
-        for url in notebook.urls() {
-            diagnostics_map.entry(url.clone()).or_default();
+        for uri in notebook.uris() {
+            diagnostics_map.entry(uri.clone()).or_default();
         }
     } else {
         diagnostics_map
-            .entry(query.make_key().into_url())
+            .entry(query.make_key().into_uri())
             .or_default();
     }
 
@@ -203,7 +203,7 @@ pub(crate) fn check(
         }
     } else {
         diagnostics_map
-            .entry(query.make_key().into_url())
+            .entry(query.make_key().into_uri())
             .or_default()
             .extend(lsp_diagnostics.map(|(_, diagnostic)| diagnostic));
     }
@@ -302,10 +302,10 @@ fn to_lsp_diagnostic(
     } else {
         (
             match diagnostic.severity() {
-                ruff_db::diagnostic::Severity::Info => lsp_types::DiagnosticSeverity::INFORMATION,
-                ruff_db::diagnostic::Severity::Warning => lsp_types::DiagnosticSeverity::WARNING,
-                ruff_db::diagnostic::Severity::Error => lsp_types::DiagnosticSeverity::ERROR,
-                ruff_db::diagnostic::Severity::Fatal => lsp_types::DiagnosticSeverity::ERROR,
+                ruff_db::diagnostic::Severity::Info => lsp_types::DiagnosticSeverity::Information,
+                ruff_db::diagnostic::Severity::Warning => lsp_types::DiagnosticSeverity::Warning,
+                ruff_db::diagnostic::Severity::Error => lsp_types::DiagnosticSeverity::Error,
+                ruff_db::diagnostic::Severity::Fatal => lsp_types::DiagnosticSeverity::Error,
             },
             diagnostic.secondary_code_or_id().to_string(),
         )
@@ -317,14 +317,14 @@ fn to_lsp_diagnostic(
             range,
             severity: Some(severity),
             tags: tags(diagnostic),
-            code: Some(lsp_types::NumberOrString::String(code)),
+            code: Some(lsp_types::Code::String(code)),
             code_description: diagnostic.documentation_url().and_then(|url| {
                 Some(lsp_types::CodeDescription {
-                    href: lsp_types::Url::parse(url).ok()?,
+                    href: lsp_types::Uri::parse(url).ok()?,
                 })
             }),
             source: Some(DIAGNOSTIC_NAME.into()),
-            message: body,
+            message: body.into(),
             related_information: None,
             data,
         },
@@ -350,8 +350,8 @@ fn severity(code: &str) -> lsp_types::DiagnosticSeverity {
     match code {
         // F821: undefined name <name>
         // E902: IOError
-        "F821" | "E902" => lsp_types::DiagnosticSeverity::ERROR,
-        _ => lsp_types::DiagnosticSeverity::WARNING,
+        "F821" | "E902" => lsp_types::DiagnosticSeverity::Error,
+        _ => lsp_types::DiagnosticSeverity::Warning,
     }
 }
 
@@ -360,10 +360,10 @@ fn tags(diagnostic: &Diagnostic) -> Option<Vec<lsp_types::DiagnosticTag>> {
         tags.iter()
             .map(|tag| match tag {
                 ruff_db::diagnostic::DiagnosticTag::Unnecessary => {
-                    lsp_types::DiagnosticTag::UNNECESSARY
+                    lsp_types::DiagnosticTag::Unnecessary
                 }
                 ruff_db::diagnostic::DiagnosticTag::Deprecated => {
-                    lsp_types::DiagnosticTag::DEPRECATED
+                    lsp_types::DiagnosticTag::Deprecated
                 }
             })
             .collect()

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -4,6 +4,9 @@ use lsp_server::Connection;
 use lsp_types as types;
 use lsp_types::InitializeParams;
 use lsp_types::MessageType;
+use lsp_types::NotebookCellLanguage;
+use lsp_types::NotebookDocumentFilterWithCells;
+use lsp_types::WorkspaceFoldersInitializeParams;
 use std::num::NonZeroUsize;
 use std::panic::PanicHookInfo;
 use std::str::FromStr;
@@ -12,11 +15,7 @@ use types::ClientCapabilities;
 use types::CodeActionKind;
 use types::CodeActionOptions;
 use types::DiagnosticOptions;
-use types::NotebookCellSelector;
 use types::NotebookDocumentSyncOptions;
-use types::NotebookSelector;
-use types::OneOf;
-use types::TextDocumentSyncCapability;
 use types::TextDocumentSyncKind;
 use types::TextDocumentSyncOptions;
 use types::WorkDoneProgressOptions;
@@ -73,7 +72,8 @@ impl Server {
 
         let InitializeParams {
             initialization_options,
-            workspace_folders,
+            workspace_folders_initialize_params:
+                WorkspaceFoldersInitializeParams { workspace_folders },
             ..
         } = init_params;
 
@@ -153,7 +153,7 @@ impl Server {
     fn server_capabilities(position_encoding: PositionEncoding) -> types::ServerCapabilities {
         types::ServerCapabilities {
             position_encoding: Some(position_encoding.into()),
-            code_action_provider: Some(types::CodeActionProviderCapability::Options(
+            code_action_provider: Some(
                 CodeActionOptions {
                     code_action_kinds: Some(
                         SupportedCodeAction::all()
@@ -164,18 +164,21 @@ impl Server {
                         work_done_progress: Some(true),
                     },
                     resolve_provider: Some(true),
-                },
-            )),
-            workspace: Some(types::WorkspaceServerCapabilities {
+                    documentation: None,
+                }
+                .into(),
+            ),
+            workspace: Some(types::WorkspaceOptions {
                 workspace_folders: Some(WorkspaceFoldersServerCapabilities {
                     supported: Some(true),
-                    change_notifications: Some(OneOf::Left(true)),
+                    change_notifications: Some(true.into()),
                 }),
                 file_operations: None,
+                text_document_content: None,
             }),
-            document_formatting_provider: Some(OneOf::Left(true)),
-            document_range_formatting_provider: Some(OneOf::Left(true)),
-            diagnostic_provider: Some(types::DiagnosticServerCapabilities::Options(
+            document_formatting_provider: Some(true.into()),
+            document_range_formatting_provider: Some(true.into()),
+            diagnostic_provider: Some(
                 DiagnosticOptions {
                     identifier: Some(crate::DIAGNOSTIC_NAME.into()),
                     // multi-file analysis could change this
@@ -184,8 +187,9 @@ impl Server {
                     work_done_progress_options: WorkDoneProgressOptions {
                         work_done_progress: Some(true),
                     },
-                },
-            )),
+                }
+                .into(),
+            ),
             execute_command_provider: Some(types::ExecuteCommandOptions {
                 commands: SupportedCommand::all()
                     .map(|command| command.identifier().to_string())
@@ -194,26 +198,32 @@ impl Server {
                     work_done_progress: Some(false),
                 },
             }),
-            hover_provider: Some(types::HoverProviderCapability::Simple(true)),
-            notebook_document_sync: Some(types::OneOf::Left(NotebookDocumentSyncOptions {
-                save: Some(false),
-                notebook_selector: [NotebookSelector::ByCells {
-                    notebook: None,
-                    cells: vec![NotebookCellSelector {
-                        language: "python".to_string(),
-                    }],
-                }]
-                .to_vec(),
-            })),
-            text_document_sync: Some(TextDocumentSyncCapability::Options(
+            hover_provider: Some(true.into()),
+            notebook_document_sync: Some(
+                NotebookDocumentSyncOptions {
+                    save: Some(false),
+                    notebook_selector: vec![
+                        NotebookDocumentFilterWithCells {
+                            notebook: None,
+                            cells: vec![NotebookCellLanguage {
+                                language: "python".to_string(),
+                            }],
+                        }
+                        .into(),
+                    ],
+                }
+                .into(),
+            ),
+            text_document_sync: Some(
                 TextDocumentSyncOptions {
                     open_close: Some(true),
-                    change: Some(TextDocumentSyncKind::INCREMENTAL),
+                    change: Some(TextDocumentSyncKind::Incremental),
                     will_save: Some(false),
                     will_save_wait_until: Some(false),
-                    ..Default::default()
-                },
-            )),
+                    save: None,
+                }
+                .into(),
+            ),
             ..Default::default()
         }
     }
@@ -246,7 +256,7 @@ impl SupportedCodeAction {
     /// Returns the LSP code action kind that map to this code action.
     fn to_kind(self) -> CodeActionKind {
         match self {
-            Self::QuickFix => CodeActionKind::QUICKFIX,
+            Self::QuickFix => CodeActionKind::QuickFix,
             Self::SourceFixAll => crate::SOURCE_FIX_ALL_RUFF,
             Self::SourceOrganizeImports => crate::SOURCE_ORGANIZE_IMPORTS_RUFF,
             Self::NotebookSourceFixAll => crate::NOTEBOOK_SOURCE_FIX_ALL_RUFF,
@@ -360,7 +370,7 @@ impl ServerPanicHookHandler {
                 client
                     .show_message(
                         "The Ruff language server exited with a panic. See the logs for more details.",
-                        MessageType::ERROR,
+                        MessageType::Error,
                     )
                     .ok();
             }

--- a/crates/ruff_server/src/server/api.rs
+++ b/crates/ruff_server/src/server/api.rs
@@ -2,7 +2,7 @@ use std::panic::UnwindSafe;
 
 use anyhow::anyhow;
 use lsp_server::{self as server, RequestId};
-use lsp_types::{notification::Notification, request::Request};
+use lsp_types::{LspNotificationMethod, LspRequestMethod, Notification, Request};
 use notifications as notification;
 use requests as request;
 
@@ -23,20 +23,20 @@ use self::traits::{NotificationHandler, RequestHandler};
 
 use super::{Result, schedule::BackgroundSchedule};
 
-/// Defines the `document_url` method for implementers of [`Request`], given the request parameter
+/// Defines the `document_uri` method for implementers of [`Request`], given the request parameter
 /// type.
 ///
 /// This would only work if the parameter type has a `text_document` field with a `uri` field
-/// that is of type [`lsp_types::Url`].
-macro_rules! define_document_url {
+/// that is of type [`lsp_types::Uri`].
+macro_rules! define_document_uri {
     ($params:ident: &$p:ty) => {
-        fn document_url($params: &$p) -> std::borrow::Cow<'_, lsp_types::Url> {
+        fn document_uri($params: &$p) -> std::borrow::Cow<'_, lsp_types::Uri> {
             std::borrow::Cow::Borrowed(&$params.text_document.uri)
         }
     };
 }
 
-use define_document_url;
+use define_document_uri;
 
 /// Processes a request from the client to the server.
 ///
@@ -47,7 +47,7 @@ use define_document_url;
 pub(super) fn request(req: server::Request) -> Task {
     let id = req.id.clone();
 
-    match req.method.as_str() {
+    match LspRequestMethod::from(req.method.as_str()) {
         request::CodeActions::METHOD => {
             background_request_task::<request::CodeActions>(req, BackgroundSchedule::Worker)
         }
@@ -67,7 +67,7 @@ pub(super) fn request(req: server::Request) -> Task {
         request::Hover::METHOD => {
             background_request_task::<request::Hover>(req, BackgroundSchedule::Worker)
         }
-        lsp_types::request::Shutdown::METHOD => sync_request_task::<requests::ShutdownHandler>(req),
+        lsp_types::ShutdownRequest::METHOD => sync_request_task::<requests::ShutdownHandler>(req),
         method => {
             tracing::warn!("Received request {method} which does not have a handler");
             let result: Result<()> = Err(Error::new(
@@ -98,7 +98,7 @@ pub(super) fn request(req: server::Request) -> Task {
 }
 
 pub(super) fn notification(notif: server::Notification) -> Task {
-    match notif.method.as_str() {
+    match LspNotificationMethod::from(notif.method.as_str()) {
         notification::DidChange::METHOD => {
             sync_notification_task::<notification::DidChange>(notif)
         }
@@ -122,10 +122,10 @@ pub(super) fn notification(notif: server::Notification) -> Task {
         notification::DidCloseNotebook::METHOD => {
             sync_notification_task::<notification::DidCloseNotebook>(notif)
         }
-        lsp_types::notification::Cancel::METHOD => {
+        lsp_types::CancelNotification::METHOD => {
             sync_notification_task::<notifications::CancelNotificationHandler>(notif)
         }
-        lsp_types::notification::SetTrace::METHOD => {
+        lsp_types::SetTraceNotification::METHOD => {
             tracing::trace!("Ignoring `setTrace` notification");
             return Task::nothing();
         }
@@ -150,7 +150,7 @@ where
 {
     let (id, params) = cast_request::<R>(req)?;
     Ok(Task::sync(move |session, client: &Client| {
-        let _span = tracing::debug_span!("request", %id, method = R::METHOD).entered();
+        let _span = tracing::debug_span!("request", %id, method = %R::METHOD).entered();
         let result = R::run(session, client, params);
         respond::<R>(&id, result, client);
     }))
@@ -176,7 +176,7 @@ where
         let snapshot = R::snapshot(session, &params);
 
         Box::new(move |client| {
-            let _span = tracing::debug_span!("request", %id, method = R::METHOD).entered();
+            let _span = tracing::debug_span!("request", %id, method = %R::METHOD).entered();
 
             // Test again if the request was cancelled since it was scheduled on the background task
             // and, if so, return early
@@ -229,7 +229,7 @@ where
 fn sync_notification_task<N: SyncNotificationHandler>(notif: server::Notification) -> Result<Task> {
     let (id, params) = cast_notification::<N>(notif)?;
     Ok(Task::sync(move |session, client| {
-        let _span = tracing::debug_span!("notification", method = N::METHOD).entered();
+        let _span = tracing::debug_span!("notification", method = %N::METHOD).entered();
         if let Err(err) = N::run(session, client, params) {
             tracing::error!("An error occurred while running {id}: {err}");
             client
@@ -249,16 +249,16 @@ where
 {
     let (id, params) = cast_notification::<N>(req)?;
     Ok(Task::background(schedule, move |session: &Session| {
-        let url = N::document_url(&params);
+        let uri = N::document_uri(&params);
 
-        let Some(snapshot) = session.take_snapshot((*url).clone()) else {
+        let Some(snapshot) = session.take_snapshot((*uri).clone()) else {
             tracing::debug!(
-                "Ignoring notification because snapshot for url `{url}` doesn't exist."
+                "Ignoring notification because snapshot for uri `{uri}` doesn't exist."
             );
             return Box::new(|_| {});
         };
         Box::new(move |client| {
-            let _span = tracing::debug_span!("notification", method = N::METHOD).entered();
+            let _span = tracing::debug_span!("notification", method = %N::METHOD).entered();
 
             let result =
                 match std::panic::catch_unwind(|| N::run_with_snapshot(snapshot, client, params)) {
@@ -303,7 +303,7 @@ where
     <<Req as RequestHandler>::RequestType as Request>::Params: UnwindSafe,
 {
     request
-        .extract(Req::METHOD)
+        .extract(Req::METHOD.as_str())
         .map_err(|err| match err {
             json_err @ server::ExtractError::JsonError { .. } => {
                 anyhow::anyhow!("JSON parsing failure:\n{json_err}")
@@ -346,7 +346,7 @@ fn respond_silent_error(id: RequestId, client: &Client, error: lsp_server::Respo
 fn cast_notification<N>(
     notification: server::Notification,
 ) -> Result<(
-    &'static str,
+    LspNotificationMethod<'static>,
     <<N as NotificationHandler>::NotificationType as Notification>::Params,
 )>
 where
@@ -355,7 +355,7 @@ where
     Ok((
         N::METHOD,
         notification
-            .extract(N::METHOD)
+            .extract(N::METHOD.as_str())
             .map_err(|err| match err {
                 json_err @ server::ExtractError::JsonError { .. } => {
                     anyhow::anyhow!("JSON parsing failure:\n{json_err}")

--- a/crates/ruff_server/src/server/api/diagnostics.rs
+++ b/crates/ruff_server/src/server/api/diagnostics.rs
@@ -24,7 +24,7 @@ pub(super) fn publish_diagnostics_for_document(
 ) -> crate::server::Result<()> {
     for (uri, diagnostics) in generate_diagnostics(snapshot) {
         client
-            .send_notification::<lsp_types::notification::PublishDiagnostics>(
+            .send_notification::<lsp_types::PublishDiagnosticsNotification>(
                 lsp_types::PublishDiagnosticsParams {
                     uri,
                     diagnostics,
@@ -42,9 +42,9 @@ pub(super) fn clear_diagnostics_for_document(
     client: &Client,
 ) -> crate::server::Result<()> {
     client
-        .send_notification::<lsp_types::notification::PublishDiagnostics>(
+        .send_notification::<lsp_types::PublishDiagnosticsNotification>(
             lsp_types::PublishDiagnosticsParams {
-                uri: query.make_key().into_url(),
+                uri: query.make_key().into_uri(),
                 diagnostics: vec![],
                 version: Some(query.version()),
             },

--- a/crates/ruff_server/src/server/api/notifications/cancel.rs
+++ b/crates/ruff_server/src/server/api/notifications/cancel.rs
@@ -1,6 +1,6 @@
 use lsp_server::RequestId;
+use lsp_types::CancelNotification;
 use lsp_types::CancelParams;
-use lsp_types::notification::Cancel;
 
 use crate::server::Result;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
@@ -9,14 +9,14 @@ use crate::session::{Client, Session};
 pub(crate) struct CancelNotificationHandler;
 
 impl NotificationHandler for CancelNotificationHandler {
-    type NotificationType = Cancel;
+    type NotificationType = CancelNotification;
 }
 
 impl SyncNotificationHandler for CancelNotificationHandler {
     fn run(session: &mut Session, client: &Client, params: CancelParams) -> Result<()> {
         let id: RequestId = match params.id {
-            lsp_types::NumberOrString::Number(id) => id.into(),
-            lsp_types::NumberOrString::String(id) => id.into(),
+            lsp_types::Id::Int(id) => id.into(),
+            lsp_types::Id::String(id) => id.into(),
         };
 
         let _ = client.cancel(session, id);

--- a/crates/ruff_server/src/server/api/notifications/did_change.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_change.rs
@@ -3,13 +3,12 @@ use crate::server::api::LSPResult;
 use crate::server::api::diagnostics::publish_diagnostics_for_document;
 use crate::session::{Client, Session};
 use lsp_server::ErrorCode;
-use lsp_types as types;
-use lsp_types::notification as notif;
+use lsp_types::{self as types, DidChangeTextDocumentNotification, TextDocumentIdentifier};
 
 pub(crate) struct DidChange;
 
 impl super::NotificationHandler for DidChange {
-    type NotificationType = notif::DidChangeTextDocument;
+    type NotificationType = DidChangeTextDocumentNotification;
 }
 
 impl super::SyncNotificationHandler for DidChange {
@@ -19,13 +18,13 @@ impl super::SyncNotificationHandler for DidChange {
         types::DidChangeTextDocumentParams {
             text_document:
                 types::VersionedTextDocumentIdentifier {
-                    uri,
+                    text_document_identifier: TextDocumentIdentifier { uri },
                     version: new_version,
                 },
             content_changes,
         }: types::DidChangeTextDocumentParams,
     ) -> Result<()> {
-        let key = session.key_from_url(uri);
+        let key = session.key_from_uri(uri);
 
         session
             .update_text_document(&key, content_changes, new_version)
@@ -33,7 +32,7 @@ impl super::SyncNotificationHandler for DidChange {
 
         // Publish diagnostics if the client doesn't support pull diagnostics
         if !session.resolved_client_capabilities().pull_diagnostics {
-            let snapshot = session.take_snapshot(key.into_url()).unwrap();
+            let snapshot = session.take_snapshot(key.into_uri()).unwrap();
             publish_diagnostics_for_document(&snapshot, client)?;
         }
 

--- a/crates/ruff_server/src/server/api/notifications/did_change_configuration.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_change_configuration.rs
@@ -1,12 +1,11 @@
 use crate::server::Result;
 use crate::session::{Client, Session};
-use lsp_types as types;
-use lsp_types::notification as notif;
+use lsp_types::{self as types, DidChangeConfigurationNotification};
 
 pub(crate) struct DidChangeConfiguration;
 
 impl super::NotificationHandler for DidChangeConfiguration {
-    type NotificationType = notif::DidChangeConfiguration;
+    type NotificationType = DidChangeConfigurationNotification;
 }
 
 impl super::SyncNotificationHandler for DidChangeConfiguration {

--- a/crates/ruff_server/src/server/api/notifications/did_change_notebook.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_change_notebook.rs
@@ -3,13 +3,12 @@ use crate::server::api::LSPResult;
 use crate::server::api::diagnostics::publish_diagnostics_for_document;
 use crate::session::{Client, Session};
 use lsp_server::ErrorCode;
-use lsp_types as types;
-use lsp_types::notification as notif;
+use lsp_types::{self as types, DidChangeNotebookDocumentNotification};
 
 pub(crate) struct DidChangeNotebook;
 
 impl super::NotificationHandler for DidChangeNotebook {
-    type NotificationType = notif::DidChangeNotebookDocument;
+    type NotificationType = DidChangeNotebookDocumentNotification;
 }
 
 impl super::SyncNotificationHandler for DidChangeNotebook {
@@ -21,14 +20,14 @@ impl super::SyncNotificationHandler for DidChangeNotebook {
             change: types::NotebookDocumentChangeEvent { cells, metadata },
         }: types::DidChangeNotebookDocumentParams,
     ) -> Result<()> {
-        let key = session.key_from_url(uri);
+        let key = session.key_from_uri(uri);
         session
             .update_notebook_document(&key, cells, metadata, version)
             .with_failure_code(ErrorCode::InternalError)?;
 
         // publish new diagnostics
         let snapshot = session
-            .take_snapshot(key.into_url())
+            .take_snapshot(key.into_uri())
             .expect("snapshot should be available");
         publish_diagnostics_for_document(&snapshot, client)?;
 

--- a/crates/ruff_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_change_watched_files.rs
@@ -2,13 +2,12 @@ use crate::server::Result;
 use crate::server::api::LSPResult;
 use crate::server::api::diagnostics::publish_diagnostics_for_document;
 use crate::session::{Client, Session};
-use lsp_types as types;
-use lsp_types::notification as notif;
+use lsp_types::{self as types, DidChangeWatchedFilesNotification};
 
 pub(crate) struct DidChangeWatchedFiles;
 
 impl super::NotificationHandler for DidChangeWatchedFiles {
-    type NotificationType = notif::DidChangeWatchedFiles;
+    type NotificationType = DidChangeWatchedFilesNotification;
 }
 
 impl super::SyncNotificationHandler for DidChangeWatchedFiles {
@@ -22,26 +21,22 @@ impl super::SyncNotificationHandler for DidChangeWatchedFiles {
         if !params.changes.is_empty() {
             if session.resolved_client_capabilities().workspace_refresh {
                 client
-                    .send_request::<types::request::WorkspaceDiagnosticRefresh>(
-                        session,
-                        (),
-                        |_, ()| (),
-                    )
+                    .send_request::<types::DiagnosticRefreshRequest>(session, (), |_, ()| ())
                     .with_failure_code(lsp_server::ErrorCode::InternalError)?;
             } else {
                 // publish diagnostics for text documents
-                for url in session.text_document_urls() {
+                for uri in session.text_document_uris() {
                     let snapshot = session
-                        .take_snapshot(url.clone())
+                        .take_snapshot(uri.clone())
                         .expect("snapshot should be available");
                     publish_diagnostics_for_document(&snapshot, client)?;
                 }
             }
 
             // always publish diagnostics for notebook files (since they don't use pull diagnostics)
-            for url in session.notebook_document_urls() {
+            for uri in session.notebook_document_uris() {
                 let snapshot = session
-                    .take_snapshot(url.clone())
+                    .take_snapshot(uri.clone())
                     .expect("snapshot should be available");
                 publish_diagnostics_for_document(&snapshot, client)?;
             }

--- a/crates/ruff_server/src/server/api/notifications/did_change_workspace.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_change_workspace.rs
@@ -1,13 +1,12 @@
 use crate::server::Result;
 use crate::server::api::LSPResult;
 use crate::session::{Client, Session};
-use lsp_types as types;
-use lsp_types::notification as notif;
+use lsp_types::{self as types, DidChangeWorkspaceFoldersNotification};
 
 pub(crate) struct DidChangeWorkspace;
 
 impl super::NotificationHandler for DidChangeWorkspace {
-    type NotificationType = notif::DidChangeWorkspaceFolders;
+    type NotificationType = DidChangeWorkspaceFoldersNotification;
 }
 
 impl super::SyncNotificationHandler for DidChangeWorkspace {

--- a/crates/ruff_server/src/server/api/notifications/did_close.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_close.rs
@@ -2,13 +2,12 @@ use crate::server::Result;
 use crate::server::api::LSPResult;
 use crate::server::api::diagnostics::clear_diagnostics_for_document;
 use crate::session::{Client, Session};
-use lsp_types as types;
-use lsp_types::notification as notif;
+use lsp_types::{self as types, DidCloseTextDocumentNotification};
 
 pub(crate) struct DidClose;
 
 impl super::NotificationHandler for DidClose {
-    type NotificationType = notif::DidCloseTextDocument;
+    type NotificationType = DidCloseTextDocumentNotification;
 }
 
 impl super::SyncNotificationHandler for DidClose {
@@ -19,9 +18,9 @@ impl super::SyncNotificationHandler for DidClose {
             text_document: types::TextDocumentIdentifier { uri },
         }: types::DidCloseTextDocumentParams,
     ) -> Result<()> {
-        let key = session.key_from_url(uri);
+        let key = session.key_from_uri(uri);
         // Publish an empty diagnostic report for the document. This will de-register any existing diagnostics.
-        let Some(snapshot) = session.take_snapshot(key.clone().into_url()) else {
+        let Some(snapshot) = session.take_snapshot(key.clone().into_uri()) else {
             tracing::debug!(
                 "Unable to close document with key {key} - the snapshot was unavailable"
             );

--- a/crates/ruff_server/src/server/api/notifications/did_close_notebook.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_close_notebook.rs
@@ -1,13 +1,12 @@
 use crate::server::Result;
 use crate::server::api::LSPResult;
 use crate::session::{Client, Session};
-use lsp_types::notification as notif;
-use lsp_types::{self as types, NotebookDocumentIdentifier};
+use lsp_types::{self as types, DidCloseNotebookDocumentNotification, NotebookDocumentIdentifier};
 
 pub(crate) struct DidCloseNotebook;
 
 impl super::NotificationHandler for DidCloseNotebook {
-    type NotificationType = notif::DidCloseNotebookDocument;
+    type NotificationType = DidCloseNotebookDocumentNotification;
 }
 
 impl super::SyncNotificationHandler for DidCloseNotebook {
@@ -19,7 +18,7 @@ impl super::SyncNotificationHandler for DidCloseNotebook {
             ..
         }: types::DidCloseNotebookDocumentParams,
     ) -> Result<()> {
-        let key = session.key_from_url(uri);
+        let key = session.key_from_uri(uri);
         session
             .close_document(&key)
             .with_failure_code(lsp_server::ErrorCode::InternalError)?;

--- a/crates/ruff_server/src/server/api/notifications/did_open.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_open.rs
@@ -3,13 +3,12 @@ use crate::server::Result;
 use crate::server::api::LSPResult;
 use crate::server::api::diagnostics::publish_diagnostics_for_document;
 use crate::session::{Client, Session};
-use lsp_types as types;
-use lsp_types::notification as notif;
+use lsp_types::{self as types, DidOpenTextDocumentNotification};
 
 pub(crate) struct DidOpen;
 
 impl super::NotificationHandler for DidOpen {
-    type NotificationType = notif::DidOpenTextDocument;
+    type NotificationType = DidOpenTextDocumentNotification;
 }
 
 impl super::SyncNotificationHandler for DidOpen {
@@ -26,7 +25,7 @@ impl super::SyncNotificationHandler for DidOpen {
                 },
         }: types::DidOpenTextDocumentParams,
     ) -> Result<()> {
-        let document = TextDocument::new(text, version).with_language_id(&language_id);
+        let document = TextDocument::new(text, version).with_language_id(language_id);
 
         session.open_text_document(uri.clone(), document);
 
@@ -35,7 +34,7 @@ impl super::SyncNotificationHandler for DidOpen {
             let snapshot = session
                 .take_snapshot(uri.clone())
                 .ok_or_else(|| {
-                    anyhow::anyhow!("Unable to take snapshot for document with URL {uri}")
+                    anyhow::anyhow!("Unable to take snapshot for document with URI {uri}")
                 })
                 .with_failure_code(lsp_server::ErrorCode::InternalError)?;
             publish_diagnostics_for_document(&snapshot, client)?;

--- a/crates/ruff_server/src/server/api/notifications/did_open_notebook.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_open_notebook.rs
@@ -4,13 +4,12 @@ use crate::server::api::LSPResult;
 use crate::server::api::diagnostics::publish_diagnostics_for_document;
 use crate::session::{Client, Session};
 use lsp_server::ErrorCode;
-use lsp_types as types;
-use lsp_types::notification as notif;
+use lsp_types::{self as types, DidOpenNotebookDocumentNotification};
 
 pub(crate) struct DidOpenNotebook;
 
 impl super::NotificationHandler for DidOpenNotebook {
-    type NotificationType = notif::DidOpenNotebookDocument;
+    type NotificationType = DidOpenNotebookDocumentNotification;
 }
 
 impl super::SyncNotificationHandler for DidOpenNotebook {

--- a/crates/ruff_server/src/server/api/requests.rs
+++ b/crates/ruff_server/src/server/api/requests.rs
@@ -8,7 +8,7 @@ mod hover;
 mod shutdown;
 
 use super::{
-    define_document_url,
+    define_document_uri,
     traits::{
         BackgroundDocumentRequestHandler, BackgroundRequestHandler, RequestHandler,
         SyncRequestHandler,

--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -1,8 +1,8 @@
 use lsp_server::ErrorCode;
-use lsp_types::{self as types, request as req};
+use lsp_types::{self as types, CodeActionRequest, CodeActionResponse};
 use ruff_python_ast::SourceType;
 use rustc_hash::FxHashSet;
-use types::{CodeActionKind, CodeActionOrCommand};
+use types::CodeActionKind;
 
 use crate::DIAGNOSTIC_NAME;
 use crate::edit::WorkspaceEditTracker;
@@ -18,26 +18,26 @@ use super::code_action_resolve::{resolve_edit_for_fix_all, resolve_edit_for_orga
 pub(crate) struct CodeActions;
 
 impl super::RequestHandler for CodeActions {
-    type RequestType = req::CodeActionRequest;
+    type RequestType = CodeActionRequest;
 }
 
 impl super::BackgroundDocumentRequestHandler for CodeActions {
-    super::define_document_url!(params: &types::CodeActionParams);
+    super::define_document_uri!(params: &types::CodeActionParams);
 
     fn run_with_snapshot(
         snapshot: Self::Snapshot,
         _client: &Client,
         params: types::CodeActionParams,
-    ) -> Result<Option<types::CodeActionResponse>> {
+    ) -> Result<Option<Vec<types::CodeActionResponse>>> {
         let snapshot = match snapshot {
             Ok(snapshot) => snapshot,
-            Err(url) => {
-                tracing::warn!("Returning no code actions because document `{url}` isn't open.");
+            Err(uri) => {
+                tracing::warn!("Returning no code actions because document `{uri}` isn't open.");
                 return Ok(None);
             }
         };
 
-        let mut response: types::CodeActionResponse = types::CodeActionResponse::default();
+        let mut response = Vec::new();
 
         let query = snapshot.query();
 
@@ -125,7 +125,7 @@ impl super::BackgroundDocumentRequestHandler for CodeActions {
 fn quick_fix(
     snapshot: &DocumentSnapshot,
     fixes: &[DiagnosticFix],
-) -> crate::Result<Vec<CodeActionOrCommand>> {
+) -> crate::Result<Vec<CodeActionResponse>> {
     let document = snapshot.query();
 
     fixes
@@ -134,21 +134,21 @@ fn quick_fix(
         .map(|fix| {
             let mut tracker = WorkspaceEditTracker::new(snapshot.resolved_client_capabilities());
 
-            let document_url = snapshot.query().make_key().into_url();
+            let document_uri = snapshot.query().make_key().into_uri();
 
             tracker.set_edits_for_document(
-                document_url.clone(),
+                document_uri.clone(),
                 document.version(),
                 fix.edits.clone(),
             )?;
 
-            Ok(types::CodeActionOrCommand::CodeAction(types::CodeAction {
+            Ok(CodeActionResponse::CodeAction(types::CodeAction {
                 title: format!("{DIAGNOSTIC_NAME} ({}): {}", fix.code, fix.title),
-                kind: Some(types::CodeActionKind::QUICKFIX),
+                kind: Some(types::CodeActionKind::QuickFix),
                 edit: Some(tracker.into_workspace_edit()),
                 diagnostics: Some(vec![fix.fixed_diagnostic.clone()]),
                 data: Some(
-                    serde_json::to_value(document_url).expect("document url should serialize"),
+                    serde_json::to_value(document_uri).expect("document uri should serialize"),
                 ),
                 ..Default::default()
             }))
@@ -156,7 +156,7 @@ fn quick_fix(
         .collect()
 }
 
-fn noqa_comments(snapshot: &DocumentSnapshot, fixes: &[DiagnosticFix]) -> Vec<CodeActionOrCommand> {
+fn noqa_comments(snapshot: &DocumentSnapshot, fixes: &[DiagnosticFix]) -> Vec<CodeActionResponse> {
     fixes
         .iter()
         .filter_map(|fix| {
@@ -166,20 +166,20 @@ fn noqa_comments(snapshot: &DocumentSnapshot, fixes: &[DiagnosticFix]) -> Vec<Co
 
             tracker
                 .set_edits_for_document(
-                    snapshot.query().make_key().into_url(),
+                    snapshot.query().make_key().into_uri(),
                     snapshot.query().version(),
                     vec![edit],
                 )
                 .ok()?;
 
-            Some(types::CodeActionOrCommand::CodeAction(types::CodeAction {
+            Some(CodeActionResponse::CodeAction(types::CodeAction {
                 title: format!("{DIAGNOSTIC_NAME} ({}): Disable for this line", fix.code),
-                kind: Some(types::CodeActionKind::QUICKFIX),
+                kind: Some(types::CodeActionKind::QuickFix),
                 edit: Some(tracker.into_workspace_edit()),
                 diagnostics: Some(vec![fix.fixed_diagnostic.clone()]),
                 data: Some(
-                    serde_json::to_value(snapshot.query().make_key().into_url())
-                        .expect("document url should serialize"),
+                    serde_json::to_value(snapshot.query().make_key().into_uri())
+                        .expect("document uri should serialize"),
                 ),
                 ..Default::default()
             }))
@@ -187,7 +187,7 @@ fn noqa_comments(snapshot: &DocumentSnapshot, fixes: &[DiagnosticFix]) -> Vec<Co
         .collect()
 }
 
-fn fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCommand> {
+fn fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionResponse> {
     let document = snapshot.query();
 
     let (edit, data) = if snapshot
@@ -198,8 +198,8 @@ fn fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCommand> {
         (
             None,
             Some(
-                serde_json::to_value(snapshot.query().make_key().into_url())
-                    .expect("document url should serialize"),
+                serde_json::to_value(snapshot.query().make_key().into_uri())
+                    .expect("document uri should serialize"),
             ),
         )
     } else {
@@ -213,7 +213,7 @@ fn fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCommand> {
         )
     };
 
-    Ok(CodeActionOrCommand::CodeAction(types::CodeAction {
+    Ok(CodeActionResponse::CodeAction(types::CodeAction {
         title: format!("{DIAGNOSTIC_NAME}: Fix all auto-fixable problems"),
         kind: Some(crate::SOURCE_FIX_ALL_RUFF),
         edit,
@@ -222,7 +222,7 @@ fn fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCommand> {
     }))
 }
 
-fn notebook_fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCommand> {
+fn notebook_fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionResponse> {
     let document = snapshot.query();
 
     let (edit, data) = if snapshot
@@ -233,8 +233,8 @@ fn notebook_fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCo
         (
             None,
             Some(
-                serde_json::to_value(snapshot.query().make_key().into_url())
-                    .expect("document url should serialize"),
+                serde_json::to_value(snapshot.query().make_key().into_uri())
+                    .expect("document uri should serialize"),
             ),
         )
     } else {
@@ -248,7 +248,7 @@ fn notebook_fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCo
         )
     };
 
-    Ok(CodeActionOrCommand::CodeAction(types::CodeAction {
+    Ok(CodeActionResponse::CodeAction(types::CodeAction {
         title: format!("{DIAGNOSTIC_NAME}: Fix all auto-fixable problems"),
         kind: Some(crate::NOTEBOOK_SOURCE_FIX_ALL_RUFF),
         edit,
@@ -257,7 +257,7 @@ fn notebook_fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCo
     }))
 }
 
-fn organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCommand> {
+fn organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionResponse> {
     let document = snapshot.query();
 
     let (edit, data) = if snapshot
@@ -268,8 +268,8 @@ fn organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCo
         (
             None,
             Some(
-                serde_json::to_value(snapshot.query().make_key().into_url())
-                    .expect("document url should serialize"),
+                serde_json::to_value(snapshot.query().make_key().into_uri())
+                    .expect("document uri should serialize"),
             ),
         )
     } else {
@@ -283,7 +283,7 @@ fn organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCo
         )
     };
 
-    Ok(CodeActionOrCommand::CodeAction(types::CodeAction {
+    Ok(CodeActionResponse::CodeAction(types::CodeAction {
         title: format!("{DIAGNOSTIC_NAME}: Organize imports"),
         kind: Some(crate::SOURCE_ORGANIZE_IMPORTS_RUFF),
         edit,
@@ -292,7 +292,7 @@ fn organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCo
     }))
 }
 
-fn notebook_organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCommand> {
+fn notebook_organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionResponse> {
     let document = snapshot.query();
 
     let (edit, data) = if snapshot
@@ -303,8 +303,8 @@ fn notebook_organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeA
         (
             None,
             Some(
-                serde_json::to_value(snapshot.query().make_key().into_url())
-                    .expect("document url should serialize"),
+                serde_json::to_value(snapshot.query().make_key().into_uri())
+                    .expect("document uri should serialize"),
             ),
         )
     } else {
@@ -318,7 +318,7 @@ fn notebook_organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeA
         )
     };
 
-    Ok(CodeActionOrCommand::CodeAction(types::CodeAction {
+    Ok(CodeActionResponse::CodeAction(types::CodeAction {
         title: format!("{DIAGNOSTIC_NAME}: Organize imports"),
         kind: Some(crate::NOTEBOOK_SOURCE_ORGANIZE_IMPORTS_RUFF),
         edit,

--- a/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
@@ -1,5 +1,6 @@
 use lsp_server::ErrorCode;
-use lsp_types::{self as types, request as req};
+use lsp_types::CodeActionResolveRequest;
+use lsp_types::{self as types};
 
 use ruff_linter::codes::Rule;
 
@@ -15,7 +16,7 @@ use crate::session::{DocumentQuery, DocumentSnapshot, ResolvedClientCapabilities
 pub(crate) struct CodeActionResolve;
 
 impl super::RequestHandler for CodeActionResolve {
-    type RequestType = req::CodeActionResolveRequest;
+    type RequestType = CodeActionResolveRequest;
 }
 
 impl super::BackgroundRequestHandler for CodeActionResolve {
@@ -27,7 +28,7 @@ impl super::BackgroundRequestHandler for CodeActionResolve {
             .clone()
             .ok_or_else(|| "it doesn't contain Ruff's document URI payload".to_string())?;
 
-        let uri: lsp_types::Url = serde_json::from_value(data)
+        let uri: lsp_types::Uri = serde_json::from_value(data)
             .map_err(|err| format!("its Ruff document URI payload is invalid: {err}"))?;
 
         session

--- a/crates/ruff_server/src/server/api/requests/diagnostic.rs
+++ b/crates/ruff_server/src/server/api/requests/diagnostic.rs
@@ -1,48 +1,44 @@
 use crate::server::api::diagnostics::generate_diagnostics;
 use crate::{server::Result, session::Client};
-use lsp_types::{self as types, request as req};
-use types::{
-    DocumentDiagnosticReportResult, FullDocumentDiagnosticReport,
-    RelatedFullDocumentDiagnosticReport,
-};
+use lsp_types::{self as types, DocumentDiagnosticReport, DocumentDiagnosticRequest};
+use types::{FullDocumentDiagnosticReport, RelatedFullDocumentDiagnosticReport};
 
 pub(crate) struct DocumentDiagnostic;
 
 impl super::RequestHandler for DocumentDiagnostic {
-    type RequestType = req::DocumentDiagnosticRequest;
+    type RequestType = DocumentDiagnosticRequest;
 }
 
 impl super::BackgroundDocumentRequestHandler for DocumentDiagnostic {
-    super::define_document_url!(params: &types::DocumentDiagnosticParams);
+    super::define_document_uri!(params: &types::DocumentDiagnosticParams);
 
     fn run_with_snapshot(
         snapshot: Self::Snapshot,
         _client: &Client,
         _params: types::DocumentDiagnosticParams,
-    ) -> Result<DocumentDiagnosticReportResult> {
+    ) -> Result<DocumentDiagnosticReport> {
         let diagnostics = match snapshot {
             Ok(snapshot) => generate_diagnostics(&snapshot)
                 .into_iter()
                 .next()
                 .map(|(_, diagnostics)| diagnostics)
                 .unwrap_or_default(),
-            Err(url) => {
-                tracing::warn!("Returning no diagnostics because document `{url}` isn't open.");
+            Err(uri) => {
+                tracing::warn!("Returning no diagnostics because document `{uri}` isn't open.");
                 Vec::new()
             }
         };
 
-        Ok(DocumentDiagnosticReportResult::Report(
-            types::DocumentDiagnosticReport::Full(RelatedFullDocumentDiagnosticReport {
-                related_documents: None,
-                full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                    // TODO(jane): eventually this will be important for caching diagnostic information.
-                    result_id: None,
-                    // Pull diagnostic requests are only called for text documents.
-                    // Since diagnostic requests generate
-                    items: diagnostics,
-                },
-            }),
-        ))
+        Ok(RelatedFullDocumentDiagnosticReport {
+            related_documents: None,
+            full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                // TODO(jane): eventually this will be important for caching diagnostic information.
+                result_id: None,
+                // Pull diagnostic requests are only called for text documents.
+                // Since diagnostic requests generate
+                items: diagnostics,
+            },
+        }
+        .into())
     }
 }

--- a/crates/ruff_server/src/server/api/requests/execute_command.rs
+++ b/crates/ruff_server/src/server/api/requests/execute_command.rs
@@ -8,14 +8,16 @@ use crate::session::{Client, Session};
 use crate::{DIAGNOSTIC_NAME, DocumentKey};
 use crate::{edit::DocumentVersion, server};
 use lsp_server::ErrorCode;
-use lsp_types::{self as types, TextDocumentIdentifier, request as req};
+use lsp_types::{
+    self as types, ApplyWorkspaceEditRequest, ExecuteCommandRequest, TextDocumentIdentifier,
+};
 use serde::Deserialize;
 
 pub(crate) struct ExecuteCommand;
 
 #[derive(Deserialize)]
 struct Argument {
-    uri: types::Url,
+    uri: types::Uri,
     version: DocumentVersion,
 }
 
@@ -31,7 +33,7 @@ struct DebugCommandArgument {
 }
 
 impl super::RequestHandler for ExecuteCommand {
-    type RequestType = req::ExecuteCommand;
+    type RequestType = ExecuteCommandRequest;
 }
 
 impl super::SyncRequestHandler for ExecuteCommand {
@@ -46,10 +48,17 @@ impl super::SyncRequestHandler for ExecuteCommand {
         if command == SupportedCommand::Debug {
             // TODO: Currently we only use the first argument i.e., the first document that's
             // provided but we could expand this to consider all *open* documents.
-            let argument: DebugCommandArgument = params.arguments.into_iter().next().map_or_else(
-                || Ok(DebugCommandArgument::default()),
-                |value| serde_json::from_value(value).with_failure_code(ErrorCode::InvalidParams),
-            )?;
+            let argument: DebugCommandArgument = params
+                .arguments
+                .unwrap_or_default()
+                .into_iter()
+                .next()
+                .map_or_else(
+                    || Ok(DebugCommandArgument::default()),
+                    |value| {
+                        serde_json::from_value(value).with_failure_code(ErrorCode::InvalidParams)
+                    },
+                )?;
             return Ok(Some(serde_json::Value::String(
                 debug_information(session, argument.text_document)
                     .with_failure_code(ErrorCode::InternalError)?,
@@ -63,6 +72,7 @@ impl super::SyncRequestHandler for ExecuteCommand {
 
         let mut arguments: Vec<Argument> = params
             .arguments
+            .unwrap_or_default()
             .into_iter()
             .map(|value| serde_json::from_value(value).with_failure_code(ErrorCode::InvalidParams))
             .collect::<server::Result<_>>()?;
@@ -130,11 +140,12 @@ fn apply_edit(
     label: &str,
     edit: types::WorkspaceEdit,
 ) -> crate::Result<()> {
-    client.send_request::<req::ApplyWorkspaceEdit>(
+    client.send_request::<ApplyWorkspaceEditRequest>(
         session,
         types::ApplyWorkspaceEditParams {
             label: Some(format!("{DIAGNOSTIC_NAME}: {label}")),
             edit,
+            metadata: None,
         },
         move |client, response| {
             if !response.applied {
@@ -196,7 +207,7 @@ config_path = {config_path:?}
 {settings}
             ",
             uri = uri.clone(),
-            kind = match session.key_from_url(uri) {
+            kind = match session.key_from_uri(uri) {
                 DocumentKey::Notebook(_) => "Notebook",
                 DocumentKey::NotebookCell(_) => "NotebookCell",
                 DocumentKey::Text(_) => "Text",

--- a/crates/ruff_server/src/server/api/requests/format.rs
+++ b/crates/ruff_server/src/server/api/requests/format.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use lsp_types::{self as types, request as req};
+use lsp_types::{self as types, DocumentFormattingRequest};
 use types::TextEdit;
 
 use ruff_source_file::LineIndex;
@@ -16,11 +16,11 @@ use crate::{PositionEncoding, TextDocument};
 pub(crate) struct Format;
 
 impl super::RequestHandler for Format {
-    type RequestType = req::Formatting;
+    type RequestType = DocumentFormattingRequest;
 }
 
 impl super::BackgroundDocumentRequestHandler for Format {
-    super::define_document_url!(params: &types::DocumentFormattingParams);
+    super::define_document_uri!(params: &types::DocumentFormattingParams);
 
     fn run_with_snapshot(
         snapshot: Self::Snapshot,
@@ -29,9 +29,9 @@ impl super::BackgroundDocumentRequestHandler for Format {
     ) -> Result<super::FormatResponse> {
         let snapshot = match snapshot {
             Ok(snapshot) => snapshot,
-            Err(url) => {
+            Err(uri) => {
                 tracing::warn!(
-                    "Returning no formatting edits because document `{url}` isn't open."
+                    "Returning no formatting edits because document `{uri}` isn't open."
                 );
                 return Ok(None);
             }
@@ -52,9 +52,9 @@ pub(super) fn format_full_document(snapshot: &DocumentSnapshot, client: &Client)
 
     match snapshot.query() {
         DocumentQuery::Notebook { notebook, .. } => {
-            for (url, text_document) in notebook
-                .urls()
-                .map(|url| (url.clone(), notebook.cell_document_by_uri(url).unwrap()))
+            for (uri, text_document) in notebook
+                .uris()
+                .map(|uri| (uri.clone(), notebook.cell_document_by_uri(uri).unwrap()))
             {
                 if let Some(changes) = format_text_document(
                     text_document,
@@ -64,7 +64,7 @@ pub(super) fn format_full_document(snapshot: &DocumentSnapshot, client: &Client)
                     backend,
                     client,
                 )? {
-                    fixes.insert(url, changes);
+                    fixes.insert(uri, changes);
                 }
             }
         }
@@ -72,7 +72,7 @@ pub(super) fn format_full_document(snapshot: &DocumentSnapshot, client: &Client)
             if let Some(changes) =
                 format_text_document(document, query, snapshot.encoding(), false, backend, client)?
             {
-                fixes.insert(snapshot.query().make_key().into_url(), changes);
+                fixes.insert(snapshot.query().make_key().into_uri(), changes);
             }
         }
     }

--- a/crates/ruff_server/src/server/api/requests/format_range.rs
+++ b/crates/ruff_server/src/server/api/requests/format_range.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use lsp_types::{self as types, Range, request as req};
+use lsp_types::{self as types, DocumentRangeFormattingRequest, Range};
 
 use crate::edit::{RangeExt, ToRangeExt};
 use crate::resolve::is_document_excluded_for_formatting;
@@ -11,11 +11,11 @@ use crate::{PositionEncoding, TextDocument};
 pub(crate) struct FormatRange;
 
 impl super::RequestHandler for FormatRange {
-    type RequestType = req::RangeFormatting;
+    type RequestType = DocumentRangeFormattingRequest;
 }
 
 impl super::BackgroundDocumentRequestHandler for FormatRange {
-    super::define_document_url!(params: &types::DocumentRangeFormattingParams);
+    super::define_document_uri!(params: &types::DocumentRangeFormattingParams);
 
     fn run_with_snapshot(
         snapshot: Self::Snapshot,
@@ -24,9 +24,9 @@ impl super::BackgroundDocumentRequestHandler for FormatRange {
     ) -> Result<super::FormatResponse> {
         let snapshot = match snapshot {
             Ok(snapshot) => snapshot,
-            Err(url) => {
+            Err(uri) => {
                 tracing::warn!(
-                    "Returning no range formatting edits because document `{url}` isn't open."
+                    "Returning no range formatting edits because document `{uri}` isn't open."
                 );
                 return Ok(None);
             }

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -1,7 +1,7 @@
 use crate::server::Result;
 use crate::session::{Client, DocumentSnapshot};
 use anyhow::Context;
-use lsp_types::{self as types, request as req};
+use lsp_types::{self as types, HoverRequest};
 use regex::Regex;
 use ruff_linter::FixAvailability;
 use ruff_linter::registry::{Linter, Rule, RuleNamespace};
@@ -12,11 +12,11 @@ use std::fmt::Write;
 pub(crate) struct Hover;
 
 impl super::RequestHandler for Hover {
-    type RequestType = req::HoverRequest;
+    type RequestType = HoverRequest;
 }
 
 impl super::BackgroundDocumentRequestHandler for Hover {
-    fn document_url(params: &types::HoverParams) -> std::borrow::Cow<'_, lsp_types::Url> {
+    fn document_uri(params: &types::HoverParams) -> std::borrow::Cow<'_, lsp_types::Uri> {
         std::borrow::Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 
@@ -27,9 +27,9 @@ impl super::BackgroundDocumentRequestHandler for Hover {
     ) -> Result<Option<types::Hover>> {
         let snapshot = match snapshot {
             Ok(snapshot) => snapshot,
-            Err(url) => {
+            Err(uri) => {
                 tracing::warn!(
-                    "Returning no hover information because document `{url}` isn't open."
+                    "Returning no hover information because document `{uri}` isn't open."
                 );
                 return Ok(None);
             }
@@ -89,10 +89,11 @@ pub(crate) fn hover(
     };
 
     let hover = types::Hover {
-        contents: types::HoverContents::Markup(types::MarkupContent {
+        contents: types::MarkupContent {
             kind: types::MarkupKind::Markdown,
             value: output,
-        }),
+        }
+        .into(),
         range: None,
     };
 

--- a/crates/ruff_server/src/server/api/requests/shutdown.rs
+++ b/crates/ruff_server/src/server/api/requests/shutdown.rs
@@ -5,7 +5,7 @@ use crate::session::Client;
 pub(crate) struct ShutdownHandler;
 
 impl RequestHandler for ShutdownHandler {
-    type RequestType = lsp_types::request::Shutdown;
+    type RequestType = lsp_types::ShutdownRequest;
 }
 
 impl SyncRequestHandler for ShutdownHandler {

--- a/crates/ruff_server/src/server/api/traits.rs
+++ b/crates/ruff_server/src/server/api/traits.rs
@@ -29,13 +29,13 @@
 
 use crate::session::{Client, DocumentSnapshot, Session};
 
-use lsp_types::notification::Notification as LSPNotification;
-use lsp_types::request::Request;
+use lsp_types::{LspNotificationMethod, LspRequestMethod, Notification, Request};
 
 /// A supertrait for any server request handler.
 pub(super) trait RequestHandler {
     type RequestType: Request;
-    const METHOD: &'static str = <<Self as RequestHandler>::RequestType as Request>::METHOD;
+    const METHOD: LspRequestMethod<'static> =
+        <<Self as RequestHandler>::RequestType as Request>::METHOD;
 }
 
 /// A request handler that needs mutable access to the session.
@@ -54,7 +54,7 @@ pub(super) trait SyncRequestHandler: RequestHandler {
 /// A request handler that can be run on a background thread.
 ///
 /// Unlike [`BackgroundDocumentRequestHandler`], this handler does not assume that it can derive a
-/// document URL from the LSP request parameters. Implementations are responsible for extracting
+/// document URI from the LSP request parameters. Implementations are responsible for extracting
 /// any state they need from the [`Session`] during [`Self::snapshot`].
 pub(super) trait BackgroundRequestHandler: RequestHandler {
     type Snapshot: Send + 'static;
@@ -75,16 +75,16 @@ pub(super) trait BackgroundRequestHandler: RequestHandler {
 ///
 /// This handler is specific to requests that operate on a single document.
 pub(super) trait BackgroundDocumentRequestHandler:
-    BackgroundRequestHandler<Snapshot = std::result::Result<DocumentSnapshot, lsp_types::Url>>
+    BackgroundRequestHandler<Snapshot = std::result::Result<DocumentSnapshot, lsp_types::Uri>>
 {
-    /// Returns the URL of the document that this request handler operates on.
+    /// Returns the URI of the document that this request handler operates on.
     ///
-    /// This method can be implemented automatically using the [`define_document_url`] macro.
+    /// This method can be implemented automatically using the [`define_document_uri`] macro.
     ///
-    /// [`define_document_url`]: super::define_document_url
-    fn document_url(
+    /// [`define_document_uri`]: super::define_document_uri
+    fn document_uri(
         params: &<<Self as RequestHandler>::RequestType as Request>::Params,
-    ) -> std::borrow::Cow<'_, lsp_types::Url>;
+    ) -> std::borrow::Cow<'_, lsp_types::Uri>;
 
     fn run_with_snapshot(
         snapshot: Self::Snapshot,
@@ -97,14 +97,14 @@ impl<T> BackgroundRequestHandler for T
 where
     T: BackgroundDocumentRequestHandler,
 {
-    type Snapshot = std::result::Result<DocumentSnapshot, lsp_types::Url>;
+    type Snapshot = std::result::Result<DocumentSnapshot, lsp_types::Uri>;
 
     fn snapshot(
         session: &Session,
         params: &<<Self as RequestHandler>::RequestType as Request>::Params,
     ) -> Self::Snapshot {
-        let url = Self::document_url(params).into_owned();
-        session.take_snapshot(url.clone()).ok_or(url)
+        let uri = Self::document_uri(params).into_owned();
+        session.take_snapshot(uri.clone()).ok_or(uri)
     }
 
     fn run_with_snapshot(
@@ -118,9 +118,9 @@ where
 
 /// A supertrait for any server notification handler.
 pub(super) trait NotificationHandler {
-    type NotificationType: LSPNotification;
-    const METHOD: &'static str =
-        <<Self as NotificationHandler>::NotificationType as LSPNotification>::METHOD;
+    type NotificationType: Notification;
+    const METHOD: LspNotificationMethod<'static> =
+        <<Self as NotificationHandler>::NotificationType as Notification>::METHOD;
 }
 
 /// A notification handler that needs mutable access to the session.
@@ -132,24 +132,24 @@ pub(super) trait SyncNotificationHandler: NotificationHandler {
     fn run(
         session: &mut Session,
         client: &Client,
-        params: <<Self as NotificationHandler>::NotificationType as LSPNotification>::Params,
+        params: <<Self as NotificationHandler>::NotificationType as Notification>::Params,
     ) -> super::Result<()>;
 }
 
 /// A notification handler that can be run on a background thread.
 pub(super) trait BackgroundDocumentNotificationHandler: NotificationHandler {
-    /// Returns the URL of the document that this notification handler operates on.
+    /// Returns the URI of the document that this notification handler operates on.
     ///
-    /// This method can be implemented automatically using the [`define_document_url`] macro.
+    /// This method can be implemented automatically using the [`define_document_uri`] macro.
     ///
-    /// [`define_document_url`]: super::define_document_url
-    fn document_url(
-        params: &<<Self as NotificationHandler>::NotificationType as LSPNotification>::Params,
-    ) -> std::borrow::Cow<'_, lsp_types::Url>;
+    /// [`define_document_uri`]: super::define_document_uri
+    fn document_uri(
+        params: &<<Self as NotificationHandler>::NotificationType as Notification>::Params,
+    ) -> std::borrow::Cow<'_, lsp_types::Uri>;
 
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,
         client: &Client,
-        params: <<Self as NotificationHandler>::NotificationType as LSPNotification>::Params,
+        params: <<Self as NotificationHandler>::NotificationType as Notification>::Params,
     ) -> super::Result<()>;
 }

--- a/crates/ruff_server/src/server/main_loop.rs
+++ b/crates/ruff_server/src/server/main_loop.rs
@@ -2,8 +2,7 @@ use anyhow::anyhow;
 use crossbeam::select;
 use lsp_server::Message;
 use lsp_types::{
-    self as types, DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher,
-    notification::Notification as _,
+    self as types, DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, Notification as _,
 };
 
 use crate::{
@@ -61,7 +60,7 @@ impl Server {
                             api::request(req)
                         }
                         Message::Notification(notification) => {
-                            if notification.method == lsp_types::notification::Exit::METHOD {
+                            if notification.method == lsp_types::ExitNotification::METHOD.as_str() {
                                 if !self.session.is_shutdown_requested() {
                                     return Err(anyhow!(
                                         "Received exit notification before a shutdown request"
@@ -156,17 +155,19 @@ impl Server {
                         serde_json::to_value(DidChangeWatchedFilesRegistrationOptions {
                             watchers: vec![
                                 FileSystemWatcher {
-                                    glob_pattern: types::GlobPattern::String(
+                                    glob_pattern: types::GlobPattern::Pattern(
                                         "**/.ruff.toml".into(),
                                     ),
                                     kind: None,
                                 },
                                 FileSystemWatcher {
-                                    glob_pattern: types::GlobPattern::String("**/ruff.toml".into()),
+                                    glob_pattern: types::GlobPattern::Pattern(
+                                        "**/ruff.toml".into(),
+                                    ),
                                     kind: None,
                                 },
                                 FileSystemWatcher {
-                                    glob_pattern: types::GlobPattern::String(
+                                    glob_pattern: types::GlobPattern::Pattern(
                                         "**/pyproject.toml".into(),
                                     ),
                                     kind: None,
@@ -182,7 +183,7 @@ impl Server {
                 tracing::info!("Configuration file watcher successfully registered");
             };
 
-            if let Err(err) = client.send_request::<lsp_types::request::RegisterCapability>(
+            if let Err(err) = client.send_request::<lsp_types::RegistrationRequest>(
                 &self.session,
                 params,
                 response_handler,

--- a/crates/ruff_server/src/session.rs
+++ b/crates/ruff_server/src/session.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use lsp_types::{ClientCapabilities, FileEvent, NotebookDocumentCellChange, Url};
+use lsp_types::{ClientCapabilities, FileEvent, NotebookDocumentCellChanges, Uri};
 use settings::ClientSettings;
 
 use crate::edit::{DocumentKey, DocumentVersion, NotebookDocument};
@@ -89,13 +89,13 @@ impl Session {
         self.shutdown_requested = requested;
     }
 
-    pub(crate) fn key_from_url(&self, url: Url) -> DocumentKey {
-        self.index.key_from_url(url)
+    pub(crate) fn key_from_uri(&self, uri: Uri) -> DocumentKey {
+        self.index.key_from_uri(uri)
     }
 
-    /// Creates a document snapshot with the URL referencing the document to snapshot.
-    pub(crate) fn take_snapshot(&self, url: Url) -> Option<DocumentSnapshot> {
-        let key = self.key_from_url(url);
+    /// Creates a document snapshot with the URI referencing the document to snapshot.
+    pub(crate) fn take_snapshot(&self, uri: Uri) -> Option<DocumentSnapshot> {
+        let key = self.key_from_uri(uri);
         Some(DocumentSnapshot {
             resolved_client_capabilities: self.resolved_client_capabilities.clone(),
             client_settings: self
@@ -107,14 +107,14 @@ impl Session {
         })
     }
 
-    /// Iterates over the LSP URLs for all open text documents. These URLs are valid file paths.
-    pub(super) fn text_document_urls(&self) -> impl Iterator<Item = &lsp_types::Url> + '_ {
-        self.index.text_document_urls()
+    /// Iterates over the LSP URIs for all open text documents. These URIs are valid file paths.
+    pub(super) fn text_document_uris(&self) -> impl Iterator<Item = &Uri> + '_ {
+        self.index.text_document_uris()
     }
 
-    /// Iterates over the LSP URLs for all open notebook documents. These URLs are valid file paths.
-    pub(super) fn notebook_document_urls(&self) -> impl Iterator<Item = &lsp_types::Url> + '_ {
-        self.index.notebook_document_urls()
+    /// Iterates over the LSP URIs for all open notebook documents. These URIs are valid file paths.
+    pub(super) fn notebook_document_uris(&self) -> impl Iterator<Item = &Uri> + '_ {
+        self.index.notebook_document_uris()
     }
 
     /// Updates a text document at the associated `key`.
@@ -140,7 +140,7 @@ impl Session {
     pub(crate) fn update_notebook_document(
         &mut self,
         key: &DocumentKey,
-        cells: Option<NotebookDocumentCellChange>,
+        cells: Option<NotebookDocumentCellChanges>,
         metadata: Option<serde_json::Map<String, serde_json::Value>>,
         version: DocumentVersion,
     ) -> crate::Result<()> {
@@ -149,16 +149,16 @@ impl Session {
             .update_notebook_document(key, cells, metadata, version, encoding)
     }
 
-    /// Registers a notebook document at the provided `url`.
+    /// Registers a notebook document at the provided `uri`.
     /// If a document is already open here, it will be overwritten.
-    pub(crate) fn open_notebook_document(&mut self, url: Url, document: NotebookDocument) {
-        self.index.open_notebook_document(url, document);
+    pub(crate) fn open_notebook_document(&mut self, uri: Uri, document: NotebookDocument) {
+        self.index.open_notebook_document(uri, document);
     }
 
-    /// Registers a text document at the provided `url`.
+    /// Registers a text document at the provided `uri`.
     /// If a document is already open here, it will be overwritten.
-    pub(crate) fn open_text_document(&mut self, url: Url, document: TextDocument) {
-        self.index.open_text_document(url, document);
+    pub(crate) fn open_text_document(&mut self, uri: Uri, document: TextDocument) {
+        self.index.open_text_document(uri, document);
     }
 
     /// De-registers a document, specified by its key.
@@ -173,15 +173,15 @@ impl Session {
         self.index.reload_settings(changes, client);
     }
 
-    /// Open a workspace folder at the given `url`.
-    pub(crate) fn open_workspace_folder(&mut self, url: Url, client: &Client) -> crate::Result<()> {
+    /// Open a workspace folder at the given `uri`.
+    pub(crate) fn open_workspace_folder(&mut self, uri: Uri, client: &Client) -> crate::Result<()> {
         self.index
-            .open_workspace_folder(url, &self.global_settings, client)
+            .open_workspace_folder(uri, &self.global_settings, client)
     }
 
-    /// Close a workspace folder at the given `url`.
-    pub(crate) fn close_workspace_folder(&mut self, url: &Url) -> crate::Result<()> {
-        self.index.close_workspace_folder(url)?;
+    /// Close a workspace folder at the given `uri`.
+    pub(crate) fn close_workspace_folder(&mut self, uri: &Uri) -> crate::Result<()> {
+        self.index.close_workspace_folder(uri)?;
         Ok(())
     }
 
@@ -236,7 +236,7 @@ impl DocumentSnapshot {
         matches!(
             &self.document_ref,
             index::DocumentQuery::Notebook {
-                cell_url: Some(_),
+                cell_uri: Some(_),
                 ..
             }
         )

--- a/crates/ruff_server/src/session/client.rs
+++ b/crates/ruff_server/src/session/client.rs
@@ -46,11 +46,11 @@ impl Client {
         response_handler: impl FnOnce(&Client, R::Result) + Send + 'static,
     ) -> crate::Result<()>
     where
-        R: lsp_types::request::Request,
+        R: lsp_types::Request,
     {
         let response_handler = Box::new(move |client: &Client, response: lsp_server::Response| {
             let _span =
-                tracing::debug_span!("client_response", id=%response.id, method = R::METHOD)
+                tracing::debug_span!("client_response", id=%response.id, method = %R::METHOD)
                     .entered();
 
             match (response.error, response.result) {
@@ -110,7 +110,7 @@ impl Client {
     /// Sends a notification to the client.
     pub(crate) fn send_notification<N>(&self, params: N::Params) -> crate::Result<()>
     where
-        N: lsp_types::notification::Notification,
+        N: lsp_types::Notification,
     {
         let method = N::METHOD.to_string();
 
@@ -190,12 +190,10 @@ impl Client {
         message: impl Display,
         message_type: lsp_types::MessageType,
     ) -> crate::Result<()> {
-        self.send_notification::<lsp_types::notification::ShowMessage>(
-            lsp_types::ShowMessageParams {
-                typ: message_type,
-                message: message.to_string(),
-            },
-        )
+        self.send_notification::<lsp_types::ShowMessageNotification>(lsp_types::ShowMessageParams {
+            kind: message_type,
+            message: message.to_string(),
+        })
     }
 
     /// Sends a request to display a warning to the client with a formatted message. The warning is
@@ -203,7 +201,7 @@ impl Client {
     ///
     /// Logs an error if the message could not be sent.
     pub(crate) fn show_warning_message(&self, message: impl Display) {
-        let result = self.show_message(message, lsp_types::MessageType::WARNING);
+        let result = self.show_message(message, lsp_types::MessageType::Warning);
 
         if let Err(err) = result {
             tracing::error!("Failed to send warning message to the client: {err}");
@@ -215,7 +213,7 @@ impl Client {
     ///
     /// Logs an error if the message could not be sent.
     pub(crate) fn show_error_message(&self, message: impl Display) {
-        let result = self.show_message(message, lsp_types::MessageType::ERROR);
+        let result = self.show_message(message, lsp_types::MessageType::Error);
 
         if let Err(err) = result {
             tracing::error!("Failed to send error message to the client: {err}");

--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::{collections::BTreeMap, path::Path, sync::Arc};
 
 use anyhow::anyhow;
-use lsp_types::{FileEvent, Url};
+use lsp_types::{FileEvent, Uri};
 use rustc_hash::{FxHashMap, FxHashSet};
 use thiserror::Error;
 
@@ -27,11 +27,11 @@ mod ruff_settings;
 /// Stores and tracks all open documents in a session, along with their associated settings.
 #[derive(Default)]
 pub(crate) struct Index {
-    /// Maps all document file URLs to the associated document controller
-    documents: FxHashMap<Url, DocumentController>,
+    /// Maps all document file URIs to the associated document controller
+    documents: FxHashMap<Uri, DocumentController>,
 
-    /// Maps opaque cell URLs to a notebook URL (document)
-    notebook_cells: FxHashMap<Url, Url>,
+    /// Maps opaque cell URIs to a notebook URI (document)
+    notebook_cells: FxHashMap<Uri, Uri>,
 
     /// Maps a workspace folder root to its settings.
     settings: WorkspaceSettingsIndex,
@@ -56,15 +56,15 @@ enum DocumentController {
 #[derive(Clone)]
 pub(crate) enum DocumentQuery {
     Text {
-        file_url: Url,
+        file_uri: Uri,
         document: Arc<TextDocument>,
         settings: Arc<RuffSettings>,
     },
     Notebook {
         /// The selected notebook cell, if it exists.
-        cell_url: Option<Url>,
-        /// The URL of the notebook.
-        file_url: Url,
+        cell_uri: Option<Uri>,
+        /// The URI of the notebook.
+        file_uri: Uri,
         notebook: Arc<NotebookDocument>,
         settings: Arc<RuffSettings>,
     },
@@ -88,18 +88,18 @@ impl Index {
         })
     }
 
-    pub(super) fn text_document_urls(&self) -> impl Iterator<Item = &Url> + '_ {
+    pub(super) fn text_document_uris(&self) -> impl Iterator<Item = &Uri> + '_ {
         self.documents
             .iter()
             .filter(|(_, doc)| doc.as_text().is_some())
-            .map(|(url, _)| url)
+            .map(|(uri, _)| uri)
     }
 
-    pub(super) fn notebook_document_urls(&self) -> impl Iterator<Item = &Url> + '_ {
+    pub(super) fn notebook_document_uris(&self) -> impl Iterator<Item = &Uri> + '_ {
         self.documents
             .iter()
             .filter(|(_, doc)| doc.as_notebook().is_some())
-            .map(|(url, _)| url)
+            .map(|(uri, _)| uri)
     }
 
     pub(super) fn update_text_document(
@@ -124,24 +124,24 @@ impl Index {
         Ok(())
     }
 
-    pub(super) fn key_from_url(&self, url: Url) -> DocumentKey {
-        if self.notebook_cells.contains_key(&url) {
-            DocumentKey::NotebookCell(url)
+    pub(super) fn key_from_uri(&self, uri: Uri) -> DocumentKey {
+        if self.notebook_cells.contains_key(&uri) {
+            DocumentKey::NotebookCell(uri)
         } else if self
             .documents
-            .get(&url)
+            .get(&uri)
             .is_some_and(|controller| controller.as_notebook().is_some())
         {
-            DocumentKey::Notebook(url)
+            DocumentKey::Notebook(uri)
         } else {
-            DocumentKey::Text(url)
+            DocumentKey::Text(uri)
         }
     }
 
     pub(super) fn update_notebook_document(
         &mut self,
         key: &DocumentKey,
-        cells: Option<lsp_types::NotebookDocumentCellChange>,
+        cells: Option<lsp_types::NotebookDocumentCellChanges>,
         metadata: Option<serde_json::Map<String, serde_json::Value>>,
         new_version: DocumentVersion,
         encoding: PositionEncoding,
@@ -152,7 +152,7 @@ impl Index {
             ..
         }) = cells.as_ref().and_then(|cells| cells.structure.as_ref())
         {
-            let Some(path) = self.url_for_key(key).cloned() else {
+            let Some(path) = self.uri_for_key(key).cloned() else {
                 anyhow::bail!("Tried to open unavailable document `{key}`");
             };
 
@@ -174,29 +174,29 @@ impl Index {
 
     pub(super) fn open_workspace_folder(
         &mut self,
-        url: Url,
+        uri: Uri,
         global: &GlobalClientSettings,
         client: &Client,
     ) -> crate::Result<()> {
         // TODO(jane): Find a way for workspace client settings to be added or changed dynamically.
         self.settings
-            .register_workspace(&Workspace::new(url), global, client)
+            .register_workspace(&Workspace::new(uri), global, client)
     }
 
-    pub(super) fn close_workspace_folder(&mut self, workspace_url: &Url) -> crate::Result<()> {
-        let workspace_path = workspace_url.to_file_path().map_err(|()| {
-            anyhow!("Failed to convert workspace URL to file path: {workspace_url}")
+    pub(super) fn close_workspace_folder(&mut self, workspace_uri: &Uri) -> crate::Result<()> {
+        let workspace_path = workspace_uri.to_file_path().map_err(|()| {
+            anyhow!("Failed to convert workspace URI to file path: {workspace_uri}")
         })?;
 
         self.settings
             .remove(&workspace_path)
-            .ok_or_else(|| anyhow!("Tried to remove non-existent workspace URI {workspace_url}"))?;
+            .ok_or_else(|| anyhow!("Tried to remove non-existent workspace URI {workspace_uri}"))?;
 
         // O(n) complexity, which isn't ideal... but this is an uncommon operation.
         self.documents
-            .retain(|url, _| !Path::new(url.path()).starts_with(&workspace_path));
+            .retain(|uri, _| !Path::new(uri.path()).starts_with(&workspace_path));
         self.notebook_cells
-            .retain(|_, url| !Path::new(url.path()).starts_with(&workspace_path));
+            .retain(|_, uri| !Path::new(uri.path()).starts_with(&workspace_path));
 
         Ok(())
     }
@@ -206,12 +206,12 @@ impl Index {
         key: DocumentKey,
         global: &GlobalClientSettings,
     ) -> Option<DocumentQuery> {
-        let url = self.url_for_key(&key)?.clone();
+        let uri = self.uri_for_key(&key)?.clone();
 
         let document_settings = self
-            .settings_for_url(&url)
+            .settings_for_uri(&uri)
             .map(|settings| {
-                if let Ok(file_path) = url.to_file_path() {
+                if let Ok(file_path) = uri.to_file_path() {
                     settings.ruff_settings.get(&file_path)
                 } else {
                     // For a new unsaved and untitled document, use the ruff settings from the top of the workspace
@@ -223,7 +223,7 @@ impl Index {
                         let workspace_path = self.settings.keys().next().unwrap();
                         settings.ruff_settings.get(&workspace_path.join("untitled"))
                     } else {
-                        tracing::debug!("Use the fallback settings for the new document '{url}'.");
+                        tracing::debug!("Use the fallback settings for the new document '{uri}'.");
                         settings.ruff_settings.fallback()
                     }
                 }
@@ -231,11 +231,11 @@ impl Index {
             .unwrap_or_else(|| {
                 tracing::warn!(
                     "No settings available for {} - falling back to default settings",
-                    url
+                    uri
                 );
                 // The path here is only for completeness, it's okay to use a non-existing path
                 // in case this is an unsaved (untitled) document.
-                let path = Path::new(url.path());
+                let path = Path::new(uri.path());
                 let root = path.parent().unwrap_or(path);
                 Arc::new(RuffSettings::fallback(
                     global.to_settings().editor_settings(),
@@ -243,12 +243,12 @@ impl Index {
                 ))
             });
 
-        let controller = self.documents.get(&url)?;
-        let cell_url = match key {
-            DocumentKey::NotebookCell(cell_url) => Some(cell_url),
+        let controller = self.documents.get(&uri)?;
+        let cell_uri = match key {
+            DocumentKey::NotebookCell(cell_uri) => Some(cell_uri),
             _ => None,
         };
-        Some(controller.make_ref(cell_url, url, document_settings))
+        Some(controller.make_ref(cell_uri, uri, document_settings))
     }
 
     /// Reload the settings for all the workspace folders that contain the changed files.
@@ -297,18 +297,18 @@ impl Index {
         }
     }
 
-    pub(super) fn open_text_document(&mut self, url: Url, document: TextDocument) {
+    pub(super) fn open_text_document(&mut self, uri: Uri, document: TextDocument) {
         self.documents
-            .insert(url, DocumentController::new_text(document));
+            .insert(uri, DocumentController::new_text(document));
     }
 
-    pub(super) fn open_notebook_document(&mut self, notebook_url: Url, document: NotebookDocument) {
-        for cell_url in document.urls() {
+    pub(super) fn open_notebook_document(&mut self, notebook_uri: Uri, document: NotebookDocument) {
+        for cell_uri in document.uris() {
             self.notebook_cells
-                .insert(cell_url.clone(), notebook_url.clone());
+                .insert(cell_uri.clone(), notebook_uri.clone());
         }
         self.documents
-            .insert(notebook_url, DocumentController::new_notebook(document));
+            .insert(notebook_uri, DocumentController::new_notebook(document));
     }
 
     pub(super) fn close_document(&mut self, key: &DocumentKey) -> crate::Result<()> {
@@ -323,21 +323,21 @@ impl Index {
             }
             return Ok(());
         }
-        let Some(url) = self.url_for_key(key).cloned() else {
+        let Some(uri) = self.uri_for_key(key).cloned() else {
             anyhow::bail!("Tried to close unavailable document `{key}`");
         };
 
-        let Some(_) = self.documents.remove(&url) else {
-            anyhow::bail!("tried to close document that didn't exist at {url}")
+        let Some(_) = self.documents.remove(&uri) else {
+            anyhow::bail!("tried to close document that didn't exist at {uri}")
         };
         Ok(())
     }
 
     pub(super) fn client_settings(&self, key: &DocumentKey) -> Option<Arc<ClientSettings>> {
-        let url = self.url_for_key(key)?;
+        let uri = self.uri_for_key(key)?;
         let WorkspaceSettings {
             client_settings, ..
-        } = self.settings_for_url(url)?;
+        } = self.settings_for_uri(uri)?;
         Some(client_settings.clone())
     }
 
@@ -345,30 +345,30 @@ impl Index {
         &mut self,
         key: &DocumentKey,
     ) -> crate::Result<&mut DocumentController> {
-        let Some(url) = self.url_for_key(key).cloned() else {
+        let Some(uri) = self.uri_for_key(key).cloned() else {
             anyhow::bail!("Tried to open unavailable document `{key}`");
         };
-        let Some(controller) = self.documents.get_mut(&url) else {
-            anyhow::bail!("Document controller not available at `{url}`");
+        let Some(controller) = self.documents.get_mut(&uri) else {
+            anyhow::bail!("Document controller not available at `{uri}`");
         };
         Ok(controller)
     }
 
-    fn url_for_key<'a>(&'a self, key: &'a DocumentKey) -> Option<&'a Url> {
+    fn uri_for_key<'a>(&'a self, key: &'a DocumentKey) -> Option<&'a Uri> {
         match key {
             DocumentKey::Notebook(path) | DocumentKey::Text(path) => Some(path),
             DocumentKey::NotebookCell(uri) => self.notebook_cells.get(uri),
         }
     }
 
-    fn settings_for_url(&self, url: &Url) -> Option<&WorkspaceSettings> {
-        if let Ok(path) = url.to_file_path() {
+    fn settings_for_uri(&self, uri: &Uri) -> Option<&WorkspaceSettings> {
+        if let Ok(path) = uri.to_file_path() {
             self.settings_for_path(&path)
         } else {
             // If there's only a single workspace, use that configuration for an untitled document.
             if self.settings.len() == 1 {
                 tracing::debug!(
-                    "Falling back to configuration of the only active workspace for the new document '{url}'."
+                    "Falling back to configuration of the only active workspace for the new document '{uri}'."
                 );
                 self.settings.values().next()
             } else {
@@ -419,16 +419,16 @@ impl WorkspaceSettingsIndex {
         global: &GlobalClientSettings,
         client: &Client,
     ) -> crate::Result<()> {
-        let workspace_url = workspace.url();
-        if workspace_url.scheme() != "file" {
-            tracing::info!("Ignoring non-file workspace URL: {workspace_url}");
+        let workspace_uri = workspace.uri();
+        if workspace_uri.scheme() != "file" {
+            tracing::info!("Ignoring non-file workspace URI: {workspace_uri}");
             client.show_warning_message(format_args!(
-                "Ruff does not support non-file workspaces; Ignoring {workspace_url}"
+                "Ruff does not support non-file workspaces; Ignoring {workspace_uri}"
             ));
             return Ok(());
         }
-        let workspace_path = workspace_url.to_file_path().map_err(|()| {
-            anyhow!("Failed to convert workspace URL to file path: {workspace_url}")
+        let workspace_path = workspace_uri.to_file_path().map_err(|()| {
+            anyhow!("Failed to convert workspace URI to file path: {workspace_uri}")
         })?;
 
         let client_settings = if let Some(workspace_options) = workspace.options() {
@@ -493,19 +493,19 @@ impl DocumentController {
 
     fn make_ref(
         &self,
-        cell_url: Option<Url>,
-        file_url: Url,
+        cell_uri: Option<Uri>,
+        file_uri: Uri,
         settings: Arc<RuffSettings>,
     ) -> DocumentQuery {
         match &self {
             Self::Notebook(notebook) => DocumentQuery::Notebook {
-                cell_url,
-                file_url,
+                cell_uri,
+                file_uri,
                 notebook: notebook.clone(),
                 settings,
             },
             Self::Text(document) => DocumentQuery::Text {
-                file_url,
+                file_uri,
                 document: document.clone(),
                 settings,
             },
@@ -545,12 +545,12 @@ impl DocumentQuery {
     /// Retrieve the original key that describes this document query.
     pub(crate) fn make_key(&self) -> DocumentKey {
         match self {
-            Self::Text { file_url, .. } => DocumentKey::Text(file_url.clone()),
+            Self::Text { file_uri, .. } => DocumentKey::Text(file_uri.clone()),
             Self::Notebook {
-                cell_url: Some(cell_uri),
+                cell_uri: Some(cell_uri),
                 ..
             } => DocumentKey::NotebookCell(cell_uri.clone()),
-            Self::Notebook { file_url, .. } => DocumentKey::Notebook(file_url.clone()),
+            Self::Notebook { file_uri, .. } => DocumentKey::Notebook(file_uri.clone()),
         }
     }
 
@@ -619,10 +619,10 @@ impl DocumentQuery {
         }
     }
 
-    /// Get the URL for the document selected by this query.
-    pub(crate) fn file_url(&self) -> &Url {
+    /// Get the URI for the document selected by this query.
+    pub(crate) fn file_uri(&self) -> &Uri {
         match self {
-            Self::Text { file_url, .. } | Self::Notebook { file_url, .. } => file_url,
+            Self::Text { file_uri, .. } | Self::Notebook { file_uri, .. } => file_uri,
         }
     }
 
@@ -633,16 +633,16 @@ impl DocumentQuery {
     /// The path isn't guaranteed to point to a real path on the filesystem. This is the case
     /// for unsaved (untitled) documents.
     pub(crate) fn file_path(&self) -> Option<PathBuf> {
-        self.file_url().to_file_path().ok()
+        self.file_uri().to_file_path().ok()
     }
 
     /// Get the path for the document selected by this query, ignoring whether the file exists on disk.
     ///
-    /// Returns the URL's path if this is an unsaved (untitled) document.
+    /// Returns the URI's path if this is an unsaved (untitled) document.
     pub(crate) fn virtual_file_path(&self) -> Cow<'_, Path> {
         self.file_path()
             .map(Cow::Owned)
-            .unwrap_or_else(|| Cow::Borrowed(Path::new(self.file_url().path())))
+            .unwrap_or_else(|| Cow::Borrowed(Path::new(self.file_uri().path())))
     }
 
     /// Attempt to access the single inner text document selected by the query.
@@ -652,8 +652,8 @@ impl DocumentQuery {
             Self::Text { document, .. } => Ok(document),
             Self::Notebook {
                 notebook,
-                file_url,
-                cell_url: cell_uri,
+                file_uri,
+                cell_uri,
                 ..
             } => {
                 if let Some(cell_uri) = cell_uri {
@@ -662,7 +662,7 @@ impl DocumentQuery {
                         .ok_or_else(|| SingleDocumentError::CellDoesNotExist(cell_uri.clone()))?;
                     Ok(cell)
                 } else {
-                    Err(SingleDocumentError::Notebook(file_url.clone()))
+                    Err(SingleDocumentError::Notebook(file_uri.clone()))
                 }
             }
         }
@@ -680,7 +680,7 @@ impl DocumentQuery {
 #[derive(Debug, Error)]
 pub(crate) enum SingleDocumentError {
     #[error("Expected a single text document, but found a notebook document: {0}")]
-    Notebook(Url),
-    #[error("Cell with URL {0} does not exist in the internal notebook document")]
-    CellDoesNotExist(Url),
+    Notebook(Uri),
+    #[error("Cell with URI {0} does not exist in the internal notebook document")]
+    CellDoesNotExist(Uri),
 }

--- a/crates/ruff_server/src/session/options.rs
+++ b/crates/ruff_server/src/session/options.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, str::FromStr as _};
 
-use lsp_types::Url;
+use lsp_types::Uri;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use serde_json::{Map, Value};
@@ -15,7 +15,7 @@ use crate::{
     },
 };
 
-pub(crate) type WorkspaceOptionsMap = FxHashMap<Url, ClientOptions>;
+pub(crate) type WorkspaceOptionsMap = FxHashMap<Uri, ClientOptions>;
 
 /// Determines how multiple conflicting configurations should be resolved - in this
 /// case, the configuration from the client settings and configuration from local
@@ -247,7 +247,7 @@ pub(crate) struct TracingOptions {
 struct WorkspaceOptions {
     #[serde(flatten)]
     options: ClientOptions,
-    workspace: Url,
+    workspace: Uri,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -772,7 +772,7 @@ mod tests {
             workspace: workspace_options,
         } = AllOptions::from_init_options(options);
         let path =
-            Url::from_str("file:///Users/test/projects/pandas").expect("path should be valid");
+            Uri::from_str("file:///Users/test/projects/pandas").expect("path should be valid");
         let all_workspace_options = workspace_options.expect("workspace options should exist");
 
         let workspace_options = all_workspace_options
@@ -811,7 +811,7 @@ mod tests {
             }
         );
         let path =
-            Url::from_str("file:///Users/test/projects/scipy").expect("path should be valid");
+            Uri::from_str("file:///Users/test/projects/scipy").expect("path should be valid");
         let workspace_options = all_workspace_options
             .get(&path)
             .expect("workspace setting should exist")

--- a/crates/ruff_server/src/workspace.rs
+++ b/crates/ruff_server/src/workspace.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use lsp_types::{Url, WorkspaceFolder};
+use lsp_types::{Uri, WorkspaceFolders};
 use thiserror::Error;
 
 use crate::session::{ClientOptions, WorkspaceOptionsMap};
@@ -12,40 +12,42 @@ impl Workspaces {
     /// Create the workspaces from the provided workspace folders as provided by the client during
     /// initialization.
     pub(crate) fn from_workspace_folders(
-        workspace_folders: Option<Vec<WorkspaceFolder>>,
+        workspace_folders: Option<WorkspaceFolders>,
         mut workspace_options: WorkspaceOptionsMap,
     ) -> std::result::Result<Workspaces, WorkspacesError> {
-        let mut client_options_for_url = |url: &Url| {
-            workspace_options.remove(url).unwrap_or_else(|| {
+        let mut client_options_for_uri = |uri: &Uri| {
+            workspace_options.remove(uri).unwrap_or_else(|| {
                 tracing::info!(
                     "No workspace options found for {}, using default options",
-                    url
+                    uri
                 );
                 ClientOptions::default()
             })
         };
 
-        let workspaces =
-            if let Some(folders) = workspace_folders.filter(|folders| !folders.is_empty()) {
-                folders
-                    .into_iter()
-                    .map(|folder| {
-                        let options = client_options_for_url(&folder.uri);
-                        Workspace::new(folder.uri).with_options(options)
-                    })
-                    .collect()
-            } else {
-                let current_dir = std::env::current_dir().map_err(WorkspacesError::Io)?;
-                tracing::info!(
-                    "No workspace(s) were provided during initialization. \
+        let workspaces = if let Some(WorkspaceFolders::WorkspaceFolderList(folders)) =
+            workspace_folders
+            && !folders.is_empty()
+        {
+            folders
+                .into_iter()
+                .map(|folder| {
+                    let options = client_options_for_uri(&folder.uri);
+                    Workspace::new(folder.uri).with_options(options)
+                })
+                .collect()
+        } else {
+            let current_dir = std::env::current_dir().map_err(WorkspacesError::Io)?;
+            tracing::info!(
+                "No workspace(s) were provided during initialization. \
                 Using the current working directory as a default workspace: {}",
-                    current_dir.display()
-                );
-                let uri = Url::from_file_path(current_dir)
-                    .map_err(|()| WorkspacesError::InvalidCurrentDir)?;
-                let options = client_options_for_url(&uri);
-                vec![Workspace::default(uri).with_options(options)]
-            };
+                current_dir.display()
+            );
+            let uri = Uri::from_file_path(current_dir)
+                .map_err(|()| WorkspacesError::InvalidCurrentDir)?;
+            let options = client_options_for_uri(&uri);
+            vec![Workspace::default(uri).with_options(options)]
+        };
 
         Ok(Workspaces(workspaces))
     }
@@ -63,14 +65,14 @@ impl Deref for Workspaces {
 pub(crate) enum WorkspacesError {
     #[error(transparent)]
     Io(#[from] std::io::Error),
-    #[error("Failed to create a URL from the current working directory")]
+    #[error("Failed to create a URI from the current working directory")]
     InvalidCurrentDir,
 }
 
 #[derive(Debug)]
 pub(crate) struct Workspace {
-    /// The [`Url`] pointing to the root of the workspace.
-    url: Url,
+    /// The [`Uri`] pointing to the root of the workspace.
+    uri: Uri,
     /// The client options for this workspace.
     options: Option<ClientOptions>,
     /// Whether this is the default workspace as created by the server. This will be the case when
@@ -79,19 +81,19 @@ pub(crate) struct Workspace {
 }
 
 impl Workspace {
-    /// Create a new workspace with the given root URL.
-    pub(crate) fn new(url: Url) -> Self {
+    /// Create a new workspace with the given root URI.
+    pub(crate) fn new(uri: Uri) -> Self {
         Self {
-            url,
+            uri,
             options: None,
             is_default: false,
         }
     }
 
-    /// Create a new default workspace with the given root URL.
-    pub(crate) fn default(url: Url) -> Self {
+    /// Create a new default workspace with the given root URI.
+    pub(crate) fn default(uri: Uri) -> Self {
         Self {
-            url,
+            uri,
             options: None,
             is_default: true,
         }
@@ -104,9 +106,9 @@ impl Workspace {
         self
     }
 
-    /// Returns the root URL of the workspace.
-    pub(crate) fn url(&self) -> &Url {
-        &self.url
+    /// Returns the root URI of the workspace.
+    pub(crate) fn uri(&self) -> &Uri {
+        &self.uri
     }
 
     /// Returns the client options for this workspace.

--- a/crates/ruff_server/tests/document.rs
+++ b/crates/ruff_server/tests/document.rs
@@ -1,6 +1,8 @@
 const PANDAS_HTML_SRC: &str = include_str!("../resources/test/fixtures/pandas_html.py");
 
-use lsp_types::{Position, Range, TextDocumentContentChangeEvent};
+use lsp_types::{
+    Position, Range, TextDocumentContentChangeEvent, TextDocumentContentChangePartial,
+};
 use ruff_server::{PositionEncoding, TextDocument};
 
 #[test]
@@ -8,76 +10,86 @@ fn delete_lines_pandas_html() {
     let mut document = TextDocument::new(PANDAS_HTML_SRC.to_string(), 1);
 
     let changes = vec![
-        TextDocumentContentChangeEvent {
-            range: Some(Range {
-                start: Position {
-                    line: 79,
-                    character: 0,
+        TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+            TextDocumentContentChangePartial {
+                range: Range {
+                    start: Position {
+                        line: 79,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 91,
+                        character: 67,
+                    },
                 },
-                end: Position {
-                    line: 91,
-                    character: 67,
+                text: String::new(),
+                ..Default::default()
+            },
+        ),
+        TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+            TextDocumentContentChangePartial {
+                range: Range {
+                    start: Position {
+                        line: 81,
+                        character: 4,
+                    },
+                    end: Position {
+                        line: 81,
+                        character: 36,
+                    },
                 },
-            }),
-            range_length: Some(388),
-            text: String::new(),
-        },
-        TextDocumentContentChangeEvent {
-            range: Some(Range {
-                start: Position {
-                    line: 81,
-                    character: 4,
+                text: "p".into(),
+                ..Default::default()
+            },
+        ),
+        TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+            TextDocumentContentChangePartial {
+                range: Range {
+                    start: Position {
+                        line: 81,
+                        character: 5,
+                    },
+                    end: Position {
+                        line: 81,
+                        character: 5,
+                    },
                 },
-                end: Position {
-                    line: 81,
-                    character: 36,
+                text: "a".into(),
+                ..Default::default()
+            },
+        ),
+        TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+            TextDocumentContentChangePartial {
+                range: Range {
+                    start: Position {
+                        line: 81,
+                        character: 6,
+                    },
+                    end: Position {
+                        line: 81,
+                        character: 6,
+                    },
                 },
-            }),
-            range_length: Some(32),
-            text: "p".into(),
-        },
-        TextDocumentContentChangeEvent {
-            range: Some(Range {
-                start: Position {
-                    line: 81,
-                    character: 5,
+                text: "s".into(),
+                ..Default::default()
+            },
+        ),
+        TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+            TextDocumentContentChangePartial {
+                range: Range {
+                    start: Position {
+                        line: 81,
+                        character: 7,
+                    },
+                    end: Position {
+                        line: 81,
+                        character: 7,
+                    },
                 },
-                end: Position {
-                    line: 81,
-                    character: 5,
-                },
-            }),
-            range_length: Some(0),
-            text: "a".into(),
-        },
-        TextDocumentContentChangeEvent {
-            range: Some(Range {
-                start: Position {
-                    line: 81,
-                    character: 6,
-                },
-                end: Position {
-                    line: 81,
-                    character: 6,
-                },
-            }),
-            range_length: Some(0),
-            text: "s".into(),
-        },
-        TextDocumentContentChangeEvent {
-            range: Some(Range {
-                start: Position {
-                    line: 81,
-                    character: 7,
-                },
-                end: Position {
-                    line: 81,
-                    character: 7,
-                },
-            }),
-            range_length: Some(0),
-            text: "s".into(),
-        },
+                text: "s".into(),
+                ..Default::default()
+            },
+        ),
     ];
 
     for (version, change) in (2..).zip(changes) {

--- a/crates/ruff_server/tests/e2e/code_action.rs
+++ b/crates/ruff_server/tests/e2e/code_action.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use insta::assert_json_snapshot;
-use lsp_types::{CodeAction, CodeActionKind, request::CodeActionResolveRequest};
+use lsp_types::{CodeAction, CodeActionKind, CodeActionResolveRequest};
 
 use crate::TestServerBuilder;
 
@@ -84,7 +84,7 @@ fn code_action_without_valid_url_returns_unchanged_action() -> Result<()> {
 
     let action = CodeAction {
         title: "Some other code action".to_string(),
-        kind: Some(CodeActionKind::QUICKFIX),
+        kind: Some(CodeActionKind::QuickFix),
         ..Default::default()
     };
 
@@ -100,7 +100,7 @@ fn invalid_code_action_resolve_data_returns_unchanged_action() -> Result<()> {
     let action = CodeAction {
         title: "Ruff: Fix all auto-fixable problems".to_string(),
         kind: Some(CodeActionKind::from("source.fixAll.ruff")),
-        data: Some(serde_json::json!("not-a-url")),
+        data: Some(serde_json::json!("not-a-uri")),
         ..Default::default()
     };
 

--- a/crates/ruff_server/tests/e2e/custom_extension.rs
+++ b/crates/ruff_server/tests/e2e/custom_extension.rs
@@ -92,8 +92,8 @@ fn lint_custom_extension_mapped_to_markdown_emits_no_diagnostics() -> Result<()>
         diagnostics,
         @r#"
     {
-      "kind": "full",
-      "items": []
+      "items": [],
+      "kind": "full"
     }
     "#
     );

--- a/crates/ruff_server/tests/e2e/main.rs
+++ b/crates/ruff_server/tests/e2e/main.rs
@@ -43,24 +43,26 @@ use anyhow::{Context, Result, anyhow};
 use crossbeam::channel::RecvTimeoutError;
 use insta::internals::SettingsBindDropGuard;
 use lsp_server::{Connection, Message, RequestId, Response, ResponseError};
-use lsp_types::notification::{
-    DidChangeTextDocument, DidChangeWatchedFiles, DidChangeWorkspaceFolders, DidCloseTextDocument,
-    DidOpenTextDocument, Exit, Initialized, Notification,
-};
-use lsp_types::request::{
-    CodeActionRequest, DocumentDiagnosticRequest, HoverRequest, Initialize, Request, Shutdown,
-};
 use lsp_types::{
     ClientCapabilities, CodeActionContext, CodeActionParams, CodeActionResponse,
     DiagnosticClientCapabilities, DidChangeTextDocumentParams, DidChangeWatchedFilesParams,
     DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    DocumentDiagnosticParams, DocumentDiagnosticReportResult, FileEvent, Hover, HoverParams,
-    InitializeParams, InitializeResult, InitializedParams, NumberOrString, PartialResultParams,
-    Position, PublishDiagnosticsClientCapabilities, Range, TextDocumentClientCapabilities,
+    DocumentDiagnosticParams, DocumentDiagnosticReport, FileEvent, Hover, HoverParams,
+    InitializeParams, InitializeResult, InitializedParams, PartialResultParams, Position,
+    PublishDiagnosticsClientCapabilities, Range, TextDocumentClientCapabilities,
     TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem,
-    TextDocumentPositionParams, TextEdit, Url, VersionedTextDocumentIdentifier,
-    WorkDoneProgressParams, WorkspaceClientCapabilities, WorkspaceFolder,
-    WorkspaceFoldersChangeEvent,
+    TextDocumentPositionParams, TextEdit, Uri, VersionedTextDocumentIdentifier,
+    WorkDoneProgressParams, WorkspaceClientCapabilities, WorkspaceFolder, WorkspaceFolders,
+    WorkspaceFoldersChangeEvent, WorkspaceFoldersInitializeParams,
+};
+use lsp_types::{
+    CodeActionRequest, DocumentDiagnosticRequest, HoverRequest, InitializeRequest, Request,
+    ShutdownRequest,
+};
+use lsp_types::{
+    DidChangeTextDocumentNotification, DidChangeWatchedFilesNotification,
+    DidChangeWorkspaceFoldersNotification, DidCloseTextDocumentNotification,
+    DidOpenTextDocumentNotification, ExitNotification, InitializedNotification, Notification,
 };
 use ruff_server::{ConnectionInitializer, LogLevel, Server, init_logging};
 use rustc_hash::FxHashMap;
@@ -245,14 +247,16 @@ impl TestServer {
     ) -> Self {
         let init_params = InitializeParams {
             capabilities,
-            workspace_folders: Some(workspace_folders),
+            workspace_folders_initialize_params: WorkspaceFoldersInitializeParams {
+                workspace_folders: Some(WorkspaceFolders::WorkspaceFolderList(workspace_folders)),
+            },
             initialization_options,
             ..Default::default()
         };
 
-        let init_request_id = self.send_request::<Initialize>(init_params);
-        self.initialize_response = Some(self.await_response::<Initialize>(&init_request_id));
-        self.send_notification::<Initialized>(InitializedParams {});
+        let init_request_id = self.send_request::<InitializeRequest>(init_params);
+        self.initialize_response = Some(self.await_response::<InitializeRequest>(&init_request_id));
+        self.send_notification::<InitializedNotification>(InitializedParams {});
 
         self
     }
@@ -331,7 +335,7 @@ impl TestServer {
         R: Request,
     {
         // Track if an Exit notification is being sent
-        if R::METHOD == lsp_types::request::Shutdown::METHOD {
+        if R::METHOD == lsp_types::ShutdownRequest::METHOD {
             self.shutdown_requested = true;
         }
 
@@ -483,7 +487,7 @@ impl TestServer {
             let notification = self
                 .notifications
                 .iter()
-                .position(|notification| N::METHOD == notification.method)
+                .position(|notification| N::METHOD.as_str() == notification.method)
                 .and_then(|index| self.notifications.remove(index));
             if let Some(notification) = notification {
                 let params = serde_json::from_value(notification.params)?;
@@ -496,7 +500,7 @@ impl TestServer {
         Err(ServerMessageError::Timeout)
     }
 
-    /// Collects `N` publish diagnostic notifications into a map, indexed by the document url.
+    /// Collects `N` publish diagnostic notifications into a map, indexed by the document uri.
     ///
     /// ## Panics
     /// If there are multiple publish diagnostics notifications for the same document.
@@ -504,19 +508,19 @@ impl TestServer {
     pub(crate) fn collect_publish_diagnostic_notifications(
         &mut self,
         count: usize,
-    ) -> BTreeMap<lsp_types::Url, Vec<lsp_types::Diagnostic>> {
+    ) -> BTreeMap<lsp_types::Uri, Vec<lsp_types::Diagnostic>> {
         let mut results = BTreeMap::default();
 
         for _ in 0..count {
             let notification =
-                self.await_notification::<lsp_types::notification::PublishDiagnostics>();
+                self.await_notification::<lsp_types::PublishDiagnosticsNotification>();
 
             if let Some(existing) =
                 results.insert(notification.uri.clone(), notification.diagnostics)
             {
                 panic!(
-                    "Received multiple publish diagnostic notifications for {url}: ({existing:#?})",
-                    url = &notification.uri
+                    "Received multiple publish diagnostic notifications for {uri}: ({existing:#?})",
+                    uri = &notification.uri
                 );
             }
         }
@@ -571,7 +575,7 @@ impl TestServer {
             let request = self
                 .requests
                 .iter()
-                .position(|request| R::METHOD == request.method)
+                .position(|request| R::METHOD.as_str() == request.method)
                 .and_then(|index| self.requests.remove(index));
             if let Some(request) = request {
                 let params = serde_json::from_value(request.params)?;
@@ -653,10 +657,10 @@ impl TestServer {
     #[expect(dead_code)]
     pub(crate) fn cancel(&mut self, request_id: &RequestId) {
         let id_string = request_id.to_string();
-        self.send_notification::<lsp_types::notification::Cancel>(lsp_types::CancelParams {
+        self.send_notification::<lsp_types::CancelNotification>(lsp_types::CancelParams {
             id: match id_string.parse() {
-                Ok(id) => NumberOrString::Number(id),
-                Err(_) => NumberOrString::String(id_string),
+                Ok(id) => lsp_types::Id::Int(id),
+                Err(_) => lsp_types::Id::String(id_string),
             },
         });
     }
@@ -667,8 +671,8 @@ impl TestServer {
         self.initialize_response.as_ref()
     }
 
-    pub(crate) fn file_uri(&self, path: impl AsRef<Path>) -> Url {
-        Url::from_file_path(self.file_path(path)).expect("Path must be a valid URL")
+    pub(crate) fn file_uri(&self, path: impl AsRef<Path>) -> Uri {
+        Uri::from_file_path(self.file_path(path)).expect("Path must be a valid URI")
     }
 
     pub(crate) fn file_path(&self, path: impl AsRef<Path>) -> PathBuf {
@@ -711,12 +715,12 @@ impl TestServer {
         let params = DidOpenTextDocumentParams {
             text_document: TextDocumentItem {
                 uri: self.file_uri(path),
-                language_id: language_id.to_string(),
+                language_id: language_id.to_string().into(),
                 version,
                 text: content.as_ref().to_string(),
             },
         };
-        self.send_notification::<DidOpenTextDocument>(params);
+        self.send_notification::<DidOpenTextDocumentNotification>(params);
     }
 
     /// Send a `textDocument/didChange` notification with the given content changes
@@ -729,12 +733,14 @@ impl TestServer {
     ) {
         let params = DidChangeTextDocumentParams {
             text_document: VersionedTextDocumentIdentifier {
-                uri: self.file_uri(path),
+                text_document_identifier: TextDocumentIdentifier {
+                    uri: self.file_uri(path),
+                },
                 version,
             },
             content_changes: changes,
         };
-        self.send_notification::<DidChangeTextDocument>(params);
+        self.send_notification::<DidChangeTextDocumentNotification>(params);
     }
 
     /// Send a `textDocument/didClose` notification
@@ -745,14 +751,14 @@ impl TestServer {
                 uri: self.file_uri(path),
             },
         };
-        self.send_notification::<DidCloseTextDocument>(params);
+        self.send_notification::<DidCloseTextDocumentNotification>(params);
     }
 
     /// Send a `workspace/didChangeWatchedFiles` notification with the given file events
     #[expect(dead_code)]
     pub(crate) fn did_change_watched_files(&mut self, events: Vec<FileEvent>) {
         let params = DidChangeWatchedFilesParams { changes: events };
-        self.send_notification::<DidChangeWatchedFiles>(params);
+        self.send_notification::<DidChangeWatchedFilesNotification>(params);
     }
 
     /// Send a `workspace/didChangeWorkspaceFolders` notification with the given added/removed
@@ -786,7 +792,7 @@ impl TestServer {
                     .collect(),
             },
         };
-        self.send_notification::<DidChangeWorkspaceFolders>(params);
+        self.send_notification::<DidChangeWorkspaceFoldersNotification>(params);
     }
 
     /// Send a `textDocument/diagnostic` request for the document at the given path.
@@ -794,7 +800,7 @@ impl TestServer {
         &mut self,
         path: impl AsRef<Path>,
         previous_result_id: Option<String>,
-    ) -> DocumentDiagnosticReportResult {
+    ) -> DocumentDiagnosticReport {
         let params = DocumentDiagnosticParams {
             text_document: TextDocumentIdentifier {
                 uri: self.file_uri(path),
@@ -829,7 +835,7 @@ impl TestServer {
 
     /// Send a `textDocument/formatting` request for the document at the given path.
     pub(crate) fn format_request(&mut self, path: impl AsRef<Path>) -> Option<Vec<TextEdit>> {
-        let id = self.send_request::<lsp_types::request::Formatting>(
+        let id = self.send_request::<lsp_types::DocumentFormattingRequest>(
             lsp_types::DocumentFormattingParams {
                 text_document: TextDocumentIdentifier {
                     uri: self.file_uri(path),
@@ -839,7 +845,7 @@ impl TestServer {
             },
         );
 
-        self.await_response::<lsp_types::request::Formatting>(&id)
+        self.await_response::<lsp_types::DocumentFormattingRequest>(&id)
     }
 
     /// Send a `textDocument/rangeFormatting` request for the document at the given path.
@@ -848,7 +854,7 @@ impl TestServer {
         path: impl AsRef<Path>,
         range: Range,
     ) -> Option<Vec<TextEdit>> {
-        let id = self.send_request::<lsp_types::request::RangeFormatting>(
+        let id = self.send_request::<lsp_types::DocumentRangeFormattingRequest>(
             lsp_types::DocumentRangeFormattingParams {
                 text_document: TextDocumentIdentifier {
                     uri: self.file_uri(path),
@@ -858,7 +864,7 @@ impl TestServer {
                 work_done_progress_params: WorkDoneProgressParams::default(),
             },
         );
-        self.await_response::<lsp_types::request::RangeFormatting>(&id)
+        self.await_response::<lsp_types::DocumentRangeFormattingRequest>(&id)
     }
 
     /// Send a `textDocument/codeAction` request for the document at the given path.
@@ -866,7 +872,7 @@ impl TestServer {
         &mut self,
         path: impl AsRef<Path>,
         diagnostics: Vec<lsp_types::Diagnostic>,
-    ) -> Option<CodeActionResponse> {
+    ) -> Option<Vec<CodeActionResponse>> {
         let params = CodeActionParams {
             text_document: TextDocumentIdentifier {
                 uri: self.file_uri(path),
@@ -913,10 +919,10 @@ impl Drop for TestServer {
         // The `server_thread` could be `None` if the server exited unexpectedly or panicked or if
         // it dropped the client connection.
         let shutdown_error = if self.server_thread.is_some() && !self.shutdown_requested {
-            let shutdown_id = self.send_request::<Shutdown>(());
-            match self.try_await_response::<Shutdown>(&shutdown_id, None) {
+            let shutdown_id = self.send_request::<ShutdownRequest>(());
+            match self.try_await_response::<ShutdownRequest>(&shutdown_id, None) {
                 Ok(()) => {
-                    self.send_notification::<Exit>(());
+                    self.send_notification::<ExitNotification>(());
 
                     None
                 }
@@ -1027,9 +1033,9 @@ impl TestServerBuilder {
         fs::create_dir_all(&workspace_path)?;
 
         self.workspaces.push(WorkspaceFolder {
-            uri: Url::from_file_path(&workspace_path).map_err(|()| {
+            uri: Uri::from_file_path(&workspace_path).map_err(|()| {
                 anyhow!(
-                    "Failed to convert workspace path to URL: {}",
+                    "Failed to convert workspace path to URI: {}",
                     workspace_path.display()
                 )
             })?,
@@ -1086,6 +1092,7 @@ impl TestServerBuilder {
             .get_or_insert_default()
             .publish_diagnostics
             .get_or_insert_default()
+            .diagnostics_capabilities
             .related_information = Some(enabled);
         self
     }
@@ -1170,13 +1177,13 @@ impl TestContext {
         .to_path_buf();
 
         let mut settings = insta::Settings::clone_current();
-        let project_dir_url = Url::from_file_path(&project_dir)
-            .map_err(|()| anyhow!("Failed to convert root directory to url"))?;
+        let project_dir_uri = Uri::from_file_path(&project_dir)
+            .map_err(|()| anyhow!("Failed to convert root directory to uri"))?;
         settings.add_filter(
             &tempdir_filter(project_dir.to_string_lossy().as_ref()),
             "<temp_dir>/",
         );
-        settings.add_filter(&tempdir_filter(project_dir_url.path()), "<temp_dir>/");
+        settings.add_filter(&tempdir_filter(project_dir_uri.path()), "<temp_dir>/");
         settings.add_filter(
             r#"The system cannot find the file specified."#,
             "No such file or directory",

--- a/crates/ruff_server/tests/e2e/notebook.rs
+++ b/crates/ruff_server/tests/e2e/notebook.rs
@@ -2,12 +2,15 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use insta::assert_json_snapshot;
-use lsp_types::notification::{DidChangeNotebookDocument, DidOpenNotebookDocument};
 use lsp_types::{
-    DidChangeNotebookDocumentParams, DidOpenNotebookDocumentParams, LSPObject, NotebookDocument,
-    NotebookDocumentCellChange, NotebookDocumentChangeEvent, NotebookDocumentChangeTextContent,
-    Position, Range, TextDocumentContentChangeEvent, TextDocumentItem,
-    VersionedNotebookDocumentIdentifier, VersionedTextDocumentIdentifier,
+    DidChangeNotebookDocumentNotification, DidOpenNotebookDocumentNotification,
+    NotebookDocumentCellContentChanges, TextDocumentContentChangePartial, TextDocumentIdentifier,
+};
+use lsp_types::{
+    DidChangeNotebookDocumentParams, DidOpenNotebookDocumentParams, LspObject, NotebookDocument,
+    NotebookDocumentCellChanges, NotebookDocumentChangeEvent, Position, Range,
+    TextDocumentContentChangeEvent, TextDocumentItem, VersionedNotebookDocumentIdentifier,
+    VersionedTextDocumentIdentifier,
 };
 use ruff_notebook::SourceValue;
 
@@ -17,8 +20,8 @@ const NOTEBOOK_FIXTURE_PATH: &str = "resources/test/fixtures/tensorflow_test_not
 
 struct NotebookChange {
     version: i32,
-    metadata: Option<LSPObject>,
-    updated_cells: NotebookDocumentCellChange,
+    metadata: Option<LspObject>,
+    updated_cells: NotebookDocumentCellChanges,
 }
 
 #[test]
@@ -37,114 +40,130 @@ fn super_resolution_overview() -> Result<()> {
     let notebook_uri = notebook_document.uri.clone();
     let cell_count = cell_text_documents.len();
 
-    server.send_notification::<DidOpenNotebookDocument>(DidOpenNotebookDocumentParams {
-        notebook_document,
-        cell_text_documents,
-    });
+    server.send_notification::<DidOpenNotebookDocumentNotification>(
+        DidOpenNotebookDocumentParams {
+            notebook_document,
+            cell_text_documents,
+        },
+    );
 
     let diagnostics = server.collect_publish_diagnostic_notifications(cell_count);
     assert_json_snapshot!("super_resolution_overview_open", diagnostics);
 
-    let changes = [NotebookChange {
-        version: 0,
-        metadata: None,
-        updated_cells: NotebookDocumentCellChange {
-            structure: None,
-            data: None,
-            text_content: Some(vec![NotebookDocumentChangeTextContent {
-                document: VersionedTextDocumentIdentifier {
-                    uri: make_cell_uri(&fixture_path, 5),
-                    version: 2,
-                },
-                changes: vec![
-                    TextDocumentContentChangeEvent {
-                        range: Some(Range {
-                            start: Position {
-                                line: 18,
-                                character: 61,
-                            },
-                            end: Position {
-                                line: 18,
-                                character: 62,
-                            },
-                        }),
-                        range_length: Some(1),
-                        text: "\"".to_string(),
-                    },
-                    TextDocumentContentChangeEvent {
-                        range: Some(Range {
-                            start: Position {
-                                line: 18,
-                                character: 55,
-                            },
-                            end: Position {
-                                line: 18,
-                                character: 56,
-                            },
-                        }),
-                        range_length: Some(1),
-                        text: "\"".to_string(),
-                    },
-                    TextDocumentContentChangeEvent {
-                        range: Some(Range {
-                            start: Position {
-                                line: 14,
-                                character: 46,
-                            },
-                            end: Position {
-                                line: 14,
-                                character: 47,
-                            },
-                        }),
-                        range_length: Some(1),
-                        text: "\"".to_string(),
-                    },
-                    TextDocumentContentChangeEvent {
-                        range: Some(Range {
-                            start: Position {
-                                line: 14,
-                                character: 40,
-                            },
-                            end: Position {
-                                line: 14,
-                                character: 41,
-                            },
-                        }),
-                        range_length: Some(1),
-                        text: "\"".to_string(),
-                    },
-                ],
-            }]),
-        },
-    },
-    NotebookChange {
-        version: 1,
-        metadata: None,
-        updated_cells: NotebookDocumentCellChange {
-            structure: None,
-            data: None,
-            text_content: Some(vec![NotebookDocumentChangeTextContent {
-                document: VersionedTextDocumentIdentifier {
-                    uri: make_cell_uri(&fixture_path, 4),
-                    version: 2,
-                },
-                changes: vec![TextDocumentContentChangeEvent {
-                    range: Some(Range {
-                        start: Position {
-                            line: 0,
-                            character: 0,
+    let changes = [
+        NotebookChange {
+            version: 0,
+            metadata: None,
+            updated_cells: NotebookDocumentCellChanges {
+                structure: None,
+                data: None,
+                text_content: Some(vec![NotebookDocumentCellContentChanges {
+                    document: VersionedTextDocumentIdentifier {
+                        text_document_identifier: TextDocumentIdentifier {
+                            uri: make_cell_uri(&fixture_path, 5),
                         },
-                        end: Position {
-                            line: 0,
-                            character: 181,
-                        },
-                    }),
-                    range_length: Some(181),
-                    text: "test_img_path = tf.keras.utils.get_file(\n    \"lr.jpg\",\n    \"https://raw.githubusercontent.com/tensorflow/examples/master/lite/examples/super_resolution/android/app/src/main/assets/lr-1.jpg\",\n)".to_string(),
-                }],
-            }]),
+                        version: 2,
+                    },
+                    changes: vec![
+                        TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                            TextDocumentContentChangePartial {
+                                range: Range {
+                                    start: Position {
+                                        line: 18,
+                                        character: 61,
+                                    },
+                                    end: Position {
+                                        line: 18,
+                                        character: 62,
+                                    },
+                                },
+                                text: "\"".to_string(),
+                                ..Default::default()
+                            },
+                        ),
+                        TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                            TextDocumentContentChangePartial {
+                                range: Range {
+                                    start: Position {
+                                        line: 18,
+                                        character: 55,
+                                    },
+                                    end: Position {
+                                        line: 18,
+                                        character: 56,
+                                    },
+                                },
+                                text: "\"".to_string(),
+                                ..Default::default()
+                            },
+                        ),
+                        TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                            TextDocumentContentChangePartial {
+                                range: Range {
+                                    start: Position {
+                                        line: 14,
+                                        character: 46,
+                                    },
+                                    end: Position {
+                                        line: 14,
+                                        character: 47,
+                                    },
+                                },
+                                text: "\"".to_string(),
+                                ..Default::default()
+                            },
+                        ),
+                        TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                            TextDocumentContentChangePartial {
+                                range: Range {
+                                    start: Position {
+                                        line: 14,
+                                        character: 40,
+                                    },
+                                    end: Position {
+                                        line: 14,
+                                        character: 41,
+                                    },
+                                },
+                                text: "\"".to_string(),
+                                ..Default::default()
+                            },
+                        ),
+                    ],
+                }]),
+            },
         },
-    }];
+        NotebookChange {
+            version: 1,
+            metadata: None,
+            updated_cells: NotebookDocumentCellChanges {
+                structure: None,
+                data: None,
+                text_content: Some(vec![NotebookDocumentCellContentChanges {
+                    document: VersionedTextDocumentIdentifier {
+                        text_document_identifier: TextDocumentIdentifier {
+                            uri: make_cell_uri(&fixture_path, 4),
+                        },
+                        version: 2,
+                    },
+                    changes: vec![TextDocumentContentChangeEvent::TextDocumentContentChangePartial(TextDocumentContentChangePartial {
+                        range: Range {
+                            start: Position {
+                                line: 0,
+                                character: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                character: 181,
+                            },
+                        },
+                        text: "test_img_path = tf.keras.utils.get_file(\n    \"lr.jpg\",\n    \"https://raw.githubusercontent.com/tensorflow/examples/master/lite/examples/super_resolution/android/app/src/main/assets/lr-1.jpg\",\n)".to_string(),
+                        ..Default::default()
+                    })],
+                }]),
+            },
+        },
+    ];
 
     let mut final_diagnostics = None;
 
@@ -154,16 +173,18 @@ fn super_resolution_overview() -> Result<()> {
         updated_cells,
     } in changes
     {
-        server.send_notification::<DidChangeNotebookDocument>(DidChangeNotebookDocumentParams {
-            notebook_document: VersionedNotebookDocumentIdentifier {
-                uri: notebook_uri.clone(),
-                version,
+        server.send_notification::<DidChangeNotebookDocumentNotification>(
+            DidChangeNotebookDocumentParams {
+                notebook_document: VersionedNotebookDocumentIdentifier {
+                    uri: notebook_uri.clone(),
+                    version,
+                },
+                change: NotebookDocumentChangeEvent {
+                    metadata,
+                    cells: Some(updated_cells),
+                },
             },
-            change: NotebookDocumentChangeEvent {
-                metadata,
-                cells: Some(updated_cells),
-            },
-        });
+        );
 
         final_diagnostics = Some(server.collect_publish_diagnostic_notifications(cell_count));
     }
@@ -191,10 +212,12 @@ fn notebook_without_ipynb_extension() -> Result<()> {
         create_lsp_notebook(&fixture_path, workspace_dir.join("notebook.py"))?;
     let cell_count = cell_text_documents.len();
 
-    server.send_notification::<DidOpenNotebookDocument>(DidOpenNotebookDocumentParams {
-        notebook_document,
-        cell_text_documents,
-    });
+    server.send_notification::<DidOpenNotebookDocumentNotification>(
+        DidOpenNotebookDocumentParams {
+            notebook_document,
+            cell_text_documents,
+        },
+    );
 
     let diagnostics = server.collect_publish_diagnostic_notifications(cell_count);
     assert_json_snapshot!("notebook_without_ipynb_extension_open", diagnostics);
@@ -213,7 +236,7 @@ fn create_lsp_notebook(
     open_uri_path: PathBuf,
 ) -> Result<(NotebookDocument, Vec<TextDocumentItem>)> {
     let notebook = ruff_notebook::Notebook::from_path(file_path)?;
-    let notebook_uri = lsp_types::Url::from_file_path(open_uri_path).unwrap();
+    let notebook_uri = lsp_types::Uri::from_file_path(open_uri_path).unwrap();
 
     let mut cells = Vec::new();
     let mut cell_text_documents = Vec::new();
@@ -242,8 +265,8 @@ fn create_lsp_notebook(
     ))
 }
 
-fn make_cell_uri(path: &Path, index: usize) -> lsp_types::Url {
-    lsp_types::Url::parse(&format!(
+fn make_cell_uri(path: &Path, index: usize) -> lsp_types::Uri {
+    lsp_types::Uri::parse(&format!(
         "notebook-cell:///Users/test/notebooks/{}.ipynb?cell={index}",
         path.file_name().unwrap().to_string_lossy()
     ))
@@ -252,7 +275,7 @@ fn make_cell_uri(path: &Path, index: usize) -> lsp_types::Url {
 
 fn cell_to_lsp_cell(
     cell: &ruff_notebook::Cell,
-    cell_uri: lsp_types::Url,
+    cell_uri: lsp_types::Uri,
 ) -> Result<(lsp_types::NotebookCell, TextDocumentItem)> {
     let contents = match cell.source() {
         SourceValue::String(string) => string.clone(),
@@ -260,7 +283,7 @@ fn cell_to_lsp_cell(
     };
     let metadata = match serde_json::to_value(cell.metadata())? {
         serde_json::Value::Null => None,
-        serde_json::Value::Object(metadata) => Some(metadata),
+        metadata @ serde_json::Value::Object(_) => Some(serde_json::from_value(metadata)?),
         _ => anyhow::bail!("Notebook cell metadata was not an object"),
     };
     Ok((
@@ -274,6 +297,6 @@ fn cell_to_lsp_cell(
             metadata,
             execution_summary: None,
         },
-        TextDocumentItem::new(cell_uri, "python".to_string(), 0, contents),
+        TextDocumentItem::new(cell_uri, lsp_types::LanguageKind::Python, 0, contents),
     ))
 }

--- a/crates/ruff_server/tests/e2e/workspace.rs
+++ b/crates/ruff_server/tests/e2e/workspace.rs
@@ -30,8 +30,8 @@ ignore = ["F401"]
         diagnostics,
         @r#"
     {
-      "kind": "full",
-      "items": []
+      "items": [],
+      "kind": "full"
     }
     "#
     );
@@ -40,7 +40,6 @@ ignore = ["F401"]
         external_diagnostics,
         @r#"
     {
-      "kind": "full",
       "items": [
         {
           "range": {
@@ -96,7 +95,8 @@ ignore = ["F401"]
             "title": "Remove unused import: `os`"
           }
         }
-      ]
+      ],
+      "kind": "full"
     }
     "#
     );
@@ -114,8 +114,8 @@ fn unavailable_document_diagnostic_returns_empty_response() -> Result<()> {
         diagnostics,
         @r#"
     {
-      "kind": "full",
-      "items": []
+      "items": [],
+      "kind": "full"
     }
     "#
     );

--- a/crates/ty_server/src/capabilities.rs
+++ b/crates/ty_server/src/capabilities.rs
@@ -1,12 +1,9 @@
 use lsp_types::{
     self as types, ClientCapabilities, CodeActionKind, CodeActionOptions, CompletionOptions,
-    DeclarationCapability, DiagnosticOptions, DiagnosticServerCapabilities,
-    HoverProviderCapability, InlayHintOptions, InlayHintServerCapabilities, MarkupKind,
-    NotebookCellSelector, NotebookSelector, OneOf, RenameOptions, SelectionRangeProviderCapability,
-    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
-    SemanticTokensServerCapabilities, ServerCapabilities, SignatureHelpOptions,
-    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
-    TypeDefinitionProviderCapability, WorkDoneProgressOptions,
+    DiagnosticOptions, DiagnosticProvider, InlayHintOptions, MarkupKind, NotebookCellLanguage,
+    NotebookDocumentFilterWithCells, NotebookSelector, RenameOptions, SemanticTokensLegend,
+    SemanticTokensOptions, ServerCapabilities, SignatureHelpOptions, TextDocumentSyncKind,
+    TextDocumentSyncOptions, WorkDoneProgressOptions,
 };
 use std::str::FromStr;
 
@@ -236,7 +233,11 @@ impl ResolvedClientCapabilities {
         if let Some(publish_diagnostics) =
             text_document.and_then(|text_document| text_document.publish_diagnostics.as_ref())
         {
-            if publish_diagnostics.related_information == Some(true) {
+            if publish_diagnostics
+                .diagnostics_capabilities
+                .related_information
+                == Some(true)
+            {
                 flags |= Self::DIAGNOSTIC_RELATED_INFORMATION;
             }
         }
@@ -394,19 +395,20 @@ pub(crate) fn server_capabilities(
             None
         } else {
             // Otherwise, we always advertise support for workspace and pull diagnostics.
-            Some(DiagnosticServerCapabilities::Options(
+            Some(DiagnosticProvider::DiagnosticOptions(
                 server_diagnostic_options(true),
             ))
         };
 
     ServerCapabilities {
         position_encoding: Some(position_encoding.into()),
-        code_action_provider: Some(types::CodeActionProviderCapability::Options(
+        code_action_provider: Some(
             CodeActionOptions {
-                code_action_kinds: Some(vec![CodeActionKind::QUICKFIX]),
+                code_action_kinds: Some(vec![CodeActionKind::QuickFix]),
                 ..CodeActionOptions::default()
-            },
-        )),
+            }
+            .into(),
+        ),
 
         execute_command_provider: Some(types::ExecuteCommandOptions {
             commands: SupportedCommand::all()
@@ -418,29 +420,28 @@ pub(crate) fn server_capabilities(
         }),
 
         diagnostic_provider,
-        text_document_sync: Some(TextDocumentSyncCapability::Options(
+        text_document_sync: Some(
             TextDocumentSyncOptions {
                 open_close: Some(true),
-                change: Some(TextDocumentSyncKind::INCREMENTAL),
+                change: Some(TextDocumentSyncKind::Incremental),
                 ..Default::default()
-            },
-        )),
-        type_definition_provider: Some(TypeDefinitionProviderCapability::Simple(true)),
-        definition_provider: Some(OneOf::Left(true)),
-        declaration_provider: Some(DeclarationCapability::Simple(true)),
-        references_provider: Some(OneOf::Left(true)),
-        rename_provider: Some(OneOf::Right(server_rename_options())),
-        document_highlight_provider: Some(OneOf::Left(true)),
-        hover_provider: Some(HoverProviderCapability::Simple(true)),
+            }
+            .into(),
+        ),
+        type_definition_provider: Some(true.into()),
+        definition_provider: Some(true.into()),
+        declaration_provider: Some(true.into()),
+        references_provider: Some(true.into()),
+        rename_provider: Some(server_rename_options().into()),
+        document_highlight_provider: Some(true.into()),
+        hover_provider: Some(true.into()),
         signature_help_provider: Some(SignatureHelpOptions {
             trigger_characters: Some(vec!["(".to_string(), ",".to_string()]),
             retrigger_characters: Some(vec![")".to_string()]),
             work_done_progress_options: WorkDoneProgressOptions::default(),
         }),
-        inlay_hint_provider: Some(OneOf::Right(InlayHintServerCapabilities::Options(
-            InlayHintOptions::default(),
-        ))),
-        semantic_tokens_provider: Some(SemanticTokensServerCapabilities::SemanticTokensOptions(
+        inlay_hint_provider: Some(InlayHintOptions::default().into()),
+        semantic_tokens_provider: Some(
             SemanticTokensOptions {
                 work_done_progress_options: WorkDoneProgressOptions::default(),
                 legend: SemanticTokensLegend {
@@ -453,39 +454,45 @@ pub(crate) fn server_capabilities(
                         .map(|&s| s.into())
                         .collect(),
                 },
-                range: Some(true),
-                full: Some(SemanticTokensFullOptions::Bool(true)),
-            },
-        )),
+                range: Some(true.into()),
+                full: Some(true.into()),
+            }
+            .into(),
+        ),
         completion_provider: Some(CompletionOptions {
             trigger_characters: Some(vec!['.'.to_string(), '"'.to_string(), '\''.to_string()]),
             ..Default::default()
         }),
-        selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
-        folding_range_provider: Some(types::FoldingRangeProviderCapability::Simple(true)),
-        document_symbol_provider: Some(OneOf::Left(true)),
-        workspace_symbol_provider: Some(OneOf::Left(true)),
-        notebook_document_sync: Some(OneOf::Left(lsp_types::NotebookDocumentSyncOptions {
-            save: Some(false),
-            notebook_selector: [NotebookSelector::ByCells {
-                notebook: None,
-                cells: vec![NotebookCellSelector {
-                    language: "python".to_string(),
-                }],
-            }]
-            .to_vec(),
-        })),
-        workspace: Some(lsp_types::WorkspaceServerCapabilities {
+        selection_range_provider: Some(true.into()),
+        folding_range_provider: Some(true.into()),
+        document_symbol_provider: Some(true.into()),
+        workspace_symbol_provider: Some(true.into()),
+        notebook_document_sync: Some(
+            lsp_types::NotebookDocumentSyncOptions {
+                save: Some(false),
+                notebook_selector: [NotebookSelector::NotebookDocumentFilterWithCells(
+                    NotebookDocumentFilterWithCells {
+                        notebook: None,
+                        cells: vec![NotebookCellLanguage {
+                            language: "python".to_string(),
+                        }],
+                    },
+                )]
+                .to_vec(),
+            }
+            .into(),
+        ),
+        workspace: Some(lsp_types::WorkspaceOptions {
             workspace_folders: Some(lsp_types::WorkspaceFoldersServerCapabilities {
                 // N.B. It seems this is purely informational:
                 // https://github.com/microsoft/language-server-protocol/issues/1720#issuecomment-1514732305
                 supported: Some(true),
-                change_notifications: Some(OneOf::Left(true)),
+                change_notifications: Some(true.into()),
             }),
             ..Default::default()
         }),
-        type_hierarchy_provider: Some(OneOf::Left(true)),
-        call_hierarchy_provider: Some(lsp_types::CallHierarchyServerCapability::Simple(true)),
+        type_hierarchy_provider: Some(true.into()),
+        call_hierarchy_provider: Some(true.into()),
         ..Default::default()
     }
 }

--- a/crates/ty_server/src/document.rs
+++ b/crates/ty_server/src/document.rs
@@ -5,7 +5,7 @@ mod notebook;
 mod range;
 mod text_document;
 
-use lsp_types::{PositionEncodingKind, Url};
+use lsp_types::{PositionEncodingKind, Uri};
 use ruff_db::system::{SystemPathBuf, SystemVirtualPath, SystemVirtualPathBuf};
 
 use crate::system::AnySystemPath;
@@ -42,7 +42,7 @@ impl From<PositionEncoding> for ruff_source_file::PositionEncoding {
     }
 }
 
-/// A unique document ID, derived from a URL passed as part of an LSP request.
+/// A unique document ID, derived from a URI passed as part of an LSP request.
 /// This document ID can point to either be a standalone Python file, a full notebook, or a cell within a notebook.
 ///
 /// The `DocumentKey` is very similar to `AnySystemPath`. The important distinction is that
@@ -65,24 +65,24 @@ pub(super) enum DocumentKey {
 }
 
 impl DocumentKey {
-    /// Converts the given [`Url`] to an [`DocumentKey`].
+    /// Converts the given [`Uri`] to an [`DocumentKey`].
     ///
-    /// If the URL scheme is `file`, then the path is converted to a [`SystemPathBuf`] unless
-    /// the url isn't a valid file path.
+    /// If the URI scheme is `file`, then the path is converted to a [`SystemPathBuf`] unless
+    /// the uri isn't a valid file path.
     ///
-    /// In all other cases, the URL is kept as an opaque identifier ([`Self::Opaque`]).
-    pub(crate) fn from_url(url: &Url) -> Self {
-        if url.scheme() == "file" {
-            if let Ok(path) = url.to_file_path() {
-                Self::File(SystemPathBuf::from_path_buf(path).expect("URL to be valid UTF-8"))
+    /// In all other cases, the URI is kept as an opaque identifier ([`Self::Opaque`]).
+    pub(crate) fn from_uri(uri: &Uri) -> Self {
+        if uri.scheme() == "file" {
+            if let Ok(path) = uri.to_file_path() {
+                Self::File(SystemPathBuf::from_path_buf(path).expect("URI to be valid UTF-8"))
             } else {
                 tracing::warn!(
-                    "Treating `file:` url `{url}` as opaque URL as it isn't a valid file path"
+                    "Treating `file:` uri `{uri}` as opaque URI as it isn't a valid file path"
                 );
-                Self::Opaque(url.to_string())
+                Self::Opaque(uri.to_string())
             }
         } else {
-            Self::Opaque(url.to_string())
+            Self::Opaque(uri.to_string())
         }
     }
 

--- a/crates/ty_server/src/document/notebook.rs
+++ b/crates/ty_server/src/document/notebook.rs
@@ -10,23 +10,23 @@ use crate::session::index::Index;
 ///
 /// This notebook document only stores the metadata about the notebook
 /// and the cell metadata. The cell contents are stored as separate
-/// [`super::TextDocument`]s (they can be looked up by the Cell's URL).
+/// [`super::TextDocument`]s (they can be looked up by the Cell's URI).
 #[derive(Clone, Debug)]
 pub struct NotebookDocument {
-    url: lsp_types::Url,
+    uri: lsp_types::Uri,
     cells: Vec<NotebookCell>,
     metadata: ruff_notebook::RawNotebookMetadata,
     version: DocumentVersion,
-    /// Map from Cell URL to their index in `cells`
-    cell_index: FxHashMap<lsp_types::Url, usize>,
+    /// Map from Cell URI to their index in `cells`
+    cell_index: FxHashMap<lsp_types::Uri, usize>,
 }
 
 /// The metadata of a single cell within a notebook.
 ///
-/// The cell's content are stored as a [`TextDocument`] and can be looked up by the Cell's URL.
+/// The cell's content are stored as a [`TextDocument`] and can be looked up by the Cell's URI.
 #[derive(Clone, Debug)]
 struct NotebookCell {
-    /// The URL uniquely identifying the cell.
+    /// The URI uniquely identifying the cell.
     ///
     /// > Cell text documents have a URI, but servers should not rely on any
     /// > format for this URI, since it is up to the client on how it will
@@ -34,14 +34,14 @@ struct NotebookCell {
     /// > cells and can therefore be used to uniquely identify a notebook cell
     /// >  or the cell’s text document.
     /// > <https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#notebookDocument_synchronization>
-    url: lsp_types::Url,
+    uri: lsp_types::Uri,
     kind: NotebookCellKind,
     execution_summary: Option<lsp_types::ExecutionSummary>,
 }
 
 impl NotebookDocument {
     pub fn new(
-        url: lsp_types::Url,
+        uri: lsp_types::Uri,
         notebook_version: DocumentVersion,
         cells: Vec<lsp_types::NotebookCell>,
         metadata: serde_json::Map<String, serde_json::Value>,
@@ -50,20 +50,20 @@ impl NotebookDocument {
         let index = cells
             .iter()
             .enumerate()
-            .map(|(index, cell)| (cell.url.clone(), index))
+            .map(|(index, cell)| (cell.uri.clone(), index))
             .collect();
 
         Ok(Self {
             cell_index: index,
-            url,
+            uri,
             version: notebook_version,
             cells,
-            metadata: serde_json::from_value(serde_json::Value::Object(metadata))?,
+            metadata: serde_json::from_value(serde_json::to_value(metadata)?)?,
         })
     }
 
-    pub(crate) fn url(&self) -> &lsp_types::Url {
-        &self.url
+    pub(crate) fn uri(&self) -> &lsp_types::Uri {
+        &self.uri
     }
 
     /// Generates a pseudo-representation of a notebook that lacks per-cell metadata and contextual information
@@ -74,15 +74,15 @@ impl NotebookDocument {
             .iter()
             .map(|cell| {
                 let cell_text =
-                    if let Ok(document) = index.document(&DocumentKey::from_url(&cell.url)) {
+                    if let Ok(document) = index.document(&DocumentKey::from_uri(&cell.uri)) {
                         if let Some(text_document) = document.as_text() {
                             Some(text_document.contents().to_string())
                         } else {
-                            tracing::warn!("Non-text document found for cell `{}`", cell.url);
+                            tracing::warn!("Non-text document found for cell `{}`", cell.uri);
                             None
                         }
                     } else {
-                        tracing::warn!("Text document not found for cell `{}`", cell.url);
+                        tracing::warn!("Text document not found for cell `{}`", cell.uri);
                         None
                     }
                     .unwrap_or_default();
@@ -148,7 +148,7 @@ impl NotebookDocument {
                 self.cells
                     .iter()
                     .enumerate()
-                    .map(|(i, cell)| (cell.url.clone(), i)),
+                    .map(|(i, cell)| (cell.uri.clone(), i)),
             );
         }
 
@@ -159,7 +159,7 @@ impl NotebookDocument {
         }
 
         if let Some(metadata_change) = metadata_change {
-            self.metadata = serde_json::from_value(serde_json::Value::Object(metadata_change))?;
+            self.metadata = serde_json::from_value(serde_json::to_value(metadata_change)?)?;
         }
 
         Ok(())
@@ -171,20 +171,20 @@ impl NotebookDocument {
     }
 
     /// Get the URI for a cell by its index within the cell array.
-    pub(crate) fn cell_uri_by_index(&self, index: OneIndexed) -> Option<&lsp_types::Url> {
+    pub(crate) fn cell_uri_by_index(&self, index: OneIndexed) -> Option<&lsp_types::Uri> {
         self.cells
             .get(index.to_zero_indexed())
-            .map(|cell| &cell.url)
+            .map(|cell| &cell.uri)
     }
 
     /// Returns a list of cell URIs in the order they appear in the array.
-    pub(crate) fn cell_urls(&self) -> impl Iterator<Item = &lsp_types::Url> {
-        self.cells.iter().map(|cell| &cell.url)
+    pub(crate) fn cell_uris(&self) -> impl Iterator<Item = &lsp_types::Uri> {
+        self.cells.iter().map(|cell| &cell.uri)
     }
 
-    pub(crate) fn cell_index_by_uri(&self, cell_url: &lsp_types::Url) -> Option<OneIndexed> {
+    pub(crate) fn cell_index_by_uri(&self, cell_uri: &lsp_types::Uri) -> Option<OneIndexed> {
         Some(OneIndexed::from_zero_indexed(
-            self.cell_index.get(cell_url).copied()?,
+            self.cell_index.get(cell_uri).copied()?,
         ))
     }
 }
@@ -192,7 +192,7 @@ impl NotebookDocument {
 impl NotebookCell {
     pub(crate) fn new(cell: lsp_types::NotebookCell) -> Self {
         Self {
-            url: cell.document,
+            uri: cell.document,
             kind: cell.kind,
             execution_summary: cell.execution_summary,
         }

--- a/crates/ty_server/src/document/range.rs
+++ b/crates/ty_server/src/document/range.rs
@@ -1,8 +1,8 @@
 use super::PositionEncoding;
 use crate::Db;
-use crate::system::file_to_url;
+use crate::system::file_to_uri;
 
-use lsp_types::Url;
+use lsp_types::Uri;
 use ruff_db::files::{File, FileRange, system_path_to_file, vendored_path_to_file};
 use ruff_db::source::{line_index, source_text};
 use ruff_db::system::SystemPathBuf;
@@ -17,7 +17,7 @@ pub(crate) struct LspRange {
     range: lsp_types::Range,
 
     /// The URI of this range's text document
-    uri: Option<lsp_types::Url>,
+    uri: Option<lsp_types::Uri>,
 }
 
 impl LspRange {
@@ -58,7 +58,7 @@ pub(crate) struct LspPosition {
     position: lsp_types::Position,
 
     /// The URI of this range's text document
-    uri: Option<lsp_types::Url>,
+    uri: Option<lsp_types::Uri>,
 }
 
 impl LspPosition {
@@ -75,7 +75,7 @@ impl LspPosition {
 
     /// Returns the uri of the text document this position belongs to.
     #[expect(unused)]
-    pub(crate) fn uri(&self) -> Option<&lsp_types::Url> {
+    pub(crate) fn uri(&self) -> Option<&lsp_types::Uri> {
         self.uri.as_ref()
     }
 }
@@ -84,13 +84,13 @@ pub(crate) trait RangeExt {
     /// Convert an LSP Range to a [`TextRange`].
     ///
     /// Returns `None` if `file` is a notebook and the
-    /// cell identified by `url` can't be looked up or if the notebook
+    /// cell identified by `uri` can't be looked up or if the notebook
     /// isn't open in the editor.
     fn to_text_range(
         &self,
         db: &dyn Db,
         file: File,
-        url: &lsp_types::Url,
+        uri: &lsp_types::Uri,
         encoding: PositionEncoding,
     ) -> Option<TextRange>;
 }
@@ -100,11 +100,11 @@ impl RangeExt for lsp_types::Range {
         &self,
         db: &dyn Db,
         file: File,
-        url: &lsp_types::Url,
+        uri: &lsp_types::Uri,
         encoding: PositionEncoding,
     ) -> Option<TextRange> {
-        let start = self.start.to_text_size(db, file, url, encoding)?;
-        let end = self.end.to_text_size(db, file, url, encoding)?;
+        let start = self.start.to_text_size(db, file, uri, encoding)?;
+        let end = self.end.to_text_size(db, file, uri, encoding)?;
 
         Some(TextRange::new(start, end))
     }
@@ -118,13 +118,13 @@ pub(crate) trait PositionExt {
     /// concatenated notebook file.
     ///
     /// Returns `None` if `file` is a notebook and the
-    /// cell identified by `url` can't be looked up or if the notebook
+    /// cell identified by `uri` can't be looked up or if the notebook
     /// isn't open in the editor.
     fn to_text_size(
         &self,
         db: &dyn Db,
         file: File,
-        url: &lsp_types::Url,
+        uri: &lsp_types::Uri,
         encoding: PositionEncoding,
     ) -> Option<TextSize>;
 }
@@ -134,7 +134,7 @@ impl PositionExt for lsp_types::Position {
         &self,
         db: &dyn Db,
         file: File,
-        url: &lsp_types::Url,
+        uri: &lsp_types::Uri,
         encoding: PositionEncoding,
     ) -> Option<TextSize> {
         let source = source_text(db, file);
@@ -142,7 +142,7 @@ impl PositionExt for lsp_types::Position {
 
         if let Some(notebook) = source.as_notebook() {
             let notebook_document = db.notebook_document(file)?;
-            let cell_index = notebook_document.cell_index_by_uri(url)?;
+            let cell_index = notebook_document.cell_index_by_uri(uri)?;
 
             let cell_start_offset = notebook.cell_offset(cell_index).unwrap_or_default();
             let cell_relative_line = OneIndexed::from_zero_indexed(u32_index_to_usize(self.line));
@@ -206,7 +206,7 @@ impl TextSizeExt for TextSize {
             });
         }
 
-        let uri = file_to_url(db, file);
+        let uri = file_to_uri(db, file);
         let position = text_size_to_lsp_position(*self, &source, &index, encoding);
 
         Some(LspPosition { position, uri })
@@ -323,7 +323,7 @@ impl ToRangeExt for TextRange {
 
         let range = text_range_to_lsp_range(*self, &source, &index, encoding);
 
-        let uri = file_to_url(db, file);
+        let uri = file_to_uri(db, file);
         Some(LspRange { range, uri })
     }
 }
@@ -353,7 +353,7 @@ impl FileRangeExt for FileRange {
 /// path types (if applicable).
 pub(crate) fn resolve_file_uri_range(
     db: &ProjectDatabase,
-    file_uri: &Url,
+    file_uri: &Uri,
     range: lsp_types::Range,
     encoding: PositionEncoding,
 ) -> Option<(File, TextSize)> {

--- a/crates/ty_server/src/document/text_document.rs
+++ b/crates/ty_server/src/document/text_document.rs
@@ -1,4 +1,7 @@
-use lsp_types::{TextDocumentContentChangeEvent, Url};
+use lsp_types::{
+    LanguageKind, TextDocumentContentChangeEvent, TextDocumentContentChangePartial,
+    TextDocumentContentChangeWholeDocument, Uri,
+};
 use ruff_source_file::LineIndex;
 
 use crate::PositionEncoding;
@@ -13,8 +16,8 @@ pub(crate) type DocumentVersion = i32;
 /// with changes made by the user, including unsaved changes.
 #[derive(Debug, Clone)]
 pub struct TextDocument {
-    /// The URL as sent by the client
-    url: Url,
+    /// The URI as sent by the client
+    uri: Uri,
 
     /// The string contents of the document.
     contents: String,
@@ -36,19 +39,24 @@ pub enum LanguageId {
     Other,
 }
 
-impl From<&str> for LanguageId {
-    fn from(language_id: &str) -> Self {
+impl From<LanguageKind> for LanguageId {
+    fn from(language_id: LanguageKind) -> Self {
         match language_id {
-            "python" => Self::Python,
+            LanguageKind::Python => Self::Python,
             _ => Self::Other,
         }
     }
 }
 
 impl TextDocument {
-    pub fn new(url: Url, contents: String, version: DocumentVersion, language_id: &str) -> Self {
+    pub fn new(
+        uri: Uri,
+        contents: String,
+        version: DocumentVersion,
+        language_id: LanguageKind,
+    ) -> Self {
         Self {
-            url,
+            uri,
             contents,
             version,
             language_id: LanguageId::from(language_id),
@@ -66,8 +74,8 @@ impl TextDocument {
         self.contents
     }
 
-    pub(crate) fn url(&self) -> &Url {
-        &self.url
+    pub(crate) fn uri(&self) -> &Uri {
+        &self.uri
     }
 
     pub fn contents(&self) -> &str {
@@ -93,9 +101,9 @@ impl TextDocument {
         encoding: PositionEncoding,
     ) {
         if let [
-            lsp_types::TextDocumentContentChangeEvent {
-                range: None, text, ..
-            },
+            lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument { text },
+            ),
         ] = changes.as_slice()
         {
             tracing::debug!("Fast path - replacing entire document");
@@ -109,21 +117,22 @@ impl TextDocument {
         let mut new_contents = self.contents().to_string();
         let mut active_index = LineIndex::from_source_text(&new_contents);
 
-        for TextDocumentContentChangeEvent {
-            range,
-            text: change,
-            ..
-        } in changes
-        {
-            if let Some(range) = range {
-                let range = lsp_range_to_text_range(range, &new_contents, &active_index, encoding);
+        for change in changes {
+            match change {
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial { range, text, .. },
+                ) => {
+                    let range =
+                        lsp_range_to_text_range(range, &new_contents, &active_index, encoding);
 
-                new_contents.replace_range(
-                    usize::from(range.start())..usize::from(range.end()),
-                    &change,
-                );
-            } else {
-                new_contents = change;
+                    new_contents
+                        .replace_range(usize::from(range.start())..usize::from(range.end()), &text);
+                }
+                TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                    TextDocumentContentChangeWholeDocument { text },
+                ) => {
+                    new_contents = text;
+                }
             }
 
             active_index = LineIndex::from_source_text(&new_contents);
@@ -152,12 +161,15 @@ impl TextDocument {
 #[cfg(test)]
 mod tests {
     use crate::{PositionEncoding, TextDocument};
-    use lsp_types::{Position, TextDocumentContentChangeEvent, Url};
+    use lsp_types::{
+        LanguageKind, Position, TextDocumentContentChangeEvent, TextDocumentContentChangePartial,
+        Uri,
+    };
 
     #[test]
     fn redo_edit() {
         let mut document = TextDocument::new(
-            Url::parse("file:///test").unwrap(),
+            Uri::parse("file:///test").unwrap(),
             r#""""
 测试comment
 一些测试内容
@@ -171,36 +183,33 @@ def interface():
 "#
             .to_string(),
             0,
-            "python",
+            LanguageKind::Python,
         );
 
         // Add an `s`, remove it again (back to the original code), and then re-add the `s`
         document.apply_changes(
             vec![
-                TextDocumentContentChangeEvent {
-                    range: Some(lsp_types::Range::new(
-                        Position::new(9, 7),
-                        Position::new(9, 7),
-                    )),
-                    range_length: Some(0),
-                    text: "s".to_string(),
-                },
-                TextDocumentContentChangeEvent {
-                    range: Some(lsp_types::Range::new(
-                        Position::new(9, 7),
-                        Position::new(9, 8),
-                    )),
-                    range_length: Some(1),
-                    text: String::new(),
-                },
-                TextDocumentContentChangeEvent {
-                    range: Some(lsp_types::Range::new(
-                        Position::new(9, 7),
-                        Position::new(9, 7),
-                    )),
-                    range_length: Some(0),
-                    text: "s".to_string(),
-                },
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial {
+                        range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 7)),
+                        text: "s".to_string(),
+                        ..Default::default()
+                    },
+                ),
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial {
+                        range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 8)),
+                        text: String::new(),
+                        ..Default::default()
+                    },
+                ),
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial {
+                        range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 7)),
+                        text: "s".to_string(),
+                        ..Default::default()
+                    },
+                ),
             ],
             1,
             PositionEncoding::UTF16,

--- a/crates/ty_server/src/lib.rs
+++ b/crates/ty_server/src/lib.rs
@@ -6,7 +6,7 @@ use ruff_db::system::{OsSystem, SystemPathBuf};
 
 use crate::db::Db;
 pub use crate::logging::{LogLevel, init_logging};
-pub use crate::server::{PartialWorkspaceProgress, PartialWorkspaceProgressParams, Server};
+pub use crate::server::Server;
 pub use crate::session::{ClientOptions, DiagnosticMode, GlobalOptions, WorkspaceOptions};
 pub use document::{NotebookDocument, PositionEncoding, TextDocument};
 pub(crate) use session::Session;

--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -6,7 +6,10 @@ use crate::capabilities::{ResolvedClientCapabilities, server_capabilities};
 use crate::session::{ClientName, InitializationOptions, Session, warn_about_unknown_options};
 use anyhow::Context;
 use lsp_server::Connection;
-use lsp_types::{ClientCapabilities, InitializeParams, MessageType, Url};
+use lsp_types::{
+    ClientCapabilities, InitializeParams, MessageType, Uri, WorkspaceFolders,
+    WorkspaceFoldersInitializeParams,
+};
 use ruff_db::system::System;
 use std::num::NonZeroUsize;
 use std::panic::{PanicHookInfo, RefUnwindSafe};
@@ -24,7 +27,6 @@ pub(crate) use main_loop::{
     Action, ConnectionSender, Event, MainLoopReceiver, MainLoopSender, SendRequest,
 };
 pub(crate) type Result<T> = std::result::Result<T, api::Error>;
-pub use api::{PartialWorkspaceProgress, PartialWorkspaceProgressParams};
 
 pub struct Server {
     connection: Connection,
@@ -46,7 +48,8 @@ impl Server {
         let InitializeParams {
             initialization_options,
             capabilities: client_capabilities,
-            workspace_folders,
+            workspace_folders_initialize_params:
+                WorkspaceFoldersInitializeParams { workspace_folders },
             client_info,
             ..
         } = serde_json::from_value(init_value)
@@ -103,7 +106,15 @@ impl Server {
 
         // Get workspace URLs without settings - settings will come from workspace/configuration
         let workspace_urls = workspace_folders
-            .filter(|folders| !folders.is_empty())
+            .and_then(|folders| {
+                if let WorkspaceFolders::WorkspaceFolderList(folders) = folders
+                    && !folders.is_empty()
+                {
+                    Some(folders)
+                } else {
+                    None
+                }
+            })
             .map(|folders| {
                 folders
                     .into_iter()
@@ -121,7 +132,7 @@ impl Server {
                     default workspace: {}",
                     current_dir.display()
                 );
-                let uri = Url::from_file_path(current_dir).ok()?;
+                let uri = Uri::from_file_path(current_dir).ok()?;
                 Some(vec![uri])
             })
             .ok_or_else(|| {
@@ -207,7 +218,7 @@ impl ServerPanicHookHandler {
             if let Some(client) = hook_client.upgrade() {
                 client.show_message(
                     "The ty language server exited with a panic. See the logs for more details.",
-                    MessageType::ERROR,
+                    MessageType::Error,
                 );
             }
         }));

--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -3,8 +3,8 @@ use crate::session::Session;
 use anyhow::anyhow;
 use lsp_server as server;
 use lsp_server::{ErrorCode, RequestId};
-use lsp_types::notification::Notification;
-use lsp_types::request::Request;
+use lsp_types::{LspNotificationMethod, Notification};
+use lsp_types::{LspRequestMethod, Request};
 use std::panic::{AssertUnwindSafe, UnwindSafe};
 
 mod diagnostics;
@@ -19,7 +19,6 @@ use self::traits::{NotificationHandler, RequestHandler};
 use super::{Result, schedule::BackgroundSchedule};
 use crate::session::client::Client;
 pub(crate) use diagnostics::publish_settings_diagnostics;
-pub use requests::{PartialWorkspaceProgress, PartialWorkspaceProgressParams};
 use ruff_db::panic::PanicError;
 
 /// Processes a request from the client to the server.
@@ -31,7 +30,7 @@ use ruff_db::panic::PanicError;
 pub(super) fn request(req: server::Request) -> Task {
     let id = req.id.clone();
 
-    match req.method.as_str() {
+    match LspRequestMethod::from(req.method.as_str()) {
         requests::ExecuteCommand::METHOD => sync_request_task::<requests::ExecuteCommand>(req),
         requests::CodeActionRequestHandler::METHOD => background_document_request_task::<
             requests::CodeActionRequestHandler,
@@ -142,7 +141,7 @@ pub(super) fn request(req: server::Request) -> Task {
                 BackgroundSchedule::Worker,
             )
         }
-        lsp_types::request::Shutdown::METHOD => sync_request_task::<requests::ShutdownHandler>(req),
+        lsp_types::ShutdownRequest::METHOD => sync_request_task::<requests::ShutdownHandler>(req),
 
         method => {
             tracing::warn!("Received request {method} which does not have a handler");
@@ -178,7 +177,7 @@ pub(super) fn request(req: server::Request) -> Task {
 }
 
 pub(super) fn notification(notif: server::Notification) -> Task {
-    match notif.method.as_str() {
+    match LspNotificationMethod::from(notif.method.as_str()) {
         notifications::DidCloseTextDocumentHandler::METHOD => {
             sync_notification_task::<notifications::DidCloseTextDocumentHandler>(notif)
         }
@@ -203,10 +202,10 @@ pub(super) fn notification(notif: server::Notification) -> Task {
         notifications::DidChangeWorkspaceFoldersHandler::METHOD => {
             sync_notification_task::<notifications::DidChangeWorkspaceFoldersHandler>(notif)
         }
-        lsp_types::notification::Cancel::METHOD => {
+        lsp_types::CancelNotification::METHOD => {
             sync_notification_task::<notifications::CancelNotificationHandler>(notif)
         }
-        lsp_types::notification::SetTrace::METHOD => {
+        lsp_types::SetTraceNotification::METHOD => {
             tracing::trace!("Ignoring `setTrace` notification");
             return Task::nothing();
         }
@@ -235,7 +234,7 @@ where
 {
     let (id, params) = cast_request::<R>(req)?;
     Ok(Task::sync(move |session, client: &Client| {
-        let _span = tracing::debug_span!("request", %id, method = R::METHOD).entered();
+        let _span = tracing::debug_span!("request", %id, method = %R::METHOD).entered();
         let result = R::run(session, client, params);
         respond::<R>(&id, result, client, session.client_name().log_guidance());
     }))
@@ -264,7 +263,7 @@ where
         let log_guidance = snapshot.0.client_name().log_guidance();
 
         Box::new(move |client| {
-            let _span = tracing::debug_span!("request", %id, method = R::METHOD).entered();
+            let _span = tracing::debug_span!("request", %id, method = %R::METHOD).entered();
 
             // Test again if the request was cancelled since it was scheduled on the background task
             // and, if so, return early
@@ -306,10 +305,10 @@ where
             .cancellation_token(&id)
             .expect("request should have been tested for cancellation before scheduling");
 
-        let url = R::document_url(&params);
+        let uri = R::document_uri(&params);
 
-        let Ok(document) = session.snapshot_document(&url) else {
-            let reason = format!("Document {url} is not open in the session");
+        let Ok(document) = session.snapshot_document(&uri) else {
+            let reason = format!("Document {uri} is not open in the session");
             tracing::warn!(
                 "Ignoring request id={id} method={} because {reason}",
                 R::METHOD
@@ -332,7 +331,7 @@ where
         let log_guidance = document.client_name().log_guidance();
 
         Box::new(move |client| {
-            let _span = tracing::debug_span!("request", %id, method = R::METHOD).entered();
+            let _span = tracing::debug_span!("request", %id, method = %R::METHOD).entered();
 
             // Test again if the request was cancelled since it was scheduled on the background task
             // and, if so, return early
@@ -403,7 +402,7 @@ fn sync_notification_task<N: traits::SyncNotificationHandler>(
 ) -> Result<Task> {
     let (id, params) = cast_notification::<N>(notif)?;
     Ok(Task::sync(move |session, client| {
-        let _span = tracing::debug_span!("notification", method = N::METHOD).entered();
+        let _span = tracing::debug_span!("notification", method = %N::METHOD).entered();
         if let Err(err) = N::run(session, client, params) {
             tracing::error!("An error occurred while running {id}: {err}");
             client.show_error_message(format!(
@@ -431,9 +430,9 @@ where
 {
     let (id, params) = cast_notification::<N>(req)?;
     Ok(Task::background(schedule, move |session: &Session| {
-        let url = N::document_url(&params);
-        let Ok(snapshot) = session.snapshot_document(&url) else {
-            let reason = format!("Document {url} is not open in the session");
+        let uri = N::document_uri(&params);
+        let Ok(snapshot) = session.snapshot_document(&uri) else {
+            let reason = format!("Document {uri} is not open in the session");
             tracing::warn!(
                 "Ignoring notification id={id} method={} because {reason}",
                 N::METHOD
@@ -444,7 +443,7 @@ where
         let log_guidance = snapshot.client_name().log_guidance();
 
         Box::new(move |client| {
-            let _span = tracing::debug_span!("notification", method = N::METHOD).entered();
+            let _span = tracing::debug_span!("notification", method = %N::METHOD).entered();
 
             let result = match ruff_db::panic::catch_unwind(|| {
                 N::run_with_snapshot(snapshot, client, params)
@@ -480,7 +479,7 @@ where
     <<Req as RequestHandler>::RequestType as Request>::Params: UnwindSafe,
 {
     request
-        .extract(Req::METHOD)
+        .extract(Req::METHOD.as_str())
         .map_err(|err| match err {
             json_err @ server::ExtractError::JsonError { .. } => {
                 anyhow::anyhow!("JSON parsing failure:\n{json_err}")
@@ -520,7 +519,7 @@ fn respond_silent_error(id: RequestId, client: &Client, error: lsp_server::Respo
 fn cast_notification<N>(
     notification: server::Notification,
 ) -> Result<(
-    &'static str,
+    LspNotificationMethod<'static>,
     <<N as NotificationHandler>::NotificationType as Notification>::Params,
 )>
 where
@@ -529,7 +528,7 @@ where
     Ok((
         N::METHOD,
         notification
-            .extract(N::METHOD)
+            .extract(N::METHOD.as_str())
             .map_err(|err| match err {
                 json_err @ server::ExtractError::JsonError { .. } => {
                     anyhow::anyhow!("JSON parsing failure:\n{json_err}")

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::hash::{DefaultHasher, Hash as _, Hasher as _};
 
-use lsp_types::notification::PublishDiagnostics;
+use lsp_types::{Code, PublishDiagnosticsNotification};
 use lsp_types::{
     CodeDescription, Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, DiagnosticTag,
-    NumberOrString, PublishDiagnosticsParams, Url,
+    Message, PublishDiagnosticsParams, Uri,
 };
 use ruff_diagnostics::Applicability;
 use ruff_text_size::Ranged;
@@ -22,7 +22,7 @@ use crate::capabilities::ResolvedClientCapabilities;
 use crate::document::{FileRangeExt, ToRangeExt};
 use crate::session::client::Client;
 use crate::session::{DocumentHandle, GlobalSettings};
-use crate::system::{AnySystemPath, file_to_url};
+use crate::system::{AnySystemPath, file_to_uri};
 use crate::{DIAGNOSTIC_NAME, Db, DiagnosticMode};
 use crate::{PositionEncoding, Session};
 
@@ -69,16 +69,16 @@ impl Diagnostics {
         global_settings: &GlobalSettings,
     ) -> LspDiagnostics {
         if let Some(notebook_document) = db.notebook_document(self.file_or_notebook) {
-            let mut cell_diagnostics: FxHashMap<Url, Vec<Diagnostic>> = FxHashMap::default();
+            let mut cell_diagnostics: FxHashMap<Uri, Vec<Diagnostic>> = FxHashMap::default();
 
-            // Populates all relevant URLs with an empty diagnostic list. This ensures that documents
+            // Populates all relevant URIs with an empty diagnostic list. This ensures that documents
             // without diagnostics still get updated.
-            for cell_url in notebook_document.cell_urls() {
-                cell_diagnostics.entry(cell_url.clone()).or_default();
+            for cell_uri in notebook_document.cell_uris() {
+                cell_diagnostics.entry(cell_uri.clone()).or_default();
             }
 
             for diagnostic in &*self.items {
-                let Some((url, lsp_diagnostic)) = to_lsp_diagnostic(
+                let Some((uri, lsp_diagnostic)) = to_lsp_diagnostic(
                     db,
                     diagnostic,
                     self.encoding,
@@ -88,19 +88,19 @@ impl Diagnostics {
                     continue;
                 };
 
-                let Some(url) = url else {
+                let Some(uri) = uri else {
                     tracing::warn!("Unable to find notebook cell");
                     continue;
                 };
 
                 cell_diagnostics
-                    .entry(url)
+                    .entry(uri)
                     .or_default()
                     .push(lsp_diagnostic);
             }
 
             for hint in &self.unnecessary_hints {
-                let Some((url, lsp_diagnostic)) = unnecessary_hint_to_lsp_diagnostic(
+                let Some((uri, lsp_diagnostic)) = unnecessary_hint_to_lsp_diagnostic(
                     db,
                     self.file_or_notebook,
                     self.encoding,
@@ -109,13 +109,13 @@ impl Diagnostics {
                     continue;
                 };
 
-                let Some(url) = url else {
+                let Some(uri) = uri else {
                     tracing::warn!("Unable to find notebook cell");
                     continue;
                 };
 
                 cell_diagnostics
-                    .entry(url)
+                    .entry(uri)
                     .or_default()
                     .push(lsp_diagnostic);
             }
@@ -153,8 +153,8 @@ impl Diagnostics {
 pub(super) enum LspDiagnostics {
     TextDocument(Vec<Diagnostic>),
 
-    /// A map of cell URLs to the diagnostics for that cell.
-    NotebookDocument(FxHashMap<Url, Vec<Diagnostic>>),
+    /// A map of cell URIs to the diagnostics for that cell.
+    NotebookDocument(FxHashMap<Uri, Vec<Diagnostic>>),
 }
 
 impl LspDiagnostics {
@@ -208,8 +208,8 @@ pub(super) fn publish_diagnostics(document: &DocumentHandle, session: &Session, 
     };
 
     // Sends a notification to the client with the diagnostics for the document.
-    let publish_diagnostics_notification = |uri: Url, diagnostics: Vec<Diagnostic>| {
-        client.send_notification::<PublishDiagnostics>(PublishDiagnosticsParams {
+    let publish_diagnostics_notification = |uri: Uri, diagnostics: Vec<Diagnostic>| {
+        client.send_notification::<PublishDiagnosticsNotification>(PublishDiagnosticsParams {
             uri,
             diagnostics,
             version: Some(document.version()),
@@ -222,11 +222,11 @@ pub(super) fn publish_diagnostics(document: &DocumentHandle, session: &Session, 
         session.global_settings(),
     ) {
         LspDiagnostics::TextDocument(diagnostics) => {
-            publish_diagnostics_notification(document.url().clone(), diagnostics);
+            publish_diagnostics_notification(document.uri().clone(), diagnostics);
         }
         LspDiagnostics::NotebookDocument(cell_diagnostics) => {
-            for (cell_url, diagnostics) in cell_diagnostics {
-                publish_diagnostics_notification(cell_url, diagnostics);
+            for (cell_uri, diagnostics) in cell_diagnostics {
+                publish_diagnostics_notification(cell_uri, diagnostics);
             }
         }
     }
@@ -258,7 +258,7 @@ pub(crate) fn publish_settings_diagnostics(
 
     let project_path = AnySystemPath::System(path);
 
-    let (mut diagnostics_by_url, old_untracked) = {
+    let (mut diagnostics_by_uri, old_untracked) = {
         let state = session.project_state_mut(&project_path);
         let db = &state.db;
         let project = db.project();
@@ -272,40 +272,40 @@ pub(crate) fn publish_settings_diagnostics(
             return;
         }
 
-        // Group diagnostics by URL
-        let mut diagnostics_by_url: FxHashMap<Url, Vec<_>> = FxHashMap::default();
+        // Group diagnostics by URI
+        let mut diagnostics_by_uri: FxHashMap<Uri, Vec<_>> = FxHashMap::default();
         for diagnostic in settings_diagnostics {
             if let Some(span) = diagnostic.primary_span() {
                 let file = span.expect_ty_file();
-                let Some(url) = file_to_url(db, file) else {
-                    tracing::debug!("Failed to convert file to URL at {}", file.path(db));
+                let Some(uri) = file_to_uri(db, file) else {
+                    tracing::debug!("Failed to convert file to URI at {}", file.path(db));
                     continue;
                 };
-                diagnostics_by_url.entry(url).or_default().push(diagnostic);
+                diagnostics_by_uri.entry(uri).or_default().push(diagnostic);
             }
         }
 
-        // Record the URLs we're sending non-empty diagnostics for, so we know to clear them
+        // Record the URIs we're sending non-empty diagnostics for, so we know to clear them
         // the next time we publish settings diagnostics!
         let old_untracked = std::mem::replace(
             &mut state.untracked_files_with_pushed_diagnostics,
-            diagnostics_by_url.keys().cloned().collect(),
+            diagnostics_by_uri.keys().cloned().collect(),
         );
 
-        (diagnostics_by_url, old_untracked)
+        (diagnostics_by_uri, old_untracked)
     };
 
     // Add empty diagnostics for any files that had diagnostics before but don't now.
     // This will clear them (either the file is no longer relevant to us or fixed!)
-    for url in old_untracked {
-        diagnostics_by_url.entry(url).or_default();
+    for uri in old_untracked {
+        diagnostics_by_uri.entry(uri).or_default();
     }
 
     let db = session.project_db(&project_path);
     let global_settings = session.global_settings();
 
     // Send the settings diagnostics!
-    for (url, file_diagnostics) in diagnostics_by_url {
+    for (uri, file_diagnostics) in diagnostics_by_uri {
         // Convert diagnostics to LSP format
         let lsp_diagnostics = file_diagnostics
             .into_iter()
@@ -323,8 +323,8 @@ pub(crate) fn publish_settings_diagnostics(
             })
             .collect::<Vec<_>>();
 
-        client.send_notification::<PublishDiagnostics>(PublishDiagnosticsParams {
-            uri: url,
+        client.send_notification::<PublishDiagnosticsNotification>(PublishDiagnosticsParams {
+            uri,
             diagnostics: lsp_diagnostics,
             version: None,
         });
@@ -373,21 +373,21 @@ fn unnecessary_hint_to_lsp_diagnostic(
     file: File,
     encoding: PositionEncoding,
     hint: &Hint,
-) -> Option<(Option<Url>, Diagnostic)> {
+) -> Option<(Option<Uri>, Diagnostic)> {
     let range = hint.range.to_lsp_range(db, file, encoding)?;
-    let url = range.to_location().map(|location| location.uri);
+    let uri = range.to_location().map(|location| location.uri);
 
     Some((
-        url,
+        uri,
         Diagnostic {
             range: range.local_range(),
-            severity: Some(DiagnosticSeverity::HINT),
+            severity: Some(DiagnosticSeverity::Hint),
             code: None,
             code_description: None,
             source: Some(DIAGNOSTIC_NAME.into()),
-            message: hint.message(),
+            message: Message::String(hint.message()),
             related_information: None,
-            tags: Some(vec![DiagnosticTag::UNNECESSARY]),
+            tags: Some(vec![DiagnosticTag::Unnecessary]),
             data: None,
         },
     ))
@@ -401,7 +401,7 @@ pub(super) fn to_lsp_diagnostic(
     encoding: PositionEncoding,
     client_capabilities: ResolvedClientCapabilities,
     global_settings: &GlobalSettings,
-) -> Option<(Option<lsp_types::Url>, Diagnostic)> {
+) -> Option<(Option<lsp_types::Uri>, Diagnostic)> {
     if diagnostic.is_invalid_syntax() && !global_settings.show_syntax_errors() {
         return None;
     }
@@ -417,15 +417,15 @@ pub(super) fn to_lsp_diagnostic(
             .to_location()
     });
 
-    let (range, url) = match location {
+    let (range, uri) = match location {
         Some(location) => (location.range, Some(location.uri)),
         None => (lsp_types::Range::default(), None),
     };
 
     let severity = match diagnostic.severity() {
-        Severity::Info => DiagnosticSeverity::INFORMATION,
-        Severity::Warning => DiagnosticSeverity::WARNING,
-        Severity::Error | Severity::Fatal => DiagnosticSeverity::ERROR,
+        Severity::Info => DiagnosticSeverity::Information,
+        Severity::Warning => DiagnosticSeverity::Warning,
+        Severity::Error | Severity::Fatal => DiagnosticSeverity::Error,
     };
 
     let tags = diagnostic
@@ -433,15 +433,15 @@ pub(super) fn to_lsp_diagnostic(
         .map(|tags| {
             tags.iter()
                 .map(|tag| match tag {
-                    ruff_db::diagnostic::DiagnosticTag::Unnecessary => DiagnosticTag::UNNECESSARY,
-                    ruff_db::diagnostic::DiagnosticTag::Deprecated => DiagnosticTag::DEPRECATED,
+                    ruff_db::diagnostic::DiagnosticTag::Unnecessary => DiagnosticTag::Unnecessary,
+                    ruff_db::diagnostic::DiagnosticTag::Deprecated => DiagnosticTag::Deprecated,
                 })
                 .collect::<Vec<DiagnosticTag>>()
         })
         .filter(|mapped_tags| !mapped_tags.is_empty());
 
     let code_description = diagnostic.documentation_url().and_then(|url| {
-        let href = Url::parse(url).ok()?;
+        let href = Uri::parse(url).ok()?;
 
         Some(CodeDescription { href })
     });
@@ -513,15 +513,15 @@ pub(super) fn to_lsp_diagnostic(
     }
 
     Some((
-        url,
+        uri,
         Diagnostic {
             range,
             severity: Some(severity),
             tags,
-            code: Some(NumberOrString::String(diagnostic.id().to_string())),
+            code: Some(Code::String(diagnostic.id().to_string())),
             code_description,
             source: Some(DIAGNOSTIC_NAME.into()),
-            message,
+            message: Message::String(message),
             related_information,
             data: serde_json::to_value(data).ok(),
         },
@@ -567,7 +567,7 @@ fn sub_diagnostic_to_related_information(
 #[derive(Serialize, Deserialize)]
 pub(crate) struct DiagnosticData {
     pub(crate) fix_title: String,
-    pub(crate) edits: HashMap<Url, Vec<lsp_types::TextEdit>>,
+    pub(crate) edits: HashMap<Uri, Vec<lsp_types::TextEdit>>,
 }
 
 impl DiagnosticData {
@@ -583,7 +583,7 @@ impl DiagnosticData {
         let primary_span = diagnostic.primary_span()?;
         let file = primary_span.expect_ty_file();
 
-        let mut lsp_edits: HashMap<Url, Vec<lsp_types::TextEdit>> = HashMap::new();
+        let mut lsp_edits: HashMap<Uri, Vec<lsp_types::TextEdit>> = HashMap::new();
 
         for edit in fix.edits() {
             let location = edit

--- a/crates/ty_server/src/server/api/notifications/cancel.rs
+++ b/crates/ty_server/src/server/api/notifications/cancel.rs
@@ -1,6 +1,6 @@
 use lsp_server::RequestId;
+use lsp_types::CancelNotification;
 use lsp_types::CancelParams;
-use lsp_types::notification::Cancel;
 
 use crate::server::Result;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
@@ -10,14 +10,14 @@ use crate::session::client::Client;
 pub(crate) struct CancelNotificationHandler;
 
 impl NotificationHandler for CancelNotificationHandler {
-    type NotificationType = Cancel;
+    type NotificationType = CancelNotification;
 }
 
 impl SyncNotificationHandler for CancelNotificationHandler {
     fn run(session: &mut Session, client: &Client, params: CancelParams) -> Result<()> {
         let id: RequestId = match params.id {
-            lsp_types::NumberOrString::Number(id) => id.into(),
-            lsp_types::NumberOrString::String(id) => id.into(),
+            lsp_types::Id::Int(id) => id.into(),
+            lsp_types::Id::String(id) => id.into(),
         };
 
         client.cancel(session, id);

--- a/crates/ty_server/src/server/api/notifications/did_change.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change.rs
@@ -1,6 +1,8 @@
 use lsp_server::ErrorCode;
-use lsp_types::notification::DidChangeTextDocument;
-use lsp_types::{DidChangeTextDocumentParams, VersionedTextDocumentIdentifier};
+use lsp_types::{
+    DidChangeTextDocumentNotification, DidChangeTextDocumentParams, TextDocumentIdentifier,
+    VersionedTextDocumentIdentifier,
+};
 
 use crate::server::Result;
 use crate::server::api::LSPResult;
@@ -12,7 +14,7 @@ use crate::session::client::Client;
 pub(crate) struct DidChangeTextDocumentHandler;
 
 impl NotificationHandler for DidChangeTextDocumentHandler {
-    type NotificationType = DidChangeTextDocument;
+    type NotificationType = DidChangeTextDocumentNotification;
 }
 
 impl SyncNotificationHandler for DidChangeTextDocumentHandler {
@@ -22,7 +24,11 @@ impl SyncNotificationHandler for DidChangeTextDocumentHandler {
         params: DidChangeTextDocumentParams,
     ) -> Result<()> {
         let DidChangeTextDocumentParams {
-            text_document: VersionedTextDocumentIdentifier { uri, version },
+            text_document:
+                VersionedTextDocumentIdentifier {
+                    text_document_identifier: TextDocumentIdentifier { uri },
+                    version,
+                },
             content_changes,
         } = params;
 

--- a/crates/ty_server/src/server/api/notifications/did_change_notebook.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_notebook.rs
@@ -1,6 +1,5 @@
 use lsp_server::ErrorCode;
-use lsp_types as types;
-use lsp_types::notification as notif;
+use lsp_types::{self as types, DidChangeNotebookDocumentNotification};
 
 use crate::server::Result;
 use crate::server::api::LSPResult;
@@ -12,7 +11,7 @@ use crate::session::client::Client;
 pub(crate) struct DidChangeNotebookHandler;
 
 impl NotificationHandler for DidChangeNotebookHandler {
-    type NotificationType = notif::DidChangeNotebookDocument;
+    type NotificationType = DidChangeNotebookDocumentNotification;
 }
 
 impl SyncNotificationHandler for DidChangeNotebookHandler {

--- a/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
@@ -7,15 +7,15 @@ use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::session::Session;
 use crate::session::client::Client;
 use crate::system::AnySystemPath;
-use lsp_types as types;
-use lsp_types::{FileChangeType, notification as notif};
+use lsp_types::FileChangeType;
+use lsp_types::{self as types, DidChangeWatchedFilesNotification};
 use ty_project::Db as _;
 use ty_project::watch::{ChangeEvent, ChangedKind, CreatedKind, DeletedKind, ExistingPathKind};
 
 pub(crate) struct DidChangeWatchedFiles;
 
 impl NotificationHandler for DidChangeWatchedFiles {
-    type NotificationType = notif::DidChangeWatchedFiles;
+    type NotificationType = DidChangeWatchedFilesNotification;
 }
 
 impl SyncNotificationHandler for DidChangeWatchedFiles {
@@ -28,7 +28,7 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
         let system = session.system();
 
         for change in params.changes {
-            let path = DocumentKey::from_url(&change.uri).into_file_path();
+            let path = DocumentKey::from_uri(&change.uri).into_file_path();
 
             let system_path = match path {
                 AnySystemPath::System(system) => system,
@@ -38,12 +38,12 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
                 }
             };
 
-            let change_event = match change.typ {
-                FileChangeType::CREATED => ChangeEvent::Created {
+            let change_event = match change.kind {
+                FileChangeType::Created => ChangeEvent::Created {
                     kind: CreatedKind::from(ExistingPathKind::from_system(system, &system_path)),
                     path: system_path,
                 },
-                FileChangeType::CHANGED => {
+                FileChangeType::Changed => {
                     // We're only interested in file content or metadata changes.
                     // Renames are modelled as create/delete events.
                     if ExistingPathKind::from_system(system, &system_path).is_file() {
@@ -55,17 +55,10 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
                         continue;
                     }
                 }
-                FileChangeType::DELETED => ChangeEvent::Deleted {
+                FileChangeType::Deleted => ChangeEvent::Deleted {
                     path: system_path,
                     kind: DeletedKind::Any,
                 },
-                _ => {
-                    tracing::debug!(
-                        "Ignoring unsupported change event type: `{:?}` for {system_path}",
-                        change.typ
-                    );
-                    continue;
-                }
             };
 
             changes.push(change_event);
@@ -90,11 +83,7 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
         let client_capabilities = session.client_capabilities();
 
         if client_capabilities.supports_workspace_diagnostic_refresh() {
-            client.send_request::<types::request::WorkspaceDiagnosticRefresh>(
-                session,
-                (),
-                |_, ()| {},
-            );
+            client.send_request::<types::DiagnosticRefreshRequest>(session, (), |_, ()| {});
         } else {
             for key in session.text_document_handles() {
                 publish_diagnostics_if_needed(&key, session, client);
@@ -102,7 +91,7 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
         }
 
         if client_capabilities.supports_inlay_hint_refresh() {
-            client.send_request::<types::request::InlayHintRefreshRequest>(session, (), |_, ()| {});
+            client.send_request::<types::InlayHintRefreshRequest>(session, (), |_, ()| {});
         }
 
         Ok(())

--- a/crates/ty_server/src/server/api/notifications/did_change_workspace_folders.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_workspace_folders.rs
@@ -1,5 +1,4 @@
-use lsp_types as types;
-use lsp_types::notification as notif;
+use lsp_types::{self as types, DidChangeWorkspaceFoldersNotification};
 
 use crate::server::Result;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
@@ -9,7 +8,7 @@ use crate::session::client::Client;
 pub(crate) struct DidChangeWorkspaceFoldersHandler;
 
 impl NotificationHandler for DidChangeWorkspaceFoldersHandler {
-    type NotificationType = notif::DidChangeWorkspaceFolders;
+    type NotificationType = DidChangeWorkspaceFoldersNotification;
 }
 
 impl SyncNotificationHandler for DidChangeWorkspaceFoldersHandler {

--- a/crates/ty_server/src/server/api/notifications/did_close.rs
+++ b/crates/ty_server/src/server/api/notifications/did_close.rs
@@ -1,5 +1,5 @@
 use lsp_server::ErrorCode;
-use lsp_types::notification::DidCloseTextDocument;
+use lsp_types::DidCloseTextDocumentNotification;
 use lsp_types::{DidCloseTextDocumentParams, TextDocumentIdentifier};
 
 use crate::server::Result;
@@ -11,7 +11,7 @@ use crate::session::client::Client;
 pub(crate) struct DidCloseTextDocumentHandler;
 
 impl NotificationHandler for DidCloseTextDocumentHandler {
-    type NotificationType = DidCloseTextDocument;
+    type NotificationType = DidCloseTextDocumentNotification;
 }
 
 impl SyncNotificationHandler for DidCloseTextDocumentHandler {

--- a/crates/ty_server/src/server/api/notifications/did_close_notebook.rs
+++ b/crates/ty_server/src/server/api/notifications/did_close_notebook.rs
@@ -1,5 +1,7 @@
-use lsp_types::notification::DidCloseNotebookDocument;
-use lsp_types::{DidCloseNotebookDocumentParams, NotebookDocumentIdentifier};
+use lsp_types::{
+    DidCloseNotebookDocumentNotification, DidCloseNotebookDocumentParams,
+    NotebookDocumentIdentifier,
+};
 
 use crate::server::Result;
 use crate::server::api::LSPResult;
@@ -10,7 +12,7 @@ use crate::session::client::Client;
 pub(crate) struct DidCloseNotebookHandler;
 
 impl NotificationHandler for DidCloseNotebookHandler {
-    type NotificationType = DidCloseNotebookDocument;
+    type NotificationType = DidCloseNotebookDocumentNotification;
 }
 
 impl SyncNotificationHandler for DidCloseNotebookHandler {

--- a/crates/ty_server/src/server/api/notifications/did_open.rs
+++ b/crates/ty_server/src/server/api/notifications/did_open.rs
@@ -1,5 +1,4 @@
-use lsp_types::notification::DidOpenTextDocument;
-use lsp_types::{DidOpenTextDocumentParams, TextDocumentItem};
+use lsp_types::{DidOpenTextDocumentNotification, DidOpenTextDocumentParams, TextDocumentItem};
 
 use crate::TextDocument;
 use crate::server::Result;
@@ -11,7 +10,7 @@ use crate::session::client::Client;
 pub(crate) struct DidOpenTextDocumentHandler;
 
 impl NotificationHandler for DidOpenTextDocumentHandler {
-    type NotificationType = DidOpenTextDocument;
+    type NotificationType = DidOpenTextDocumentNotification;
 }
 
 impl SyncNotificationHandler for DidOpenTextDocumentHandler {
@@ -30,7 +29,7 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
                 },
         } = params;
 
-        let text_doc = TextDocument::new(uri, text, version, &language_id);
+        let text_doc = TextDocument::new(uri, text, version, language_id);
         let document = session.open_text_document(text_doc);
         publish_diagnostics_if_needed(&document, session, client);
 

--- a/crates/ty_server/src/server/api/notifications/did_open_notebook.rs
+++ b/crates/ty_server/src/server/api/notifications/did_open_notebook.rs
@@ -1,6 +1,5 @@
 use lsp_server::ErrorCode;
-use lsp_types::DidOpenNotebookDocumentParams;
-use lsp_types::notification::DidOpenNotebookDocument;
+use lsp_types::{DidOpenNotebookDocumentNotification, DidOpenNotebookDocumentParams};
 
 use crate::TextDocument;
 use crate::document::NotebookDocument;
@@ -14,7 +13,7 @@ use crate::session::client::Client;
 pub(crate) struct DidOpenNotebookHandler;
 
 impl NotificationHandler for DidOpenNotebookHandler {
-    type NotificationType = DidOpenNotebookDocument;
+    type NotificationType = DidOpenNotebookDocumentNotification;
 }
 
 impl SyncNotificationHandler for DidOpenNotebookHandler {
@@ -40,7 +39,7 @@ impl SyncNotificationHandler for DidOpenNotebookHandler {
 
         for cell in params.cell_text_documents {
             let cell_document =
-                TextDocument::new(cell.uri, cell.text, cell.version, &cell.language_id)
+                TextDocument::new(cell.uri, cell.text, cell.version, cell.language_id)
                     .with_notebook(notebook_path.clone());
             session.open_text_document(cell_document);
         }

--- a/crates/ty_server/src/server/api/requests.rs
+++ b/crates/ty_server/src/server/api/requests.rs
@@ -69,5 +69,3 @@ pub(super) use type_hierarchy_subtypes::TypeHierarchySubtypesRequestHandler;
 pub(super) use type_hierarchy_supertypes::TypeHierarchySupertypesRequestHandler;
 pub(super) use workspace_diagnostic::WorkspaceDiagnosticRequestHandler;
 pub(super) use workspace_symbols::WorkspaceSymbolRequestHandler;
-
-pub use workspace_diagnostic::{PartialWorkspaceProgress, PartialWorkspaceProgressParams};

--- a/crates/ty_server/src/server/api/requests/call_hierarchy_incoming_calls.rs
+++ b/crates/ty_server/src/server/api/requests/call_hierarchy_incoming_calls.rs
@@ -1,4 +1,4 @@
-use lsp_types::request::CallHierarchyIncomingCalls;
+use lsp_types::CallHierarchyIncomingCallsRequest;
 use lsp_types::{CallHierarchyIncomingCall, CallHierarchyIncomingCallsParams};
 
 use crate::document::{ToRangeExt as _, resolve_file_uri_range};
@@ -17,7 +17,7 @@ use crate::session::client::Client;
 pub(crate) struct CallHierarchyIncomingCallsRequestHandler;
 
 impl RequestHandler for CallHierarchyIncomingCallsRequestHandler {
-    type RequestType = CallHierarchyIncomingCalls;
+    type RequestType = CallHierarchyIncomingCallsRequest;
 }
 
 impl BackgroundRequestHandler for CallHierarchyIncomingCallsRequestHandler {

--- a/crates/ty_server/src/server/api/requests/call_hierarchy_outgoing_calls.rs
+++ b/crates/ty_server/src/server/api/requests/call_hierarchy_outgoing_calls.rs
@@ -1,4 +1,4 @@
-use lsp_types::request::CallHierarchyOutgoingCalls;
+use lsp_types::CallHierarchyOutgoingCallsRequest;
 use lsp_types::{CallHierarchyOutgoingCall, CallHierarchyOutgoingCallsParams};
 
 use crate::document::{ToRangeExt as _, resolve_file_uri_range};
@@ -17,7 +17,7 @@ use crate::session::client::Client;
 pub(crate) struct CallHierarchyOutgoingCallsRequestHandler;
 
 impl RequestHandler for CallHierarchyOutgoingCallsRequestHandler {
-    type RequestType = CallHierarchyOutgoingCalls;
+    type RequestType = CallHierarchyOutgoingCallsRequest;
 }
 
 impl BackgroundRequestHandler for CallHierarchyOutgoingCallsRequestHandler {

--- a/crates/ty_server/src/server/api/requests/code_action.rs
+++ b/crates/ty_server/src/server/api/requests/code_action.rs
@@ -1,13 +1,13 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use lsp_types::{self as types, NumberOrString, TextEdit, Url, request as req};
+use lsp_types::{self as types, Code, CodeActionRequest, CodeActionResponse, TextEdit, Uri};
 use ruff_db::files::File;
 use ruff_diagnostics::Edit;
 use ruff_text_size::Ranged;
 use ty_ide::code_actions;
 use ty_project::ProjectDatabase;
-use types::{CodeActionKind, CodeActionOrCommand};
+use types::CodeActionKind;
 
 use crate::db::Db;
 use crate::document::{RangeExt, ToRangeExt};
@@ -22,11 +22,11 @@ use crate::{DIAGNOSTIC_NAME, PositionEncoding};
 pub(crate) struct CodeActionRequestHandler;
 
 impl RequestHandler for CodeActionRequestHandler {
-    type RequestType = req::CodeActionRequest;
+    type RequestType = CodeActionRequest;
 }
 
 impl BackgroundDocumentRequestHandler for CodeActionRequestHandler {
-    fn document_url(params: &types::CodeActionParams) -> Cow<'_, Url> {
+    fn document_uri(params: &types::CodeActionParams) -> Cow<'_, Uri> {
         Cow::Borrowed(&params.text_document.uri)
     }
 
@@ -35,7 +35,7 @@ impl BackgroundDocumentRequestHandler for CodeActionRequestHandler {
         snapshot: &DocumentSnapshot,
         _client: &Client,
         params: types::CodeActionParams,
-    ) -> Result<Option<types::CodeActionResponse>> {
+    ) -> Result<Option<Vec<CodeActionResponse>>> {
         let diagnostics = params.context.diagnostics;
 
         let Some(file) = snapshot.to_notebook_or_file(db) else {
@@ -57,9 +57,9 @@ impl BackgroundDocumentRequestHandler for CodeActionRequestHandler {
                     }
                 };
 
-                actions.push(CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
+                actions.push(CodeActionResponse::CodeAction(lsp_types::CodeAction {
                     title: data.fix_title,
-                    kind: Some(CodeActionKind::QUICKFIX),
+                    kind: Some(CodeActionKind::QuickFix),
                     diagnostics: Some(vec![diagnostic.clone()]),
                     edit: Some(lsp_types::WorkspaceEdit {
                         changes: Some(data.edits),
@@ -70,6 +70,7 @@ impl BackgroundDocumentRequestHandler for CodeActionRequestHandler {
                     command: None,
                     disabled: None,
                     data: None,
+                    tags: None,
                 }));
             }
 
@@ -78,15 +79,15 @@ impl BackgroundDocumentRequestHandler for CodeActionRequestHandler {
             // This is only for actions that are messy to compute at the time of the diagnostic.
             // For instance, suggesting imports requires finding symbols for the entire project,
             // which is dubious when you're in the middle of resolving symbols.
-            let url = snapshot.url();
+            let uri = snapshot.uri();
             let encoding = snapshot.encoding();
-            if let Some(NumberOrString::String(diagnostic_id)) = &diagnostic.code
-                && let Some(range) = diagnostic.range.to_text_range(db, file, url, encoding)
+            if let Some(Code::String(diagnostic_id)) = &diagnostic.code
+                && let Some(range) = diagnostic.range.to_text_range(db, file, uri, encoding)
             {
                 for action in code_actions(db, file, range, diagnostic_id) {
-                    actions.push(CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
+                    actions.push(CodeActionResponse::CodeAction(lsp_types::CodeAction {
                         title: action.title,
-                        kind: Some(CodeActionKind::QUICKFIX),
+                        kind: Some(CodeActionKind::QuickFix),
                         diagnostics: Some(vec![diagnostic.clone()]),
                         edit: Some(lsp_types::WorkspaceEdit {
                             changes: to_lsp_edits(db, file, encoding, action.edits),
@@ -97,6 +98,7 @@ impl BackgroundDocumentRequestHandler for CodeActionRequestHandler {
                         command: None,
                         disabled: None,
                         data: None,
+                        tags: None,
                     }));
                 }
             }
@@ -115,8 +117,8 @@ fn to_lsp_edits(
     file: File,
     encoding: PositionEncoding,
     edits: Vec<Edit>,
-) -> Option<HashMap<Url, Vec<TextEdit>>> {
-    let mut lsp_edits: HashMap<Url, Vec<lsp_types::TextEdit>> = HashMap::new();
+) -> Option<HashMap<Uri, Vec<TextEdit>>> {
+    let mut lsp_edits: HashMap<Uri, Vec<lsp_types::TextEdit>> = HashMap::new();
 
     for edit in edits {
         let location = edit

--- a/crates/ty_server/src/server/api/requests/completion.rs
+++ b/crates/ty_server/src/server/api/requests/completion.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
 use std::time::Instant;
 
-use lsp_types::request::Completion;
 use lsp_types::{
     CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionList,
-    CompletionParams, CompletionResponse, Documentation, InsertTextFormat, TextEdit, Url,
+    CompletionParams, CompletionRequest, CompletionResponse, Documentation, InsertTextFormat,
+    TextEdit, Uri,
 };
 use ruff_source_file::OneIndexed;
 use ruff_text_size::Ranged;
@@ -21,12 +21,12 @@ use crate::session::client::Client;
 pub(crate) struct CompletionRequestHandler;
 
 impl RequestHandler for CompletionRequestHandler {
-    type RequestType = Completion;
+    type RequestType = CompletionRequest;
 }
 
 impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
-    fn document_url(params: &CompletionParams) -> Cow<'_, Url> {
-        Cow::Borrowed(&params.text_document_position.text_document.uri)
+    fn document_uri(params: &CompletionParams) -> Cow<'_, Uri> {
+        Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 
     fn run_with_snapshot(
@@ -48,10 +48,10 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
             return Ok(None);
         };
 
-        let Some(offset) = params.text_document_position.position.to_text_size(
+        let Some(offset) = params.text_document_position_params.position.to_text_size(
             db,
             file,
-            snapshot.url(),
+            snapshot.uri(),
             snapshot.encoding(),
         ) else {
             return Ok(None);
@@ -126,7 +126,7 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
                 let insert_text = comp.insert.map(String::from);
                 let insert_text_format = match comp.insert_text_format {
                     CompletionInsertTextFormat::PlainText => None,
-                    CompletionInsertTextFormat::Snippet => Some(InsertTextFormat::SNIPPET),
+                    CompletionInsertTextFormat::Snippet => Some(InsertTextFormat::Snippet),
                 };
 
                 CompletionItem {
@@ -144,9 +144,11 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
             })
             .collect();
         let len = items.len();
-        let response = CompletionResponse::List(CompletionList {
+        let response = CompletionResponse::CompletionList(CompletionList {
             is_incomplete: true,
             items,
+            item_defaults: None,
+            apply_kind: None,
         });
         tracing::debug!(
             "Completions request returned {len} suggestions in {elapsed:?}",
@@ -167,30 +169,30 @@ fn ty_kind_to_lsp_kind(kind: CompletionKind) -> CompletionItemKind {
 
     // ref https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItemKind
     match kind {
-        Text => CompletionItemKind::TEXT,
-        Method => CompletionItemKind::METHOD,
-        Function => CompletionItemKind::FUNCTION,
-        Constructor => CompletionItemKind::CONSTRUCTOR,
-        Field => CompletionItemKind::FIELD,
-        Variable => CompletionItemKind::VARIABLE,
-        Class => CompletionItemKind::CLASS,
-        Interface => CompletionItemKind::INTERFACE,
-        Module => CompletionItemKind::MODULE,
-        Property => CompletionItemKind::PROPERTY,
-        Unit => CompletionItemKind::UNIT,
-        Value => CompletionItemKind::VALUE,
-        Enum => CompletionItemKind::ENUM,
-        Keyword => CompletionItemKind::KEYWORD,
-        Snippet => CompletionItemKind::SNIPPET,
-        Color => CompletionItemKind::COLOR,
-        File => CompletionItemKind::FILE,
-        Reference => CompletionItemKind::REFERENCE,
-        Folder => CompletionItemKind::FOLDER,
-        EnumMember => CompletionItemKind::ENUM_MEMBER,
-        Constant => CompletionItemKind::CONSTANT,
-        Struct => CompletionItemKind::STRUCT,
-        Event => CompletionItemKind::EVENT,
-        Operator => CompletionItemKind::OPERATOR,
-        TypeParameter => CompletionItemKind::TYPE_PARAMETER,
+        Text => CompletionItemKind::Text,
+        Method => CompletionItemKind::Method,
+        Function => CompletionItemKind::Function,
+        Constructor => CompletionItemKind::Constructor,
+        Field => CompletionItemKind::Field,
+        Variable => CompletionItemKind::Variable,
+        Class => CompletionItemKind::Class,
+        Interface => CompletionItemKind::Interface,
+        Module => CompletionItemKind::Module,
+        Property => CompletionItemKind::Property,
+        Unit => CompletionItemKind::Unit,
+        Value => CompletionItemKind::Value,
+        Enum => CompletionItemKind::Enum,
+        Keyword => CompletionItemKind::Keyword,
+        Snippet => CompletionItemKind::Snippet,
+        Color => CompletionItemKind::Color,
+        File => CompletionItemKind::File,
+        Reference => CompletionItemKind::Reference,
+        Folder => CompletionItemKind::Folder,
+        EnumMember => CompletionItemKind::EnumMember,
+        Constant => CompletionItemKind::Constant,
+        Struct => CompletionItemKind::Struct,
+        Event => CompletionItemKind::Event,
+        Operator => CompletionItemKind::Operator,
+        TypeParameter => CompletionItemKind::TypeParameter,
     }
 }

--- a/crates/ty_server/src/server/api/requests/diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/diagnostic.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
 
-use lsp_types::request::DocumentDiagnosticRequest;
+use lsp_types::DocumentDiagnosticRequest;
 use lsp_types::{
-    DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReportResult,
-    FullDocumentDiagnosticReport, RelatedFullDocumentDiagnosticReport,
-    RelatedUnchangedDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport, Url,
+    DocumentDiagnosticParams, DocumentDiagnosticReport, FullDocumentDiagnosticReport,
+    RelatedFullDocumentDiagnosticReport, RelatedUnchangedDocumentDiagnosticReport,
+    UnchangedDocumentDiagnosticReport, Uri,
 };
 
 use crate::server::Result;
@@ -23,7 +23,7 @@ impl RequestHandler for DocumentDiagnosticRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for DocumentDiagnosticRequestHandler {
-    fn document_url(params: &DocumentDiagnosticParams) -> Cow<'_, Url> {
+    fn document_uri(params: &DocumentDiagnosticParams) -> Cow<'_, Uri> {
         Cow::Borrowed(&params.text_document.uri)
     }
 
@@ -32,34 +32,31 @@ impl BackgroundDocumentRequestHandler for DocumentDiagnosticRequestHandler {
         snapshot: &DocumentSnapshot,
         _client: &Client,
         params: DocumentDiagnosticParams,
-    ) -> Result<DocumentDiagnosticReportResult> {
+    ) -> Result<DocumentDiagnosticReport> {
         if snapshot.global_settings().diagnostic_mode().is_off() {
-            return Ok(DocumentDiagnosticReportResult::Report(
-                DocumentDiagnosticReport::Full(RelatedFullDocumentDiagnosticReport::default()),
-            ));
+            return Ok(RelatedFullDocumentDiagnosticReport::default().into());
         }
 
         let diagnostics = compute_diagnostics(db, snapshot.document(), snapshot.encoding());
 
         let Some(diagnostics) = diagnostics else {
-            return Ok(DocumentDiagnosticReportResult::Report(
-                DocumentDiagnosticReport::Full(RelatedFullDocumentDiagnosticReport::default()),
-            ));
+            return Ok(RelatedFullDocumentDiagnosticReport::default().into());
         };
 
         let result_id = diagnostics.result_id();
 
         let report = match result_id {
             Some(new_id) if Some(&new_id) == params.previous_result_id.as_ref() => {
-                DocumentDiagnosticReport::Unchanged(RelatedUnchangedDocumentDiagnosticReport {
+                RelatedUnchangedDocumentDiagnosticReport {
                     related_documents: None,
                     unchanged_document_diagnostic_report: UnchangedDocumentDiagnosticReport {
                         result_id: new_id,
                     },
-                })
+                }
+                .into()
             }
             new_id => {
-                DocumentDiagnosticReport::Full(RelatedFullDocumentDiagnosticReport {
+                RelatedFullDocumentDiagnosticReport {
                     related_documents: None,
                     full_document_diagnostic_report: FullDocumentDiagnosticReport {
                         result_id: new_id,
@@ -73,11 +70,12 @@ impl BackgroundDocumentRequestHandler for DocumentDiagnosticRequestHandler {
                             )
                             .expect_text_document(),
                     },
-                })
+                }
+                .into()
             }
         };
 
-        Ok(DocumentDiagnosticReportResult::Report(report))
+        Ok(report)
     }
 }
 

--- a/crates/ty_server/src/server/api/requests/doc_highlights.rs
+++ b/crates/ty_server/src/server/api/requests/doc_highlights.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use lsp_types::request::DocumentHighlightRequest;
-use lsp_types::{DocumentHighlight, DocumentHighlightKind, DocumentHighlightParams, Url};
+use lsp_types::DocumentHighlightRequest;
+use lsp_types::{DocumentHighlight, DocumentHighlightKind, DocumentHighlightParams, Uri};
 use ty_ide::{ReferenceKind, document_highlights};
 use ty_project::ProjectDatabase;
 
@@ -19,7 +19,7 @@ impl RequestHandler for DocumentHighlightRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for DocumentHighlightRequestHandler {
-    fn document_url(params: &DocumentHighlightParams) -> Cow<'_, Url> {
+    fn document_uri(params: &DocumentHighlightParams) -> Cow<'_, Uri> {
         Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 
@@ -43,7 +43,7 @@ impl BackgroundDocumentRequestHandler for DocumentHighlightRequestHandler {
         let Some(offset) = params.text_document_position_params.position.to_text_size(
             db,
             file,
-            snapshot.url(),
+            snapshot.uri(),
             snapshot.encoding(),
         ) else {
             return Ok(None);
@@ -62,9 +62,9 @@ impl BackgroundDocumentRequestHandler for DocumentHighlightRequestHandler {
                     .local_range();
 
                 let kind = match target.kind() {
-                    ReferenceKind::Read => Some(DocumentHighlightKind::READ),
-                    ReferenceKind::Write => Some(DocumentHighlightKind::WRITE),
-                    ReferenceKind::Other => Some(DocumentHighlightKind::TEXT),
+                    ReferenceKind::Read => Some(DocumentHighlightKind::Read),
+                    ReferenceKind::Write => Some(DocumentHighlightKind::Write),
+                    ReferenceKind::Other => Some(DocumentHighlightKind::Text),
                 };
 
                 Some(DocumentHighlight { range, kind })

--- a/crates/ty_server/src/server/api/requests/document_symbols.rs
+++ b/crates/ty_server/src/server/api/requests/document_symbols.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use lsp_types::request::DocumentSymbolRequest;
-use lsp_types::{DocumentSymbol, DocumentSymbolParams, SymbolInformation, Url};
+use lsp_types::DocumentSymbolRequest;
+use lsp_types::{DocumentSymbol, DocumentSymbolParams, Uri};
 use ruff_db::files::File;
 use ty_ide::{HierarchicalSymbols, SymbolId, SymbolInfo, document_symbols};
 use ty_project::ProjectDatabase;
@@ -22,7 +22,7 @@ impl RequestHandler for DocumentSymbolRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for DocumentSymbolRequestHandler {
-    fn document_url(params: &DocumentSymbolParams) -> Cow<'_, Url> {
+    fn document_uri(params: &DocumentSymbolParams) -> Cow<'_, Uri> {
         Cow::Borrowed(&params.text_document.uri)
     }
 
@@ -55,7 +55,7 @@ impl BackgroundDocumentRequestHandler for DocumentSymbolRequestHandler {
 
         if supports_hierarchical {
             let symbols = symbols.to_hierarchical();
-            let lsp_symbols: Vec<DocumentSymbol> = symbols
+            let lsp_symbols = symbols
                 .iter()
                 .filter_map(|(id, symbol)| {
                     convert_to_lsp_document_symbol(
@@ -69,17 +69,21 @@ impl BackgroundDocumentRequestHandler for DocumentSymbolRequestHandler {
                 })
                 .collect();
 
-            Ok(Some(lsp_types::DocumentSymbolResponse::Nested(lsp_symbols)))
+            Ok(Some(lsp_types::DocumentSymbolResponse::DocumentSymbolList(
+                lsp_symbols,
+            )))
         } else {
             // Return flattened symbols as SymbolInformation
-            let lsp_symbols: Vec<SymbolInformation> = symbols
+            let lsp_symbols = symbols
                 .iter()
                 .filter_map(|(_, symbol)| {
                     convert_to_lsp_symbol_information(db, file, symbol, snapshot.encoding())
                 })
                 .collect();
 
-            Ok(Some(lsp_types::DocumentSymbolResponse::Flat(lsp_symbols)))
+            Ok(Some(
+                lsp_types::DocumentSymbolResponse::SymbolInformationList(lsp_symbols),
+            ))
         }
     }
 }

--- a/crates/ty_server/src/server/api/requests/execute_command.rs
+++ b/crates/ty_server/src/server/api/requests/execute_command.rs
@@ -6,7 +6,8 @@ use crate::server::api::traits::SyncRequestHandler;
 use crate::session::Session;
 use crate::session::client::Client;
 use lsp_server::ErrorCode;
-use lsp_types::{self as types, request as req};
+use lsp_types::ExecuteCommandRequest;
+use lsp_types::{self as types};
 use std::fmt::{self, Write};
 use std::str::FromStr;
 use ty_module_resolver::ModuleResolveMode;
@@ -16,7 +17,7 @@ use ty_python_core::program::Program;
 pub(crate) struct ExecuteCommand;
 
 impl RequestHandler for ExecuteCommand {
-    type RequestType = req::ExecuteCommand;
+    type RequestType = ExecuteCommandRequest;
 }
 
 impl SyncRequestHandler for ExecuteCommand {
@@ -59,7 +60,7 @@ fn debug_information(session: &Session) -> crate::Result<String> {
     writeln!(buffer)?;
 
     for (root, workspace) in session.workspaces() {
-        writeln!(buffer, "Workspace {root} ({})", workspace.url())?;
+        writeln!(buffer, "Workspace {root} ({})", workspace.uri())?;
         writeln!(buffer, "Settings: {:#?}", workspace.settings())?;
         writeln!(buffer)?;
     }

--- a/crates/ty_server/src/server/api/requests/folding_range.rs
+++ b/crates/ty_server/src/server/api/requests/folding_range.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use lsp_types::request::FoldingRangeRequest;
-use lsp_types::{FoldingRange, FoldingRangeKind, FoldingRangeParams, Url};
+use lsp_types::FoldingRangeRequest;
+use lsp_types::{FoldingRange, FoldingRangeKind, FoldingRangeParams, Uri};
 use ruff_db::source::source_text;
 use ruff_text_size::TextRange;
 use ty_ide::folding_ranges;
@@ -22,7 +22,7 @@ impl RequestHandler for FoldingRangeRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for FoldingRangeRequestHandler {
-    fn document_url(params: &FoldingRangeParams) -> Cow<'_, Url> {
+    fn document_uri(params: &FoldingRangeParams) -> Cow<'_, Uri> {
         Cow::Borrowed(&params.text_document.uri)
     }
 
@@ -52,7 +52,7 @@ impl BackgroundDocumentRequestHandler for FoldingRangeRequestHandler {
             && let Some(notebook_document) = db.notebook_document(file)
             && let Some(notebook) = source_text(db, file).as_notebook()
         {
-            let cell_index = notebook_document.cell_index_by_uri(snapshot.url());
+            let cell_index = notebook_document.cell_index_by_uri(snapshot.uri());
             cell_range = cell_index.and_then(|index| notebook.cell_range(index));
         }
 

--- a/crates/ty_server/src/server/api/requests/goto_declaration.rs
+++ b/crates/ty_server/src/server/api/requests/goto_declaration.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
-use lsp_types::request::{GotoDeclaration, GotoDeclarationParams};
-use lsp_types::{GotoDefinitionResponse, Url};
+use lsp_types::{DeclarationParams, DeclarationRequest, DeclarationResponse, Uri};
 use ty_ide::goto_declaration;
 use ty_project::ProjectDatabase;
 
@@ -15,11 +14,11 @@ use crate::session::client::Client;
 pub(crate) struct GotoDeclarationRequestHandler;
 
 impl RequestHandler for GotoDeclarationRequestHandler {
-    type RequestType = GotoDeclaration;
+    type RequestType = DeclarationRequest;
 }
 
 impl BackgroundDocumentRequestHandler for GotoDeclarationRequestHandler {
-    fn document_url(params: &GotoDeclarationParams) -> Cow<'_, Url> {
+    fn document_uri(params: &DeclarationParams) -> Cow<'_, Uri> {
         Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 
@@ -27,8 +26,8 @@ impl BackgroundDocumentRequestHandler for GotoDeclarationRequestHandler {
         db: &ProjectDatabase,
         snapshot: &DocumentSnapshot,
         _client: &Client,
-        params: GotoDeclarationParams,
-    ) -> crate::server::Result<Option<GotoDefinitionResponse>> {
+        params: DeclarationParams,
+    ) -> crate::server::Result<Option<DeclarationResponse>> {
         if snapshot
             .workspace_settings()
             .is_language_services_disabled()
@@ -43,7 +42,7 @@ impl BackgroundDocumentRequestHandler for GotoDeclarationRequestHandler {
         let Some(offset) = params.text_document_position_params.position.to_text_size(
             db,
             file,
-            snapshot.url(),
+            snapshot.uri(),
             snapshot.encoding(),
         ) else {
             return Ok(None);
@@ -63,14 +62,14 @@ impl BackgroundDocumentRequestHandler for GotoDeclarationRequestHandler {
                 .filter_map(|target| target.to_link(db, src, snapshot.encoding()))
                 .collect();
 
-            Ok(Some(GotoDefinitionResponse::Link(links)))
+            Ok(Some(links.into()))
         } else {
             let locations: Vec<_> = ranged
                 .into_iter()
                 .filter_map(|target| target.to_location(db, snapshot.encoding()))
                 .collect();
 
-            Ok(Some(GotoDefinitionResponse::Array(locations)))
+            Ok(Some(DeclarationResponse::Declaration(locations.into())))
         }
     }
 }

--- a/crates/ty_server/src/server/api/requests/goto_definition.rs
+++ b/crates/ty_server/src/server/api/requests/goto_definition.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use lsp_types::request::GotoDefinition;
-use lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, Url};
+use lsp_types::DefinitionRequest;
+use lsp_types::{DefinitionParams, DefinitionResponse, Uri};
 use ty_ide::goto_definition;
 use ty_project::ProjectDatabase;
 
@@ -15,11 +15,11 @@ use crate::session::client::Client;
 pub(crate) struct GotoDefinitionRequestHandler;
 
 impl RequestHandler for GotoDefinitionRequestHandler {
-    type RequestType = GotoDefinition;
+    type RequestType = DefinitionRequest;
 }
 
 impl BackgroundDocumentRequestHandler for GotoDefinitionRequestHandler {
-    fn document_url(params: &GotoDefinitionParams) -> Cow<'_, Url> {
+    fn document_uri(params: &DefinitionParams) -> Cow<'_, Uri> {
         Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 
@@ -27,8 +27,8 @@ impl BackgroundDocumentRequestHandler for GotoDefinitionRequestHandler {
         db: &ProjectDatabase,
         snapshot: &DocumentSnapshot,
         _client: &Client,
-        params: GotoDefinitionParams,
-    ) -> crate::server::Result<Option<GotoDefinitionResponse>> {
+        params: DefinitionParams,
+    ) -> crate::server::Result<Option<DefinitionResponse>> {
         if snapshot
             .workspace_settings()
             .is_language_services_disabled()
@@ -43,7 +43,7 @@ impl BackgroundDocumentRequestHandler for GotoDefinitionRequestHandler {
         let Some(offset) = params.text_document_position_params.position.to_text_size(
             db,
             file,
-            snapshot.url(),
+            snapshot.uri(),
             snapshot.encoding(),
         ) else {
             return Ok(None);
@@ -63,14 +63,14 @@ impl BackgroundDocumentRequestHandler for GotoDefinitionRequestHandler {
                 .filter_map(|target| target.to_link(db, src, snapshot.encoding()))
                 .collect();
 
-            Ok(Some(GotoDefinitionResponse::Link(links)))
+            Ok(Some(links.into()))
         } else {
             let locations: Vec<_> = ranged
                 .into_iter()
                 .filter_map(|target| target.to_location(db, snapshot.encoding()))
                 .collect();
 
-            Ok(Some(GotoDefinitionResponse::Array(locations)))
+            Ok(Some(DefinitionResponse::Definition(locations.into())))
         }
     }
 }

--- a/crates/ty_server/src/server/api/requests/goto_type_definition.rs
+++ b/crates/ty_server/src/server/api/requests/goto_type_definition.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use lsp_types::request::{GotoTypeDefinition, GotoTypeDefinitionParams};
-use lsp_types::{GotoDefinitionResponse, Url};
+use lsp_types::{TypeDefinitionParams, TypeDefinitionRequest};
+use lsp_types::{TypeDefinitionResponse, Uri};
 use ty_ide::goto_type_definition;
 use ty_project::ProjectDatabase;
 
@@ -15,11 +15,11 @@ use crate::session::client::Client;
 pub(crate) struct GotoTypeDefinitionRequestHandler;
 
 impl RequestHandler for GotoTypeDefinitionRequestHandler {
-    type RequestType = GotoTypeDefinition;
+    type RequestType = TypeDefinitionRequest;
 }
 
 impl BackgroundDocumentRequestHandler for GotoTypeDefinitionRequestHandler {
-    fn document_url(params: &GotoTypeDefinitionParams) -> Cow<'_, Url> {
+    fn document_uri(params: &TypeDefinitionParams) -> Cow<'_, Uri> {
         Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 
@@ -27,8 +27,8 @@ impl BackgroundDocumentRequestHandler for GotoTypeDefinitionRequestHandler {
         db: &ProjectDatabase,
         snapshot: &DocumentSnapshot,
         _client: &Client,
-        params: GotoTypeDefinitionParams,
-    ) -> crate::server::Result<Option<GotoDefinitionResponse>> {
+        params: TypeDefinitionParams,
+    ) -> crate::server::Result<Option<TypeDefinitionResponse>> {
         if snapshot
             .workspace_settings()
             .is_language_services_disabled()
@@ -43,7 +43,7 @@ impl BackgroundDocumentRequestHandler for GotoTypeDefinitionRequestHandler {
         let Some(offset) = params.text_document_position_params.position.to_text_size(
             db,
             file,
-            snapshot.url(),
+            snapshot.uri(),
             snapshot.encoding(),
         ) else {
             return Ok(None);
@@ -63,14 +63,14 @@ impl BackgroundDocumentRequestHandler for GotoTypeDefinitionRequestHandler {
                 .filter_map(|target| target.to_link(db, src, snapshot.encoding()))
                 .collect();
 
-            Ok(Some(GotoDefinitionResponse::Link(links)))
+            Ok(Some(links.into()))
         } else {
             let locations: Vec<_> = ranged
                 .into_iter()
                 .filter_map(|target| target.to_location(db, snapshot.encoding()))
                 .collect();
 
-            Ok(Some(GotoDefinitionResponse::Array(locations)))
+            Ok(Some(TypeDefinitionResponse::Definition(locations.into())))
         }
     }
 }

--- a/crates/ty_server/src/server/api/requests/hover.rs
+++ b/crates/ty_server/src/server/api/requests/hover.rs
@@ -6,8 +6,8 @@ use crate::server::api::traits::{
 };
 use crate::session::DocumentSnapshot;
 use crate::session::client::Client;
-use lsp_types::request::HoverRequest;
-use lsp_types::{HoverContents, HoverParams, MarkupContent, Url};
+use lsp_types::HoverRequest;
+use lsp_types::{HoverParams, MarkupContent, Uri};
 use ty_ide::{MarkupKind, hover};
 use ty_project::ProjectDatabase;
 
@@ -18,7 +18,7 @@ impl RequestHandler for HoverRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for HoverRequestHandler {
-    fn document_url(params: &HoverParams) -> Cow<'_, Url> {
+    fn document_uri(params: &HoverParams) -> Cow<'_, Uri> {
         Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 
@@ -42,7 +42,7 @@ impl BackgroundDocumentRequestHandler for HoverRequestHandler {
         let Some(offset) = params.text_document_position_params.position.to_text_size(
             db,
             file,
-            snapshot.url(),
+            snapshot.uri(),
             snapshot.encoding(),
         ) else {
             return Ok(None);
@@ -64,10 +64,11 @@ impl BackgroundDocumentRequestHandler for HoverRequestHandler {
         let contents = range_info.display(db, markup_kind).to_string();
 
         Ok(Some(lsp_types::Hover {
-            contents: HoverContents::Markup(MarkupContent {
+            contents: MarkupContent {
                 kind: lsp_markup_kind,
                 value: contents,
-            }),
+            }
+            .into(),
             range: range_info
                 .file_range()
                 .to_lsp_range(db, snapshot.encoding())

--- a/crates/ty_server/src/server/api/requests/inlay_hints.rs
+++ b/crates/ty_server/src/server/api/requests/inlay_hints.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 use std::time::Instant;
 
-use lsp_types::request::InlayHintRequest;
-use lsp_types::{InlayHintParams, Url};
+use lsp_types::InlayHintRequest;
+use lsp_types::{InlayHintParams, Uri};
 use ruff_db::files::File;
 use ty_ide::{InlayHintKind, InlayHintLabel, InlayHintTextEdit, inlay_hints};
 use ty_project::ProjectDatabase;
@@ -22,7 +22,7 @@ impl RequestHandler for InlayHintRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for InlayHintRequestHandler {
-    fn document_url(params: &InlayHintParams) -> Cow<'_, Url> {
+    fn document_uri(params: &InlayHintParams) -> Cow<'_, Uri> {
         Cow::Borrowed(&params.text_document.uri)
     }
 
@@ -46,7 +46,7 @@ impl BackgroundDocumentRequestHandler for InlayHintRequestHandler {
 
         let Some(range) = params
             .range
-            .to_text_range(db, file, snapshot.url(), snapshot.encoding())
+            .to_text_range(db, file, snapshot.uri(), snapshot.encoding())
         else {
             return Ok(None);
         };
@@ -93,8 +93,8 @@ impl RetriableRequestHandler for InlayHintRequestHandler {}
 
 fn inlay_hint_kind(inlay_hint_kind: &InlayHintKind) -> lsp_types::InlayHintKind {
     match inlay_hint_kind {
-        InlayHintKind::Type => lsp_types::InlayHintKind::TYPE,
-        InlayHintKind::CallArgumentName => lsp_types::InlayHintKind::PARAMETER,
+        InlayHintKind::Type => lsp_types::InlayHintKind::Type,
+        InlayHintKind::CallArgumentName => lsp_types::InlayHintKind::Parameter,
     }
 }
 
@@ -102,7 +102,7 @@ fn inlay_hint_label(
     inlay_hint_label: &InlayHintLabel,
     db: &ProjectDatabase,
     encoding: PositionEncoding,
-) -> lsp_types::InlayHintLabel {
+) -> lsp_types::Label {
     let mut label_parts = Vec::new();
     for part in inlay_hint_label.parts() {
         label_parts.push(lsp_types::InlayHintLabelPart {
@@ -114,7 +114,7 @@ fn inlay_hint_label(
             command: None,
         });
     }
-    lsp_types::InlayHintLabel::LabelParts(label_parts)
+    lsp_types::Label::InlayHintLabelPartList(label_parts)
 }
 
 fn inlay_hint_text_edit(

--- a/crates/ty_server/src/server/api/requests/prepare_call_hierarchy.rs
+++ b/crates/ty_server/src/server/api/requests/prepare_call_hierarchy.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use lsp_types::request::CallHierarchyPrepare;
-use lsp_types::{CallHierarchyItem, CallHierarchyPrepareParams, Url};
+use lsp_types::CallHierarchyPrepareRequest;
+use lsp_types::{CallHierarchyItem, CallHierarchyPrepareParams, Uri};
 use ty_project::ProjectDatabase;
 
 use crate::PositionEncoding;
@@ -12,7 +12,7 @@ use crate::server::api::traits::{
 };
 use crate::session::DocumentSnapshot;
 use crate::session::client::Client;
-use crate::system::file_to_url;
+use crate::system::file_to_uri;
 
 /// Handles `textDocument/prepareCallHierarchy`.
 ///
@@ -23,11 +23,11 @@ use crate::system::file_to_url;
 pub(crate) struct PrepareCallHierarchyRequestHandler;
 
 impl RequestHandler for PrepareCallHierarchyRequestHandler {
-    type RequestType = CallHierarchyPrepare;
+    type RequestType = CallHierarchyPrepareRequest;
 }
 
 impl BackgroundDocumentRequestHandler for PrepareCallHierarchyRequestHandler {
-    fn document_url(params: &CallHierarchyPrepareParams) -> Cow<'_, Url> {
+    fn document_uri(params: &CallHierarchyPrepareParams) -> Cow<'_, Uri> {
         Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 
@@ -51,7 +51,7 @@ impl BackgroundDocumentRequestHandler for PrepareCallHierarchyRequestHandler {
         let Some(offset) = params.text_document_position_params.position.to_text_size(
             db,
             file,
-            snapshot.url(),
+            snapshot.uri(),
             snapshot.encoding(),
         ) else {
             return Ok(None);
@@ -81,7 +81,7 @@ pub(super) fn convert_to_lsp_item(
     item: ty_ide::CallHierarchyItem,
     encoding: PositionEncoding,
 ) -> Option<CallHierarchyItem> {
-    let uri = file_to_url(db, item.file)?;
+    let uri = file_to_uri(db, item.file)?;
     let full_range = item.full_range.to_lsp_range(db, item.file, encoding)?;
     let selection_range = item.selection_range.to_lsp_range(db, item.file, encoding)?;
 

--- a/crates/ty_server/src/server/api/requests/prepare_rename.rs
+++ b/crates/ty_server/src/server/api/requests/prepare_rename.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
-use lsp_types::request::PrepareRenameRequest;
-use lsp_types::{PrepareRenameResponse, TextDocumentPositionParams, Url};
+use lsp_types::{PrepareRenameParams, PrepareRenameRequest, PrepareRenameResult, Uri};
 use ty_ide::can_rename;
 use ty_project::ProjectDatabase;
 
@@ -19,16 +18,16 @@ impl RequestHandler for PrepareRenameRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for PrepareRenameRequestHandler {
-    fn document_url(params: &TextDocumentPositionParams) -> Cow<'_, Url> {
-        Cow::Borrowed(&params.text_document.uri)
+    fn document_uri(params: &PrepareRenameParams) -> Cow<'_, Uri> {
+        Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 
     fn run_with_snapshot(
         db: &ProjectDatabase,
         snapshot: &DocumentSnapshot,
         _client: &Client,
-        params: TextDocumentPositionParams,
-    ) -> crate::server::Result<Option<PrepareRenameResponse>> {
+        params: PrepareRenameParams,
+    ) -> crate::server::Result<Option<PrepareRenameResult>> {
         if snapshot
             .workspace_settings()
             .is_language_services_disabled()
@@ -40,11 +39,12 @@ impl BackgroundDocumentRequestHandler for PrepareRenameRequestHandler {
             return Ok(None);
         };
 
-        let Some(offset) =
-            params
-                .position
-                .to_text_size(db, file, snapshot.url(), snapshot.encoding())
-        else {
+        let Some(offset) = params.text_document_position_params.position.to_text_size(
+            db,
+            file,
+            snapshot.uri(),
+            snapshot.encoding(),
+        ) else {
             return Ok(None);
         };
 
@@ -59,7 +59,7 @@ impl BackgroundDocumentRequestHandler for PrepareRenameRequestHandler {
             return Ok(None);
         };
 
-        Ok(Some(PrepareRenameResponse::Range(lsp_range)))
+        Ok(Some(lsp_range.into()))
     }
 }
 

--- a/crates/ty_server/src/server/api/requests/prepare_type_hierarchy.rs
+++ b/crates/ty_server/src/server/api/requests/prepare_type_hierarchy.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use lsp_types::request::TypeHierarchyPrepare;
-use lsp_types::{TypeHierarchyItem, TypeHierarchyPrepareParams, Url};
+use lsp_types::TypeHierarchyPrepareRequest;
+use lsp_types::{TypeHierarchyItem, TypeHierarchyPrepareParams, Uri};
 use ty_project::ProjectDatabase;
 
 use crate::document::PositionExt;
@@ -24,11 +24,11 @@ use crate::session::client::Client;
 pub(crate) struct PrepareTypeHierarchyRequestHandler;
 
 impl RequestHandler for PrepareTypeHierarchyRequestHandler {
-    type RequestType = TypeHierarchyPrepare;
+    type RequestType = TypeHierarchyPrepareRequest;
 }
 
 impl BackgroundDocumentRequestHandler for PrepareTypeHierarchyRequestHandler {
-    fn document_url(params: &TypeHierarchyPrepareParams) -> Cow<'_, Url> {
+    fn document_uri(params: &TypeHierarchyPrepareParams) -> Cow<'_, Uri> {
         Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 
@@ -52,7 +52,7 @@ impl BackgroundDocumentRequestHandler for PrepareTypeHierarchyRequestHandler {
         let Some(offset) = params.text_document_position_params.position.to_text_size(
             db,
             file,
-            snapshot.url(),
+            snapshot.uri(),
             snapshot.encoding(),
         ) else {
             return Ok(None);

--- a/crates/ty_server/src/server/api/requests/references.rs
+++ b/crates/ty_server/src/server/api/requests/references.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use lsp_types::request::References;
-use lsp_types::{Location, ReferenceParams, Url};
+use lsp_types::ReferencesRequest;
+use lsp_types::{Location, ReferenceParams, Uri};
 use ty_ide::find_references;
 use ty_project::ProjectDatabase;
 
@@ -15,12 +15,12 @@ use crate::session::client::Client;
 pub(crate) struct ReferencesRequestHandler;
 
 impl RequestHandler for ReferencesRequestHandler {
-    type RequestType = References;
+    type RequestType = ReferencesRequest;
 }
 
 impl BackgroundDocumentRequestHandler for ReferencesRequestHandler {
-    fn document_url(params: &ReferenceParams) -> Cow<'_, Url> {
-        Cow::Borrowed(&params.text_document_position.text_document.uri)
+    fn document_uri(params: &ReferenceParams) -> Cow<'_, Uri> {
+        Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 
     fn run_with_snapshot(
@@ -40,10 +40,10 @@ impl BackgroundDocumentRequestHandler for ReferencesRequestHandler {
             return Ok(None);
         };
 
-        let Some(offset) = params.text_document_position.position.to_text_size(
+        let Some(offset) = params.text_document_position_params.position.to_text_size(
             db,
             file,
-            snapshot.url(),
+            snapshot.uri(),
             snapshot.encoding(),
         ) else {
             return Ok(None);

--- a/crates/ty_server/src/server/api/requests/rename.rs
+++ b/crates/ty_server/src/server/api/requests/rename.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use lsp_types::request::Rename;
-use lsp_types::{RenameParams, TextEdit, Url, WorkspaceEdit};
+use lsp_types::RenameRequest;
+use lsp_types::{RenameParams, TextEdit, Uri, WorkspaceEdit};
 use ty_ide::rename;
 use ty_project::ProjectDatabase;
 
@@ -16,12 +16,12 @@ use crate::session::client::Client;
 pub(crate) struct RenameRequestHandler;
 
 impl RequestHandler for RenameRequestHandler {
-    type RequestType = Rename;
+    type RequestType = RenameRequest;
 }
 
 impl BackgroundDocumentRequestHandler for RenameRequestHandler {
-    fn document_url(params: &RenameParams) -> Cow<'_, Url> {
-        Cow::Borrowed(&params.text_document_position.text_document.uri)
+    fn document_uri(params: &RenameParams) -> Cow<'_, Uri> {
+        Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 
     fn run_with_snapshot(
@@ -41,10 +41,10 @@ impl BackgroundDocumentRequestHandler for RenameRequestHandler {
             return Ok(None);
         };
 
-        let Some(offset) = params.text_document_position.position.to_text_size(
+        let Some(offset) = params.text_document_position_params.position.to_text_size(
             db,
             file,
-            snapshot.url(),
+            snapshot.uri(),
             snapshot.encoding(),
         ) else {
             return Ok(None);
@@ -55,7 +55,7 @@ impl BackgroundDocumentRequestHandler for RenameRequestHandler {
         };
 
         // Group text edits by file
-        let mut changes: HashMap<Url, Vec<TextEdit>> = HashMap::new();
+        let mut changes: HashMap<Uri, Vec<TextEdit>> = HashMap::new();
 
         for reference in rename_results {
             if let Some(location) = reference.to_location(db, snapshot.encoding()) {

--- a/crates/ty_server/src/server/api/requests/selection_range.rs
+++ b/crates/ty_server/src/server/api/requests/selection_range.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 
-use lsp_types::request::SelectionRangeRequest;
-use lsp_types::{SelectionRange as LspSelectionRange, SelectionRangeParams, Url};
+use lsp_types::{
+    SelectionRange as LspSelectionRange, SelectionRangeParams, SelectionRangeRequest, Uri,
+};
 use ty_ide::selection_range;
 use ty_project::ProjectDatabase;
 
@@ -19,7 +20,7 @@ impl RequestHandler for SelectionRangeRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for SelectionRangeRequestHandler {
-    fn document_url(params: &SelectionRangeParams) -> Cow<'_, Url> {
+    fn document_uri(params: &SelectionRangeParams) -> Cow<'_, Uri> {
         Cow::Borrowed(&params.text_document.uri)
     }
 
@@ -43,7 +44,7 @@ impl BackgroundDocumentRequestHandler for SelectionRangeRequestHandler {
         let mut results = Vec::new();
 
         for position in params.positions {
-            let Some(offset) = position.to_text_size(db, file, snapshot.url(), snapshot.encoding())
+            let Some(offset) = position.to_text_size(db, file, snapshot.uri(), snapshot.encoding())
             else {
                 continue;
             };

--- a/crates/ty_server/src/server/api/requests/semantic_tokens.rs
+++ b/crates/ty_server/src/server/api/requests/semantic_tokens.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use lsp_types::{SemanticTokens, SemanticTokensParams, SemanticTokensResult, Url};
+use lsp_types::{SemanticTokens, SemanticTokensParams, Uri};
 use ruff_db::source::source_text;
 use ty_project::ProjectDatabase;
 
@@ -15,11 +15,11 @@ use crate::session::client::Client;
 pub(crate) struct SemanticTokensRequestHandler;
 
 impl RequestHandler for SemanticTokensRequestHandler {
-    type RequestType = lsp_types::request::SemanticTokensFullRequest;
+    type RequestType = lsp_types::SemanticTokensRequest;
 }
 
 impl BackgroundDocumentRequestHandler for SemanticTokensRequestHandler {
-    fn document_url(params: &SemanticTokensParams) -> Cow<'_, Url> {
+    fn document_uri(params: &SemanticTokensParams) -> Cow<'_, Uri> {
         Cow::Borrowed(&params.text_document.uri)
     }
 
@@ -28,7 +28,7 @@ impl BackgroundDocumentRequestHandler for SemanticTokensRequestHandler {
         snapshot: &DocumentSnapshot,
         _client: &Client,
         _params: SemanticTokensParams,
-    ) -> crate::server::Result<Option<SemanticTokensResult>> {
+    ) -> crate::server::Result<Option<SemanticTokens>> {
         if snapshot
             .workspace_settings()
             .is_language_services_disabled()
@@ -50,7 +50,7 @@ impl BackgroundDocumentRequestHandler for SemanticTokensRequestHandler {
             && let Some(notebook_document) = db.notebook_document(file)
             && let Some(notebook) = source_text(db, file).as_notebook()
         {
-            let cell_index = notebook_document.cell_index_by_uri(snapshot.url());
+            let cell_index = notebook_document.cell_index_by_uri(snapshot.uri());
 
             cell_range = cell_index.and_then(|index| notebook.cell_range(index));
         }
@@ -65,10 +65,10 @@ impl BackgroundDocumentRequestHandler for SemanticTokensRequestHandler {
                 .supports_multiline_semantic_tokens(),
         );
 
-        Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
+        Ok(Some(SemanticTokens {
             result_id: None,
             data: lsp_tokens,
-        })))
+        }))
     }
 }
 

--- a/crates/ty_server/src/server/api/requests/semantic_tokens_range.rs
+++ b/crates/ty_server/src/server/api/requests/semantic_tokens_range.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use lsp_types::{SemanticTokens, SemanticTokensRangeParams, SemanticTokensRangeResult, Url};
+use lsp_types::{SemanticTokens, SemanticTokensRangeParams, Uri};
 use ty_project::ProjectDatabase;
 
 use crate::document::RangeExt;
@@ -14,11 +14,11 @@ use crate::session::client::Client;
 pub(crate) struct SemanticTokensRangeRequestHandler;
 
 impl RequestHandler for SemanticTokensRangeRequestHandler {
-    type RequestType = lsp_types::request::SemanticTokensRangeRequest;
+    type RequestType = lsp_types::SemanticTokensRangeRequest;
 }
 
 impl BackgroundDocumentRequestHandler for SemanticTokensRangeRequestHandler {
-    fn document_url(params: &SemanticTokensRangeParams) -> Cow<'_, Url> {
+    fn document_uri(params: &SemanticTokensRangeParams) -> Cow<'_, Uri> {
         Cow::Borrowed(&params.text_document.uri)
     }
 
@@ -27,7 +27,7 @@ impl BackgroundDocumentRequestHandler for SemanticTokensRangeRequestHandler {
         snapshot: &DocumentSnapshot,
         _client: &Client,
         params: SemanticTokensRangeParams,
-    ) -> crate::server::Result<Option<SemanticTokensRangeResult>> {
+    ) -> crate::server::Result<Option<SemanticTokens>> {
         if snapshot
             .workspace_settings()
             .is_language_services_disabled()
@@ -43,7 +43,7 @@ impl BackgroundDocumentRequestHandler for SemanticTokensRangeRequestHandler {
         let Some(requested_range) =
             params
                 .range
-                .to_text_range(db, file, snapshot.url(), snapshot.encoding())
+                .to_text_range(db, file, snapshot.uri(), snapshot.encoding())
         else {
             return Ok(None);
         };
@@ -58,10 +58,10 @@ impl BackgroundDocumentRequestHandler for SemanticTokensRangeRequestHandler {
                 .supports_multiline_semantic_tokens(),
         );
 
-        Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
+        Ok(Some(SemanticTokens {
             result_id: None,
             data: lsp_tokens,
-        })))
+        }))
     }
 }
 

--- a/crates/ty_server/src/server/api/requests/shutdown.rs
+++ b/crates/ty_server/src/server/api/requests/shutdown.rs
@@ -2,13 +2,13 @@ use crate::Session;
 use crate::server::api::traits::{RequestHandler, SyncRequestHandler};
 use crate::session::client::Client;
 
-use lsp_types::{WorkspaceDiagnosticReport, WorkspaceDiagnosticReportResult};
+use lsp_types::WorkspaceDiagnosticReport;
 use salsa::Database;
 
 pub(crate) struct ShutdownHandler;
 
 impl RequestHandler for ShutdownHandler {
-    type RequestType = lsp_types::request::Shutdown;
+    type RequestType = lsp_types::ShutdownRequest;
 }
 
 impl SyncRequestHandler for ShutdownHandler {
@@ -21,9 +21,7 @@ impl SyncRequestHandler for ShutdownHandler {
         {
             client.respond(
                 &suspended_workspace_request.id,
-                Ok(WorkspaceDiagnosticReportResult::Report(
-                    WorkspaceDiagnosticReport::default(),
-                )),
+                Ok(WorkspaceDiagnosticReport::default()),
             );
         }
 

--- a/crates/ty_server/src/server/api/requests/signature_help.rs
+++ b/crates/ty_server/src/server/api/requests/signature_help.rs
@@ -6,10 +6,10 @@ use crate::server::api::traits::{
 };
 use crate::session::DocumentSnapshot;
 use crate::session::client::Client;
-use lsp_types::request::SignatureHelpRequest;
+use lsp_types::{ActiveParameter, SignatureHelpRequest};
 use lsp_types::{
-    Documentation, ParameterInformation, ParameterLabel, SignatureHelp, SignatureHelpParams,
-    SignatureInformation, Url,
+    Documentation, ParameterInformation, ParameterInformationLabel, SignatureHelp,
+    SignatureHelpParams, SignatureInformation, Uri,
 };
 use ty_ide::signature_help;
 use ty_project::ProjectDatabase;
@@ -21,7 +21,7 @@ impl RequestHandler for SignatureHelpRequestHandler {
 }
 
 impl BackgroundDocumentRequestHandler for SignatureHelpRequestHandler {
-    fn document_url(params: &SignatureHelpParams) -> Cow<'_, Url> {
+    fn document_uri(params: &SignatureHelpParams) -> Cow<'_, Uri> {
         Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 
@@ -45,7 +45,7 @@ impl BackgroundDocumentRequestHandler for SignatureHelpRequestHandler {
         let Some(offset) = params.text_document_position_params.position.to_text_size(
             db,
             file,
-            snapshot.url(),
+            snapshot.uri(),
             snapshot.encoding(),
         ) else {
             return Ok(None);
@@ -63,7 +63,8 @@ impl BackgroundDocumentRequestHandler for SignatureHelpRequestHandler {
             .active_signature
             .and_then(|s| signature_help_info.signatures.get(s))
             .and_then(|sig| sig.active_parameter)
-            .and_then(|p| u32::try_from(p).ok());
+            .and_then(|p| u32::try_from(p).ok())
+            .map(ActiveParameter::Int);
 
         // Convert from IDE types to LSP types
         let signatures = signature_help_info
@@ -102,12 +103,12 @@ impl BackgroundDocumentRequestHandler for SignatureHelpRequestHandler {
                                 let start_u32 =
                                     u32::try_from(start_char_offset).unwrap_or(u32::MAX);
                                 let end_u32 = u32::try_from(end_char_offset).unwrap_or(u32::MAX);
-                                ParameterLabel::LabelOffsets([start_u32, end_u32])
+                                ParameterInformationLabel::Tuple((start_u32, end_u32))
                             } else {
-                                ParameterLabel::Simple(param.label)
+                                ParameterInformationLabel::String(param.label)
                             }
                         } else {
-                            ParameterLabel::Simple(param.label)
+                            ParameterInformationLabel::String(param.label)
                         };
 
                         ParameterInformation {
@@ -119,7 +120,9 @@ impl BackgroundDocumentRequestHandler for SignatureHelpRequestHandler {
 
                 let active_parameter =
                     if resolved_capabilities.supports_signature_active_parameter() {
-                        sig.active_parameter.and_then(|p| u32::try_from(p).ok())
+                        sig.active_parameter
+                            .and_then(|p| u32::try_from(p).ok())
+                            .map(ActiveParameter::Int)
                     } else {
                         None
                     };

--- a/crates/ty_server/src/server/api/requests/type_hierarchy_subtypes.rs
+++ b/crates/ty_server/src/server/api/requests/type_hierarchy_subtypes.rs
@@ -1,4 +1,4 @@
-use lsp_types::request::TypeHierarchySubtypes;
+use lsp_types::TypeHierarchySubtypesRequest;
 use lsp_types::{TypeHierarchyItem, TypeHierarchySubtypesParams};
 
 use crate::server::api::traits::{
@@ -16,7 +16,7 @@ use crate::session::client::Client;
 pub(crate) struct TypeHierarchySubtypesRequestHandler;
 
 impl RequestHandler for TypeHierarchySubtypesRequestHandler {
-    type RequestType = TypeHierarchySubtypes;
+    type RequestType = TypeHierarchySubtypesRequest;
 }
 
 impl BackgroundRequestHandler for TypeHierarchySubtypesRequestHandler {

--- a/crates/ty_server/src/server/api/requests/type_hierarchy_supertypes.rs
+++ b/crates/ty_server/src/server/api/requests/type_hierarchy_supertypes.rs
@@ -1,4 +1,4 @@
-use lsp_types::request::TypeHierarchySupertypes;
+use lsp_types::TypeHierarchySupertypesRequest;
 use lsp_types::{TypeHierarchyItem, TypeHierarchySupertypesParams};
 
 use crate::server::api::traits::{
@@ -16,7 +16,7 @@ use crate::session::client::Client;
 pub(crate) struct TypeHierarchySupertypesRequestHandler;
 
 impl RequestHandler for TypeHierarchySupertypesRequestHandler {
-    type RequestType = TypeHierarchySupertypes;
+    type RequestType = TypeHierarchySupertypesRequest;
 }
 
 impl BackgroundRequestHandler for TypeHierarchySupertypesRequestHandler {

--- a/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
@@ -3,19 +3,20 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use lsp_server::RequestId;
-use lsp_types::request::WorkspaceDiagnosticRequest;
+use lsp_types::WorkspaceDiagnosticRequest;
 use lsp_types::{
-    FullDocumentDiagnosticReport, PreviousResultId, ProgressToken,
-    UnchangedDocumentDiagnosticReport, Url, WorkspaceDiagnosticParams, WorkspaceDiagnosticReport,
-    WorkspaceDiagnosticReportPartialResult, WorkspaceDiagnosticReportResult,
+    FullDocumentDiagnosticReport, PreviousResultId, ProgressNotification, ProgressParams,
+    ProgressToken, UnchangedDocumentDiagnosticReport, Uri, WorkspaceDiagnosticParams,
+    WorkspaceDiagnosticReport, WorkspaceDiagnosticReportPartialResult,
     WorkspaceDocumentDiagnosticReport, WorkspaceFullDocumentDiagnosticReport,
-    WorkspaceUnchangedDocumentDiagnosticReport, notification::Notification,
+    WorkspaceUnchangedDocumentDiagnosticReport,
 };
 use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::File;
 use ruff_db::source::source_text;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use ty_ide::{Hint, hints};
 use ty_project::{ProgressReporter, ProjectDatabase};
 
@@ -33,7 +34,7 @@ use crate::server::{Action, Result};
 use crate::session::client::Client;
 use crate::session::index::Index;
 use crate::session::{GlobalSettings, SessionSnapshot, SuspendedWorkspaceDiagnosticRequest};
-use crate::system::file_to_url;
+use crate::system::file_to_uri;
 
 /// Handler for [Workspace diagnostics](workspace-diagnostics)
 ///
@@ -110,12 +111,10 @@ impl BackgroundRequestHandler for WorkspaceDiagnosticRequestHandler {
         snapshot: &SessionSnapshot,
         client: &Client,
         params: WorkspaceDiagnosticParams,
-    ) -> Result<WorkspaceDiagnosticReportResult> {
+    ) -> Result<WorkspaceDiagnosticReport> {
         if !snapshot.global_settings().diagnostic_mode().is_workspace() {
             tracing::debug!("Workspace diagnostics is disabled; returning empty report");
-            return Ok(WorkspaceDiagnosticReportResult::Report(
-                WorkspaceDiagnosticReport { items: vec![] },
-            ));
+            return Ok(WorkspaceDiagnosticReport { items: vec![] });
         }
 
         let writer = ResponseWriter::new(
@@ -161,11 +160,15 @@ impl BackgroundRequestHandler for WorkspaceDiagnosticRequestHandler {
         //   case we shouldn't do any long polling because some diagnostics changed).
         // * If this is a full report, then check if all items are unchanged (or empty), the same as for
         //   the non-streaming case.
-        if let Ok(WorkspaceDiagnosticReportResult::Report(full)) = &result {
-            let all_unchanged = full
-                .items
-                .iter()
-                .all(|item| matches!(item, WorkspaceDocumentDiagnosticReport::Unchanged(_)));
+        if let Ok(WorkspaceDiagnosticReport { items }) = &result {
+            let all_unchanged = items.iter().all(|item| {
+                matches!(
+                    item,
+                    WorkspaceDocumentDiagnosticReport::WorkspaceUnchangedDocumentDiagnosticReport(
+                        _
+                    )
+                )
+            });
 
             if all_unchanged {
                 tracing::debug!(
@@ -175,7 +178,7 @@ impl BackgroundRequestHandler for WorkspaceDiagnosticRequestHandler {
                 client.queue_action(Action::SuspendWorkspaceDiagnostics(Box::new(
                     SuspendedWorkspaceDiagnosticRequest {
                         id: id.clone(),
-                        params: serde_json::to_value(&params).unwrap(),
+                        params: json!(&params),
                         revision: snapshot.revision(),
                     },
                 )));
@@ -194,10 +197,9 @@ impl RetriableRequestHandler for WorkspaceDiagnosticRequestHandler {
         lsp_server::ResponseError {
             code: lsp_server::ErrorCode::ServerCancelled as i32,
             message: "server cancelled the request".to_owned(),
-            data: serde_json::to_value(lsp_types::DiagnosticServerCancellationData {
+            data: Some(json!(lsp_types::DiagnosticServerCancellationData {
                 retrigger_request: true,
-            })
-            .ok(),
+            })),
         }
     }
 }
@@ -224,7 +226,7 @@ impl<'a> WorkspaceDiagnosticsProgressReporter<'a> {
         }
     }
 
-    fn into_final_report(self) -> WorkspaceDiagnosticReportResult {
+    fn into_final_report(self) -> WorkspaceDiagnosticReport {
         let state = self.state.into_inner().unwrap();
         state.response.into_final_report()
     }
@@ -324,10 +326,10 @@ struct ResponseWriter<'a> {
     index: &'a Index,
     position_encoding: PositionEncoding,
     client_capabilities: ResolvedClientCapabilities,
-    // It's important that we use `AnySystemPath` over `Url` here because
-    // `file_to_url` isn't guaranteed to return the exact same URL as the one provided
+    // It's important that we use `AnySystemPath` over `Uri` here because
+    // `file_to_uri` isn't guaranteed to return the exact same URI as the one provided
     // by the client.
-    previous_result_ids: FxHashMap<DocumentKey, (Url, String)>,
+    previous_result_ids: FxHashMap<DocumentKey, (Uri, String)>,
     global_settings: &'a GlobalSettings,
 }
 
@@ -357,7 +359,7 @@ impl<'a> ResponseWriter<'a> {
 
         let previous_result_ids = previous_result_ids
             .into_iter()
-            .map(|prev| (DocumentKey::from_url(&prev.uri), (prev.uri, prev.value)))
+            .map(|prev| (DocumentKey::from_uri(&prev.uri), (prev.uri, prev.value)))
             .collect();
 
         Self {
@@ -377,8 +379,8 @@ impl<'a> ResponseWriter<'a> {
         diagnostics: &[Diagnostic],
         unnecessary_hints: &[Hint],
     ) {
-        let Some(url) = file_to_url(db, file) else {
-            tracing::debug!("Failed to convert file path to URL at {}", file.path(db));
+        let Some(uri) = file_to_uri(db, file) else {
+            tracing::debug!("Failed to convert file path to URI at {}", file.path(db));
             return;
         };
 
@@ -390,22 +392,22 @@ impl<'a> ResponseWriter<'a> {
             return;
         }
 
-        let key = DocumentKey::from_url(&url);
+        let key = DocumentKey::from_uri(&uri);
         let version = self
             .index
-            .document_handle(&url)
-            .map(|doc| i64::from(doc.version()))
+            .document_handle(&uri)
+            .map(|doc| doc.version())
             .ok();
 
         let result_id = Diagnostics::result_id_from_hash(diagnostics, unnecessary_hints);
 
-        let previous_result_id = self.previous_result_ids.remove(&key).map(|(_url, id)| id);
+        let previous_result_id = self.previous_result_ids.remove(&key).map(|(_uri, id)| id);
 
         let report = match result_id {
             Some(new_id) if Some(&new_id) == previous_result_id.as_ref() => {
-                WorkspaceDocumentDiagnosticReport::Unchanged(
+                WorkspaceDocumentDiagnosticReport::WorkspaceUnchangedDocumentDiagnosticReport(
                     WorkspaceUnchangedDocumentDiagnosticReport {
-                        uri: url,
+                        uri,
                         version,
                         unchanged_document_diagnostic_report: UnchangedDocumentDiagnosticReport {
                             result_id: new_id,
@@ -436,14 +438,16 @@ impl<'a> ResponseWriter<'a> {
                     unnecessary_hints,
                 ));
 
-                WorkspaceDocumentDiagnosticReport::Full(WorkspaceFullDocumentDiagnosticReport {
-                    uri: url,
-                    version,
-                    full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                        result_id: new_id,
-                        items: lsp_diagnostics,
+                WorkspaceDocumentDiagnosticReport::WorkspaceFullDocumentDiagnosticReport(
+                    WorkspaceFullDocumentDiagnosticReport {
+                        uri,
+                        version,
+                        full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                            result_id: new_id,
+                            items: lsp_diagnostics,
+                        },
                     },
-                })
+                )
             }
         };
 
@@ -475,41 +479,42 @@ impl<'a> ResponseWriter<'a> {
     ///
     /// The result can be a partial or full report depending on whether the server's streaming
     /// diagnostics and if it already sent some diagnostics.
-    fn into_final_report(mut self) -> WorkspaceDiagnosticReportResult {
+    fn into_final_report(mut self) -> WorkspaceDiagnosticReport {
         let mut items = Vec::new();
 
         // Handle files that had diagnostics in previous request but no longer have any
         // Any remaining entries in previous_results are files that were fixed
-        for (key, (previous_url, previous_result_id)) in self.previous_result_ids {
+        for (key, (previous_uri, previous_result_id)) in self.previous_result_ids {
             // This file had diagnostics before but doesn't now, so we need to report it as having no diagnostics
             let version = self
                 .index
                 .document(&key)
                 .ok()
-                .map(|doc| i64::from(doc.version()));
+                .map(crate::session::index::Document::version);
 
             let new_result_id = Diagnostics::result_id_from_hash(&[], &[]);
 
             let report = match new_result_id {
                 Some(new_id) if new_id == previous_result_id => {
-                    WorkspaceDocumentDiagnosticReport::Unchanged(
-                        WorkspaceUnchangedDocumentDiagnosticReport {
-                            uri: previous_url,
-                            version,
-                            unchanged_document_diagnostic_report:
-                                UnchangedDocumentDiagnosticReport { result_id: new_id },
+                    WorkspaceUnchangedDocumentDiagnosticReport {
+                        uri: previous_uri,
+                        version,
+                        unchanged_document_diagnostic_report: UnchangedDocumentDiagnosticReport {
+                            result_id: new_id,
                         },
-                    )
+                    }
+                    .into()
                 }
                 new_id => {
-                    WorkspaceDocumentDiagnosticReport::Full(WorkspaceFullDocumentDiagnosticReport {
-                        uri: previous_url,
+                    WorkspaceFullDocumentDiagnosticReport {
+                        uri: previous_uri,
                         version,
                         full_document_diagnostic_report: FullDocumentDiagnosticReport {
                             result_id: new_id,
                             items: vec![], // No diagnostics
                         },
-                    })
+                    }
+                    .into()
                 }
             };
 
@@ -519,15 +524,13 @@ impl<'a> ResponseWriter<'a> {
         match &mut self.mode {
             ReportingMode::Streaming(streaming) => {
                 items.extend(
-                    std::mem::take(&mut streaming.changed)
-                        .into_iter()
-                        .map(WorkspaceDocumentDiagnosticReport::Full),
+                    std::mem::take(&mut streaming.changed).into_iter().map(
+                        WorkspaceDocumentDiagnosticReport::WorkspaceFullDocumentDiagnosticReport,
+                    ),
                 );
-                items.extend(
-                    std::mem::take(&mut streaming.unchanged)
-                        .into_iter()
-                        .map(WorkspaceDocumentDiagnosticReport::Unchanged),
-                );
+                items.extend(std::mem::take(&mut streaming.unchanged).into_iter().map(
+                    WorkspaceDocumentDiagnosticReport::WorkspaceUnchangedDocumentDiagnosticReport,
+                ));
             }
             ReportingMode::Bulk(all) => {
                 all.extend(items);
@@ -554,12 +557,15 @@ impl ReportingMode {
     fn create_result(
         &mut self,
         items: Vec<WorkspaceDocumentDiagnosticReport>,
-    ) -> WorkspaceDiagnosticReportResult {
+    ) -> WorkspaceDiagnosticReport {
         match self {
-            ReportingMode::Streaming(streaming) => streaming.create_result(items),
-            ReportingMode::Bulk(..) => {
-                WorkspaceDiagnosticReportResult::Report(WorkspaceDiagnosticReport { items })
-            }
+            ReportingMode::Streaming(streaming) => match streaming.create_result(items) {
+                WorkspaceDiagnosticReportResult::Report(report) => report,
+                WorkspaceDiagnosticReportResult::PartialReport(
+                    WorkspaceDiagnosticReportPartialResult { items },
+                ) => WorkspaceDiagnosticReport { items },
+            },
+            ReportingMode::Bulk(..) => WorkspaceDiagnosticReport { items },
         }
     }
 }
@@ -583,13 +589,22 @@ struct Streaming {
     unchanged: Vec<WorkspaceUnchangedDocumentDiagnosticReport>,
 }
 
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
+enum WorkspaceDiagnosticReportResult {
+    Report(WorkspaceDiagnosticReport),
+    PartialReport(WorkspaceDiagnosticReportPartialResult),
+}
+
 impl Streaming {
     fn write_report(&mut self, report: WorkspaceDocumentDiagnosticReport) {
         match report {
-            WorkspaceDocumentDiagnosticReport::Full(full) => {
+            WorkspaceDocumentDiagnosticReport::WorkspaceFullDocumentDiagnosticReport(full) => {
                 self.changed.push(full);
             }
-            WorkspaceDocumentDiagnosticReport::Unchanged(unchanged) => {
+            WorkspaceDocumentDiagnosticReport::WorkspaceUnchangedDocumentDiagnosticReport(
+                unchanged,
+            ) => {
                 self.unchanged.push(unchanged);
             }
         }
@@ -613,14 +628,14 @@ impl Streaming {
         let items = self
             .changed
             .drain(..)
-            .map(WorkspaceDocumentDiagnosticReport::Full)
+            .map(WorkspaceDocumentDiagnosticReport::WorkspaceFullDocumentDiagnosticReport)
             .collect();
 
         let report = self.create_result(items);
         self.client
-            .send_notification::<PartialWorkspaceProgress>(PartialWorkspaceProgressParams {
+            .send_notification::<ProgressNotification>(ProgressParams {
                 token: self.token.clone(),
-                value: report,
+                value: json!(report),
             });
         self.last_flush = Instant::now();
     }
@@ -636,25 +651,9 @@ impl Streaming {
             self.first = false;
             WorkspaceDiagnosticReportResult::Report(WorkspaceDiagnosticReport { items })
         } else {
-            WorkspaceDiagnosticReportResult::Partial(WorkspaceDiagnosticReportPartialResult {
+            WorkspaceDiagnosticReportResult::PartialReport(WorkspaceDiagnosticReportPartialResult {
                 items,
             })
         }
     }
-}
-
-/// The `$/progress` notification for partial workspace diagnostics.
-///
-/// This type is missing in `lsp_types`. That's why we define it here.
-pub struct PartialWorkspaceProgress;
-
-impl Notification for PartialWorkspaceProgress {
-    type Params = PartialWorkspaceProgressParams;
-    const METHOD: &'static str = "$/progress";
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct PartialWorkspaceProgressParams {
-    pub token: ProgressToken,
-    pub value: WorkspaceDiagnosticReportResult,
 }

--- a/crates/ty_server/src/server/api/requests/workspace_symbols.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_symbols.rs
@@ -1,4 +1,4 @@
-use lsp_types::request::WorkspaceSymbolRequest;
+use lsp_types::WorkspaceSymbolRequest;
 use lsp_types::{WorkspaceSymbolParams, WorkspaceSymbolResponse};
 use ty_ide::{WorkspaceSymbolInfo, workspace_symbols};
 
@@ -58,7 +58,7 @@ impl BackgroundRequestHandler for WorkspaceSymbolRequestHandler {
         if all_symbols.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(WorkspaceSymbolResponse::Flat(all_symbols)))
+            Ok(Some(all_symbols.into()))
         }
     }
 }

--- a/crates/ty_server/src/server/api/symbols.rs
+++ b/crates/ty_server/src/server/api/symbols.rs
@@ -1,7 +1,7 @@
 //! Utility functions common to language server request handlers
 //! that return symbol information.
 
-use lsp_types::{SymbolInformation, SymbolKind};
+use lsp_types::{BaseSymbolInformation, SymbolInformation, SymbolKind};
 use ty_ide::SymbolInfo;
 
 use crate::Db;
@@ -10,25 +10,25 @@ use crate::document::{PositionEncoding, ToRangeExt};
 /// Convert `ty_ide` `SymbolKind` to LSP `SymbolKind`
 pub(crate) fn convert_symbol_kind(kind: ty_ide::SymbolKind) -> SymbolKind {
     match kind {
-        ty_ide::SymbolKind::Module => SymbolKind::MODULE,
-        ty_ide::SymbolKind::Class => SymbolKind::CLASS,
-        ty_ide::SymbolKind::Method => SymbolKind::METHOD,
-        ty_ide::SymbolKind::Function => SymbolKind::FUNCTION,
-        ty_ide::SymbolKind::Variable => SymbolKind::VARIABLE,
-        ty_ide::SymbolKind::Constant => SymbolKind::CONSTANT,
-        ty_ide::SymbolKind::Property => SymbolKind::PROPERTY,
-        ty_ide::SymbolKind::Field => SymbolKind::FIELD,
-        ty_ide::SymbolKind::Constructor => SymbolKind::CONSTRUCTOR,
-        ty_ide::SymbolKind::Parameter => SymbolKind::VARIABLE,
-        ty_ide::SymbolKind::TypeParameter => SymbolKind::TYPE_PARAMETER,
-        ty_ide::SymbolKind::Import => SymbolKind::MODULE,
+        ty_ide::SymbolKind::Module => SymbolKind::Module,
+        ty_ide::SymbolKind::Class => SymbolKind::Class,
+        ty_ide::SymbolKind::Method => SymbolKind::Method,
+        ty_ide::SymbolKind::Function => SymbolKind::Function,
+        ty_ide::SymbolKind::Variable => SymbolKind::Variable,
+        ty_ide::SymbolKind::Constant => SymbolKind::Constant,
+        ty_ide::SymbolKind::Property => SymbolKind::Property,
+        ty_ide::SymbolKind::Field => SymbolKind::Field,
+        ty_ide::SymbolKind::Constructor => SymbolKind::Constructor,
+        ty_ide::SymbolKind::Parameter => SymbolKind::Variable,
+        ty_ide::SymbolKind::TypeParameter => SymbolKind::TypeParameter,
+        ty_ide::SymbolKind::Import => SymbolKind::Module,
     }
 }
 
 /// Convert a `ty_ide` `SymbolInfo` to LSP `SymbolInformation`
 ///
 /// Returns `None` if the symbol's range cannot be converted to a location
-/// (e.g., if the file cannot be converted to a URL).
+/// (e.g., if the file cannot be converted to a URI).
 pub(crate) fn convert_to_lsp_symbol_information(
     db: &dyn Db,
     file: ruff_db::files::File,
@@ -41,12 +41,14 @@ pub(crate) fn convert_to_lsp_symbol_information(
         .to_lsp_range(db, file, encoding)?
         .to_location()?;
     Some(SymbolInformation {
-        name: symbol.name.into_owned(),
-        kind: symbol_kind,
-        tags: None,
+        base_symbol_information: BaseSymbolInformation {
+            name: symbol.name.into_owned(),
+            kind: symbol_kind,
+            tags: None,
+            container_name: None,
+        },
         #[allow(deprecated)]
         deprecated: None,
         location,
-        container_name: None,
     })
 }

--- a/crates/ty_server/src/server/api/traits.rs
+++ b/crates/ty_server/src/server/api/traits.rs
@@ -38,15 +38,13 @@ use crate::session::{DocumentSnapshot, Session, SessionSnapshot};
 use lsp_server::RequestId;
 use std::borrow::Cow;
 
-use lsp_types::Url;
-use lsp_types::notification::Notification;
-use lsp_types::request::Request;
+use lsp_types::{LspNotificationMethod, LspRequestMethod, Notification, Request, Uri};
 use ty_project::ProjectDatabase;
 
 /// A supertrait for any server request handler.
 pub(super) trait RequestHandler {
     type RequestType: Request;
-    const METHOD: &'static str = <<Self as RequestHandler>::RequestType>::METHOD;
+    const METHOD: LspRequestMethod<'static> = <<Self as RequestHandler>::RequestType>::METHOD;
 }
 
 /// A request handler that needs mutable access to the session.
@@ -86,10 +84,10 @@ pub(super) trait RetriableRequestHandler: RequestHandler {
 ///
 /// This handler is specific to requests that operate on a single document.
 pub(super) trait BackgroundDocumentRequestHandler: RetriableRequestHandler {
-    /// Returns the URL of the document that this request handler operates on.
-    fn document_url(
+    /// Returns the URI of the document that this request handler operates on.
+    fn document_uri(
         params: &<<Self as RequestHandler>::RequestType as Request>::Params,
-    ) -> Cow<'_, Url>;
+    ) -> Cow<'_, Uri>;
 
     /// Processes the request parameters and returns the LSP request result.
     ///
@@ -169,7 +167,8 @@ pub(super) trait BackgroundRequestHandler: RetriableRequestHandler {
 /// A supertrait for any server notification handler.
 pub(super) trait NotificationHandler {
     type NotificationType: Notification;
-    const METHOD: &'static str = <<Self as NotificationHandler>::NotificationType>::METHOD;
+    const METHOD: LspNotificationMethod<'static> =
+        <<Self as NotificationHandler>::NotificationType>::METHOD;
 }
 
 /// A notification handler that needs mutable access to the session.
@@ -187,10 +186,10 @@ pub(super) trait SyncNotificationHandler: NotificationHandler {
 
 /// A notification handler that can be run on a background thread.
 pub(super) trait BackgroundDocumentNotificationHandler: NotificationHandler {
-    /// Returns the URL of the document that this notification handler operates on.
-    fn document_url(
+    /// Returns the URI of the document that this notification handler operates on.
+    fn document_uri(
         params: &<<Self as NotificationHandler>::NotificationType as Notification>::Params,
-    ) -> Cow<'_, Url>;
+    ) -> Cow<'_, Uri>;
 
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,

--- a/crates/ty_server/src/server/api/type_hierarchy.rs
+++ b/crates/ty_server/src/server/api/type_hierarchy.rs
@@ -6,7 +6,7 @@ use ty_project::ProjectDatabase;
 use crate::PositionEncoding;
 use crate::document::{ToRangeExt, resolve_file_uri_range};
 use crate::session::SessionSnapshot;
-use crate::system::file_to_url;
+use crate::system::file_to_uri;
 
 /// The subtype and supertype implementation.
 ///
@@ -46,13 +46,13 @@ pub(crate) fn convert_to_lsp_item(
     item: ty_ide::TypeHierarchyItem,
     encoding: PositionEncoding,
 ) -> Option<TypeHierarchyItem> {
-    let uri = file_to_url(db, item.file)?;
+    let uri = file_to_uri(db, item.file)?;
     let full_range = item.full_range.to_lsp_range(db, item.file, encoding)?;
     let selection_range = item.selection_range.to_lsp_range(db, item.file, encoding)?;
 
     Some(TypeHierarchyItem {
         name: item.name.into(),
-        kind: SymbolKind::CLASS,
+        kind: SymbolKind::Class,
         tags: None,
         detail: item.detail,
         uri,

--- a/crates/ty_server/src/server/lazy_work_done_progress.rs
+++ b/crates/ty_server/src/server/lazy_work_done_progress.rs
@@ -1,9 +1,8 @@
 use crate::capabilities::ResolvedClientCapabilities;
 use crate::session::client::Client;
-use lsp_types::request::WorkDoneProgressCreate;
 use lsp_types::{
-    ProgressParams, ProgressParamsValue, ProgressToken, WorkDoneProgress, WorkDoneProgressBegin,
-    WorkDoneProgressCreateParams, WorkDoneProgressEnd, WorkDoneProgressReport,
+    ProgressParams, ProgressToken, WorkDoneProgressBegin, WorkDoneProgressCreateParams,
+    WorkDoneProgressCreateRequest, WorkDoneProgressEnd, WorkDoneProgressReport,
 };
 use std::fmt::Display;
 use std::sync::Arc;
@@ -83,7 +82,7 @@ impl LazyWorkDoneProgress {
             let work_done = work_done.clone();
             let title = title.to_string();
 
-            client.send_deferred_request::<WorkDoneProgressCreate>(
+            client.send_deferred_request::<WorkDoneProgressCreateRequest>(
                 WorkDoneProgressCreateParams {
                     token: token.clone(),
                 },
@@ -106,14 +105,15 @@ impl LazyWorkDoneProgress {
     }
 
     fn send_begin(client: &Client, token: ProgressToken, title: String) {
-        client.send_notification::<lsp_types::notification::Progress>(ProgressParams {
+        client.send_notification::<lsp_types::ProgressNotification>(ProgressParams {
             token,
-            value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(WorkDoneProgressBegin {
+            value: serde_json::to_value(WorkDoneProgressBegin {
                 title,
                 cancellable: Some(false),
                 message: None,
                 percentage: Some(0),
-            })),
+            })
+            .expect("Failed to serialize work done progress begin"),
         });
     }
 
@@ -125,15 +125,14 @@ impl LazyWorkDoneProgress {
 
         self.inner
             .client
-            .send_notification::<lsp_types::notification::Progress>(ProgressParams {
+            .send_notification::<lsp_types::ProgressNotification>(ProgressParams {
                 token: token.clone(),
-                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Report(
-                    WorkDoneProgressReport {
-                        cancellable: Some(false),
-                        message: Some(message.to_string()),
-                        percentage,
-                    },
-                )),
+                value: serde_json::to_value(WorkDoneProgressReport {
+                    cancellable: Some(false),
+                    message: Some(message.to_string()),
+                    percentage,
+                })
+                .expect("Failed to serialize work done progress report"),
             });
     }
 }
@@ -157,11 +156,12 @@ impl Drop for Inner {
             .and_then(|mut message| message.take());
 
         self.client
-            .send_notification::<lsp_types::notification::Progress>(ProgressParams {
+            .send_notification::<lsp_types::ProgressNotification>(ProgressParams {
                 token: token.clone(),
-                value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(WorkDoneProgressEnd {
+                value: serde_json::to_value(WorkDoneProgressEnd {
                     message: finish_message,
-                })),
+                })
+                .expect("Failed to serialize work done progress end"),
             });
     }
 }

--- a/crates/ty_server/src/server/main_loop.rs
+++ b/crates/ty_server/src/server/main_loop.rs
@@ -5,8 +5,8 @@ use crate::session::{ClientOptions, SuspendedWorkspaceDiagnosticRequest};
 use anyhow::anyhow;
 use crossbeam::select;
 use lsp_server::Message;
-use lsp_types::Url;
-use lsp_types::notification::Notification;
+use lsp_types::Notification;
+use lsp_types::Uri;
 
 pub(crate) type ConnectionSender = crossbeam::channel::Sender<Message>;
 pub(crate) type MainLoopSender = crossbeam::channel::Sender<Event>;
@@ -63,7 +63,7 @@ impl Server {
                             api::request(req)
                         }
                         Message::Notification(notification) => {
-                            if notification.method == lsp_types::notification::Exit::METHOD {
+                            if notification.method == lsp_types::ExitNotification::METHOD.as_str() {
                                 if !self.session.is_shutdown_requested() {
                                     return Err(anyhow!(
                                         "Received exit notification before a shutdown request"
@@ -216,7 +216,7 @@ pub(crate) enum Action {
 
     /// Initialize the workspace after the server received
     /// the options from the client.
-    InitializeWorkspaces(Vec<(Url, ClientOptions)>),
+    InitializeWorkspaces(Vec<(Uri, ClientOptions)>),
 }
 
 #[derive(Debug)]

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -7,15 +7,15 @@ use std::sync::Arc;
 
 use anyhow::{Context, anyhow};
 use lsp_server::{Message, RequestId};
-use lsp_types::notification::{DidChangeWatchedFiles, Exit, Notification};
-use lsp_types::request::{
-    DocumentDiagnosticRequest, RegisterCapability, Request, Shutdown, UnregisterCapability,
-    WorkspaceDiagnosticRequest,
-};
 use lsp_types::{
-    ClientInfo, DiagnosticRegistrationOptions, DiagnosticServerCapabilities,
+    ClientInfo, DiagnosticProvider, DiagnosticRegistrationOptions,
     DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, Registration, RegistrationParams,
-    TextDocumentContentChangeEvent, Unregistration, UnregistrationParams, Url,
+    TextDocumentContentChangeEvent, Unregistration, UnregistrationParams, Uri,
+};
+use lsp_types::{DidChangeWatchedFilesNotification, ExitNotification, Notification};
+use lsp_types::{
+    DocumentDiagnosticRequest, RegistrationRequest, Request, ShutdownRequest,
+    UnregistrationRequest, WorkspaceDiagnosticRequest,
 };
 use ruff_db::Db;
 use ruff_db::files::{File, system_path_to_file};
@@ -125,7 +125,7 @@ pub(crate) struct ProjectState {
     /// the user about them! So we remember which ones we have emitted diagnostics
     /// for so that we can clear the diagnostics for all of them before we go
     /// to update any of them.
-    pub(crate) untracked_files_with_pushed_diagnostics: Vec<Url>,
+    pub(crate) untracked_files_with_pushed_diagnostics: Vec<Uri>,
 
     // Note: This field should be last to ensure the `db` gets dropped last.
     // The db drop order matters because we call `Arc::into_inner` on some Arc's
@@ -140,7 +140,7 @@ impl Session {
     pub(crate) fn new(
         resolved_client_capabilities: ResolvedClientCapabilities,
         position_encoding: PositionEncoding,
-        workspace_urls: Vec<Url>,
+        workspace_uris: Vec<Uri>,
         initialization_options: InitializationOptions,
         native_system: Arc<dyn System + 'static + Send + Sync + RefUnwindSafe>,
         client_name: ClientName,
@@ -151,8 +151,8 @@ impl Session {
         let mut workspaces = Workspaces::default();
         // Register workspaces with default settings - they'll be initialized with real settings
         // when workspace/configuration response is received
-        for url in workspace_urls {
-            workspaces.register(url)?;
+        for uri in workspace_uris {
+            workspaces.register(uri)?;
         }
 
         Ok(Self {
@@ -269,7 +269,7 @@ impl Session {
         } else {
             match &message {
                 Message::Request(request) => {
-                    if request.method == Shutdown::METHOD {
+                    if request.method == ShutdownRequest::METHOD.as_str() {
                         return Some(message);
                     }
                     tracing::debug!(
@@ -282,7 +282,7 @@ impl Session {
                     return Some(message);
                 }
                 Message::Notification(notification) => {
-                    if notification.method == Exit::METHOD {
+                    if notification.method == ExitNotification::METHOD.as_str() {
                         return Some(message);
                     }
                     tracing::debug!(
@@ -437,14 +437,14 @@ impl Session {
         self.projects.values_mut()
     }
 
-    /// Initializes a sequence of workspace folders identified by URL
+    /// Initializes a sequence of workspace folders identified by URI
     /// along with its corresponding options.
     ///
     /// This is meant to be called when a response from a
     /// `workspace/configuration` request is received. (This is where
     /// the `ClientOptions` comes from.)
     ///
-    /// It is legal to call this on URLs corresponding to workspace
+    /// It is legal to call this on URIs corresponding to workspace
     /// folders that are already initialized. When that occurs,
     /// they are skipped by this routine. That is, they are not
     /// re-initialized.
@@ -457,7 +457,7 @@ impl Session {
     pub(crate) fn initialize_workspace_folders(
         &mut self,
         client: &Client,
-        workspace_folders: Vec<(Url, ClientOptions)>,
+        workspace_folders: Vec<(Uri, ClientOptions)>,
     ) {
         // Every workspace folder can come with its own
         // global options. In theory, these can have different
@@ -504,7 +504,7 @@ impl Session {
         // https://github.com/astral-sh/ruff/pull/19614
         let mut global_options: Option<GlobalOptions> = None;
 
-        for (url, options) in workspace_folders {
+        for (uri, options) in workspace_folders {
             // Last setting wins.
             global_options = Some(
                 self.initialization_options
@@ -514,9 +514,9 @@ impl Session {
                     .combine(options.global),
             );
             if !options.unknown.is_empty() {
-                warn_about_unknown_options(client, Some(&url), &options.unknown);
+                warn_about_unknown_options(client, Some(&uri), &options.unknown);
             }
-            self.initialize_workspace_folder(client, &url, options.workspace);
+            self.initialize_workspace_folder(client, &uri, options.workspace);
         }
 
         if let Some(global_options) = global_options {
@@ -532,7 +532,7 @@ impl Session {
         self.register_capabilities(client);
     }
 
-    /// Initializes a single workspace folder with the given URL
+    /// Initializes a single workspace folder with the given URI
     /// and options.
     ///
     /// If this workspace folder has already been initialized, then
@@ -543,7 +543,7 @@ impl Session {
     pub(crate) fn initialize_workspace_folder(
         &mut self,
         client: &Client,
-        url: &Url,
+        uri: &Uri,
         options: WorkspaceOptions,
     ) {
         let options = self
@@ -553,14 +553,14 @@ impl Session {
             .clone()
             .combine(options);
 
-        tracing::debug!("Initializing workspace `{url}`: {options:#?}");
+        tracing::debug!("Initializing workspace `{uri}`: {options:#?}");
 
-        let Ok(root) = url.to_file_path() else {
-            tracing::debug!("Ignoring workspace with non-path root: {url}");
+        let Ok(root) = uri.to_file_path() else {
+            tracing::debug!("Ignoring workspace with non-path root: {uri}");
             return;
         };
 
-        // Realistically I don't think this can fail because we got the path from a Url
+        // Realistically I don't think this can fail because we got the path from a Uri
         let root = match SystemPathBuf::from_path_buf(root) {
             Ok(root) => root,
             Err(root) => {
@@ -574,12 +574,12 @@ impl Session {
 
         let settings = options.into_settings(&root, client, &*self.native_system);
         let Some(workspace) = self.workspaces.workspaces.get_mut(&root) else {
-            tracing::debug!("Ignoring workspace `{url}` since it was not registered");
+            tracing::debug!("Ignoring workspace `{uri}` since it was not registered");
             return;
         };
         if workspace.is_initialized() {
             tracing::debug!(
-                "Ignoring workspace initialization for `{url}` \
+                "Ignoring workspace initialization for `{uri}` \
                  since it has already been initialized"
             );
             return;
@@ -623,12 +623,12 @@ impl Session {
             Ok(db) => (root, db),
             Err(err) => {
                 tracing::error!(
-                    "Failed to create project for workspace `{url}`: {err:#}. \
+                    "Failed to create project for workspace `{uri}`: {err:#}. \
                         Falling back to default settings"
                 );
 
                 client.show_error_message(format!(
-                    "Failed to load project for workspace {url}. {}",
+                    "Failed to load project for workspace {uri}. {}",
                     self.client_name.log_guidance(),
                 ));
 
@@ -670,14 +670,14 @@ impl Session {
     /// when it has already been added.
     ///
     /// If there was a problem adding the workspace folder (e.g., the
-    /// path derived from the given URL is not valid UTF-8), then an
+    /// path derived from the given URI is not valid UTF-8), then an
     /// error is returned and no workspace folder is registered.
     ///
     /// To initialize the workspace folder, callers must initiate
     /// a request for workspace folder configuration via
     /// `Session::request_uninitialized_workspace_folder_configuration`.
-    pub(crate) fn register_workspace_folder(&mut self, url: Url) -> anyhow::Result<bool> {
-        self.workspaces.register(url)
+    pub(crate) fn register_workspace_folder(&mut self, uri: Uri) -> anyhow::Result<bool> {
+        self.workspaces.register(uri)
     }
 
     /// Requests configuration for each registered but uninitialized
@@ -704,14 +704,14 @@ impl Session {
             return;
         }
 
-        let uninit_workspace_urls: Vec<Url> = self
+        let uninit_workspace_uris: Vec<Uri> = self
             .workspaces()
             .into_iter()
             .filter_map(|(_, workspace)| {
                 if workspace.is_initialized() {
                     None
                 } else {
-                    Some(workspace.url().clone())
+                    Some(workspace.uri().clone())
                 }
             })
             .collect();
@@ -726,24 +726,24 @@ impl Session {
             );
             self.initialize_workspace_folders(
                 client,
-                uninit_workspace_urls
+                uninit_workspace_uris
                     .into_iter()
-                    .map(|url| (url, self.initialization_options().options.clone()))
+                    .map(|uri| (uri, self.initialization_options().options.clone()))
                     .collect::<Vec<_>>(),
             );
             return;
         }
 
-        let items: Vec<lsp_types::ConfigurationItem> = uninit_workspace_urls
+        let items: Vec<lsp_types::ConfigurationItem> = uninit_workspace_uris
             .iter()
-            .map(|url| lsp_types::ConfigurationItem {
-                scope_uri: Some(url.clone()),
+            .map(|uri| lsp_types::ConfigurationItem {
+                scope_uri: Some(uri.clone()),
                 section: Some("ty".to_string()),
             })
             .collect();
 
         tracing::debug!("Requesting workspace configuration for workspaces");
-        client.send_request::<lsp_types::request::WorkspaceConfiguration>(
+        client.send_request::<lsp_types::ConfigurationRequest>(
             self,
             lsp_types::ConfigurationParams { items },
             move |client, result: Vec<serde_json::Value>| {
@@ -753,31 +753,31 @@ impl Session {
                 // `null` value even if it cannot provide a configuration for a workspace.
                 assert_eq!(
                     result.len(),
-                    uninit_workspace_urls.len(),
-                    "Mismatch in number of workspace URLs ({}) and configuration results ({})",
-                    uninit_workspace_urls.len(),
+                    uninit_workspace_uris.len(),
+                    "Mismatch in number of workspace URIs ({}) and configuration results ({})",
+                    uninit_workspace_uris.len(),
                     result.len()
                 );
 
-                let workspaces_with_options: Vec<_> = uninit_workspace_urls
+                let workspaces_with_options: Vec<_> = uninit_workspace_uris
                     .into_iter()
                     .zip(result)
-                    .map(|(url, value)| {
+                    .map(|(uri, value)| {
                         if value.is_null() {
                             tracing::debug!(
-                                "No workspace options provided for {url}, using default options"
+                                "No workspace options provided for {uri}, using default options"
                             );
-                            return (url, ClientOptions::default());
+                            return (uri, ClientOptions::default());
                         }
                         let options: ClientOptions =
                             serde_json::from_value(value).unwrap_or_else(|err| {
                                 tracing::error!(
-                                    "Failed to deserialize workspace options for {url}: {err}. \
+                                    "Failed to deserialize workspace options for {uri}: {err}. \
                                         Using default options"
                                 );
                                 ClientOptions::default()
                             });
-                        (url, options)
+                        (uri, options)
                     })
                     .collect();
 
@@ -786,7 +786,7 @@ impl Session {
         );
     }
 
-    /// Removes a workspace folder at the given URL.
+    /// Removes a workspace folder at the given URI.
     ///
     /// This removes the workspace folder and its associated project database,
     /// and clears diagnostics for any documents that were in the workspace.
@@ -798,19 +798,19 @@ impl Session {
     pub(crate) fn remove_workspace_folder(
         &mut self,
         client: &Client,
-        url: &Url,
+        uri: &Uri,
     ) -> anyhow::Result<()> {
-        tracing::info!("Removing workspace folder: {url}");
+        tracing::info!("Removing workspace folder: {uri}");
 
-        let path = url
+        let path = uri
             .to_file_path()
-            .map_err(|()| anyhow!("Workspace URL is not a file path: {url}"))?;
+            .map_err(|()| anyhow!("Workspace URI is not a file path: {uri}"))?;
         let workspace_path = SystemPathBuf::from_path_buf(path)
             .map_err(|path| anyhow!("Workspace path is not valid UTF-8: {}", path.display()))?;
 
         anyhow::ensure!(
             self.workspaces.unregister(&workspace_path),
-            "Workspace not found: {url}",
+            "Workspace not found: {uri}",
         );
 
         // Note that it is somewhat unclear whether we actually need to
@@ -830,8 +830,8 @@ impl Session {
         // Remove the associated project database.
         if let Some(project_state) = self.projects.remove(&workspace_path) {
             // Clear diagnostics for any files that had pushed diagnostics in this project.
-            for file_url in project_state.untracked_files_with_pushed_diagnostics {
-                self.clear_diagnostics(client, &file_url);
+            for file_uri in project_state.untracked_files_with_pushed_diagnostics {
+                self.clear_diagnostics(client, &file_uri);
             }
         }
 
@@ -863,7 +863,7 @@ impl Session {
         {
             return;
         }
-        self.clear_diagnostics(client, document.url());
+        self.clear_diagnostics(client, document.uri());
     }
 
     /// Clears the diagnostics for the document identified by `uri`.
@@ -871,11 +871,11 @@ impl Session {
     /// This is done by notifying the client with an empty list of diagnostics for the document.
     /// For notebook cells, this clears diagnostics for the specific cell.
     /// For other document types, this clears diagnostics for the main document.
-    pub(crate) fn clear_diagnostics(&self, client: &Client, uri: &Url) {
+    pub(crate) fn clear_diagnostics(&self, client: &Client, uri: &Uri) {
         if self.global_settings().diagnostic_mode().is_off() {
             return;
         }
-        client.send_notification::<lsp_types::notification::PublishDiagnostics>(
+        client.send_notification::<lsp_types::PublishDiagnosticsNotification>(
             lsp_types::PublishDiagnosticsParams {
                 uri: uri.clone(),
                 diagnostics: vec![],
@@ -916,7 +916,7 @@ impl Session {
         {
             if self
                 .registrations
-                .contains(DocumentDiagnosticRequest::METHOD)
+                .contains(DocumentDiagnosticRequest::METHOD.as_str())
             {
                 unregistrations.push(Unregistration {
                     id: DIAGNOSTIC_REGISTRATION_ID.into(),
@@ -941,7 +941,7 @@ impl Session {
                         method: DocumentDiagnosticRequest::METHOD.into(),
                         register_options: Some(
                             serde_json::to_value(
-                                DiagnosticServerCapabilities::RegistrationOptions(
+                                DiagnosticProvider::DiagnosticRegistrationOptions(
                                     DiagnosticRegistrationOptions {
                                         diagnostic_options: server_diagnostic_options(
                                             diagnostic_mode.is_workspace(),
@@ -958,15 +958,18 @@ impl Session {
         }
 
         if let Some(register_options) = self.file_watcher_registration_options() {
-            if self.registrations.contains(DidChangeWatchedFiles::METHOD) {
+            if self
+                .registrations
+                .contains(DidChangeWatchedFilesNotification::METHOD.as_str())
+            {
                 unregistrations.push(Unregistration {
                     id: FILE_WATCHER_REGISTRATION_ID.into(),
-                    method: DidChangeWatchedFiles::METHOD.into(),
+                    method: DidChangeWatchedFilesNotification::METHOD.into(),
                 });
             }
             registrations.push(Registration {
                 id: FILE_WATCHER_REGISTRATION_ID.into(),
-                method: DidChangeWatchedFiles::METHOD.into(),
+                method: DidChangeWatchedFilesNotification::METHOD.into(),
                 register_options: Some(serde_json::to_value(register_options).unwrap()),
             });
         }
@@ -986,7 +989,7 @@ impl Session {
             self.registrations.insert(registration.method.clone());
         }
 
-        client.send_request::<RegisterCapability>(
+        client.send_request::<RegistrationRequest>(
             self,
             RegistrationParams { registrations },
             |_: &Client, ()| {
@@ -1014,7 +1017,7 @@ impl Session {
             }
         }
 
-        client.send_request::<UnregisterCapability>(
+        client.send_request::<UnregistrationRequest>(
             self,
             UnregistrationParams {
                 unregisterations: unregistrations,
@@ -1035,21 +1038,28 @@ impl Session {
     ) -> Option<DidChangeWatchedFilesRegistrationOptions> {
         fn make_watcher(glob: &str) -> FileSystemWatcher {
             FileSystemWatcher {
-                glob_pattern: lsp_types::GlobPattern::String(glob.into()),
-                kind: Some(lsp_types::WatchKind::all()),
+                glob_pattern: lsp_types::GlobPattern::Pattern(glob.into()),
+                // When `kind` is omitted, it defaults to `WatchKind.Create | WatchKind.Change | WatchKind.Delete`.
+                // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#fileSystemWatcher
+                kind: None,
             }
         }
 
         fn make_relative_watcher(relative_to: &SystemPath, glob: &str) -> FileSystemWatcher {
-            let base_uri = Url::from_file_path(relative_to.as_std_path())
+            let base_uri = Uri::from_file_path(relative_to.as_std_path())
                 .expect("system path must be a valid URI");
-            let glob_pattern = lsp_types::GlobPattern::Relative(lsp_types::RelativePattern {
-                base_uri: lsp_types::OneOf::Right(base_uri),
-                pattern: glob.to_string(),
-            });
+            let glob_pattern =
+                lsp_types::GlobPattern::RelativePattern(lsp_types::RelativePattern {
+                    base_uri: base_uri.into(),
+                    pattern: glob.to_string(),
+                });
             FileSystemWatcher {
                 glob_pattern,
-                kind: Some(lsp_types::WatchKind::all()),
+                kind: Some(
+                    lsp_types::WatchKind::Change
+                        | lsp_types::WatchKind::Delete
+                        | lsp_types::WatchKind::Create,
+                ),
             }
         }
 
@@ -1100,10 +1110,10 @@ impl Session {
         Some(DidChangeWatchedFilesRegistrationOptions { watchers })
     }
 
-    /// Creates a document snapshot with the URL referencing the document to snapshot.
-    pub(crate) fn snapshot_document(&self, url: &Url) -> Result<DocumentSnapshot, DocumentError> {
+    /// Creates a document snapshot with the URI referencing the document to snapshot.
+    pub(crate) fn snapshot_document(&self, uri: &Uri) -> Result<DocumentSnapshot, DocumentError> {
         let index = self.index();
-        let document_handle = index.document_handle(url)?;
+        let document_handle = index.document_handle(uri)?;
 
         Ok(DocumentSnapshot {
             resolved_client_capabilities: self.resolved_client_capabilities,
@@ -1159,16 +1169,16 @@ impl Session {
             .map(|(_, document)| DocumentHandle::from_text_document(document))
     }
 
-    /// Returns a handle to the document specified by its URL.
+    /// Returns a handle to the document specified by its URI.
     ///
     /// # Errors
     ///
     /// If the document is not found.
     pub(crate) fn document_handle(
         &self,
-        url: &lsp_types::Url,
+        uri: &lsp_types::Uri,
     ) -> Result<DocumentHandle, DocumentError> {
-        self.index().document_handle(url)
+        self.index().document_handle(uri)
     }
 
     /// Registers a notebook document at the provided `path`.
@@ -1384,8 +1394,8 @@ impl DocumentSnapshot {
         &self.document
     }
 
-    pub(crate) fn url(&self) -> &lsp_types::Url {
-        self.document.url()
+    pub(crate) fn uri(&self) -> &lsp_types::Uri {
+        self.document.uri()
     }
 
     pub(crate) fn to_notebook_or_file(&self, db: &dyn Db) -> Option<File> {
@@ -1393,7 +1403,7 @@ impl DocumentSnapshot {
         if file.is_none() {
             tracing::debug!(
                 "Failed to resolve file: file not found for `{}`",
-                self.document.url()
+                self.document.uri()
             );
         }
         file
@@ -1502,7 +1512,7 @@ pub(crate) struct Workspaces {
 }
 
 impl Workspaces {
-    /// Registers a new workspace with the given URL and default settings for the workspace.
+    /// Registers a new workspace with the given URI and default settings for the workspace.
     ///
     /// This returns `true` when this workspace is added and `false`
     /// when it has already been added.
@@ -1514,14 +1524,14 @@ impl Workspaces {
     /// to the server during the `initialize` request, but the resolved
     /// settings are only available after the client has responded to the
     /// `workspace/configuration` request.
-    fn register(&mut self, url: Url) -> anyhow::Result<bool> {
-        let path = url
+    fn register(&mut self, uri: Uri) -> anyhow::Result<bool> {
+        let path = uri
             .to_file_path()
-            .map_err(|()| anyhow!("Workspace URL is not a file or directory: {url:?}"))?;
+            .map_err(|()| anyhow!("Workspace URI is not a file or directory: {uri:?}"))?;
 
-        // Realistically I don't think this can fail because we got the path from a Url
+        // Realistically I don't think this can fail because we got the path from a Uri
         let system_path = SystemPathBuf::from_path_buf(path)
-            .map_err(|_| anyhow!("Workspace URL is not valid UTF8"))?;
+            .map_err(|_| anyhow!("Workspace URI is not valid UTF8"))?;
 
         if self.workspaces.contains_key(&system_path) {
             return Ok(false);
@@ -1530,7 +1540,7 @@ impl Workspaces {
         self.workspaces.insert(
             system_path,
             Workspace {
-                url,
+                uri,
                 settings: Arc::new(WorkspaceSettings::default()),
                 initialized: false,
             },
@@ -1584,8 +1594,8 @@ impl<'a> IntoIterator for &'a Workspaces {
 
 #[derive(Debug)]
 pub(crate) struct Workspace {
-    /// The workspace root URL as sent by the client during initialization.
-    url: Url,
+    /// The workspace root URI as sent by the client during initialization.
+    uri: Uri,
     /// The settings for this workspace.
     ///
     /// The settings here have already been "combined" with the initialization
@@ -1602,8 +1612,8 @@ pub(crate) struct Workspace {
 }
 
 impl Workspace {
-    pub(crate) fn url(&self) -> &Url {
-        &self.url
+    pub(crate) fn uri(&self) -> &Uri {
+        &self.uri
     }
 
     pub(crate) fn settings(&self) -> &WorkspaceSettings {
@@ -1666,24 +1676,24 @@ impl SuspendedWorkspaceDiagnosticRequest {
 
 /// A handle to a document stored within [`Index`].
 ///
-/// Allows identifying the document within the index but it also carries the URL used by the
+/// Allows identifying the document within the index but it also carries the URI used by the
 /// client to reference the document as well as the version of the document.
 ///
 /// It also exposes methods to get the file-path of the corresponding ty-file.
 #[derive(Clone, Debug)]
 pub(crate) enum DocumentHandle {
     Text {
-        url: lsp_types::Url,
+        uri: lsp_types::Uri,
         path: AnySystemPath,
         version: DocumentVersion,
     },
     Notebook {
-        url: lsp_types::Url,
+        uri: lsp_types::Uri,
         path: AnySystemPath,
         version: DocumentVersion,
     },
     Cell {
-        url: lsp_types::Url,
+        uri: lsp_types::Uri,
         version: DocumentVersion,
         notebook_path: AnySystemPath,
     },
@@ -1694,21 +1704,21 @@ impl DocumentHandle {
         match document.notebook() {
             None => Self::Text {
                 version: document.version(),
-                url: document.url().clone(),
-                path: DocumentKey::from_url(document.url()).into_file_path(),
+                uri: document.uri().clone(),
+                path: DocumentKey::from_uri(document.uri()).into_file_path(),
             },
             Some(notebook) => Self::Cell {
                 notebook_path: notebook.clone(),
                 version: document.version(),
-                url: document.url().clone(),
+                uri: document.uri().clone(),
             },
         }
     }
 
     fn from_notebook_document(document: &NotebookDocument) -> Self {
         Self::Notebook {
-            path: DocumentKey::from_url(document.url()).into_file_path(),
-            url: document.url().clone(),
+            path: DocumentKey::from_uri(document.uri()).into_file_path(),
+            uri: document.uri().clone(),
             version: document.version(),
         }
     }
@@ -1721,7 +1731,7 @@ impl DocumentHandle {
     }
 
     fn key(&self) -> DocumentKey {
-        DocumentKey::from_url(self.url())
+        DocumentKey::from_uri(self.uri())
     }
 
     pub(crate) const fn version(&self) -> DocumentVersion {
@@ -1732,16 +1742,16 @@ impl DocumentHandle {
         }
     }
 
-    /// The URL as used by the client to reference this document.
-    pub(crate) fn url(&self) -> &lsp_types::Url {
+    /// The URI as used by the client to reference this document.
+    pub(crate) fn uri(&self) -> &lsp_types::Uri {
         match self {
-            Self::Text { url, .. } | Self::Notebook { url, .. } | Self::Cell { url, .. } => url,
+            Self::Text { uri, .. } | Self::Notebook { uri, .. } | Self::Cell { uri, .. } => uri,
         }
     }
 
     /// The path to the enclosing file for this document.
     ///
-    /// This is the path corresponding to the URL, except for notebook cells where the
+    /// This is the path corresponding to the URI, except for notebook cells where the
     /// path corresponds to the notebook file.
     pub(crate) fn notebook_or_file_path(&self) -> &AnySystemPath {
         match self {
@@ -1823,8 +1833,8 @@ impl DocumentHandle {
     pub(crate) fn update_notebook_document(
         &mut self,
         session: &mut Session,
-        cells: Option<lsp_types::NotebookDocumentCellChange>,
-        metadata: Option<lsp_types::LSPObject>,
+        cells: Option<lsp_types::NotebookDocumentCellChanges>,
+        metadata: Option<lsp_types::LspObject>,
         new_version: DocumentVersion,
     ) -> crate::Result<()> {
         let position_encoding = session.position_encoding();
@@ -1956,16 +1966,16 @@ impl DocumentHandle {
 
 /// Warns about unknown options received by the server.
 ///
-/// If `workspace_url` is `Some`, it indicates that the unknown options were received during a
+/// If `workspace_uri` is `Some`, it indicates that the unknown options were received during a
 /// workspace initialization, otherwise they were received during the server initialization.
 pub(super) fn warn_about_unknown_options(
     client: &Client,
-    workspace_url: Option<&Url>,
+    workspace_uri: Option<&Uri>,
     unknown_options: &HashMap<String, serde_json::Value>,
 ) {
-    let message = if let Some(workspace_url) = workspace_url {
+    let message = if let Some(workspace_uri) = workspace_uri {
         format!(
-            "Received unknown options for workspace `{workspace_url}`: {}",
+            "Received unknown options for workspace `{workspace_uri}`: {}",
             serde_json::to_string_pretty(unknown_options)
                 .unwrap_or_else(|_| format!("{unknown_options:?}"))
         )

--- a/crates/ty_server/src/session/client.rs
+++ b/crates/ty_server/src/session/client.rs
@@ -40,7 +40,7 @@ impl Client {
         params: R::Params,
         response_handler: impl FnOnce(&Client, R::Result) + Send + 'static,
     ) where
-        R: lsp_types::request::Request,
+        R: lsp_types::Request,
     {
         self.send_request_raw(
             session,
@@ -64,7 +64,7 @@ impl Client {
         params: R::Params,
         response_handler: impl FnOnce(&Client, R::Result) + Send + 'static,
     ) where
-        R: lsp_types::request::Request,
+        R: lsp_types::Request,
     {
         self.main_loop_sender
             .send(Event::Action(Action::SendRequest(SendRequest {
@@ -99,7 +99,7 @@ impl Client {
     /// Sends a notification to the client.
     pub(crate) fn send_notification<N>(&self, params: N::Params)
     where
-        N: lsp_types::notification::Notification,
+        N: lsp_types::Notification,
     {
         if let Err(err) =
             self.client_sender
@@ -172,9 +172,9 @@ impl Client {
     ///
     /// This opens a pop up in VS Code showing `message`.
     pub(crate) fn show_message(&self, message: impl Display, message_type: lsp_types::MessageType) {
-        self.send_notification::<lsp_types::notification::ShowMessage>(
+        self.send_notification::<lsp_types::ShowMessageNotification>(
             lsp_types::ShowMessageParams {
-                typ: message_type,
+                kind: message_type,
                 message: message.to_string(),
             },
         );
@@ -185,7 +185,7 @@ impl Client {
     ///
     /// Logs an error if the message could not be sent.
     pub(crate) fn show_warning_message(&self, message: impl Display) {
-        self.show_message(message, lsp_types::MessageType::WARNING);
+        self.show_message(message, lsp_types::MessageType::Warning);
     }
 
     /// Sends a request to display an error to the client with a formatted message. The error is
@@ -193,7 +193,7 @@ impl Client {
     ///
     /// Logs an error if the message could not be sent.
     pub(crate) fn show_error_message(&self, message: impl Display) {
-        self.show_message(message, lsp_types::MessageType::ERROR);
+        self.show_message(message, lsp_types::MessageType::Error);
     }
 
     /// Re-queues this request after a salsa cancellation for a retry.
@@ -245,12 +245,12 @@ pub(crate) struct ClientResponseHandler(Box<dyn FnOnce(&Client, lsp_server::Resp
 impl ClientResponseHandler {
     fn for_request<R>(response_handler: impl FnOnce(&Client, R::Result) + Send + 'static) -> Self
     where
-        R: lsp_types::request::Request,
+        R: lsp_types::Request,
     {
         Self(Box::new(
             move |client: &Client, response: lsp_server::Response| {
                 let _span =
-                    tracing::debug_span!("client_response", id=%response.id, method = R::METHOD)
+                    tracing::debug_span!("client_response", id=%response.id, method = %R::METHOD)
                         .entered();
 
                 match (response.error, response.result) {

--- a/crates/ty_server/src/session/index.rs
+++ b/crates/ty_server/src/session/index.rs
@@ -33,9 +33,9 @@ impl Index {
 
     pub(crate) fn document_handle(
         &self,
-        url: &lsp_types::Url,
+        uri: &lsp_types::Uri,
     ) -> Result<DocumentHandle, DocumentError> {
-        let key = DocumentKey::from_url(url);
+        let key = DocumentKey::from_uri(uri);
         let Some(document) = self.documents.get(&key) else {
             return Err(DocumentError::NotFound(key));
         };
@@ -54,7 +54,7 @@ impl Index {
     pub(super) fn update_notebook_document(
         &mut self,
         notebook_key: &DocumentKey,
-        cells: Option<lsp_types::NotebookDocumentCellChange>,
+        cells: Option<lsp_types::NotebookDocumentCellChanges>,
         metadata: Option<serde_json::Map<String, serde_json::Value>>,
         new_version: DocumentVersion,
         encoding: PositionEncoding,
@@ -66,7 +66,7 @@ impl Index {
 
         let (structure, data, text_content) = cells
             .map(|cells| {
-                let lsp_types::NotebookDocumentCellChange {
+                let lsp_types::NotebookDocumentCellChanges {
                     structure,
                     data,
                     text_content,
@@ -108,13 +108,13 @@ impl Index {
 
         for opened_cell in did_open.into_iter().flatten() {
             self.documents.insert(
-                DocumentKey::from_url(&opened_cell.uri),
+                DocumentKey::from_uri(&opened_cell.uri),
                 Document::Text(
                     TextDocument::new(
                         opened_cell.uri,
                         opened_cell.text,
                         opened_cell.version,
-                        &opened_cell.language_id,
+                        opened_cell.language_id,
                     )
                     .with_notebook(notebook_path.clone())
                     .into(),
@@ -123,12 +123,12 @@ impl Index {
         }
 
         for updated_cell in text_content.into_iter().flatten() {
-            let Ok(document_mut) =
-                self.document_mut(&DocumentKey::from_url(&updated_cell.document.uri))
-            else {
+            let Ok(document_mut) = self.document_mut(&DocumentKey::from_uri(
+                &updated_cell.document.text_document_identifier.uri,
+            )) else {
                 tracing::warn!(
                     "Could not find document for cell {}",
-                    updated_cell.document.uri
+                    updated_cell.document.text_document_identifier.uri
                 );
                 continue;
             };
@@ -162,7 +162,7 @@ impl Index {
 
     /// Create a document reference corresponding to the given document key.
     ///
-    /// Returns an error if the document is not found or if the path cannot be converted to a URL.
+    /// Returns an error if the document is not found or if the path cannot be converted to a URI.
     pub(crate) fn document(&self, key: &DocumentKey) -> Result<&Document, DocumentError> {
         let Some(document) = self.documents.get(key) else {
             return Err(DocumentError::NotFound(key.clone()));
@@ -172,7 +172,7 @@ impl Index {
     }
 
     pub(super) fn open_text_document(&mut self, document: TextDocument) -> DocumentHandle {
-        let key = DocumentKey::from_url(document.url());
+        let key = DocumentKey::from_uri(document.uri());
 
         let handle = DocumentHandle::from_text_document(&document);
 
@@ -183,7 +183,7 @@ impl Index {
 
     pub(super) fn open_notebook_document(&mut self, document: NotebookDocument) -> DocumentHandle {
         let handle = DocumentHandle::from_notebook_document(&document);
-        let notebook_key = DocumentKey::from_url(document.url());
+        let notebook_key = DocumentKey::from_uri(document.uri());
 
         self.documents
             .insert(notebook_key, Document::new_notebook(document));

--- a/crates/ty_server/src/session/options.rs
+++ b/crates/ty_server/src/session/options.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use lsp_types::Url;
+use lsp_types::Uri;
 use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use ruff_macros::Combine;
 use ruff_python_ast::PythonVersion;
@@ -504,7 +504,7 @@ pub(crate) struct EnvironmentVersion {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PythonEnvironment {
     #[deprecated]
-    pub(crate) folder_uri: Option<Url>,
+    pub(crate) folder_uri: Option<Uri>,
     #[deprecated]
     #[serde(rename = "type")]
     pub(crate) kind: Option<String>,
@@ -516,6 +516,6 @@ pub(crate) struct PythonEnvironment {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PythonExecutable {
     #[deprecated]
-    pub(crate) uri: Option<Url>,
+    pub(crate) uri: Option<Uri>,
     pub(crate) sys_prefix: SystemPathBuf,
 }

--- a/crates/ty_server/src/system.rs
+++ b/crates/ty_server/src/system.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use crate::Db;
 use crate::document::{DocumentKey, LanguageId};
 use crate::session::index::{Document, Index};
-use lsp_types::Url;
+use lsp_types::Uri;
 use ruff_db::file_revision::FileRevision;
 use ruff_db::files::{File, FilePath};
 use ruff_db::system::walk_directory::WalkDirectoryBuilder;
@@ -20,15 +20,15 @@ use ruff_notebook::{Notebook, NotebookError};
 use ruff_python_ast::PySourceType;
 use ty_ide::cached_vendored_path;
 
-/// Returns a [`Url`] for the given [`File`].
-pub(crate) fn file_to_url(db: &dyn Db, file: File) -> Option<Url> {
+/// Returns a [`Uri`] for the given [`File`].
+pub(crate) fn file_to_uri(db: &dyn Db, file: File) -> Option<Uri> {
     match file.path(db) {
-        FilePath::System(system) => Url::from_file_path(system.as_std_path()).ok(),
-        FilePath::SystemVirtual(path) => Url::parse(path.as_str()).ok(),
+        FilePath::System(system) => Uri::from_file_path(system.as_std_path()).ok(),
+        FilePath::SystemVirtual(path) => Uri::parse(path.as_str()).ok(),
         FilePath::Vendored(path) => {
             let system_path = cached_vendored_path(db, path)?;
 
-            Url::from_file_path(system_path.as_std_path()).ok()
+            Uri::from_file_path(system_path.as_std_path()).ok()
         }
     }
 }
@@ -318,8 +318,8 @@ fn document_revision(document: &Document, index: &Index) -> FileRevision {
             // The notification updating the cell content on paste re-used the same version as when the cell was added.
             // Because of that, hash all cell versions and the notebook versions together.
             let mut hasher = DefaultHasher::new();
-            for cell_url in notebook.cell_urls() {
-                if let Ok(cell) = index.document(&DocumentKey::from_url(cell_url)) {
+            for cell_uri in notebook.cell_uris() {
+                if let Ok(cell) = index.document(&DocumentKey::from_uri(cell_uri)) {
                     cell.version().hash(&mut hasher);
                 }
             }

--- a/crates/ty_server/tests/e2e/call_hierarchy.rs
+++ b/crates/ty_server/tests/e2e/call_hierarchy.rs
@@ -1,11 +1,12 @@
-use lsp_types::request::{
-    CallHierarchyIncomingCalls, CallHierarchyOutgoingCalls, CallHierarchyPrepare,
-};
 use lsp_types::{
     CallHierarchyIncomingCall, CallHierarchyIncomingCallsParams, CallHierarchyItem,
     CallHierarchyOutgoingCall, CallHierarchyOutgoingCallsParams, CallHierarchyPrepareParams,
     PartialResultParams, Position, TextDocumentIdentifier, TextDocumentPositionParams,
     WorkDoneProgressParams,
+};
+use lsp_types::{
+    CallHierarchyIncomingCallsRequest, CallHierarchyOutgoingCallsRequest,
+    CallHierarchyPrepareRequest,
 };
 
 use crate::TestServerBuilder;
@@ -271,7 +272,7 @@ fn prepare(
     path: impl AsRef<ruff_db::system::SystemPath>,
     position: Position,
 ) -> Option<Vec<CallHierarchyItem>> {
-    server.send_request_await::<CallHierarchyPrepare>(CallHierarchyPrepareParams {
+    server.send_request_await::<CallHierarchyPrepareRequest>(CallHierarchyPrepareParams {
         text_document_position_params: TextDocumentPositionParams {
             text_document: TextDocumentIdentifier {
                 uri: server.file_uri(path),
@@ -286,20 +287,24 @@ fn incoming(
     server: &mut crate::TestServer,
     item: CallHierarchyItem,
 ) -> Option<Vec<CallHierarchyIncomingCall>> {
-    server.send_request_await::<CallHierarchyIncomingCalls>(CallHierarchyIncomingCallsParams {
-        item,
-        work_done_progress_params: WorkDoneProgressParams::default(),
-        partial_result_params: PartialResultParams::default(),
-    })
+    server.send_request_await::<CallHierarchyIncomingCallsRequest>(
+        CallHierarchyIncomingCallsParams {
+            item,
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        },
+    )
 }
 
 fn outgoing(
     server: &mut crate::TestServer,
     item: CallHierarchyItem,
 ) -> Option<Vec<CallHierarchyOutgoingCall>> {
-    server.send_request_await::<CallHierarchyOutgoingCalls>(CallHierarchyOutgoingCallsParams {
-        item,
-        work_done_progress_params: WorkDoneProgressParams::default(),
-        partial_result_params: PartialResultParams::default(),
-    })
+    server.send_request_await::<CallHierarchyOutgoingCallsRequest>(
+        CallHierarchyOutgoingCallsParams {
+            item,
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        },
+    )
 }

--- a/crates/ty_server/tests/e2e/code_actions.rs
+++ b/crates/ty_server/tests/e2e/code_actions.rs
@@ -1,11 +1,11 @@
 use crate::{TestServer, TestServerBuilder};
 use anyhow::Result;
-use lsp_types::{DocumentDiagnosticReportResult, Position, Range, request::CodeActionRequest};
+use lsp_types::{CodeActionRequest, DocumentDiagnosticReport, Position, Range};
 use ruff_db::system::SystemPath;
 
 fn code_actions_at(
     server: &TestServer,
-    diagnostics: DocumentDiagnosticReportResult,
+    diagnostics: DocumentDiagnosticReport,
     file: &SystemPath,
     range: Range,
 ) -> lsp_types::CodeActionParams {
@@ -16,10 +16,12 @@ fn code_actions_at(
         range,
         context: lsp_types::CodeActionContext {
             diagnostics: match diagnostics {
-                lsp_types::DocumentDiagnosticReportResult::Report(
-                    lsp_types::DocumentDiagnosticReport::Full(report),
-                ) => report.full_document_diagnostic_report.items,
-                _ => panic!("Expected full diagnostic report"),
+                DocumentDiagnosticReport::RelatedFullDocumentDiagnosticReport(report) => {
+                    report.full_document_diagnostic_report.items
+                }
+                DocumentDiagnosticReport::RelatedUnchangedDocumentDiagnosticReport(_) => {
+                    panic!("Expected full diagnostic report")
+                }
             },
             only: None,
             trigger_kind: None,

--- a/crates/ty_server/tests/e2e/commands.rs
+++ b/crates/ty_server/tests/e2e/commands.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use lsp_types::{ExecuteCommandParams, WorkDoneProgressParams, request::ExecuteCommand};
+use lsp_types::{ExecuteCommandParams, ExecuteCommandRequest, WorkDoneProgressParams};
 use ruff_db::system::SystemPath;
 
 use crate::{TestServer, TestServerBuilder};
@@ -12,11 +12,11 @@ fn execute_command(
 ) -> Option<serde_json::Value> {
     let params = ExecuteCommandParams {
         command,
-        arguments,
+        arguments: Some(arguments),
         work_done_progress_params: WorkDoneProgressParams::default(),
     };
-    let id = server.send_request::<ExecuteCommand>(params);
-    server.await_response::<ExecuteCommand>(&id)
+    let id = server.send_request::<ExecuteCommandRequest>(params);
+    server.await_response::<ExecuteCommandRequest>(&id)
 }
 
 #[test]

--- a/crates/ty_server/tests/e2e/configuration.rs
+++ b/crates/ty_server/tests/e2e/configuration.rs
@@ -90,7 +90,7 @@ unresolved-reference="warn"
         .wait_until_workspaces_are_initialized();
 
     server.open_text_document(foo, foo_content, 1);
-    let show_message = server.await_notification::<lsp_types::notification::ShowMessage>();
+    let show_message = server.await_notification::<lsp_types::ShowMessageNotification>();
     let diagnostics = server.document_diagnostic_request(foo, None);
 
     assert_json_snapshot!(show_message, @r#"
@@ -238,7 +238,6 @@ reveal_type(sys.version_info[:2])
 
     assert_json_snapshot!(diagnostics, @r#"
     {
-      "kind": "full",
       "resultId": "[RESULT_ID]",
       "items": [
         {
@@ -257,7 +256,8 @@ reveal_type(sys.version_info[:2])
           "source": "ty",
           "message": "Revealed type: `tuple[Literal[3], Literal[14]]`"
         }
-      ]
+      ],
+      "kind": "full"
     }
     "#);
 

--- a/crates/ty_server/tests/e2e/initialize.rs
+++ b/crates/ty_server/tests/e2e/initialize.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use lsp_types::notification::ShowMessage;
-use lsp_types::{Position, request::RegisterCapability};
+use lsp_types::ShowMessageNotification;
+use lsp_types::{Position, RegistrationRequest};
 use ruff_db::system::SystemPath;
 use serde_json::Value;
 use ty_server::{ClientOptions, DiagnosticMode};
@@ -53,7 +53,7 @@ fn workspace_diagnostic_registration_without_configuration() -> Result<()> {
     // No need to wait for workspaces to initialize as the client does not support workspace
     // configuration.
 
-    let (_, params) = server.await_request::<RegisterCapability>();
+    let (_, params) = server.await_request::<RegistrationRequest>();
     let [registration] = params.registrations.as_slice() else {
         panic!(
             "Expected a single registration, got: {:#?}",
@@ -96,7 +96,7 @@ fn open_files_diagnostic_registration_without_configuration() -> Result<()> {
     // No need to wait for workspaces to initialize as the client does not support workspace
     // configuration.
 
-    let (_, params) = server.await_request::<RegisterCapability>();
+    let (_, params) = server.await_request::<RegistrationRequest>();
     let [registration] = params.registrations.as_slice() else {
         panic!(
             "Expected a single registration, got: {:#?}",
@@ -135,7 +135,7 @@ fn workspace_diagnostic_registration_via_initialization() -> Result<()> {
         .build()
         .wait_until_workspaces_are_initialized();
 
-    let (_, params) = server.await_request::<RegisterCapability>();
+    let (_, params) = server.await_request::<RegistrationRequest>();
     let [registration] = params.registrations.as_slice() else {
         panic!(
             "Expected a single registration, got: {:#?}",
@@ -174,7 +174,7 @@ fn open_files_diagnostic_registration_via_initialization() -> Result<()> {
         .build()
         .wait_until_workspaces_are_initialized();
 
-    let (_, params) = server.await_request::<RegisterCapability>();
+    let (_, params) = server.await_request::<RegistrationRequest>();
     let [registration] = params.registrations.as_slice() else {
         panic!(
             "Expected a single registration, got: {:#?}",
@@ -213,7 +213,7 @@ fn workspace_diagnostic_registration() -> Result<()> {
         .build()
         .wait_until_workspaces_are_initialized();
 
-    let (_, params) = server.await_request::<RegisterCapability>();
+    let (_, params) = server.await_request::<RegistrationRequest>();
     let [registration] = params.registrations.as_slice() else {
         panic!(
             "Expected a single registration, got: {:#?}",
@@ -252,7 +252,7 @@ fn open_files_diagnostic_registration() -> Result<()> {
         .build()
         .wait_until_workspaces_are_initialized();
 
-    let (_, params) = server.await_request::<RegisterCapability>();
+    let (_, params) = server.await_request::<RegistrationRequest>();
     let [registration] = params.registrations.as_slice() else {
         panic!(
             "Expected a single registration, got: {:#?}",
@@ -395,7 +395,7 @@ fn unknown_initialization_options() -> Result<()> {
         .build()
         .wait_until_workspaces_are_initialized();
 
-    let show_message_params = server.await_notification::<ShowMessage>();
+    let show_message_params = server.await_notification::<ShowMessageNotification>();
 
     insta::assert_json_snapshot!(show_message_params, @r#"
     {
@@ -420,7 +420,7 @@ fn unknown_options_in_workspace_configuration() -> Result<()> {
         .build()
         .wait_until_workspaces_are_initialized();
 
-    let show_message_params = server.await_notification::<ShowMessage>();
+    let show_message_params = server.await_notification::<ShowMessageNotification>();
 
     insta::assert_json_snapshot!(show_message_params, @r#"
     {
@@ -451,7 +451,7 @@ fn register_multiple_capabilities() -> Result<()> {
         .build()
         .wait_until_workspaces_are_initialized();
 
-    let (_, params) = server.await_request::<RegisterCapability>();
+    let (_, params) = server.await_request::<RegistrationRequest>();
     let registrations = params.registrations;
 
     insta::assert_json_snapshot!(registrations, @r#"
@@ -487,7 +487,7 @@ fn missing_virtual_env_does_not_panic() -> Result<()> {
         .build()
         .wait_until_workspaces_are_initialized();
 
-    let show_message_params = server.await_notification::<ShowMessage>();
+    let show_message_params = server.await_notification::<ShowMessageNotification>();
 
     insta::assert_snapshot!(show_message_params.message, @"Failed to load project for workspace file://<temp_dir>/project. Please refer to the logs for more details.");
 

--- a/crates/ty_server/tests/e2e/inlay_hints.rs
+++ b/crates/ty_server/tests/e2e/inlay_hints.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
-use lsp_types::notification::DidOpenTextDocument;
-use lsp_types::request::InlayHintRequest;
+use lsp_types::DidOpenTextDocumentNotification;
+use lsp_types::InlayHintRequest;
+use lsp_types::LanguageKind;
 use lsp_types::{
     DidOpenTextDocumentParams, InlayHintParams, Position, Range, TextDocumentIdentifier,
-    TextDocumentItem, Url, WorkDoneProgressParams,
+    TextDocumentItem, Uri, WorkDoneProgressParams,
 };
 use ruff_db::system::SystemPath;
 use ty_server::ClientOptions;
@@ -181,12 +182,12 @@ fn variable_inlay_hints_disabled_for_virtual_file() -> Result<()> {
         .wait_until_workspaces_are_initialized();
 
     let file_uri = server.file_uri(file);
-    let virtual_uri = Url::parse(&format!("untitled://{}", file_uri.path())).unwrap();
+    let virtual_uri = Uri::parse(&format!("untitled://{}", file_uri.path())).unwrap();
 
-    server.send_notification::<DidOpenTextDocument>(DidOpenTextDocumentParams {
+    server.send_notification::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
             uri: virtual_uri.clone(),
-            language_id: "python".to_string(),
+            language_id: LanguageKind::Python,
             version: 1,
             text: content.to_string(),
         },

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -55,29 +55,26 @@ use anyhow::{Context, Result, anyhow};
 use crossbeam::channel::RecvTimeoutError;
 use insta::internals::SettingsBindDropGuard;
 use lsp_server::{Connection, Message, RequestId, Response, ResponseError};
-use lsp_types::notification::{
-    DidChangeTextDocument, DidChangeWatchedFiles, DidChangeWorkspaceFolders, DidCloseTextDocument,
-    DidOpenTextDocument, Exit, Initialized, Notification,
-};
-use lsp_types::request::{
-    Completion, DocumentDiagnosticRequest, HoverRequest, Initialize, InlayHintRequest,
-    PrepareRenameRequest, Request, Shutdown, SignatureHelpRequest, WorkspaceConfiguration,
-    WorkspaceDiagnosticRequest,
-};
 use lsp_types::{
-    ClientCapabilities, CompletionItem, CompletionParams, CompletionResponse,
-    CompletionTriggerKind, ConfigurationParams, DiagnosticClientCapabilities,
-    DidChangeTextDocumentParams, DidChangeWatchedFilesClientCapabilities,
-    DidChangeWatchedFilesParams, DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReportResult, FileEvent,
-    FoldingRange, FoldingRangeParams, Hover, HoverParams, InitializeParams, InitializeResult,
-    InitializedParams, InlayHint, InlayHintClientCapabilities, InlayHintParams, NumberOrString,
-    PartialResultParams, Position, PreviousResultId, PublishDiagnosticsClientCapabilities, Range,
-    SemanticTokensResult, SignatureHelp, SignatureHelpParams, SignatureHelpTriggerKind,
+    ClientCapabilities, CompletionItem, CompletionParams, CompletionRequest, CompletionResponse,
+    CompletionTriggerKind, ConfigurationParams, ConfigurationRequest, DiagnosticClientCapabilities,
+    DidChangeTextDocumentNotification, DidChangeTextDocumentParams,
+    DidChangeWatchedFilesClientCapabilities, DidChangeWatchedFilesNotification,
+    DidChangeWatchedFilesParams, DidChangeWorkspaceFoldersNotification,
+    DidChangeWorkspaceFoldersParams, DidCloseTextDocumentNotification, DidCloseTextDocumentParams,
+    DidOpenTextDocumentNotification, DidOpenTextDocumentParams, DocumentDiagnosticParams,
+    DocumentDiagnosticReport, DocumentDiagnosticRequest, ExitNotification, FileEvent, FoldingRange,
+    FoldingRangeParams, Hover, HoverParams, HoverRequest, InitializeParams, InitializeRequest,
+    InitializeResult, InitializedNotification, InitializedParams, InlayHint,
+    InlayHintClientCapabilities, InlayHintParams, InlayHintRequest, LanguageKind, Notification,
+    PartialResultParams, Position, PrepareRenameRequest, PreviousResultId,
+    PublishDiagnosticsClientCapabilities, Range, Request, SemanticTokens, ShutdownRequest,
+    SignatureHelp, SignatureHelpParams, SignatureHelpRequest, SignatureHelpTriggerKind,
     TextDocumentClientCapabilities, TextDocumentContentChangeEvent, TextDocumentIdentifier,
-    TextDocumentItem, TextDocumentPositionParams, Url, VersionedTextDocumentIdentifier,
+    TextDocumentItem, TextDocumentPositionParams, Uri, VersionedTextDocumentIdentifier,
     WorkDoneProgressParams, WorkspaceClientCapabilities, WorkspaceDiagnosticParams,
-    WorkspaceDiagnosticReportResult, WorkspaceEdit, WorkspaceFolder, WorkspaceFoldersChangeEvent,
+    WorkspaceDiagnosticReport, WorkspaceDiagnosticRequest, WorkspaceEdit, WorkspaceFolder,
+    WorkspaceFoldersChangeEvent, WorkspaceFoldersInitializeParams,
 };
 use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf, TestSystem};
 use rustc_hash::FxHashMap;
@@ -202,7 +199,7 @@ pub(crate) struct TestServer {
     initialize_response: Option<InitializeResult>,
 
     /// Workspace configurations for `workspace/configuration` requests
-    workspace_configurations: HashMap<Url, ClientOptions>,
+    workspace_configurations: HashMap<Uri, ClientOptions>,
 
     /// Whether a Shutdown request has been sent by the test
     /// and the exit sequence should be skipped during `Drop`
@@ -293,7 +290,9 @@ impl TestServer {
     ) -> Self {
         let init_params = InitializeParams {
             capabilities,
-            workspace_folders: Some(workspace_folders),
+            workspace_folders_initialize_params: WorkspaceFoldersInitializeParams {
+                workspace_folders: Some(workspace_folders.into()),
+            },
             initialization_options: initialization_options.map(|options| {
                 serde_json::to_value(options)
                     .context("Failed to serialize initialization options to `ClientOptions`")
@@ -302,9 +301,9 @@ impl TestServer {
             ..Default::default()
         };
 
-        let init_request_id = self.send_request::<Initialize>(init_params);
-        self.initialize_response = Some(self.await_response::<Initialize>(&init_request_id));
-        self.send_notification::<Initialized>(InitializedParams {});
+        let init_request_id = self.send_request::<InitializeRequest>(init_params);
+        self.initialize_response = Some(self.await_response::<InitializeRequest>(&init_request_id));
+        self.send_notification::<InitializedNotification>(InitializedParams {});
 
         self
     }
@@ -317,7 +316,7 @@ impl TestServer {
     /// This should only be called if the server is expected to send this request.
     #[track_caller]
     pub(crate) fn wait_until_workspaces_are_initialized(mut self) -> Self {
-        let (request_id, params) = self.await_request::<WorkspaceConfiguration>();
+        let (request_id, params) = self.await_request::<ConfigurationRequest>();
         self.handle_workspace_configuration_request(request_id, &params);
         self
     }
@@ -396,7 +395,7 @@ impl TestServer {
         R: Request,
     {
         // Track if an Exit notification is being sent
-        if R::METHOD == lsp_types::request::Shutdown::METHOD {
+        if R::METHOD == lsp_types::ShutdownRequest::METHOD {
             self.shutdown_requested = true;
         }
 
@@ -547,7 +546,7 @@ impl TestServer {
             let notification = self
                 .notifications
                 .iter()
-                .position(|notification| N::METHOD == notification.method)
+                .position(|notification| N::METHOD.as_str() == notification.method)
                 .and_then(|index| self.notifications.remove(index));
             if let Some(notification) = notification {
                 let params = serde_json::from_value(notification.params)?;
@@ -560,7 +559,7 @@ impl TestServer {
         Err(ServerMessageError::Timeout)
     }
 
-    /// Collects `N` publish diagnostic notifications into a map, indexed by the document url.
+    /// Collects `N` publish diagnostic notifications into a map, indexed by the document URI.
     ///
     /// ## Panics
     /// If there are multiple publish diagnostics notifications for the same document.
@@ -568,19 +567,19 @@ impl TestServer {
     pub(crate) fn collect_publish_diagnostic_notifications(
         &mut self,
         count: usize,
-    ) -> BTreeMap<lsp_types::Url, Vec<lsp_types::Diagnostic>> {
+    ) -> BTreeMap<Uri, Vec<lsp_types::Diagnostic>> {
         let mut results = BTreeMap::default();
 
         for _ in 0..count {
             let notification =
-                self.await_notification::<lsp_types::notification::PublishDiagnostics>();
+                self.await_notification::<lsp_types::PublishDiagnosticsNotification>();
 
             if let Some(existing) =
                 results.insert(notification.uri.clone(), notification.diagnostics)
             {
                 panic!(
-                    "Received multiple publish diagnostic notifications for {url}: ({existing:#?})",
-                    url = &notification.uri
+                    "Received multiple publish diagnostic notifications for {uri}: ({existing:#?})",
+                    uri = &notification.uri
                 );
             }
         }
@@ -634,7 +633,7 @@ impl TestServer {
             let request = self
                 .requests
                 .iter()
-                .position(|request| R::METHOD == request.method)
+                .position(|request| R::METHOD.as_str() == request.method)
                 .and_then(|index| self.requests.remove(index));
             if let Some(request) = request {
                 let params = serde_json::from_value(request.params)?;
@@ -715,10 +714,10 @@ impl TestServer {
 
     pub(crate) fn cancel(&mut self, request_id: &RequestId) {
         let id_string = request_id.to_string();
-        self.send_notification::<lsp_types::notification::Cancel>(lsp_types::CancelParams {
+        self.send_notification::<lsp_types::CancelNotification>(lsp_types::CancelParams {
             id: match id_string.parse() {
-                Ok(id) => NumberOrString::Number(id),
-                Err(_) => NumberOrString::String(id_string),
+                Ok(id) => lsp_types::Id::Int(id),
+                Err(_) => lsp_types::Id::String(id_string),
             },
         });
     }
@@ -781,8 +780,8 @@ impl TestServer {
         self.initialize_response.as_ref()
     }
 
-    pub(crate) fn file_uri(&self, path: impl AsRef<SystemPath>) -> Url {
-        Url::from_file_path(self.file_path(path).as_std_path()).expect("Path must be a valid URL")
+    pub(crate) fn file_uri(&self, path: impl AsRef<SystemPath>) -> Uri {
+        Uri::from_file_path(self.file_path(path).as_std_path()).expect("Path must be a valid URI")
     }
 
     pub(crate) fn file_path(&self, path: impl AsRef<SystemPath>) -> SystemPathBuf {
@@ -814,12 +813,12 @@ impl TestServer {
         let params = DidOpenTextDocumentParams {
             text_document: TextDocumentItem {
                 uri: self.file_uri(path),
-                language_id: "python".to_string(),
+                language_id: LanguageKind::Python,
                 version,
                 text: content.as_ref().to_string(),
             },
         };
-        self.send_notification::<DidOpenTextDocument>(params);
+        self.send_notification::<DidOpenTextDocumentNotification>(params);
     }
 
     /// Send a `textDocument/didChange` notification with the given content changes
@@ -831,12 +830,14 @@ impl TestServer {
     ) {
         let params = DidChangeTextDocumentParams {
             text_document: VersionedTextDocumentIdentifier {
-                uri: self.file_uri(path),
+                text_document_identifier: TextDocumentIdentifier {
+                    uri: self.file_uri(path),
+                },
                 version,
             },
             content_changes: changes,
         };
-        self.send_notification::<DidChangeTextDocument>(params);
+        self.send_notification::<DidChangeTextDocumentNotification>(params);
     }
 
     /// Send a `textDocument/didClose` notification
@@ -846,13 +847,13 @@ impl TestServer {
                 uri: self.file_uri(path),
             },
         };
-        self.send_notification::<DidCloseTextDocument>(params);
+        self.send_notification::<DidCloseTextDocumentNotification>(params);
     }
 
     /// Send a `workspace/didChangeWatchedFiles` notification with the given file events
     pub(crate) fn did_change_watched_files(&mut self, events: Vec<FileEvent>) {
         let params = DidChangeWatchedFilesParams { changes: events };
-        self.send_notification::<DidChangeWatchedFiles>(params);
+        self.send_notification::<DidChangeWatchedFilesNotification>(params);
     }
 
     /// Send a `workspace/didChangeWorkspaceFolders` notification with the given added/removed
@@ -881,21 +882,24 @@ impl TestServer {
                     .collect(),
             },
         };
-        self.send_notification::<DidChangeWorkspaceFolders>(params);
+        self.send_notification::<DidChangeWorkspaceFoldersNotification>(params);
     }
 
     pub(crate) fn rename(
         &mut self,
-        document: &Url,
+        document: &Uri,
         position: lsp_types::Position,
         new_name: &str,
     ) -> Result<Option<WorkspaceEdit>, ()> {
         if self
-            .send_request_await::<PrepareRenameRequest>(lsp_types::TextDocumentPositionParams {
-                text_document: TextDocumentIdentifier {
-                    uri: document.clone(),
+            .send_request_await::<PrepareRenameRequest>(lsp_types::PrepareRenameParams {
+                text_document_position_params: TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier {
+                        uri: document.clone(),
+                    },
+                    position,
                 },
-                position,
+                work_done_progress_params: WorkDoneProgressParams::default(),
             })
             .is_none()
         {
@@ -903,8 +907,8 @@ impl TestServer {
         }
 
         Ok(
-            self.send_request_await::<lsp_types::request::Rename>(lsp_types::RenameParams {
-                text_document_position: TextDocumentPositionParams {
+            self.send_request_await::<lsp_types::RenameRequest>(lsp_types::RenameParams {
+                text_document_position_params: TextDocumentPositionParams {
                     text_document: TextDocumentIdentifier {
                         uri: document.clone(),
                     },
@@ -921,7 +925,7 @@ impl TestServer {
         &mut self,
         path: impl AsRef<SystemPath>,
         previous_result_id: Option<String>,
-    ) -> DocumentDiagnosticReportResult {
+    ) -> DocumentDiagnosticReport {
         let params = DocumentDiagnosticParams {
             text_document: TextDocumentIdentifier {
                 uri: self.file_uri(path),
@@ -938,9 +942,9 @@ impl TestServer {
     /// Send a `workspace/diagnostic` request with optional previous result IDs.
     pub(crate) fn workspace_diagnostic_request(
         &mut self,
-        work_done_token: Option<lsp_types::NumberOrString>,
+        work_done_token: Option<lsp_types::ProgressToken>,
         previous_result_ids: Option<Vec<PreviousResultId>>,
-    ) -> WorkspaceDiagnosticReportResult {
+    ) -> WorkspaceDiagnosticReport {
         let params = WorkspaceDiagnosticParams {
             identifier: Some("ty".to_string()),
             previous_result_ids: previous_result_ids.unwrap_or_default(),
@@ -988,35 +992,37 @@ impl TestServer {
         self.await_response::<InlayHintRequest>(&id)
     }
 
-    /// Sends a `textDocument/completion` request for the document at the given URL and position.
+    /// Sends a `textDocument/completion` request for the document at the given URI and position.
     pub(crate) fn completion_request(
         &mut self,
-        uri: &Url,
+        uri: &Uri,
         position: Position,
     ) -> Vec<CompletionItem> {
-        let completions_id = self.send_request::<Completion>(CompletionParams {
-            text_document_position: TextDocumentPositionParams {
+        let completions_id = self.send_request::<CompletionRequest>(CompletionParams {
+            text_document_position_params: TextDocumentPositionParams {
                 text_document: TextDocumentIdentifier { uri: uri.clone() },
                 position,
             },
             work_done_progress_params: lsp_types::WorkDoneProgressParams::default(),
             partial_result_params: lsp_types::PartialResultParams::default(),
             context: Some(lsp_types::CompletionContext {
-                trigger_kind: CompletionTriggerKind::TRIGGER_FOR_INCOMPLETE_COMPLETIONS,
+                trigger_kind: CompletionTriggerKind::TriggerForIncompleteCompletions,
                 trigger_character: None,
             }),
         });
-        match self.await_response::<lsp_types::request::Completion>(&completions_id) {
-            Some(CompletionResponse::Array(array)) => array,
-            Some(CompletionResponse::List(lsp_types::CompletionList { items, .. })) => items,
+        match self.await_response::<lsp_types::CompletionRequest>(&completions_id) {
+            Some(CompletionResponse::CompletionItemList(array)) => array,
+            Some(CompletionResponse::CompletionList(lsp_types::CompletionList {
+                items, ..
+            })) => items,
             None => vec![],
         }
     }
 
-    /// Sends a `textDocument/signatureHelp` request for the document at the given URL and position.
+    /// Sends a `textDocument/signatureHelp` request for the document at the given URI and position.
     pub(crate) fn signature_help_request(
         &mut self,
-        uri: &Url,
+        uri: &Uri,
         position: Position,
     ) -> Option<SignatureHelp> {
         let signature_help_id = self.send_request::<SignatureHelpRequest>(SignatureHelpParams {
@@ -1026,7 +1032,7 @@ impl TestServer {
             },
             work_done_progress_params: lsp_types::WorkDoneProgressParams::default(),
             context: Some(lsp_types::SignatureHelpContext {
-                trigger_kind: SignatureHelpTriggerKind::INVOKED,
+                trigger_kind: SignatureHelpTriggerKind::Invoked,
                 trigger_character: None,
                 is_retrigger: false,
                 active_signature_help: None,
@@ -1035,11 +1041,8 @@ impl TestServer {
         self.await_response::<SignatureHelpRequest>(&signature_help_id)
     }
 
-    pub(crate) fn semantic_tokens_full_request(
-        &mut self,
-        uri: &Url,
-    ) -> Option<SemanticTokensResult> {
-        self.send_request_await::<lsp_types::request::SemanticTokensFullRequest>(
+    pub(crate) fn semantic_tokens_full_request(&mut self, uri: &Uri) -> Option<SemanticTokens> {
+        self.send_request_await::<lsp_types::SemanticTokensRequest>(
             lsp_types::SemanticTokensParams {
                 text_document: TextDocumentIdentifier { uri: uri.clone() },
                 work_done_progress_params: lsp_types::WorkDoneProgressParams::default(),
@@ -1048,8 +1051,8 @@ impl TestServer {
         )
     }
 
-    pub(crate) fn folding_range_request(&mut self, uri: &Url) -> Option<Vec<FoldingRange>> {
-        self.send_request_await::<lsp_types::request::FoldingRangeRequest>(FoldingRangeParams {
+    pub(crate) fn folding_range_request(&mut self, uri: &Uri) -> Option<Vec<FoldingRange>> {
+        self.send_request_await::<lsp_types::FoldingRangeRequest>(FoldingRangeParams {
             text_document: TextDocumentIdentifier { uri: uri.clone() },
             work_done_progress_params: WorkDoneProgressParams::default(),
             partial_result_params: PartialResultParams::default(),
@@ -1067,17 +1070,17 @@ impl TestServer {
     /// # Errors
     ///
     /// This can return an error when there is a problem converting the
-    /// given workspace folder root path to a URL.
+    /// given workspace folder root path to a URI.
     pub(crate) fn add_workspace_folder(
         &mut self,
         path: &SystemPath,
         options: Option<ClientOptions>,
     ) -> Result<()> {
         let path = self.test_context.root().join(path);
-        let url = Url::from_file_path(path.as_std_path())
-            .map_err(|()| anyhow!("Failed to convert workspace path to URL: {path}"))?;
+        let uri = Uri::from_file_path(path.as_std_path())
+            .map_err(|()| anyhow!("Failed to convert workspace path to URI: {path}"))?;
         self.workspace_configurations
-            .insert(url, options.unwrap_or_default());
+            .insert(uri, options.unwrap_or_default());
         Ok(())
     }
 }
@@ -1105,10 +1108,10 @@ impl Drop for TestServer {
         // The `server_thread` could be `None` if the server exited unexpectedly or panicked or if
         // it dropped the client connection.
         let shutdown_error = if self.server_thread.is_some() && !self.shutdown_requested {
-            let shutdown_id = self.send_request::<Shutdown>(());
-            match self.try_await_response::<Shutdown>(&shutdown_id, None) {
+            let shutdown_id = self.send_request::<ShutdownRequest>(());
+            match self.try_await_response::<ShutdownRequest>(&shutdown_id, None) {
                 Ok(()) => {
-                    self.send_notification::<Exit>(());
+                    self.send_notification::<ExitNotification>(());
 
                     None
                 }
@@ -1242,8 +1245,8 @@ impl TestServerBuilder {
 
         self.workspaces.push((
             WorkspaceFolder {
-                uri: Url::from_file_path(workspace_path.as_std_path()).map_err(|()| {
-                    anyhow!("Failed to convert workspace path to URL: {workspace_path}")
+                uri: Uri::from_file_path(workspace_path.as_std_path()).map_err(|()| {
+                    anyhow!("Failed to convert workspace path to URI: {workspace_path}")
                 })?,
                 name: workspace_root.file_name().unwrap_or("test").to_string(),
             },
@@ -1332,6 +1335,7 @@ impl TestServerBuilder {
             .get_or_insert_default()
             .publish_diagnostics
             .get_or_insert_default()
+            .diagnostics_capabilities
             .related_information = Some(enabled);
         self
     }
@@ -1357,8 +1361,8 @@ impl TestServerBuilder {
         self.test_context.root().join(path)
     }
 
-    pub(crate) fn file_uri(&self, path: impl AsRef<SystemPath>) -> Url {
-        Url::from_file_path(self.file_path(path).as_std_path()).expect("Path must be a valid URL")
+    pub(crate) fn file_uri(&self, path: impl AsRef<SystemPath>) -> Uri {
+        Uri::from_file_path(self.file_path(path).as_std_path()).expect("Path must be a valid URI")
     }
 
     /// Write a file to the test directory
@@ -1439,10 +1443,10 @@ impl TestContext {
         })?;
 
         let mut settings = insta::Settings::clone_current();
-        let project_dir_url = Url::from_file_path(project_dir.as_std_path())
-            .map_err(|()| anyhow!("Failed to convert root directory to url"))?;
+        let project_dir_uri = Uri::from_file_path(project_dir.as_std_path())
+            .map_err(|()| anyhow!("Failed to convert root directory to uri"))?;
         settings.add_filter(&tempdir_filter(project_dir.as_str()), "<temp_dir>/");
-        settings.add_filter(&tempdir_filter(project_dir_url.path()), "<temp_dir>/");
+        settings.add_filter(&tempdir_filter(project_dir_uri.path()), "<temp_dir>/");
         settings.add_filter(
             r#"The system cannot find the file specified."#,
             "No such file or directory",

--- a/crates/ty_server/tests/e2e/notebook.rs
+++ b/crates/ty_server/tests/e2e/notebook.rs
@@ -1,5 +1,8 @@
 use insta::assert_json_snapshot;
-use lsp_types::{NotebookCellKind, Position, Range};
+use lsp_types::{
+    Message, NotebookCellKind, Position, Range, TextDocumentContentChangePartial,
+    TextDocumentIdentifier,
+};
 use ruff_db::system::SystemPath;
 use ty_server::ClientOptions;
 
@@ -45,11 +48,11 @@ type Style = Literal["italic", "bold", "underline"]"#,
     builder.open(&mut server);
 
     let cell1_diagnostics =
-        server.await_notification::<lsp_types::notification::PublishDiagnostics>();
+        server.await_notification::<lsp_types::PublishDiagnosticsNotification>();
     let cell2_diagnostics =
-        server.await_notification::<lsp_types::notification::PublishDiagnostics>();
+        server.await_notification::<lsp_types::PublishDiagnosticsNotification>();
     let cell3_diagnostics =
-        server.await_notification::<lsp_types::notification::PublishDiagnostics>();
+        server.await_notification::<lsp_types::PublishDiagnosticsNotification>();
 
     assert_json_snapshot!([cell1_diagnostics, cell2_diagnostics, cell3_diagnostics]);
 
@@ -140,33 +143,33 @@ type Style = Literal["italic", "bold", "underline"]"#,
 IOError"#,
     );
 
-    let notebook_url = builder.open(&mut server);
+    let notebook_uri = builder.open(&mut server);
 
     server.collect_publish_diagnostic_notifications(3);
 
-    server.send_notification::<lsp_types::notification::DidChangeNotebookDocument>(
+    server.send_notification::<lsp_types::DidChangeNotebookDocumentNotification>(
         lsp_types::DidChangeNotebookDocumentParams {
             notebook_document: lsp_types::VersionedNotebookDocumentIdentifier {
                 version: 0,
-                uri: notebook_url,
+                uri: notebook_uri,
             },
             change: lsp_types::NotebookDocumentChangeEvent {
                 metadata: None,
-                cells: Some(lsp_types::NotebookDocumentCellChange {
+                cells: Some(lsp_types::NotebookDocumentCellChanges {
                     structure: None,
                     data: None,
-                    text_content: Some(vec![lsp_types::NotebookDocumentChangeTextContent {
+                    text_content: Some(vec![lsp_types::NotebookDocumentCellContentChanges {
                         document: lsp_types::VersionedTextDocumentIdentifier {
-                            uri: cell_3,
+                            text_document_identifier: TextDocumentIdentifier { uri: cell_3 },
                             version: 0,
                         },
 
                         changes: {
-                            vec![lsp_types::TextDocumentContentChangeEvent {
-                                range: Some(Range::new(Position::new(0, 16), Position::new(0, 17))),
-                                range_length: Some(1),
+                            vec![lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangePartial (TextDocumentContentChangePartial{
+                                range: Range::new(Position::new(0, 16), Position::new(0, 17)),
                                 text: String::new(),
-                            }]
+                                ..Default::default()
+                            })]
                         },
                     }]),
                 }),
@@ -252,12 +255,10 @@ x = cast("list[str]", [])"#,
     // Assert that we didn't receive any semantic tokens for the empty cell.
     // This proves that none were leaked from the first cell.
     let response = semantic_tokens_full_for_cell(&mut server, &second_cell);
-    assert!(matches!(
-        response,
-        Some(lsp_types::SemanticTokensResult::Tokens(_))
-    ));
-    if let Some(lsp_types::SemanticTokensResult::Tokens(tokens)) = response {
+    if let Some(tokens) = response {
         assert!(tokens.data.is_empty());
+    } else {
+        panic!("Expected semantic tokens, but response was empty");
     }
 
     server.collect_publish_diagnostic_notifications(2);
@@ -316,7 +317,7 @@ fn swap_cells() -> anyhow::Result<()> {
     "#);
 
     // Re-order the cells from `b`, `a`, `c` to `a`, `b`, `c` (swapping cell 1 and 2)
-    server.send_notification::<lsp_types::notification::DidChangeNotebookDocument>(
+    server.send_notification::<lsp_types::DidChangeNotebookDocumentNotification>(
         lsp_types::DidChangeNotebookDocumentParams {
             notebook_document: lsp_types::VersionedNotebookDocumentIdentifier {
                 version: 1,
@@ -324,7 +325,7 @@ fn swap_cells() -> anyhow::Result<()> {
             },
             change: lsp_types::NotebookDocumentChangeEvent {
                 metadata: None,
-                cells: Some(lsp_types::NotebookDocumentCellChange {
+                cells: Some(lsp_types::NotebookDocumentCellChanges {
                     structure: Some(lsp_types::NotebookDocumentCellChangeStructure {
                         array: lsp_types::NotebookCellArrayChange {
                             start: 0,
@@ -553,7 +554,8 @@ fn invalid_syntax_with_syntax_errors_disabled() -> anyhow::Result<()> {
         diagnostics
             .values()
             .flatten()
-            .all(|diagnostic| diagnostic.message != "unexpected EOF while parsing")
+            .all(|diagnostic| diagnostic.message
+                != Message::String("unexpected EOF while parsing".into()))
     );
 
     Ok(())
@@ -561,51 +563,50 @@ fn invalid_syntax_with_syntax_errors_disabled() -> anyhow::Result<()> {
 
 fn semantic_tokens_full_for_cell(
     server: &mut TestServer,
-    cell_uri: &lsp_types::Url,
-) -> Option<lsp_types::SemanticTokensResult> {
-    let cell1_tokens_req_id = server.send_request::<lsp_types::request::SemanticTokensFullRequest>(
-        lsp_types::SemanticTokensParams {
+    cell_uri: &lsp_types::Uri,
+) -> Option<lsp_types::SemanticTokens> {
+    let cell1_tokens_req_id =
+        server.send_request::<lsp_types::SemanticTokensRequest>(lsp_types::SemanticTokensParams {
             work_done_progress_params: lsp_types::WorkDoneProgressParams::default(),
             partial_result_params: lsp_types::PartialResultParams::default(),
             text_document: lsp_types::TextDocumentIdentifier {
                 uri: cell_uri.clone(),
             },
-        },
-    );
+        });
 
-    server.await_response::<lsp_types::request::SemanticTokensFullRequest>(&cell1_tokens_req_id)
+    server.await_response::<lsp_types::SemanticTokensRequest>(&cell1_tokens_req_id)
 }
 
 #[derive(Debug)]
 pub(crate) struct NotebookBuilder {
-    notebook_url: lsp_types::Url,
+    notebook_uri: lsp_types::Uri,
     // The cells: (cell_metadata, content, language_id)
     cells: Vec<(lsp_types::NotebookCell, String, String)>,
 }
 
 impl NotebookBuilder {
     pub(crate) fn virtual_file(name: &str) -> Self {
-        let url: lsp_types::Url = format!("vs-code:/{name}").parse().unwrap();
+        let uri: lsp_types::Uri = format!("vs-code:/{name}").parse().unwrap();
         Self {
-            notebook_url: url,
+            notebook_uri: uri,
             cells: Vec::new(),
         }
     }
 
-    pub(crate) fn add_python_cell(&mut self, content: &str) -> lsp_types::Url {
+    pub(crate) fn add_python_cell(&mut self, content: &str) -> lsp_types::Uri {
         let index = self.cells.len();
         let id = format!(
             "vscode-notebook-cell:/{}#{}",
-            self.notebook_url.path(),
+            self.notebook_uri.path(),
             index
         );
 
-        let url: lsp_types::Url = id.parse().unwrap();
+        let uri: lsp_types::Uri = id.parse().unwrap();
 
         self.cells.push((
             lsp_types::NotebookCell {
                 kind: NotebookCellKind::Code,
-                document: url.clone(),
+                document: uri.clone(),
                 metadata: None,
                 execution_summary: None,
             },
@@ -613,14 +614,14 @@ impl NotebookBuilder {
             "python".to_string(),
         ));
 
-        url
+        uri
     }
 
-    pub(crate) fn open(self, server: &mut TestServer) -> lsp_types::Url {
-        server.send_notification::<lsp_types::notification::DidOpenNotebookDocument>(
+    pub(crate) fn open(self, server: &mut TestServer) -> lsp_types::Uri {
+        server.send_notification::<lsp_types::DidOpenNotebookDocumentNotification>(
             lsp_types::DidOpenNotebookDocumentParams {
                 notebook_document: lsp_types::NotebookDocument {
-                    uri: self.notebook_url.clone(),
+                    uri: self.notebook_uri.clone(),
                     notebook_type: "jupyter-notebook".to_string(),
                     version: 0,
                     metadata: None,
@@ -631,7 +632,7 @@ impl NotebookBuilder {
                     .iter()
                     .map(|(cell, content, language_id)| lsp_types::TextDocumentItem {
                         uri: cell.document.clone(),
-                        language_id: language_id.clone(),
+                        language_id: language_id.clone().into(),
                         version: 0,
                         text: content.clone(),
                     })
@@ -639,13 +640,13 @@ impl NotebookBuilder {
             },
         );
 
-        self.notebook_url
+        self.notebook_uri
     }
 }
 
 fn literal_completions(
     server: &mut TestServer,
-    cell: &lsp_types::Url,
+    cell: &lsp_types::Uri,
     position: Position,
 ) -> Vec<lsp_types::CompletionItem> {
     let mut items = server.completion_request(cell, position);

--- a/crates/ty_server/tests/e2e/publish_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/publish_diagnostics.rs
@@ -2,8 +2,10 @@ use std::time::Duration;
 
 use anyhow::Result;
 use lsp_types::{
-    DidOpenTextDocumentParams, FileChangeType, FileEvent, Position, Range, TextDocumentItem, Url,
-    notification::{DidOpenTextDocument, PublishDiagnostics},
+    DidOpenTextDocumentNotification, DidOpenTextDocumentParams, FileChangeType, FileEvent,
+    LanguageKind, Message, Position, PublishDiagnosticsNotification, Range,
+    TextDocumentContentChangePartial, TextDocumentContentChangeWholeDocument, TextDocumentItem,
+    Uri,
 };
 use ruff_db::system::SystemPath;
 use ty_server::ClientOptions;
@@ -27,7 +29,7 @@ def foo() -> str:
         .wait_until_workspaces_are_initialized();
 
     server.open_text_document(foo, foo_content, 1);
-    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
 
     insta::assert_debug_snapshot!(diagnostics);
 
@@ -58,7 +60,7 @@ def foo() -> str:
         .wait_until_workspaces_are_initialized();
 
     server.open_text_document(foo, foo_content, 1);
-    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
     insta::assert_debug_snapshot!(diagnostics);
 
     Ok(())
@@ -91,14 +93,14 @@ def foo() -> str:
         .wait_until_workspaces_are_initialized();
 
     server.open_text_document(foo, foo_content, 1);
-    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
     insta::assert_debug_snapshot!(diagnostics);
 
     Ok(())
 }
 
 /// Like `on_did_open_non_existing_file_workspace_with_file_uri`, but uses
-/// a `untitled://...` URL instead of `file://...`.
+/// a `untitled://...` URI instead of `file://...`.
 ///
 /// Notably, this makes diagnostics for opened files that aren't saved to
 /// disk yet work without needing to check the open file set explicitly. It's
@@ -130,18 +132,18 @@ def foo() -> str:
         .build()
         .wait_until_workspaces_are_initialized();
 
-    server.send_notification::<DidOpenTextDocument>(DidOpenTextDocumentParams {
+    server.send_notification::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
             uri: {
                 let uri = server.file_uri(foo);
-                Url::parse(&format!("untitled://{}", uri.path())).unwrap()
+                Uri::parse(&format!("untitled://{}", uri.path())).unwrap()
             },
-            language_id: "python".to_string(),
+            language_id: LanguageKind::Python,
             version: 1,
             text: foo_content.to_string(),
         },
     });
-    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
     insta::assert_debug_snapshot!(diagnostics);
 
     Ok(())
@@ -167,8 +169,8 @@ def foo() -> str:
         .wait_until_workspaces_are_initialized();
 
     server.open_text_document(foo, foo_content, 1);
-    let diagnostics =
-        server.try_await_notification::<PublishDiagnostics>(Some(Duration::from_millis(100)));
+    let diagnostics = server
+        .try_await_notification::<PublishDiagnosticsNotification>(Some(Duration::from_millis(100)));
 
     assert!(
         diagnostics.is_err(),
@@ -195,17 +197,19 @@ def foo() -> str:
         .wait_until_workspaces_are_initialized();
 
     server.open_text_document(foo, foo_content, 1);
-    let _ = server.await_notification::<PublishDiagnostics>();
+    let _ = server.await_notification::<PublishDiagnosticsNotification>();
 
-    let changes = vec![lsp_types::TextDocumentContentChangeEvent {
-        range: None,
-        range_length: None,
-        text: "def foo() -> int: return 42".to_string(),
-    }];
+    let changes = vec![
+        lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+            TextDocumentContentChangeWholeDocument {
+                text: "def foo() -> int: return 42".to_string(),
+            },
+        ),
+    ];
 
     server.change_text_document(foo, changes, 2);
 
-    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
 
     assert_eq!(diagnostics.version, Some(2));
 
@@ -230,19 +234,23 @@ something, somethingelse = (1, 2)
         .wait_until_workspaces_are_initialized();
 
     server.open_text_document(foo, foo_content, 1);
-    let _ = server.await_notification::<PublishDiagnostics>();
+    let _ = server.await_notification::<PublishDiagnosticsNotification>();
 
     server.change_text_document(
         foo,
-        vec![lsp_types::TextDocumentContentChangeEvent {
-            range: Some(Range::new(Position::new(0, 11), Position::new(0, 24))),
-            range_length: None,
-            text: "not".to_string(),
-        }],
+        vec![
+            lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                TextDocumentContentChangePartial {
+                    range: Range::new(Position::new(0, 11), Position::new(0, 24)),
+                    text: "not".to_string(),
+                    ..Default::default()
+                },
+            ),
+        ],
         2,
     );
 
-    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
 
     assert_eq!(diagnostics.version, Some(2));
 
@@ -267,19 +275,23 @@ something, somethingelse = (1, 2)
         .wait_until_workspaces_are_initialized();
 
     server.open_text_document(foo, foo_content, 1);
-    let _ = server.await_notification::<PublishDiagnostics>();
+    let _ = server.await_notification::<PublishDiagnosticsNotification>();
 
     server.change_text_document(
         foo,
-        vec![lsp_types::TextDocumentContentChangeEvent {
-            range: Some(Range::new(Position::new(0, 11), Position::new(0, 24))),
-            range_length: None,
-            text: "not x".to_string(),
-        }],
+        vec![
+            lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                TextDocumentContentChangePartial {
+                    range: Range::new(Position::new(0, 11), Position::new(0, 24)),
+                    text: "not x".to_string(),
+                    ..Default::default()
+                },
+            ),
+        ],
         2,
     );
 
-    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
 
     assert_eq!(diagnostics.version, Some(2));
 
@@ -309,16 +321,18 @@ def foo() -> str:
 
     server.open_text_document(foo, foo_content, 1);
 
-    let changes = vec![lsp_types::TextDocumentContentChangeEvent {
-        range: None,
-        range_length: None,
-        text: "def foo() -> int: return 42".to_string(),
-    }];
+    let changes = vec![
+        lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+            TextDocumentContentChangeWholeDocument {
+                text: "def foo() -> int: return 42".to_string(),
+            },
+        ),
+    ];
 
     server.change_text_document(foo, changes, 2);
 
-    let diagnostics =
-        server.try_await_notification::<PublishDiagnostics>(Some(Duration::from_millis(100)));
+    let diagnostics = server
+        .try_await_notification::<PublishDiagnosticsNotification>(Some(Duration::from_millis(100)));
 
     assert!(
         diagnostics.is_err(),
@@ -346,7 +360,7 @@ assert_type("test", list[str])
         .wait_until_workspaces_are_initialized();
 
     server.open_text_document(foo, foo_content, 1);
-    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
 
     insta::assert_debug_snapshot!(diagnostics);
 
@@ -372,7 +386,7 @@ assert_type("test", list[str])
         .wait_until_workspaces_are_initialized();
 
     server.open_text_document(foo, foo_content, 1);
-    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
 
     insta::assert_debug_snapshot!(diagnostics);
 
@@ -399,16 +413,16 @@ def foo() -> str:
 
     server.open_text_document(&foo, "", 1);
 
-    let _open_diagnostics = server.await_notification::<PublishDiagnostics>();
+    let _open_diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
 
     std::fs::write(&foo, foo_content)?;
 
     server.did_change_watched_files(vec![FileEvent {
         uri: server.file_uri(foo),
-        typ: FileChangeType::CHANGED,
+        kind: FileChangeType::Changed,
     }]);
 
-    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
 
     // Note how ty reports no diagnostics here. This is because
     // the contents received by didOpen/didChange take precedence over the file
@@ -445,11 +459,11 @@ def foo() -> str:
 
     server.did_change_watched_files(vec![FileEvent {
         uri: server.file_uri(foo),
-        typ: FileChangeType::CHANGED,
+        kind: FileChangeType::Changed,
     }]);
 
-    let diagnostics =
-        server.try_await_notification::<PublishDiagnostics>(Some(Duration::from_millis(100)));
+    let diagnostics = server
+        .try_await_notification::<PublishDiagnosticsNotification>(Some(Duration::from_millis(100)));
 
     assert!(
         diagnostics.is_err(),
@@ -475,7 +489,7 @@ def foo() -> str:
         .wait_until_workspaces_are_initialized();
 
     server.open_text_document(foo, foo_content, 1);
-    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
 
     insta::assert_debug_snapshot!(diagnostics);
 
@@ -499,13 +513,19 @@ def foo() -> str:
         .wait_until_workspaces_are_initialized();
 
     server.open_text_document(foo, foo_content, 1);
-    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
     let [diagnostic] = diagnostics.diagnostics.as_slice() else {
         panic!("expected one diagnostic, got {diagnostics:#?}");
     };
+    let Message::String(message) = &diagnostic.message else {
+        panic!(
+            "expected string-type diagnostic message, got {:#?}",
+            diagnostic.message
+        );
+    };
 
     insta::assert_snapshot!(
-        diagnostic.message,
+        message,
         @"Return type does not match returned value: expected `str`, found `Literal[42]`"
     );
 
@@ -528,24 +548,24 @@ def foo() -> str:
         .wait_until_workspaces_are_initialized();
 
     server.open_text_document(foo, foo_content, 1);
-    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
 
     insta::assert_debug_snapshot!(diagnostics);
 
     server.close_text_document(foo);
-    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
     insta::assert_debug_snapshot!(diagnostics);
 
     let params = DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
             uri: server.file_uri(foo),
-            language_id: "text".to_string(),
+            language_id: LanguageKind::new("text"),
             version: 1,
             text: foo_content.to_string(),
         },
     };
-    server.send_notification::<DidOpenTextDocument>(params);
-    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    server.send_notification::<DidOpenTextDocumentNotification>(params);
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
 
     insta::assert_debug_snapshot!(diagnostics);
 
@@ -572,7 +592,7 @@ def foo(
 
     server.open_text_document(foo, foo_content, 1);
 
-    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
 
     insta::assert_debug_snapshot!(diagnostics);
 

--- a/crates/ty_server/tests/e2e/pull_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/pull_diagnostics.rs
@@ -3,13 +3,15 @@ use std::time::Duration;
 use anyhow::Result;
 use insta::{assert_compact_json_snapshot, assert_debug_snapshot};
 use lsp_server::RequestId;
-use lsp_types::request::WorkspaceDiagnosticRequest;
 use lsp_types::{
-    NumberOrString, PartialResultParams, PreviousResultId, Url, WorkDoneProgressParams,
-    WorkspaceDiagnosticParams, WorkspaceDiagnosticReportResult, WorkspaceDocumentDiagnosticReport,
+    DocumentDiagnosticReport, PartialResultParams, PreviousResultId, ProgressNotification, Uri,
+    WorkDoneProgressBegin, WorkDoneProgressEnd, WorkDoneProgressParams, WorkspaceDiagnosticParams,
+    WorkspaceDiagnosticReport, WorkspaceDiagnosticReportPartialResult,
+    WorkspaceDocumentDiagnosticReport,
 };
+use lsp_types::{TextDocumentContentChangeWholeDocument, WorkspaceDiagnosticRequest};
 use ruff_db::system::SystemPath;
-use ty_server::{ClientOptions, DiagnosticMode, PartialWorkspaceProgress};
+use ty_server::{ClientOptions, DiagnosticMode};
 
 use crate::workspace_folders::condensed_document_diagnostic_snapshot;
 use crate::{AwaitResponseError, TestServer, TestServerBuilder};
@@ -273,7 +275,7 @@ def buy_sell_once(prices: list[float]) -> float:
     server.open_text_document(foo, foo_content, 1);
     let diagnostics = server.document_diagnostic_request(foo, None);
 
-    assert_compact_json_snapshot!(diagnostics, @r#"{"kind": "full", "items": []}"#);
+    assert_compact_json_snapshot!(diagnostics, @r#"{"items": [], "kind": "full"}"#);
 
     Ok(())
 }
@@ -301,7 +303,7 @@ def foo() -> str:
     server.open_text_document(foo, foo_content, 1);
     let diagnostics = server.document_diagnostic_request(foo, None);
 
-    assert_compact_json_snapshot!(diagnostics, @r#"{"kind": "full", "items": []}"#);
+    assert_compact_json_snapshot!(diagnostics, @r#"{"items": [], "kind": "full"}"#);
 
     Ok(())
 }
@@ -335,11 +337,11 @@ def foo(
     {
       "items": [
         {
-          "kind": "full",
           "uri": "file://<temp_dir>/src/foo.py",
           "version": null,
           "resultId": "[RESULT_ID]",
-          "items": []
+          "items": [],
+          "kind": "full"
         }
       ]
     }
@@ -348,7 +350,7 @@ def foo(
     server.open_text_document(foo, foo_content, 1);
     let diagnostics = server.document_diagnostic_request(foo, None);
 
-    assert_compact_json_snapshot!(diagnostics, @r#"{"kind": "full", "resultId": "[RESULT_ID]", "items": []}"#);
+    assert_compact_json_snapshot!(diagnostics, @r#"{"resultId": "[RESULT_ID]", "items": [], "kind": "full"}"#);
 
     Ok(())
 }
@@ -445,15 +447,15 @@ def foo() -> str:
 
     // Extract result ID from first response
     let result_id = match &first_response {
-        lsp_types::DocumentDiagnosticReportResult::Report(
-            lsp_types::DocumentDiagnosticReport::Full(report),
-        ) => report
+        DocumentDiagnosticReport::RelatedFullDocumentDiagnosticReport(report) => report
             .full_document_diagnostic_report
             .result_id
             .as_ref()
             .expect("First response should have a result ID")
             .clone(),
-        _ => panic!("First response should be a full report"),
+        DocumentDiagnosticReport::RelatedUnchangedDocumentDiagnosticReport(_) => {
+            panic!("First response should be a full report")
+        }
     };
 
     // Second request with the previous result ID - should return Unchanged
@@ -461,12 +463,12 @@ def foo() -> str:
 
     // Verify it's an unchanged report
     match second_response {
-        lsp_types::DocumentDiagnosticReportResult::Report(
-            lsp_types::DocumentDiagnosticReport::Unchanged(_),
-        ) => {
+        DocumentDiagnosticReport::RelatedUnchangedDocumentDiagnosticReport(_) => {
             // Success - got unchanged report as expected
         }
-        _ => panic!("Expected an unchanged report when diagnostics haven't changed"),
+        DocumentDiagnosticReport::RelatedFullDocumentDiagnosticReport(_) => {
+            panic!("Expected an unchanged report when diagnostics haven't changed")
+        }
     }
 
     Ok(())
@@ -500,25 +502,27 @@ def foo() -> str:
 
     // Extract result ID from first response
     let result_id = match &first_response {
-        lsp_types::DocumentDiagnosticReportResult::Report(
-            lsp_types::DocumentDiagnosticReport::Full(report),
-        ) => report
+        DocumentDiagnosticReport::RelatedFullDocumentDiagnosticReport(report) => report
             .full_document_diagnostic_report
             .result_id
             .as_ref()
             .expect("First response should have a result ID")
             .clone(),
-        _ => panic!("First response should be a full report"),
+        DocumentDiagnosticReport::RelatedUnchangedDocumentDiagnosticReport(_) => {
+            panic!("First response should be a full report")
+        }
     };
 
     // Change the document to fix the error
     server.change_text_document(
         foo,
-        vec![lsp_types::TextDocumentContentChangeEvent {
-            range: None,
-            range_length: None,
-            text: foo_content_v2.to_string(),
-        }],
+        vec![
+            lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument {
+                    text: foo_content_v2.to_string(),
+                },
+            ),
+        ],
         2,
     );
 
@@ -527,13 +531,13 @@ def foo() -> str:
 
     // Verify it's a full report (not unchanged)
     match second_response {
-        lsp_types::DocumentDiagnosticReportResult::Report(
-            lsp_types::DocumentDiagnosticReport::Full(report),
-        ) => {
+        DocumentDiagnosticReport::RelatedFullDocumentDiagnosticReport(report) => {
             // Should have no diagnostics now
             assert_eq!(report.full_document_diagnostic_report.items.len(), 0);
         }
-        _ => panic!("Expected a full report when diagnostics have changed"),
+        DocumentDiagnosticReport::RelatedUnchangedDocumentDiagnosticReport(_) => {
+            panic!("Expected a full report when diagnostics have changed")
+        }
     }
 
     Ok(())
@@ -615,8 +619,10 @@ def foo() -> str:
     server.open_text_document(file_a, file_a_content, 1);
 
     // First request with no previous result IDs
-    let mut first_response = server
-        .workspace_diagnostic_request(Some(NumberOrString::String("progress-1".to_string())), None);
+    let mut first_response = server.workspace_diagnostic_request(
+        Some(lsp_types::ProgressToken::String("progress-1".to_string())),
+        None,
+    );
     sort_workspace_diagnostic_response(&mut first_response);
 
     assert_debug_snapshot!("workspace_diagnostic_initial_state", first_response);
@@ -637,44 +643,52 @@ def foo() -> str:
     // File B: Add a new error
     server.change_text_document(
         file_b,
-        vec![lsp_types::TextDocumentContentChangeEvent {
-            range: None,
-            range_length: None,
-            text: file_b_content_v2.to_string(),
-        }],
+        vec![
+            lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument {
+                    text: file_b_content_v2.to_string(),
+                },
+            ),
+        ],
         2,
     );
 
     // File C: Fix the error
     server.change_text_document(
         file_c,
-        vec![lsp_types::TextDocumentContentChangeEvent {
-            range: None,
-            range_length: None,
-            text: file_c_content_v2.to_string(),
-        }],
+        vec![
+            lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument {
+                    text: file_c_content_v2.to_string(),
+                },
+            ),
+        ],
         2,
     );
 
     // File D: Change the error
     server.change_text_document(
         file_d,
-        vec![lsp_types::TextDocumentContentChangeEvent {
-            range: None,
-            range_length: None,
-            text: file_d_content_v2.to_string(),
-        }],
+        vec![
+            lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument {
+                    text: file_d_content_v2.to_string(),
+                },
+            ),
+        ],
         2,
     );
 
     // File E: Modify the file but keep the same diagnostic
     server.change_text_document(
         file_e,
-        vec![lsp_types::TextDocumentContentChangeEvent {
-            range: None,
-            range_length: None,
-            text: file_e_content_v2.to_string(),
-        }],
+        vec![
+            lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument {
+                    text: file_e_content_v2.to_string(),
+                },
+            ),
+        ],
         2,
     );
 
@@ -686,7 +700,7 @@ def foo() -> str:
     // - File D: Full report (diagnostic content changed)
     // - File E: Full report (the range changes)
     let mut second_response = server.workspace_diagnostic_request(
-        Some(NumberOrString::String("progress-2".to_string())),
+        Some(lsp_types::ProgressToken::String("progress-2".to_string())),
         Some(previous_result_ids),
     );
     sort_workspace_diagnostic_response(&mut second_response);
@@ -726,7 +740,7 @@ def foo() -> str:
     let mut previous_result_ids = extract_result_ids_from_response(&first_response);
 
     for previous_id in &mut previous_result_ids {
-        // VS Code URL encodes paths, so that `:` is encoded as `%3A`.
+        // VS Code URI encodes paths, so that `:` is encoded as `%3A`.
         previous_id
             .uri
             .set_path(&previous_id.uri.path().replace(':', "%3A"));
@@ -740,13 +754,13 @@ def foo() -> str:
             partial_result_params: PartialResultParams::default(),
         });
 
-    // The URL mismatch shouldn't result in a full document report.
-    // The server needs to match the previous result IDs by the path, not the URL.
+    // The URI mismatch shouldn't result in a full document report.
+    // The server needs to match the previous result IDs by the path, not the URI.
     assert_workspace_diagnostics_suspends_for_long_polling(&mut server, &workspace_request_id);
 
     let second_response = shutdown_and_await_workspace_diagnostic(server, &workspace_request_id);
 
-    insta::assert_compact_debug_snapshot!(second_response, @"Report(WorkspaceDiagnosticReport { items: [] })");
+    insta::assert_compact_debug_snapshot!(second_response, @"WorkspaceDiagnosticReport { items: [] }");
 
     Ok(())
 }
@@ -760,23 +774,19 @@ pub(crate) fn filter_result_id() -> insta::internals::SettingsBindDropGuard {
 
 fn consume_all_progress_notifications(server: &mut TestServer) -> Result<()> {
     // Always consume Begin
-    let begin_params = server.await_notification::<lsp_types::notification::Progress>();
+    let begin_params = server.await_notification::<lsp_types::ProgressNotification>();
 
     // The params are already the ProgressParams type
-    let lsp_types::ProgressParamsValue::WorkDone(lsp_types::WorkDoneProgress::Begin(_)) =
-        begin_params.value
-    else {
+    let Ok(_) = serde_json::from_value::<WorkDoneProgressBegin>(begin_params.value) else {
         return Err(anyhow::anyhow!("Expected Begin progress notification"));
     };
 
     // Consume Report notifications - there may be multiple based on number of files
     // Keep consuming until we hit the End notification
     loop {
-        let params = server.await_notification::<lsp_types::notification::Progress>();
+        let params = server.await_notification::<lsp_types::ProgressNotification>();
 
-        if let lsp_types::ProgressParamsValue::WorkDone(lsp_types::WorkDoneProgress::End(_)) =
-            params.value
-        {
+        if serde_json::from_value::<WorkDoneProgressEnd>(params.value).is_ok() {
             // Found the End notification, we're done
             break;
         }
@@ -839,13 +849,7 @@ def foo() -> str:
     let final_response = server.await_response::<WorkspaceDiagnosticRequest>(&request_id);
 
     // Process the final report.
-    // This should always be a partial report. However, the type definition in the LSP specification
-    // is broken in the sense that both `Report` and `Partial` have the exact same shape
-    // and deserializing a previously serialized `Partial` result will yield a `Report` type.
-    let response_items = match final_response {
-        WorkspaceDiagnosticReportResult::Report(report) => report.items,
-        WorkspaceDiagnosticReportResult::Partial(partial) => partial.items,
-    };
+    let response_items = final_response.items;
 
     // The last batch should contain 1 item because the server sends a partial result with
     // 2 items each.
@@ -854,18 +858,13 @@ def foo() -> str:
 
     // Collect any partial results sent via progress notifications
     while let Ok(params) =
-        server.try_await_notification::<PartialWorkspaceProgress>(Some(Duration::from_secs(1)))
+        server.try_await_notification::<ProgressNotification>(Some(Duration::from_secs(1)))
     {
         if params.token == partial_token {
-            let streamed_items = match params.value {
-                // Ideally we'd assert that only the first response is a full report
-                // However, the type definition in the LSP specification is broken
-                // in the sense that both `Report` and `Partial` have the exact same structure
-                // but it also doesn't use a tag to tell them apart...
-                // That means, a client can never tell if it's a full report or a partial report
-                WorkspaceDiagnosticReportResult::Report(report) => report.items,
-                WorkspaceDiagnosticReportResult::Partial(partial) => partial.items,
-            };
+            let report =
+                serde_json::from_value::<WorkspaceDiagnosticReportPartialResult>(params.value)
+                    .unwrap();
+            let streamed_items = report.items;
 
             // All streamed batches should contain 2 items (test behavior).
             assert_eq!(streamed_items.len(), 2);
@@ -922,31 +921,37 @@ fn workspace_diagnostic_streaming_with_caching() -> Result<()> {
     // Fix three errors
     server.change_text_document(
         SystemPath::new("src/error_0.py"),
-        vec![lsp_types::TextDocumentContentChangeEvent {
-            range: None,
-            range_length: None,
-            text: changed_content.to_string(),
-        }],
+        vec![
+            lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument {
+                    text: changed_content.to_string(),
+                },
+            ),
+        ],
         2,
     );
 
     server.change_text_document(
         SystemPath::new("src/error_1.py"),
-        vec![lsp_types::TextDocumentContentChangeEvent {
-            range: None,
-            range_length: None,
-            text: changed_content.to_string(),
-        }],
+        vec![
+            lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument {
+                    text: changed_content.to_string(),
+                },
+            ),
+        ],
         2,
     );
 
     server.change_text_document(
         SystemPath::new("src/error_2.py"),
-        vec![lsp_types::TextDocumentContentChangeEvent {
-            range: None,
-            range_length: None,
-            text: changed_content.to_string(),
-        }],
+        vec![
+            lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument {
+                    text: changed_content.to_string(),
+                },
+            ),
+        ],
         2,
     );
 
@@ -969,10 +974,7 @@ fn workspace_diagnostic_streaming_with_caching() -> Result<()> {
     let mut all_items = Vec::new();
 
     // The final response should contain one fixed file and all unchanged files
-    let items = match final_response2 {
-        WorkspaceDiagnosticReportResult::Report(report) => report.items,
-        WorkspaceDiagnosticReportResult::Partial(partial) => partial.items,
-    };
+    let items = final_response2.items;
 
     assert_eq!(items.len(), NUM_FILES - 3 + 1); // 3 fixed, 4 unchanged, 1 full report for fixed file
 
@@ -980,18 +982,13 @@ fn workspace_diagnostic_streaming_with_caching() -> Result<()> {
 
     // Collect any partial results sent via progress notifications
     while let Ok(params) =
-        server.try_await_notification::<PartialWorkspaceProgress>(Some(Duration::from_secs(1)))
+        server.try_await_notification::<ProgressNotification>(Some(Duration::from_secs(1)))
     {
         if params.token == partial_token {
-            let streamed_items = match params.value {
-                // Ideally we'd assert that only the first response is a full report
-                // However, the type definition in the LSP specification is broken
-                // in the sense that both `Report` and `Partial` have the exact same structure
-                // but it also doesn't use a tag to tell them apart...
-                // That means, a client can never tell if it's a full report or a partial report
-                WorkspaceDiagnosticReportResult::Report(report) => report.items,
-                WorkspaceDiagnosticReportResult::Partial(partial) => partial.items,
-            };
+            let report =
+                serde_json::from_value::<WorkspaceDiagnosticReportPartialResult>(params.value)
+                    .unwrap();
+            let streamed_items = report.items;
 
             // All streamed batches should contain 2 items.
             assert_eq!(streamed_items.len(), 2);
@@ -1010,20 +1007,19 @@ fn workspace_diagnostic_streaming_with_caching() -> Result<()> {
     Ok(())
 }
 
-fn sort_workspace_diagnostic_response(response: &mut WorkspaceDiagnosticReportResult) {
-    let items = match response {
-        WorkspaceDiagnosticReportResult::Report(report) => &mut report.items,
-        WorkspaceDiagnosticReportResult::Partial(partial) => &mut partial.items,
-    };
-
-    sort_workspace_report_items(items);
+fn sort_workspace_diagnostic_response(response: &mut WorkspaceDiagnosticReport) {
+    sort_workspace_report_items(&mut response.items);
 }
 
 fn sort_workspace_report_items(items: &mut [WorkspaceDocumentDiagnosticReport]) {
-    fn item_uri(item: &WorkspaceDocumentDiagnosticReport) -> &Url {
+    fn item_uri(item: &WorkspaceDocumentDiagnosticReport) -> &Uri {
         match item {
-            WorkspaceDocumentDiagnosticReport::Full(full_report) => &full_report.uri,
-            WorkspaceDocumentDiagnosticReport::Unchanged(unchanged_report) => &unchanged_report.uri,
+            WorkspaceDocumentDiagnosticReport::WorkspaceFullDocumentDiagnosticReport(
+                full_report,
+            ) => &full_report.uri,
+            WorkspaceDocumentDiagnosticReport::WorkspaceUnchangedDocumentDiagnosticReport(
+                unchanged_report,
+            ) => &unchanged_report.uri,
         }
     }
 
@@ -1100,11 +1096,13 @@ def hello() -> str:
     // Now introduce an error to the file - this should trigger the long-polling request to complete
     server.change_text_document(
         file_path,
-        vec![lsp_types::TextDocumentContentChangeEvent {
-            range: None,
-            range_length: None,
-            text: file_content_with_error.to_string(),
-        }],
+        vec![
+            lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument {
+                    text: file_content_with_error.to_string(),
+                },
+            ),
+        ],
         2,
     );
 
@@ -1200,11 +1198,13 @@ def hello() -> str:
     // PHASE 2: Introduce error to trigger response
     server.change_text_document(
         file_path,
-        vec![lsp_types::TextDocumentContentChangeEvent {
-            range: None,
-            range_length: None,
-            text: file_content_with_error.to_string(),
-        }],
+        vec![
+            lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument {
+                    text: file_content_with_error.to_string(),
+                },
+            ),
+        ],
         2,
     );
 
@@ -1233,11 +1233,13 @@ def hello() -> str:
     // PHASE 4: Fix the error to trigger the second response
     server.change_text_document(
         file_path,
-        vec![lsp_types::TextDocumentContentChangeEvent {
-            range: None,
-            range_length: None,
-            text: file_content_fixed.to_string(),
-        }],
+        vec![
+            lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument {
+                    text: file_content_fixed.to_string(),
+                },
+            ),
+        ],
         3,
     );
 
@@ -1353,16 +1355,16 @@ pub(crate) fn send_workspace_diagnostic_request(server: &mut TestServer) -> lsp_
 pub(crate) fn shutdown_and_await_workspace_diagnostic(
     mut server: TestServer,
     request_id: &RequestId,
-) -> WorkspaceDiagnosticReportResult {
+) -> WorkspaceDiagnosticReport {
     // Send shutdown request - this should cause the suspended workspace diagnostic request to respond
-    let shutdown_id = server.send_request::<lsp_types::request::Shutdown>(());
+    let shutdown_id = server.send_request::<lsp_types::ShutdownRequest>(());
 
     // The workspace diagnostic request should now respond with an empty report
     let workspace_response = server.await_response::<WorkspaceDiagnosticRequest>(request_id);
 
     // Complete shutdown sequence
-    server.await_response::<lsp_types::request::Shutdown>(&shutdown_id);
-    server.send_notification::<lsp_types::notification::Exit>(());
+    server.await_response::<lsp_types::ShutdownRequest>(&shutdown_id);
+    server.send_notification::<lsp_types::ExitNotification>(());
 
     workspace_response
 }
@@ -1389,21 +1391,15 @@ pub(crate) fn assert_workspace_diagnostics_suspends_for_long_polling(
     }
 }
 
-fn extract_result_ids_from_response(
-    response: &WorkspaceDiagnosticReportResult,
-) -> Vec<PreviousResultId> {
-    let items = match response {
-        WorkspaceDiagnosticReportResult::Report(report) => &report.items,
-        WorkspaceDiagnosticReportResult::Partial(partial) => {
-            // For partial results, extract from items the same way
-            &partial.items
-        }
-    };
+fn extract_result_ids_from_response(response: &WorkspaceDiagnosticReport) -> Vec<PreviousResultId> {
+    let items = &response.items;
 
     items
         .iter()
         .filter_map(|item| match item {
-            WorkspaceDocumentDiagnosticReport::Full(full_report) => {
+            WorkspaceDocumentDiagnosticReport::WorkspaceFullDocumentDiagnosticReport(
+                full_report,
+            ) => {
                 let result_id = full_report
                     .full_document_diagnostic_report
                     .result_id
@@ -1414,7 +1410,7 @@ fn extract_result_ids_from_response(
                     value: result_id.clone(),
                 })
             }
-            WorkspaceDocumentDiagnosticReport::Unchanged(_) => {
+            WorkspaceDocumentDiagnosticReport::WorkspaceUnchangedDocumentDiagnosticReport(_) => {
                 // Unchanged reports don't provide new result IDs
                 None
             }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action.snap
@@ -30,6 +30,7 @@ expression: code_actions
         ]
       }
     ],
+    "isPreferred": true,
     "edit": {
       "changes": {
         "file://<temp_dir>/src/foo.py": [
@@ -48,8 +49,7 @@ expression: code_actions
           }
         ]
       }
-    },
-    "isPreferred": true
+    }
   },
   {
     "title": "Ignore 'unused-ignore-comment' for this line",
@@ -78,6 +78,7 @@ expression: code_actions
         ]
       }
     ],
+    "isPreferred": false,
     "edit": {
       "changes": {
         "file://<temp_dir>/src/foo.py": [
@@ -96,7 +97,6 @@ expression: code_actions
           }
         ]
       }
-    },
-    "isPreferred": false
+    }
   }
 ]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_attribute_access_on_unimported.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_attribute_access_on_unimported.snap
@@ -27,6 +27,7 @@ expression: code_actions
         "message": "Name `typing` used when not defined"
       }
     ],
+    "isPreferred": true,
     "edit": {
       "changes": {
         "file://<temp_dir>/src/foo.py": [
@@ -45,8 +46,7 @@ expression: code_actions
           }
         ]
       }
-    },
-    "isPreferred": true
+    }
   },
   {
     "title": "Ignore 'unresolved-reference' for this line",
@@ -72,6 +72,7 @@ expression: code_actions
         "message": "Name `typing` used when not defined"
       }
     ],
+    "isPreferred": false,
     "edit": {
       "changes": {
         "file://<temp_dir>/src/foo.py": [
@@ -90,7 +91,6 @@ expression: code_actions
           }
         ]
       }
-    },
-    "isPreferred": false
+    }
   }
 ]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_existing_import_undefined_decorator.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_existing_import_undefined_decorator.snap
@@ -27,6 +27,7 @@ expression: code_actions
         "message": "Name `deprecated` used when not defined"
       }
     ],
+    "isPreferred": true,
     "edit": {
       "changes": {
         "file://<temp_dir>/src/foo.py": [
@@ -45,8 +46,7 @@ expression: code_actions
           }
         ]
       }
-    },
-    "isPreferred": true
+    }
   },
   {
     "title": "qualify warnings.deprecated",
@@ -72,6 +72,7 @@ expression: code_actions
         "message": "Name `deprecated` used when not defined"
       }
     ],
+    "isPreferred": true,
     "edit": {
       "changes": {
         "file://<temp_dir>/src/foo.py": [
@@ -90,8 +91,7 @@ expression: code_actions
           }
         ]
       }
-    },
-    "isPreferred": true
+    }
   },
   {
     "title": "Ignore 'unresolved-reference' for this line",
@@ -117,6 +117,7 @@ expression: code_actions
         "message": "Name `deprecated` used when not defined"
       }
     ],
+    "isPreferred": false,
     "edit": {
       "changes": {
         "file://<temp_dir>/src/foo.py": [
@@ -135,7 +136,6 @@ expression: code_actions
           }
         ]
       }
-    },
-    "isPreferred": false
+    }
   }
 ]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_invalid_string_annotations.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_invalid_string_annotations.snap
@@ -27,6 +27,7 @@ expression: code_actions
         "message": "Name `foobar` used when not defined"
       }
     ],
+    "isPreferred": false,
     "edit": {
       "changes": {
         "file://<temp_dir>/src/foo.py": [
@@ -45,7 +46,6 @@ expression: code_actions
           }
         ]
       }
-    },
-    "isPreferred": false
+    }
   }
 ]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_possible_missing_submodule_attribute.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_possible_missing_submodule_attribute.snap
@@ -27,6 +27,7 @@ expression: code_actions
         "message": "Submodule `parser` might not have been imported\n\nhelp: Consider explicitly importing `html.parser`"
       }
     ],
+    "isPreferred": false,
     "edit": {
       "changes": {
         "file://<temp_dir>/src/foo.py": [
@@ -45,7 +46,6 @@ expression: code_actions
           }
         ]
       }
-    },
-    "isPreferred": false
+    }
   }
 ]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_undefined_decorator.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_undefined_decorator.snap
@@ -27,6 +27,7 @@ expression: code_actions
         "message": "Name `deprecated` used when not defined"
       }
     ],
+    "isPreferred": true,
     "edit": {
       "changes": {
         "file://<temp_dir>/src/foo.py": [
@@ -45,8 +46,7 @@ expression: code_actions
           }
         ]
       }
-    },
-    "isPreferred": true
+    }
   },
   {
     "title": "Ignore 'unresolved-reference' for this line",
@@ -72,6 +72,7 @@ expression: code_actions
         "message": "Name `deprecated` used when not defined"
       }
     ],
+    "isPreferred": false,
     "edit": {
       "changes": {
         "file://<temp_dir>/src/foo.py": [
@@ -90,7 +91,6 @@ expression: code_actions
           }
         ]
       }
-    },
-    "isPreferred": false
+    }
   }
 ]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_undefined_reference_multi.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_undefined_reference_multi.snap
@@ -27,6 +27,7 @@ expression: code_actions
         "message": "Name `Literal` used when not defined"
       }
     ],
+    "isPreferred": true,
     "edit": {
       "changes": {
         "file://<temp_dir>/src/foo.py": [
@@ -45,8 +46,7 @@ expression: code_actions
           }
         ]
       }
-    },
-    "isPreferred": true
+    }
   },
   {
     "title": "Ignore 'unresolved-reference' for this line",
@@ -72,6 +72,7 @@ expression: code_actions
         "message": "Name `Literal` used when not defined"
       }
     ],
+    "isPreferred": false,
     "edit": {
       "changes": {
         "file://<temp_dir>/src/foo.py": [
@@ -90,7 +91,6 @@ expression: code_actions
           }
         ]
       }
-    },
-    "isPreferred": false
+    }
   }
 ]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__configuration__configuration_file.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__configuration__configuration_file.snap
@@ -3,7 +3,6 @@ source: crates/ty_server/tests/e2e/configuration.rs
 expression: diagnostics
 ---
 {
-  "kind": "full",
   "resultId": "[RESULT_ID]",
   "items": [
     {
@@ -25,5 +24,6 @@ expression: diagnostics
       "source": "ty",
       "message": "Name `a` used when not defined"
     }
-  ]
+  ],
+  "kind": "full"
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__configuration__configuration_file_and_overrides.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__configuration__configuration_file_and_overrides.snap
@@ -3,6 +3,6 @@ source: crates/ty_server/tests/e2e/configuration.rs
 expression: diagnostics
 ---
 {
-  "kind": "full",
-  "items": []
+  "items": [],
+  "kind": "full"
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__configuration__configuration_overrides.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__configuration__configuration_overrides.snap
@@ -3,7 +3,6 @@ source: crates/ty_server/tests/e2e/configuration.rs
 expression: diagnostics
 ---
 {
-  "kind": "full",
   "resultId": "[RESULT_ID]",
   "items": [
     {
@@ -25,5 +24,6 @@ expression: diagnostics
       "source": "ty",
       "message": "Name `a` used when not defined"
     }
-  ]
+  ],
+  "kind": "full"
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__configuration__invalid_configuration_file-2.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__configuration__invalid_configuration_file-2.snap
@@ -3,7 +3,6 @@ source: crates/ty_server/tests/e2e/configuration.rs
 expression: diagnostics
 ---
 {
-  "kind": "full",
   "resultId": "[RESULT_ID]",
   "items": [
     {
@@ -25,5 +24,6 @@ expression: diagnostics
       "source": "ty",
       "message": "Name `a` used when not defined"
     }
-  ]
+  ],
+  "kind": "full"
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization.snap
@@ -21,8 +21,6 @@ expression: initialization_result
       ],
       "save": false
     },
-    "selectionRangeProvider": true,
-    "hoverProvider": true,
     "completionProvider": {
       "triggerCharacters": [
         ".",
@@ -30,6 +28,7 @@ expression: initialization_result
         "'"
       ]
     },
+    "hoverProvider": true,
     "signatureHelpProvider": {
       "triggerCharacters": [
         "(",
@@ -39,33 +38,28 @@ expression: initialization_result
         ")"
       ]
     },
+    "declarationProvider": true,
     "definitionProvider": true,
     "typeDefinitionProvider": true,
     "referencesProvider": true,
     "documentHighlightProvider": true,
     "documentSymbolProvider": true,
-    "workspaceSymbolProvider": true,
     "codeActionProvider": {
       "codeActionKinds": [
         "quickfix"
       ]
     },
+    "workspaceSymbolProvider": true,
     "renameProvider": {
       "prepareProvider": true
     },
     "foldingRangeProvider": true,
-    "declarationProvider": true,
+    "selectionRangeProvider": true,
     "executeCommandProvider": {
       "commands": [
         "ty.printDebugInformation"
       ],
       "workDoneProgress": false
-    },
-    "workspace": {
-      "workspaceFolders": {
-        "supported": true,
-        "changeNotifications": true
-      }
     },
     "callHierarchyProvider": true,
     "semanticTokensProvider": {
@@ -104,6 +98,12 @@ expression: initialization_result
       "interFileDependencies": true,
       "workspaceDiagnostics": true,
       "workDoneProgress": true
+    },
+    "workspace": {
+      "workspaceFolders": {
+        "supported": true,
+        "changeNotifications": true
+      }
     }
   },
   "serverInfo": {

--- a/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization_with_workspace.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization_with_workspace.snap
@@ -21,8 +21,6 @@ expression: initialization_result
       ],
       "save": false
     },
-    "selectionRangeProvider": true,
-    "hoverProvider": true,
     "completionProvider": {
       "triggerCharacters": [
         ".",
@@ -30,6 +28,7 @@ expression: initialization_result
         "'"
       ]
     },
+    "hoverProvider": true,
     "signatureHelpProvider": {
       "triggerCharacters": [
         "(",
@@ -39,33 +38,28 @@ expression: initialization_result
         ")"
       ]
     },
+    "declarationProvider": true,
     "definitionProvider": true,
     "typeDefinitionProvider": true,
     "referencesProvider": true,
     "documentHighlightProvider": true,
     "documentSymbolProvider": true,
-    "workspaceSymbolProvider": true,
     "codeActionProvider": {
       "codeActionKinds": [
         "quickfix"
       ]
     },
+    "workspaceSymbolProvider": true,
     "renameProvider": {
       "prepareProvider": true
     },
     "foldingRangeProvider": true,
-    "declarationProvider": true,
+    "selectionRangeProvider": true,
     "executeCommandProvider": {
       "commands": [
         "ty.printDebugInformation"
       ],
       "workDoneProgress": false
-    },
-    "workspace": {
-      "workspaceFolders": {
-        "supported": true,
-        "changeNotifications": true
-      }
     },
     "callHierarchyProvider": true,
     "semanticTokensProvider": {
@@ -104,6 +98,12 @@ expression: initialization_result
       "interFileDependencies": true,
       "workspaceDiagnostics": true,
       "workDoneProgress": true
+    },
+    "workspace": {
+      "workspaceFolders": {
+        "supported": true,
+        "changeNotifications": true
+      }
     }
   },
   "serverInfo": {

--- a/crates/ty_server/tests/e2e/snapshots/e2e__notebook__publish_diagnostics_open.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__notebook__publish_diagnostics_open.snap
@@ -5,6 +5,7 @@ expression: "[cell1_diagnostics, cell2_diagnostics, cell3_diagnostics]"
 [
   {
     "uri": "vscode-notebook-cell://test.ipynb#1",
+    "version": 0,
     "diagnostics": [
       {
         "range": {
@@ -26,11 +27,11 @@ expression: "[cell1_diagnostics, cell2_diagnostics, cell3_diagnostics]"
         "message": "Function can implicitly return `None`, which is not assignable to return type `str`",
         "relatedInformation": []
       }
-    ],
-    "version": 0
+    ]
   },
   {
     "uri": "vscode-notebook-cell://test.ipynb#2",
+    "version": 0,
     "diagnostics": [
       {
         "range": {
@@ -85,12 +86,11 @@ expression: "[cell1_diagnostics, cell2_diagnostics, cell3_diagnostics]"
           }
         ]
       }
-    ],
-    "version": 0
+    ]
   },
   {
     "uri": "vscode-notebook-cell://test.ipynb#0",
-    "diagnostics": [],
-    "version": 0
+    "version": 0,
+    "diagnostics": []
   }
 ]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__changing_language_of_file_without_extension-2.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__changing_language_of_file_without_extension-2.snap
@@ -14,6 +14,6 @@ PublishDiagnosticsParams {
         query: None,
         fragment: None,
     },
-    diagnostics: [],
     version: None,
+    diagnostics: [],
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__changing_language_of_file_without_extension-3.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__changing_language_of_file_without_extension-3.snap
@@ -14,8 +14,8 @@ PublishDiagnosticsParams {
         query: None,
         fragment: None,
     },
-    diagnostics: [],
     version: Some(
         1,
     ),
+    diagnostics: [],
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__changing_language_of_file_without_extension.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__changing_language_of_file_without_extension.snap
@@ -14,6 +14,9 @@ PublishDiagnosticsParams {
         query: None,
         fragment: None,
     },
+    version: Some(
+        1,
+    ),
     diagnostics: [
         Diagnostic {
             range: Range {
@@ -58,13 +61,12 @@ PublishDiagnosticsParams {
             source: Some(
                 "ty",
             ),
-            message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
-            related_information: None,
+            message: String(
+                "Return type does not match returned value: expected `str`, found `Literal[42]`",
+            ),
             tags: None,
+            related_information: None,
             data: None,
         },
     ],
-    version: Some(
-        1,
-    ),
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__invalid_syntax_with_syntax_errors_disabled.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__invalid_syntax_with_syntax_errors_disabled.snap
@@ -14,8 +14,8 @@ PublishDiagnosticsParams {
         query: None,
         fragment: None,
     },
-    diagnostics: [],
     version: Some(
         1,
     ),
+    diagnostics: [],
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__message_with_related_information_support.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__message_with_related_information_support.snap
@@ -14,6 +14,9 @@ PublishDiagnosticsParams {
         query: None,
         fragment: None,
     },
+    version: Some(
+        1,
+    ),
     diagnostics: [
         Diagnostic {
             range: Range {
@@ -58,7 +61,10 @@ PublishDiagnosticsParams {
             source: Some(
                 "ty",
             ),
-            message: "Argument does not have asserted type `list[str]`\n\ninfo: `list[str]` and `Literal[\"test\"]` are not equivalent types",
+            message: String(
+                "Argument does not have asserted type `list[str]`\n\ninfo: `list[str]` and `Literal[\"test\"]` are not equivalent types",
+            ),
+            tags: None,
             related_information: Some(
                 [
                     DiagnosticRelatedInformation {
@@ -89,11 +95,7 @@ PublishDiagnosticsParams {
                     },
                 ],
             ),
-            tags: None,
             data: None,
         },
     ],
-    version: Some(
-        1,
-    ),
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__message_without_related_information_support.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__message_without_related_information_support.snap
@@ -14,6 +14,9 @@ PublishDiagnosticsParams {
         query: None,
         fragment: None,
     },
+    version: Some(
+        1,
+    ),
     diagnostics: [
         Diagnostic {
             range: Range {
@@ -58,13 +61,12 @@ PublishDiagnosticsParams {
             source: Some(
                 "ty",
             ),
-            message: "Type `Literal[\"test\"]` does not match asserted type `list[str]`\n\ninfo: `list[str]` and `Literal[\"test\"]` are not equivalent types",
-            related_information: None,
+            message: String(
+                "Type `Literal[\"test\"]` does not match asserted type `list[str]`\n\ninfo: `list[str]` and `Literal[\"test\"]` are not equivalent types",
+            ),
             tags: None,
+            related_information: None,
             data: None,
         },
     ],
-    version: Some(
-        1,
-    ),
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_change.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_change.snap
@@ -14,8 +14,8 @@ PublishDiagnosticsParams {
         query: None,
         fragment: None,
     },
-    diagnostics: [],
     version: Some(
         2,
     ),
+    diagnostics: [],
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_change_invalid_tuple_assignment_target_does_not_panic.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_change_invalid_tuple_assignment_target_does_not_panic.snap
@@ -14,6 +14,9 @@ PublishDiagnosticsParams {
         query: None,
         fragment: None,
     },
+    version: Some(
+        2,
+    ),
     diagnostics: [
         Diagnostic {
             range: Range {
@@ -38,9 +41,11 @@ PublishDiagnosticsParams {
             source: Some(
                 "ty",
             ),
-            message: "Invalid assignment target",
-            related_information: None,
+            message: String(
+                "Invalid assignment target",
+            ),
             tags: None,
+            related_information: None,
             data: None,
         },
         Diagnostic {
@@ -66,13 +71,12 @@ PublishDiagnosticsParams {
             source: Some(
                 "ty",
             ),
-            message: "Expected an expression",
-            related_information: None,
+            message: String(
+                "Expected an expression",
+            ),
             tags: None,
+            related_information: None,
             data: None,
         },
     ],
-    version: Some(
-        2,
-    ),
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_change_nested_invalid_tuple_assignment_target_does_not_panic.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_change_nested_invalid_tuple_assignment_target_does_not_panic.snap
@@ -14,6 +14,9 @@ PublishDiagnosticsParams {
         query: None,
         fragment: None,
     },
+    version: Some(
+        2,
+    ),
     diagnostics: [
         Diagnostic {
             range: Range {
@@ -38,13 +41,12 @@ PublishDiagnosticsParams {
             source: Some(
                 "ty",
             ),
-            message: "Invalid assignment target",
-            related_information: None,
+            message: String(
+                "Invalid assignment target",
+            ),
             tags: None,
+            related_information: None,
             data: None,
         },
     ],
-    version: Some(
-        2,
-    ),
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_change_watched_files.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_change_watched_files.snap
@@ -4,6 +4,6 @@ expression: diagnostics
 ---
 {
   "uri": "file://<temp_dir>/src/foo.py",
-  "diagnostics": [],
-  "version": 1
+  "version": 1,
+  "diagnostics": []
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open.snap
@@ -14,6 +14,9 @@ PublishDiagnosticsParams {
         query: None,
         fragment: None,
     },
+    version: Some(
+        1,
+    ),
     diagnostics: [
         Diagnostic {
             range: Range {
@@ -58,13 +61,12 @@ PublishDiagnosticsParams {
             source: Some(
                 "ty",
             ),
-            message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
-            related_information: None,
+            message: String(
+                "Return type does not match returned value: expected `str`, found `Literal[42]`",
+            ),
             tags: None,
+            related_information: None,
             data: None,
         },
     ],
-    version: Some(
-        1,
-    ),
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_file_without_extension_but_python_language.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_file_without_extension_but_python_language.snap
@@ -14,6 +14,9 @@ PublishDiagnosticsParams {
         query: None,
         fragment: None,
     },
+    version: Some(
+        1,
+    ),
     diagnostics: [
         Diagnostic {
             range: Range {
@@ -58,13 +61,12 @@ PublishDiagnosticsParams {
             source: Some(
                 "ty",
             ),
-            message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
-            related_information: None,
+            message: String(
+                "Return type does not match returned value: expected `str`, found `Literal[42]`",
+            ),
             tags: None,
+            related_information: None,
             data: None,
         },
     ],
-    version: Some(
-        1,
-    ),
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_non_existing_file_open_files_only.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_non_existing_file_open_files_only.snap
@@ -14,6 +14,9 @@ PublishDiagnosticsParams {
         query: None,
         fragment: None,
     },
+    version: Some(
+        1,
+    ),
     diagnostics: [
         Diagnostic {
             range: Range {
@@ -58,13 +61,12 @@ PublishDiagnosticsParams {
             source: Some(
                 "ty",
             ),
-            message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
-            related_information: None,
+            message: String(
+                "Return type does not match returned value: expected `str`, found `Literal[42]`",
+            ),
             tags: None,
+            related_information: None,
             data: None,
         },
     ],
-    version: Some(
-        1,
-    ),
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_non_existing_file_workspace_with_file_uri.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_non_existing_file_workspace_with_file_uri.snap
@@ -14,6 +14,9 @@ PublishDiagnosticsParams {
         query: None,
         fragment: None,
     },
+    version: Some(
+        1,
+    ),
     diagnostics: [
         Diagnostic {
             range: Range {
@@ -58,13 +61,12 @@ PublishDiagnosticsParams {
             source: Some(
                 "ty",
             ),
-            message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
-            related_information: None,
+            message: String(
+                "Return type does not match returned value: expected `str`, found `Literal[42]`",
+            ),
             tags: None,
+            related_information: None,
             data: None,
         },
     ],
-    version: Some(
-        1,
-    ),
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_non_existing_file_workspace_with_untitled_uri.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_non_existing_file_workspace_with_untitled_uri.snap
@@ -14,6 +14,9 @@ PublishDiagnosticsParams {
         query: None,
         fragment: None,
     },
+    version: Some(
+        1,
+    ),
     diagnostics: [
         Diagnostic {
             range: Range {
@@ -58,13 +61,12 @@ PublishDiagnosticsParams {
             source: Some(
                 "ty",
             ),
-            message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
-            related_information: None,
+            message: String(
+                "Return type does not match returned value: expected `str`, found `Literal[42]`",
+            ),
             tags: None,
+            related_information: None,
             data: None,
         },
     ],
-    version: Some(
-        1,
-    ),
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__current_analysis_unreachable_code_has_unnecessary_hint_tag.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__current_analysis_unreachable_code_has_unnecessary_hint_tag.snap
@@ -3,7 +3,6 @@ source: crates/ty_server/tests/e2e/pull_diagnostics.rs
 expression: diagnostics
 ---
 {
-  "kind": "full",
   "resultId": "[RESULT_ID]",
   "items": [
     {
@@ -24,5 +23,6 @@ expression: diagnostics
         1
       ]
     }
-  ]
+  ],
+  "kind": "full"
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__excluded.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__excluded.snap
@@ -2,4 +2,4 @@
 source: crates/ty_server/tests/e2e/pull_diagnostics.rs
 expression: excluded_diagnostics
 ---
-{"kind": "full", "items": []}
+{"items": [], "kind": "full"}

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__main.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__main.snap
@@ -3,7 +3,6 @@ source: crates/ty_server/tests/e2e/pull_diagnostics.rs
 expression: main_diagnostics
 ---
 {
-  "kind": "full",
   "resultId": "[RESULT_ID]",
   "items": [
     {
@@ -41,5 +40,6 @@ expression: main_diagnostics
       "source": "ty",
       "message": "Revealed type: `Literal[\"included\"]`"
     }
-  ]
+  ],
+  "kind": "full"
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__on_did_open.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__on_did_open.snap
@@ -2,65 +2,65 @@
 source: crates/ty_server/tests/e2e/pull_diagnostics.rs
 expression: diagnostics
 ---
-Report(
-    Full(
-        RelatedFullDocumentDiagnosticReport {
-            related_documents: None,
-            full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                result_id: Some(
-                    "[RESULT_ID]",
-                ),
-                items: [
-                    Diagnostic {
-                        range: Range {
-                            start: Position {
-                                line: 1,
-                                character: 11,
-                            },
-                            end: Position {
-                                line: 1,
-                                character: 13,
+RelatedFullDocumentDiagnosticReport(
+    RelatedFullDocumentDiagnosticReport {
+        related_documents: None,
+        full_document_diagnostic_report: FullDocumentDiagnosticReport {
+            result_id: Some(
+                "[RESULT_ID]",
+            ),
+            items: [
+                Diagnostic {
+                    range: Range {
+                        start: Position {
+                            line: 1,
+                            character: 11,
+                        },
+                        end: Position {
+                            line: 1,
+                            character: 13,
+                        },
+                    },
+                    severity: Some(
+                        Error,
+                    ),
+                    code: Some(
+                        String(
+                            "invalid-return-type",
+                        ),
+                    ),
+                    code_description: Some(
+                        CodeDescription {
+                            href: Url {
+                                scheme: "https",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: Some(
+                                    Domain(
+                                        "ty.dev",
+                                    ),
+                                ),
+                                port: None,
+                                path: "/rules",
+                                query: None,
+                                fragment: Some(
+                                    "invalid-return-type",
+                                ),
                             },
                         },
-                        severity: Some(
-                            Error,
-                        ),
-                        code: Some(
-                            String(
-                                "invalid-return-type",
-                            ),
-                        ),
-                        code_description: Some(
-                            CodeDescription {
-                                href: Url {
-                                    scheme: "https",
-                                    cannot_be_a_base: false,
-                                    username: "",
-                                    password: None,
-                                    host: Some(
-                                        Domain(
-                                            "ty.dev",
-                                        ),
-                                    ),
-                                    port: None,
-                                    path: "/rules",
-                                    query: None,
-                                    fragment: Some(
-                                        "invalid-return-type",
-                                    ),
-                                },
-                            },
-                        ),
-                        source: Some(
-                            "ty",
-                        ),
-                        message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
-                        related_information: None,
-                        tags: None,
-                        data: None,
-                    },
-                ],
-            },
+                    ),
+                    source: Some(
+                        "ty",
+                    ),
+                    message: String(
+                        "Return type does not match returned value: expected `str`, found `Literal[42]`",
+                    ),
+                    tags: None,
+                    related_information: None,
+                    data: None,
+                },
+            ],
         },
-    ),
+    },
 )

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__stack_size.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__stack_size.snap
@@ -3,7 +3,6 @@ source: crates/ty_server/tests/e2e/pull_diagnostics.rs
 expression: diagnostics
 ---
 {
-  "kind": "full",
   "resultId": "[RESULT_ID]",
   "items": [
     {
@@ -22,5 +21,6 @@ expression: diagnostics
       "source": "ty",
       "message": "Revealed type: `Literal[2000]`"
     }
-  ]
+  ],
+  "kind": "full"
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__unreachable_code_has_unnecessary_hint_tag.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__unreachable_code_has_unnecessary_hint_tag.snap
@@ -3,7 +3,6 @@ source: crates/ty_server/tests/e2e/pull_diagnostics.rs
 expression: diagnostics
 ---
 {
-  "kind": "full",
   "resultId": "[RESULT_ID]",
   "items": [
     {
@@ -24,5 +23,6 @@ expression: diagnostics
         1
       ]
     }
-  ]
+  ],
+  "kind": "full"
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__unreachable_code_suppresses_unused_binding_hint.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__unreachable_code_suppresses_unused_binding_hint.snap
@@ -3,7 +3,6 @@ source: crates/ty_server/tests/e2e/pull_diagnostics.rs
 expression: diagnostics
 ---
 {
-  "kind": "full",
   "resultId": "[RESULT_ID]",
   "items": [
     {
@@ -24,5 +23,6 @@ expression: diagnostics
         1
       ]
     }
-  ]
+  ],
+  "kind": "full"
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__unused_binding_has_unnecessary_hint_tag.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__unused_binding_has_unnecessary_hint_tag.snap
@@ -3,7 +3,6 @@ source: crates/ty_server/tests/e2e/pull_diagnostics.rs
 expression: diagnostics
 ---
 {
-  "kind": "full",
   "resultId": "[RESULT_ID]",
   "items": [
     {
@@ -24,5 +23,6 @@ expression: diagnostics
         1
       ]
     }
-  ]
+  ],
+  "kind": "full"
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_diagnostic_after_changes.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_diagnostic_after_changes.snap
@@ -2,271 +2,275 @@
 source: crates/ty_server/tests/e2e/pull_diagnostics.rs
 expression: second_response
 ---
-Report(
-    WorkspaceDiagnosticReport {
-        items: [
-            Full(
-                WorkspaceFullDocumentDiagnosticReport {
-                    uri: Url {
-                        scheme: "file",
-                        cannot_be_a_base: false,
-                        username: "",
-                        password: None,
-                        host: None,
-                        port: None,
-                        path: "<temp_dir>/src/changed_error.py",
-                        query: None,
-                        fragment: None,
-                    },
-                    version: Some(
-                        2,
+WorkspaceDiagnosticReport {
+    items: [
+        WorkspaceFullDocumentDiagnosticReport(
+            WorkspaceFullDocumentDiagnosticReport {
+                uri: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "<temp_dir>/src/changed_error.py",
+                    query: None,
+                    fragment: None,
+                },
+                version: Some(
+                    2,
+                ),
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: Some(
+                        "[RESULT_ID]",
                     ),
-                    full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                        result_id: Some(
-                            "[RESULT_ID]",
-                        ),
-                        items: [
-                            Diagnostic {
-                                range: Range {
-                                    start: Position {
-                                        line: 1,
-                                        character: 11,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        character: 18,
+                    items: [
+                        Diagnostic {
+                            range: Range {
+                                start: Position {
+                                    line: 1,
+                                    character: 11,
+                                },
+                                end: Position {
+                                    line: 1,
+                                    character: 18,
+                                },
+                            },
+                            severity: Some(
+                                Error,
+                            ),
+                            code: Some(
+                                String(
+                                    "invalid-return-type",
+                                ),
+                            ),
+                            code_description: Some(
+                                CodeDescription {
+                                    href: Url {
+                                        scheme: "https",
+                                        cannot_be_a_base: false,
+                                        username: "",
+                                        password: None,
+                                        host: Some(
+                                            Domain(
+                                                "ty.dev",
+                                            ),
+                                        ),
+                                        port: None,
+                                        path: "/rules",
+                                        query: None,
+                                        fragment: Some(
+                                            "invalid-return-type",
+                                        ),
                                     },
                                 },
-                                severity: Some(
-                                    Error,
-                                ),
-                                code: Some(
-                                    String(
-                                        "invalid-return-type",
-                                    ),
-                                ),
-                                code_description: Some(
-                                    CodeDescription {
-                                        href: Url {
-                                            scheme: "https",
-                                            cannot_be_a_base: false,
-                                            username: "",
-                                            password: None,
-                                            host: Some(
-                                                Domain(
-                                                    "ty.dev",
-                                                ),
-                                            ),
-                                            port: None,
-                                            path: "/rules",
-                                            query: None,
-                                            fragment: Some(
-                                                "invalid-return-type",
-                                            ),
-                                        },
-                                    },
-                                ),
-                                source: Some(
-                                    "ty",
-                                ),
-                                message: "Return type does not match returned value: expected `int`, found `Literal[\"hello\"]`",
-                                related_information: None,
-                                tags: None,
-                                data: None,
+                            ),
+                            source: Some(
+                                "ty",
+                            ),
+                            message: String(
+                                "Return type does not match returned value: expected `int`, found `Literal[\"hello\"]`",
+                            ),
+                            tags: None,
+                            related_information: None,
+                            data: None,
+                        },
+                    ],
+                },
+            },
+        ),
+        WorkspaceFullDocumentDiagnosticReport(
+            WorkspaceFullDocumentDiagnosticReport {
+                uri: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "<temp_dir>/src/fixed_error.py",
+                    query: None,
+                    fragment: None,
+                },
+                version: Some(
+                    2,
+                ),
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: None,
+                    items: [],
+                },
+            },
+        ),
+        WorkspaceFullDocumentDiagnosticReport(
+            WorkspaceFullDocumentDiagnosticReport {
+                uri: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "<temp_dir>/src/modified_same_error.py",
+                    query: None,
+                    fragment: None,
+                },
+                version: Some(
+                    2,
+                ),
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: Some(
+                        "[RESULT_ID]",
+                    ),
+                    items: [
+                        Diagnostic {
+                            range: Range {
+                                start: Position {
+                                    line: 4,
+                                    character: 11,
+                                },
+                                end: Position {
+                                    line: 4,
+                                    character: 13,
+                                },
                             },
-                        ],
-                    },
-                },
-            ),
-            Full(
-                WorkspaceFullDocumentDiagnosticReport {
-                    uri: Url {
-                        scheme: "file",
-                        cannot_be_a_base: false,
-                        username: "",
-                        password: None,
-                        host: None,
-                        port: None,
-                        path: "<temp_dir>/src/fixed_error.py",
-                        query: None,
-                        fragment: None,
-                    },
-                    version: Some(
-                        2,
-                    ),
-                    full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                        result_id: None,
-                        items: [],
-                    },
-                },
-            ),
-            Full(
-                WorkspaceFullDocumentDiagnosticReport {
-                    uri: Url {
-                        scheme: "file",
-                        cannot_be_a_base: false,
-                        username: "",
-                        password: None,
-                        host: None,
-                        port: None,
-                        path: "<temp_dir>/src/modified_same_error.py",
-                        query: None,
-                        fragment: None,
-                    },
-                    version: Some(
-                        2,
-                    ),
-                    full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                        result_id: Some(
-                            "[RESULT_ID]",
-                        ),
-                        items: [
-                            Diagnostic {
-                                range: Range {
-                                    start: Position {
-                                        line: 4,
-                                        character: 11,
-                                    },
-                                    end: Position {
-                                        line: 4,
-                                        character: 13,
+                            severity: Some(
+                                Error,
+                            ),
+                            code: Some(
+                                String(
+                                    "invalid-return-type",
+                                ),
+                            ),
+                            code_description: Some(
+                                CodeDescription {
+                                    href: Url {
+                                        scheme: "https",
+                                        cannot_be_a_base: false,
+                                        username: "",
+                                        password: None,
+                                        host: Some(
+                                            Domain(
+                                                "ty.dev",
+                                            ),
+                                        ),
+                                        port: None,
+                                        path: "/rules",
+                                        query: None,
+                                        fragment: Some(
+                                            "invalid-return-type",
+                                        ),
                                     },
                                 },
-                                severity: Some(
-                                    Error,
-                                ),
-                                code: Some(
-                                    String(
-                                        "invalid-return-type",
-                                    ),
-                                ),
-                                code_description: Some(
-                                    CodeDescription {
-                                        href: Url {
-                                            scheme: "https",
-                                            cannot_be_a_base: false,
-                                            username: "",
-                                            password: None,
-                                            host: Some(
-                                                Domain(
-                                                    "ty.dev",
-                                                ),
-                                            ),
-                                            port: None,
-                                            path: "/rules",
-                                            query: None,
-                                            fragment: Some(
-                                                "invalid-return-type",
-                                            ),
-                                        },
-                                    },
-                                ),
-                                source: Some(
-                                    "ty",
-                                ),
-                                message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
-                                related_information: None,
-                                tags: None,
-                                data: None,
-                            },
-                        ],
-                    },
+                            ),
+                            source: Some(
+                                "ty",
+                            ),
+                            message: String(
+                                "Return type does not match returned value: expected `str`, found `Literal[42]`",
+                            ),
+                            tags: None,
+                            related_information: None,
+                            data: None,
+                        },
+                    ],
                 },
-            ),
-            Full(
-                WorkspaceFullDocumentDiagnosticReport {
-                    uri: Url {
-                        scheme: "file",
-                        cannot_be_a_base: false,
-                        username: "",
-                        password: None,
-                        host: None,
-                        port: None,
-                        path: "<temp_dir>/src/new_error.py",
-                        query: None,
-                        fragment: None,
-                    },
-                    version: Some(
-                        2,
+            },
+        ),
+        WorkspaceFullDocumentDiagnosticReport(
+            WorkspaceFullDocumentDiagnosticReport {
+                uri: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "<temp_dir>/src/new_error.py",
+                    query: None,
+                    fragment: None,
+                },
+                version: Some(
+                    2,
+                ),
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: Some(
+                        "[RESULT_ID]",
                     ),
-                    full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                        result_id: Some(
-                            "[RESULT_ID]",
-                        ),
-                        items: [
-                            Diagnostic {
-                                range: Range {
-                                    start: Position {
-                                        line: 1,
-                                        character: 11,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        character: 13,
+                    items: [
+                        Diagnostic {
+                            range: Range {
+                                start: Position {
+                                    line: 1,
+                                    character: 11,
+                                },
+                                end: Position {
+                                    line: 1,
+                                    character: 13,
+                                },
+                            },
+                            severity: Some(
+                                Error,
+                            ),
+                            code: Some(
+                                String(
+                                    "invalid-return-type",
+                                ),
+                            ),
+                            code_description: Some(
+                                CodeDescription {
+                                    href: Url {
+                                        scheme: "https",
+                                        cannot_be_a_base: false,
+                                        username: "",
+                                        password: None,
+                                        host: Some(
+                                            Domain(
+                                                "ty.dev",
+                                            ),
+                                        ),
+                                        port: None,
+                                        path: "/rules",
+                                        query: None,
+                                        fragment: Some(
+                                            "invalid-return-type",
+                                        ),
                                     },
                                 },
-                                severity: Some(
-                                    Error,
-                                ),
-                                code: Some(
-                                    String(
-                                        "invalid-return-type",
-                                    ),
-                                ),
-                                code_description: Some(
-                                    CodeDescription {
-                                        href: Url {
-                                            scheme: "https",
-                                            cannot_be_a_base: false,
-                                            username: "",
-                                            password: None,
-                                            host: Some(
-                                                Domain(
-                                                    "ty.dev",
-                                                ),
-                                            ),
-                                            port: None,
-                                            path: "/rules",
-                                            query: None,
-                                            fragment: Some(
-                                                "invalid-return-type",
-                                            ),
-                                        },
-                                    },
-                                ),
-                                source: Some(
-                                    "ty",
-                                ),
-                                message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
-                                related_information: None,
-                                tags: None,
-                                data: None,
-                            },
-                        ],
-                    },
+                            ),
+                            source: Some(
+                                "ty",
+                            ),
+                            message: String(
+                                "Return type does not match returned value: expected `str`, found `Literal[42]`",
+                            ),
+                            tags: None,
+                            related_information: None,
+                            data: None,
+                        },
+                    ],
                 },
-            ),
-            Unchanged(
-                WorkspaceUnchangedDocumentDiagnosticReport {
-                    uri: Url {
-                        scheme: "file",
-                        cannot_be_a_base: false,
-                        username: "",
-                        password: None,
-                        host: None,
-                        port: None,
-                        path: "<temp_dir>/src/unchanged.py",
-                        query: None,
-                        fragment: None,
-                    },
-                    version: Some(
-                        1,
-                    ),
-                    unchanged_document_diagnostic_report: UnchangedDocumentDiagnosticReport {
-                        result_id: "[RESULT_ID]",
-                    },
+            },
+        ),
+        WorkspaceUnchangedDocumentDiagnosticReport(
+            WorkspaceUnchangedDocumentDiagnosticReport {
+                uri: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "<temp_dir>/src/unchanged.py",
+                    query: None,
+                    fragment: None,
                 },
-            ),
-        ],
-    },
-)
+                version: Some(
+                    1,
+                ),
+                unchanged_document_diagnostic_report: UnchangedDocumentDiagnosticReport {
+                    result_id: "[RESULT_ID]",
+                },
+            },
+        ),
+    ],
+}

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_diagnostic_initial_state.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_diagnostic_initial_state.snap
@@ -2,295 +2,301 @@
 source: crates/ty_server/tests/e2e/pull_diagnostics.rs
 expression: first_response
 ---
-Report(
-    WorkspaceDiagnosticReport {
-        items: [
-            Full(
-                WorkspaceFullDocumentDiagnosticReport {
-                    uri: Url {
-                        scheme: "file",
-                        cannot_be_a_base: false,
-                        username: "",
-                        password: None,
-                        host: None,
-                        port: None,
-                        path: "<temp_dir>/src/changed_error.py",
-                        query: None,
-                        fragment: None,
-                    },
-                    version: None,
-                    full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                        result_id: Some(
-                            "[RESULT_ID]",
-                        ),
-                        items: [
-                            Diagnostic {
-                                range: Range {
-                                    start: Position {
-                                        line: 1,
-                                        character: 11,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        character: 13,
-                                    },
-                                },
-                                severity: Some(
-                                    Error,
-                                ),
-                                code: Some(
-                                    String(
-                                        "invalid-return-type",
-                                    ),
-                                ),
-                                code_description: Some(
-                                    CodeDescription {
-                                        href: Url {
-                                            scheme: "https",
-                                            cannot_be_a_base: false,
-                                            username: "",
-                                            password: None,
-                                            host: Some(
-                                                Domain(
-                                                    "ty.dev",
-                                                ),
-                                            ),
-                                            port: None,
-                                            path: "/rules",
-                                            query: None,
-                                            fragment: Some(
-                                                "invalid-return-type",
-                                            ),
-                                        },
-                                    },
-                                ),
-                                source: Some(
-                                    "ty",
-                                ),
-                                message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
-                                related_information: None,
-                                tags: None,
-                                data: None,
-                            },
-                        ],
-                    },
+WorkspaceDiagnosticReport {
+    items: [
+        WorkspaceFullDocumentDiagnosticReport(
+            WorkspaceFullDocumentDiagnosticReport {
+                uri: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "<temp_dir>/src/changed_error.py",
+                    query: None,
+                    fragment: None,
                 },
-            ),
-            Full(
-                WorkspaceFullDocumentDiagnosticReport {
-                    uri: Url {
-                        scheme: "file",
-                        cannot_be_a_base: false,
-                        username: "",
-                        password: None,
-                        host: None,
-                        port: None,
-                        path: "<temp_dir>/src/fixed_error.py",
-                        query: None,
-                        fragment: None,
-                    },
-                    version: None,
-                    full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                        result_id: Some(
-                            "[RESULT_ID]",
-                        ),
-                        items: [
-                            Diagnostic {
-                                range: Range {
-                                    start: Position {
-                                        line: 1,
-                                        character: 11,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        character: 13,
-                                    },
-                                },
-                                severity: Some(
-                                    Error,
-                                ),
-                                code: Some(
-                                    String(
-                                        "invalid-return-type",
-                                    ),
-                                ),
-                                code_description: Some(
-                                    CodeDescription {
-                                        href: Url {
-                                            scheme: "https",
-                                            cannot_be_a_base: false,
-                                            username: "",
-                                            password: None,
-                                            host: Some(
-                                                Domain(
-                                                    "ty.dev",
-                                                ),
-                                            ),
-                                            port: None,
-                                            path: "/rules",
-                                            query: None,
-                                            fragment: Some(
-                                                "invalid-return-type",
-                                            ),
-                                        },
-                                    },
-                                ),
-                                source: Some(
-                                    "ty",
-                                ),
-                                message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
-                                related_information: None,
-                                tags: None,
-                                data: None,
-                            },
-                        ],
-                    },
-                },
-            ),
-            Full(
-                WorkspaceFullDocumentDiagnosticReport {
-                    uri: Url {
-                        scheme: "file",
-                        cannot_be_a_base: false,
-                        username: "",
-                        password: None,
-                        host: None,
-                        port: None,
-                        path: "<temp_dir>/src/modified_same_error.py",
-                        query: None,
-                        fragment: None,
-                    },
-                    version: None,
-                    full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                        result_id: Some(
-                            "[RESULT_ID]",
-                        ),
-                        items: [
-                            Diagnostic {
-                                range: Range {
-                                    start: Position {
-                                        line: 1,
-                                        character: 11,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        character: 13,
-                                    },
-                                },
-                                severity: Some(
-                                    Error,
-                                ),
-                                code: Some(
-                                    String(
-                                        "invalid-return-type",
-                                    ),
-                                ),
-                                code_description: Some(
-                                    CodeDescription {
-                                        href: Url {
-                                            scheme: "https",
-                                            cannot_be_a_base: false,
-                                            username: "",
-                                            password: None,
-                                            host: Some(
-                                                Domain(
-                                                    "ty.dev",
-                                                ),
-                                            ),
-                                            port: None,
-                                            path: "/rules",
-                                            query: None,
-                                            fragment: Some(
-                                                "invalid-return-type",
-                                            ),
-                                        },
-                                    },
-                                ),
-                                source: Some(
-                                    "ty",
-                                ),
-                                message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
-                                related_information: None,
-                                tags: None,
-                                data: None,
-                            },
-                        ],
-                    },
-                },
-            ),
-            Full(
-                WorkspaceFullDocumentDiagnosticReport {
-                    uri: Url {
-                        scheme: "file",
-                        cannot_be_a_base: false,
-                        username: "",
-                        password: None,
-                        host: None,
-                        port: None,
-                        path: "<temp_dir>/src/unchanged.py",
-                        query: None,
-                        fragment: None,
-                    },
-                    version: Some(
-                        1,
+                version: None,
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: Some(
+                        "[RESULT_ID]",
                     ),
-                    full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                        result_id: Some(
-                            "[RESULT_ID]",
-                        ),
-                        items: [
-                            Diagnostic {
-                                range: Range {
-                                    start: Position {
-                                        line: 1,
-                                        character: 11,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        character: 13,
+                    items: [
+                        Diagnostic {
+                            range: Range {
+                                start: Position {
+                                    line: 1,
+                                    character: 11,
+                                },
+                                end: Position {
+                                    line: 1,
+                                    character: 13,
+                                },
+                            },
+                            severity: Some(
+                                Error,
+                            ),
+                            code: Some(
+                                String(
+                                    "invalid-return-type",
+                                ),
+                            ),
+                            code_description: Some(
+                                CodeDescription {
+                                    href: Url {
+                                        scheme: "https",
+                                        cannot_be_a_base: false,
+                                        username: "",
+                                        password: None,
+                                        host: Some(
+                                            Domain(
+                                                "ty.dev",
+                                            ),
+                                        ),
+                                        port: None,
+                                        path: "/rules",
+                                        query: None,
+                                        fragment: Some(
+                                            "invalid-return-type",
+                                        ),
                                     },
                                 },
-                                severity: Some(
-                                    Error,
-                                ),
-                                code: Some(
-                                    String(
-                                        "invalid-return-type",
-                                    ),
-                                ),
-                                code_description: Some(
-                                    CodeDescription {
-                                        href: Url {
-                                            scheme: "https",
-                                            cannot_be_a_base: false,
-                                            username: "",
-                                            password: None,
-                                            host: Some(
-                                                Domain(
-                                                    "ty.dev",
-                                                ),
-                                            ),
-                                            port: None,
-                                            path: "/rules",
-                                            query: None,
-                                            fragment: Some(
-                                                "invalid-return-type",
-                                            ),
-                                        },
-                                    },
-                                ),
-                                source: Some(
-                                    "ty",
-                                ),
-                                message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
-                                related_information: None,
-                                tags: None,
-                                data: None,
-                            },
-                        ],
-                    },
+                            ),
+                            source: Some(
+                                "ty",
+                            ),
+                            message: String(
+                                "Return type does not match returned value: expected `str`, found `Literal[42]`",
+                            ),
+                            tags: None,
+                            related_information: None,
+                            data: None,
+                        },
+                    ],
                 },
-            ),
-        ],
-    },
-)
+            },
+        ),
+        WorkspaceFullDocumentDiagnosticReport(
+            WorkspaceFullDocumentDiagnosticReport {
+                uri: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "<temp_dir>/src/fixed_error.py",
+                    query: None,
+                    fragment: None,
+                },
+                version: None,
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: Some(
+                        "[RESULT_ID]",
+                    ),
+                    items: [
+                        Diagnostic {
+                            range: Range {
+                                start: Position {
+                                    line: 1,
+                                    character: 11,
+                                },
+                                end: Position {
+                                    line: 1,
+                                    character: 13,
+                                },
+                            },
+                            severity: Some(
+                                Error,
+                            ),
+                            code: Some(
+                                String(
+                                    "invalid-return-type",
+                                ),
+                            ),
+                            code_description: Some(
+                                CodeDescription {
+                                    href: Url {
+                                        scheme: "https",
+                                        cannot_be_a_base: false,
+                                        username: "",
+                                        password: None,
+                                        host: Some(
+                                            Domain(
+                                                "ty.dev",
+                                            ),
+                                        ),
+                                        port: None,
+                                        path: "/rules",
+                                        query: None,
+                                        fragment: Some(
+                                            "invalid-return-type",
+                                        ),
+                                    },
+                                },
+                            ),
+                            source: Some(
+                                "ty",
+                            ),
+                            message: String(
+                                "Return type does not match returned value: expected `str`, found `Literal[42]`",
+                            ),
+                            tags: None,
+                            related_information: None,
+                            data: None,
+                        },
+                    ],
+                },
+            },
+        ),
+        WorkspaceFullDocumentDiagnosticReport(
+            WorkspaceFullDocumentDiagnosticReport {
+                uri: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "<temp_dir>/src/modified_same_error.py",
+                    query: None,
+                    fragment: None,
+                },
+                version: None,
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: Some(
+                        "[RESULT_ID]",
+                    ),
+                    items: [
+                        Diagnostic {
+                            range: Range {
+                                start: Position {
+                                    line: 1,
+                                    character: 11,
+                                },
+                                end: Position {
+                                    line: 1,
+                                    character: 13,
+                                },
+                            },
+                            severity: Some(
+                                Error,
+                            ),
+                            code: Some(
+                                String(
+                                    "invalid-return-type",
+                                ),
+                            ),
+                            code_description: Some(
+                                CodeDescription {
+                                    href: Url {
+                                        scheme: "https",
+                                        cannot_be_a_base: false,
+                                        username: "",
+                                        password: None,
+                                        host: Some(
+                                            Domain(
+                                                "ty.dev",
+                                            ),
+                                        ),
+                                        port: None,
+                                        path: "/rules",
+                                        query: None,
+                                        fragment: Some(
+                                            "invalid-return-type",
+                                        ),
+                                    },
+                                },
+                            ),
+                            source: Some(
+                                "ty",
+                            ),
+                            message: String(
+                                "Return type does not match returned value: expected `str`, found `Literal[42]`",
+                            ),
+                            tags: None,
+                            related_information: None,
+                            data: None,
+                        },
+                    ],
+                },
+            },
+        ),
+        WorkspaceFullDocumentDiagnosticReport(
+            WorkspaceFullDocumentDiagnosticReport {
+                uri: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "<temp_dir>/src/unchanged.py",
+                    query: None,
+                    fragment: None,
+                },
+                version: Some(
+                    1,
+                ),
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: Some(
+                        "[RESULT_ID]",
+                    ),
+                    items: [
+                        Diagnostic {
+                            range: Range {
+                                start: Position {
+                                    line: 1,
+                                    character: 11,
+                                },
+                                end: Position {
+                                    line: 1,
+                                    character: 13,
+                                },
+                            },
+                            severity: Some(
+                                Error,
+                            ),
+                            code: Some(
+                                String(
+                                    "invalid-return-type",
+                                ),
+                            ),
+                            code_description: Some(
+                                CodeDescription {
+                                    href: Url {
+                                        scheme: "https",
+                                        cannot_be_a_base: false,
+                                        username: "",
+                                        password: None,
+                                        host: Some(
+                                            Domain(
+                                                "ty.dev",
+                                            ),
+                                        ),
+                                        port: None,
+                                        path: "/rules",
+                                        query: None,
+                                        fragment: Some(
+                                            "invalid-return-type",
+                                        ),
+                                    },
+                                },
+                            ),
+                            source: Some(
+                                "ty",
+                            ),
+                            message: String(
+                                "Return type does not match returned value: expected `str`, found `Literal[42]`",
+                            ),
+                            tags: None,
+                            related_information: None,
+                            data: None,
+                        },
+                    ],
+                },
+            },
+        ),
+    ],
+}

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_diagnostic_long_polling_change_response.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_diagnostic_long_polling_change_response.snap
@@ -2,82 +2,82 @@
 source: crates/ty_server/tests/e2e/pull_diagnostics.rs
 expression: workspace_response
 ---
-Report(
-    WorkspaceDiagnosticReport {
-        items: [
-            Full(
-                WorkspaceFullDocumentDiagnosticReport {
-                    uri: Url {
-                        scheme: "file",
-                        cannot_be_a_base: false,
-                        username: "",
-                        password: None,
-                        host: None,
-                        port: None,
-                        path: "<temp_dir>/src/test.py",
-                        query: None,
-                        fragment: None,
-                    },
-                    version: Some(
-                        2,
+WorkspaceDiagnosticReport {
+    items: [
+        WorkspaceFullDocumentDiagnosticReport(
+            WorkspaceFullDocumentDiagnosticReport {
+                uri: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "<temp_dir>/src/test.py",
+                    query: None,
+                    fragment: None,
+                },
+                version: Some(
+                    2,
+                ),
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: Some(
+                        "[RESULT_ID]",
                     ),
-                    full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                        result_id: Some(
-                            "[RESULT_ID]",
-                        ),
-                        items: [
-                            Diagnostic {
-                                range: Range {
-                                    start: Position {
-                                        line: 1,
-                                        character: 11,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        character: 13,
+                    items: [
+                        Diagnostic {
+                            range: Range {
+                                start: Position {
+                                    line: 1,
+                                    character: 11,
+                                },
+                                end: Position {
+                                    line: 1,
+                                    character: 13,
+                                },
+                            },
+                            severity: Some(
+                                Error,
+                            ),
+                            code: Some(
+                                String(
+                                    "invalid-return-type",
+                                ),
+                            ),
+                            code_description: Some(
+                                CodeDescription {
+                                    href: Url {
+                                        scheme: "https",
+                                        cannot_be_a_base: false,
+                                        username: "",
+                                        password: None,
+                                        host: Some(
+                                            Domain(
+                                                "ty.dev",
+                                            ),
+                                        ),
+                                        port: None,
+                                        path: "/rules",
+                                        query: None,
+                                        fragment: Some(
+                                            "invalid-return-type",
+                                        ),
                                     },
                                 },
-                                severity: Some(
-                                    Error,
-                                ),
-                                code: Some(
-                                    String(
-                                        "invalid-return-type",
-                                    ),
-                                ),
-                                code_description: Some(
-                                    CodeDescription {
-                                        href: Url {
-                                            scheme: "https",
-                                            cannot_be_a_base: false,
-                                            username: "",
-                                            password: None,
-                                            host: Some(
-                                                Domain(
-                                                    "ty.dev",
-                                                ),
-                                            ),
-                                            port: None,
-                                            path: "/rules",
-                                            query: None,
-                                            fragment: Some(
-                                                "invalid-return-type",
-                                            ),
-                                        },
-                                    },
-                                ),
-                                source: Some(
-                                    "ty",
-                                ),
-                                message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
-                                related_information: None,
-                                tags: None,
-                                data: None,
-                            },
-                        ],
-                    },
+                            ),
+                            source: Some(
+                                "ty",
+                            ),
+                            message: String(
+                                "Return type does not match returned value: expected `str`, found `Literal[42]`",
+                            ),
+                            tags: None,
+                            related_information: None,
+                            data: None,
+                        },
+                    ],
                 },
-            ),
-        ],
-    },
-)
+            },
+        ),
+    ],
+}

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_diagnostic_long_polling_shutdown_response.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_diagnostic_long_polling_shutdown_response.snap
@@ -2,8 +2,6 @@
 source: crates/ty_server/tests/e2e/pull_diagnostics.rs
 expression: workspace_response
 ---
-Report(
-    WorkspaceDiagnosticReport {
-        items: [],
-    },
-)
+WorkspaceDiagnosticReport {
+    items: [],
+}

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_diagnostic_streaming_with_caching.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_diagnostic_streaming_with_caching.snap
@@ -3,7 +3,7 @@ source: crates/ty_server/tests/e2e/pull_diagnostics.rs
 expression: all_items
 ---
 [
-    Full(
+    WorkspaceFullDocumentDiagnosticReport(
         WorkspaceFullDocumentDiagnosticReport {
             uri: Url {
                 scheme: "file",
@@ -67,16 +67,18 @@ expression: all_items
                         source: Some(
                             "ty",
                         ),
-                        message: "Name `true` used when not defined",
-                        related_information: None,
+                        message: String(
+                            "Name `true` used when not defined",
+                        ),
                         tags: None,
+                        related_information: None,
                         data: None,
                     },
                 ],
             },
         },
     ),
-    Full(
+    WorkspaceFullDocumentDiagnosticReport(
         WorkspaceFullDocumentDiagnosticReport {
             uri: Url {
                 scheme: "file",
@@ -140,16 +142,18 @@ expression: all_items
                         source: Some(
                             "ty",
                         ),
-                        message: "Name `true` used when not defined",
-                        related_information: None,
+                        message: String(
+                            "Name `true` used when not defined",
+                        ),
                         tags: None,
+                        related_information: None,
                         data: None,
                     },
                 ],
             },
         },
     ),
-    Full(
+    WorkspaceFullDocumentDiagnosticReport(
         WorkspaceFullDocumentDiagnosticReport {
             uri: Url {
                 scheme: "file",
@@ -213,16 +217,18 @@ expression: all_items
                         source: Some(
                             "ty",
                         ),
-                        message: "Name `true` used when not defined",
-                        related_information: None,
+                        message: String(
+                            "Name `true` used when not defined",
+                        ),
                         tags: None,
+                        related_information: None,
                         data: None,
                     },
                 ],
             },
         },
     ),
-    Unchanged(
+    WorkspaceUnchangedDocumentDiagnosticReport(
         WorkspaceUnchangedDocumentDiagnosticReport {
             uri: Url {
                 scheme: "file",
@@ -241,7 +247,7 @@ expression: all_items
             },
         },
     ),
-    Unchanged(
+    WorkspaceUnchangedDocumentDiagnosticReport(
         WorkspaceUnchangedDocumentDiagnosticReport {
             uri: Url {
                 scheme: "file",
@@ -260,7 +266,7 @@ expression: all_items
             },
         },
     ),
-    Unchanged(
+    WorkspaceUnchangedDocumentDiagnosticReport(
         WorkspaceUnchangedDocumentDiagnosticReport {
             uri: Url {
                 scheme: "file",
@@ -279,7 +285,7 @@ expression: all_items
             },
         },
     ),
-    Unchanged(
+    WorkspaceUnchangedDocumentDiagnosticReport(
         WorkspaceUnchangedDocumentDiagnosticReport {
             uri: Url {
                 scheme: "file",

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_diagnostic_suspend_change_suspend_first_response.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_diagnostic_suspend_change_suspend_first_response.snap
@@ -2,82 +2,82 @@
 source: crates/ty_server/tests/e2e/pull_diagnostics.rs
 expression: first_response
 ---
-Report(
-    WorkspaceDiagnosticReport {
-        items: [
-            Full(
-                WorkspaceFullDocumentDiagnosticReport {
-                    uri: Url {
-                        scheme: "file",
-                        cannot_be_a_base: false,
-                        username: "",
-                        password: None,
-                        host: None,
-                        port: None,
-                        path: "<temp_dir>/src/test.py",
-                        query: None,
-                        fragment: None,
-                    },
-                    version: Some(
-                        2,
+WorkspaceDiagnosticReport {
+    items: [
+        WorkspaceFullDocumentDiagnosticReport(
+            WorkspaceFullDocumentDiagnosticReport {
+                uri: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "<temp_dir>/src/test.py",
+                    query: None,
+                    fragment: None,
+                },
+                version: Some(
+                    2,
+                ),
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: Some(
+                        "[RESULT_ID]",
                     ),
-                    full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                        result_id: Some(
-                            "[RESULT_ID]",
-                        ),
-                        items: [
-                            Diagnostic {
-                                range: Range {
-                                    start: Position {
-                                        line: 1,
-                                        character: 11,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        character: 13,
+                    items: [
+                        Diagnostic {
+                            range: Range {
+                                start: Position {
+                                    line: 1,
+                                    character: 11,
+                                },
+                                end: Position {
+                                    line: 1,
+                                    character: 13,
+                                },
+                            },
+                            severity: Some(
+                                Error,
+                            ),
+                            code: Some(
+                                String(
+                                    "invalid-return-type",
+                                ),
+                            ),
+                            code_description: Some(
+                                CodeDescription {
+                                    href: Url {
+                                        scheme: "https",
+                                        cannot_be_a_base: false,
+                                        username: "",
+                                        password: None,
+                                        host: Some(
+                                            Domain(
+                                                "ty.dev",
+                                            ),
+                                        ),
+                                        port: None,
+                                        path: "/rules",
+                                        query: None,
+                                        fragment: Some(
+                                            "invalid-return-type",
+                                        ),
                                     },
                                 },
-                                severity: Some(
-                                    Error,
-                                ),
-                                code: Some(
-                                    String(
-                                        "invalid-return-type",
-                                    ),
-                                ),
-                                code_description: Some(
-                                    CodeDescription {
-                                        href: Url {
-                                            scheme: "https",
-                                            cannot_be_a_base: false,
-                                            username: "",
-                                            password: None,
-                                            host: Some(
-                                                Domain(
-                                                    "ty.dev",
-                                                ),
-                                            ),
-                                            port: None,
-                                            path: "/rules",
-                                            query: None,
-                                            fragment: Some(
-                                                "invalid-return-type",
-                                            ),
-                                        },
-                                    },
-                                ),
-                                source: Some(
-                                    "ty",
-                                ),
-                                message: "Return type does not match returned value: expected `str`, found `Literal[42]`",
-                                related_information: None,
-                                tags: None,
-                                data: None,
-                            },
-                        ],
-                    },
+                            ),
+                            source: Some(
+                                "ty",
+                            ),
+                            message: String(
+                                "Return type does not match returned value: expected `str`, found `Literal[42]`",
+                            ),
+                            tags: None,
+                            related_information: None,
+                            data: None,
+                        },
+                    ],
                 },
-            ),
-        ],
-    },
-)
+            },
+        ),
+    ],
+}

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_diagnostic_suspend_change_suspend_second_response.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_diagnostic_suspend_change_suspend_second_response.snap
@@ -2,31 +2,29 @@
 source: crates/ty_server/tests/e2e/pull_diagnostics.rs
 expression: second_response
 ---
-Report(
-    WorkspaceDiagnosticReport {
-        items: [
-            Full(
-                WorkspaceFullDocumentDiagnosticReport {
-                    uri: Url {
-                        scheme: "file",
-                        cannot_be_a_base: false,
-                        username: "",
-                        password: None,
-                        host: None,
-                        port: None,
-                        path: "<temp_dir>/src/test.py",
-                        query: None,
-                        fragment: None,
-                    },
-                    version: Some(
-                        3,
-                    ),
-                    full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                        result_id: None,
-                        items: [],
-                    },
+WorkspaceDiagnosticReport {
+    items: [
+        WorkspaceFullDocumentDiagnosticReport(
+            WorkspaceFullDocumentDiagnosticReport {
+                uri: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "<temp_dir>/src/test.py",
+                    query: None,
+                    fragment: None,
                 },
-            ),
-        ],
-    },
-)
+                version: Some(
+                    3,
+                ),
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: None,
+                    items: [],
+                },
+            },
+        ),
+    ],
+}

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_reports_current_analysis_unreachable_code_hint_tag.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_reports_current_analysis_unreachable_code_hint_tag.snap
@@ -5,7 +5,6 @@ expression: diagnostics
 {
   "items": [
     {
-      "kind": "full",
       "uri": "file://<temp_dir>/src/foo.py",
       "version": null,
       "resultId": "[RESULT_ID]",
@@ -28,7 +27,8 @@ expression: diagnostics
             1
           ]
         }
-      ]
+      ],
+      "kind": "full"
     }
   ]
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_reports_unreachable_code_hint_tag.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_reports_unreachable_code_hint_tag.snap
@@ -5,7 +5,6 @@ expression: diagnostics
 {
   "items": [
     {
-      "kind": "full",
       "uri": "file://<temp_dir>/src/foo.py",
       "version": null,
       "resultId": "[RESULT_ID]",
@@ -28,7 +27,8 @@ expression: diagnostics
             1
           ]
         }
-      ]
+      ],
+      "kind": "full"
     }
   ]
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_reports_unused_binding_hint_tag.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__workspace_reports_unused_binding_hint_tag.snap
@@ -5,7 +5,6 @@ expression: diagnostics
 {
   "items": [
     {
-      "kind": "full",
       "uri": "file://<temp_dir>/src/foo.py",
       "version": null,
       "resultId": "[RESULT_ID]",
@@ -28,7 +27,8 @@ expression: diagnostics
             1
           ]
         }
-      ]
+      ],
+      "kind": "full"
     }
   ]
 }

--- a/crates/ty_server/tests/e2e/type_hierarchy.rs
+++ b/crates/ty_server/tests/e2e/type_hierarchy.rs
@@ -1,8 +1,10 @@
-use lsp_types::request::{TypeHierarchyPrepare, TypeHierarchySubtypes, TypeHierarchySupertypes};
 use lsp_types::{
     PartialResultParams, Position, TextDocumentIdentifier, TextDocumentPositionParams,
     TypeHierarchyPrepareParams, TypeHierarchySubtypesParams, TypeHierarchySupertypesParams,
     WorkDoneProgressParams,
+};
+use lsp_types::{
+    TypeHierarchyPrepareRequest, TypeHierarchySubtypesRequest, TypeHierarchySupertypesRequest,
 };
 
 use crate::TestServerBuilder;
@@ -161,7 +163,7 @@ fn prepare(
     path: impl AsRef<ruff_db::system::SystemPath>,
     position: Position,
 ) -> Option<Vec<lsp_types::TypeHierarchyItem>> {
-    server.send_request_await::<TypeHierarchyPrepare>(TypeHierarchyPrepareParams {
+    server.send_request_await::<TypeHierarchyPrepareRequest>(TypeHierarchyPrepareParams {
         text_document_position_params: TextDocumentPositionParams {
             text_document: TextDocumentIdentifier {
                 uri: server.file_uri(path),
@@ -177,7 +179,7 @@ fn supertypes(
     server: &mut crate::TestServer,
     item: lsp_types::TypeHierarchyItem,
 ) -> Option<Vec<lsp_types::TypeHierarchyItem>> {
-    server.send_request_await::<TypeHierarchySupertypes>(TypeHierarchySupertypesParams {
+    server.send_request_await::<TypeHierarchySupertypesRequest>(TypeHierarchySupertypesParams {
         item,
         work_done_progress_params: WorkDoneProgressParams::default(),
         partial_result_params: PartialResultParams::default(),
@@ -189,7 +191,7 @@ fn subtypes(
     server: &mut crate::TestServer,
     item: lsp_types::TypeHierarchyItem,
 ) -> Option<Vec<lsp_types::TypeHierarchyItem>> {
-    server.send_request_await::<TypeHierarchySubtypes>(TypeHierarchySubtypesParams {
+    server.send_request_await::<TypeHierarchySubtypesRequest>(TypeHierarchySubtypesParams {
         item,
         work_done_progress_params: WorkDoneProgressParams::default(),
         partial_result_params: PartialResultParams::default(),

--- a/crates/ty_server/tests/e2e/workspace_folders.rs
+++ b/crates/ty_server/tests/e2e/workspace_folders.rs
@@ -1,10 +1,8 @@
 use anyhow::Result;
 use insta::assert_snapshot;
 use lsp_types::{
-    DiagnosticSeverity, DocumentDiagnosticReport, DocumentDiagnosticReportResult,
-    FullDocumentDiagnosticReport, Position, WorkspaceDiagnosticReport,
-    WorkspaceDiagnosticReportPartialResult, WorkspaceDiagnosticReportResult,
-    WorkspaceDocumentDiagnosticReport,
+    DiagnosticSeverity, DocumentDiagnosticReport, FullDocumentDiagnosticReport, Message, Position,
+    WorkspaceDiagnosticReport, WorkspaceDocumentDiagnosticReport,
 };
 use ruff_db::system::SystemPath;
 use ty_server::{ClientOptions, DiagnosticMode, GlobalOptions, WorkspaceOptions};
@@ -705,24 +703,23 @@ fn global_settings_change() -> Result<()> {
 /// LSP is correctly recognizing and reporting diagnostics for each
 /// workspace folder. This isn't really meant to test the diagnostics
 /// themselves, hence the condensed output.
-fn condensed_workspace_diagnostic_snapshot(report: WorkspaceDiagnosticReportResult) -> String {
-    let items = match report {
-        WorkspaceDiagnosticReportResult::Report(WorkspaceDiagnosticReport { items }) => items,
-        WorkspaceDiagnosticReportResult::Partial(WorkspaceDiagnosticReportPartialResult {
-            items,
-        }) => items,
-    };
+fn condensed_workspace_diagnostic_snapshot(report: WorkspaceDiagnosticReport) -> String {
+    let items = report.items;
     items
         .into_iter()
         .map(|item| match item {
-            WorkspaceDocumentDiagnosticReport::Full(doc_report) => {
+            WorkspaceDocumentDiagnosticReport::WorkspaceFullDocumentDiagnosticReport(
+                doc_report,
+            ) => {
                 let diagnostics = condensed_full_document_diagnostic_report(
                     doc_report.full_document_diagnostic_report,
                 )
                 .join("\n\t");
                 format!("{}\n\t{diagnostics}", doc_report.uri)
             }
-            WorkspaceDocumentDiagnosticReport::Unchanged(doc_report) => {
+            WorkspaceDocumentDiagnosticReport::WorkspaceUnchangedDocumentDiagnosticReport(
+                doc_report,
+            ) => {
                 format!("{}\n\tUNCHANGED", doc_report.uri)
             }
         })
@@ -730,21 +727,18 @@ fn condensed_workspace_diagnostic_snapshot(report: WorkspaceDiagnosticReportResu
         .join("\n")
 }
 
-pub(crate) fn condensed_document_diagnostic_snapshot(
-    report: DocumentDiagnosticReportResult,
-) -> String {
+pub(crate) fn condensed_document_diagnostic_snapshot(report: DocumentDiagnosticReport) -> String {
     match report {
-        DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(full)) => {
+        DocumentDiagnosticReport::RelatedFullDocumentDiagnosticReport(full) => {
             condensed_full_document_diagnostic_report(full.full_document_diagnostic_report)
                 .join("\n")
         }
         // NOTE: It might be worth providing more details for these
         // cases, but I don't think there's currently a use case for
         // it.
-        DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Unchanged(_)) => {
+        DocumentDiagnosticReport::RelatedUnchangedDocumentDiagnosticReport(_) => {
             "UNCHANGED".to_string()
         }
-        DocumentDiagnosticReportResult::Partial(_) => "PARTIAL".to_string(),
     }
 }
 
@@ -761,13 +755,19 @@ fn condensed_full_document_diagnostic_report(report: FullDocumentDiagnosticRepor
                 end_char = d.range.end.character,
             );
             let severity = match d.severity {
-                Some(DiagnosticSeverity::ERROR) => "ERROR",
-                Some(DiagnosticSeverity::WARNING) => "WARNING",
-                Some(DiagnosticSeverity::INFORMATION) => "INFORMATION",
-                Some(DiagnosticSeverity::HINT) => "HINT",
-                None | Some(_) => "unknown",
+                Some(DiagnosticSeverity::Error) => "ERROR",
+                Some(DiagnosticSeverity::Warning) => "WARNING",
+                Some(DiagnosticSeverity::Information) => "INFORMATION",
+                Some(DiagnosticSeverity::Hint) => "HINT",
+                None => "unknown",
             };
-            format!("{range}[{severity}]: {message}", message = d.message)
+            let Message::String(message) = d.message else {
+                panic!(
+                    "Only string-type diagnostic messages supported, got: {:?}",
+                    d.message
+                );
+            };
+            format!("{range}[{severity}]: {message}")
         })
         .collect()
 }
@@ -787,7 +787,7 @@ fn condensed_full_document_diagnostic_report(report: FullDocumentDiagnosticRepor
 /// expect to never have a response for.
 fn get_expected_empty_workspace_diagnostics_and_shutdown(
     mut server: TestServer,
-) -> WorkspaceDiagnosticReportResult {
+) -> WorkspaceDiagnosticReport {
     let request_id = send_workspace_diagnostic_request(&mut server);
     assert_workspace_diagnostics_suspends_for_long_polling(&mut server, &request_id);
     shutdown_and_await_workspace_diagnostic(server, &request_id)


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

[gen-lsp-types](https://github.com/ribru17/gen-lsp-types) is an alternative to the lsp-types crate, with types generated via codegen from the official LSP Metamodel for correctness and completeness.

lsp-types issues fixed in gen-lsp-types:

- https://github.com/gluon-lang/lsp-types/issues/310
- https://github.com/gluon-lang/lsp-types/issues/308
- https://github.com/gluon-lang/lsp-types/issues/284
- https://github.com/gluon-lang/lsp-types/issues/278
- https://github.com/gluon-lang/lsp-types/issues/277
- https://github.com/gluon-lang/lsp-types/issues/260
- https://github.com/gluon-lang/lsp-types/issues/245
- https://github.com/gluon-lang/lsp-types/issues/93

## Test Plan

All affected test fixtures updated. Most (all?) are just field reordering, struct type name renaming