### PR TITLE
[ty] Server changes for Python Environment Extension support

### DIFF
--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -32,6 +32,7 @@ specifies ty's implementation of Python's import resolution algorithm.
 */
 
 use std::borrow::Cow;
+use std::fmt;
 use std::iter::FusedIterator;
 
 use rustc_hash::{FxBuildHasher, FxHashSet};
@@ -733,6 +734,18 @@ impl SearchPaths {
         }
     }
 
+    pub fn display<'a>(
+        &'a self,
+        db: &'a dyn Db,
+        mode: ModuleResolveMode,
+    ) -> DisplaySearchPaths<'a> {
+        DisplaySearchPaths {
+            search_paths: self,
+            db,
+            mode,
+        }
+    }
+
     pub fn custom_stdlib(&self) -> Option<&SystemPath> {
         self.stdlib_path
             .as_ref()
@@ -741,6 +754,28 @@ impl SearchPaths {
 
     pub fn typeshed_versions(&self) -> &TypeshedVersions {
         &self.typeshed_versions
+    }
+}
+
+pub struct DisplaySearchPaths<'a> {
+    search_paths: &'a SearchPaths,
+    db: &'a dyn Db,
+    mode: ModuleResolveMode,
+}
+
+impl fmt::Display for DisplaySearchPaths<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut paths = self.search_paths.iter(self.db, self.mode).peekable();
+
+        if paths.peek().is_none() {
+            return f.write_str("[]");
+        }
+
+        writeln!(f, "[")?;
+        for path in paths {
+            writeln!(f, "  {path},")?;
+        }
+        f.write_str("]")
     }
 }
 

--- a/crates/ty_server/src/server/api/requests/execute_command.rs
+++ b/crates/ty_server/src/server/api/requests/execute_command.rs
@@ -7,9 +7,11 @@ use crate::session::Session;
 use crate::session::client::Client;
 use lsp_server::ErrorCode;
 use lsp_types::{self as types, request as req};
-use std::fmt::Write;
+use std::fmt::{self, Write};
 use std::str::FromStr;
+use ty_module_resolver::ModuleResolveMode;
 use ty_project::Db as _;
+use ty_python_core::program::Program;
 
 pub(crate) struct ExecuteCommand;
 
@@ -64,6 +66,27 @@ fn debug_information(session: &Session) -> crate::Result<String> {
 
     for db in session.project_dbs() {
         writeln!(buffer, "Project at {}", db.project().root(db))?;
+        let program = Program::get(db);
+        writeln!(buffer, "Program:")?;
+        writeln!(
+            buffer,
+            "  python-version: {}",
+            program.python_version_with_source(db).version
+        )?;
+        writeln!(buffer, "  python-platform: {}", program.python_platform(db))?;
+        let mut writer = IndentingWriter {
+            inner: &mut buffer,
+            indent: "  ",
+            at_line_start: false,
+        };
+        writeln!(
+            writer,
+            "  search-paths: {:#}",
+            program
+                .search_paths(db)
+                .display(db, ModuleResolveMode::StubsAllowed)
+        )?;
+
         writeln!(buffer, "Settings: {:#?}", db.project().settings(db))?;
         writeln!(buffer)?;
         writeln!(
@@ -73,4 +96,24 @@ fn debug_information(session: &Session) -> crate::Result<String> {
         )?;
     }
     Ok(buffer)
+}
+
+struct IndentingWriter<'a> {
+    inner: &'a mut String,
+    indent: &'static str,
+    at_line_start: bool,
+}
+
+impl Write for IndentingWriter<'_> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for part in s.split_inclusive('\n') {
+            if self.at_line_start {
+                self.inner.write_str(self.indent)?;
+            }
+            self.inner.write_str(part)?;
+            self.at_line_start = part.ends_with('\n');
+        }
+
+        Ok(())
+    }
 }

--- a/crates/ty_server/src/session/options.rs
+++ b/crates/ty_server/src/session/options.rs
@@ -468,6 +468,7 @@ impl Combine for PythonExtension {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ActiveEnvironment {
     pub(crate) executable: PythonExecutable,
+    #[deprecated]
     pub(crate) environment: Option<PythonEnvironment>,
     pub(crate) version: Option<EnvironmentVersion>,
 }
@@ -478,11 +479,11 @@ pub(crate) struct EnvironmentVersion {
     pub(crate) major: i64,
     pub(crate) minor: i64,
     #[deprecated(
-        note = "Unused by the server. Use `major` and `minor` instead. This can be omitted when the Python Environments extension reports a major/minor-only version; Zed omits the entire `version` object."
+        note = "Not provided by all clients (Zed, VS Code when using the Python Environment extension). Use `major` and `minor` instead."
     )]
     pub(crate) patch: Option<i64>,
     #[deprecated(
-        note = "Unused by the server. Use `major` and `minor` instead. This is not provided by the Python Environments extension; Zed omits the entire `version` object."
+        note = "Not provided by all clients (Zed, VS Code when using the Python Environment extension)."
     )]
     pub(crate) sys_version: Option<String>,
 }
@@ -490,23 +491,19 @@ pub(crate) struct EnvironmentVersion {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PythonEnvironment {
-    #[deprecated(
-        note = "Unused by the server. Use `executable.sysPrefix` instead. This can point to a Python executable instead of an environment root; Zed omits the entire `environment` object."
-    )]
+    #[deprecated]
     pub(crate) folder_uri: Option<Url>,
-    #[deprecated(
-        note = "Unused by the server. This is not provided by the Python Environments extension; Zed omits the entire `environment` object."
-    )]
+    #[deprecated]
     #[serde(rename = "type")]
     pub(crate) kind: Option<String>,
-    #[deprecated(note = "Unused by the server. Zed omits the entire `environment` object.")]
+    #[deprecated]
     pub(crate) name: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PythonExecutable {
-    #[deprecated(note = "Unused by the server. Use `sys_prefix` instead.")]
+    #[deprecated]
     pub(crate) uri: Option<Url>,
     pub(crate) sys_prefix: SystemPathBuf,
 }

--- a/crates/ty_server/src/session/options.rs
+++ b/crates/ty_server/src/session/options.rs
@@ -252,17 +252,9 @@ impl WorkspaceOptions {
         if let Some(extension) = self.python_extension
             && let Some(active_environment) = extension.active_environment
         {
-            overrides.fallback_python = if let Some(environment) = &active_environment.environment {
-                environment.folder_uri.to_file_path().ok().and_then(|path| {
-                    Some(RelativePathBuf::python_extension(
-                        SystemPathBuf::from_path_buf(path).ok()?,
-                    ))
-                })
-            } else {
-                Some(RelativePathBuf::python_extension(
-                    active_environment.executable.sys_prefix,
-                ))
-            };
+            overrides.fallback_python = Some(RelativePathBuf::python_extension(
+                active_environment.executable.sys_prefix,
+            ));
 
             overrides.fallback_python_version = active_environment
                 .version
@@ -485,27 +477,36 @@ pub(crate) struct ActiveEnvironment {
 pub(crate) struct EnvironmentVersion {
     pub(crate) major: i64,
     pub(crate) minor: i64,
-    #[allow(dead_code)]
-    pub(crate) patch: i64,
-    #[allow(dead_code)]
-    pub(crate) sys_version: String,
+    #[deprecated(
+        note = "Unused by the server. Use `major` and `minor` instead. This can be omitted when the Python Environments extension reports a major/minor-only version; Zed omits the entire `version` object."
+    )]
+    pub(crate) patch: Option<i64>,
+    #[deprecated(
+        note = "Unused by the server. Use `major` and `minor` instead. This is not provided by the Python Environments extension; Zed omits the entire `version` object."
+    )]
+    pub(crate) sys_version: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PythonEnvironment {
-    pub(crate) folder_uri: Url,
-    #[allow(dead_code)]
+    #[deprecated(
+        note = "Unused by the server. Use `executable.sysPrefix` instead. This can point to a Python executable instead of an environment root; Zed omits the entire `environment` object."
+    )]
+    pub(crate) folder_uri: Option<Url>,
+    #[deprecated(
+        note = "Unused by the server. This is not provided by the Python Environments extension; Zed omits the entire `environment` object."
+    )]
     #[serde(rename = "type")]
-    pub(crate) kind: String,
-    #[allow(dead_code)]
+    pub(crate) kind: Option<String>,
+    #[deprecated(note = "Unused by the server. Zed omits the entire `environment` object.")]
     pub(crate) name: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PythonExecutable {
-    #[allow(dead_code)]
-    pub(crate) uri: Url,
+    #[deprecated(note = "Unused by the server. Use `sys_prefix` instead.")]
+    pub(crate) uri: Option<Url>,
     pub(crate) sys_prefix: SystemPathBuf,
 }

--- a/crates/ty_server/tests/e2e/commands.rs
+++ b/crates/ty_server/tests/e2e/commands.rs
@@ -23,14 +23,21 @@ fn execute_command(
 fn debug_command() -> Result<()> {
     let workspace_root = SystemPath::new("src");
     let foo = SystemPath::new("src/foo.py");
+    let ty_toml = SystemPath::new("ty.toml");
     let foo_content = "\
 def foo() -> str:
 return 42
+";
+    let ty_toml_content = "\
+[environment]
+python-version = \"3.10\"
+python-platform = \"linux\"
 ";
 
     let mut server = TestServerBuilder::new()?
         .with_workspace(workspace_root, None)?
         .with_file(foo, foo_content)?
+        .with_file(ty_toml, ty_toml_content)?
         .enable_pull_diagnostics(false)
         .build()
         .wait_until_workspaces_are_initialized();
@@ -42,15 +49,15 @@ return 42
         .as_str()
         .expect("debug command to return a string response");
 
-    insta::with_settings!({
-        filters => vec![
-            (r"\b[0-9]+.[0-9]+MB\b", "[X.XXMB]"),
-            (r"Workspace .+\)", "Workspace XXX"),
-            (r"Project at .+", "Project at XXX"),
-            (r"rules: \{(.|\n)+?\}\,", "rules: <RULES>,"),
-    ]}, {
-        insta::assert_snapshot!(response);
-    });
+    let mut settings = insta::Settings::clone_current();
+    settings.add_filter(r"\b[0-9]+.[0-9]+MB\b", "[X.XXMB]");
+    settings.add_filter(r"Workspace .+\)", "Workspace XXX");
+    settings.add_filter(r"Project at .+", "Project at XXX");
+    settings.add_filter(r"(?m)^(\s+).*/site-packages,$", "$1<site-packages>,");
+    settings.add_filter(r"rules: \{(.|\n)+?\}\,", "rules: <RULES>,");
+    let _settings = settings.bind_to_scope();
+
+    insta::assert_snapshot!(response);
 
     Ok(())
 }

--- a/crates/ty_server/tests/e2e/configuration.rs
+++ b/crates/ty_server/tests/e2e/configuration.rs
@@ -179,16 +179,12 @@ reveal_type(sys.version_info[:2])
     let builder = TestServerBuilder::new()?;
     let python_home = builder.file_path(python_home);
     let sys_prefix = builder.file_path("venv");
-    let misleading_environment_uri = builder.file_uri(base_python);
 
     let workspace_options: ClientOptions = serde_json::from_value(json!({
         "pythonExtension": {
             "activeEnvironment": {
                 "executable": {
                     "sysPrefix": sys_prefix,
-                },
-                "environment": {
-                    "folderUri": misleading_environment_uri,
                 },
                 "version": {
                     "major": 3,

--- a/crates/ty_server/tests/e2e/configuration.rs
+++ b/crates/ty_server/tests/e2e/configuration.rs
@@ -179,20 +179,20 @@ reveal_type(sys.version_info[:2])
     let builder = TestServerBuilder::new()?;
     let python_home = builder.file_path(python_home);
     let sys_prefix = builder.file_path("venv");
-    let python_uri = builder.file_uri(python);
+    let misleading_environment_uri = builder.file_uri(base_python);
 
     let workspace_options: ClientOptions = serde_json::from_value(json!({
         "pythonExtension": {
             "activeEnvironment": {
                 "executable": {
-                    "uri": python_uri,
                     "sysPrefix": sys_prefix,
+                },
+                "environment": {
+                    "folderUri": misleading_environment_uri,
                 },
                 "version": {
                     "major": 3,
                     "minor": 16,
-                    "patch": 0,
-                    "sysVersion": "3.16.0",
                 }
             }
         }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -27,6 +27,15 @@ Settings: WorkspaceSettings {
 }
 
 Project at XXX
+Program:
+  python-version: 3.10
+  python-platform: linux
+  search-paths: [
+    <temp_dir>/src,
+    <temp_dir>/,
+    vendored://stdlib,
+    <site-packages>,
+  ]
 Settings: Settings {
     rules: <RULES>,
     terminal: TerminalSettings {
@@ -169,8 +178,11 @@ Memory report:
 =======SALSA STRUCTS=======
 `Program`                                          metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `Project`                                          metadata=[X.XXMB]   fields=[X.XXMB]   count=1
-`FileRoot`                                         metadata=[X.XXMB]   fields=[X.XXMB]   count=1
+`FileRoot`                                         metadata=[X.XXMB]   fields=[X.XXMB]   count=2
+`ModuleResolveModeIngredient`                      metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 =======SALSA QUERIES=======
+`dynamic_resolution_paths -> alloc::vec::Vec<ty_module_resolver::path::SearchPath>`
+    metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 =======SALSA SUMMARY=======
 TOTAL MEMORY USAGE: [X.XXMB]
     struct metadata = [X.XXMB]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -34,7 +34,6 @@ Program:
     <temp_dir>/src,
     <temp_dir>/,
     vendored://stdlib,
-    <site-packages>,
   ]
 Settings: Settings {
     rules: <RULES>,
@@ -178,7 +177,7 @@ Memory report:
 =======SALSA STRUCTS=======
 `Program`                                          metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `Project`                                          metadata=[X.XXMB]   fields=[X.XXMB]   count=1
-`FileRoot`                                         metadata=[X.XXMB]   fields=[X.XXMB]   count=2
+`FileRoot`                                         metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `ModuleResolveModeIngredient`                      metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 =======SALSA QUERIES=======
 `dynamic_resolution_paths -> alloc::vec::Vec<ty_module_resolver::path::SearchPath>`


### PR DESCRIPTION
## Summary

This PR makes a few server-side changes that are necessary for adding support for the Python Environment extension:

1. Extend the `printDebugInformation` command to include the `ProgramSettings`. This is technically not necessary, but it makes testing the change so much easier :)
2. Deprecate most of the `ActiveEnvironment` fields and make them accept an `Option`. The Python Environment extension doesn't provide the same fields and we only use a subset anyway. Making those fields optional and deprecating them should allow us to remove them in a future ty release.
