### PR TITLE
[ty] Document inference behavior of unannotated parameters with default values

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/function/parameters.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/parameters.md
@@ -1,12 +1,54 @@
 # Function parameter types
 
+## Basic
+
 Within a function scope, the declared type of each parameter is its annotated type (or Unknown if
-not annotated). The initial inferred type is the annotated type of the parameter, if any. If there
-is no annotation, it is the union of `Unknown` with the type of the default value expression (if
-any).
+not annotated). The initial inferred type is the annotated type of the parameter, if any:
+
+```py
+def f(declared: int, unannotated):
+    reveal_type(declared)  # revealed: int
+    reveal_type(unannotated)  # revealed: Unknown
+```
 
 The variadic parameter is a variadic tuple of its annotated type; the variadic-keywords parameter is
-a dictionary from strings to its annotated type.
+a dictionary from strings to its annotated type:
+
+```py
+def g(*args: int, **kwargs: int):
+    reveal_type(args)  # revealed: tuple[int, ...]
+    reveal_type(kwargs)  # revealed: dict[str, int]
+```
+
+## Unannotated parameters with defaults
+
+If there is no annotation but there is a default value, the inferred paramter type is the union of
+the inferred type of the default value and `Unknown`:
+
+```py
+def f(a="foo", b=0, c=True, d=None):
+    reveal_type(a)  # revealed: Unknown | Literal["foo"]
+    reveal_type(b)  # revealed: Unknown | Literal[0]
+    reveal_type(c)  # revealed: Unknown | Literal[True]
+    reveal_type(d)  # revealed: Unknown | None
+```
+
+This means that the code in the function body needs to handle the case where the parameter is set to
+the default value:
+
+```py
+def g(x=0):
+    print(x + 1)
+
+    # error: [unsupported-operator] "Operator `+` is not supported between objects of type `Unknown | Literal[0]` and `Literal["foo"]`"
+    x + "foo"
+```
+
+But it still allows callers to pass in arguments of a wider type:
+
+```py
+g(1.5)  # fine
+```
 
 ## Parameter kinds
 


### PR DESCRIPTION
## Summary

In this PR, I explored the proposal in https://github.com/astral-sh/ty/issues/3251. The idea was to treat a function like `def f(x="foo"): ...` as if the `x` parameter was declared as `str`. This is what pyright does, and would follow what we do for unannotated class attributes with default values. However, implementing this showed a huge ecosystem impact of 8700 new diagnostics.

I tried various things to improve this. For example, I promoted `None` to `Unknown | None` because it seems unreasonable to assume that you only ever want callers to pass in `None`. Then there's a lot of code that takes `x=()` as a default value and wants callers to be able to pass in arbitrary tuples. I tried patching that by promoting `tuple[()] -> tuple[Unknown, ...]`.

But the biggest problem is with functions that take a default int value (e.g. `x=0`), but want to allow their callers to pass in float values. I tried promoting the type of `x` from `int` to `float`/`complex`, but that leads to the opposite problem: now the function body of *every* function that takes `x=0` must also handle the possibility that `x` is `float`/`complex`.

Ultimately, I think a scenario like this:
```py
def some_computation(..., tolerance=0): ...

some_computation(..., tolerance=1e-3)
```
is just far more common than the corresponding scenario with class attributes.

I think it's unfortunate that our behavior is inconsistent with what we do for class attributes, but I don't think it's worth introducing ~8000 diagnostics (no variant that I tried went below that limit). The corresponding PR for attributes introduced an order of magnitude fewer new diagnostics (https://github.com/astral-sh/ruff/pull/24531). 

So in this PR, all I do is to document the current behavior.

closes https://github.com/astral-sh/ty/issues/3251