### PR TITLE
[ty] Preserve ParamSpec argument context through wrapper calls

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -761,7 +761,7 @@ parameter types of the callable argument. This mirrors wrappers like `asyncio.to
 clients that expose large `Unpack[TypedDict]` keyword signatures.
 
 ```py
-from typing import Callable, TypedDict, Unpack
+from typing import Callable, TypedDict, Unpack, overload
 
 class Tag(TypedDict):
     Key: str
@@ -782,6 +782,23 @@ to_thread_like(put_tags, reveal_type([{"Key": "k", "Value": "v"}]))  # revealed:
 to_thread_like(put_object, TagSet=reveal_type([{"Key": "k", "Value": "v"}]))  # revealed: list[Tag]
 to_thread_like_keyword(func=put_object, TagSet=reveal_type([{"Key": "k", "Value": "v"}]))  # revealed: list[Tag]
 to_thread_like_keyword(TagSet=reveal_type([{"Key": "k", "Value": "v"}]), func=put_object)  # revealed: list[Tag]
+
+def requires_x(*, x: int) -> str:
+    return ""
+
+def with_flag[**P, R](func: Callable[P, R], flag: int, *args: P.args, **kwargs: P.kwargs) -> R:
+    return func(*args, **kwargs)
+
+with_flag(x=1, func=requires_x, flag=1)
+with_flag(x=1, func=requires_x, flag="bad")  # error: [invalid-argument-type]
+
+@overload
+def overloaded_put_object(*, TagSet: list[Tag]) -> None: ...
+@overload
+def overloaded_put_object(*, func: object, TagSet: list[int]) -> None: ...
+def overloaded_put_object(*, TagSet: object, func: object = None) -> None: ...
+
+to_thread_like_keyword(TagSet=reveal_type([{"Key": "k", "Value": "v"}]), func=overloaded_put_object)  # revealed: list[Tag]
 ```
 
 ParamSpec forwarding should not use raw unspecialized type variables from a wrapped generic callable
@@ -791,10 +808,16 @@ as argument context, since that can hide errors between forwarded arguments.
 from typing import Callable
 
 def generic_pair[T](x: list[T], y: list[T], /) -> None: ...
+def generic_pair_with_container[T](x: T, y: list[T], /) -> None: ...
 def to_thread_like[**P, R](func: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R:
     return func(*args, **kwargs)
 
-to_thread_like(generic_pair, [1], [""])  # error: [invalid-argument-type]
+# error: [invalid-argument-type]
+# error: [invalid-argument-type]
+to_thread_like(generic_pair, [1], reveal_type([""]))  # revealed: list[str]
+
+# error: [invalid-argument-type]
+to_thread_like(generic_pair_with_container, 1, reveal_type([""]))  # revealed: list[str]
 ```
 
 ### Specializing `ParamSpec` with another `ParamSpec`

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -756,6 +756,47 @@ foo1(f1, 1, "a", "b")
 foo1(f1, x=1, z="a")
 ```
 
+Inline literals passed through `ParamSpec` components should be inferred using the specialized
+parameter types of the callable argument. This mirrors wrappers like `asyncio.to_thread` around
+clients that expose large `Unpack[TypedDict]` keyword signatures.
+
+```py
+from typing import Callable, TypedDict, Unpack
+
+class Tag(TypedDict):
+    Key: str
+    Value: str
+
+class PutObjectRequest(TypedDict):
+    TagSet: list[Tag]
+
+def put_tags(tags: list[Tag], /) -> None: ...
+def put_object(**kwargs: Unpack[PutObjectRequest]) -> None: ...
+def to_thread_like[**P, R](func: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R:
+    return func(*args, **kwargs)
+
+def to_thread_like_keyword[**P, R](func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+    return func(*args, **kwargs)
+
+to_thread_like(put_tags, reveal_type([{"Key": "k", "Value": "v"}]))  # revealed: list[Tag]
+to_thread_like(put_object, TagSet=reveal_type([{"Key": "k", "Value": "v"}]))  # revealed: list[Tag]
+to_thread_like_keyword(func=put_object, TagSet=reveal_type([{"Key": "k", "Value": "v"}]))  # revealed: list[Tag]
+to_thread_like_keyword(TagSet=reveal_type([{"Key": "k", "Value": "v"}]), func=put_object)  # revealed: list[Tag]
+```
+
+ParamSpec forwarding should not use raw unspecialized type variables from a wrapped generic callable
+as argument context, since that can hide errors between forwarded arguments.
+
+```py
+from typing import Callable
+
+def generic_pair[T](x: list[T], y: list[T], /) -> None: ...
+def to_thread_like[**P, R](func: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R:
+    return func(*args, **kwargs)
+
+to_thread_like(generic_pair, [1], [""])  # error: [invalid-argument-type]
+```
+
 ### Specializing `ParamSpec` with another `ParamSpec`
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -758,7 +758,8 @@ foo1(f1, x=1, z="a")
 
 Inline literals passed through `ParamSpec` components should be inferred using the specialized
 parameter types of the callable argument. This mirrors wrappers like `asyncio.to_thread` around
-clients that expose large `Unpack[TypedDict]` keyword signatures.
+clients that expose large `Unpack[TypedDict]` keyword signatures, but also applies to other
+context-sensitive literals.
 
 ```py
 from typing import Callable, TypedDict, Unpack, overload
@@ -772,6 +773,9 @@ class PutObjectRequest(TypedDict):
 
 def put_tags(tags: list[Tag], /) -> None: ...
 def put_object(**kwargs: Unpack[PutObjectRequest]) -> None: ...
+def put_int_list(values: list[int], /) -> None: ...
+def put_int_tuple(values: tuple[int, ...], /) -> None: ...
+def put_int_tuples(values: list[tuple[int, ...]], /) -> None: ...
 def to_thread_like[**P, R](func: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R:
     return func(*args, **kwargs)
 
@@ -780,8 +784,30 @@ def to_thread_like_keyword[**P, R](func: Callable[P, R], *args: P.args, **kwargs
 
 to_thread_like(put_tags, reveal_type([{"Key": "k", "Value": "v"}]))  # revealed: list[Tag]
 to_thread_like(put_object, TagSet=reveal_type([{"Key": "k", "Value": "v"}]))  # revealed: list[Tag]
+to_thread_like(put_int_list, reveal_type([1, 2]))  # revealed: list[int]
+to_thread_like(put_int_tuple, reveal_type((1, 2)))  # revealed: tuple[Literal[1], Literal[2]]
+to_thread_like(put_int_tuples, reveal_type([(1, 2)]))  # revealed: list[tuple[int, ...]]
 to_thread_like_keyword(func=put_object, TagSet=reveal_type([{"Key": "k", "Value": "v"}]))  # revealed: list[Tag]
 to_thread_like_keyword(TagSet=reveal_type([{"Key": "k", "Value": "v"}]), func=put_object)  # revealed: list[Tag]
+
+class ThreadRunner:
+    def run[**P, R](self, func: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R:
+        return func(*args, **kwargs)
+
+class ClassThreadRunner:
+    @classmethod
+    def run[**P, R](cls, func: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R:
+        return func(*args, **kwargs)
+
+runner = ThreadRunner()
+runner.run(put_tags, reveal_type([{"Key": "k", "Value": "v"}]))  # revealed: list[Tag]
+runner.run(put_object, TagSet=reveal_type([{"Key": "k", "Value": "v"}]))  # revealed: list[Tag]
+runner.run(put_int_list, reveal_type([1, 2]))  # revealed: list[int]
+runner.run(put_int_tuple, reveal_type((1, 2)))  # revealed: tuple[Literal[1], Literal[2]]
+runner.run(put_int_tuples, reveal_type([(1, 2)]))  # revealed: list[tuple[int, ...]]
+ClassThreadRunner.run(put_int_list, reveal_type([1, 2]))  # revealed: list[int]
+ClassThreadRunner.run(put_int_tuple, reveal_type((1, 2)))  # revealed: tuple[Literal[1], Literal[2]]
+ClassThreadRunner.run(put_int_tuples, reveal_type([(1, 2)]))  # revealed: list[tuple[int, ...]]
 
 def requires_x(*, x: int) -> str:
     return ""

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -827,16 +827,25 @@ def overloaded_put_object(*, TagSet: object, func: object = None) -> None: ...
 to_thread_like_keyword(TagSet=reveal_type([{"Key": "k", "Value": "v"}]), func=overloaded_put_object)  # revealed: list[Tag]
 ```
 
-ParamSpec forwarding should not use raw unspecialized type variables from a wrapped generic callable
-as argument context, since that can hide errors between forwarded arguments.
+ParamSpec forwarding should not use raw unspecialized parameter types from a wrapped generic
+callable as argument context. The forwarded list literals should be inferred the same way as in the
+equivalent direct generic call, not with a raw `list[T]` context from the wrapped callable.
 
 ```py
 from typing import Callable
 
 def generic_pair[T](x: list[T], y: list[T], /) -> None: ...
 def generic_pair_with_container[T](x: T, y: list[T], /) -> None: ...
+def generic_identity_list[T](x: list[T], /) -> list[T]:
+    raise NotImplementedError
+
 def to_thread_like[**P, R](func: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R:
     return func(*args, **kwargs)
+
+# TODO: This should not error once the call-expression type context specializes the generic
+# wrapped callable before we infer forwarded `ParamSpec` arguments.
+# error: [invalid-assignment]
+union_list_result: list[int | str] = to_thread_like(generic_identity_list, reveal_type([1]))  # revealed: list[int]
 
 # error: [invalid-argument-type]
 # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -262,6 +262,16 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         }
     }
 
+    /// Create a new [`CallArguments`] containing only the arguments at the specified indices.
+    pub(crate) fn select(&self, indices: &[usize]) -> Self {
+        Self {
+            items: indices
+                .iter()
+                .map(|index| self.items[*index].clone())
+                .collect(),
+        }
+    }
+
     /// Returns the `functools.partial(...)` bound-argument slice when argument expansion is
     /// concrete enough for partial-application analysis.
     pub(crate) fn functools_partial_bound_arguments(&self, db: &'db dyn Db) -> Option<Self> {

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -207,6 +207,19 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         self.items.get(index).map(|item| &item.types)
     }
 
+    pub(crate) fn insert_type(
+        &mut self,
+        index: usize,
+        tcx: impl Into<TypeContext<'db>>,
+        ty: Type<'db>,
+    ) {
+        self.items
+            .get_mut(index)
+            .expect("argument index should be valid")
+            .types
+            .insert(tcx, ty);
+    }
+
     pub(crate) fn iter_types(&self) -> impl Iterator<Item = &CallArgumentTypes<'db>> + '_ {
         self.items.iter().map(|item| &item.types)
     }

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -207,6 +207,11 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         self.items.get(index).map(|item| &item.types)
     }
 
+    /// Insert an inferred type for the argument at `index` under the given type context.
+    ///
+    /// This is useful when argument inference is driven from outside the argument iterator, for
+    /// example when a wrapper call first infers a context for an earlier ParamSpec-binding
+    /// argument and then stores that result back on the original call argument.
     pub(crate) fn insert_type(
         &mut self,
         index: usize,
@@ -263,6 +268,14 @@ impl<'a, 'db> CallArguments<'a, 'db> {
     }
 
     /// Create a new [`CallArguments`] containing only the arguments at the specified indices.
+    ///
+    /// The resulting argument list preserves the order of `indices`. This is used to turn the
+    /// subset of forwarded outer arguments into the argument list for a synthetic sub-call:
+    ///
+    /// ```py
+    /// def wrapper[**P, R](func: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R: ...
+    /// wrapper(f, 1, y="x")  # select the `1` and `y="x"` arguments for the call to `f`
+    /// ```
     pub(crate) fn select(&self, indices: &[usize]) -> Self {
         Self {
             items: indices

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -207,11 +207,6 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         self.items.get(index).map(|item| &item.types)
     }
 
-    /// Insert an inferred type for the argument at `index` under the given type context.
-    ///
-    /// This is useful when argument inference is driven from outside the argument iterator, for
-    /// example when a wrapper call first infers a context for an earlier ParamSpec-binding
-    /// argument and then stores that result back on the original call argument.
     pub(crate) fn insert_type(
         &mut self,
         index: usize,

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -269,12 +269,13 @@ impl<'a, 'db> CallArguments<'a, 'db> {
 
     /// Create a new [`CallArguments`] containing only the arguments at the specified indices.
     ///
-    /// The resulting argument list preserves the order of `indices`. This is used to turn the
-    /// subset of forwarded outer arguments into the argument list for a synthetic sub-call:
+    /// The resulting argument list preserves the order of `indices`. Unlike [`Self::start_from`],
+    /// this can project a non-contiguous subset of the original call arguments. This is used to
+    /// turn the forwarded outer arguments into the argument list for a synthetic sub-call:
     ///
     /// ```py
-    /// def wrapper[**P, R](func: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R: ...
-    /// wrapper(f, 1, y="x")  # select the `1` and `y="x"` arguments for the call to `f`
+    /// def wrapper[**P, R](func: Callable[P, R], **kwargs: P.kwargs) -> R: ...
+    /// wrapper(TagSet=[...], func=f)  # select `TagSet=[...]`, but not the later `func=f`
     /// ```
     pub(crate) fn select(&self, indices: &[usize]) -> Self {
         Self {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4571,6 +4571,26 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         })
     }
 
+    fn paramspec_argument_indices(&self, prefix_len: usize) -> Vec<usize> {
+        self.argument_matches
+            .iter()
+            .enumerate()
+            .filter_map(|(argument_index, argument_matches)| {
+                argument_matches
+                    .parameters
+                    .iter()
+                    .any(|parameter_index| *parameter_index >= prefix_len)
+                    .then_some(argument_index)
+            })
+            .collect()
+    }
+
+    fn adjusted_argument_indices(&self) -> Vec<Option<usize>> {
+        self.enumerate_argument_types()
+            .map(|(_, adjusted_argument_index, _, _)| adjusted_argument_index)
+            .collect()
+    }
+
     fn infer_specialization(&mut self, constraints: &ConstraintSetBuilder<'db>) {
         let Some(generic_context) = self.signature.generic_context else {
             return;
@@ -4942,17 +4962,35 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
     fn check_argument_types(&mut self, constraints: &ConstraintSetBuilder<'db>) {
         let paramspec = self.signature.parameters().as_paramspec_with_prefix();
+        let mut paramspec_evaluated = false;
 
         for (argument_index, adjusted_argument_index, argument, argument_types) in
             self.enumerate_argument_types()
         {
-            if let Some((_, paramspec)) = paramspec {
-                if self.try_paramspec_evaluation_at(constraints, argument_index, paramspec) {
-                    // Once we find an argument that matches the `ParamSpec`, we can stop checking
-                    // the remaining arguments since `ParamSpec` should always be the last
-                    // parameter.
-                    return;
+            let paramspec_component_start = if let Some((prefix, paramspec)) = paramspec {
+                if !paramspec_evaluated
+                    && self.try_paramspec_evaluation_at(constraints, argument_index, paramspec)
+                {
+                    paramspec_evaluated = true;
                 }
+
+                paramspec_evaluated.then_some(prefix.len())
+            } else {
+                None
+            };
+
+            let is_paramspec_component_parameter = |parameter_index: usize| {
+                paramspec_component_start.is_some_and(|start| parameter_index >= start)
+            };
+
+            let matched_parameters = &self.argument_matches[argument_index].parameters;
+            if paramspec_component_start.is_some()
+                && !matched_parameters.is_empty()
+                && matched_parameters
+                    .iter()
+                    .all(|parameter_index| is_paramspec_component_parameter(*parameter_index))
+            {
+                continue;
             }
 
             match argument {
@@ -4961,6 +4999,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     argument_index,
                     adjusted_argument_index,
                     argument,
+                    paramspec_component_start,
                 ),
                 Argument::Keywords => self.check_keyword_variadic_argument_type(
                     constraints,
@@ -4969,10 +5008,15 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     argument,
                     // Splatted arguments are inferred without type context.
                     argument_types.get_default().unwrap_or(Type::unknown()),
+                    paramspec_component_start,
                 ),
                 _ => {
                     // If the argument isn't splatted, just check its type directly.
                     for parameter_index in &self.argument_matches[argument_index].parameters {
+                        if is_paramspec_component_parameter(*parameter_index) {
+                            continue;
+                        }
+
                         let declared_type =
                             self.signature.parameters()[*parameter_index].annotated_type();
                         let argument_type = argument_types.get_for_declared_type(declared_type);
@@ -4990,7 +5034,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             }
         }
 
-        if let Some((_, paramspec)) = paramspec {
+        if let Some((_, paramspec)) = paramspec
+            && !paramspec_evaluated
+        {
             // If we reach here, none of the arguments matched the `ParamSpec` parameter, but the
             // `ParamSpec` could specialize to a parameter list containing some parameters. For
             // example,
@@ -5062,10 +5108,10 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         self.evaluate_paramspec_sub_call(constraints, Some(argument_index), paramspec)
     }
 
-    /// Invoke a sub-call for the given `ParamSpec` type variable, using the remaining arguments.
+    /// Invoke a sub-call for the given `ParamSpec` type variable, using the forwarded arguments.
     ///
-    /// The remaining arguments start from `argument_index` if provided, otherwise no arguments
-    /// are passed.
+    /// The forwarded arguments are those matched to the `ParamSpec` components if
+    /// `argument_index` is provided, otherwise no arguments are passed.
     ///
     /// This method returns `false` if the specialization does not contain a mapping for the given
     /// `paramspec` or contains an invalid mapping (i.e., not a `Callable` of kind `ParamSpecValue`).
@@ -5093,20 +5139,29 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             return false;
         }
 
-        let (sub_arguments, error_offset) = if let Some(argument_index) = argument_index {
-            let num_synthetic_args = self
-                .arguments
+        let (sub_arguments, error_argument_indices) = if let Some(argument_index) = argument_index {
+            let Some((prefix, _)) = self.signature.parameters().as_paramspec_with_prefix() else {
+                return false;
+            };
+            let paramspec_argument_indices = self.paramspec_argument_indices(prefix.len());
+            if !paramspec_argument_indices.contains(&argument_index) {
+                return false;
+            }
+
+            let adjusted_argument_indices = self.adjusted_argument_indices();
+            let error_argument_indices: Vec<Option<usize>> = paramspec_argument_indices
                 .iter()
-                .filter(|(arg, _)| matches!(arg, Argument::Synthetic))
-                .count();
+                .map(|argument_index| adjusted_argument_indices[*argument_index])
+                .collect();
 
             (
-                self.arguments.start_from(argument_index),
-                Some(argument_index - num_synthetic_args),
+                self.arguments.select(&paramspec_argument_indices),
+                Some(error_argument_indices),
             )
         } else {
             (CallArguments::none(), None)
         };
+        let error_argument_indices = error_argument_indices.as_deref();
 
         // Create Bindings with all overloads and perform full overload resolution
         let callable_binding =
@@ -5139,7 +5194,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                             .errors
                             .iter()
                             .cloned()
-                            .map(|err| err.maybe_apply_argument_index_offset(error_offset)),
+                            .map(|err| err.maybe_remap_argument_indices(error_argument_indices)),
                     );
                 } else {
                     let index = callable_binding
@@ -5154,7 +5209,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                             .errors
                             .iter()
                             .cloned()
-                            .map(|err| err.maybe_apply_argument_index_offset(error_offset)),
+                            .map(|err| err.maybe_remap_argument_indices(error_argument_indices)),
                     );
                 }
             }
@@ -5166,7 +5221,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         .errors
                         .iter()
                         .cloned()
-                        .map(|err| err.maybe_apply_argument_index_offset(error_offset)),
+                        .map(|err| err.maybe_remap_argument_indices(error_argument_indices)),
                 );
             }
             MatchingOverloadIndex::Multiple(_) => {
@@ -5182,7 +5237,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                             .errors
                             .iter()
                             .cloned()
-                            .map(|err| err.maybe_apply_argument_index_offset(error_offset)),
+                            .map(|err| err.maybe_remap_argument_indices(error_argument_indices)),
                     );
                 }
             }
@@ -5197,10 +5252,15 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         argument_index: usize,
         adjusted_argument_index: Option<usize>,
         argument: Argument<'a>,
+        paramspec_component_start: Option<usize>,
     ) {
         for (parameter_index, variadic_argument_type) in
             self.argument_matches[argument_index].iter()
         {
+            if paramspec_component_start.is_some_and(|start| parameter_index >= start) {
+                continue;
+            }
+
             self.check_argument_type(
                 constraints,
                 argument_index,
@@ -5219,6 +5279,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         adjusted_argument_index: Option<usize>,
         argument: Argument<'a>,
         argument_type: Type<'db>,
+        paramspec_component_start: Option<usize>,
     ) {
         if let Some(unpacked_keys) =
             extract_unpacked_typed_dict_keys_from_value_type(self.db, argument_type)
@@ -5228,6 +5289,10 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 .map(|unpacked_key| unpacked_key.value_ty)
                 .zip(&self.argument_matches[argument_index].parameters)
             {
+                if paramspec_component_start.is_some_and(|start| *parameter_index >= start) {
+                    continue;
+                }
+
                 self.check_argument_type(
                     constraints,
                     argument_index,
@@ -5265,6 +5330,10 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             };
 
         for parameter_index in &self.argument_matches[argument_index].parameters {
+            if paramspec_component_start.is_some_and(|start| *parameter_index >= start) {
+                continue;
+            }
+
             let value_type = if let Some(value_type) = value_type_paramspec {
                 value_type
             } else {
@@ -6167,6 +6236,47 @@ impl BindingError<'_> {
             self.apply_argument_index_offset(offset);
         }
         self
+    }
+
+    fn maybe_remap_argument_indices(mut self, argument_indices: Option<&[Option<usize>]>) -> Self {
+        if let Some(argument_indices) = argument_indices {
+            self.remap_argument_indices(argument_indices);
+        }
+        self
+    }
+
+    fn remap_argument_indices(&mut self, argument_indices: &[Option<usize>]) {
+        let remap = |argument_index: &mut Option<usize>| {
+            *argument_index = argument_index
+                .and_then(|index| argument_indices.get(index).copied())
+                .flatten();
+        };
+
+        match self {
+            BindingError::InvalidArgumentType { argument_index, .. }
+            | BindingError::InvalidKeyType { argument_index, .. }
+            | BindingError::UnknownArgument { argument_index, .. }
+            | BindingError::PositionalOnlyParameterAsKwarg { argument_index, .. }
+            | BindingError::ParameterAlreadyAssigned { argument_index, .. }
+            | BindingError::SpecializationError { argument_index, .. } => {
+                remap(argument_index);
+            }
+
+            BindingError::TooManyPositionalArguments {
+                first_excess_argument_index,
+                ..
+            } => {
+                remap(first_excess_argument_index);
+            }
+
+            BindingError::CalledTopCallable(..)
+            | BindingError::InternalCallError(..)
+            | BindingError::InvalidDataclassApplication(..)
+            | BindingError::MissingArguments { .. }
+            | BindingError::UnmatchedOverload
+            | BindingError::PropertyHasNoSetter(..)
+            | BindingError::PropertyHasNoDeleter(..) => {}
+        }
     }
 
     /// Applies the given offset to the argument indices in this error, if any.

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4965,23 +4965,48 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
     fn check_argument_types(&mut self, constraints: &ConstraintSetBuilder<'db>) {
         let paramspec = self.signature.parameters().as_paramspec_with_prefix();
-        let mut paramspec_evaluated = false;
+        let paramspec_component_start = paramspec.and_then(|(prefix, paramspec)| {
+            let prefix_len = prefix.len();
+            let paramspec_arguments = self.paramspec_argument_indices(prefix_len);
+            if paramspec_arguments.is_empty() {
+                self.evaluate_paramspec_sub_call(constraints, None, paramspec);
+                return None;
+            }
+
+            let has_paramspec_component_argument =
+                paramspec_arguments.iter().any(|(argument_index, _)| {
+                    let [parameter_index] =
+                        self.argument_matches[*argument_index].parameters.as_slice()
+                    else {
+                        return false;
+                    };
+
+                    let Type::TypeVar(typevar) =
+                        self.signature.parameters()[*parameter_index].annotated_type()
+                    else {
+                        return false;
+                    };
+
+                    typevar.is_paramspec(self.db)
+                });
+
+            if has_paramspec_component_argument
+                && self.evaluate_paramspec_sub_call(
+                    constraints,
+                    Some(&paramspec_arguments),
+                    paramspec,
+                )
+            {
+                Some(prefix_len)
+            } else {
+                self.evaluate_paramspec_sub_call(constraints, None, paramspec);
+                None
+            }
+        });
 
         for (argument_index, adjusted_argument_index, argument, argument_types) in
             self.enumerate_argument_types()
         {
-            let paramspec_component_start = if let Some((prefix, paramspec)) = paramspec {
-                if !paramspec_evaluated
-                    && self.try_paramspec_evaluation_at(constraints, argument_index, paramspec)
-                {
-                    paramspec_evaluated = true;
-                }
-
-                paramspec_evaluated.then_some(prefix.len())
-            } else {
-                None
-            };
-
             let is_paramspec_component_parameter = |parameter_index: usize| {
                 paramspec_component_start.is_some_and(|start| parameter_index >= start)
             };
@@ -5036,94 +5061,28 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 }
             }
         }
-
-        if let Some((_, paramspec)) = paramspec
-            && !paramspec_evaluated
-        {
-            // If we reach here, none of the arguments matched the `ParamSpec` parameter, but the
-            // `ParamSpec` could specialize to a parameter list containing some parameters. For
-            // example,
-            //
-            // ```py
-            // from typing import Callable
-            //
-            // def foo[**P](f: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
-            //
-            // def f(x: int) -> None: ...
-            //
-            // foo(f)
-            // ```
-            //
-            // Here, no arguments match the `ParamSpec` parameter, but `P` specializes to `(x: int)`,
-            // so we need to perform a sub-call with no arguments.
-            self.evaluate_paramspec_sub_call(constraints, None, paramspec);
-        }
     }
 
-    /// Try to evaluate a `ParamSpec` sub-call at the given argument index.
+    /// Invoke a sub-call for the given `ParamSpec` type variable, using the forwarded arguments.
     ///
-    /// The `ParamSpec` parameter is always going to be at the end of the parameter list but there
-    /// can be other parameter before it. If one of these prepended positional parameters contains
-    /// a free `ParamSpec`, we consider that variable in scope for the purposes of extracting the
-    /// components of that `ParamSpec`. For example:
+    /// The forwarded arguments are those matched to the `ParamSpec` components if provided,
+    /// otherwise no arguments are passed. No forwarded arguments can still require a sub-call:
     ///
     /// ```py
     /// from typing import Callable
     ///
     /// def foo[**P](f: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+    /// def f(x: int) -> None: ...
     ///
-    /// def f(x: int, y: str) -> None: ...
-    ///
-    /// foo(f, 1, "hello")  # P: (x: int, y: str)
+    /// foo(f)  # P specializes to `(x: int)`, so `f` is checked with no arguments.
     /// ```
-    ///
-    /// Here, `P` specializes to `(x: int, y: str)` when `foo` is called with `f`, which means that
-    /// the parameters of `f` become a part of `foo`'s parameter list replacing the `ParamSpec`
-    /// parameter which is:
-    ///
-    /// ```py
-    /// def foo(f: Callable[[x: int, y: str], None], x: int, y: str) -> None: ...
-    /// ```
-    ///
-    /// This method will check whether the parameter matching the argument at `argument_index` is
-    /// annotated with the components of `ParamSpec`, and if so, will invoke a sub-call considering
-    /// the arguments starting from `argument_index` against the specialized parameter list.
-    ///
-    /// Returns `true` if the sub-call was invoked, `false` otherwise.
-    fn try_paramspec_evaluation_at(
-        &mut self,
-        constraints: &ConstraintSetBuilder<'db>,
-        argument_index: usize,
-        paramspec: BoundTypeVarInstance<'db>,
-    ) -> bool {
-        let [parameter_index] = self.argument_matches[argument_index].parameters.as_slice() else {
-            return false;
-        };
-
-        let Type::TypeVar(typevar) = self.signature.parameters()[*parameter_index].annotated_type()
-        else {
-            return false;
-        };
-        if !typevar.is_paramspec(self.db) {
-            return false;
-        }
-
-        self.evaluate_paramspec_sub_call(constraints, Some(argument_index), paramspec)
-    }
-
-    /// Invoke a sub-call for the given `ParamSpec` type variable, using the forwarded arguments.
-    ///
-    /// The forwarded arguments are those matched to the `ParamSpec` components if
-    /// `argument_index` is provided, otherwise no arguments are passed.
     ///
     /// This method returns `false` if the specialization does not contain a mapping for the given
     /// `paramspec` or contains an invalid mapping (i.e., not a `Callable` of kind `ParamSpecValue`).
-    ///
-    /// For more details, refer to [`Self::try_paramspec_evaluation_at`].
     fn evaluate_paramspec_sub_call(
         &mut self,
         constraints: &ConstraintSetBuilder<'db>,
-        argument_index: Option<usize>,
+        paramspec_arguments: Option<&[(usize, Option<usize>)]>,
         paramspec: BoundTypeVarInstance<'db>,
     ) -> bool {
         let Some(Type::Callable(callable)) = self
@@ -5142,28 +5101,18 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             return false;
         }
 
-        let (sub_arguments, error_argument_indices) = if let Some(argument_index) = argument_index {
-            let Some((prefix, _)) = self.signature.parameters().as_paramspec_with_prefix() else {
-                return false;
+        let (sub_arguments, error_argument_indices) =
+            if let Some(paramspec_arguments) = paramspec_arguments {
+                let (paramspec_argument_indices, error_argument_indices): (Vec<_>, Vec<_>) =
+                    paramspec_arguments.iter().copied().unzip();
+
+                (
+                    self.arguments.select(&paramspec_argument_indices),
+                    Some(error_argument_indices),
+                )
+            } else {
+                (CallArguments::none(), None)
             };
-            let paramspec_arguments = self.paramspec_argument_indices(prefix.len());
-            if !paramspec_arguments
-                .iter()
-                .any(|(paramspec_argument_index, _)| *paramspec_argument_index == argument_index)
-            {
-                return false;
-            }
-
-            let (paramspec_argument_indices, error_argument_indices): (Vec<_>, Vec<_>) =
-                paramspec_arguments.into_iter().unzip();
-
-            (
-                self.arguments.select(&paramspec_argument_indices),
-                Some(error_argument_indices),
-            )
-        } else {
-            (CallArguments::none(), None)
-        };
         let error_argument_indices = error_argument_indices.as_deref();
 
         // Create Bindings with all overloads and perform full overload resolution

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -54,11 +54,11 @@ use crate::types::typed_dict::extract_unpacked_typed_dict_keys_from_value_type;
 use crate::types::typevar::BoundTypeVarIdentity;
 use crate::types::{
     BoundMethodType, BoundTypeVarInstance, CallableType, CallableTypes, ClassLiteral,
-    DATACLASS_FLAGS, DataclassFlags, DataclassParams, GenericAlias, InternedConstraintSet,
-    IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
-    NominalInstanceType, PropertyInstanceType, SpecialFormType, TypeAliasType, TypeContext,
-    TypeVarBoundOrConstraints, TypeVarVariance, UnionAccumulator, UnionBuilder, UnionType,
-    WrapperDescriptorKind, enums, list_members,
+    DATACLASS_FLAGS, DataclassFlags, DataclassParams, DynamicType, GenericAlias,
+    InternedConstraintSet, IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType,
+    LiteralValueTypeKind, NominalInstanceType, PropertyInstanceType, SpecialFormType,
+    TypeAliasType, TypeContext, TypeVarBoundOrConstraints, TypeVarVariance, UnionAccumulator,
+    UnionBuilder, UnionType, WrapperDescriptorKind, enums, list_members,
 };
 use crate::{DisplaySettings, FxOrderSet, Program};
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity};
@@ -4571,23 +4571,26 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         })
     }
 
-    fn paramspec_argument_indices(&self, prefix_len: usize) -> Vec<usize> {
-        self.argument_matches
-            .iter()
-            .enumerate()
-            .filter_map(|(argument_index, argument_matches)| {
-                argument_matches
+    /// Returns argument-index mappings for arguments matched to the expanded `ParamSpec` component.
+    ///
+    /// `prefix_len` is the number of non-ParamSpec prefix parameters in a callable like
+    /// `Concatenate[Prefix, P]`. Any argument matched to a later parameter belongs to `P`. The
+    /// first item is the matched-argument index; the second is the source argument index, or `None`
+    /// for synthetic arguments such as bound `self` or `cls`.
+    ///
+    /// ```py
+    /// def wrapper[**P, R](func: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R: ...
+    /// wrapper(f, 1, y="x")  # returns the indices for `1` and `y="x"`
+    /// ```
+    fn paramspec_argument_indices(&self, prefix_len: usize) -> Vec<(usize, Option<usize>)> {
+        self.enumerate_argument_types()
+            .filter_map(|(argument_index, adjusted_argument_index, _, _)| {
+                self.argument_matches[argument_index]
                     .parameters
                     .iter()
                     .any(|parameter_index| *parameter_index >= prefix_len)
-                    .then_some(argument_index)
+                    .then_some((argument_index, adjusted_argument_index))
             })
-            .collect()
-    }
-
-    fn adjusted_argument_indices(&self) -> Vec<Option<usize>> {
-        self.enumerate_argument_types()
-            .map(|(_, adjusted_argument_index, _, _)| adjusted_argument_index)
             .collect()
     }
 
@@ -5143,16 +5146,16 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             let Some((prefix, _)) = self.signature.parameters().as_paramspec_with_prefix() else {
                 return false;
             };
-            let paramspec_argument_indices = self.paramspec_argument_indices(prefix.len());
-            if !paramspec_argument_indices.contains(&argument_index) {
+            let paramspec_arguments = self.paramspec_argument_indices(prefix.len());
+            if !paramspec_arguments
+                .iter()
+                .any(|(paramspec_argument_index, _)| *paramspec_argument_index == argument_index)
+            {
                 return false;
             }
 
-            let adjusted_argument_indices = self.adjusted_argument_indices();
-            let error_argument_indices: Vec<Option<usize>> = paramspec_argument_indices
-                .iter()
-                .map(|argument_index| adjusted_argument_indices[*argument_index])
-                .collect();
+            let (paramspec_argument_indices, error_argument_indices): (Vec<_>, Vec<_>) =
+                paramspec_arguments.into_iter().unzip();
 
             (
                 self.arguments.select(&paramspec_argument_indices),
@@ -5184,18 +5187,21 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             .single_element()
             .expect("ParamSpec sub-call should only contain a single CallableBinding");
 
+        let mut extend_errors = |errors: &[BindingError<'db>]| {
+            self.errors.extend(
+                errors
+                    .iter()
+                    .cloned()
+                    .map(|err| err.maybe_remap_argument_indices(error_argument_indices)),
+            );
+        };
+
         match callable_binding.matching_overload_index() {
             MatchingOverloadIndex::None => {
                 if let [binding] = callable_binding.overloads() {
                     // This is not an overloaded function, so we can propagate its errors to the
                     // outer bindings.
-                    self.errors.extend(
-                        binding
-                            .errors
-                            .iter()
-                            .cloned()
-                            .map(|err| err.maybe_remap_argument_indices(error_argument_indices)),
-                    );
+                    extend_errors(&binding.errors);
                 } else {
                     let index = callable_binding
                         .best_failing_overload_index(
@@ -5204,41 +5210,20 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         .unwrap_or(0);
                     // TODO: We should also update the specialization for the `ParamSpec` to reflect
                     // the matching overload here.
-                    self.errors.extend(
-                        callable_binding.overloads()[index]
-                            .errors
-                            .iter()
-                            .cloned()
-                            .map(|err| err.maybe_remap_argument_indices(error_argument_indices)),
-                    );
+                    extend_errors(&callable_binding.overloads()[index].errors);
                 }
             }
             MatchingOverloadIndex::Single(index) => {
                 // TODO: We should also update the specialization for the `ParamSpec` to reflect the
                 // matching overload here.
-                self.errors.extend(
-                    callable_binding.overloads()[index]
-                        .errors
-                        .iter()
-                        .cloned()
-                        .map(|err| err.maybe_remap_argument_indices(error_argument_indices)),
-                );
+                extend_errors(&callable_binding.overloads()[index].errors);
             }
             MatchingOverloadIndex::Multiple(_) => {
                 if !matches!(
                     callable_binding.overload_call_return_type,
                     Some(OverloadCallReturnType::ArgumentTypeExpansion(_))
                 ) {
-                    self.errors.extend(
-                        callable_binding
-                            .overloads()
-                            .first()
-                            .unwrap()
-                            .errors
-                            .iter()
-                            .cloned()
-                            .map(|err| err.maybe_remap_argument_indices(error_argument_indices)),
-                    );
+                    extend_errors(&callable_binding.overloads().first().unwrap().errors);
                 }
             }
         }
@@ -5419,9 +5404,66 @@ impl<'db> MatchedArgument<'db> {
     }
 }
 
+/// The declared type context to use when inferring a call-site argument.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ArgumentTypeContext<'db> {
+    /// The lookup key for the inferred argument type.
+    pub(crate) declared_type: Type<'db>,
+    /// The unspecialized parameter annotation that later type checking may still request.
+    original_declared_type: Type<'db>,
+    /// The concrete type context to use while inferring the argument expression.
+    pub(crate) type_context: TypeContext<'db>,
+}
+
+impl<'db> ArgumentTypeContext<'db> {
+    /// Creates an argument type context.
+    ///
+    /// `declared_type` is the lookup key for the inferred argument type. `original_declared_type`
+    /// is the unspecialized parameter annotation that later type checking may still request.
+    fn new(
+        declared_type: Type<'db>,
+        original_declared_type: Type<'db>,
+        type_context: Type<'db>,
+    ) -> Self {
+        Self {
+            declared_type,
+            original_declared_type,
+            type_context: TypeContext::new(Some(type_context)),
+        }
+    }
+
+    /// Stores an inferred argument type under every declared-type key that can later request it.
+    ///
+    /// For a forwarded `ParamSpec` argument, the expression is inferred against the specialized
+    /// wrapped parameter but may still be looked up through the original `P.args` or `P.kwargs`
+    /// annotation during the outer wrapper call check.
+    pub(crate) fn insert_inferred_type(
+        self,
+        arguments_types: &mut CallArguments<'_, 'db>,
+        argument_index: usize,
+        inferred_ty: Type<'db>,
+    ) {
+        arguments_types.insert_type(argument_index, self.declared_type, inferred_ty);
+        if self.declared_type != self.original_declared_type {
+            arguments_types.insert_type(argument_index, self.original_declared_type, inferred_ty);
+        }
+    }
+}
+
 /// Indicates that a parameter of the given name was not found.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct UnknownParameterNameError;
+
+#[derive(Clone, Copy)]
+struct ParamSpecArgumentContext<'a, 'call, 'db> {
+    db: &'db dyn Db,
+    constraints: &'a ConstraintSetBuilder<'db>,
+    binding: &'a CallableBinding<'db>,
+    callable: CallableType<'db>,
+    arguments_types: &'a CallArguments<'call, 'db>,
+    argument_index: usize,
+    call_expression_tcx: TypeContext<'db>,
+}
 
 /// Binding information for one of the overloads of a callable.
 #[derive(Debug, Clone)]
@@ -5480,6 +5522,346 @@ impl<'db> Binding<'db> {
             parameter_tys: Box::from([]),
             errors: vec![],
         }
+    }
+
+    /// Returns the matched-argument entry for a source call argument.
+    ///
+    /// [`CallableBinding`] prepends a synthetic bound receiver before matching bound methods, while
+    /// inference still iterates over source call arguments. This method centralizes that offset.
+    fn matched_argument_for_call_argument(
+        &self,
+        binding: &CallableBinding<'db>,
+        argument_index: usize,
+    ) -> Option<&MatchedArgument<'db>> {
+        self.argument_matches
+            .get(argument_index + usize::from(binding.bound_type.is_some()))
+    }
+
+    /// Returns source argument indices whose matched parameters satisfy `matches_parameter`.
+    ///
+    /// The returned indices are relative to the original call site, excluding any synthetic bound
+    /// receiver. For example, this can select all arguments forwarded through `P.args` and
+    /// `P.kwargs` after the wrapper's prefix parameters.
+    ///
+    /// ```py
+    /// def wrapper[**P, R](func: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R: ...
+    /// wrapper(f, 1, y="x")  # can select `1` and `y="x"` without including `func`
+    /// ```
+    fn call_argument_indices_matching_parameters(
+        &self,
+        binding: &CallableBinding<'db>,
+        mut matches_parameter: impl FnMut(usize) -> bool,
+    ) -> Vec<usize> {
+        let bound_argument_offset = usize::from(binding.bound_type.is_some());
+
+        self.argument_matches
+            .iter()
+            .enumerate()
+            .filter_map(|(matched_argument_index, argument_matches)| {
+                if matched_argument_index < bound_argument_offset {
+                    return None;
+                }
+
+                argument_matches
+                    .parameters
+                    .iter()
+                    .any(|parameter_index| matches_parameter(*parameter_index))
+                    .then_some(matched_argument_index - bound_argument_offset)
+            })
+            .collect()
+    }
+
+    /// Infers the callable value that a `ParamSpec` maps to for this overload.
+    ///
+    /// The wrapper's current arguments are rechecked against this single overload so that a binder
+    /// argument such as `func: Callable[P, R]` can specialize `P` before forwarded arguments are
+    /// inferred.
+    ///
+    /// ```py
+    /// def put_tags(tags: list[Tag], /) -> None: ...
+    /// def wrapper[**P, R](func: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R: ...
+    /// wrapper(put_tags, [{"Key": "k", "Value": "v"}])  # infers `P` from `put_tags`
+    /// ```
+    fn inferred_paramspec_callable(
+        &self,
+        db: &'db dyn Db,
+        constraints: &ConstraintSetBuilder<'db>,
+        binding: &CallableBinding<'db>,
+        paramspec: BoundTypeVarInstance<'db>,
+        arguments_types: &CallArguments<'_, 'db>,
+        call_expression_tcx: TypeContext<'db>,
+    ) -> Option<CallableType<'db>> {
+        let mut specialized_binding =
+            CallableBinding::from_overloads(self.signature_type, [self.signature.clone()]);
+        if let Some(bound_type) = binding.bound_type {
+            specialized_binding = specialized_binding.with_bound_type(bound_type);
+        }
+
+        // Reuse the normal binding checker to infer `P` from the arguments that have already
+        // been inferred. This avoids duplicating specialization logic here; the current
+        // `P.args`/`P.kwargs` argument is still uninferred, so it only contributes `Unknown`.
+        let mut specialized_bindings =
+            Bindings::from(specialized_binding).match_parameters(db, arguments_types);
+        let _ = specialized_bindings.check_types_impl(
+            db,
+            constraints,
+            arguments_types,
+            call_expression_tcx,
+            &[],
+        );
+
+        let Type::Callable(callable) = specialized_bindings
+            .single_element()
+            .and_then(|binding| binding.matching_overloads().exactly_one().ok())
+            .and_then(|(_, overload)| overload.specialization())
+            .and_then(|specialization| specialization.get(db, paramspec))?
+        else {
+            return None;
+        };
+
+        (callable.kind(db) == CallableTypeKind::ParamSpecValue).then_some(callable)
+    }
+
+    /// Returns the specialized wrapped-call parameter type for a forwarded argument.
+    ///
+    /// The forwarded outer arguments are first projected into a sub-call against the callable stored
+    /// in `P`. The parameter matched by `argument_index` in that sub-call becomes the context for
+    /// bidirectional inference.
+    ///
+    /// ```py
+    /// def put_object(*, TagSet: list[Tag]) -> None: ...
+    /// def wrapper[**P, R](func: Callable[P, R], /, **kwargs: P.kwargs) -> R: ...
+    /// wrapper(put_object, TagSet=[{"Key": "k", "Value": "v"}])  # context is `list[Tag]`
+    /// ```
+    fn paramspec_argument_context(
+        &self,
+        context: ParamSpecArgumentContext<'_, '_, 'db>,
+    ) -> Option<Type<'db>> {
+        let ParamSpecArgumentContext {
+            db,
+            constraints,
+            binding,
+            callable,
+            arguments_types,
+            argument_index,
+            call_expression_tcx,
+        } = context;
+        let (prefix, _) = self.signature.parameters().as_paramspec_with_prefix()?;
+        let paramspec_argument_indices = self
+            .call_argument_indices_matching_parameters(binding, |parameter_index| {
+                parameter_index >= prefix.len()
+            });
+        let sub_argument_index = paramspec_argument_indices
+            .iter()
+            .position(|paramspec_argument_index| *paramspec_argument_index == argument_index)?;
+
+        let specialized_binding = CallableBinding::from_overloads(
+            self.signature_type,
+            callable.signatures(db).iter().cloned(),
+        );
+        let sub_arguments = arguments_types.select(&paramspec_argument_indices);
+        let mut specialized_bindings =
+            Bindings::from(specialized_binding).match_parameters(db, &sub_arguments);
+        let _ = specialized_bindings.check_types_impl(
+            db,
+            constraints,
+            &sub_arguments,
+            call_expression_tcx,
+            &[],
+        );
+
+        let specialized_binding = specialized_bindings.single_element()?;
+        let (_, specialized_overload) = specialized_binding
+            .matching_overloads()
+            .exactly_one()
+            .ok()?;
+        let [specialized_parameter_index] = specialized_overload
+            .argument_matches()
+            .get(sub_argument_index)?
+            .parameters
+            .as_slice()
+        else {
+            return None;
+        };
+
+        let parameter_type = specialized_overload.signature.parameters()
+            [*specialized_parameter_index]
+            .annotated_type();
+        // A context like `list[Unknown]` or `list[T@g]` is worse than no context here:
+        // it can erase the concrete literal type that should later specialize the wrapped
+        // callable. Check the parameter before applying the sub-call specialization so an
+        // earlier forwarded argument cannot turn `list[T@g]` into apparently-safe `list[int]`.
+        if parameter_type.has_dynamic(db) || parameter_type.has_typevar_or_typevar_instance(db) {
+            return None;
+        }
+
+        let parameter_type = specialized_overload
+            .specialization()
+            .map_or(parameter_type, |specialization| {
+                parameter_type.apply_specialization(db, specialization)
+            });
+
+        (!parameter_type.has_dynamic(db) && !parameter_type.has_typevar_or_typevar_instance(db))
+            .then_some(parameter_type)
+    }
+
+    /// Returns the wrapper parameter type that can bind the `ParamSpec` used by forwarded arguments.
+    ///
+    /// This is used before normal source-order inference so a keyword forwarded through `P.kwargs`
+    /// can still use a later binder argument such as `func=put_object`.
+    ///
+    /// ```py
+    /// def put_object(*, TagSet: list[Tag]) -> None: ...
+    /// def wrapper[**P, R](func: Callable[P, R], **kwargs: P.kwargs) -> R: ...
+    /// wrapper(TagSet=[{"Key": "k", "Value": "v"}], func=put_object)
+    /// ```
+    pub(crate) fn paramspec_binder_parameter_type(
+        &self,
+        db: &'db dyn Db,
+        binding: &CallableBinding<'db>,
+        argument_index: usize,
+    ) -> Option<Type<'db>> {
+        let (prefix, paramspec) = self.signature.parameters().as_paramspec_with_prefix()?;
+        let [parameter_index] = self
+            .matched_argument_for_call_argument(binding, argument_index)?
+            .parameters
+            .as_slice()
+        else {
+            return None;
+        };
+
+        if *parameter_index >= prefix.len() {
+            return None;
+        }
+
+        let parameter_type = self.signature.parameters()[*parameter_index].annotated_type();
+        parameter_type
+            .references_typevar(db, paramspec.typevar(db).identity(db))
+            .then_some(parameter_type)
+    }
+
+    /// Returns the type context to use for bidirectional inference of a source call argument.
+    ///
+    /// This covers the normal parameter annotation path, generic return-context specialization, and
+    /// the `ParamSpec` forwarding path where a wrapper argument receives context from the wrapped
+    /// callable's parameter.
+    ///
+    /// ```py
+    /// def put_tags(tags: list[Tag], /) -> None: ...
+    /// def wrapper[**P, R](func: Callable[P, R], /, *args: P.args) -> R: ...
+    /// wrapper(put_tags, [{"Key": "k", "Value": "v"}])  # forwarded list gets `list[Tag]`
+    /// ```
+    pub(crate) fn argument_type_context(
+        &self,
+        db: &'db dyn Db,
+        constraints: &ConstraintSetBuilder<'db>,
+        binding: &CallableBinding<'db>,
+        arguments_types: &CallArguments<'_, 'db>,
+        argument_index: usize,
+        call_expression_tcx: TypeContext<'db>,
+    ) -> Option<ArgumentTypeContext<'db>> {
+        let argument_matches = self.matched_argument_for_call_argument(binding, argument_index)?;
+        let [parameter_index] = argument_matches.parameters.as_slice() else {
+            return None;
+        };
+
+        let parameter = &self.signature.parameters()[*parameter_index];
+        let mut parameter_type = parameter.annotated_type();
+        let original_parameter_type = parameter_type;
+
+        // If the parameter is a single non-ParamSpec type variable with an upper bound,
+        // e.g., `typing.Self`, use the upper bound as type context. ParamSpec components
+        // need to reach generic call specialization below, where earlier arguments can
+        // specialize the full `ParamSpec`.
+        if let Type::TypeVar(typevar) = parameter_type
+            && !typevar.is_paramspec(db)
+            && let Some(TypeVarBoundOrConstraints::UpperBound(bound)) =
+                typevar.typevar(db).bound_or_constraints(db)
+        {
+            return Some(ArgumentTypeContext::new(
+                original_parameter_type,
+                original_parameter_type,
+                bound,
+            ));
+        }
+
+        // If this is a generic call, attempt to specialize the parameter type using the
+        // declared type context, propagating the declared types of any type variables.
+        if let Some(generic_context) = self.signature.generic_context {
+            let mut builder =
+                SpecializationBuilder::new(db, constraints, generic_context.inferable_typevars(db));
+
+            if let Some(declared_return_ty) = call_expression_tcx.annotation {
+                let return_ty = self
+                    .normalized_constructor_return(db)
+                    .unwrap_or(self.signature.return_ty);
+
+                let _ = builder.infer(declared_return_ty, return_ty);
+            }
+
+            let paramspec = if let Type::TypeVar(typevar) = original_parameter_type
+                && typevar.is_paramspec(db)
+                && typevar.paramspec_attr(db).is_some()
+            {
+                Some(typevar.without_paramspec_attr(db))
+            } else {
+                None
+            };
+
+            // Default specialize any type variables to a marker type, which will be ignored
+            // during argument inference, allowing the concrete subset of the parameter
+            // type to still affect argument inference.
+            //
+            // TODO: Eventually, we want to "tie together" the typevars of the two calls
+            // so that we can infer their specializations at the same time — or at least, for
+            // the specialization of one to influence the specialization of the other. It's
+            // not yet clear how we're going to do that. (We might have to start inferring
+            // constraint sets for each expression, instead of simple types?)
+            let specialization = builder.build_with(generic_context, |_, bounds| {
+                if bounds.is_none() {
+                    Some(Type::Dynamic(DynamicType::UnspecializedTypeVar))
+                } else {
+                    None
+                }
+            });
+
+            // A `P.args`/`P.kwargs` parameter has a useful context only after another
+            // argument, usually a `Callable[P, R]`, specializes `P`.
+            if let Some(paramspec) = paramspec
+                && let Some(callable) = self.inferred_paramspec_callable(
+                    db,
+                    constraints,
+                    binding,
+                    paramspec,
+                    arguments_types,
+                    call_expression_tcx,
+                )
+                && let Some(specialized_parameter_type) =
+                    self.paramspec_argument_context(ParamSpecArgumentContext {
+                        db,
+                        constraints,
+                        binding,
+                        callable,
+                        arguments_types,
+                        argument_index,
+                        call_expression_tcx,
+                    })
+            {
+                return Some(ArgumentTypeContext::new(
+                    specialized_parameter_type,
+                    original_parameter_type,
+                    specialized_parameter_type,
+                ));
+            }
+
+            parameter_type = parameter_type.apply_specialization(db, specialization);
+        }
+
+        Some(ArgumentTypeContext::new(
+            original_parameter_type,
+            original_parameter_type,
+            parameter_type,
+        ))
     }
 
     fn replace_callable_type(&mut self, before: Type<'db>, after: Type<'db>) {
@@ -6238,20 +6620,36 @@ impl BindingError<'_> {
         self
     }
 
+    /// Remaps any argument index in this error when a remapping table is available.
+    ///
+    /// This is used when propagating errors from a synthetic sub-call back to the original call.
+    /// Each sub-call argument index is looked up in `argument_indices`; `None` means the error
+    /// should be reported on the whole call expression.
     fn maybe_remap_argument_indices(mut self, argument_indices: Option<&[Option<usize>]>) -> Self {
         if let Some(argument_indices) = argument_indices {
-            self.remap_argument_indices(argument_indices);
+            self.map_argument_indices(|argument_index| {
+                argument_index
+                    .and_then(|index| argument_indices.get(index).copied())
+                    .flatten()
+            });
         }
         self
     }
 
-    fn remap_argument_indices(&mut self, argument_indices: &[Option<usize>]) {
-        let remap = |argument_index: &mut Option<usize>| {
-            *argument_index = argument_index
-                .and_then(|index| argument_indices.get(index).copied())
-                .flatten();
+    /// Rewrites every stored argument index with the provided mapping function.
+    ///
+    /// This supports both simple offsets and sparse sub-call remapping. For a forwarded `ParamSpec`
+    /// call, the sub-call only contains the arguments supplied to `P`. An error at sub-call
+    /// argument `0` might therefore refer to outer-call argument `1`:
+    ///
+    /// ```py
+    /// def wrapper[**P, R](func: Callable[P, R], /, *args: P.args) -> R: ...
+    /// wrapper(func, "bad")  # sub-call index 0 maps back to the outer `"bad"` argument
+    /// ```
+    fn map_argument_indices(&mut self, mut map: impl FnMut(Option<usize>) -> Option<usize>) {
+        let mut remap = |argument_index: &mut Option<usize>| {
+            *argument_index = map(*argument_index);
         };
-
         match self {
             BindingError::InvalidArgumentType { argument_index, .. }
             | BindingError::InvalidKeyType { argument_index, .. }
@@ -6286,35 +6684,7 @@ impl BindingError<'_> {
     /// argument list rather than the original call's argument list. The `offset` should be the
     /// number of arguments in the original call that were matched before the `ParamSpec` component.
     pub(crate) fn apply_argument_index_offset(&mut self, offset: usize) {
-        match self {
-            BindingError::InvalidArgumentType { argument_index, .. }
-            | BindingError::InvalidKeyType { argument_index, .. }
-            | BindingError::UnknownArgument { argument_index, .. }
-            | BindingError::PositionalOnlyParameterAsKwarg { argument_index, .. }
-            | BindingError::ParameterAlreadyAssigned { argument_index, .. }
-            | BindingError::SpecializationError { argument_index, .. } => {
-                if let Some(argument_index) = argument_index {
-                    *argument_index += offset;
-                }
-            }
-
-            BindingError::TooManyPositionalArguments {
-                first_excess_argument_index,
-                ..
-            } => {
-                if let Some(first_excess_argument_index) = first_excess_argument_index {
-                    *first_excess_argument_index += offset;
-                }
-            }
-
-            BindingError::CalledTopCallable(..)
-            | BindingError::InternalCallError(..)
-            | BindingError::InvalidDataclassApplication(..)
-            | BindingError::MissingArguments { .. }
-            | BindingError::UnmatchedOverload
-            | BindingError::PropertyHasNoSetter(..)
-            | BindingError::PropertyHasNoDeleter(..) => {}
-        }
+        self.map_argument_indices(|argument_index| argument_index.map(|index| index + offset));
     }
 }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5354,31 +5354,71 @@ impl<'db> MatchedArgument<'db> {
     }
 }
 
-/// The declared type context to use when inferring a call-site argument.
+/// The type context to use when inferring a call-site argument.
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct ArgumentTypeContext<'db> {
-    /// The lookup key for the inferred argument type.
-    pub(crate) declared_type: Type<'db>,
-    /// The unspecialized parameter annotation that later type checking may still request.
-    original_declared_type: Type<'db>,
-    /// The concrete type context to use while inferring the argument expression.
-    pub(crate) type_context: TypeContext<'db>,
+pub(crate) enum ArgumentTypeContext<'db> {
+    Standard {
+        /// The raw parameter type from the overload signature.
+        raw_parameter_type: Type<'db>,
+        /// The parameter type to use as context, possibly specialized from the call expression's
+        /// declared type.
+        parameter_type: Type<'db>,
+    },
+    ParamSpec {
+        /// The `P.args` or `P.kwargs` parameter that this argument is bound to.
+        paramspec_parameter_type: Type<'db>,
+        /// The declared type of this argument on the callable stored in the `ParamSpec`.
+        declared_type: Type<'db>,
+    },
 }
 
 impl<'db> ArgumentTypeContext<'db> {
-    /// Creates an argument type context.
+    /// Creates a context for ordinary parameter annotations.
     ///
-    /// `declared_type` is the lookup key for the inferred argument type. `original_declared_type`
-    /// is the unspecialized parameter annotation that later type checking may still request.
-    fn new(
-        declared_type: Type<'db>,
-        original_declared_type: Type<'db>,
-        type_context: Type<'db>,
-    ) -> Self {
-        Self {
+    /// `raw_parameter_type` is the lookup key used by later type checking. `parameter_type` is the
+    /// possibly-specialized context used to infer the argument expression.
+    fn standard(raw_parameter_type: Type<'db>, parameter_type: Type<'db>) -> Self {
+        Self::Standard {
+            raw_parameter_type,
+            parameter_type,
+        }
+    }
+
+    /// Creates a context for an argument forwarded through a `ParamSpec` component.
+    ///
+    /// `paramspec_parameter_type` is the original `P.args` or `P.kwargs` lookup key on the wrapper
+    /// call. `declared_type` is the concrete parameter type on the callable stored in the
+    /// `ParamSpec`.
+    fn paramspec(paramspec_parameter_type: Type<'db>, declared_type: Type<'db>) -> Self {
+        Self::ParamSpec {
+            paramspec_parameter_type,
             declared_type,
-            original_declared_type,
-            type_context: TypeContext::new(Some(type_context)),
+        }
+    }
+
+    /// Returns the type context used for inferring the argument expression.
+    pub(crate) fn type_context(self) -> TypeContext<'db> {
+        match self {
+            Self::Standard { parameter_type, .. }
+            | Self::ParamSpec {
+                declared_type: parameter_type,
+                ..
+            } => TypeContext::new(Some(parameter_type)),
+        }
+    }
+
+    /// Returns the key used to deduplicate speculative inference attempts.
+    ///
+    /// Standard parameters are cached by their raw parameter type, since later type checking asks
+    /// for that type. `ParamSpec` arguments are cached by the concrete forwarded parameter type,
+    /// but still inserted through their full context so the original `P.args` or `P.kwargs` lookup
+    /// key is populated too.
+    pub(crate) fn inference_cache_key(self) -> Type<'db> {
+        match self {
+            Self::Standard {
+                raw_parameter_type, ..
+            } => raw_parameter_type,
+            Self::ParamSpec { declared_type, .. } => declared_type,
         }
     }
 
@@ -5393,9 +5433,25 @@ impl<'db> ArgumentTypeContext<'db> {
         argument_index: usize,
         inferred_ty: Type<'db>,
     ) {
-        arguments_types.insert_type(argument_index, self.declared_type, inferred_ty);
-        if self.declared_type != self.original_declared_type {
-            arguments_types.insert_type(argument_index, self.original_declared_type, inferred_ty);
+        match self {
+            Self::Standard {
+                raw_parameter_type, ..
+            } => {
+                arguments_types.insert_type(argument_index, raw_parameter_type, inferred_ty);
+            }
+            Self::ParamSpec {
+                paramspec_parameter_type,
+                declared_type,
+            } => {
+                arguments_types.insert_type(argument_index, declared_type, inferred_ty);
+                if declared_type != paramspec_parameter_type {
+                    arguments_types.insert_type(
+                        argument_index,
+                        paramspec_parameter_type,
+                        inferred_ty,
+                    );
+                }
+            }
         }
     }
 }
@@ -5726,8 +5782,7 @@ impl<'db> Binding<'db> {
             && let Some(TypeVarBoundOrConstraints::UpperBound(bound)) =
                 typevar.typevar(db).bound_or_constraints(db)
         {
-            return Some(ArgumentTypeContext::new(
-                original_parameter_type,
+            return Some(ArgumentTypeContext::standard(
                 original_parameter_type,
                 bound,
             ));
@@ -5795,8 +5850,7 @@ impl<'db> Binding<'db> {
                         call_expression_tcx,
                     })
             {
-                return Some(ArgumentTypeContext::new(
-                    specialized_parameter_type,
+                return Some(ArgumentTypeContext::paramspec(
                     original_parameter_type,
                     specialized_parameter_type,
                 ));
@@ -5805,8 +5859,7 @@ impl<'db> Binding<'db> {
             parameter_type = parameter_type.apply_specialization(db, specialization);
         }
 
-        Some(ArgumentTypeContext::new(
-            original_parameter_type,
+        Some(ArgumentTypeContext::standard(
             original_parameter_type,
             parameter_type,
         ))

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4571,9 +4571,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         })
     }
 
-    /// Returns argument-index mappings for arguments matched to the expanded `ParamSpec` component.
+    /// Returns argument-index mappings for arguments matched to the `ParamSpec` component.
     ///
-    /// `prefix_len` is the number of non-ParamSpec prefix parameters in a callable like
+    /// `prefix_len` is the number of parameters before the `ParamSpec` components in a callable like
     /// `Concatenate[Prefix, P]`. Any argument matched to a later parameter belongs to `P`. The
     /// first item is the matched-argument index; the second is the source argument index, or `None`
     /// for synthetic arguments such as bound `self` or `cls`.
@@ -4967,33 +4967,35 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         let paramspec = self.signature.parameters().as_paramspec_with_prefix();
         let paramspec_component_start = paramspec.and_then(|(prefix, paramspec)| {
             let prefix_len = prefix.len();
-            let paramspec_arguments = self.paramspec_argument_indices(prefix_len);
-            if paramspec_arguments.is_empty() {
+            let paramspec_argument_indices = self.paramspec_argument_indices(prefix_len);
+            if paramspec_argument_indices.is_empty() {
                 self.evaluate_paramspec_sub_call(constraints, None, paramspec);
                 return None;
             }
 
             let has_paramspec_component_argument =
-                paramspec_arguments.iter().any(|(argument_index, _)| {
-                    let [parameter_index] =
-                        self.argument_matches[*argument_index].parameters.as_slice()
-                    else {
-                        return false;
-                    };
+                paramspec_argument_indices
+                    .iter()
+                    .any(|(argument_index, _)| {
+                        let [parameter_index] =
+                            self.argument_matches[*argument_index].parameters.as_slice()
+                        else {
+                            return false;
+                        };
 
-                    let Type::TypeVar(typevar) =
-                        self.signature.parameters()[*parameter_index].annotated_type()
-                    else {
-                        return false;
-                    };
+                        let Type::TypeVar(typevar) =
+                            self.signature.parameters()[*parameter_index].annotated_type()
+                        else {
+                            return false;
+                        };
 
-                    typevar.is_paramspec(self.db)
-                });
+                        typevar.is_paramspec(self.db)
+                    });
 
             if has_paramspec_component_argument
                 && self.evaluate_paramspec_sub_call(
                     constraints,
-                    Some(&paramspec_arguments),
+                    Some(&paramspec_argument_indices),
                     paramspec,
                 )
             {
@@ -5004,16 +5006,15 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             }
         });
 
+        let is_paramspec_component_parameter = |parameter_index: usize| {
+            paramspec_component_start.is_some_and(|start| parameter_index >= start)
+        };
+
         for (argument_index, adjusted_argument_index, argument, argument_types) in
             self.enumerate_argument_types()
         {
-            let is_paramspec_component_parameter = |parameter_index: usize| {
-                paramspec_component_start.is_some_and(|start| parameter_index >= start)
-            };
-
             let matched_parameters = &self.argument_matches[argument_index].parameters;
-            if paramspec_component_start.is_some()
-                && !matched_parameters.is_empty()
+            if !matched_parameters.is_empty()
                 && matched_parameters
                     .iter()
                     .all(|parameter_index| is_paramspec_component_parameter(*parameter_index))
@@ -5486,7 +5487,7 @@ impl<'db> Binding<'db> {
             .get(argument_index + usize::from(binding.bound_type.is_some()))
     }
 
-    /// Returns source argument indices whose matched parameters satisfy `matches_parameter`.
+    /// Returns source argument indices matched to the `ParamSpec` component.
     ///
     /// The returned indices are relative to the original call site, excluding any synthetic bound
     /// receiver. For example, this can select all arguments forwarded through `P.args` and
@@ -5496,10 +5497,10 @@ impl<'db> Binding<'db> {
     /// def wrapper[**P, R](func: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R: ...
     /// wrapper(f, 1, y="x")  # can select `1` and `y="x"` without including `func`
     /// ```
-    fn call_argument_indices_matching_parameters(
+    fn paramspec_call_argument_indices(
         &self,
         binding: &CallableBinding<'db>,
-        mut matches_parameter: impl FnMut(usize) -> bool,
+        prefix_len: usize,
     ) -> Vec<usize> {
         let bound_argument_offset = usize::from(binding.bound_type.is_some());
 
@@ -5514,7 +5515,7 @@ impl<'db> Binding<'db> {
                 argument_matches
                     .parameters
                     .iter()
-                    .any(|parameter_index| matches_parameter(*parameter_index))
+                    .any(|parameter_index| *parameter_index >= prefix_len)
                     .then_some(matched_argument_index - bound_argument_offset)
             })
             .collect()
@@ -5596,10 +5597,8 @@ impl<'db> Binding<'db> {
             call_expression_tcx,
         } = context;
         let (prefix, _) = self.signature.parameters().as_paramspec_with_prefix()?;
-        let paramspec_argument_indices = self
-            .call_argument_indices_matching_parameters(binding, |parameter_index| {
-                parameter_index >= prefix.len()
-            });
+        let paramspec_argument_indices =
+            self.paramspec_call_argument_indices(binding, prefix.len());
         let sub_argument_index = paramspec_argument_indices
             .iter()
             .position(|paramspec_argument_index| *paramspec_argument_index == argument_index)?;

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5317,16 +5317,167 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
+        fn insert_inferred_argument_type<'db>(
+            arguments_types: &mut CallArguments<'_, 'db>,
+            argument_index: usize,
+            declared_type: Type<'db>,
+            original_declared_type: Type<'db>,
+            inferred_ty: Type<'db>,
+        ) {
+            arguments_types.insert_type(argument_index, declared_type, inferred_ty);
+            if declared_type != original_declared_type {
+                arguments_types.insert_type(argument_index, original_declared_type, inferred_ty);
+            }
+        }
+
+        fn inferred_paramspec_callable<'db>(
+            db: &'db dyn Db,
+            constraints: &ConstraintSetBuilder<'db>,
+            overload: &Binding<'db>,
+            binding: &CallableBinding<'db>,
+            paramspec: BoundTypeVarInstance<'db>,
+            arguments_types: &CallArguments<'_, 'db>,
+            call_expression_tcx: TypeContext<'db>,
+        ) -> Option<CallableType<'db>> {
+            let mut specialized_binding = CallableBinding::from_overloads(
+                overload.signature_type,
+                [overload.signature.clone()],
+            );
+            if let Some(bound_type) = binding.bound_type {
+                specialized_binding = specialized_binding.with_bound_type(bound_type);
+            }
+
+            // Reuse the normal binding checker to infer `P` from the arguments that have already
+            // been inferred. This avoids duplicating specialization logic here; the current
+            // `P.args`/`P.kwargs` argument is still uninferred, so it only contributes `Unknown`.
+            let mut specialized_bindings =
+                Bindings::from(specialized_binding).match_parameters(db, arguments_types);
+            let _ = specialized_bindings.check_types_impl(
+                db,
+                constraints,
+                arguments_types,
+                call_expression_tcx,
+                &[],
+            );
+
+            let Type::Callable(callable) = specialized_bindings
+                .single_element()
+                .and_then(|binding| binding.matching_overloads().exactly_one().ok())
+                .and_then(|(_, overload)| overload.specialization())
+                .and_then(|specialization| specialization.get(db, paramspec))?
+            else {
+                return None;
+            };
+
+            (callable.kind(db) == CallableTypeKind::ParamSpecValue).then_some(callable)
+        }
+
+        #[expect(clippy::too_many_arguments)]
+        fn paramspec_argument_context<'db>(
+            db: &'db dyn Db,
+            constraints: &ConstraintSetBuilder<'db>,
+            overload: &Binding<'db>,
+            binding: &CallableBinding<'db>,
+            callable: CallableType<'db>,
+            arguments_types: &CallArguments<'_, 'db>,
+            argument_index: usize,
+            call_expression_tcx: TypeContext<'db>,
+        ) -> Option<Type<'db>> {
+            let (prefix, _) = overload.signature.parameters().as_paramspec_with_prefix()?;
+            // The callable stored for `P` represents the tail call accepted by the
+            // `P.args`/`P.kwargs` parameters, so rematch the argument suffix against that callable.
+            let paramspec_start_argument_index = overload
+                .argument_matches()
+                .iter()
+                .position(|argument_matches| {
+                    argument_matches
+                        .parameters
+                        .iter()
+                        .any(|parameter_index| *parameter_index >= prefix.len())
+                })?
+                .checked_sub(usize::from(binding.bound_type.is_some()))?;
+            let sub_argument_index = argument_index.checked_sub(paramspec_start_argument_index)?;
+
+            let specialized_binding = CallableBinding::from_overloads(
+                overload.signature_type,
+                callable.signatures(db).iter().cloned(),
+            );
+            let sub_arguments = arguments_types.start_from(paramspec_start_argument_index);
+            let mut specialized_bindings =
+                Bindings::from(specialized_binding).match_parameters(db, &sub_arguments);
+            let _ = specialized_bindings.check_types_impl(
+                db,
+                constraints,
+                &sub_arguments,
+                call_expression_tcx,
+                &[],
+            );
+
+            let specialized_binding = specialized_bindings.single_element()?;
+            let (_, specialized_overload) = specialized_binding
+                .matching_overloads()
+                .exactly_one()
+                .ok()?;
+            let [specialized_parameter_index] = specialized_overload
+                .argument_matches()
+                .get(sub_argument_index)?
+                .parameters
+                .as_slice()
+            else {
+                return None;
+            };
+
+            let parameter_type = specialized_overload.signature.parameters()
+                [*specialized_parameter_index]
+                .annotated_type();
+            let parameter_type = specialized_overload
+                .specialization()
+                .map_or(parameter_type, |specialization| {
+                    parameter_type.apply_specialization(db, specialization)
+                });
+
+            // A context like `list[Unknown]` or `list[T@g]` is worse than no context here:
+            // it can erase the concrete literal type that should later specialize the wrapped
+            // callable.
+            (!parameter_type.has_dynamic(db) && !parameter_type.has_typevar_or_typevar_instance(db))
+                .then_some(parameter_type)
+        }
+
+        fn paramspec_binder_parameter_type<'db>(
+            db: &'db dyn Db,
+            overload: &Binding<'db>,
+            binding: &CallableBinding<'db>,
+            argument_index: usize,
+        ) -> Option<Type<'db>> {
+            let (prefix, paramspec) = overload.signature.parameters().as_paramspec_with_prefix()?;
+            let adjusted_argument_index = if binding.bound_type.is_some() {
+                argument_index + 1
+            } else {
+                argument_index
+            };
+            let [parameter_index] = overload
+                .argument_matches()
+                .get(adjusted_argument_index)?
+                .parameters
+                .as_slice()
+            else {
+                return None;
+            };
+
+            if *parameter_index >= prefix.len() {
+                return None;
+            }
+
+            let parameter_type = overload.signature.parameters()[*parameter_index].annotated_type();
+            parameter_type
+                .references_typevar(db, paramspec.typevar(db).identity(db))
+                .then_some(parameter_type)
+        }
+
         debug_assert_eq!(arguments_types.len(), bindings.argument_forms().len());
 
         let db = self.db();
         let constraints = ConstraintSetBuilder::new();
-        let iter = itertools::izip!(
-            0..,
-            arguments_types.iter_mut(),
-            bindings.argument_forms().iter().copied(),
-            ast_arguments
-        );
 
         let mut overloads_with_binding: Vec<(&Binding<'db>, &CallableBinding<'db>)> = Vec::new();
 
@@ -5334,7 +5485,59 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             add_overloads_from_binding(&mut overloads_with_binding, binding);
         });
 
-        for (argument_index, (_, argument_types), argument_form, ast_argument) in iter {
+        // A keyword argument matched to `**P.kwargs` can appear before the keyword argument that
+        // binds `P`, e.g. `wrapper(TagSet=[...], func=put_object)`. Seed those binder argument
+        // types first so the normal ParamSpec context path below is not source-order dependent.
+        for (argument_index, (argument_form, ast_argument)) in bindings
+            .argument_forms()
+            .iter()
+            .copied()
+            .zip(ast_arguments.clone())
+            .enumerate()
+        {
+            let ast_argument = match ast_argument {
+                ast::ArgOrKeyword::Arg(ast::Expr::Starred(_))
+                | ast::ArgOrKeyword::Keyword(ast::Keyword { arg: None, .. }) => continue,
+
+                ast::ArgOrKeyword::Arg(arg) => arg,
+                ast::ArgOrKeyword::Keyword(ast::Keyword { value, .. }) => value,
+            };
+
+            if matches!(argument_form, Some(ParameterForm::Type)) {
+                continue;
+            }
+
+            let mut inferred_declared_types = FxHashSet::default();
+            for declared_type in overloads_with_binding
+                .iter()
+                .filter_map(|(overload, binding)| {
+                    paramspec_binder_parameter_type(db, overload, binding, argument_index)
+                })
+            {
+                if !inferred_declared_types.insert(declared_type) {
+                    continue;
+                }
+
+                let mut speculative_builder = self.speculate();
+                let inferred_ty = infer_argument_ty(
+                    &mut speculative_builder,
+                    (
+                        argument_index,
+                        ast_argument,
+                        TypeContext::new(Some(declared_type)),
+                    ),
+                );
+                arguments_types.insert_type(argument_index, declared_type, inferred_ty);
+            }
+        }
+
+        for (argument_index, (argument_form, ast_argument)) in bindings
+            .argument_forms()
+            .iter()
+            .copied()
+            .zip(ast_arguments)
+            .enumerate()
+        {
             let ast_argument = match ast_argument {
                 // Splatted arguments are inferred before parameter matching to
                 // determine their length.
@@ -5349,7 +5552,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Type-form arguments are inferred without type context, so we can infer the argument type directly.
             if let Some(ParameterForm::Type) = argument_form {
-                argument_types.insert(
+                arguments_types.insert_type(
+                    argument_index,
                     TypeContext::default(),
                     self.infer_type_expression(ast_argument),
                 );
@@ -5360,27 +5564,35 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Retrieve the parameter type context for the current argument in a given overload and its binding.
             let parameter_tcx = |overload: &'bindings Binding<'db>,
                                  binding: &CallableBinding<'db>| {
-                let argument_index = if binding.bound_type.is_some() {
+                let adjusted_argument_index = if binding.bound_type.is_some() {
                     argument_index + 1
                 } else {
                     argument_index
                 };
 
-                let argument_matches = &overload.argument_matches()[argument_index];
+                let argument_matches = &overload.argument_matches()[adjusted_argument_index];
                 let [parameter_index] = argument_matches.parameters.as_slice() else {
                     return None;
                 };
 
                 let parameter = &overload.signature.parameters()[*parameter_index];
                 let mut parameter_type = parameter.annotated_type();
+                let original_parameter_type = parameter_type;
 
-                // If the parameter is a single type variable with an upper bound, e.g., `typing.Self`,
-                // use the upper bound as type context.
+                // If the parameter is a single non-ParamSpec type variable with an upper bound,
+                // e.g., `typing.Self`, use the upper bound as type context. ParamSpec components
+                // need to reach generic call specialization below, where earlier arguments can
+                // specialize the full `ParamSpec`.
                 if let Type::TypeVar(typevar) = parameter_type
+                    && !typevar.is_paramspec(db)
                     && let Some(TypeVarBoundOrConstraints::UpperBound(bound)) =
                         typevar.typevar(db).bound_or_constraints(db)
                 {
-                    return Some((parameter, TypeContext::new(Some(bound))));
+                    return Some((
+                        original_parameter_type,
+                        original_parameter_type,
+                        TypeContext::new(Some(bound)),
+                    ));
                 }
 
                 // If this is a generic call, attempt to specialize the parameter type using the
@@ -5400,6 +5612,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         let _ = builder.infer(declared_return_ty, return_ty);
                     }
 
+                    let paramspec = if let Type::TypeVar(typevar) = original_parameter_type
+                        && typevar.is_paramspec(db)
+                        && typevar.paramspec_attr(db).is_some()
+                    {
+                        Some(typevar.without_paramspec_attr(db))
+                    } else {
+                        None
+                    };
+
                     // Default specialize any type variables to a marker type, which will be ignored
                     // during argument inference, allowing the concrete subset of the parameter
                     // type to still affect argument inference.
@@ -5417,43 +5638,88 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         }
                     });
 
+                    // A `P.args`/`P.kwargs` parameter has a useful context only after another
+                    // argument, usually a `Callable[P, R]`, specializes `P`.
+                    if let Some(paramspec) = paramspec
+                        && let Some(callable) = inferred_paramspec_callable(
+                            db,
+                            &constraints,
+                            overload,
+                            binding,
+                            paramspec,
+                            arguments_types,
+                            call_expression_tcx,
+                        )
+                        && let Some(specialized_parameter_type) = paramspec_argument_context(
+                            db,
+                            &constraints,
+                            overload,
+                            binding,
+                            callable,
+                            arguments_types,
+                            argument_index,
+                            call_expression_tcx,
+                        )
+                    {
+                        return Some((
+                            specialized_parameter_type,
+                            original_parameter_type,
+                            TypeContext::new(Some(specialized_parameter_type)),
+                        ));
+                    }
+
                     parameter_type = parameter_type.apply_specialization(db, specialization);
                 }
 
-                Some((parameter, TypeContext::new(Some(parameter_type))))
+                Some((
+                    original_parameter_type,
+                    original_parameter_type,
+                    TypeContext::new(Some(parameter_type)),
+                ))
             };
 
             // If there is only a single binding and overload, we can infer the argument directly with
             // the unique parameter type annotation.
             if let Ok((overload, binding)) = overloads_with_binding.iter().exactly_one() {
-                if let Some((parameter, parameter_tcx)) = parameter_tcx(overload, binding) {
-                    argument_types.insert(
-                        parameter.annotated_type(),
-                        infer_argument_ty(self, (argument_index, ast_argument, parameter_tcx)),
+                let parameter_context = parameter_tcx(overload, binding);
+
+                if let Some((declared_type, original_declared_type, parameter_tcx)) =
+                    parameter_context
+                {
+                    let inferred_ty =
+                        infer_argument_ty(self, (argument_index, ast_argument, parameter_tcx));
+                    insert_inferred_argument_type(
+                        arguments_types,
+                        argument_index,
+                        declared_type,
+                        original_declared_type,
+                        inferred_ty,
                     );
                 } else {
-                    argument_types.insert(
+                    let inferred_ty = infer_argument_ty(
+                        self,
+                        (argument_index, ast_argument, TypeContext::default()),
+                    );
+                    arguments_types.insert_type(
+                        argument_index,
                         TypeContext::default(),
-                        infer_argument_ty(
-                            self,
-                            (argument_index, ast_argument, TypeContext::default()),
-                        ),
+                        inferred_ty,
                     );
                 }
             } else {
+                // Infer the type of each argument once with each distinct parameter type as type context.
+                let parameter_types: Vec<_> = overloads_with_binding
+                    .iter()
+                    .filter_map(|(overload, binding)| parameter_tcx(overload, binding))
+                    .collect();
+
                 // We perform inference once without any type context, emitting any diagnostics that are unrelated
                 // to bidirectional type inference.
-                argument_types.insert(
-                    TypeContext::default(),
-                    infer_argument_ty(self, (argument_index, ast_argument, TypeContext::default())),
-                );
+                let default_ty =
+                    infer_argument_ty(self, (argument_index, ast_argument, TypeContext::default()));
+                arguments_types.insert_type(argument_index, TypeContext::default(), default_ty);
 
-                // Infer the type of each argument once with each distinct parameter type as type context.
-                let parameter_types = overloads_with_binding
-                    .iter()
-                    .filter_map(|(overload, binding)| parameter_tcx(overload, binding));
-
-                let mut seen = FxHashSet::default();
+                let mut inferred_by_declared_type = FxHashMap::default();
 
                 // Cache expressions inferred across speculative inference attempts.
                 //
@@ -5461,8 +5727,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // as inner expressions are repeatedly inferred with the same type context.
                 let teardown = self.setup_expression_cache();
 
-                for (parameter, parameter_tcx) in parameter_types {
-                    if !seen.insert(parameter.annotated_type()) {
+                for (declared_type, original_declared_type, parameter_tcx) in parameter_types {
+                    if let Some(inferred_ty) =
+                        inferred_by_declared_type.get(&declared_type).copied()
+                    {
+                        if declared_type != original_declared_type {
+                            arguments_types.insert_type(
+                                argument_index,
+                                original_declared_type,
+                                inferred_ty,
+                            );
+                        }
                         continue;
                     }
 
@@ -5474,8 +5749,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         &mut speculative_builder,
                         (argument_index, ast_argument, parameter_tcx),
                     );
+                    inferred_by_declared_type.insert(declared_type, inferred_ty);
                     self.union_expected_types(&speculative_builder.expected_types);
-                    argument_types.insert(parameter.annotated_type(), inferred_ty);
+                    insert_inferred_argument_type(
+                        arguments_types,
+                        argument_index,
+                        declared_type,
+                        original_declared_type,
+                        inferred_ty,
+                    );
                 }
 
                 if teardown {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5328,10 +5328,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             add_overloads_from_binding(&mut overloads_with_binding, binding);
         });
 
-        let single_overload_with_binding =
-            overloads_with_binding.iter().copied().exactly_one().ok();
-        let mut inferred_paramspec_binder_arguments = FxHashSet::default();
-
         // A keyword argument matched to `**P.kwargs` can appear before the keyword argument that
         // binds `P`, e.g. `wrapper(TagSet=[...], func=put_object)`. Seed those binder argument
         // types first so the normal ParamSpec context path below is not source-order dependent.
@@ -5351,36 +5347,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             };
 
             if matches!(argument_form, Some(ParameterForm::Type)) {
-                continue;
-            }
-
-            if let Some((overload, binding)) = single_overload_with_binding
-                && overload
-                    .paramspec_binder_parameter_type(db, binding, argument_index)
-                    .is_some()
-                && let Some(parameter_context) = overload.argument_type_context(
-                    db,
-                    &constraints,
-                    binding,
-                    arguments_types,
-                    argument_index,
-                    call_expression_tcx,
-                )
-            {
-                let inferred_ty = infer_argument_ty(
-                    self,
-                    (
-                        argument_index,
-                        ast_argument,
-                        parameter_context.type_context(),
-                    ),
-                );
-                parameter_context.insert_inferred_type(
-                    arguments_types,
-                    argument_index,
-                    inferred_ty,
-                );
-                inferred_paramspec_binder_arguments.insert(argument_index);
                 continue;
             }
 
@@ -5427,10 +5393,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ast::ArgOrKeyword::Keyword(ast::Keyword { value, .. }) => value,
             };
 
-            if inferred_paramspec_binder_arguments.contains(&argument_index) {
-                continue;
-            }
-
             // Type-form arguments are inferred without type context, so we can infer the argument type directly.
             if let Some(ParameterForm::Type) = argument_form {
                 arguments_types.insert_type(
@@ -5456,7 +5418,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // If there is only a single binding and overload, we can infer the argument directly with
             // the unique parameter type annotation.
-            if let Some((overload, binding)) = single_overload_with_binding {
+            if let Ok((overload, binding)) = overloads_with_binding.iter().exactly_one() {
                 let parameter_context = parameter_tcx(overload, binding);
 
                 if let Some(parameter_context) = parameter_context {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5372,6 +5372,31 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             (callable.kind(db) == CallableTypeKind::ParamSpecValue).then_some(callable)
         }
 
+        fn paramspec_argument_indices<'db>(
+            overload: &Binding<'db>,
+            binding: &CallableBinding<'db>,
+            prefix_len: usize,
+        ) -> Vec<usize> {
+            let bound_argument_offset = usize::from(binding.bound_type.is_some());
+
+            overload
+                .argument_matches()
+                .iter()
+                .enumerate()
+                .filter_map(|(matched_argument_index, argument_matches)| {
+                    if matched_argument_index < bound_argument_offset {
+                        return None;
+                    }
+
+                    argument_matches
+                        .parameters
+                        .iter()
+                        .any(|parameter_index| *parameter_index >= prefix_len)
+                        .then_some(matched_argument_index - bound_argument_offset)
+                })
+                .collect()
+        }
+
         #[expect(clippy::too_many_arguments)]
         fn paramspec_argument_context<'db>(
             db: &'db dyn Db,
@@ -5384,25 +5409,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             call_expression_tcx: TypeContext<'db>,
         ) -> Option<Type<'db>> {
             let (prefix, _) = overload.signature.parameters().as_paramspec_with_prefix()?;
-            // The callable stored for `P` represents the tail call accepted by the
-            // `P.args`/`P.kwargs` parameters, so rematch the argument suffix against that callable.
-            let paramspec_start_argument_index = overload
-                .argument_matches()
+            let paramspec_argument_indices =
+                paramspec_argument_indices(overload, binding, prefix.len());
+            let sub_argument_index = paramspec_argument_indices
                 .iter()
-                .position(|argument_matches| {
-                    argument_matches
-                        .parameters
-                        .iter()
-                        .any(|parameter_index| *parameter_index >= prefix.len())
-                })?
-                .checked_sub(usize::from(binding.bound_type.is_some()))?;
-            let sub_argument_index = argument_index.checked_sub(paramspec_start_argument_index)?;
+                .position(|paramspec_argument_index| *paramspec_argument_index == argument_index)?;
 
             let specialized_binding = CallableBinding::from_overloads(
                 overload.signature_type,
                 callable.signatures(db).iter().cloned(),
             );
-            let sub_arguments = arguments_types.start_from(paramspec_start_argument_index);
+            let sub_arguments = arguments_types.select(&paramspec_argument_indices);
             let mut specialized_bindings =
                 Bindings::from(specialized_binding).match_parameters(db, &sub_arguments);
             let _ = specialized_bindings.check_types_impl(
@@ -5430,15 +5447,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let parameter_type = specialized_overload.signature.parameters()
                 [*specialized_parameter_index]
                 .annotated_type();
+            // A context like `list[Unknown]` or `list[T@g]` is worse than no context here:
+            // it can erase the concrete literal type that should later specialize the wrapped
+            // callable. Check the parameter before applying the sub-call specialization so an
+            // earlier forwarded argument cannot turn `list[T@g]` into apparently-safe `list[int]`.
+            if parameter_type.has_dynamic(db) || parameter_type.has_typevar_or_typevar_instance(db)
+            {
+                return None;
+            }
+
             let parameter_type = specialized_overload
                 .specialization()
                 .map_or(parameter_type, |specialization| {
                     parameter_type.apply_specialization(db, specialization)
                 });
 
-            // A context like `list[Unknown]` or `list[T@g]` is worse than no context here:
-            // it can erase the concrete literal type that should later specialize the wrapped
-            // callable.
             (!parameter_type.has_dynamic(db) && !parameter_type.has_typevar_or_typevar_instance(db))
                 .then_some(parameter_type)
         }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5328,6 +5328,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             add_overloads_from_binding(&mut overloads_with_binding, binding);
         });
 
+        let single_overload_with_binding =
+            overloads_with_binding.iter().copied().exactly_one().ok();
+        let mut inferred_paramspec_binder_arguments = FxHashSet::default();
+
         // A keyword argument matched to `**P.kwargs` can appear before the keyword argument that
         // binds `P`, e.g. `wrapper(TagSet=[...], func=put_object)`. Seed those binder argument
         // types first so the normal ParamSpec context path below is not source-order dependent.
@@ -5347,6 +5351,36 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             };
 
             if matches!(argument_form, Some(ParameterForm::Type)) {
+                continue;
+            }
+
+            if let Some((overload, binding)) = single_overload_with_binding
+                && overload
+                    .paramspec_binder_parameter_type(db, binding, argument_index)
+                    .is_some()
+                && let Some(parameter_context) = overload.argument_type_context(
+                    db,
+                    &constraints,
+                    binding,
+                    arguments_types,
+                    argument_index,
+                    call_expression_tcx,
+                )
+            {
+                let inferred_ty = infer_argument_ty(
+                    self,
+                    (
+                        argument_index,
+                        ast_argument,
+                        parameter_context.type_context(),
+                    ),
+                );
+                parameter_context.insert_inferred_type(
+                    arguments_types,
+                    argument_index,
+                    inferred_ty,
+                );
+                inferred_paramspec_binder_arguments.insert(argument_index);
                 continue;
             }
 
@@ -5393,6 +5427,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ast::ArgOrKeyword::Keyword(ast::Keyword { value, .. }) => value,
             };
 
+            if inferred_paramspec_binder_arguments.contains(&argument_index) {
+                continue;
+            }
+
             // Type-form arguments are inferred without type context, so we can infer the argument type directly.
             if let Some(ParameterForm::Type) = argument_form {
                 arguments_types.insert_type(
@@ -5418,7 +5456,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // If there is only a single binding and overload, we can infer the argument directly with
             // the unique parameter type annotation.
-            if let Ok((overload, binding)) = overloads_with_binding.iter().exactly_one() {
+            if let Some((overload, binding)) = single_overload_with_binding {
                 let parameter_context = parameter_tcx(overload, binding);
 
                 if let Some(parameter_context) = parameter_context {
@@ -5448,7 +5486,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             } else {
                 // Infer the type of each argument once with each distinct parameter type as type context.
-                let parameter_types: Vec<_> = overloads_with_binding
+                let parameter_contexts: Vec<_> = overloads_with_binding
                     .iter()
                     .filter_map(|(overload, binding)| parameter_tcx(overload, binding))
                     .collect();
@@ -5467,7 +5505,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // as inner expressions are repeatedly inferred with the same type context.
                 let teardown = self.setup_expression_cache();
 
-                for parameter_context in parameter_types {
+                for parameter_context in parameter_contexts {
                     let inference_cache_key = parameter_context.inference_cache_key();
                     if let Some(inferred_ty) =
                         inferred_by_cache_key.get(&inference_cache_key).copied()

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5317,186 +5317,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
-        fn insert_inferred_argument_type<'db>(
-            arguments_types: &mut CallArguments<'_, 'db>,
-            argument_index: usize,
-            declared_type: Type<'db>,
-            original_declared_type: Type<'db>,
-            inferred_ty: Type<'db>,
-        ) {
-            arguments_types.insert_type(argument_index, declared_type, inferred_ty);
-            if declared_type != original_declared_type {
-                arguments_types.insert_type(argument_index, original_declared_type, inferred_ty);
-            }
-        }
-
-        fn inferred_paramspec_callable<'db>(
-            db: &'db dyn Db,
-            constraints: &ConstraintSetBuilder<'db>,
-            overload: &Binding<'db>,
-            binding: &CallableBinding<'db>,
-            paramspec: BoundTypeVarInstance<'db>,
-            arguments_types: &CallArguments<'_, 'db>,
-            call_expression_tcx: TypeContext<'db>,
-        ) -> Option<CallableType<'db>> {
-            let mut specialized_binding = CallableBinding::from_overloads(
-                overload.signature_type,
-                [overload.signature.clone()],
-            );
-            if let Some(bound_type) = binding.bound_type {
-                specialized_binding = specialized_binding.with_bound_type(bound_type);
-            }
-
-            // Reuse the normal binding checker to infer `P` from the arguments that have already
-            // been inferred. This avoids duplicating specialization logic here; the current
-            // `P.args`/`P.kwargs` argument is still uninferred, so it only contributes `Unknown`.
-            let mut specialized_bindings =
-                Bindings::from(specialized_binding).match_parameters(db, arguments_types);
-            let _ = specialized_bindings.check_types_impl(
-                db,
-                constraints,
-                arguments_types,
-                call_expression_tcx,
-                &[],
-            );
-
-            let Type::Callable(callable) = specialized_bindings
-                .single_element()
-                .and_then(|binding| binding.matching_overloads().exactly_one().ok())
-                .and_then(|(_, overload)| overload.specialization())
-                .and_then(|specialization| specialization.get(db, paramspec))?
-            else {
-                return None;
-            };
-
-            (callable.kind(db) == CallableTypeKind::ParamSpecValue).then_some(callable)
-        }
-
-        fn paramspec_argument_indices<'db>(
-            overload: &Binding<'db>,
-            binding: &CallableBinding<'db>,
-            prefix_len: usize,
-        ) -> Vec<usize> {
-            let bound_argument_offset = usize::from(binding.bound_type.is_some());
-
-            overload
-                .argument_matches()
-                .iter()
-                .enumerate()
-                .filter_map(|(matched_argument_index, argument_matches)| {
-                    if matched_argument_index < bound_argument_offset {
-                        return None;
-                    }
-
-                    argument_matches
-                        .parameters
-                        .iter()
-                        .any(|parameter_index| *parameter_index >= prefix_len)
-                        .then_some(matched_argument_index - bound_argument_offset)
-                })
-                .collect()
-        }
-
-        #[expect(clippy::too_many_arguments)]
-        fn paramspec_argument_context<'db>(
-            db: &'db dyn Db,
-            constraints: &ConstraintSetBuilder<'db>,
-            overload: &Binding<'db>,
-            binding: &CallableBinding<'db>,
-            callable: CallableType<'db>,
-            arguments_types: &CallArguments<'_, 'db>,
-            argument_index: usize,
-            call_expression_tcx: TypeContext<'db>,
-        ) -> Option<Type<'db>> {
-            let (prefix, _) = overload.signature.parameters().as_paramspec_with_prefix()?;
-            let paramspec_argument_indices =
-                paramspec_argument_indices(overload, binding, prefix.len());
-            let sub_argument_index = paramspec_argument_indices
-                .iter()
-                .position(|paramspec_argument_index| *paramspec_argument_index == argument_index)?;
-
-            let specialized_binding = CallableBinding::from_overloads(
-                overload.signature_type,
-                callable.signatures(db).iter().cloned(),
-            );
-            let sub_arguments = arguments_types.select(&paramspec_argument_indices);
-            let mut specialized_bindings =
-                Bindings::from(specialized_binding).match_parameters(db, &sub_arguments);
-            let _ = specialized_bindings.check_types_impl(
-                db,
-                constraints,
-                &sub_arguments,
-                call_expression_tcx,
-                &[],
-            );
-
-            let specialized_binding = specialized_bindings.single_element()?;
-            let (_, specialized_overload) = specialized_binding
-                .matching_overloads()
-                .exactly_one()
-                .ok()?;
-            let [specialized_parameter_index] = specialized_overload
-                .argument_matches()
-                .get(sub_argument_index)?
-                .parameters
-                .as_slice()
-            else {
-                return None;
-            };
-
-            let parameter_type = specialized_overload.signature.parameters()
-                [*specialized_parameter_index]
-                .annotated_type();
-            // A context like `list[Unknown]` or `list[T@g]` is worse than no context here:
-            // it can erase the concrete literal type that should later specialize the wrapped
-            // callable. Check the parameter before applying the sub-call specialization so an
-            // earlier forwarded argument cannot turn `list[T@g]` into apparently-safe `list[int]`.
-            if parameter_type.has_dynamic(db) || parameter_type.has_typevar_or_typevar_instance(db)
-            {
-                return None;
-            }
-
-            let parameter_type = specialized_overload
-                .specialization()
-                .map_or(parameter_type, |specialization| {
-                    parameter_type.apply_specialization(db, specialization)
-                });
-
-            (!parameter_type.has_dynamic(db) && !parameter_type.has_typevar_or_typevar_instance(db))
-                .then_some(parameter_type)
-        }
-
-        fn paramspec_binder_parameter_type<'db>(
-            db: &'db dyn Db,
-            overload: &Binding<'db>,
-            binding: &CallableBinding<'db>,
-            argument_index: usize,
-        ) -> Option<Type<'db>> {
-            let (prefix, paramspec) = overload.signature.parameters().as_paramspec_with_prefix()?;
-            let adjusted_argument_index = if binding.bound_type.is_some() {
-                argument_index + 1
-            } else {
-                argument_index
-            };
-            let [parameter_index] = overload
-                .argument_matches()
-                .get(adjusted_argument_index)?
-                .parameters
-                .as_slice()
-            else {
-                return None;
-            };
-
-            if *parameter_index >= prefix.len() {
-                return None;
-            }
-
-            let parameter_type = overload.signature.parameters()[*parameter_index].annotated_type();
-            parameter_type
-                .references_typevar(db, paramspec.typevar(db).identity(db))
-                .then_some(parameter_type)
-        }
-
         debug_assert_eq!(arguments_types.len(), bindings.argument_forms().len());
 
         let db = self.db();
@@ -5534,7 +5354,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             for declared_type in overloads_with_binding
                 .iter()
                 .filter_map(|(overload, binding)| {
-                    paramspec_binder_parameter_type(db, overload, binding, argument_index)
+                    overload.paramspec_binder_parameter_type(db, binding, argument_index)
                 })
             {
                 if !inferred_declared_types.insert(declared_type) {
@@ -5584,121 +5404,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 continue;
             }
 
-            // Retrieve the parameter type context for the current argument in a given overload and its binding.
             let parameter_tcx = |overload: &'bindings Binding<'db>,
                                  binding: &CallableBinding<'db>| {
-                let adjusted_argument_index = if binding.bound_type.is_some() {
-                    argument_index + 1
-                } else {
-                    argument_index
-                };
-
-                let argument_matches = &overload.argument_matches()[adjusted_argument_index];
-                let [parameter_index] = argument_matches.parameters.as_slice() else {
-                    return None;
-                };
-
-                let parameter = &overload.signature.parameters()[*parameter_index];
-                let mut parameter_type = parameter.annotated_type();
-                let original_parameter_type = parameter_type;
-
-                // If the parameter is a single non-ParamSpec type variable with an upper bound,
-                // e.g., `typing.Self`, use the upper bound as type context. ParamSpec components
-                // need to reach generic call specialization below, where earlier arguments can
-                // specialize the full `ParamSpec`.
-                if let Type::TypeVar(typevar) = parameter_type
-                    && !typevar.is_paramspec(db)
-                    && let Some(TypeVarBoundOrConstraints::UpperBound(bound)) =
-                        typevar.typevar(db).bound_or_constraints(db)
-                {
-                    return Some((
-                        original_parameter_type,
-                        original_parameter_type,
-                        TypeContext::new(Some(bound)),
-                    ));
-                }
-
-                // If this is a generic call, attempt to specialize the parameter type using the
-                // declared type context, propagating the declared types of any type variables.
-                if let Some(generic_context) = overload.signature.generic_context {
-                    let mut builder = SpecializationBuilder::new(
-                        db,
-                        &constraints,
-                        generic_context.inferable_typevars(db),
-                    );
-
-                    if let Some(declared_return_ty) = call_expression_tcx.annotation {
-                        let return_ty = overload
-                            .normalized_constructor_return(db)
-                            .unwrap_or(overload.signature.return_ty);
-
-                        let _ = builder.infer(declared_return_ty, return_ty);
-                    }
-
-                    let paramspec = if let Type::TypeVar(typevar) = original_parameter_type
-                        && typevar.is_paramspec(db)
-                        && typevar.paramspec_attr(db).is_some()
-                    {
-                        Some(typevar.without_paramspec_attr(db))
-                    } else {
-                        None
-                    };
-
-                    // Default specialize any type variables to a marker type, which will be ignored
-                    // during argument inference, allowing the concrete subset of the parameter
-                    // type to still affect argument inference.
-                    //
-                    // TODO: Eventually, we want to "tie together" the typevars of the two calls
-                    // so that we can infer their specializations at the same time — or at least, for
-                    // the specialization of one to influence the specialization of the other. It's
-                    // not yet clear how we're going to do that. (We might have to start inferring
-                    // constraint sets for each expression, instead of simple types?)
-                    let specialization = builder.build_with(generic_context, |_, bounds| {
-                        if bounds.is_none() {
-                            Some(Type::Dynamic(DynamicType::UnspecializedTypeVar))
-                        } else {
-                            None
-                        }
-                    });
-
-                    // A `P.args`/`P.kwargs` parameter has a useful context only after another
-                    // argument, usually a `Callable[P, R]`, specializes `P`.
-                    if let Some(paramspec) = paramspec
-                        && let Some(callable) = inferred_paramspec_callable(
-                            db,
-                            &constraints,
-                            overload,
-                            binding,
-                            paramspec,
-                            arguments_types,
-                            call_expression_tcx,
-                        )
-                        && let Some(specialized_parameter_type) = paramspec_argument_context(
-                            db,
-                            &constraints,
-                            overload,
-                            binding,
-                            callable,
-                            arguments_types,
-                            argument_index,
-                            call_expression_tcx,
-                        )
-                    {
-                        return Some((
-                            specialized_parameter_type,
-                            original_parameter_type,
-                            TypeContext::new(Some(specialized_parameter_type)),
-                        ));
-                    }
-
-                    parameter_type = parameter_type.apply_specialization(db, specialization);
-                }
-
-                Some((
-                    original_parameter_type,
-                    original_parameter_type,
-                    TypeContext::new(Some(parameter_type)),
-                ))
+                overload.argument_type_context(
+                    db,
+                    &constraints,
+                    binding,
+                    arguments_types,
+                    argument_index,
+                    call_expression_tcx,
+                )
             };
 
             // If there is only a single binding and overload, we can infer the argument directly with
@@ -5706,16 +5421,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if let Ok((overload, binding)) = overloads_with_binding.iter().exactly_one() {
                 let parameter_context = parameter_tcx(overload, binding);
 
-                if let Some((declared_type, original_declared_type, parameter_tcx)) =
-                    parameter_context
-                {
-                    let inferred_ty =
-                        infer_argument_ty(self, (argument_index, ast_argument, parameter_tcx));
-                    insert_inferred_argument_type(
+                if let Some(parameter_context) = parameter_context {
+                    let inferred_ty = infer_argument_ty(
+                        self,
+                        (argument_index, ast_argument, parameter_context.type_context),
+                    );
+                    parameter_context.insert_inferred_type(
                         arguments_types,
                         argument_index,
-                        declared_type,
-                        original_declared_type,
                         inferred_ty,
                     );
                 } else {
@@ -5750,17 +5463,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // as inner expressions are repeatedly inferred with the same type context.
                 let teardown = self.setup_expression_cache();
 
-                for (declared_type, original_declared_type, parameter_tcx) in parameter_types {
+                for parameter_context in parameter_types {
+                    let declared_type = parameter_context.declared_type;
                     if let Some(inferred_ty) =
                         inferred_by_declared_type.get(&declared_type).copied()
                     {
-                        if declared_type != original_declared_type {
-                            arguments_types.insert_type(
-                                argument_index,
-                                original_declared_type,
-                                inferred_ty,
-                            );
-                        }
+                        parameter_context.insert_inferred_type(
+                            arguments_types,
+                            argument_index,
+                            inferred_ty,
+                        );
                         continue;
                     }
 
@@ -5770,15 +5482,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let mut speculative_builder = self.speculate();
                     let inferred_ty = infer_argument_ty(
                         &mut speculative_builder,
-                        (argument_index, ast_argument, parameter_tcx),
+                        (argument_index, ast_argument, parameter_context.type_context),
                     );
                     inferred_by_declared_type.insert(declared_type, inferred_ty);
                     self.union_expected_types(&speculative_builder.expected_types);
-                    insert_inferred_argument_type(
+                    parameter_context.insert_inferred_type(
                         arguments_types,
                         argument_index,
-                        declared_type,
-                        original_declared_type,
                         inferred_ty,
                     );
                 }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5424,7 +5424,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if let Some(parameter_context) = parameter_context {
                     let inferred_ty = infer_argument_ty(
                         self,
-                        (argument_index, ast_argument, parameter_context.type_context),
+                        (
+                            argument_index,
+                            ast_argument,
+                            parameter_context.type_context(),
+                        ),
                     );
                     parameter_context.insert_inferred_type(
                         arguments_types,
@@ -5455,7 +5459,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     infer_argument_ty(self, (argument_index, ast_argument, TypeContext::default()));
                 arguments_types.insert_type(argument_index, TypeContext::default(), default_ty);
 
-                let mut inferred_by_declared_type = FxHashMap::default();
+                let mut inferred_by_cache_key = FxHashMap::default();
 
                 // Cache expressions inferred across speculative inference attempts.
                 //
@@ -5464,10 +5468,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let teardown = self.setup_expression_cache();
 
                 for parameter_context in parameter_types {
-                    let declared_type = parameter_context.declared_type;
+                    let inference_cache_key = parameter_context.inference_cache_key();
                     if let Some(inferred_ty) =
-                        inferred_by_declared_type.get(&declared_type).copied()
+                        inferred_by_cache_key.get(&inference_cache_key).copied()
                     {
+                        // Even when the inference cache key is identical, this overload may later
+                        // look up the inferred type through a different original `ParamSpec`
+                        // annotation, so insert through its own context.
                         parameter_context.insert_inferred_type(
                             arguments_types,
                             argument_index,
@@ -5482,9 +5489,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let mut speculative_builder = self.speculate();
                     let inferred_ty = infer_argument_ty(
                         &mut speculative_builder,
-                        (argument_index, ast_argument, parameter_context.type_context),
+                        (
+                            argument_index,
+                            ast_argument,
+                            parameter_context.type_context(),
+                        ),
                     );
-                    inferred_by_declared_type.insert(declared_type, inferred_ty);
+                    inferred_by_cache_key.insert(inference_cache_key, inferred_ty);
                     self.union_expected_types(&speculative_builder.expected_types);
                     parameter_context.insert_inferred_type(
                         arguments_types,


### PR DESCRIPTION
## Summary

This PR preserves bidirectional type context through `ParamSpec` wrappers, like:

```python
def wrapper[**P, R](func: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R: ...
```

As we walk the call arguments, we keep a record of the types inferred for earlier arguments. When the current parameter is a `ParamSpec` component like `P.args` or `P.kwargs`, we use those earlier arguments to infer a specialization for the full `P`. If that gives us a concrete `ParamSpec` callable value, we apply the specialization to the wrapper’s signature, re-run parameter matching against that specialized signature, and use the resulting concrete parameter type as the type context for the current argument.

In bumping ty in pyx, we saw a bunch of cases (especially around `asyncio.to_thread`) which required manual annotation due to the loss of bidirectional type context. This PR removes all of that awkwardness in the ty upgrade.