### PR TITLE
[ty] Nominal Tagged Union Narrowing

### DIFF
--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -654,16 +654,25 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
             self.add_narrowing_target(comparator, &mut places);
         }
 
+        let can_narrow_attribute_base =
+            matches!(&*expr_compare.ops, [ast::CmpOp::Eq | ast::CmpOp::NotEq]);
+        let can_narrow_subscript_base = matches!(
+            &*expr_compare.ops,
+            [ast::CmpOp::Eq | ast::CmpOp::NotEq | ast::CmpOp::Is | ast::CmpOp::IsNot]
+        );
+
         // For subscript expressions on either side, the subscript base can also be narrowed.
         // (TypedDict and tuple discriminated union narrowing.)
         for expr in std::iter::once(&*expr_compare.left).chain(&expr_compare.comparators) {
-            if let ast::Expr::Subscript(subscript) = expr.expression_value()
+            if can_narrow_subscript_base
+                && let ast::Expr::Subscript(subscript) = expr.expression_value()
                 && let Some(place_expr) = PlaceExpr::try_from_expr(&subscript.value)
                 && let Some(place) = self.places.place_id((&place_expr).into())
             {
                 places.insert(place);
             }
-            if let ast::Expr::Attribute(attribute) = expr
+            if can_narrow_attribute_base
+                && let ast::Expr::Attribute(attribute) = expr
                 && let Some(place_expr) = PlaceExpr::try_from_expr(&attribute.value)
                 && let Some(place) = self.places.place_id((&place_expr).into())
             {

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -663,6 +663,12 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
             {
                 places.insert(place);
             }
+            if let ast::Expr::Attribute(attribute) = expr
+                && let Some(place_expr) = PlaceExpr::try_from_expr(&attribute.value)
+                && let Some(place) = self.places.place_id((&place_expr).into())
+            {
+                places.insert(place);
+            }
         }
 
         places
@@ -766,6 +772,12 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
                     places.insert(place);
                 }
             }
+        }
+        if let ast::Expr::Attribute(attribute) = subject_node
+            && let Some(place_expr) = PlaceExpr::try_from_expr(&attribute.value)
+            && let Some(place) = self.places.place_id((&place_expr).into())
+        {
+            places.insert(place);
         }
 
         // Handle Or patterns by recursing into each alternative

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -370,7 +370,7 @@ def _(x: A | B):
         reveal_type(x)  # revealed: A
 ```
 
-Non-literal tag arms block positive narrowing:
+Non-literal tag arms are preserved during positive narrowing:
 
 ```py
 from typing import Literal
@@ -381,9 +381,12 @@ class A:
 class B:
     tag: str
 
-def _(x: A | B):
+class C:
+    tag: Literal["c"]
+
+def _(x: A | B | C):
     if x.tag == "a":
         reveal_type(x)  # revealed: A | B
     else:
-        reveal_type(x)  # revealed: B
+        reveal_type(x)  # revealed: B | C
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -337,3 +337,53 @@ def _(x: Literal["a", "b"] | tuple[int, int]):
         # tuple type remains in the else branch
         reveal_type(x)  # revealed: Literal["b"] | tuple[int, int]
 ```
+
+## Narrowing tagged unions of nominal classes by attribute
+
+```py
+from typing import Literal
+
+class A:
+    tag: Literal["a"]
+    field_a: int
+
+class B:
+    tag: Literal["b"]
+    field_b: str
+
+def _(x: A | B):
+    if x.tag == "a":
+        reveal_type(x)  # revealed: A
+        reveal_type(x.field_a)  # revealed: int
+    else:
+        reveal_type(x)  # revealed: B
+        reveal_type(x.field_b)  # revealed: str
+
+    if "b" == x.tag:
+        reveal_type(x)  # revealed: B
+    else:
+        reveal_type(x)  # revealed: A
+
+    if x.tag != "a":
+        reveal_type(x)  # revealed: B
+    else:
+        reveal_type(x)  # revealed: A
+```
+
+Non-literal tag arms block positive narrowing:
+
+```py
+from typing import Literal
+
+class A:
+    tag: Literal["a"]
+
+class B:
+    tag: str
+
+def _(x: A | B):
+    if x.tag == "a":
+        reveal_type(x)  # revealed: A | B
+    else:
+        reveal_type(x)  # revealed: B
+```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -552,3 +552,47 @@ def _(u: tuple[Literal["foo"], int] | tuple[Literal["bar"], str]):
             # still narrow to `tuple[Literal["bar"], str]` when `u[0]` equals "bar".
             reveal_type(u)  # revealed: tuple[Literal["bar"], str]
 ```
+
+## Narrowing tagged unions of nominal classes by attribute
+
+```py
+from typing import Literal
+
+class A:
+    tag: Literal["a"]
+    field_a: int
+
+class B:
+    tag: Literal["b"]
+    field_b: str
+
+def _(x: A | B):
+    match x.tag:
+        case "a":
+            reveal_type(x)  # revealed: A
+            reveal_type(x.field_a)  # revealed: int
+        case "b":
+            reveal_type(x)  # revealed: B
+            reveal_type(x.field_b)  # revealed: str
+        case _:
+            reveal_type(x)  # revealed: Never
+```
+
+Non-literal tag arms block positive narrowing:
+
+```py
+from typing import Literal
+
+class A:
+    tag: Literal["a"]
+
+class B:
+    tag: str
+
+def _(x: A | B):
+    match x.tag:
+        case "a":
+            reveal_type(x)  # revealed: A | B
+        case _:
+            reveal_type(x)  # revealed: B
+```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -578,7 +578,7 @@ def _(x: A | B):
             reveal_type(x)  # revealed: Never
 ```
 
-Non-literal tag arms block positive narrowing:
+Non-literal tag arms are preserved during positive narrowing:
 
 ```py
 from typing import Literal
@@ -589,10 +589,13 @@ class A:
 class B:
     tag: str
 
-def _(x: A | B):
+class C:
+    tag: Literal["c"]
+
+def _(x: A | B | C):
     match x.tag:
         case "a":
             reveal_type(x)  # revealed: A | B
         case _:
-            reveal_type(x)  # revealed: B
+            reveal_type(x)  # revealed: B | C
 ```

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -581,6 +581,19 @@ impl<'db> From<Type<'db>> for NarrowingConstraint<'db> {
 
 type NarrowingConstraints<'db> = FxHashMap<ScopedPlaceId, NarrowingConstraint<'db>>;
 
+fn insert_narrowing_constraint<'db>(
+    constraints: &mut NarrowingConstraints<'db>,
+    place: ScopedPlaceId,
+    constraint: NarrowingConstraint<'db>,
+) {
+    constraints
+        .entry(place)
+        .and_modify(|existing| {
+            *existing = existing.merge_constraint_and(constraint.clone());
+        })
+        .or_insert(constraint);
+}
+
 /// Merge constraints with AND semantics (intersection/conjunction).
 ///
 /// When we have `constraint1 & constraint2`, we need to distribute AND over the OR
@@ -1470,12 +1483,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     other_type,
                     constrain_with_equality,
                 ) {
-                    constraints
-                        .entry(place)
-                        .and_modify(|existing| {
-                            *existing = existing.merge_constraint_and(constraint.clone());
-                        })
-                        .or_insert(constraint);
+                    insert_narrowing_constraint(&mut constraints, place, constraint);
                 } else if let Some((place, constraint)) = self.narrow_tuple_subscript(
                     value_type,
                     &subscript.value,
@@ -1483,12 +1491,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     other_type,
                     constrain_with_equality,
                 ) {
-                    constraints
-                        .entry(place)
-                        .and_modify(|existing| {
-                            *existing = existing.merge_constraint_and(constraint.clone());
-                        })
-                        .or_insert(constraint);
+                    insert_narrowing_constraint(&mut constraints, place, constraint);
                 }
             };
 
@@ -1498,6 +1501,28 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
             if let ast::Expr::Subscript(subscript) = comparators[0].expression_value() {
                 narrow_subscript(subscript, inference.expression_type(&**left));
+            }
+
+            let mut narrow_attribute = |attribute: &ast::ExprAttribute, other_type: Type<'db>| {
+                let value_type = inference.expression_type(&*attribute.value);
+
+                if let Some((place, constraint)) = self.narrow_nominal_attribute(
+                    value_type,
+                    &attribute.value,
+                    attribute.attr.id(),
+                    other_type,
+                    constrain_with_equality,
+                ) {
+                    insert_narrowing_constraint(&mut constraints, place, constraint);
+                }
+            };
+
+            if let ast::Expr::Attribute(attribute) = &**left {
+                narrow_attribute(attribute, inference.expression_type(&comparators[0]));
+            }
+
+            if let ast::Expr::Attribute(attribute) = &comparators[0] {
+                narrow_attribute(attribute, inference.expression_type(&**left));
             }
         }
 
@@ -1990,6 +2015,17 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             ) {
                 constraints.insert(place, constraint);
             }
+        } else if let ast::Expr::Attribute(attribute) = subject_node {
+            let inference = infer_expression_types(self.db, subject, TypeContext::default());
+            if let Some((place, constraint)) = self.narrow_nominal_attribute(
+                inference.expression_type(&*attribute.value),
+                &attribute.value,
+                attribute.attr.id(),
+                value_ty,
+                is_positive,
+            ) {
+                constraints.insert(place, constraint);
+            }
         }
 
         Some(constraints)
@@ -2213,6 +2249,48 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             None
         }
     }
+
+    fn narrow_nominal_attribute(
+        &self,
+        attribute_value_type: Type<'db>,
+        attribute_value_expr: &ast::Expr,
+        attribute_name: &str,
+        rhs_type: Type<'db>,
+        constrain_with_equality: bool,
+    ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
+        let resolved_attribute_value_type = attribute_value_type.resolve_type_alias(self.db);
+        if !is_or_contains_nominal_instance(self.db, resolved_attribute_value_type) {
+            return None;
+        }
+        if !is_supported_tag_literal(rhs_type) {
+            return None;
+        }
+        if constrain_with_equality
+            && !all_matching_nominal_attributes_have_literal_types(
+                self.db,
+                resolved_attribute_value_type,
+                attribute_name,
+            )
+        {
+            return None;
+        }
+
+        let narrowed = narrow_nominal_attribute_type(
+            self.db,
+            resolved_attribute_value_type,
+            attribute_name,
+            rhs_type,
+            constrain_with_equality,
+        );
+
+        if narrowed == resolved_attribute_value_type {
+            return None;
+        }
+
+        let attribute_value_place_expr = PlaceExpr::try_from_expr(attribute_value_expr)?;
+        let place = self.expect_place(&attribute_value_place_expr);
+        Some((place, NarrowingConstraint::replacement(narrowed)))
+    }
 }
 
 // Return true if the given type is a `TypedDict` or a union or intersection that includes at least
@@ -2262,6 +2340,53 @@ fn is_or_contains_typeddict<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     }
 }
 
+fn is_or_contains_nominal_instance<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    match ty {
+        Type::NominalInstance(_) => true,
+        Type::Intersection(intersection) => {
+            intersection
+                .positive(db)
+                .iter()
+                .any(|intersection_element_ty| {
+                    is_or_contains_nominal_instance(db, *intersection_element_ty)
+                })
+        }
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .any(|union_member_ty| is_or_contains_nominal_instance(db, *union_member_ty)),
+        Type::TypeAlias(alias) => is_or_contains_nominal_instance(db, alias.value_type(db)),
+
+        Type::Dynamic(_)
+        | Type::Divergent(_)
+        | Type::Never
+        | Type::FunctionLiteral(_)
+        | Type::BoundMethod(_)
+        | Type::KnownBoundMethod(_)
+        | Type::WrapperDescriptor(_)
+        | Type::DataclassDecorator(_)
+        | Type::DataclassTransformer(_)
+        | Type::Callable(_)
+        | Type::ModuleLiteral(_)
+        | Type::ClassLiteral(_)
+        | Type::GenericAlias(_)
+        | Type::SubclassOf(_)
+        | Type::TypedDict(_)
+        | Type::ProtocolInstance(_)
+        | Type::SpecialForm(_)
+        | Type::KnownInstance(_)
+        | Type::PropertyInstance(_)
+        | Type::AlwaysTruthy
+        | Type::AlwaysFalsy
+        | Type::LiteralValue(_)
+        | Type::TypeVar(_)
+        | Type::BoundSuper(_)
+        | Type::TypeIs(_)
+        | Type::TypeGuard(_)
+        | Type::NewTypeInstance(_) => false,
+    }
+}
+
 fn is_supported_tag_literal(ty: Type) -> bool {
     matches!(
         ty.as_literal_value_kind(),
@@ -2273,6 +2398,77 @@ fn is_supported_tag_literal(ty: Type) -> bool {
                 | LiteralValueTypeKind::Int(_)
         )
     )
+}
+
+fn nominal_attribute_type<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    attribute_name: &str,
+) -> Option<Type<'db>> {
+    let resolved_ty = ty.resolve_type_alias(db);
+    if resolved_ty.is_nominal_instance() {
+        resolved_ty
+            .member(db, attribute_name)
+            .place
+            .ignore_possibly_undefined()
+    } else {
+        None
+    }
+}
+
+fn narrow_nominal_attribute_type<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    attribute_name: &str,
+    rhs_type: Type<'db>,
+    constrain_with_equality: bool,
+) -> Type<'db> {
+    match ty {
+        Type::NominalInstance(_) => {
+            let Some(attribute_type) = nominal_attribute_type(db, ty, attribute_name) else {
+                return ty;
+            };
+            let keep = if constrain_with_equality {
+                !attribute_type.is_disjoint_from(db, rhs_type)
+            } else {
+                !attribute_type.is_subtype_of(db, rhs_type)
+            };
+            if keep { ty } else { Type::Never }
+        }
+        Type::Intersection(intersection) => {
+            let mut builder = IntersectionBuilder::new(db);
+            for positive in intersection.positive(db) {
+                builder = builder.add_positive(narrow_nominal_attribute_type(
+                    db,
+                    *positive,
+                    attribute_name,
+                    rhs_type,
+                    constrain_with_equality,
+                ));
+            }
+            for negative in intersection.negative(db) {
+                builder = builder.add_negative(*negative);
+            }
+            builder.build()
+        }
+        Type::Union(union) => union.map(db, |element| {
+            narrow_nominal_attribute_type(
+                db,
+                *element,
+                attribute_name,
+                rhs_type,
+                constrain_with_equality,
+            )
+        }),
+        Type::TypeAlias(alias) => narrow_nominal_attribute_type(
+            db,
+            alias.value_type(db),
+            attribute_name,
+            rhs_type,
+            constrain_with_equality,
+        ),
+        _ => ty,
+    }
 }
 
 // Return true if the given type is a `TypedDict` whose `field_name` field has a supported tag literal
@@ -2352,6 +2548,77 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
         | Type::NewTypeInstance(_) => {
             unreachable!(
                 "invalid type {} in all_matching_typeddict_fields_have_literal_types",
+                ty.display(db)
+            )
+        }
+    }
+}
+
+fn all_matching_nominal_attributes_have_literal_types<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    attribute_name: &str,
+) -> bool {
+    match ty {
+        Type::NominalInstance(_) => {
+            nominal_attribute_type(db, ty, attribute_name).is_some_and(is_supported_tag_literal)
+        }
+        Type::Union(union) => union.elements(db).iter().all(|union_member_ty| {
+            !is_or_contains_nominal_instance(db, *union_member_ty)
+                || all_matching_nominal_attributes_have_literal_types(
+                    db,
+                    *union_member_ty,
+                    attribute_name,
+                )
+        }),
+        Type::TypeAlias(alias) => all_matching_nominal_attributes_have_literal_types(
+            db,
+            alias.value_type(db),
+            attribute_name,
+        ),
+        Type::Intersection(intersection) => {
+            intersection
+                .positive(db)
+                .iter()
+                .all(|intersection_member_ty| {
+                    !is_or_contains_nominal_instance(db, *intersection_member_ty)
+                        || all_matching_nominal_attributes_have_literal_types(
+                            db,
+                            *intersection_member_ty,
+                            attribute_name,
+                        )
+                })
+        }
+
+        Type::Dynamic(_)
+        | Type::Divergent(_)
+        | Type::Never
+        | Type::FunctionLiteral(_)
+        | Type::BoundMethod(_)
+        | Type::KnownBoundMethod(_)
+        | Type::WrapperDescriptor(_)
+        | Type::DataclassDecorator(_)
+        | Type::DataclassTransformer(_)
+        | Type::Callable(_)
+        | Type::ModuleLiteral(_)
+        | Type::ClassLiteral(_)
+        | Type::GenericAlias(_)
+        | Type::SubclassOf(_)
+        | Type::TypedDict(_)
+        | Type::ProtocolInstance(_)
+        | Type::SpecialForm(_)
+        | Type::KnownInstance(_)
+        | Type::PropertyInstance(_)
+        | Type::AlwaysTruthy
+        | Type::AlwaysFalsy
+        | Type::LiteralValue(_)
+        | Type::TypeVar(_)
+        | Type::BoundSuper(_)
+        | Type::TypeIs(_)
+        | Type::TypeGuard(_)
+        | Type::NewTypeInstance(_) => {
+            unreachable!(
+                "invalid type {} in all_matching_nominal_attributes_have_literal_types",
                 ty.display(db)
             )
         }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2258,32 +2258,25 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         rhs_type: Type<'db>,
         constrain_with_equality: bool,
     ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
-        let resolved_attribute_value_type = attribute_value_type.resolve_type_alias(self.db);
-        if !is_or_contains_nominal_instance(self.db, resolved_attribute_value_type) {
+        let Type::Union(union) = attribute_value_type.resolve_type_alias(self.db) else {
             return None;
-        }
+        };
         if !is_supported_tag_literal(rhs_type) {
             return None;
         }
-        if constrain_with_equality
-            && !all_matching_nominal_attributes_have_literal_types(
-                self.db,
-                resolved_attribute_value_type,
-                attribute_name,
-            )
-        {
-            return None;
-        }
 
-        let narrowed = narrow_nominal_attribute_type(
-            self.db,
-            resolved_attribute_value_type,
-            attribute_name,
-            rhs_type,
-            constrain_with_equality,
-        );
+        let narrowed = union.filter(self.db, |element| {
+            nominal_attribute_type(self.db, *element, attribute_name).is_none_or(|attribute_type| {
+                if constrain_with_equality {
+                    !is_supported_tag_literal(attribute_type)
+                        || !attribute_type.is_disjoint_from(self.db, rhs_type)
+                } else {
+                    !attribute_type.is_subtype_of(self.db, rhs_type)
+                }
+            })
+        });
 
-        if narrowed == resolved_attribute_value_type {
+        if narrowed == Type::Union(union) {
             return None;
         }
 
@@ -2340,53 +2333,6 @@ fn is_or_contains_typeddict<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     }
 }
 
-fn is_or_contains_nominal_instance<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-    match ty {
-        Type::NominalInstance(_) => true,
-        Type::Intersection(intersection) => {
-            intersection
-                .positive(db)
-                .iter()
-                .any(|intersection_element_ty| {
-                    is_or_contains_nominal_instance(db, *intersection_element_ty)
-                })
-        }
-        Type::Union(union) => union
-            .elements(db)
-            .iter()
-            .any(|union_member_ty| is_or_contains_nominal_instance(db, *union_member_ty)),
-        Type::TypeAlias(alias) => is_or_contains_nominal_instance(db, alias.value_type(db)),
-
-        Type::Dynamic(_)
-        | Type::Divergent(_)
-        | Type::Never
-        | Type::FunctionLiteral(_)
-        | Type::BoundMethod(_)
-        | Type::KnownBoundMethod(_)
-        | Type::WrapperDescriptor(_)
-        | Type::DataclassDecorator(_)
-        | Type::DataclassTransformer(_)
-        | Type::Callable(_)
-        | Type::ModuleLiteral(_)
-        | Type::ClassLiteral(_)
-        | Type::GenericAlias(_)
-        | Type::SubclassOf(_)
-        | Type::TypedDict(_)
-        | Type::ProtocolInstance(_)
-        | Type::SpecialForm(_)
-        | Type::KnownInstance(_)
-        | Type::PropertyInstance(_)
-        | Type::AlwaysTruthy
-        | Type::AlwaysFalsy
-        | Type::LiteralValue(_)
-        | Type::TypeVar(_)
-        | Type::BoundSuper(_)
-        | Type::TypeIs(_)
-        | Type::TypeGuard(_)
-        | Type::NewTypeInstance(_) => false,
-    }
-}
-
 fn is_supported_tag_literal(ty: Type) -> bool {
     matches!(
         ty.as_literal_value_kind(),
@@ -2413,61 +2359,6 @@ fn nominal_attribute_type<'db>(
             .ignore_possibly_undefined()
     } else {
         None
-    }
-}
-
-fn narrow_nominal_attribute_type<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-    attribute_name: &str,
-    rhs_type: Type<'db>,
-    constrain_with_equality: bool,
-) -> Type<'db> {
-    match ty {
-        Type::NominalInstance(_) => {
-            let Some(attribute_type) = nominal_attribute_type(db, ty, attribute_name) else {
-                return ty;
-            };
-            let keep = if constrain_with_equality {
-                !attribute_type.is_disjoint_from(db, rhs_type)
-            } else {
-                !attribute_type.is_subtype_of(db, rhs_type)
-            };
-            if keep { ty } else { Type::Never }
-        }
-        Type::Intersection(intersection) => {
-            let mut builder = IntersectionBuilder::new(db);
-            for positive in intersection.positive(db) {
-                builder = builder.add_positive(narrow_nominal_attribute_type(
-                    db,
-                    *positive,
-                    attribute_name,
-                    rhs_type,
-                    constrain_with_equality,
-                ));
-            }
-            for negative in intersection.negative(db) {
-                builder = builder.add_negative(*negative);
-            }
-            builder.build()
-        }
-        Type::Union(union) => union.map(db, |element| {
-            narrow_nominal_attribute_type(
-                db,
-                *element,
-                attribute_name,
-                rhs_type,
-                constrain_with_equality,
-            )
-        }),
-        Type::TypeAlias(alias) => narrow_nominal_attribute_type(
-            db,
-            alias.value_type(db),
-            attribute_name,
-            rhs_type,
-            constrain_with_equality,
-        ),
-        _ => ty,
     }
 }
 
@@ -2548,77 +2439,6 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
         | Type::NewTypeInstance(_) => {
             unreachable!(
                 "invalid type {} in all_matching_typeddict_fields_have_literal_types",
-                ty.display(db)
-            )
-        }
-    }
-}
-
-fn all_matching_nominal_attributes_have_literal_types<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-    attribute_name: &str,
-) -> bool {
-    match ty {
-        Type::NominalInstance(_) => {
-            nominal_attribute_type(db, ty, attribute_name).is_some_and(is_supported_tag_literal)
-        }
-        Type::Union(union) => union.elements(db).iter().all(|union_member_ty| {
-            !is_or_contains_nominal_instance(db, *union_member_ty)
-                || all_matching_nominal_attributes_have_literal_types(
-                    db,
-                    *union_member_ty,
-                    attribute_name,
-                )
-        }),
-        Type::TypeAlias(alias) => all_matching_nominal_attributes_have_literal_types(
-            db,
-            alias.value_type(db),
-            attribute_name,
-        ),
-        Type::Intersection(intersection) => {
-            intersection
-                .positive(db)
-                .iter()
-                .all(|intersection_member_ty| {
-                    !is_or_contains_nominal_instance(db, *intersection_member_ty)
-                        || all_matching_nominal_attributes_have_literal_types(
-                            db,
-                            *intersection_member_ty,
-                            attribute_name,
-                        )
-                })
-        }
-
-        Type::Dynamic(_)
-        | Type::Divergent(_)
-        | Type::Never
-        | Type::FunctionLiteral(_)
-        | Type::BoundMethod(_)
-        | Type::KnownBoundMethod(_)
-        | Type::WrapperDescriptor(_)
-        | Type::DataclassDecorator(_)
-        | Type::DataclassTransformer(_)
-        | Type::Callable(_)
-        | Type::ModuleLiteral(_)
-        | Type::ClassLiteral(_)
-        | Type::GenericAlias(_)
-        | Type::SubclassOf(_)
-        | Type::TypedDict(_)
-        | Type::ProtocolInstance(_)
-        | Type::SpecialForm(_)
-        | Type::KnownInstance(_)
-        | Type::PropertyInstance(_)
-        | Type::AlwaysTruthy
-        | Type::AlwaysFalsy
-        | Type::LiteralValue(_)
-        | Type::TypeVar(_)
-        | Type::BoundSuper(_)
-        | Type::TypeIs(_)
-        | Type::TypeGuard(_)
-        | Type::NewTypeInstance(_) => {
-            unreachable!(
-                "invalid type {} in all_matching_nominal_attributes_have_literal_types",
                 ty.display(db)
             )
         }


### PR DESCRIPTION
## Summary
Adds narrowing for tagged unions of nominal class instances based on literal attribute comparisons. Addresses part of astral-sh/ty#1479. Related to astral-sh/ty#2897.

This allows ty to narrow code such as `x.tag == "a"`, `"a" == x.tag`, `x.tag != "a"`, and `match x.tag` when `x` is a union of classes whose tag attributes are annotated with supported literal types.
* non-literal tag arms are preserved during positive narrowing
* impossible literal arms are removed
* unsupported cases such as enum literals are left for future work

To keep the performance impact small, the new place tracking is gated by comparison operator. We only add base places for attribute/subscript expressions when the operator can produce a relevant narrowing constraint, which avoids extra Salsa narrowing queries for unrelated comparisons.


## Test Plan

* Updated md tests
* Ran ecosystem analyzer on pydantic and prefect
* Ran memory profiler