### PR TITLE
[ty] Prevent string annotation tokens from leaking across notebook cells.

### DIFF
--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -974,7 +974,7 @@ impl SourceOrderVisitor<'_> for SemanticTokenVisitor<'_> {
                 // Highlight the sub-AST of a string annotation
                 if let Some((sub_ast, sub_model)) = self.model.enter_string_annotation(string_expr)
                 {
-                    let mut sub_visitor = SemanticTokenVisitor::new(&sub_model, None);
+                    let mut sub_visitor = SemanticTokenVisitor::new(&sub_model, self.range_filter);
                     sub_visitor.visit_expr(sub_ast.expr());
                     self.tokens.extend(sub_visitor.tokens);
                 } else {

--- a/crates/ty_server/tests/e2e/notebook.rs
+++ b/crates/ty_server/tests/e2e/notebook.rs
@@ -228,7 +228,7 @@ type Style = Literal["italic", "bold", "underline"]"#,
 }
 
 #[test]
-fn semantic_tokens_for_cell_do_not_leak_quoted_annotations() -> anyhow::Result<()> {
+fn semantic_tokens_for_cell_do_not_leak_stringified_annotations() -> anyhow::Result<()> {
     let mut server = TestServerBuilder::new()?
         .build()
         .wait_until_workspaces_are_initialized();

--- a/crates/ty_server/tests/e2e/notebook.rs
+++ b/crates/ty_server/tests/e2e/notebook.rs
@@ -228,6 +228,44 @@ type Style = Literal["italic", "bold", "underline"]"#,
 }
 
 #[test]
+fn semantic_tokens_for_cell_do_not_leak_quoted_annotations() -> anyhow::Result<()> {
+    let mut server = TestServerBuilder::new()?
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.initialization_result().unwrap();
+
+    let mut builder = NotebookBuilder::virtual_file("src/test.ipynb");
+
+    // Create a first cell that contains semantic tokens.
+    builder.add_python_cell(
+        r#"from typing import cast
+
+x = cast("list[str]", [])"#,
+    );
+
+    // Create a second, empty cell that does not contain any semantic tokens.
+    let second_cell = builder.add_python_cell("");
+
+    builder.open(&mut server);
+
+    // Assert that we didn't receive any semantic tokens for the empty cell.
+    // This proves that none were leaked from the first cell.
+    let response = semantic_tokens_full_for_cell(&mut server, &second_cell);
+    assert!(matches!(
+        response,
+        Some(lsp_types::SemanticTokensResult::Tokens(_))
+    ));
+    if let Some(lsp_types::SemanticTokensResult::Tokens(tokens)) = response {
+        assert!(tokens.data.is_empty());
+    }
+
+    server.collect_publish_diagnostic_notifications(2);
+
+    Ok(())
+}
+
+#[test]
 fn swap_cells() -> anyhow::Result<()> {
     let mut server = TestServerBuilder::new()?
         .build()


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This prevents semantic tokens from a string type annotation from leaking across notebook cells. Previously, such a leak would cause wonky syntax highlighting as described in https://github.com/astral-sh/ty/issues/3307.

The root cause of the issue was accidental omission of a cell's source range from the filter used to determine the bounds of the semantic token request.

Closes https://github.com/astral-sh/ty/issues/3307.

## Test Plan

Please see added regression test.
<!-- How was it tested? -->
