### PR TITLE
[ty] Preserve lexical ParamSpec scope for returned Callable annotations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
@@ -243,6 +243,17 @@ reveal_type(generic_context(outside_callable(int_identity)))
 outside_callable(int_identity)("string")
 ```
 
+The function's type parameters are still in scope inside the body, even if they only appear in a
+return-position `Callable` and are scoped to the returned callable:
+
+```py
+from typing import Callable, cast
+
+def body_annotation[**P]() -> Callable[P, None]:
+    local: Callable[P, None] = cast(Callable[P, None], object())
+    return local
+```
+
 ## Overloaded callable as generic `Callable` argument
 
 An overloaded callable should be assignable to a non-overloaded callable type when the overload set

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -79,7 +79,7 @@ use crate::types::known_instance::DeprecatedInstance;
 use crate::types::list_members::all_members;
 use crate::types::narrow::ClassInfoConstraintFunction;
 use crate::types::relation::TypeRelationChecker;
-use crate::types::signatures::{CallableSignature, Signature};
+use crate::types::signatures::{CallableSignature, ReturnCallableTypeVarScope, Signature};
 use crate::types::visitor::any_over_type;
 use crate::types::{
     ApplyTypeMappingVisitor, BoundMethodType, BoundTypeVarInstance, CallableType, ClassBase,
@@ -446,6 +446,25 @@ impl<'db> OverloadLiteral<'db> {
     /// a cross-module dependency directly on the full AST which will lead to cache
     /// over-invalidation.
     pub(super) fn raw_signature(self, db: &'db dyn Db) -> Signature<'db> {
+        self.raw_signature_impl(db, ReturnCallableTypeVarScope::Public)
+    }
+
+    /// Typed internally-visible "raw" signature using the function's lexical generic context.
+    ///
+    /// Unlike [`raw_signature`](Self::raw_signature), this does not rescope type variables that
+    /// only appear in a return-position `Callable` to the returned callable. Use this view for
+    /// function body inference, where PEP 695 type parameters remain lexically in scope.
+    pub(super) fn lexical_raw_signature(self, db: &'db dyn Db) -> Signature<'db> {
+        self.raw_signature_impl(db, ReturnCallableTypeVarScope::Lexical)
+    }
+
+    /// Builds the internally-visible raw signature with the requested return-`Callable` type
+    /// variable binding policy.
+    fn raw_signature_impl(
+        self,
+        db: &'db dyn Db,
+        return_callable_typevar_scope: ReturnCallableTypeVarScope,
+    ) -> Signature<'db> {
         /// `self` or `cls` can be implicitly positional-only if:
         /// - It is a method AND
         /// - No parameters in the method use PEP-570 syntax AND
@@ -526,6 +545,7 @@ impl<'db> OverloadLiteral<'db> {
             definition,
             function_stmt_node,
             has_implicitly_positional_first_parameter,
+            return_callable_typevar_scope,
         );
 
         let generic_context = raw_signature.generic_context;
@@ -790,6 +810,12 @@ impl<'db> FunctionLiteral<'db> {
     /// over-invalidation.
     fn last_definition_raw_signature(self, db: &'db dyn Db) -> Signature<'db> {
         self.last_definition.raw_signature(db)
+    }
+
+    /// Typed externally-visible "raw" lexical signature of the last overload or implementation of
+    /// this function.
+    fn last_definition_lexical_raw_signature(self, db: &'db dyn Db) -> Signature<'db> {
+        self.last_definition.lexical_raw_signature(db)
     }
 
     /// Return `Some()` if this function is an abstract method.
@@ -1189,6 +1215,21 @@ impl<'db> FunctionType<'db> {
     )]
     pub(crate) fn last_definition_raw_signature(self, db: &'db dyn Db) -> Signature<'db> {
         self.literal(db).last_definition_raw_signature(db)
+    }
+
+    /// Typed externally-visible "raw" lexical signature of the last overload or implementation of
+    /// this function.
+    ///
+    /// This preserves the function's lexical generic context for return-position `Callable` type
+    /// variables. Use it when checking code inside the function body; callers should use
+    /// [`last_definition_raw_signature`](Self::last_definition_raw_signature).
+    #[salsa::tracked(
+        returns(ref),
+        cycle_initial=last_definition_signature_cycle_initial,
+        heap_size=ruff_memory_usage::heap_size,
+    )]
+    pub(crate) fn last_definition_lexical_raw_signature(self, db: &'db dyn Db) -> Signature<'db> {
+        self.literal(db).last_definition_lexical_raw_signature(db)
     }
 
     /// Convert the `FunctionType` into a [`CallableType`].

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -420,7 +420,7 @@ impl<'db> OverloadLiteral<'db> {
     /// a cross-module dependency directly on the full AST which will lead to cache
     /// over-invalidation.
     pub(crate) fn signature(self, db: &'db dyn Db) -> Signature<'db> {
-        let mut signature = self.raw_signature(db);
+        let mut signature = self.raw_signature(db, ReturnCallableTypeVarScope::Public);
 
         let scope = self.body_scope(db);
         let module = parsed_module(db, self.file(db)).load(db);
@@ -438,6 +438,8 @@ impl<'db> OverloadLiteral<'db> {
 
     /// Typed internally-visible "raw" signature for this function.
     /// That is, the return types of async functions are not wrapped in `CoroutineType[...]`.
+    /// The `return_callable_typevar_scope` controls whether type variables that only appear in a
+    /// return-position `Callable` stay bound to the function or move to the returned callable.
     ///
     /// ## Warning
     ///
@@ -445,22 +447,7 @@ impl<'db> OverloadLiteral<'db> {
     /// calling query is not in the same file as this function is defined in, then this will create
     /// a cross-module dependency directly on the full AST which will lead to cache
     /// over-invalidation.
-    pub(super) fn raw_signature(self, db: &'db dyn Db) -> Signature<'db> {
-        self.raw_signature_impl(db, ReturnCallableTypeVarScope::Public)
-    }
-
-    /// Typed internally-visible "raw" signature using the function's lexical generic context.
-    ///
-    /// Unlike [`raw_signature`](Self::raw_signature), this does not rescope type variables that
-    /// only appear in a return-position `Callable` to the returned callable. Use this view for
-    /// function body inference, where PEP 695 type parameters remain lexically in scope.
-    pub(super) fn lexical_raw_signature(self, db: &'db dyn Db) -> Signature<'db> {
-        self.raw_signature_impl(db, ReturnCallableTypeVarScope::Lexical)
-    }
-
-    /// Builds the internally-visible raw signature with the requested return-`Callable` type
-    /// variable binding policy.
-    fn raw_signature_impl(
+    pub(super) fn raw_signature(
         self,
         db: &'db dyn Db,
         return_callable_typevar_scope: ReturnCallableTypeVarScope,
@@ -801,6 +788,8 @@ impl<'db> FunctionLiteral<'db> {
     }
 
     /// Typed externally-visible "raw" signature of the last overload or implementation of this function.
+    /// The `return_callable_typevar_scope` controls whether type variables that only appear in a
+    /// return-position `Callable` stay bound to the function or move to the returned callable.
     ///
     /// ## Warning
     ///
@@ -808,14 +797,13 @@ impl<'db> FunctionLiteral<'db> {
     /// calling query is not in the same file as this function is defined in, then this will create
     /// a cross-module dependency directly on the full AST which will lead to cache
     /// over-invalidation.
-    fn last_definition_raw_signature(self, db: &'db dyn Db) -> Signature<'db> {
-        self.last_definition.raw_signature(db)
-    }
-
-    /// Typed externally-visible "raw" lexical signature of the last overload or implementation of
-    /// this function.
-    fn last_definition_lexical_raw_signature(self, db: &'db dyn Db) -> Signature<'db> {
-        self.last_definition.lexical_raw_signature(db)
+    fn last_definition_raw_signature(
+        self,
+        db: &'db dyn Db,
+        return_callable_typevar_scope: ReturnCallableTypeVarScope,
+    ) -> Signature<'db> {
+        self.last_definition
+            .raw_signature(db, return_callable_typevar_scope)
     }
 
     /// Return `Some()` if this function is an abstract method.
@@ -1209,27 +1197,19 @@ impl<'db> FunctionType<'db> {
     }
 
     /// Typed externally-visible "raw" signature of the last overload or implementation of this function.
+    /// The `return_callable_typevar_scope` controls whether type variables that only appear in a
+    /// return-position `Callable` stay bound to the function or move to the returned callable.
     #[salsa::tracked(
-        returns(ref), cycle_initial=last_definition_signature_cycle_initial,
+        returns(ref), cycle_initial=last_definition_raw_signature_cycle_initial,
         heap_size=ruff_memory_usage::heap_size,
     )]
-    pub(crate) fn last_definition_raw_signature(self, db: &'db dyn Db) -> Signature<'db> {
-        self.literal(db).last_definition_raw_signature(db)
-    }
-
-    /// Typed externally-visible "raw" lexical signature of the last overload or implementation of
-    /// this function.
-    ///
-    /// This preserves the function's lexical generic context for return-position `Callable` type
-    /// variables. Use it when checking code inside the function body; callers should use
-    /// [`last_definition_raw_signature`](Self::last_definition_raw_signature).
-    #[salsa::tracked(
-        returns(ref),
-        cycle_initial=last_definition_signature_cycle_initial,
-        heap_size=ruff_memory_usage::heap_size,
-    )]
-    pub(crate) fn last_definition_lexical_raw_signature(self, db: &'db dyn Db) -> Signature<'db> {
-        self.literal(db).last_definition_lexical_raw_signature(db)
+    pub(crate) fn last_definition_raw_signature(
+        self,
+        db: &'db dyn Db,
+        return_callable_typevar_scope: ReturnCallableTypeVarScope,
+    ) -> Signature<'db> {
+        self.literal(db)
+            .last_definition_raw_signature(db, return_callable_typevar_scope)
     }
 
     /// Convert the `FunctionType` into a [`CallableType`].
@@ -1636,6 +1616,15 @@ fn last_definition_signature_cycle_initial<'db>(
     _db: &'db dyn Db,
     _id: salsa::Id,
     _function: FunctionType<'db>,
+) -> Signature<'db> {
+    Signature::bottom()
+}
+
+fn last_definition_raw_signature_cycle_initial<'db>(
+    _db: &'db dyn Db,
+    _id: salsa::Id,
+    _function: FunctionType<'db>,
+    _return_callable_typevar_scope: ReturnCallableTypeVarScope,
 ) -> Signature<'db> {
     Signature::bottom()
 }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -108,8 +108,21 @@ pub(crate) fn bind_typevar<'db>(
         let is_class_scope = ancestor_scope.kind().is_class();
         // If we've already crossed a class boundary, skip class-scoped generic contexts.
         // This prevents inner classes from accessing type parameters of outer classes.
+        let generic_context = match ancestor_scope.node() {
+            NodeWithScopeKind::FunctionTypeParameters(function) => {
+                let definition = index.expect_single_definition(function);
+                infer_definition_types(db, definition)
+                    .function_type(definition)
+                    .and_then(|function_type| {
+                        function_type
+                            .last_definition_lexical_raw_signature(db)
+                            .generic_context
+                    })
+            }
+            node => GenericContext::of_node(db, node, index),
+        };
         if (!is_class_scope || !crossed_class_scope)
-            && let Some(generic_context) = GenericContext::of_node(db, ancestor_scope.node(), index)
+            && let Some(generic_context) = generic_context
             && let Some(bound) = generic_context.binds_typevar(db, typevar)
         {
             return Some(bound);
@@ -312,7 +325,7 @@ impl<'db> GenericContext<'db> {
     /// Creates a generic context from a list of PEP-695 type parameters.
     pub(crate) fn from_type_params(
         db: &'db dyn Db,
-        index: &'db SemanticIndex<'db>,
+        index: &SemanticIndex<'db>,
         binding_context: Definition<'db>,
         type_params_node: &ast::TypeParams,
     ) -> Self {
@@ -492,7 +505,7 @@ impl<'db> GenericContext<'db> {
 
     fn variable_from_type_param(
         db: &'db dyn Db,
-        index: &'db SemanticIndex<'db>,
+        index: &SemanticIndex<'db>,
         binding_context: Definition<'db>,
         type_param_node: &ast::TypeParam,
     ) -> Option<BoundTypeVarInstance<'db>> {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -17,7 +17,9 @@ use crate::types::constraints::{
 use crate::types::relation::{
     DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
 };
-use crate::types::signatures::{CallableSignature, Parameters, SignatureRelationVisitor};
+use crate::types::signatures::{
+    CallableSignature, Parameters, ReturnCallableTypeVarScope, SignatureRelationVisitor,
+};
 use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
 use crate::types::type_alias::{walk_manual_pep_695_type_alias, walk_pep_695_type_alias};
 use crate::types::typevar::{
@@ -106,8 +108,6 @@ pub(crate) fn bind_typevar<'db>(
     let mut crossed_class_scope = false;
     for (_, ancestor_scope) in index.ancestor_scopes(containing_scope) {
         let is_class_scope = ancestor_scope.kind().is_class();
-        // If we've already crossed a class boundary, skip class-scoped generic contexts.
-        // This prevents inner classes from accessing type parameters of outer classes.
         let generic_context = match ancestor_scope.node() {
             NodeWithScopeKind::FunctionTypeParameters(function) => {
                 let definition = index.expect_single_definition(function);
@@ -115,12 +115,14 @@ pub(crate) fn bind_typevar<'db>(
                     .function_type(definition)
                     .and_then(|function_type| {
                         function_type
-                            .last_definition_lexical_raw_signature(db)
+                            .last_definition_raw_signature(db, ReturnCallableTypeVarScope::Lexical)
                             .generic_context
                     })
             }
             node => GenericContext::of_node(db, node, index),
         };
+        // If we've already crossed a class boundary, skip class-scoped generic contexts.
+        // This prevents inner classes from accessing type parameters of outer classes.
         if (!is_class_scope || !crossed_class_scope)
             && let Some(generic_context) = generic_context
             && let Some(bound) = generic_context.binds_typevar(db, typevar)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4642,7 +4642,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // the expected type passed should be the "raw" type,
                     // i.e. type variables in the return type are non-inferable,
                     // and the return types of async functions are not wrapped in `CoroutineType[...]`.
-                    let return_ty = func.last_definition_raw_signature(self.db()).return_ty;
+                    let return_ty = func
+                        .last_definition_lexical_raw_signature(self.db())
+                        .return_ty;
 
                     // For generator functions, the declared return type is e.g.
                     // `Generator[YieldType, SendType, ReturnType]`. The type context

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -83,7 +83,7 @@ use crate::types::infer::{
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::newtype::NewType;
 use crate::types::set_theoretic::RecursivelyDefined;
-use crate::types::signatures::CallableSignature;
+use crate::types::signatures::{CallableSignature, ReturnCallableTypeVarScope};
 use crate::types::special_form::TypeQualifier;
 use crate::types::subclass_of::SubclassOfInner;
 use crate::types::tuple::promotion::TupleSizePromotionConstraints;
@@ -4643,7 +4643,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // i.e. type variables in the return type are non-inferable,
                     // and the return types of async functions are not wrapped in `CoroutineType[...]`.
                     let return_ty = func
-                        .last_definition_lexical_raw_signature(self.db())
+                        .last_definition_raw_signature(
+                            self.db(),
+                            ReturnCallableTypeVarScope::Lexical,
+                        )
                         .return_ty;
 
                     // For generator functions, the declared return type is e.g.
@@ -7644,7 +7647,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return Type::unknown();
         };
         let declared_return_ty = enclosing_function
-            .last_definition_raw_signature(self.db())
+            .last_definition_raw_signature(self.db(), ReturnCallableTypeVarScope::Public)
             .return_ty;
         let return_type_span = enclosing_function.spans(self.db()).return_type;
 
@@ -7692,7 +7695,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return Type::unknown();
         };
         let annotated_return_ty = enclosing_function
-            .last_definition_raw_signature(self.db())
+            .last_definition_raw_signature(self.db(), ReturnCallableTypeVarScope::Public)
             .return_ty;
 
         let Some(outer_expected) = annotated_return_ty.generator_types(self.db()) else {

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -51,6 +51,56 @@ fn parameters_have_annotations(parameters: &ast::Parameters) -> bool {
             .is_some_and(|param| param.annotation.is_some())
 }
 
+/// Return type policy for checking explicit `return` statements in a function body.
+#[derive(Debug, Copy, Clone)]
+struct ExpectedReturnType<'db> {
+    /// The externally-visible return type.
+    public: Type<'db>,
+    /// The lexical return type, if it differs for a generic PEP 695 function.
+    lexical: Option<Type<'db>>,
+}
+
+impl<'db> ExpectedReturnType<'db> {
+    /// Creates the expected return type policy for `function_node`.
+    fn from_function(
+        db: &'db dyn Db,
+        function: FunctionType<'db>,
+        function_node: &ast::StmtFunctionDef,
+    ) -> Self {
+        /// Normalizes special return annotations to the type actually returned by expressions.
+        fn normalize<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+            match ty {
+                Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool.to_instance(db),
+                ty => ty,
+            }
+        }
+
+        let public = normalize(db, function.last_definition_raw_signature(db).return_ty);
+        let lexical = function_node.type_params.is_some().then(|| {
+            normalize(
+                db,
+                function.last_definition_lexical_raw_signature(db).return_ty,
+            )
+        });
+
+        Self { public, lexical }
+    }
+
+    /// Returns the externally-visible return type.
+    fn public(self) -> Type<'db> {
+        self.public
+    }
+
+    /// Returns `true` if `ty` is accepted by either the public return type or the lexical return
+    /// type.
+    fn accepts(self, db: &'db dyn Db, ty: Type<'db>) -> bool {
+        ty.is_assignable_to(db, self.public)
+            || self
+                .lexical
+                .is_some_and(|lexical| ty.is_assignable_to(db, lexical))
+    }
+}
+
 impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     pub(super) fn infer_function_body(&mut self, function: &ast::StmtFunctionDef) {
         fn can_implicitly_return_none<'db>(db: &'db dyn Db, use_def: &UseDefMap<'db>) -> bool {
@@ -110,10 +160,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let declared_ty = enclosing_function
                 .last_definition_raw_signature(db)
                 .return_ty;
-            let expected_ty = match declared_ty {
-                Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool.to_instance(db),
-                ty => ty,
-            };
+            let expected_return =
+                ExpectedReturnType::from_function(db, enclosing_function, function);
+            let expected_ty = expected_return.public();
 
             let scope_id = self.index.node_scope(NodeWithScopeRef::Function(function));
             if scope_id.is_generator_function(self.index) {
@@ -195,7 +244,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     ty if ty.is_notimplemented(db) => None,
                     _ => Some(ty_range),
                 })
-                .filter(|ty_range| !ty_range.ty.is_assignable_to(db, expected_ty))
+                .filter(|ty_range| !expected_return.accepts(db, ty_range.ty))
             {
                 report_invalid_return_type(
                     &self.context,

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -24,7 +24,9 @@ use crate::{
             },
             function_known_decorators, infer_statement_types, nearest_enclosing_function,
         },
-        infer_definition_types, infer_scope_types, todo_type,
+        infer_definition_types, infer_scope_types,
+        signatures::ReturnCallableTypeVarScope,
+        todo_type,
         typed_dict::extract_unpacked_typed_dict_keys_from_kwargs_annotation,
     },
 };
@@ -75,11 +77,18 @@ impl<'db> ExpectedReturnType<'db> {
             }
         }
 
-        let public = normalize(db, function.last_definition_raw_signature(db).return_ty);
+        let public = normalize(
+            db,
+            function
+                .last_definition_raw_signature(db, ReturnCallableTypeVarScope::Public)
+                .return_ty,
+        );
         let lexical = function_node.type_params.is_some().then(|| {
             normalize(
                 db,
-                function.last_definition_lexical_raw_signature(db).return_ty,
+                function
+                    .last_definition_raw_signature(db, ReturnCallableTypeVarScope::Lexical)
+                    .return_ty,
             )
         });
 
@@ -158,7 +167,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let enclosing_function = nearest_enclosing_function(db, self.index, self.scope())
                 .expect("should be in a function body scope");
             let declared_ty = enclosing_function
-                .last_definition_raw_signature(db)
+                .last_definition_raw_signature(db, ReturnCallableTypeVarScope::Public)
                 .return_ty;
             let expected_return =
                 ExpectedReturnType::from_function(db, enclosing_function, function);

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -6,6 +6,7 @@ use crate::{
         diagnostic::{INVALID_LEGACY_POSITIONAL_PARAMETER, INVALID_TYPE_VARIABLE_DEFAULT},
         function::OverloadLiteral,
         infer_definition_types,
+        signatures::ReturnCallableTypeVarScope,
         typevar::TypeVarInstance,
         visitor::find_over_type,
     },
@@ -32,7 +33,7 @@ pub(crate) fn check_function_definition<'db>(
     };
 
     let last_definition = function_type.literal(db).last_definition;
-    let signature = last_definition.raw_signature(db);
+    let signature = last_definition.raw_signature(db, ReturnCallableTypeVarScope::Public);
 
     check_legacy_positional_only_convention(context, last_definition, &signature);
     check_legacy_typevar_defaults(context, last_definition, &signature, file_expression_type);

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -45,6 +45,16 @@ use crate::{Db, FxOrderSet};
 use ruff_python_ast::{self as ast, name::Name};
 use ty_python_core::definition::Definition;
 
+/// Selects which binding context to use for type variables that only appear in a return-position
+/// `Callable`.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub(super) enum ReturnCallableTypeVarScope {
+    /// Keep the type variables bound to the function's lexical generic context.
+    Lexical,
+    /// Move the type variables to the returned `Callable`'s generic context.
+    Public,
+}
+
 /// Infer the type of a parameter or return annotation in a function signature.
 ///
 /// This is very similar to `definition_expression_type`, but knows that `TypeInferenceBuilder`
@@ -637,6 +647,7 @@ impl<'db> Signature<'db> {
         definition: Definition<'db>,
         function_node: &ast::StmtFunctionDef,
         has_implicitly_positional_first_parameter: bool,
+        return_callable_typevar_scope: ReturnCallableTypeVarScope,
     ) -> Self {
         let parameters = Parameters::from_parameters(
             db,
@@ -657,16 +668,21 @@ impl<'db> Signature<'db> {
             legacy_generic_context,
         );
 
-        // Look for any typevars bound by this function that are only mentioned in a Callable
-        // return type. (We do this after merging the legacy and PEP-695 contexts because we need
-        // to apply this heuristic to PEP-695 typevars as well.)
-        let (generic_context, return_ty) = GenericContext::remove_callable_only_typevars(
-            db,
-            full_generic_context,
-            &parameters,
-            return_ty,
-            definition,
-        );
+        let (generic_context, return_ty) = match return_callable_typevar_scope {
+            ReturnCallableTypeVarScope::Lexical => (full_generic_context, return_ty),
+            ReturnCallableTypeVarScope::Public => {
+                // Look for any typevars bound by this function that are only mentioned in a
+                // Callable return type. (We do this after merging the legacy and PEP-695 contexts
+                // because we need to apply this heuristic to PEP-695 typevars as well.)
+                GenericContext::remove_callable_only_typevars(
+                    db,
+                    full_generic_context,
+                    &parameters,
+                    return_ty,
+                    definition,
+                )
+            }
+        };
 
         Self {
             generic_context,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -47,7 +47,7 @@ use ty_python_core::definition::Definition;
 
 /// Selects which binding context to use for type variables that only appear in a return-position
 /// `Callable`.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
 pub(super) enum ReturnCallableTypeVarScope {
     /// Keep the type variables bound to the function's lexical generic context.
     Lexical,


### PR DESCRIPTION
## Summary

This PR preserves the distinction between a function's "public" signature and the lexical type-parameter scope used inside the function body.

As an example:

```python
from typing import Callable, cast

def make_callback[**P]() -> Callable[P, None]:
    local: Callable[P, None] = cast(Callable[P, None], object())
    return local
```

`make_callback` returns a generic callable, and `P` belongs to that returned `Callable`, not to `make_callback` itself.

But within `make_callback`, PEP 695 type parameters are still lexically in scope. Previously, our rescoping could remove `P` from the generic context too early, so annotations like `local: Callable[P, None]` would be checked against the wrong scope.

We now look at the lexical signature for function body inference, while keeping the existing public signature for callers.

Closes https://github.com/astral-sh/ty/issues/3316.
