### PR TITLE
Simplify the playground's markdown template

### DIFF
--- a/playground/ruff/src/Editor/settings.ts
+++ b/playground/ruff/src/Editor/settings.ts
@@ -73,13 +73,13 @@ export async function copyAsMarkdown(
   }
 
   await navigator.clipboard.writeText(
-    `## [Playground](${url})
-
-\`\`\`py
+    `\`\`\`py
 ${pythonSource}
 \`\`\`
 
 ${settingsBlock}
+
+[Playground](${url})
 `,
   );
 }

--- a/playground/shared/src/ShareButton.tsx
+++ b/playground/shared/src/ShareButton.tsx
@@ -11,7 +11,7 @@ import {
 } from "react-aria-components";
 import AstralButton from "./AstralButton";
 
-type ShareStatus = "initial" | "copied";
+type ShareStatus = "initial" | "copied" | "failed";
 type ShareAction = "share" | "copyMarkdownLink" | "copyMarkdown" | "reset";
 
 export default function ShareButton({
@@ -27,18 +27,24 @@ export default function ShareButton({
 }) {
   const [status, dispatch, isPending] = useActionState(
     async (_previousStatus: ShareStatus, action: ShareAction) => {
-      switch (action) {
-        case "reset":
-          return "initial";
-        case "share":
-          await onShare();
-          break;
-        case "copyMarkdownLink":
-          await onCopyMarkdownLink();
-          break;
-        case "copyMarkdown":
-          await onCopyMarkdown();
-          break;
+      try {
+        switch (action) {
+          case "reset":
+            return "initial";
+          case "share":
+            await onShare();
+            break;
+          case "copyMarkdownLink":
+            await onCopyMarkdownLink();
+            break;
+          case "copyMarkdown":
+            await onCopyMarkdown();
+            break;
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error("Failed to share playground.", error);
+        return "failed";
       }
       return "copied";
     },
@@ -46,7 +52,7 @@ export default function ShareButton({
   );
 
   useEffect(() => {
-    if (status === "copied") {
+    if (status === "copied" || status === "failed") {
       const timeout = setTimeout(
         () => startTransition(() => dispatch("reset")),
         2000,
@@ -56,6 +62,7 @@ export default function ShareButton({
   }, [status, dispatch]);
 
   const copied = status === "copied" && !isPending;
+  const failed = status === "failed" && !isPending;
 
   return (
     <MenuTrigger>
@@ -73,9 +80,9 @@ export default function ShareButton({
           <span
             className={classNames(
               "absolute inset-0 flex items-center justify-center",
-              copied && "invisible",
+              (copied || failed) && "invisible",
             )}
-            aria-hidden={copied}
+            aria-hidden={copied || failed}
           >
             Share
           </span>
@@ -84,6 +91,15 @@ export default function ShareButton({
             aria-hidden={!copied}
           >
             Copied!
+          </span>
+          <span
+            className={classNames(
+              "absolute inset-0 flex items-center justify-center",
+              !failed && "invisible",
+            )}
+            aria-hidden={!failed}
+          >
+            Failed
           </span>
         </AstralButton>
       </Pressable>

--- a/playground/ty/src/Editor/markdown.ts
+++ b/playground/ty/src/Editor/markdown.ts
@@ -37,19 +37,25 @@ export function generatePlaygroundMarkdown(
   files: { [name: string]: string },
   shareUrl: string,
 ): string {
-  let markdown = `## [Playground](${shareUrl})
-
-`;
+  let markdown = "";
+  const showFilenames = Object.keys(files).length > 1;
 
   for (const [filename, content] of Object.entries(files)) {
-    markdown += `### \`${filename}\`
+    if (showFilenames) {
+      markdown += `\`${filename}\`:
 
-\`\`\`${getLanguageTag(filename)}
+`;
+    }
+
+    markdown += `\`\`\`${getLanguageTag(filename)}
 ${content}
 \`\`\`
 
 `;
   }
+
+  markdown += `[Playground](${shareUrl})
+`;
 
   return markdown;
 }


### PR DESCRIPTION
## Summary

After using the playground's *share markdown* feature for a while, I've come to the conclusion that the current format is never what I want. Mainly because the `## Playground` and the `### file` headers mess with the headings in my issue summary or comment. 

This PR changes the markdown output to something closer to what we use in mdtests. Instead of a header, we use `file:` as the file header, and the playground link appears after the example.

## Test Plan

Example markdown as copied from the ty playground

`main.py`:

```py
from typing import TypedDict
from main2 import Lib

class Dict(TypedDict):
    fg: int
    g: str

print(Lib())

Dict(fg=12)
```

`ty.json`:

```json
{
    "environment": {
        "python-version": "3.14"
    },
    "rules": {
        "undefined-reveal": "ignore"
    }
}
```

`main2.py`:

```py
from typing import Literal


x: Literal["apple"] = "app"
```

[Playground](http://localhost:5173/10397f50-37c1-430b-b5f2-a6cb9672eae0)

