### PR TITLE
[ty] Respect commented-out lines in the conformance test suite

### DIFF
--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -450,6 +450,10 @@ def collect_expected_diagnostics(test_files: Sequence[Path]) -> list[ExpectedErr
     for file in test_files:
         for idx, line in enumerate(file.read_text().splitlines(), 1):
             if match := re.search(CONFORMANCE_ERROR_PATTERN, line):
+                prefix = line[: match.start()].lstrip()
+                if not prefix or prefix.startswith("#"):
+                    continue
+
                 errors.append(
                     ExpectedError(
                         description=(match.group("description") or "Missing"),


### PR DESCRIPTION
## Summary

We were treating this line from the conformance tests as a false negative:

https://github.com/python/typing/blob/5a701a037b5243df1f39622b642893d865f06205/conformance/tests/generics_syntax_infer_variance.py#L72
