### PR TITLE
fix for invalid unpacking target panic

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/invalid_syntax.md
+++ b/crates/ty_python_semantic/resources/mdtest/invalid_syntax.md
@@ -141,3 +141,26 @@ InvalidEmptyAnnotated = Annotated[]
 def _(a: InvalidEmptyAnnotated):
     reveal_type(a)  # revealed: Unknown
 ```
+
+## Invalid unpacking target
+
+Regression test: ensure that ty does not panic when a stub file contains an assignment with an
+invalid unpacking target combined with a malformed RHS, and another module star-imports from it.
+
+`type_stubs.pyi`:
+
+```pyi
+# error: [invalid-syntax]
+# error: [invalid-syntax]
+# error: [invalid-syntax]
+# error: [invalid-syntax]
+'',~=
+```
+
+`main.py`:
+
+```py
+from type_stubs import *
+
+x = 1
+```

--- a/crates/ty_python_semantic/src/types/unpacker.rs
+++ b/crates/ty_python_semantic/src/types/unpacker.rs
@@ -269,16 +269,10 @@ impl<'db> UnpackResult<'db> {
     /// Returns the inferred type for a given sub-expression of the left-hand side target
     /// of an unpacking assignment.
     ///
-    /// # Panics
-    ///
-    /// May panic if a scoped expression ID is passed in that does not correspond to a sub-
-    /// expression of the target.
-    #[track_caller]
+    /// Falls back to `Type::unknown()` when no type was recorded.
     pub(crate) fn expression_type(&self, expr_id: impl Into<ExpressionNodeKey>) -> Type<'db> {
-        self.try_expression_type(expr_id).expect(
-            "expression should belong to this `UnpackResult` and \
-            `Unpacker` should have inferred a type for it",
-        )
+        self.try_expression_type(expr_id)
+            .unwrap_or_else(Type::unknown)
     }
 
     pub(crate) fn try_expression_type(


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

The text `'',~=` in a stub or imported file currently causes a panic.

No idea if this is the best solution - I'm mostly submit the PR as an MRE + most obvious fix.

## Test Plan

There's a test.
