### PR TITLE
Semantic syntax errors: better error message for global vs parameter

### DIFF
--- a/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_global_parameter.py_3.10.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__semantic_syntax_error_global_parameter.py_3.10.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/linter.rs
 ---
-invalid-syntax: name `a` is parameter and global
+invalid-syntax: name `a` cannot refer to a parameter and a global variable
  --> resources/test/fixtures/semantic_errors/global_parameter.py:2:12
   |
 1 | def f(a):
@@ -11,7 +11,7 @@ invalid-syntax: name `a` is parameter and global
 4 | def g(a):
   |
 
-invalid-syntax: name `a` is parameter and global
+invalid-syntax: name `a` cannot refer to a parameter and a global variable
  --> resources/test/fixtures/semantic_errors/global_parameter.py:6:16
   |
 4 | def g(a):
@@ -22,7 +22,7 @@ invalid-syntax: name `a` is parameter and global
 8 | def h(a):
   |
 
-invalid-syntax: name `a` is parameter and global
+invalid-syntax: name `a` cannot refer to a parameter and a global variable
   --> resources/test/fixtures/semantic_errors/global_parameter.py:14:16
    |
 12 | def i(a):
@@ -33,7 +33,7 @@ invalid-syntax: name `a` is parameter and global
 16 |         pass
    |
 
-invalid-syntax: name `a` is parameter and global
+invalid-syntax: name `a` cannot refer to a parameter and a global variable
   --> resources/test/fixtures/semantic_errors/global_parameter.py:20:12
    |
 18 | def f(a):
@@ -44,7 +44,7 @@ invalid-syntax: name `a` is parameter and global
 22 | def f(a):
    |
 
-invalid-syntax: name `a` is parameter and global
+invalid-syntax: name `a` cannot refer to a parameter and a global variable
   --> resources/test/fixtures/semantic_errors/global_parameter.py:25:12
    |
 23 |     a = 1

--- a/crates/ruff_python_parser/src/semantic_errors.rs
+++ b/crates/ruff_python_parser/src/semantic_errors.rs
@@ -1344,7 +1344,10 @@ impl Display for SemanticSyntaxError {
             SemanticSyntaxErrorKind::BreakOutsideLoop => f.write_str("`break` outside loop"),
             SemanticSyntaxErrorKind::ContinueOutsideLoop => f.write_str("`continue` outside loop"),
             SemanticSyntaxErrorKind::GlobalParameter(name) => {
-                write!(f, "name `{name}` is parameter and global")
+                write!(
+                    f,
+                    "name `{name}` cannot refer to a parameter and a global variable"
+                )
             }
             SemanticSyntaxErrorKind::DifferentMatchPatternBindings => {
                 write!(f, "alternative patterns bind different names")

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
@@ -459,7 +459,7 @@ error[invalid-syntax]: `continue` outside loop
    |
 ```
 
-## name is parameter and global
+## name cannot refer to a parameter and a global variable
 
 ```py
 a = None
@@ -496,7 +496,7 @@ def f(a):
 ```
 
 ```snapshot
-error[invalid-syntax]: name `a` is parameter and global
+error[invalid-syntax]: name `a` cannot refer to a parameter and a global variable
  --> src/mdtest_snippet.py:4:12
   |
 4 |     global a  # snapshot: invalid-syntax
@@ -504,7 +504,7 @@ error[invalid-syntax]: name `a` is parameter and global
   |
 
 
-error[invalid-syntax]: name `a` is parameter and global
+error[invalid-syntax]: name `a` cannot refer to a parameter and a global variable
  --> src/mdtest_snippet.py:8:16
   |
 8 |         global a  # snapshot: invalid-syntax
@@ -512,7 +512,7 @@ error[invalid-syntax]: name `a` is parameter and global
   |
 
 
-error[invalid-syntax]: name `a` is parameter and global
+error[invalid-syntax]: name `a` cannot refer to a parameter and a global variable
   --> src/mdtest_snippet.py:16:16
    |
 16 |         global a  # snapshot: invalid-syntax
@@ -520,7 +520,7 @@ error[invalid-syntax]: name `a` is parameter and global
    |
 
 
-error[invalid-syntax]: name `a` is parameter and global
+error[invalid-syntax]: name `a` cannot refer to a parameter and a global variable
   --> src/mdtest_snippet.py:22:12
    |
 22 |     global a  # snapshot: invalid-syntax
@@ -528,7 +528,7 @@ error[invalid-syntax]: name `a` is parameter and global
    |
 
 
-error[invalid-syntax]: name `a` is parameter and global
+error[invalid-syntax]: name `a` cannot refer to a parameter and a global variable
   --> src/mdtest_snippet.py:27:12
    |
 27 |     global a  # snapshot: invalid-syntax


### PR DESCRIPTION
## Summary

This is an attempt to improve the error message for something like
```py
a = 1

def f(a):
    global a
```

I realize that the previous wording ("name 'a' is parameter and global") is used by CPython itself, but unless we are trying to be consistent with CPython, I think we can improve upon this? The previous version seemed a bit cryptic to me when I first saw it.

## Test Plan

Updated snapshot tests