### PR TITLE
Update renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,7 @@
   suppressNotifications: ["prEditedNotification"],
   extends: ["github>astral-sh/renovate-config"],
   labels: ["internal"],
-  schedule: ["before 0am on Wednesday"],
+  schedule: ["before 4am on Wednesday"],
   semanticCommits: "disabled",
   separateMajorMinor: false,
   enabledManagers: ["github-actions", "pre-commit", "cargo", "pep621", "pip_requirements", "npm"],


### PR DESCRIPTION
## Summary

Follow up to https://github.com/astral-sh/ruff/pull/24874

This reverts changing the schedule to `0am`. I misunderstood how that field works. 
I now reverted it back to `4am`, so that the only change in schedule is that renovate now runs on Wednesday.

Closes https://github.com/astral-sh/ruff/issues/24920

## Test Plan

```
npx --yes --package renovate -- renovate-config-validator
 INFO: Validating .github/renovate.json5
 INFO: Config validated successfully
```
