### PR TITLE
[ty] Include error context for overload consistency diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -592,6 +592,23 @@ def parameter_type(x: int) -> int | str:
     return 1
 ```
 
+Generic overloads are left to the full implementation-consistency check.
+
+```py
+from typing import TypeVar, overload
+
+T = TypeVar("T")
+
+@overload
+def generic_parameter_type(x: T) -> T: ...
+@overload
+def generic_parameter_type(x: str) -> str: ...
+def generic_parameter_type(x: int) -> int | str:
+    return x
+```
+
+### Implementation consistency parameter mismatch diagnostics
+
 Non-generic implementation checks require parameter names and positional-only forms to line up with
 each overload signature.
 
@@ -608,7 +625,7 @@ class ColumnSelector:
     @overload
     def _extract(self, row_key: int) -> object: ...
     @overload
-    # error: [invalid-overload] "Implementation does not accept all arguments of this overload"
+    # snapshot: invalid-overload
     def _extract(self, column_key: int) -> object: ...
     def _extract(self, row_key: int | None = None, column_key: int | None = None) -> object:
         return object()
@@ -617,25 +634,72 @@ class PositionalOnlyWithKwargs:
     @overload
     def update(self, params: Iterable[tuple[str, str | Iterable[str]]], /, **kwds: str) -> None: ...
     @overload
-    # error: [invalid-overload] "Implementation does not accept all arguments of this overload"
+    # snapshot: invalid-overload
     def update(self, **kwds: str | Iterable[str]) -> None: ...
     def update(self, params=(), /, **kwds) -> None:
         pass
 ```
 
-Generic overloads are left to the full implementation-consistency check.
+```snapshot
+error[invalid-overload]: Implementation does not accept all arguments of this overload
+  --> src/mdtest_snippet.py:9:9
+   |
+ 9 |     def _extract(self, column_key: int) -> object: ...
+   |         ^^^^^^^^
+10 |     def _extract(self, row_key: int | None = None, column_key: int | None = None) -> object:
+   |         -------- Implementation defined here
+   |
+info: Implementation signature `(self, row_key: int | None = None, column_key: int | None = None) -> object` is not assignable to overload signature `(self, column_key: int) -> object`
+info: the parameter named `row_key` does not match `column_key` (and can be used as a keyword parameter)
+
+
+error[invalid-overload]: Implementation does not accept all arguments of this overload
+  --> src/mdtest_snippet.py:18:9
+   |
+18 |     def update(self, **kwds: str | Iterable[str]) -> None: ...
+   |         ^^^^^^
+19 |     def update(self, params=(), /, **kwds) -> None:
+   |         ------ Implementation defined here
+   |
+info: Implementation signature `(self, params=..., /, **kwds) -> None` is not assignable to overload signature `(self, **kwds: Iterable[str]) -> None`
+info: parameter `self` is positional-only but must also accept keyword arguments
+```
+
+### Implementation consistency return type diagnostics
+
+Non-generic implementation checks show why an overload return type is not assignable to the
+implementation return type.
+
+```toml
+[environment]
+python-version = "3.12"
+```
 
 ```py
-from typing import TypeVar, overload
-
-T = TypeVar("T")
+from typing import overload
 
 @overload
-def generic_parameter_type(x: T) -> T: ...
+# snapshot: invalid-overload
+def return_tuple(x: int) -> tuple[str]: ...
 @overload
-def generic_parameter_type(x: str) -> str: ...
-def generic_parameter_type(x: int) -> int | str:
-    return x
+def return_tuple(x: str) -> tuple[int]: ...
+def return_tuple(x: int | str) -> tuple[int]:
+    return (1,)
+```
+
+```snapshot
+error[invalid-overload]: Overload return type is not assignable to implementation return type
+ --> src/mdtest_snippet.py:5:5
+  |
+5 | def return_tuple(x: int) -> tuple[str]: ...
+  |     ^^^^^^^^^^^^
+6 | @overload
+7 | def return_tuple(x: str) -> tuple[int]: ...
+8 | def return_tuple(x: int | str) -> tuple[int]:
+  |     ------------ Implementation defined here
+  |
+info: Overload returns `tuple[str]`, which is not assignable to implementation return type `tuple[int]`
+info: the first tuple element is not compatible: `str` is not assignable to `int`
 ```
 
 ### Inconsistent decorators

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -13,6 +13,7 @@ use crate::{
         context::InferContext,
         diagnostic::INVALID_OVERLOAD,
         function::{FunctionDecorators, FunctionType, KnownFunction, OverloadLiteral},
+        signatures::{ParameterConsistency, ReturnTypeConsistency},
     },
 };
 use ty_python_core::{
@@ -298,35 +299,59 @@ fn check_non_generic_overload_implementation_consistency<'db>(
 
     for (overload, overload_signature) in overload_signatures {
         let function_node = overload.node(db, context.file(), context.module());
-        let parameters_are_consistent = implementation_signature
-            .are_non_generic_implementation_parameters_consistent_with(db, &overload_signature);
-        let return_type_is_consistent = overload_signature
-            .return_ty
-            .is_assignable_to(db, implementation_signature.return_ty);
+        let parameter_consistency = implementation_signature
+            .non_generic_implementation_parameters_consistency_with(db, &overload_signature);
+        let return_type_consistency = implementation_signature
+            .non_generic_implementation_return_type_consistency_with(db, &overload_signature);
 
-        if parameters_are_consistent && return_type_is_consistent {
-            continue;
-        }
+        let (parameter_error_context, return_type_error_context, message) =
+            match (parameter_consistency, return_type_consistency) {
+                (ParameterConsistency::Consistent, ReturnTypeConsistency::Consistent) => continue,
+                (
+                    ParameterConsistency::Inconsistent(error_context),
+                    ReturnTypeConsistency::Consistent,
+                ) => (
+                    Some(error_context),
+                    None,
+                    "Implementation does not accept all arguments of this overload",
+                ),
+                (
+                    ParameterConsistency::Consistent,
+                    ReturnTypeConsistency::Inconsistent(error_context),
+                ) => (
+                    None,
+                    Some(error_context),
+                    "Overload return type is not assignable to implementation return type",
+                ),
+                (
+                    ParameterConsistency::Inconsistent(parameter_error_context),
+                    ReturnTypeConsistency::Inconsistent(return_type_error_context),
+                ) => (
+                    Some(parameter_error_context),
+                    Some(return_type_error_context),
+                    "Overload signature is not consistent with implementation",
+                ),
+            };
 
         let Some(builder) = context.report_lint(&INVALID_OVERLOAD, &function_node.name) else {
             continue;
         };
-        let message = match (parameters_are_consistent, return_type_is_consistent) {
-            (false, true) => "Implementation does not accept all arguments of this overload",
-            (true, false) => "Overload return type is not assignable to implementation return type",
-            (false, false) => "Overload signature is not consistent with implementation",
-            (true, true) => continue,
-        };
-        let mut diagnostic = builder.into_diagnostic(message);
-        if !parameters_are_consistent {
-            diagnostic.info("Implementation does not accept all arguments of this overload");
+        let mut diagnostic = builder.into_diagnostic(format_args!("{message}"));
+        if let Some(error_context) = parameter_error_context {
+            diagnostic.info(format_args!(
+                "Implementation signature `{}` is not assignable to overload signature `{}`",
+                implementation_signature.display(db),
+                overload_signature.display(db),
+            ));
+            error_context.attach_to(db, &mut diagnostic);
         }
-        if !return_type_is_consistent {
+        if let Some(error_context) = return_type_error_context {
             diagnostic.info(format_args!(
                 "Overload returns `{}`, which is not assignable to implementation return type `{}`",
                 overload_signature.return_ty.display(db),
                 implementation_signature.return_ty.display(db),
             ));
+            error_context.attach_to(db, &mut diagnostic);
         }
         diagnostic.annotate(
             context

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -709,11 +709,55 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         }
     }
 
+    pub(super) fn constraint_set_assignability_with_context(
+        constraints: &'c ConstraintSetBuilder<'db>,
+        relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
+        disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
+        signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
+        materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
+    ) -> Self {
+        Self {
+            constraints,
+            inferable: InferableTypeVars::None,
+            relation: TypeRelation::ConstraintSetAssignability,
+            context_tree: ErrorContextTree::enabled(),
+            given: ConstraintSet::from_bool(constraints, false),
+            relation_visitor,
+            disjointness_visitor,
+            signature_relation_visitor,
+            materialization_visitor,
+        }
+    }
+
+    pub(super) fn assignability_with_context(
+        constraints: &'c ConstraintSetBuilder<'db>,
+        relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
+        disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
+        signature_relation_visitor: &'a SignatureRelationVisitor<'db>,
+        materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
+    ) -> Self {
+        Self {
+            constraints,
+            inferable: InferableTypeVars::None,
+            relation: TypeRelation::Assignability,
+            context_tree: ErrorContextTree::enabled(),
+            given: ConstraintSet::from_bool(constraints, false),
+            relation_visitor,
+            disjointness_visitor,
+            signature_relation_visitor,
+            materialization_visitor,
+        }
+    }
+
     pub(super) fn with_inferable_typevars(&self, inferable: InferableTypeVars<'db>) -> Self {
         Self {
             inferable,
             ..self.clone()
         }
+    }
+
+    pub(super) fn into_error_context(self) -> ErrorContextTree<'db> {
+        self.context_tree
     }
 
     pub(super) fn always(&self) -> ConstraintSet<'db, 'c> {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -37,9 +37,9 @@ use crate::types::typed_dict::{
 use crate::types::typevar::BoundTypeVarIdentity;
 use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType, ErrorContext,
-    FindLegacyTypeVarsVisitor, KnownClass, MaterializationKind, ParamSpecAttrKind,
-    ParameterDescription, SelfBinding, TypeContext, TypeMapping, UnionBuilder, VarianceInferable,
-    infer_complete_scope_types, todo_type,
+    ErrorContextTree, FindLegacyTypeVarsVisitor, KnownClass, MaterializationKind,
+    ParamSpecAttrKind, ParameterDescription, SelfBinding, TypeContext, TypeMapping, UnionBuilder,
+    VarianceInferable, infer_complete_scope_types, todo_type,
 };
 use crate::{Db, FxOrderSet};
 use ruff_python_ast::{self as ast, name::Name};
@@ -483,6 +483,22 @@ pub struct Signature<'db> {
 
     /// Return type. If no annotation was provided, this is `Unknown`.
     pub(crate) return_ty: Type<'db>,
+}
+
+/// Whether one callable signature's parameters are compatible with another's.
+pub(crate) enum ParameterConsistency<'db> {
+    /// The parameters are compatible.
+    Consistent,
+    /// The parameters are incompatible, with context explaining the incompatibility.
+    Inconsistent(ErrorContextTree<'db>),
+}
+
+/// Whether one callable signature's return type is compatible with another's.
+pub(crate) enum ReturnTypeConsistency<'db> {
+    /// The return types are compatible.
+    Consistent,
+    /// The return types are incompatible, with context explaining the incompatibility.
+    Inconsistent(ErrorContextTree<'db>),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -1078,26 +1094,77 @@ impl<'db> Signature<'db> {
     }
 
     /// Return whether this non-generic implementation accepts the arguments of a non-generic
-    /// overload.
+    /// overload, and the relation error context if it does not.
     ///
     /// This is a deliberately narrow first pass for overload implementation consistency. Generic
     /// signatures need additional type-variable-domain handling and should be left to the full
     /// implementation.
-    pub(crate) fn are_non_generic_implementation_parameters_consistent_with(
+    pub(crate) fn non_generic_implementation_parameters_consistency_with(
         &self,
         db: &'db dyn Db,
         overload: &Self,
-    ) -> bool {
+    ) -> ParameterConsistency<'db> {
         debug_assert!(self.is_non_generic());
         debug_assert!(overload.is_non_generic());
 
         let implementation = self.clone().with_return_type(Type::unknown());
         let overload = overload.clone().with_return_type(Type::unknown());
         let constraints = ConstraintSetBuilder::new();
+        let relation_visitor = HasRelationToVisitor::default(&constraints);
+        let disjointness_visitor = IsDisjointVisitor::default(&constraints);
+        let signature_relation_visitor = SignatureRelationVisitor::default();
+        let materialization_visitor = ApplyTypeMappingVisitor::default();
+        let checker = TypeRelationChecker::constraint_set_assignability_with_context(
+            &constraints,
+            &relation_visitor,
+            &disjointness_visitor,
+            &signature_relation_visitor,
+            &materialization_visitor,
+        );
 
-        implementation
-            .when_constraint_set_assignable_to(db, &overload, &constraints)
-            .is_always_satisfied(db)
+        let is_consistent = checker
+            .check_signature_pair(db, &implementation, &overload)
+            .is_always_satisfied(db);
+
+        if is_consistent {
+            ParameterConsistency::Consistent
+        } else {
+            ParameterConsistency::Inconsistent(checker.into_error_context())
+        }
+    }
+
+    /// Return whether a non-generic overload return type is assignable to a non-generic
+    /// implementation return type, and the relation error context if it is not.
+    pub(crate) fn non_generic_implementation_return_type_consistency_with(
+        &self,
+        db: &'db dyn Db,
+        overload: &Self,
+    ) -> ReturnTypeConsistency<'db> {
+        debug_assert!(self.is_non_generic());
+        debug_assert!(overload.is_non_generic());
+
+        let constraints = ConstraintSetBuilder::new();
+        let relation_visitor = HasRelationToVisitor::default(&constraints);
+        let disjointness_visitor = IsDisjointVisitor::default(&constraints);
+        let signature_relation_visitor = SignatureRelationVisitor::default();
+        let materialization_visitor = ApplyTypeMappingVisitor::default();
+        let checker = TypeRelationChecker::assignability_with_context(
+            &constraints,
+            &relation_visitor,
+            &disjointness_visitor,
+            &signature_relation_visitor,
+            &materialization_visitor,
+        );
+
+        let is_consistent = checker
+            .check_type_pair(db, overload.return_ty, self.return_ty)
+            .is_always_satisfied(db);
+
+        if is_consistent {
+            ReturnTypeConsistency::Consistent
+        } else {
+            ReturnTypeConsistency::Inconsistent(checker.into_error_context())
+        }
     }
 
     pub(crate) fn when_constraint_set_assignable_to_signatures<'c>(


### PR DESCRIPTION
## Summary

No functional changes, but we now surface the error context from failed assignability when constructing diagnostics for invalid overload implementations (e.g., we now explain which parameter was mismatched).
