### PR TITLE
[ty] Fix `TypeIs` assignability with gradual types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1451,6 +1451,43 @@ static_assert(not is_assignable_to(TypeGuard[Unknown], str))
 static_assert(not is_assignable_to(TypeIs[Any], str))
 ```
 
+## `TypeIs` with gradual types
+
+`TypeIs` is invariant in its declared type. But gradual types are assignable to and from any type,
+so `TypeIs` annotations that differ only by `Any` are still compatible:
+
+```py
+from collections.abc import Sequence
+from ty_extensions import is_assignable_to, static_assert
+from typing_extensions import Any, TypeIs
+
+static_assert(is_assignable_to(TypeIs[Sequence[int]], TypeIs[Sequence[Any]]))
+static_assert(is_assignable_to(TypeIs[Sequence[Any]], TypeIs[Sequence[int]]))
+static_assert(not is_assignable_to(TypeIs[Sequence[int]], TypeIs[Sequence[object]]))
+```
+
+## `callable` as a `TypeIs` predicate
+
+The runtime predicate type and the declared `TypeIs` type are related but distinct. The builtin
+`callable` predicate can be used where a predicate for `Callable[..., Any]` is expected:
+
+```py
+from collections.abc import Callable
+from typing import Any
+from typing_extensions import TypeIs
+
+Plugin = Callable[..., Any]
+IsPlugin = Callable[[object], TypeIs[Plugin]]
+
+def accepts_plugin_predicate(plugin_type: IsPlugin = callable) -> None:
+    pass
+
+def takes_plugin_predicate(plugin_type: IsPlugin) -> None:
+    pass
+
+takes_plugin_predicate(callable)
+```
+
 ## `ParamSpec`
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -854,11 +854,11 @@ fn recursive_type_normalize_type_guard_like<'db, T: TypeGuardLike<'db>>(
 ) -> Option<Type<'db>> {
     let ty = if nested {
         guard
-            .return_type(db)
+            .type_argument(db)
             .recursive_type_normalized_impl(db, div, true)?
     } else {
         guard
-            .return_type(db)
+            .type_argument(db)
             .recursive_type_normalized_impl(db, div, true)
             .unwrap_or(div)
     };
@@ -5719,18 +5719,13 @@ impl<'db> Type<'db> {
                 builder.build()
             }
 
-            // TODO(jelle): Materialize should be handled differently, since TypeIs is invariant
             Type::TypeIs(type_is) => visitor.visit(self, type_mapping, || {
-                Type::TypeIs(TypeIsType::new(
+                type_is.with_type(
                     db,
-                    type_is
-                        .return_type(db)
-                        .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                     type_is
                         .declared_type(db)
                         .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-                    type_is.place_info(db),
-                ))
+                )
             }),
 
             Type::TypeGuard(type_guard) => visitor.visit(self, type_mapping, || {
@@ -5979,12 +5974,6 @@ impl<'db> Type<'db> {
             }
 
             Type::TypeIs(type_is) => {
-                type_is.return_type(db).find_legacy_typevars_impl(
-                    db,
-                    binding_context,
-                    typevars,
-                    visitor,
-                );
                 type_is.declared_type(db).find_legacy_typevars_impl(
                     db,
                     binding_context,
@@ -7654,8 +7643,7 @@ pub(super) struct MetaclassTransformInfo<'db> {
 
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct TypeIsType<'db> {
-    return_type: Type<'db>,
-    declared_type: Type<'db>,
+    type_argument: Type<'db>,
     /// The ID of the scope to which the place belongs
     /// and the ID of the place itself within that scope.
     place_info: Option<(ScopeId<'db>, ScopedPlaceId)>,
@@ -7666,7 +7654,7 @@ fn walk_typeis_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     typeis_type: TypeIsType<'db>,
     visitor: &V,
 ) {
-    visitor.visit_type(db, typeis_type.return_type(db));
+    visitor.visit_type(db, typeis_type.declared_type(db));
 }
 
 // The Salsa heap is tracked separately.
@@ -7682,8 +7670,8 @@ impl<'db> TypeIsType<'db> {
 
     /// Construct an unbound `TypeIs` return type from the user-written type expression.
     ///
-    /// The stored return type uses the top materialization for narrowing while the declared type is
-    /// preserved for `TypeIs` invariance checks.
+    /// The user-written type is preserved for `TypeIs` invariance checks, while the return type
+    /// used for narrowing applies the top materialization on demand.
     ///
     /// ```python
     /// from typing import TypeIs
@@ -7692,12 +7680,20 @@ impl<'db> TypeIsType<'db> {
     ///     return isinstance(value, tuple)
     /// ```
     pub(crate) fn from_type_expression(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+        Type::TypeIs(Self::new(db, ty, None))
+    }
+
+    pub(crate) fn declared_type(self, db: &'db dyn Db) -> Type<'db> {
+        self.type_argument(db)
+    }
+
+    pub(crate) fn return_type(self, db: &'db dyn Db) -> Type<'db> {
         // N.B. Using the top materialization here is a pragmatic decision that
         // makes us produce more intuitive results given how `TypeIs` is used in
         // the real world (in particular, in typeshed). However, there's some
         // debate about whether this is really fully correct. See
         // <https://github.com/astral-sh/ruff/pull/20591> for more discussion.
-        Type::TypeIs(Self::new(db, ty.top_materialization(db), ty, None))
+        self.declared_type(db).top_materialization(db)
     }
 
     #[must_use]
@@ -7707,17 +7703,12 @@ impl<'db> TypeIsType<'db> {
         scope: ScopeId<'db>,
         place: ScopedPlaceId,
     ) -> Type<'db> {
-        Type::TypeIs(Self::new(
-            db,
-            self.return_type(db),
-            self.declared_type(db),
-            Some((scope, place)),
-        ))
+        Type::TypeIs(Self::new(db, self.declared_type(db), Some((scope, place))))
     }
 
     #[must_use]
     pub(crate) fn with_type(self, db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
-        Type::TypeIs(Self::new(db, ty, ty, self.place_info(db)))
+        Type::TypeIs(Self::new(db, ty, self.place_info(db)))
     }
 
     pub(crate) fn is_bound(self, db: &'db dyn Db) -> bool {
@@ -7729,7 +7720,7 @@ impl<'db> VarianceInferable<'db> for TypeIsType<'db> {
     // See the [typing spec] on why `TypeIs` is invariant in its type.
     // [typing spec]: https://typing.python.org/en/latest/spec/narrowing.html#typeis
     fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarVariance {
-        self.return_type(db)
+        self.declared_type(db)
             .with_polarity(TypeVarVariance::Invariant)
             .variance_of(db, typevar)
     }
@@ -7809,13 +7800,13 @@ pub(crate) trait TypeGuardLike<'db>: Copy {
     /// The name of this type guard form (for error messages and display)
     const FORM_NAME: &'static str;
 
-    /// Get the return type that the type guard narrows to
-    fn return_type(self, db: &'db dyn Db) -> Type<'db>;
+    /// Get the annotation argument stored in the type guard form.
+    fn type_argument(self, db: &'db dyn Db) -> Type<'db>;
 
     /// Get the human-readable place name if bound
     fn place_name(self, db: &'db dyn Db) -> Option<String>;
 
-    /// Create a new instance with a different return type, wrapped in Type
+    /// Create a new instance with a different type argument, wrapped in Type.
     fn with_type(self, db: &'db dyn Db, ty: Type<'db>) -> Type<'db>;
 
     /// The `SpecialFormType` for display purposes
@@ -7825,8 +7816,8 @@ pub(crate) trait TypeGuardLike<'db>: Copy {
 impl<'db> TypeGuardLike<'db> for TypeIsType<'db> {
     const FORM_NAME: &'static str = "TypeIs";
 
-    fn return_type(self, db: &'db dyn Db) -> Type<'db> {
-        TypeIsType::return_type(self, db)
+    fn type_argument(self, db: &'db dyn Db) -> Type<'db> {
+        TypeIsType::declared_type(self, db)
     }
 
     fn place_name(self, db: &'db dyn Db) -> Option<String> {
@@ -7845,7 +7836,7 @@ impl<'db> TypeGuardLike<'db> for TypeIsType<'db> {
 impl<'db> TypeGuardLike<'db> for TypeGuardType<'db> {
     const FORM_NAME: &'static str = "TypeGuard";
 
-    fn return_type(self, db: &'db dyn Db) -> Type<'db> {
+    fn type_argument(self, db: &'db dyn Db) -> Type<'db> {
         TypeGuardType::return_type(self, db)
     }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5723,7 +5723,7 @@ impl<'db> Type<'db> {
                 type_is.with_type(
                     db,
                     type_is
-                        .declared_type(db)
+                        .type_argument(db)
                         .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 )
             }),
@@ -5974,7 +5974,7 @@ impl<'db> Type<'db> {
             }
 
             Type::TypeIs(type_is) => {
-                type_is.declared_type(db).find_legacy_typevars_impl(
+                type_is.type_argument(db).find_legacy_typevars_impl(
                     db,
                     binding_context,
                     typevars,
@@ -7654,7 +7654,7 @@ fn walk_typeis_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     typeis_type: TypeIsType<'db>,
     visitor: &V,
 ) {
-    visitor.visit_type(db, typeis_type.declared_type(db));
+    visitor.visit_type(db, typeis_type.type_argument(db));
 }
 
 // The Salsa heap is tracked separately.
@@ -7683,17 +7683,13 @@ impl<'db> TypeIsType<'db> {
         Type::TypeIs(Self::new(db, ty, None))
     }
 
-    pub(crate) fn declared_type(self, db: &'db dyn Db) -> Type<'db> {
-        self.type_argument(db)
-    }
-
     pub(crate) fn return_type(self, db: &'db dyn Db) -> Type<'db> {
         // N.B. Using the top materialization here is a pragmatic decision that
         // makes us produce more intuitive results given how `TypeIs` is used in
         // the real world (in particular, in typeshed). However, there's some
         // debate about whether this is really fully correct. See
         // <https://github.com/astral-sh/ruff/pull/20591> for more discussion.
-        self.declared_type(db).top_materialization(db)
+        self.type_argument(db).top_materialization(db)
     }
 
     #[must_use]
@@ -7703,7 +7699,7 @@ impl<'db> TypeIsType<'db> {
         scope: ScopeId<'db>,
         place: ScopedPlaceId,
     ) -> Type<'db> {
-        Type::TypeIs(Self::new(db, self.declared_type(db), Some((scope, place))))
+        Type::TypeIs(Self::new(db, self.type_argument(db), Some((scope, place))))
     }
 
     #[must_use]
@@ -7720,7 +7716,7 @@ impl<'db> VarianceInferable<'db> for TypeIsType<'db> {
     // See the [typing spec] on why `TypeIs` is invariant in its type.
     // [typing spec]: https://typing.python.org/en/latest/spec/narrowing.html#typeis
     fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarVariance {
-        self.declared_type(db)
+        self.type_argument(db)
             .with_polarity(TypeVarVariance::Invariant)
             .variance_of(db, typevar)
     }
@@ -7817,7 +7813,7 @@ impl<'db> TypeGuardLike<'db> for TypeIsType<'db> {
     const FORM_NAME: &'static str = "TypeIs";
 
     fn type_argument(self, db: &'db dyn Db) -> Type<'db> {
-        TypeIsType::declared_type(self, db)
+        TypeIsType::type_argument(self, db)
     }
 
     fn place_name(self, db: &'db dyn Db) -> Option<String> {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5721,12 +5721,16 @@ impl<'db> Type<'db> {
 
             // TODO(jelle): Materialize should be handled differently, since TypeIs is invariant
             Type::TypeIs(type_is) => visitor.visit(self, type_mapping, || {
-                type_is.with_type(
+                Type::TypeIs(TypeIsType::new(
                     db,
                     type_is
                         .return_type(db)
                         .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-                )
+                    type_is
+                        .declared_type(db)
+                        .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                    type_is.place_info(db),
+                ))
             }),
 
             Type::TypeGuard(type_guard) => visitor.visit(self, type_mapping, || {
@@ -5976,6 +5980,12 @@ impl<'db> Type<'db> {
 
             Type::TypeIs(type_is) => {
                 type_is.return_type(db).find_legacy_typevars_impl(
+                    db,
+                    binding_context,
+                    typevars,
+                    visitor,
+                );
+                type_is.declared_type(db).find_legacy_typevars_impl(
                     db,
                     binding_context,
                     typevars,
@@ -7645,6 +7655,7 @@ pub(super) struct MetaclassTransformInfo<'db> {
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct TypeIsType<'db> {
     return_type: Type<'db>,
+    declared_type: Type<'db>,
     /// The ID of the scope to which the place belongs
     /// and the ID of the place itself within that scope.
     place_info: Option<(ScopeId<'db>, ScopedPlaceId)>,
@@ -7669,17 +7680,24 @@ impl<'db> TypeIsType<'db> {
         Some(format!("{}", table.place(place)))
     }
 
-    pub(crate) fn unbound(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
-        Type::TypeIs(Self::new(db, ty, None))
-    }
-
-    pub(crate) fn bound(
-        db: &'db dyn Db,
-        return_type: Type<'db>,
-        scope: ScopeId<'db>,
-        place: ScopedPlaceId,
-    ) -> Type<'db> {
-        Type::TypeIs(Self::new(db, return_type, Some((scope, place))))
+    /// Construct an unbound `TypeIs` return type from the user-written type expression.
+    ///
+    /// The stored return type uses the top materialization for narrowing while the declared type is
+    /// preserved for `TypeIs` invariance checks.
+    ///
+    /// ```python
+    /// from typing import TypeIs
+    ///
+    /// def is_tuple(value: object) -> TypeIs[tuple[int, ...]]:
+    ///     return isinstance(value, tuple)
+    /// ```
+    pub(crate) fn from_type_expression(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+        // N.B. Using the top materialization here is a pragmatic decision that
+        // makes us produce more intuitive results given how `TypeIs` is used in
+        // the real world (in particular, in typeshed). However, there's some
+        // debate about whether this is really fully correct. See
+        // <https://github.com/astral-sh/ruff/pull/20591> for more discussion.
+        Type::TypeIs(Self::new(db, ty.top_materialization(db), ty, None))
     }
 
     #[must_use]
@@ -7689,12 +7707,17 @@ impl<'db> TypeIsType<'db> {
         scope: ScopeId<'db>,
         place: ScopedPlaceId,
     ) -> Type<'db> {
-        Self::bound(db, self.return_type(db), scope, place)
+        Type::TypeIs(Self::new(
+            db,
+            self.return_type(db),
+            self.declared_type(db),
+            Some((scope, place)),
+        ))
     }
 
     #[must_use]
     pub(crate) fn with_type(self, db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
-        Type::TypeIs(Self::new(db, ty, self.place_info(db)))
+        Type::TypeIs(Self::new(db, ty, ty, self.place_info(db)))
     }
 
     pub(crate) fn is_bound(self, db: &'db dyn Db) -> bool {

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -833,7 +833,7 @@ fn fmt_type_guard_like<'db, T: TypeGuardLike<'db>>(
         .write_str(T::FORM_NAME)?;
     f.write_char('[')?;
     guard
-        .return_type(db)
+        .type_argument(db)
         .display_with(db, settings.singleline())
         .fmt_detailed(f)?;
     if let Some(name) = guard.place_name(db) {

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2136,16 +2136,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     if expanded.is_divergent() {
                         expanded
                     } else {
-                        TypeIsType::unbound(
-                            self.db(),
-                            // N.B. Using the top materialization here is a pragmatic decision
-                            // that makes us produce more intuitive results given how
-                            // `TypeIs` is used in the real world (in particular, in typeshed).
-                            // However, there's some debate about whether this is really
-                            // fully correct. See <https://github.com/astral-sh/ruff/pull/20591>
-                            // for more discussion.
-                            narrowed.top_materialization(self.db()),
-                        )
+                        TypeIsType::from_type_expression(self.db(), narrowed)
                     }
                 }
             },

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1683,8 +1683,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // `TypeIs` is invariant.
             (Type::TypeIs(source), Type::TypeIs(target)) => {
-                let source_return = source.return_type(db);
-                let target_return = target.return_type(db);
+                let source_return = source.declared_type(db);
+                let target_return = target.declared_type(db);
                 self.check_type_pair(db, source_return, target_return).and(
                     db,
                     self.constraints,

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1683,13 +1683,12 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // `TypeIs` is invariant.
             (Type::TypeIs(source), Type::TypeIs(target)) => {
-                let source_return = source.declared_type(db);
-                let target_return = target.declared_type(db);
-                self.check_type_pair(db, source_return, target_return).and(
-                    db,
-                    self.constraints,
-                    || self.check_type_pair(db, target_return, source_return),
-                )
+                let source_type = source.type_argument(db);
+                let target_type = target.type_argument(db);
+                self.check_type_pair(db, source_type, target_type)
+                    .and(db, self.constraints, || {
+                        self.check_type_pair(db, target_type, source_type)
+                    })
             }
 
             // `TypeGuard` is covariant.


### PR DESCRIPTION
## Summary

Prior to this change, for `TypeIs`, we only stored the `T.top_materialization()` of the type. So for assignability, we checked against the materialized narrowing type, rather than the user-declared type. The two are conflated.

I think this causes problems for cases like:

```python
static_assert(is_assignable_to(TypeIs[Sequence[int]], TypeIs[Sequence[Any]]))
static_assert(not is_assignable_to(TypeIs[Sequence[int]], TypeIs[Sequence[object]]))
```

On `main`, the first assertion fails.