### PR TITLE
[ty] Make the Monaco model the source of truth

### DIFF
--- a/playground/ty/src/Editor/Chrome.tsx
+++ b/playground/ty/src/Editor/Chrome.tsx
@@ -27,7 +27,7 @@ import SecondaryPanel, {
 } from "./SecondaryPanel";
 import Diagnostics, { Diagnostic } from "./Diagnostics";
 import VendoredFileBanner from "./VendoredFileBanner";
-import { FileId, ReadonlyFiles } from "../Playground";
+import type { FileId, PlaygroundSession, ReadonlyFiles } from "../Playground";
 import type { editor } from "monaco-editor";
 import type { Monaco } from "@monaco-editor/react";
 
@@ -41,17 +41,17 @@ interface CheckResult {
 }
 
 export interface Props {
-  workspacePromise: Promise<Workspace>;
+  sessionPromise: Promise<PlaygroundSession>;
   files: ReadonlyFiles;
   theme: Theme;
   selectedFileName: string;
   onRun(): Promise<string>;
 
-  onAddFile(workspace: Workspace, name: string): void;
+  onAddFile(session: PlaygroundSession, name: string): void;
 
-  onRenameFile(workspace: Workspace, file: FileId, newName: string): void;
+  onRenameFile(session: PlaygroundSession, file: FileId, newName: string): void;
 
-  onRemoveFile(workspace: Workspace, file: FileId): void;
+  onRemoveFile(session: PlaygroundSession, file: FileId): void;
 
   onSelectFile(id: FileId): void;
 
@@ -63,7 +63,7 @@ export interface Props {
 export default function Chrome({
   files,
   selectedFileName,
-  workspacePromise,
+  sessionPromise,
   theme,
   onRun,
   onAddFile,
@@ -73,7 +73,8 @@ export default function Chrome({
   onSelectVendoredFile,
   onClearVendoredFile,
 }: Props) {
-  const workspace = use(workspacePromise);
+  const session = use(sessionPromise);
+  const workspace = session.workspace;
 
   const [secondaryTool, setSecondaryTool] = useState<SecondaryTool | null>(
     null,
@@ -85,9 +86,16 @@ export default function Chrome({
   } | null>(null);
 
   const handleFileRenamed = (file: FileId, newName: string) => {
-    onRenameFile(workspace, file, newName);
+    onRenameFile(session, file, newName);
     editorRef.current?.editor.focus();
   };
+
+  const handleAdd = useCallback(
+    (name: string) => {
+      onAddFile(session, name);
+    },
+    [session, onAddFile],
+  );
 
   const handleBackToUserFile = useCallback(() => {
     if (editorRef.current && files.selected != null) {
@@ -143,9 +151,9 @@ export default function Chrome({
 
   const handleRemoved = useCallback(
     (id: FileId) => {
-      onRemoveFile(workspace, id);
+      onRemoveFile(session, id);
     },
-    [workspace, onRemoveFile],
+    [session, onRemoveFile],
   );
 
   const { defaultLayout, onLayoutChange } = useDefaultLayout({
@@ -170,7 +178,7 @@ export default function Chrome({
             metadata={files.metadata}
             theme={theme}
             selected={files.selected}
-            onAdd={(name) => onAddFile(workspace, name)}
+            onAdd={handleAdd}
             onRename={handleFileRenamed}
             onSelect={onSelectFile}
             onRemove={handleRemoved}

--- a/playground/ty/src/Editor/Chrome.tsx
+++ b/playground/ty/src/Editor/Chrome.tsx
@@ -45,7 +45,6 @@ export interface Props {
   files: ReadonlyFiles;
   theme: Theme;
   selectedFileName: string;
-  documentRevision: number;
   onRun(): Promise<string>;
 
   onAddFile(workspace: Workspace, name: string): void;
@@ -66,7 +65,6 @@ export default function Chrome({
   selectedFileName,
   workspacePromise,
   theme,
-  documentRevision,
   onRun,
   onAddFile,
   onRenameFile,
@@ -160,7 +158,7 @@ export default function Chrome({
     workspace,
     secondaryTool,
     files.currentVendoredFile ?? null,
-    documentRevision,
+    files.revision,
   );
 
   return (
@@ -244,7 +242,6 @@ export default function Chrome({
                 <Panel id="secondary-panel" minSize={100}>
                   <SecondaryPanel
                     files={files}
-                    documentRevision={documentRevision}
                     onRun={onRun}
                     theme={theme}
                     tool={secondaryTool}
@@ -269,9 +266,9 @@ function useCheckResult(
   workspace: Workspace,
   secondaryTool: SecondaryTool | null,
   currentVendoredFileHandle: FileHandle | null,
-  documentRevision: number,
+  revision: number,
 ): CheckResult {
-  const deferredDocumentRevision = useDeferredValue(documentRevision);
+  const deferredRevision = useDeferredValue(revision);
 
   return useMemo(() => {
     // Determine which file handle to use
@@ -367,7 +364,7 @@ function useCheckResult(
     workspace,
     secondaryTool,
     currentVendoredFileHandle,
-    deferredDocumentRevision,
+    deferredRevision,
   ]);
 }
 

--- a/playground/ty/src/Editor/Chrome.tsx
+++ b/playground/ty/src/Editor/Chrome.tsx
@@ -45,10 +45,10 @@ export interface Props {
   files: ReadonlyFiles;
   theme: Theme;
   selectedFileName: string;
+  documentRevision: number;
+  onRun(): Promise<string>;
 
   onAddFile(workspace: Workspace, name: string): void;
-
-  onChangeFile(workspace: Workspace, content: string): void;
 
   onRenameFile(workspace: Workspace, file: FileId, newName: string): void;
 
@@ -66,11 +66,12 @@ export default function Chrome({
   selectedFileName,
   workspacePromise,
   theme,
+  documentRevision,
+  onRun,
   onAddFile,
   onRenameFile,
   onRemoveFile,
   onSelectFile,
-  onChangeFile,
   onSelectVendoredFile,
   onClearVendoredFile,
 }: Props) {
@@ -97,7 +98,7 @@ export default function Chrome({
       );
       if (selectedFile != null) {
         const monaco = editorRef.current.monaco;
-        const fileUri = monaco.Uri.file(selectedFile.name);
+        const fileUri = monaco.Uri.parse(selectedFile.name);
         const userModel = monaco.editor.getModel(fileUri);
 
         if (userModel != null) {
@@ -146,29 +147,10 @@ export default function Chrome({
   }, []);
 
   const handleRemoved = useCallback(
-    async (id: FileId) => {
-      const name = files.index.find((file) => file.id === id)?.name;
-
-      if (name != null && editorRef.current != null) {
-        // Remove the file from the monaco state to avoid that monaco "restores" the old content.
-        // An alternative is to use a `key` on the `Editor` but that means we lose focus and selection
-        // range when changing between tabs.
-        const monaco = await import("monaco-editor");
-        editorRef.current.monaco.editor
-          .getModel(monaco.Uri.file(name))
-          ?.dispose();
-      }
-
+    (id: FileId) => {
       onRemoveFile(workspace, id);
     },
-    [workspace, files.index, onRemoveFile],
-  );
-
-  const handleChange = useCallback(
-    (content: string) => {
-      onChangeFile(workspace, content);
-    },
-    [onChangeFile, workspace],
+    [workspace, onRemoveFile],
   );
 
   const { defaultLayout, onLayoutChange } = useDefaultLayout({
@@ -181,6 +163,7 @@ export default function Chrome({
     workspace,
     secondaryTool,
     files.currentVendoredFile ?? null,
+    documentRevision,
   );
 
   return (
@@ -224,13 +207,11 @@ export default function Chrome({
                     theme={theme}
                     visible={true}
                     files={files}
-                    selected={files.selected}
                     fileName={selectedFileName}
                     diagnostics={checkResult.diagnostics}
                     hints={checkResult.hints}
                     workspace={workspace}
                     onMount={handleEditorMount}
-                    onChange={handleChange}
                     onOpenFile={onSelectFile}
                     onVendoredFileChange={onSelectVendoredFile}
                     onBackToUserFile={handleBackToUserFile}
@@ -265,6 +246,8 @@ export default function Chrome({
                 <Panel id="secondary-panel" minSize={100}>
                   <SecondaryPanel
                     files={files}
+                    documentRevision={documentRevision}
+                    onRun={onRun}
                     theme={theme}
                     tool={secondaryTool}
                     result={checkResult.secondary}
@@ -288,10 +271,9 @@ function useCheckResult(
   workspace: Workspace,
   secondaryTool: SecondaryTool | null,
   currentVendoredFileHandle: FileHandle | null,
+  documentRevision: number,
 ): CheckResult {
-  const deferredContent = useDeferredValue(
-    files.selected == null ? null : files.contents[files.selected],
-  );
+  const deferredDocumentRevision = useDeferredValue(documentRevision);
 
   return useMemo(() => {
     // Determine which file handle to use
@@ -304,7 +286,6 @@ function useCheckResult(
     // Regular file handling
     if (
       currentHandle == null ||
-      deferredContent == null ||
       !isPythonFile(currentHandle)
     ) {
       return {
@@ -384,7 +365,7 @@ function useCheckResult(
       };
     }
   }, [
-    deferredContent,
+    deferredDocumentRevision,
     workspace,
     files.selected,
     files.handles,

--- a/playground/ty/src/Editor/Chrome.tsx
+++ b/playground/ty/src/Editor/Chrome.tsx
@@ -93,9 +93,7 @@ export default function Chrome({
 
   const handleBackToUserFile = useCallback(() => {
     if (editorRef.current && files.selected != null) {
-      const selectedFile = files.index.find(
-        (file) => file.id === files.selected,
-      );
+      const selectedFile = files.metadata[files.selected];
       if (selectedFile != null) {
         const monaco = editorRef.current.monaco;
         const fileUri = monaco.Uri.parse(selectedFile.name);
@@ -107,7 +105,7 @@ export default function Chrome({
         }
       }
     }
-  }, [files.selected, files.index, onClearVendoredFile]);
+  }, [files.selected, files.metadata, onClearVendoredFile]);
 
   const handleSecondaryToolSelected = useCallback(
     (tool: SecondaryTool | null) => {
@@ -171,7 +169,8 @@ export default function Chrome({
       {files.selected != null ? (
         <>
           <Files
-            files={files.index}
+            order={files.order}
+            metadata={files.metadata}
             theme={theme}
             selected={files.selected}
             onAdd={(name) => onAddFile(workspace, name)}
@@ -279,15 +278,12 @@ function useCheckResult(
     // Determine which file handle to use
     const currentHandle =
       currentVendoredFileHandle ??
-      (files.selected == null ? null : files.handles[files.selected]);
+      (files.selected == null ? null : files.metadata[files.selected].handle);
 
     const isVendoredFile = currentVendoredFileHandle != null;
 
     // Regular file handling
-    if (
-      currentHandle == null ||
-      !isPythonFile(currentHandle)
-    ) {
+    if (currentHandle == null || !isPythonFile(currentHandle)) {
       return {
         diagnostics: [],
         hints: [],
@@ -364,13 +360,15 @@ function useCheckResult(
         secondary: null,
       };
     }
+    // Monaco document edits mutate the workspace in place. The deferred
+    // revision is an invalidation token for this memoized check.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    deferredDocumentRevision,
+    files,
     workspace,
-    files.selected,
-    files.handles,
     secondaryTool,
     currentVendoredFileHandle,
+    deferredDocumentRevision,
   ]);
 }
 

--- a/playground/ty/src/Editor/Chrome.tsx
+++ b/playground/ty/src/Editor/Chrome.tsx
@@ -96,8 +96,7 @@ export default function Chrome({
       const selectedFile = files.metadata[files.selected];
       if (selectedFile != null) {
         const monaco = editorRef.current.monaco;
-        const fileUri = monaco.Uri.parse(selectedFile.name);
-        const userModel = monaco.editor.getModel(fileUri);
+        const userModel = monaco.editor.getModel(selectedFile.uri);
 
         if (userModel != null) {
           onClearVendoredFile();

--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -485,7 +485,7 @@ class PlaygroundServer
   private getPlaygroundFileIdForUri(uri: Uri): FileId | null {
     return (
       Object.values(this.props.files.metadata).find((file) => {
-        return isUriForPlaygroundFile(uri, file.name);
+        return file.uri.toString() === uri.toString();
       })?.id ?? null
     );
   }
@@ -561,11 +561,8 @@ class PlaygroundServer
       return;
     }
 
-    const handle = selectedFile.handle;
     const editor = this.monaco.editor;
-    const model =
-      editor.getModel(Uri.parse(handle.path())) ??
-      editor.getModel(Uri.parse(selectedFile.name));
+    const model = editor.getModel(selectedFile.uri);
 
     if (model == null) {
       return;
@@ -870,8 +867,8 @@ class PlaygroundServer
           } as languages.LocationLink;
         }
 
-        const fileName = this.props.files.metadata[fileId].name;
-        const model = this.monaco.editor.getModel(Uri.parse(fileName));
+        const file = this.props.files.metadata[fileId];
+        const model = this.monaco.editor.getModel(file.uri);
         if (model != null) {
           uri = model.uri;
         }
@@ -933,14 +930,6 @@ function monacoRangeToTyRange(range: IRange): TyRange {
   return new TyRange(
     new TyPosition(range.startLineNumber, range.startColumn),
     new TyPosition(range.endLineNumber, range.endColumn),
-  );
-}
-
-function isUriForPlaygroundFile(uri: Uri, fileName: string): boolean {
-  return (
-    Uri.parse(fileName).toString() === uri.toString() ||
-    uri.path === fileName ||
-    uri.path === `/${fileName}`
   );
 }
 

--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -34,7 +34,6 @@ import {
   TextEdit,
 } from "ty_wasm";
 import { FileId, ReadonlyFiles } from "../Playground";
-import { isPythonFile } from "./Files";
 import { Diagnostic } from "./Diagnostics";
 import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
 import CompletionItemKind = languages.CompletionItemKind;
@@ -485,7 +484,7 @@ class PlaygroundServer
 
   private getPlaygroundFileIdForUri(uri: Uri): FileId | null {
     return (
-      this.props.files.index.find((file) => {
+      Object.values(this.props.files.metadata).find((file) => {
         return isUriForPlaygroundFile(uri, file.name);
       })?.id ?? null
     );
@@ -518,7 +517,7 @@ class PlaygroundServer
       return null;
     }
 
-    return this.props.files.handles[fileId] ?? null;
+    return this.props.files.metadata[fileId].handle;
   }
 
   private formatSignatureHelp(
@@ -557,21 +556,16 @@ class PlaygroundServer
       return;
     }
 
-    const handle = this.props.files.handles[this.props.files.selected];
-
-    if (handle == null) {
+    const selectedFile = this.props.files.metadata[this.props.files.selected];
+    if (selectedFile.handle == null) {
       return;
     }
 
+    const handle = selectedFile.handle;
     const editor = this.monaco.editor;
-    const selectedFileName = this.props.files.index.find(
-      (file) => file.id === this.props.files.selected,
-    )?.name;
     const model =
       editor.getModel(Uri.parse(handle.path())) ??
-      (selectedFileName == null
-        ? null
-        : editor.getModel(Uri.parse(selectedFileName)));
+      editor.getModel(Uri.parse(selectedFile.name));
 
     if (model == null) {
       return;
@@ -876,13 +870,8 @@ class PlaygroundServer
           } as languages.LocationLink;
         }
 
-        const fileName = this.props.files.index.find(
-          (file) => file.id === fileId,
-        )?.name;
-        const model =
-          fileName == null
-            ? null
-            : this.monaco.editor.getModel(Uri.parse(fileName));
+        const fileName = this.props.files.metadata[fileId].name;
+        const model = this.monaco.editor.getModel(Uri.parse(fileName));
         if (model != null) {
           uri = model.uri;
         }

--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -42,13 +42,11 @@ import CompletionItemKind = languages.CompletionItemKind;
 type Props = {
   visible: boolean;
   fileName: string;
-  selected: FileId;
   files: ReadonlyFiles;
   diagnostics: Diagnostic[];
   hints: Hint[];
   theme: Theme;
   workspace: Workspace;
-  onChange(content: string): void;
   onMount(editor: IStandaloneCodeEditor, monaco: Monaco): void;
   onOpenFile(file: FileId): void;
   onVendoredFileChange: (vendoredFileHandle: FileHandle) => void;
@@ -59,13 +57,11 @@ type Props = {
 export default function Editor({
   visible,
   fileName,
-  selected,
   files,
   theme,
   diagnostics,
   hints,
   workspace,
-  onChange,
   onMount,
   onOpenFile,
   onVendoredFileChange,
@@ -104,16 +100,6 @@ export default function Editor({
 
     server.updateMarkers(diagnostics, hints);
   }, [diagnostics, hints]);
-
-  const handleChange = useCallback(
-    (value: string | undefined) => {
-      // Don't update file content when viewing vendored files
-      if (!isViewingVendoredFile) {
-        onChange(value ?? "");
-      }
-    },
-    [onChange, isViewingVendoredFile],
-  );
 
   useEffect(() => {
     return () => {
@@ -169,8 +155,6 @@ export default function Editor({
       path={fileName}
       wrapperProps={visible ? {} : { style: { display: "none" } }}
       theme={theme === "light" ? "Ayu-Light" : "Ayu-Dark"}
-      value={files.contents[selected]}
-      onChange={handleChange}
     />
   );
 }
@@ -502,7 +486,7 @@ class PlaygroundServer
   private getPlaygroundFileIdForUri(uri: Uri): FileId | null {
     return (
       this.props.files.index.find((file) => {
-        return Uri.file(file.name).toString() === uri.toString();
+        return isUriForPlaygroundFile(uri, file.name);
       })?.id ?? null
     );
   }
@@ -580,7 +564,14 @@ class PlaygroundServer
     }
 
     const editor = this.monaco.editor;
-    const model = editor.getModel(Uri.parse(handle.path()));
+    const selectedFileName = this.props.files.index.find(
+      (file) => file.id === this.props.files.selected,
+    )?.name;
+    const model =
+      editor.getModel(Uri.parse(handle.path())) ??
+      (selectedFileName == null
+        ? null
+        : editor.getModel(Uri.parse(selectedFileName)));
 
     if (model == null) {
       return;
@@ -865,7 +856,7 @@ class PlaygroundServer
   }
 
   private mapNavigationTarget(link: LocationLink): languages.LocationLink {
-    const uri = Uri.parse(link.path);
+    let uri = Uri.parse(link.path);
 
     // Pre-create models to ensure peek definition works
     if (this.monaco.editor.getModel(uri) == null) {
@@ -876,19 +867,24 @@ class PlaygroundServer
         const content = this.props.workspace.sourceText(fileHandle);
         this.monaco.editor.createModel(content, "python", uri);
       } else {
-        // Handle regular files
+        // Regular file models are owned by Monaco and created by the playground.
         const fileId = this.getPlaygroundFileIdForUri(uri);
+        if (fileId == null) {
+          return {
+            uri,
+            range: tyRangeToMonacoRange(link.full_range),
+          } as languages.LocationLink;
+        }
 
-        if (fileId != null) {
-          const handle = this.props.files.handles[fileId];
-          if (handle != null) {
-            const language = isPythonFile(handle) ? "python" : undefined;
-            this.monaco.editor.createModel(
-              this.props.files.contents[fileId],
-              language,
-              uri,
-            );
-          }
+        const fileName = this.props.files.index.find(
+          (file) => file.id === fileId,
+        )?.name;
+        const model =
+          fileName == null
+            ? null
+            : this.monaco.editor.getModel(Uri.parse(fileName));
+        if (model != null) {
+          uri = model.uri;
         }
       }
     }
@@ -948,6 +944,14 @@ function monacoRangeToTyRange(range: IRange): TyRange {
   return new TyRange(
     new TyPosition(range.startLineNumber, range.startColumn),
     new TyPosition(range.endLineNumber, range.endColumn),
+  );
+}
+
+function isUriForPlaygroundFile(uri: Uri, fileName: string): boolean {
+  return (
+    Uri.parse(fileName).toString() === uri.toString() ||
+    uri.path === fileName ||
+    uri.path === `/${fileName}`
   );
 }
 

--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -33,7 +33,7 @@ import {
   LocationLink,
   TextEdit,
 } from "ty_wasm";
-import { FileId, ReadonlyFiles } from "../Playground";
+import { FileId, PlaygroundFile, ReadonlyFiles } from "../Playground";
 import { Diagnostic } from "./Diagnostics";
 import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
 import CompletionItemKind = languages.CompletionItemKind;
@@ -482,11 +482,11 @@ class PlaygroundServer
     this.inVendoredFileCondition.set(isViewingVendoredFile);
   }
 
-  private getPlaygroundFileIdForUri(uri: Uri): FileId | null {
+  private getPlaygroundFileForUri(uri: Uri): PlaygroundFile | null {
     return (
       Object.values(this.props.files.metadata).find((file) => {
         return file.uri.toString() === uri.toString();
-      })?.id ?? null
+      }) ?? null
     );
   }
 
@@ -512,12 +512,12 @@ class PlaygroundServer
       return this.getOrCreateVendoredFileHandle(vendoredPath);
     }
 
-    const fileId = this.getPlaygroundFileIdForUri(model.uri);
-    if (fileId == null) {
+    const file = this.getPlaygroundFileForUri(model.uri);
+    if (file == null) {
       return null;
     }
 
-    return this.props.files.metadata[fileId].handle;
+    return file.handle;
   }
 
   private formatSignatureHelp(
@@ -798,15 +798,15 @@ class PlaygroundServer
       this.props.onVendoredFileChange(fileHandle);
     } else {
       // Handle regular files
-      const fileId = this.getPlaygroundFileIdForUri(resource);
+      const file = this.getPlaygroundFileForUri(resource);
 
-      if (fileId == null) {
+      if (file == null) {
         return false;
       }
 
       // Set the model and trigger UI updates
-      if (files.selected !== fileId) {
-        this.props.onOpenFile(fileId);
+      if (files.selected !== file.id) {
+        this.props.onOpenFile(file.id);
       }
     }
 
@@ -859,15 +859,14 @@ class PlaygroundServer
         this.monaco.editor.createModel(content, "python", uri);
       } else {
         // Regular file models are owned by Monaco and created by the playground.
-        const fileId = this.getPlaygroundFileIdForUri(uri);
-        if (fileId == null) {
+        const file = this.getPlaygroundFileForUri(uri);
+        if (file == null) {
           return {
             uri,
             range: tyRangeToMonacoRange(link.full_range),
           } as languages.LocationLink;
         }
 
-        const file = this.props.files.metadata[fileId];
         const model = this.monaco.editor.getModel(file.uri);
         if (model != null) {
           uri = model.uri;

--- a/playground/ty/src/Editor/Files.tsx
+++ b/playground/ty/src/Editor/Files.tsx
@@ -1,12 +1,12 @@
 import { Icons, Theme } from "shared";
 import classNames from "classnames";
 import { useState } from "react";
-import { FileId } from "../Playground";
+import { FileId, FileMetadata } from "../Playground";
 import { type FileHandle } from "ty_wasm";
 
 export interface Props {
-  // The file names
-  files: ReadonlyArray<{ id: FileId; name: string }>;
+  order: ReadonlyArray<FileId>;
+  metadata: FileMetadata;
   theme: Theme;
   selected: FileId;
 
@@ -20,7 +20,8 @@ export interface Props {
 }
 
 export function Files({
-  files,
+  order,
+  metadata,
   selected,
   theme,
   onAdd,
@@ -28,11 +29,14 @@ export function Files({
   onRename,
   onSelect,
 }: Props) {
+  const hasFileNamed = (fileName: string) =>
+    Object.values(metadata).some((file) => file.name === fileName);
+
   const handleAdd = () => {
     let index: number | null = null;
     let fileName = "module.py";
 
-    while (files.some(({ name }) => name === fileName)) {
+    while (hasFileNamed(fileName)) {
       index = (index ?? 0) + 1;
       fileName = `module${index}.py`;
     }
@@ -40,7 +44,7 @@ export function Files({
     onAdd(fileName);
   };
 
-  const lastFile = files.length === 1;
+  const lastFile = order.length === 1;
 
   return (
     <ul
@@ -49,30 +53,34 @@ export function Files({
         theme === "dark" ? "text-white border-rock" : null,
       )}
     >
-      {files.map(({ id, name }) => (
-        <ListItem key={id} selected={selected === id} theme={theme}>
-          <FileEntry
-            selected={selected === id}
-            name={name}
-            onClicked={() => onSelect(id)}
-            onRenamed={(newName) => {
-              if (!files.some(({ name }) => name === newName)) {
-                onRename(id, newName);
-              }
-            }}
-          />
+      {order.map((id) => {
+        const file = metadata[id];
 
-          <button
-            disabled={lastFile}
-            onClick={lastFile ? undefined : () => onRemove(id)}
-            className={"inline-block disabled:opacity-50 cursor-pointer"}
-            title="Close file"
-          >
-            <span className="sr-only">Close</span>
-            <Icons.Close />
-          </button>
-        </ListItem>
-      ))}
+        return (
+          <ListItem key={id} selected={selected === id} theme={theme}>
+            <FileEntry
+              selected={selected === id}
+              name={file.name}
+              onClicked={() => onSelect(id)}
+              onRenamed={(newName) => {
+                if (!hasFileNamed(newName)) {
+                  onRename(id, newName);
+                }
+              }}
+            />
+
+            <button
+              disabled={lastFile}
+              onClick={lastFile ? undefined : () => onRemove(id)}
+              className={"inline-block disabled:opacity-50 cursor-pointer"}
+              title="Close file"
+            >
+              <span className="sr-only">Close</span>
+              <Icons.Close />
+            </button>
+          </ListItem>
+        );
+      })}
       <ListItem selected={false} theme={theme}>
         <button
           onClick={handleAdd}

--- a/playground/ty/src/Editor/SecondaryPanel.tsx
+++ b/playground/ty/src/Editor/SecondaryPanel.tsx
@@ -17,7 +17,6 @@ export type SecondaryPanelResult =
 
 export interface SecondaryPanelProps {
   files: ReadonlyFiles;
-  documentRevision: number;
   onRun(): Promise<string>;
   tool: SecondaryTool;
   result: SecondaryPanelResult;
@@ -28,7 +27,6 @@ export default function SecondaryPanel({
   tool,
   result,
   files,
-  documentRevision,
   onRun,
   theme,
 }: SecondaryPanelProps) {
@@ -39,7 +37,7 @@ export default function SecondaryPanel({
         result={result}
         theme={theme}
         onRun={onRun}
-        revision={files.revision + documentRevision}
+        revision={files.revision}
       />
     </div>
   );

--- a/playground/ty/src/Editor/SecondaryPanel.tsx
+++ b/playground/ty/src/Editor/SecondaryPanel.tsx
@@ -38,7 +38,6 @@ export default function SecondaryPanel({
         tool={tool}
         result={result}
         theme={theme}
-        files={files}
         onRun={onRun}
         revision={files.revision + documentRevision}
       />
@@ -47,7 +46,6 @@ export default function SecondaryPanel({
 }
 
 function Content({
-  files,
   tool,
   result,
   theme,
@@ -55,7 +53,6 @@ function Content({
   onRun,
 }: {
   tool: SecondaryTool;
-  files: ReadonlyFiles;
   onRun(): Promise<string>;
   revision: number;
   result: SecondaryPanelResult;
@@ -77,9 +74,7 @@ function Content({
             break;
 
           case "Run":
-            return (
-              <Run theme={theme} onRun={onRun} key={`${revision}`} />
-            );
+            return <Run theme={theme} onRun={onRun} key={`${revision}`} />;
         }
 
         return (
@@ -111,13 +106,7 @@ function Content({
   }
 }
 
-function Run({
-  onRun,
-  theme,
-}: {
-  onRun(): Promise<string>;
-  theme: Theme;
-}) {
+function Run({ onRun, theme }: { onRun(): Promise<string>; theme: Theme }) {
   const [runOutput, setRunOutput] = useState<Promise<string> | null>(null);
   const handleRun = () => {
     setRunOutput(onRun());

--- a/playground/ty/src/Editor/SecondaryPanel.tsx
+++ b/playground/ty/src/Editor/SecondaryPanel.tsx
@@ -2,7 +2,6 @@ import MonacoEditor from "@monaco-editor/react";
 import { AstralButton, Theme } from "shared";
 import { ReadonlyFiles } from "../Playground";
 import { Suspense, use, useState } from "react";
-import { loadPyodide } from "pyodide";
 import classNames from "classnames";
 
 export enum SecondaryTool {
@@ -18,6 +17,8 @@ export type SecondaryPanelResult =
 
 export interface SecondaryPanelProps {
   files: ReadonlyFiles;
+  documentRevision: number;
+  onRun(): Promise<string>;
   tool: SecondaryTool;
   result: SecondaryPanelResult;
   theme: Theme;
@@ -27,6 +28,8 @@ export default function SecondaryPanel({
   tool,
   result,
   files,
+  documentRevision,
+  onRun,
   theme,
 }: SecondaryPanelProps) {
   return (
@@ -36,7 +39,8 @@ export default function SecondaryPanel({
         result={result}
         theme={theme}
         files={files}
-        revision={files.revision}
+        onRun={onRun}
+        revision={files.revision + documentRevision}
       />
     </div>
   );
@@ -48,9 +52,11 @@ function Content({
   result,
   theme,
   revision,
+  onRun,
 }: {
   tool: SecondaryTool;
   files: ReadonlyFiles;
+  onRun(): Promise<string>;
   revision: number;
   result: SecondaryPanelResult;
   theme: Theme;
@@ -71,7 +77,9 @@ function Content({
             break;
 
           case "Run":
-            return <Run theme={theme} files={files} key={`${revision}`} />;
+            return (
+              <Run theme={theme} onRun={onRun} key={`${revision}`} />
+            );
         }
 
         return (
@@ -103,78 +111,16 @@ function Content({
   }
 }
 
-const SANDBOX_BASE_DIRECTORY = "/playground/";
-
-function Run({ files, theme }: { files: ReadonlyFiles; theme: Theme }) {
+function Run({
+  onRun,
+  theme,
+}: {
+  onRun(): Promise<string>;
+  theme: Theme;
+}) {
   const [runOutput, setRunOutput] = useState<Promise<string> | null>(null);
   const handleRun = () => {
-    const output = (async () => {
-      const pyodide = await loadPyodide({
-        env: {
-          HOME: SANDBOX_BASE_DIRECTORY,
-        },
-      });
-
-      let combined_output = "";
-
-      const outputHandler = (output: string) => {
-        combined_output += output + "\n";
-      };
-
-      pyodide.setStdout({ batched: outputHandler });
-      pyodide.setStderr({ batched: outputHandler });
-
-      const main = files.selected == null ? "" : files.contents[files.selected];
-
-      let fileName = "main.py";
-      for (const file of files.index) {
-        const last_separator = file.name.lastIndexOf("/");
-
-        if (last_separator !== -1) {
-          const directory =
-            SANDBOX_BASE_DIRECTORY + file.name.slice(0, last_separator);
-          pyodide.FS.mkdirTree(directory);
-        }
-        pyodide.FS.writeFile(
-          SANDBOX_BASE_DIRECTORY + file.name,
-          files.contents[file.id],
-        );
-
-        if (file.id === files.selected) {
-          fileName = file.name;
-        }
-      }
-
-      const dict = pyodide.globals.get("dict");
-      const globals = dict();
-
-      try {
-        // Patch `reveal_type` to print runtime values
-        pyodide.runPython(`
-        import builtins
-
-        def reveal_type(obj):
-          import typing
-          print(f"Runtime value is '{obj}'")
-          return typing.reveal_type(obj)
-
-        builtins.reveal_type = reveal_type`);
-
-        pyodide.runPython(main, {
-          globals,
-          locals: globals,
-          filename: fileName,
-        });
-
-        return combined_output;
-      } catch (e) {
-        return `Failed to run Python script: ${e}`;
-      } finally {
-        globals.destroy();
-        dict.destroy();
-      }
-    })();
-    setRunOutput(output);
+    setRunOutput(onRun());
   };
 
   if (runOutput == null) {

--- a/playground/ty/src/Editor/runPython.ts
+++ b/playground/ty/src/Editor/runPython.ts
@@ -1,0 +1,62 @@
+import { loadPyodide } from "pyodide";
+import { SerializedFiles } from "../Playground";
+
+const SANDBOX_BASE_DIRECTORY = "/playground/";
+
+export async function runPython(workspace: SerializedFiles): Promise<string> {
+  const pyodide = await loadPyodide({
+    env: {
+      HOME: SANDBOX_BASE_DIRECTORY,
+    },
+  });
+
+  let combinedOutput = "";
+
+  const outputHandler = (output: string) => {
+    combinedOutput += output + "\n";
+  };
+
+  pyodide.setStdout({ batched: outputHandler });
+  pyodide.setStderr({ batched: outputHandler });
+
+  for (const [fileName, content] of Object.entries(workspace.files)) {
+    const lastSeparator = fileName.lastIndexOf("/");
+
+    if (lastSeparator !== -1) {
+      const directory =
+        SANDBOX_BASE_DIRECTORY + fileName.slice(0, lastSeparator);
+      pyodide.FS.mkdirTree(directory);
+    }
+
+    pyodide.FS.writeFile(SANDBOX_BASE_DIRECTORY + fileName, content);
+  }
+
+  const dict = pyodide.globals.get("dict");
+  const globals = dict();
+
+  try {
+    // Patch `reveal_type` to print runtime values
+    pyodide.runPython(`
+        import builtins
+
+        def reveal_type(obj):
+          import typing
+          print(f"Runtime value is '{obj}'")
+          return typing.reveal_type(obj)
+
+        builtins.reveal_type = reveal_type`);
+
+    pyodide.runPython(workspace.files[workspace.current] ?? "", {
+      globals,
+      locals: globals,
+      filename: workspace.current,
+    });
+
+    return combinedOutput;
+  } catch (error) {
+    return `Failed to run Python script: ${error}`;
+  } finally {
+    globals.destroy();
+    dict.destroy();
+  }
+}

--- a/playground/ty/src/Playground.tsx
+++ b/playground/ty/src/Playground.tsx
@@ -41,10 +41,6 @@ export default function Playground() {
   const [error, setError] = useState<string | null>(null);
   const [workspace, setWorkspace] = useState<Workspace | null>(null);
   const [files, dispatchFiles] = useReducer(filesReducer, INIT_FILES_STATE);
-  const [documentRevision, bumpDocumentRevision] = useReducer(
-    (revision) => revision + 1,
-    0,
-  );
   const documentStoreRef = useRef<MonacoDocumentStore | null>(null);
 
   const workspacePromiseRef = useRef<Promise<Workspace> | null>(null);
@@ -56,7 +52,7 @@ export default function Playground() {
         fetched.monaco,
         workspace,
         setError,
-        bumpDocumentRevision,
+        () => dispatchFiles({ type: "documentChanged" }),
       );
       documentStoreRef.current = documentStore;
       restoreWorkspace(
@@ -82,7 +78,7 @@ export default function Playground() {
       : files.metadata[files.selected].name;
   }, [files.metadata, files.selected]);
 
-  usePersistLocally(files, documentStoreRef, documentRevision);
+  usePersistLocally(files, documentStoreRef);
 
   const handleShare = useCallback(async () => {
     const serializedFiles = serializeFiles(files, documentStoreRef.current);
@@ -273,7 +269,7 @@ export default function Playground() {
         tool="ty"
         version={version}
         onChangeTheme={setTheme}
-        edit={files.revision + documentRevision}
+        edit={files.revision}
         onShare={handleShare}
         onCopyMarkdownLink={handleCopyMarkdownLink}
         onCopyMarkdown={handleCopyMarkdown}
@@ -291,7 +287,6 @@ export default function Playground() {
           onRenameFile={handleFileRenamed}
           onRemoveFile={handleFileRemoved}
           onSelectFile={handleFileSelected}
-          documentRevision={documentRevision}
           onRun={handleRun}
           onSelectVendoredFile={handleVendoredFileSelected}
           onClearVendoredFile={handleVendoredFileCleared}
@@ -362,17 +357,15 @@ const DEFAULT_WORKSPACE = {
 function usePersistLocally(
   files: FilesState,
   documentStoreRef: RefObject<MonacoDocumentStore | null>,
-  documentRevision: number,
 ): void {
   const deferredFiles = useDeferredValue(files);
-  const deferredDocumentRevision = useDeferredValue(documentRevision);
 
   useEffect(() => {
     const serialized = serializeFiles(deferredFiles, documentStoreRef.current);
     if (serialized != null) {
       persistLocal(serialized);
     }
-  }, [deferredFiles, deferredDocumentRevision, documentStoreRef]);
+  }, [deferredFiles, documentStoreRef]);
 }
 
 export type FileId = number;
@@ -405,7 +398,7 @@ interface FilesState {
   metadata: FileMetadata;
 
   /**
-   * The revision. Gets incremented every time files changes.
+   * Invalidation token for file metadata changes and document content changes.
    */
   revision: number;
 
@@ -444,6 +437,7 @@ export type FileAction =
     }
   | { type: "selectFile"; id: FileId }
   | { type: "selectFileByName"; name: string }
+  | { type: "documentChanged" }
   | { type: "reset" }
   | {
       type: "selectVendoredFile";
@@ -516,6 +510,7 @@ function filesReducer(
           ...state.metadata,
           [id]: { ...file, name: to, uri: newUri, handle: newHandle },
         },
+        revision: state.revision + 1,
       };
     }
 
@@ -547,6 +542,13 @@ function filesReducer(
       return {
         ...INIT_FILES_STATE,
         playgroundRevision: state.playgroundRevision + 1,
+        revision: state.revision + 1,
+      };
+    }
+
+    case "documentChanged": {
+      return {
+        ...state,
         revision: state.revision + 1,
       };
     }
@@ -686,7 +688,9 @@ class MonacoDocumentStore {
     content: string,
     handle: FileHandle | null,
   ): editor.ITextModel {
-    this.closeDocument(name);
+    if (this.model(name) != null) {
+      throw new Error(`Document ${name} is already open`);
+    }
 
     const model = this.monaco.editor.createModel(
       content,
@@ -705,9 +709,7 @@ class MonacoDocumentStore {
   ): editor.ITextModel {
     const content = this.text(oldName) ?? "";
     this.closeDocument(oldName);
-    const model = this.openDocument(newName, content, newHandle);
-    this.onChanged();
-    return model;
+    return this.openDocument(newName, content, newHandle);
   }
 
   closeDocument(name: string): void {

--- a/playground/ty/src/Playground.tsx
+++ b/playground/ty/src/Playground.tsx
@@ -72,34 +72,34 @@ export default function Playground() {
   usePersistLocally(files, session);
 
   const handleShare = useCallback(async () => {
-    const serializedFiles = serializeFiles(files, session);
+    const serialized = serializeFiles(files, session);
 
-    if (serializedFiles != null) {
-      await persist(serializedFiles);
+    if (serialized != null) {
+      await persist(serialized);
     }
   }, [session, files]);
 
   const handleCopyMarkdown = useCallback(async () => {
-    const serializedFiles = serializeFiles(files, session);
+    const serialized = serializeFiles(files, session);
 
-    if (serializedFiles != null) {
-      await copyAsMarkdown(serializedFiles);
+    if (serialized != null) {
+      await copyAsMarkdown(serialized);
     }
   }, [session, files]);
 
   const handleCopyMarkdownLink = useCallback(async () => {
-    const serializedFiles = serializeFiles(files, session);
+    const serialized = serializeFiles(files, session);
 
-    if (serializedFiles != null) {
-      await copyAsMarkdownLink(serializedFiles);
+    if (serialized != null) {
+      await copyAsMarkdownLink(serialized);
     }
   }, [session, files]);
 
   const handleDownload = useCallback(async () => {
-    const serializedFiles = serializeFiles(files, session);
+    const serialized = serializeFiles(files, session);
 
-    if (serializedFiles != null) {
-      const downloadFiles = { ...serializedFiles.files };
+    if (serialized != null) {
+      const downloadFiles = { ...serialized.files };
 
       if (SETTINGS_FILE_NAME in downloadFiles) {
         try {
@@ -119,8 +119,8 @@ export default function Playground() {
   }, [session, files]);
 
   const handleRun = useCallback(async () => {
-    const serializedFiles = serializeFiles(files, session);
-    return serializedFiles == null ? "" : runPython(serializedFiles);
+    const serialized = serializeFiles(files, session);
+    return serialized == null ? "" : runPython(serialized);
   }, [session, files]);
 
   const handleFileAdded = useCallback(
@@ -681,7 +681,7 @@ export class PlaygroundSession {
       languageForFile(handle ?? name),
       this.uri(name),
     );
-    this.registerWorkspaceSync(name, handle, model);
+    this.registerModelChanged(name, handle, model);
 
     return model;
   }
@@ -710,7 +710,7 @@ export class PlaygroundSession {
     return this.model(name)?.getValue() ?? null;
   }
 
-  private registerWorkspaceSync(
+  private registerModelChanged(
     name: string,
     handle: FileHandle | null,
     model: editor.ITextModel,

--- a/playground/ty/src/Playground.tsx
+++ b/playground/ty/src/Playground.tsx
@@ -31,7 +31,7 @@ import Chrome, { formatError } from "./Editor/Chrome";
 import { isPythonFile } from "./Editor/Files";
 import { runPython } from "./Editor/runPython";
 import type { Monaco } from "@monaco-editor/react";
-import type { editor } from "monaco-editor";
+import type { editor, Uri } from "monaco-editor";
 
 export const SETTINGS_FILE_NAME = "ty.json";
 
@@ -150,8 +150,13 @@ export default function Playground() {
       handle = workspace.openFile(name, "");
     }
 
-    documentStore.openDocument(name, "", handle);
-    dispatchFiles({ type: "add", name, handle });
+    const model = documentStore.openDocument(name, "", handle);
+    dispatchFiles({
+      type: "add",
+      name,
+      uri: model.uri,
+      handle,
+    });
   }, []);
 
   const handleFileRenamed = useCallback(
@@ -187,8 +192,14 @@ export default function Playground() {
         newHandle = workspace.openFile(newName, content);
       }
 
-      documentStore.renameDocument(oldName, newName, newHandle);
-      dispatchFiles({ type: "rename", id: file, to: newName, newHandle });
+      const model = documentStore.renameDocument(oldName, newName, newHandle);
+      dispatchFiles({
+        type: "rename",
+        id: file,
+        to: newName,
+        newUri: model.uri,
+        newHandle,
+      });
     },
     [files.metadata],
   );
@@ -369,6 +380,7 @@ export type FileId = number;
 export interface PlaygroundFile {
   id: FileId;
   name: string;
+  uri: Readonly<Uri>;
   handle: FileHandle | null;
 }
 
@@ -417,8 +429,15 @@ export type FileAction =
       handle: FileHandle | null;
       /// The file name
       name: string;
+      uri: Readonly<Uri>;
     }
-  | { type: "rename"; id: FileId; to: string; newHandle: FileHandle | null }
+  | {
+      type: "rename";
+      id: FileId;
+      to: string;
+      newUri: Readonly<Uri>;
+      newHandle: FileHandle | null;
+    }
   | {
       type: "remove";
       id: FileId;
@@ -448,13 +467,13 @@ function filesReducer(
 ): FilesState {
   switch (action.type) {
     case "add": {
-      const { handle, name } = action;
+      const { handle, name, uri } = action;
       const id = state.nextId;
       return {
         ...state,
         selected: id,
         order: [...state.order, id],
-        metadata: { ...state.metadata, [id]: { id, name, handle } },
+        metadata: { ...state.metadata, [id]: { id, name, uri, handle } },
         nextId: state.nextId + 1,
         revision: state.revision + 1,
         currentVendoredFile: null, // Clear vendored file when adding new file
@@ -488,14 +507,14 @@ function filesReducer(
       };
     }
     case "rename": {
-      const { id, to, newHandle } = action;
+      const { id, to, newUri, newHandle } = action;
       const file = state.metadata[id];
 
       return {
         ...state,
         metadata: {
           ...state.metadata,
-          [id]: { ...file, name: to, handle: newHandle },
+          [id]: { ...file, name: to, uri: newUri, handle: newHandle },
         },
       };
     }
@@ -784,8 +803,13 @@ function restoreWorkspace(
       handle = workspace.openFile(name, content);
     }
 
-    documentStore.openDocument(name, content, handle);
-    dispatchFiles({ type: "add", handle, name });
+    const model = documentStore.openDocument(name, content, handle);
+    dispatchFiles({
+      type: "add",
+      handle,
+      name,
+      uri: model.uri,
+    });
   }
 
   if (!hasSettings) {

--- a/playground/ty/src/Playground.tsx
+++ b/playground/ty/src/Playground.tsx
@@ -29,6 +29,7 @@ import { loader } from "@monaco-editor/react";
 import tySchema from "../../../ty.schema.json";
 import Chrome, { formatError } from "./Editor/Chrome";
 import { isPythonFile } from "./Editor/Files";
+import { runPython } from "./Editor/runPython";
 import type { Monaco } from "@monaco-editor/react";
 import type { editor } from "monaco-editor";
 
@@ -76,10 +77,10 @@ export default function Playground() {
   const workspacePromise = workspacePromiseRef.current;
 
   const fileName = useMemo(() => {
-    return (
-      files.index.find((file) => file.id === files.selected)?.name ?? "lib.py"
-    );
-  }, [files.index, files.selected]);
+    return files.selected == null
+      ? "lib.py"
+      : files.metadata[files.selected].name;
+  }, [files.metadata, files.selected]);
 
   usePersistLocally(files, documentStoreRef, documentRevision);
 
@@ -169,13 +170,10 @@ export default function Playground() {
         return;
       }
 
-      const oldName = files.index.find(({ id }) => id === file)?.name;
-      if (oldName == null) {
-        return;
-      }
-
+      const oldFile = files.metadata[file];
+      const oldName = oldFile.name;
       const content = documentStore.text(oldName) ?? "";
-      const handle = files.handles[file];
+      const handle = oldFile.handle;
       let newHandle: FileHandle | null = null;
       if (handle == null) {
         updateOptions(workspace, null, setError);
@@ -192,26 +190,24 @@ export default function Playground() {
       documentStore.renameDocument(oldName, newName, newHandle);
       dispatchFiles({ type: "rename", id: file, to: newName, newHandle });
     },
-    [files.handles, files.index],
+    [files.metadata],
   );
 
   const handleFileRemoved = useCallback(
     (workspace: Workspace, file: FileId) => {
       const documentStore = documentStoreRef.current;
-      const name = files.index.find(({ id }) => id === file)?.name;
-      const handle = files.handles[file];
+      const removedFile = files.metadata[file];
+      const { handle, name } = removedFile;
       if (handle == null) {
         updateOptions(workspace, null, setError);
       } else {
         workspace.closeFile(handle);
       }
 
-      if (name != null) {
-        documentStore?.closeDocument(name);
-      }
+      documentStore?.closeDocument(name);
       dispatchFiles({ type: "remove", id: file });
     },
-    [files.handles, files.index],
+    [files.metadata],
   );
 
   const handleFileSelected = useCallback((file: FileId) => {
@@ -232,12 +228,10 @@ export default function Playground() {
     }
 
     // Close all open files
-    for (const file of files.index) {
-      const handle = files.handles[file.id];
-
-      if (handle != null) {
+    for (const file of Object.values(files.metadata)) {
+      if (file.handle != null) {
         try {
-          workspace.closeFile(handle);
+          workspace.closeFile(file.handle);
         } catch (e) {
           setError(formatError(e));
         }
@@ -245,7 +239,7 @@ export default function Playground() {
     }
 
     documentStoreRef.current?.closeDocuments(
-      files.index.map((file) => file.name),
+      Object.values(files.metadata).map((file) => file.name),
     );
     dispatchFiles({ type: "reset" });
 
@@ -259,7 +253,7 @@ export default function Playground() {
         setError,
       );
     }
-  }, [files.handles, files.index, workspace]);
+  }, [files, workspace]);
 
   return (
     <main className="flex flex-col h-full bg-ayu-background dark:bg-ayu-background-dark">
@@ -372,6 +366,14 @@ function usePersistLocally(
 
 export type FileId = number;
 
+export interface PlaygroundFile {
+  id: FileId;
+  name: string;
+  handle: FileHandle | null;
+}
+
+export type FileMetadata = Readonly<Record<FileId, PlaygroundFile>>;
+
 export type ReadonlyFiles = Readonly<FilesState>;
 
 interface FilesState {
@@ -383,15 +385,12 @@ interface FilesState {
   /**
    * The files in display order (ordering is sensitive)
    */
-  index: ReadonlyArray<{ id: FileId; name: string }>;
+  order: ReadonlyArray<FileId>;
 
   /**
-   * The database file handles by file id.
-   *
-   * Files without a file handle are well-known files that are only handled by the
-   * playground (e.g. ty.json)
+   * File metadata by file id.
    */
-  handles: Readonly<{ [id: FileId]: FileHandle | null }>;
+  metadata: FileMetadata;
 
   /**
    * The revision. Gets incremented every time files changes.
@@ -434,8 +433,8 @@ export type FileAction =
   | { type: "clearVendoredFile" };
 
 const INIT_FILES_STATE: ReadonlyFiles = {
-  index: [],
-  handles: Object.create(null),
+  order: [],
+  metadata: Object.create(null),
   nextId: 0,
   revision: 0,
   selected: null,
@@ -454,8 +453,8 @@ function filesReducer(
       return {
         ...state,
         selected: id,
-        index: [...state.index, { id, name }],
-        handles: { ...state.handles, [id]: handle },
+        order: [...state.order, id],
+        metadata: { ...state.metadata, [id]: { id, name, handle } },
         nextId: state.nextId + 1,
         revision: state.revision + 1,
         currentVendoredFile: null, // Clear vendored file when adding new file
@@ -465,38 +464,39 @@ function filesReducer(
     case "remove": {
       const { id } = action;
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { [id]: _handle, ...handles } = state.handles;
-
       let selected = state.selected;
 
       if (state.selected === id) {
-        const index = state.index.findIndex((file) => file.id === id);
+        const position = state.order.indexOf(id);
 
         selected =
-          index > 0 ? state.index[index - 1].id : state.index[index + 1].id;
+          (position > 0
+            ? state.order[position - 1]
+            : state.order[position + 1]) ?? null;
       }
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [id]: _metadata, ...metadata } = state.metadata;
 
       return {
         ...state,
         selected,
-        index: state.index.filter((file) => file.id !== id),
-        handles,
+        order: state.order.filter((fileId) => fileId !== id),
+        metadata,
         revision: state.revision + 1,
         currentVendoredFile: null, // Clear vendored file when removing file
       };
     }
     case "rename": {
       const { id, to, newHandle } = action;
-
-      const index = state.index.findIndex((file) => file.id === id);
-      const newIndex = [...state.index];
-      newIndex.splice(index, 1, { id, name: to });
+      const file = state.metadata[id];
 
       return {
         ...state,
-        index: newIndex,
-        handles: { ...state.handles, [id]: newHandle },
+        metadata: {
+          ...state.metadata,
+          [id]: { ...file, name: to, handle: newHandle },
+        },
       };
     }
 
@@ -513,12 +513,13 @@ function filesReducer(
     case "selectFileByName": {
       const { name } = action;
 
-      const selected =
-        state.index.find((file) => file.name === name)?.id ?? null;
+      const selected = state.order.find(
+        (id) => state.metadata[id].name === name,
+      );
 
       return {
         ...state,
-        selected,
+        selected: selected ?? null,
         currentVendoredFile: null, // Clear vendored file when selecting regular file
       };
     }
@@ -565,7 +566,8 @@ function serializeFiles(
   const serializedFiles = Object.create(null);
   let selected = null;
 
-  for (const { id, name } of files.index) {
+  for (const id of files.order) {
+    const { name } = files.metadata[id];
     const text = documentStore.text(name);
     if (text == null) {
       return null;
@@ -583,67 +585,6 @@ function serializeFiles(
   }
 
   return { files: serializedFiles, current: selected };
-}
-
-const SANDBOX_BASE_DIRECTORY = "/playground/";
-
-async function runPython(workspace: SerializedFiles): Promise<string> {
-  const { loadPyodide } = await import("pyodide");
-  const pyodide = await loadPyodide({
-    env: {
-      HOME: SANDBOX_BASE_DIRECTORY,
-    },
-  });
-
-  let combinedOutput = "";
-
-  const outputHandler = (output: string) => {
-    combinedOutput += output + "\n";
-  };
-
-  pyodide.setStdout({ batched: outputHandler });
-  pyodide.setStderr({ batched: outputHandler });
-
-  for (const [fileName, content] of Object.entries(workspace.files)) {
-    const lastSeparator = fileName.lastIndexOf("/");
-
-    if (lastSeparator !== -1) {
-      const directory =
-        SANDBOX_BASE_DIRECTORY + fileName.slice(0, lastSeparator);
-      pyodide.FS.mkdirTree(directory);
-    }
-
-    pyodide.FS.writeFile(SANDBOX_BASE_DIRECTORY + fileName, content);
-  }
-
-  const dict = pyodide.globals.get("dict");
-  const globals = dict();
-
-  try {
-    // Patch `reveal_type` to print runtime values
-    pyodide.runPython(`
-        import builtins
-
-        def reveal_type(obj):
-          import typing
-          print(f"Runtime value is '{obj}'")
-          return typing.reveal_type(obj)
-
-        builtins.reveal_type = reveal_type`);
-
-    pyodide.runPython(workspace.files[workspace.current] ?? "", {
-      globals,
-      locals: globals,
-      filename: workspace.current,
-    });
-
-    return combinedOutput;
-  } catch (error) {
-    return `Failed to run Python script: ${error}`;
-  } finally {
-    globals.destroy();
-    dict.destroy();
-  }
 }
 
 export interface InitializedPlayground {
@@ -795,7 +736,9 @@ class MonacoDocumentStore {
 
 function languageForFile(file: FileHandle | string): string | undefined {
   if (typeof file === "string") {
-    return file.endsWith(".py") || file.endsWith(".pyi") || file.endsWith(".pyw")
+    return file.endsWith(".py") ||
+      file.endsWith(".pyi") ||
+      file.endsWith(".pyw")
       ? "python"
       : undefined;
   }

--- a/playground/ty/src/Playground.tsx
+++ b/playground/ty/src/Playground.tsx
@@ -1,5 +1,6 @@
 import {
   ActionDispatch,
+  RefObject,
   Suspense,
   useCallback,
   useDeferredValue,
@@ -27,6 +28,9 @@ import {
 import { loader } from "@monaco-editor/react";
 import tySchema from "../../../ty.schema.json";
 import Chrome, { formatError } from "./Editor/Chrome";
+import { isPythonFile } from "./Editor/Files";
+import type { Monaco } from "@monaco-editor/react";
+import type { editor } from "monaco-editor";
 
 export const SETTINGS_FILE_NAME = "ty.json";
 
@@ -36,13 +40,31 @@ export default function Playground() {
   const [error, setError] = useState<string | null>(null);
   const [workspace, setWorkspace] = useState<Workspace | null>(null);
   const [files, dispatchFiles] = useReducer(filesReducer, INIT_FILES_STATE);
+  const [documentRevision, bumpDocumentRevision] = useReducer(
+    (revision) => revision + 1,
+    0,
+  );
+  const documentStoreRef = useRef<MonacoDocumentStore | null>(null);
 
   const workspacePromiseRef = useRef<Promise<Workspace> | null>(null);
   if (workspacePromiseRef.current == null) {
     workspacePromiseRef.current = startPlayground().then((fetched) => {
       setVersion(fetched.version);
       const workspace = new Workspace("/", PositionEncoding.Utf16, {});
-      restoreWorkspace(workspace, fetched.workspace, dispatchFiles, setError);
+      const documentStore = new MonacoDocumentStore(
+        fetched.monaco,
+        workspace,
+        setError,
+        bumpDocumentRevision,
+      );
+      documentStoreRef.current = documentStore;
+      restoreWorkspace(
+        workspace,
+        documentStore,
+        fetched.workspace,
+        dispatchFiles,
+        setError,
+      );
       setWorkspace(workspace);
       return workspace;
     });
@@ -59,37 +81,37 @@ export default function Playground() {
     );
   }, [files.index, files.selected]);
 
-  usePersistLocally(files);
+  usePersistLocally(files, documentStoreRef, documentRevision);
 
   const handleShare = useCallback(async () => {
-    const serialized = serializeFiles(files);
+    const serializedFiles = serializeFiles(files, documentStoreRef.current);
 
-    if (serialized != null) {
-      await persist(serialized);
+    if (serializedFiles != null) {
+      await persist(serializedFiles);
     }
   }, [files]);
 
   const handleCopyMarkdown = useCallback(async () => {
-    const serialized = serializeFiles(files);
+    const serializedFiles = serializeFiles(files, documentStoreRef.current);
 
-    if (serialized != null) {
-      await copyAsMarkdown(serialized);
+    if (serializedFiles != null) {
+      await copyAsMarkdown(serializedFiles);
     }
   }, [files]);
 
   const handleCopyMarkdownLink = useCallback(async () => {
-    const serialized = serializeFiles(files);
+    const serializedFiles = serializeFiles(files, documentStoreRef.current);
 
-    if (serialized != null) {
-      await copyAsMarkdownLink(serialized);
+    if (serializedFiles != null) {
+      await copyAsMarkdownLink(serializedFiles);
     }
   }, [files]);
 
   const handleDownload = useCallback(async () => {
-    const serialized = serializeFiles(files);
+    const serializedFiles = serializeFiles(files, documentStoreRef.current);
 
-    if (serialized != null) {
-      const downloadFiles = { ...serialized.files };
+    if (serializedFiles != null) {
+      const downloadFiles = { ...serializedFiles.files };
 
       if (SETTINGS_FILE_NAME in downloadFiles) {
         try {
@@ -107,7 +129,18 @@ export default function Playground() {
       await downloadZip(downloadFiles, "ty-playground");
     }
   }, [files]);
+
+  const handleRun = useCallback(async () => {
+    const serializedFiles = serializeFiles(files, documentStoreRef.current);
+    return serializedFiles == null ? "" : runPython(serializedFiles);
+  }, [files]);
+
   const handleFileAdded = useCallback((workspace: Workspace, name: string) => {
+    const documentStore = documentStoreRef.current;
+    if (documentStore == null) {
+      return;
+    }
+
     let handle = null;
 
     if (name === SETTINGS_FILE_NAME) {
@@ -116,31 +149,9 @@ export default function Playground() {
       handle = workspace.openFile(name, "");
     }
 
-    dispatchFiles({ type: "add", name, handle, content: "" });
+    documentStore.openDocument(name, "", handle);
+    dispatchFiles({ type: "add", name, handle });
   }, []);
-
-  const handleFileChanged = useCallback(
-    (workspace: Workspace, content: string) => {
-      if (files.selected == null) {
-        return;
-      }
-
-      const handle = files.handles[files.selected];
-
-      if (handle != null) {
-        updateFile(workspace, handle, content, setError);
-      } else if (fileName === SETTINGS_FILE_NAME) {
-        updateOptions(workspace, content, setError);
-      }
-
-      dispatchFiles({
-        type: "change",
-        id: files.selected,
-        content,
-      });
-    },
-    [fileName, files.handles, files.selected],
-  );
 
   const handleFileRenamed = useCallback(
     (workspace: Workspace, file: FileId, newName: string) => {
@@ -153,6 +164,17 @@ export default function Playground() {
         return;
       }
 
+      const documentStore = documentStoreRef.current;
+      if (documentStore == null) {
+        return;
+      }
+
+      const oldName = files.index.find(({ id }) => id === file)?.name;
+      if (oldName == null) {
+        return;
+      }
+
+      const content = documentStore.text(oldName) ?? "";
       const handle = files.handles[file];
       let newHandle: FileHandle | null = null;
       if (handle == null) {
@@ -162,18 +184,21 @@ export default function Playground() {
       }
 
       if (newName === SETTINGS_FILE_NAME) {
-        updateOptions(workspace, files.contents[file], setError);
+        updateOptions(workspace, content, setError);
       } else {
-        newHandle = workspace.openFile(newName, files.contents[file]);
+        newHandle = workspace.openFile(newName, content);
       }
 
+      documentStore.renameDocument(oldName, newName, newHandle);
       dispatchFiles({ type: "rename", id: file, to: newName, newHandle });
     },
-    [files.contents, files.handles],
+    [files.handles, files.index],
   );
 
   const handleFileRemoved = useCallback(
     (workspace: Workspace, file: FileId) => {
+      const documentStore = documentStoreRef.current;
+      const name = files.index.find(({ id }) => id === file)?.name;
       const handle = files.handles[file];
       if (handle == null) {
         updateOptions(workspace, null, setError);
@@ -181,9 +206,12 @@ export default function Playground() {
         workspace.closeFile(handle);
       }
 
+      if (name != null) {
+        documentStore?.closeDocument(name);
+      }
       dispatchFiles({ type: "remove", id: file });
     },
-    [files.handles],
+    [files.handles, files.index],
   );
 
   const handleFileSelected = useCallback((file: FileId) => {
@@ -216,9 +244,21 @@ export default function Playground() {
       }
     }
 
+    documentStoreRef.current?.closeDocuments(
+      files.index.map((file) => file.name),
+    );
     dispatchFiles({ type: "reset" });
 
-    restoreWorkspace(workspace, DEFAULT_WORKSPACE, dispatchFiles, setError);
+    const documentStore = documentStoreRef.current;
+    if (documentStore != null) {
+      restoreWorkspace(
+        workspace,
+        documentStore,
+        DEFAULT_WORKSPACE,
+        dispatchFiles,
+        setError,
+      );
+    }
   }, [files.handles, files.index, workspace]);
 
   return (
@@ -228,7 +268,7 @@ export default function Playground() {
         tool="ty"
         version={version}
         onChangeTheme={setTheme}
-        edit={files.revision}
+        edit={files.revision + documentRevision}
         onShare={handleShare}
         onCopyMarkdownLink={handleCopyMarkdownLink}
         onCopyMarkdown={handleCopyMarkdown}
@@ -246,7 +286,8 @@ export default function Playground() {
           onRenameFile={handleFileRenamed}
           onRemoveFile={handleFileRemoved}
           onSelectFile={handleFileSelected}
-          onChangeFile={handleFileChanged}
+          documentRevision={documentRevision}
+          onRun={handleRun}
           onSelectVendoredFile={handleVendoredFileSelected}
           onClearVendoredFile={handleVendoredFileCleared}
         />
@@ -313,15 +354,20 @@ const DEFAULT_WORKSPACE = {
 /**
  * Persists the files to local storage. This is done deferred to avoid too frequent writes.
  */
-function usePersistLocally(files: FilesState): void {
+function usePersistLocally(
+  files: FilesState,
+  documentStoreRef: RefObject<MonacoDocumentStore | null>,
+  documentRevision: number,
+): void {
   const deferredFiles = useDeferredValue(files);
+  const deferredDocumentRevision = useDeferredValue(documentRevision);
 
   useEffect(() => {
-    const serialized = serializeFiles(deferredFiles);
+    const serialized = serializeFiles(deferredFiles, documentStoreRef.current);
     if (serialized != null) {
       persistLocal(serialized);
     }
-  }, [deferredFiles]);
+  }, [deferredFiles, deferredDocumentRevision, documentStoreRef]);
 }
 
 export type FileId = number;
@@ -348,11 +394,6 @@ interface FilesState {
   handles: Readonly<{ [id: FileId]: FileHandle | null }>;
 
   /**
-   * The content per file indexed by file id.
-   */
-  contents: Readonly<{ [id: FileId]: string }>;
-
-  /**
    * The revision. Gets incremented every time files changes.
    */
   revision: number;
@@ -377,12 +418,6 @@ export type FileAction =
       handle: FileHandle | null;
       /// The file name
       name: string;
-      content: string;
-    }
-  | {
-      type: "change";
-      id: FileId;
-      content: string;
     }
   | { type: "rename"; id: FileId; to: string; newHandle: FileHandle | null }
   | {
@@ -400,7 +435,6 @@ export type FileAction =
 
 const INIT_FILES_STATE: ReadonlyFiles = {
   index: [],
-  contents: Object.create(null),
   handles: Object.create(null),
   nextId: 0,
   revision: 0,
@@ -415,34 +449,22 @@ function filesReducer(
 ): FilesState {
   switch (action.type) {
     case "add": {
-      const { handle, name, content } = action;
+      const { handle, name } = action;
       const id = state.nextId;
       return {
         ...state,
         selected: id,
         index: [...state.index, { id, name }],
         handles: { ...state.handles, [id]: handle },
-        contents: { ...state.contents, [id]: content },
         nextId: state.nextId + 1,
         revision: state.revision + 1,
         currentVendoredFile: null, // Clear vendored file when adding new file
       };
     }
 
-    case "change": {
-      const { id, content } = action;
-      return {
-        ...state,
-        contents: { ...state.contents, [id]: content },
-        revision: state.revision + 1,
-      };
-    }
-
     case "remove": {
       const { id } = action;
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { [id]: _content, ...contents } = state.contents;
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { [id]: _handle, ...handles } = state.handles;
 
@@ -459,7 +481,6 @@ function filesReducer(
         ...state,
         selected,
         index: state.index.filter((file) => file.id !== id),
-        contents,
         handles,
         revision: state.revision + 1,
         currentVendoredFile: null, // Clear vendored file when removing file
@@ -528,15 +549,29 @@ function filesReducer(
   }
 }
 
-function serializeFiles(files: FilesState): {
+export interface SerializedFiles {
   files: { [name: string]: string };
   current: string;
-} | null {
+}
+
+function serializeFiles(
+  files: FilesState,
+  documentStore: MonacoDocumentStore | null,
+): SerializedFiles | null {
+  if (documentStore == null) {
+    return null;
+  }
+
   const serializedFiles = Object.create(null);
   let selected = null;
 
   for (const { id, name } of files.index) {
-    serializedFiles[name] = files.contents[id];
+    const text = documentStore.text(name);
+    if (text == null) {
+      return null;
+    }
+
+    serializedFiles[name] = text;
 
     if (files.selected === id) {
       selected = name;
@@ -550,8 +585,70 @@ function serializeFiles(files: FilesState): {
   return { files: serializedFiles, current: selected };
 }
 
+const SANDBOX_BASE_DIRECTORY = "/playground/";
+
+async function runPython(workspace: SerializedFiles): Promise<string> {
+  const { loadPyodide } = await import("pyodide");
+  const pyodide = await loadPyodide({
+    env: {
+      HOME: SANDBOX_BASE_DIRECTORY,
+    },
+  });
+
+  let combinedOutput = "";
+
+  const outputHandler = (output: string) => {
+    combinedOutput += output + "\n";
+  };
+
+  pyodide.setStdout({ batched: outputHandler });
+  pyodide.setStderr({ batched: outputHandler });
+
+  for (const [fileName, content] of Object.entries(workspace.files)) {
+    const lastSeparator = fileName.lastIndexOf("/");
+
+    if (lastSeparator !== -1) {
+      const directory =
+        SANDBOX_BASE_DIRECTORY + fileName.slice(0, lastSeparator);
+      pyodide.FS.mkdirTree(directory);
+    }
+
+    pyodide.FS.writeFile(SANDBOX_BASE_DIRECTORY + fileName, content);
+  }
+
+  const dict = pyodide.globals.get("dict");
+  const globals = dict();
+
+  try {
+    // Patch `reveal_type` to print runtime values
+    pyodide.runPython(`
+        import builtins
+
+        def reveal_type(obj):
+          import typing
+          print(f"Runtime value is '{obj}'")
+          return typing.reveal_type(obj)
+
+        builtins.reveal_type = reveal_type`);
+
+    pyodide.runPython(workspace.files[workspace.current] ?? "", {
+      globals,
+      locals: globals,
+      filename: workspace.current,
+    });
+
+    return combinedOutput;
+  } catch (error) {
+    return `Failed to run Python script: ${error}`;
+  } finally {
+    globals.destroy();
+    dict.destroy();
+  }
+}
+
 export interface InitializedPlayground {
   version: string;
+  monaco: Monaco;
   workspace: { files: { [name: string]: string }; current: string };
 }
 
@@ -581,6 +678,7 @@ async function startPlayground(): Promise<InitializedPlayground> {
 
   return {
     version,
+    monaco,
     workspace,
   };
 }
@@ -615,6 +713,96 @@ function updateFile(
   }
 }
 
+class MonacoDocumentStore {
+  constructor(
+    private monaco: Monaco,
+    private workspace: Workspace,
+    private setError: (error: string | null) => void,
+    private onChanged: () => void,
+  ) {}
+
+  openDocument(
+    name: string,
+    content: string,
+    handle: FileHandle | null,
+  ): editor.ITextModel {
+    this.closeDocument(name);
+
+    const model = this.monaco.editor.createModel(
+      content,
+      languageForFile(handle ?? name),
+      this.uri(name),
+    );
+    this.registerWorkspaceSync(name, handle, model);
+
+    return model;
+  }
+
+  renameDocument(
+    oldName: string,
+    newName: string,
+    newHandle: FileHandle | null,
+  ): editor.ITextModel {
+    const content = this.text(oldName) ?? "";
+    this.closeDocument(oldName);
+    const model = this.openDocument(newName, content, newHandle);
+    this.onChanged();
+    return model;
+  }
+
+  closeDocument(name: string): void {
+    this.model(name)?.dispose();
+  }
+
+  closeDocuments(names: Iterable<string>): void {
+    for (const name of names) {
+      this.closeDocument(name);
+    }
+  }
+
+  text(name: string): string | null {
+    return this.model(name)?.getValue() ?? null;
+  }
+
+  private registerWorkspaceSync(
+    name: string,
+    handle: FileHandle | null,
+    model: editor.ITextModel,
+  ): void {
+    const syncDisposable = model.onDidChangeContent(() => {
+      const content = model.getValue();
+
+      if (handle != null) {
+        updateFile(this.workspace, handle, content, this.setError);
+      } else if (name === SETTINGS_FILE_NAME) {
+        updateOptions(this.workspace, content, this.setError);
+      }
+
+      this.onChanged();
+    });
+
+    model.onWillDispose(() => syncDisposable.dispose());
+  }
+
+  private model(name: string): editor.ITextModel | null {
+    return this.monaco.editor.getModel(this.uri(name));
+  }
+
+  private uri(name: string) {
+    return this.monaco.Uri.parse(name);
+  }
+}
+
+function languageForFile(file: FileHandle | string): string | undefined {
+  if (typeof file === "string") {
+    return file.endsWith(".py") || file.endsWith(".pyi") || file.endsWith(".pyw")
+      ? "python"
+      : undefined;
+  }
+
+  return isPythonFile(file) ? "python" : undefined;
+}
+
 function Loading() {
   return (
     <div className="align-middle text-current text-center my-2 dark:text-white">
@@ -625,6 +813,7 @@ function Loading() {
 
 function restoreWorkspace(
   workspace: Workspace,
+  documentStore: MonacoDocumentStore,
   state: {
     files: { [name: string]: string };
     current: string;
@@ -652,7 +841,8 @@ function restoreWorkspace(
       handle = workspace.openFile(name, content);
     }
 
-    dispatchFiles({ type: "add", handle, content, name });
+    documentStore.openDocument(name, content, handle);
+    dispatchFiles({ type: "add", handle, name });
   }
 
   if (!hasSettings) {

--- a/playground/ty/src/Playground.tsx
+++ b/playground/ty/src/Playground.tsx
@@ -1,6 +1,5 @@
 import {
   ActionDispatch,
-  RefObject,
   Suspense,
   useCallback,
   useDeferredValue,
@@ -39,38 +38,30 @@ export default function Playground() {
   const [theme, setTheme] = useTheme();
   const [version, setVersion] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [workspace, setWorkspace] = useState<Workspace | null>(null);
   const [files, dispatchFiles] = useReducer(filesReducer, INIT_FILES_STATE);
-  const documentStoreRef = useRef<MonacoDocumentStore | null>(null);
+  const [session, setSession] = useState<PlaygroundSession | null>(null);
 
-  const workspacePromiseRef = useRef<Promise<Workspace> | null>(null);
-  if (workspacePromiseRef.current == null) {
-    workspacePromiseRef.current = startPlayground().then((fetched) => {
+  const sessionPromiseRef = useRef<Promise<PlaygroundSession> | null>(null);
+  if (sessionPromiseRef.current == null) {
+    sessionPromiseRef.current = startPlayground().then((fetched) => {
       setVersion(fetched.version);
       const workspace = new Workspace("/", PositionEncoding.Utf16, {});
-      const documentStore = new MonacoDocumentStore(
+      const session = new PlaygroundSession(
         fetched.monaco,
         workspace,
         setError,
         () => dispatchFiles({ type: "documentChanged" }),
       );
-      documentStoreRef.current = documentStore;
-      restoreWorkspace(
-        workspace,
-        documentStore,
-        fetched.workspace,
-        dispatchFiles,
-        setError,
-      );
-      setWorkspace(workspace);
-      return workspace;
+      restoreWorkspace(session, fetched.workspace, dispatchFiles, setError);
+      setSession(session);
+      return session;
     });
   }
   // This is safe as this is only called once on startup.
   // We need useRef to avoid duplicate initialization when
   // running locally due to react rendering
   // everything twice in strict mode in debug builds.
-  const workspacePromise = workspacePromiseRef.current;
+  const sessionPromise = sessionPromiseRef.current;
 
   const fileName = useMemo(() => {
     return files.selected == null
@@ -78,34 +69,34 @@ export default function Playground() {
       : files.metadata[files.selected].name;
   }, [files.metadata, files.selected]);
 
-  usePersistLocally(files, documentStoreRef);
+  usePersistLocally(files, session);
 
   const handleShare = useCallback(async () => {
-    const serializedFiles = serializeFiles(files, documentStoreRef.current);
+    const serializedFiles = serializeFiles(files, session);
 
     if (serializedFiles != null) {
       await persist(serializedFiles);
     }
-  }, [files]);
+  }, [session, files]);
 
   const handleCopyMarkdown = useCallback(async () => {
-    const serializedFiles = serializeFiles(files, documentStoreRef.current);
+    const serializedFiles = serializeFiles(files, session);
 
     if (serializedFiles != null) {
       await copyAsMarkdown(serializedFiles);
     }
-  }, [files]);
+  }, [session, files]);
 
   const handleCopyMarkdownLink = useCallback(async () => {
-    const serializedFiles = serializeFiles(files, documentStoreRef.current);
+    const serializedFiles = serializeFiles(files, session);
 
     if (serializedFiles != null) {
       await copyAsMarkdownLink(serializedFiles);
     }
-  }, [files]);
+  }, [session, files]);
 
   const handleDownload = useCallback(async () => {
-    const serializedFiles = serializeFiles(files, documentStoreRef.current);
+    const serializedFiles = serializeFiles(files, session);
 
     if (serializedFiles != null) {
       const downloadFiles = { ...serializedFiles.files };
@@ -125,38 +116,37 @@ export default function Playground() {
 
       await downloadZip(downloadFiles, "ty-playground");
     }
-  }, [files]);
+  }, [session, files]);
 
   const handleRun = useCallback(async () => {
-    const serializedFiles = serializeFiles(files, documentStoreRef.current);
+    const serializedFiles = serializeFiles(files, session);
     return serializedFiles == null ? "" : runPython(serializedFiles);
-  }, [files]);
+  }, [session, files]);
 
-  const handleFileAdded = useCallback((workspace: Workspace, name: string) => {
-    const documentStore = documentStoreRef.current;
-    if (documentStore == null) {
-      return;
-    }
+  const handleFileAdded = useCallback(
+    (session: PlaygroundSession, name: string) => {
+      const workspace = session.workspace;
+      let handle = null;
 
-    let handle = null;
+      if (name === SETTINGS_FILE_NAME) {
+        updateOptions(workspace, "{}", setError);
+      } else {
+        handle = workspace.openFile(name, "");
+      }
 
-    if (name === SETTINGS_FILE_NAME) {
-      updateOptions(workspace, "{}", setError);
-    } else {
-      handle = workspace.openFile(name, "");
-    }
-
-    const model = documentStore.openDocument(name, "", handle);
-    dispatchFiles({
-      type: "add",
-      name,
-      uri: model.uri,
-      handle,
-    });
-  }, []);
+      const model = session.openDocument(name, "", handle);
+      dispatchFiles({
+        type: "add",
+        name,
+        uri: model.uri,
+        handle,
+      });
+    },
+    [],
+  );
 
   const handleFileRenamed = useCallback(
-    (workspace: Workspace, file: FileId, newName: string) => {
+    (session: PlaygroundSession, file: FileId, newName: string) => {
       if (newName.startsWith("/")) {
         setError("File names cannot start with '/'.");
         return;
@@ -166,14 +156,10 @@ export default function Playground() {
         return;
       }
 
-      const documentStore = documentStoreRef.current;
-      if (documentStore == null) {
-        return;
-      }
-
+      const workspace = session.workspace;
       const oldFile = files.metadata[file];
       const oldName = oldFile.name;
-      const content = documentStore.text(oldName) ?? "";
+      const content = session.text(oldName) ?? "";
       const handle = oldFile.handle;
       let newHandle: FileHandle | null = null;
       if (handle == null) {
@@ -188,7 +174,7 @@ export default function Playground() {
         newHandle = workspace.openFile(newName, content);
       }
 
-      const model = documentStore.renameDocument(oldName, newName, newHandle);
+      const model = session.renameDocument(oldName, newName, newHandle);
       dispatchFiles({
         type: "rename",
         id: file,
@@ -201,8 +187,8 @@ export default function Playground() {
   );
 
   const handleFileRemoved = useCallback(
-    (workspace: Workspace, file: FileId) => {
-      const documentStore = documentStoreRef.current;
+    (session: PlaygroundSession, file: FileId) => {
+      const workspace = session.workspace;
       const removedFile = files.metadata[file];
       const { handle, name } = removedFile;
       if (handle == null) {
@@ -211,7 +197,7 @@ export default function Playground() {
         workspace.closeFile(handle);
       }
 
-      documentStore?.closeDocument(name);
+      session.closeDocument(name);
       dispatchFiles({ type: "remove", id: file });
     },
     [files.metadata],
@@ -230,9 +216,11 @@ export default function Playground() {
   }, []);
 
   const handleReset = useCallback(() => {
-    if (workspace == null) {
+    if (session == null) {
       return;
     }
+
+    const workspace = session.workspace;
 
     // Close all open files
     for (const file of Object.values(files.metadata)) {
@@ -245,22 +233,13 @@ export default function Playground() {
       }
     }
 
-    documentStoreRef.current?.closeDocuments(
+    session.closeDocuments(
       Object.values(files.metadata).map((file) => file.name),
     );
     dispatchFiles({ type: "reset" });
 
-    const documentStore = documentStoreRef.current;
-    if (documentStore != null) {
-      restoreWorkspace(
-        workspace,
-        documentStore,
-        DEFAULT_WORKSPACE,
-        dispatchFiles,
-        setError,
-      );
-    }
-  }, [files, workspace]);
+    restoreWorkspace(session, DEFAULT_WORKSPACE, dispatchFiles, setError);
+  }, [session, files]);
 
   return (
     <main className="flex flex-col h-full bg-ayu-background dark:bg-ayu-background-dark">
@@ -274,13 +253,13 @@ export default function Playground() {
         onCopyMarkdownLink={handleCopyMarkdownLink}
         onCopyMarkdown={handleCopyMarkdown}
         onDownload={handleDownload}
-        onReset={workspace == null ? undefined : handleReset}
+        onReset={session == null ? undefined : handleReset}
       />
 
       <Suspense fallback={<Loading />}>
         <Chrome
           files={files}
-          workspacePromise={workspacePromise}
+          sessionPromise={sessionPromise}
           theme={theme}
           selectedFileName={fileName}
           onAddFile={handleFileAdded}
@@ -356,16 +335,16 @@ const DEFAULT_WORKSPACE = {
  */
 function usePersistLocally(
   files: FilesState,
-  documentStoreRef: RefObject<MonacoDocumentStore | null>,
+  session: PlaygroundSession | null,
 ): void {
   const deferredFiles = useDeferredValue(files);
 
   useEffect(() => {
-    const serialized = serializeFiles(deferredFiles, documentStoreRef.current);
+    const serialized = serializeFiles(deferredFiles, session);
     if (serialized != null) {
       persistLocal(serialized);
     }
-  }, [deferredFiles, documentStoreRef]);
+  }, [deferredFiles, session]);
 }
 
 export type FileId = number;
@@ -578,9 +557,9 @@ export interface SerializedFiles {
 
 function serializeFiles(
   files: FilesState,
-  documentStore: MonacoDocumentStore | null,
+  session: PlaygroundSession | null,
 ): SerializedFiles | null {
-  if (documentStore == null) {
+  if (session == null) {
     return null;
   }
 
@@ -589,7 +568,7 @@ function serializeFiles(
 
   for (const id of files.order) {
     const { name } = files.metadata[id];
-    const text = documentStore.text(name);
+    const text = session.text(name);
     if (text == null) {
       return null;
     }
@@ -675,10 +654,15 @@ function updateFile(
   }
 }
 
-class MonacoDocumentStore {
+/**
+ * Owns the mutable playground state: the ty workspace, Monaco models, and the
+ * synchronization from Monaco document edits into the workspace. Immutable UI
+ * metadata, like file names and selection, lives in `FilesState`.
+ */
+export class PlaygroundSession {
   constructor(
     private monaco: Monaco,
-    private workspace: Workspace,
+    readonly workspace: Workspace,
     private setError: (error: string | null) => void,
     private onChanged: () => void,
   ) {}
@@ -776,8 +760,7 @@ function Loading() {
 }
 
 function restoreWorkspace(
-  workspace: Workspace,
-  documentStore: MonacoDocumentStore,
+  session: PlaygroundSession,
   state: {
     files: { [name: string]: string };
     current: string;
@@ -785,6 +768,7 @@ function restoreWorkspace(
   dispatchFiles: ActionDispatch<[FileAction]>,
   setError: (error: string | null) => void,
 ) {
+  const workspace = session.workspace;
   let hasSettings = false;
 
   // eslint-disable-next-line prefer-const
@@ -805,7 +789,7 @@ function restoreWorkspace(
       handle = workspace.openFile(name, content);
     }
 
-    const model = documentStore.openDocument(name, content, handle);
+    const model = session.openDocument(name, content, handle);
     dispatchFiles({
       type: "add",
       handle,


### PR DESCRIPTION
## Summary

This PR refactors the playground's internal state model to use Monaco's state as the source of truth for document state, rather than syncing it with `files.content`. The syncing has become rather awkward, and the current model doesn't scale well to features like renaming, where edits are applied to many documents (all of which need synchronization).

This PR removes `files.content` entirely and instead uses Monaco's state exclusively. The React layer is responsible only for syncing content from Monaco to ty's Workspace. This integration is still somewhat awkward, but it's now at least in a single place.

## Test plan

I performed various operations in the Playground. I didn't test all possible interactions and this is certainly a risky change. But given that we're the main users, I don't think it's worth me trying to test every possible use case.