### PR TITLE
[ty] Distinguish `typing.Callable` from `collections.abc.Callable`

### DIFF
--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -321,6 +321,8 @@ pub enum KnownModule {
     Collections,
     #[strum(serialize = "collections.abc")]
     CollectionsAbc,
+    #[strum(serialize = "_collections_abc")]
+    CollectionsAbcInternal,
     Inspect,
     #[strum(serialize = "string.templatelib")]
     Templatelib,
@@ -357,6 +359,7 @@ impl KnownModule {
             Self::Functools => "functools",
             Self::Collections => "collections",
             Self::CollectionsAbc => "collections.abc",
+            Self::CollectionsAbcInternal => "_collections_abc",
             Self::Inspect => "inspect",
             Self::TypeCheckerInternals => "_typeshed._type_checker_internals",
             Self::TyExtensions => "ty_extensions",

--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -319,6 +319,8 @@ pub enum KnownModule {
     Dataclasses,
     Functools,
     Collections,
+    #[strum(serialize = "collections.abc")]
+    CollectionsAbc,
     Inspect,
     #[strum(serialize = "string.templatelib")]
     Templatelib,
@@ -354,6 +356,7 @@ impl KnownModule {
             Self::Dataclasses => "dataclasses",
             Self::Functools => "functools",
             Self::Collections => "collections",
+            Self::CollectionsAbc => "collections.abc",
             Self::Inspect => "inspect",
             Self::TypeCheckerInternals => "_typeshed._type_checker_internals",
             Self::TyExtensions => "ty_extensions",

--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -542,4 +542,64 @@ static_assert(
 )
 ```
 
+## `typing.Callable` and `collections.abc.Callable` parity
+
+`typing.Callable` is a deprecated alias for `collections.abc.Callable`. Internally we model them as
+distinct `SpecialFormType` variants so that we can give different runtime behavior to each (calling
+`typing.Callable()` raises `TypeError`; calling `collections.abc.Callable()` does not), but in a
+type expression the two should be interchangeable.
+
+### Bare form
+
+```py
+from typing import Any
+import typing
+import collections.abc
+
+def _(c1: typing.Callable, c2: collections.abc.Callable):
+    reveal_type(c1)  # revealed: (...) -> Unknown
+    reveal_type(c2)  # revealed: (...) -> Unknown
+```
+
+### Parameterized form
+
+```py
+import typing
+import collections.abc
+
+def _(c1: typing.Callable[[int], str], c2: collections.abc.Callable[[int], str]):
+    reveal_type(c1)  # revealed: (int, /) -> str
+    reveal_type(c2)  # revealed: (int, /) -> str
+```
+
+### Equivalence
+
+```py
+import typing
+import collections.abc
+from ty_extensions import is_equivalent_to, static_assert
+
+static_assert(is_equivalent_to(typing.Callable[[int], str], collections.abc.Callable[[int], str]))
+static_assert(is_equivalent_to(typing.Callable, collections.abc.Callable))
+```
+
+### Inside `type[...]`
+
+`type[Callable[...]]` is not a valid type expression (the argument to `type[...]` must be a class
+object), but both modules' `Callable` should produce the same diagnostic and resolved type.
+
+```py
+import typing
+import collections.abc
+
+def _(
+    # error: [invalid-type-form] "The argument to `type[]` must be a class object type"
+    c1: type[typing.Callable[[int], str]],
+    # error: [invalid-type-form] "The argument to `type[]` must be a class object type"
+    c2: type[collections.abc.Callable[[int], str]],
+):
+    reveal_type(c1)  # revealed: type[Unknown]
+    reveal_type(c2)  # revealed: type[Unknown]
+```
+
 [gradual form]: https://typing.python.org/en/latest/spec/glossary.html#term-gradual-form

--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -81,7 +81,7 @@ Using a parameter list:
 ```py
 from typing import Callable
 
-# error: [invalid-type-form] "Special form `typing.Callable` expected exactly two arguments (parameter types and return type)"
+# error: [invalid-type-form] "Special form `Callable` expected exactly two arguments (parameter types and return type)"
 def _(c: Callable[[int, str]]):
     reveal_type(c)  # revealed: (...) -> Unknown
 ```
@@ -89,7 +89,7 @@ def _(c: Callable[[int, str]]):
 Or, an ellipsis:
 
 ```py
-# error: [invalid-type-form] "Special form `typing.Callable` expected exactly two arguments (parameter types and return type)"
+# error: [invalid-type-form] "Special form `Callable` expected exactly two arguments (parameter types and return type)"
 def _(c: Callable[...]):
     reveal_type(c)  # revealed: (...) -> Unknown
 ```
@@ -99,7 +99,7 @@ Or something else that's invalid in a type expression generally:
 ```py
 # fmt: off
 
-def _(c: Callable[  # error: [invalid-type-form] "Special form `typing.Callable` expected exactly two arguments (parameter types and return type)"
+def _(c: Callable[  # error: [invalid-type-form] "Special form `Callable` expected exactly two arguments (parameter types and return type)"
             {1, 2}  # error: [invalid-type-form] "The first argument to `Callable` must be either a list of types, ParamSpec, Concatenate, or `...`"
         ]
     ):
@@ -129,7 +129,7 @@ which argument corresponds to either the parameters or the return type.
 ```py
 from typing import Callable
 
-# error: [invalid-type-form] "Special form `typing.Callable` expected exactly two arguments (parameter types and return type)"
+# error: [invalid-type-form] "Special form `Callable` expected exactly two arguments (parameter types and return type)"
 def _(c: Callable[[int], str, str]):
     reveal_type(c)  # revealed: (...) -> Unknown
 ```
@@ -182,7 +182,7 @@ from typing import Callable
 # fmt: off
 
 
-def _(c: Callable[  # error: [invalid-type-form] "Special form `typing.Callable` expected exactly two arguments (parameter types and return type)"
+def _(c: Callable[  # error: [invalid-type-form] "Special form `Callable` expected exactly two arguments (parameter types and return type)"
             [int],
             [str],  # error: [invalid-type-form] "List literals are not allowed in this context in a parameter annotation"
             [bytes]  # error: [invalid-type-form] "List literals are not allowed in this context in a parameter annotation"

--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -545,9 +545,9 @@ static_assert(
 ## `typing.Callable` and `collections.abc.Callable` parity
 
 `typing.Callable` is a deprecated alias for `collections.abc.Callable`. Internally we model them as
-distinct `SpecialFormType` variants so that we can give different runtime behavior to each (calling
-`typing.Callable()` raises `TypeError`; calling `collections.abc.Callable()` does not), but in a
-type expression the two should be interchangeable.
+distinct `SpecialFormType` variants so that we can support usage of the latter in `match`
+statements, while disallowing the former, but otherwise they should be interchangeable in type
+expressions.
 
 ### Bare form
 

--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -445,7 +445,7 @@ reveal_type(Sum)  # revealed: <class 'tuple[T@Sum, U@Sum]'>
 reveal_type(ListOrTuple)  # revealed: <types.UnionType special-form 'list[T@ListOrTuple] | tuple[T@ListOrTuple, ...]'>
 # revealed: <types.UnionType special-form 'list[T@ListOrTupleLegacy] | tuple[T@ListOrTupleLegacy, ...]'>
 reveal_type(ListOrTupleLegacy)
-reveal_type(MyCallable)  # revealed: <typing.Callable special-form '(**P@MyCallable) -> T@MyCallable'>
+reveal_type(MyCallable)  # revealed: <Callable special-form '(**P@MyCallable) -> T@MyCallable'>
 reveal_type(AnnotatedType)  # revealed: <special-form 'typing.Annotated[T@AnnotatedType, <metadata>]'>
 reveal_type(TransparentAlias)  # revealed: TypeVar
 reveal_type(MyOptional)  # revealed: <types.UnionType special-form 'T@MyOptional | None'>
@@ -510,7 +510,7 @@ reveal_type(ListOfPairs)  # revealed: <class 'list[tuple[str, str]]'>
 reveal_type(ListOrTupleOfInts)  # revealed: <types.UnionType special-form 'list[int] | tuple[int, ...]'>
 reveal_type(AnnotatedInt)  # revealed: <special-form 'typing.Annotated[int, <metadata>]'>
 reveal_type(SubclassOfInt)  # revealed: <special-form 'type[int]'>
-reveal_type(CallableIntToStr)  # revealed: <typing.Callable special-form '(int, /) -> str'>
+reveal_type(CallableIntToStr)  # revealed: <Callable special-form '(int, /) -> str'>
 
 def _(
     ints_or_none: IntsOrNone,
@@ -1606,9 +1606,9 @@ CallableNoArgs = Callable[[], None]
 BasicCallable = Callable[[int, str], bytes]
 GradualCallable = Callable[..., str]
 
-reveal_type(CallableNoArgs)  # revealed: <typing.Callable special-form '() -> None'>
-reveal_type(BasicCallable)  # revealed: <typing.Callable special-form '(int, str, /) -> bytes'>
-reveal_type(GradualCallable)  # revealed: <typing.Callable special-form '(...) -> str'>
+reveal_type(CallableNoArgs)  # revealed: <Callable special-form '() -> None'>
+reveal_type(BasicCallable)  # revealed: <Callable special-form '(int, str, /) -> bytes'>
+reveal_type(GradualCallable)  # revealed: <Callable special-form '(...) -> str'>
 
 def _(
     callable_no_args: CallableNoArgs,
@@ -1634,14 +1634,14 @@ def _(takes_callable: TakesCallable, returns_callable: ReturnsCallable):
 Invalid uses result in diagnostics:
 
 ```py
-# error: [invalid-type-form] "Special form `typing.Callable` expected exactly two arguments (parameter types and return type)"
+# error: [invalid-type-form] "Special form `Callable` expected exactly two arguments (parameter types and return type)"
 InvalidCallable1 = Callable[[int]]
 
 # error: [invalid-type-form] "The first argument to `Callable` must be either a list of types, ParamSpec, Concatenate, or `...`"
 InvalidCallable2 = Callable[int, str]
 
-reveal_type(InvalidCallable1)  # revealed: <typing.Callable special-form '(...) -> Unknown'>
-reveal_type(InvalidCallable2)  # revealed: <typing.Callable special-form '(...) -> Unknown'>
+reveal_type(InvalidCallable1)  # revealed: <Callable special-form '(...) -> Unknown'>
+reveal_type(InvalidCallable2)  # revealed: <Callable special-form '(...) -> Unknown'>
 
 def _(invalid_callable1: InvalidCallable1, invalid_callable2: InvalidCallable2):
     reveal_type(invalid_callable1)  # revealed: (...) -> Unknown

--- a/crates/ty_python_semantic/resources/mdtest/import/star.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/star.md
@@ -1437,7 +1437,7 @@ are present due to `*` imports.
 import collections.abc
 
 reveal_type(collections.abc.Sequence)  # revealed: <class 'Sequence'>
-reveal_type(collections.abc.Callable)  # revealed: <special-form 'typing.Callable'>
+reveal_type(collections.abc.Callable)  # revealed: <special-form 'collections.abc.Callable'>
 reveal_type(collections.abc.Set)  # revealed: <class 'AbstractSet'>
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/invalid_syntax.md
+++ b/crates/ty_python_semantic/resources/mdtest/invalid_syntax.md
@@ -116,7 +116,7 @@ out = (obj[0] := obj).attr
 from typing import Callable
 
 # error: [invalid-syntax] "Expected index or slice expression"
-# error: [invalid-type-form] "Special form `typing.Callable` expected exactly two arguments (parameter types and return type)"
+# error: [invalid-type-form] "Special form `Callable` expected exactly two arguments (parameter types and return type)"
 def _(c: Callable[]):
     reveal_type(c)  # revealed: (...) -> Unknown
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
@@ -132,26 +132,57 @@ def f(x: object):
         reveal_type(x)  # revealed: Top[(...) -> object]
 ```
 
-## Class-pattern diagnostics distinguish `typing.Callable` from `collections.abc.Callable`
+## `Callable` special-form identity
 
-`Callable` is a special form, not a class, so it cannot be used as the class in a class pattern. The
-resulting `invalid-match-pattern` diagnostic should name the symbol by the module it was imported
-from, not the module its definition site happens to live in.
+`typing.Callable` and `collections.abc.Callable` are both modeled as special forms. Import
+resolution should preserve which module the symbol comes from, even when the symbol is re-exported
+through another module. These tests only check symbol resolution; class-pattern behavior is tested
+separately below.
 
-### `from collections.abc import Callable`
+### Direct imports
+
+```py
+import collections.abc
+import typing
+from collections.abc import Callable as CollectionsAbcCallable
+from typing import Callable as TypingCallable
+
+reveal_type(TypingCallable)  # revealed: <special-form 'typing.Callable'>
+reveal_type(typing.Callable)  # revealed: <special-form 'typing.Callable'>
+reveal_type(CollectionsAbcCallable)  # revealed: <special-form 'collections.abc.Callable'>
+reveal_type(collections.abc.Callable)  # revealed: <special-form 'collections.abc.Callable'>
+```
+
+### Imports proxied through another module
+
+`typing_compat.py`:
+
+```py
+from typing import Callable
+```
+
+`collections_abc_compat.py`:
 
 ```py
 from collections.abc import Callable
-
-def _(subj: int | Callable[..., str]) -> None:
-    match subj:
-        # TODO: Should be valid.
-        # error: [invalid-match-pattern] "`<special-form 'collections.abc.Callable'>` cannot be used in a class pattern because it is not a type"
-        case Callable(): ...
-        case _: ...
 ```
 
-### `import collections.abc; collections.abc.Callable()`
+`main.py`:
+
+```py
+from collections_abc_compat import Callable as CollectionsAbcCallable
+from typing_compat import Callable as TypingCallable
+
+reveal_type(TypingCallable)  # revealed: <special-form 'typing.Callable'>
+reveal_type(CollectionsAbcCallable)  # revealed: <special-form 'collections.abc.Callable'>
+```
+
+## Class-pattern behavior for `typing.Callable` and `collections.abc.Callable`
+
+At runtime, `collections.abc.Callable` is supported in `match` statement class patterns, however
+`typing.Callable` is not.
+
+### `collections.abc.Callable`
 
 ```py
 import collections.abc
@@ -164,19 +195,7 @@ def _(subj: int | collections.abc.Callable[..., str]) -> None:
         case _: ...
 ```
 
-### `from typing import Callable`
-
-```py
-from typing import Callable
-
-def _(subj: int | Callable[..., str]) -> None:
-    match subj:
-        # error: [invalid-match-pattern] "`<special-form 'typing.Callable'>` cannot be used in a class pattern because it is not a type"
-        case Callable(): ...
-        case _: ...
-```
-
-### `import typing; typing.Callable()`
+### `typing.Callable`
 
 ```py
 import typing

--- a/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
@@ -115,3 +115,19 @@ def f(x: object):
         # x has type `Top[(...) -> object]`, which should be assignable to `Callable[..., Any]`
         wrap(x)
 ```
+
+## `isinstance` parity for `typing.Callable` and `collections.abc.Callable`
+
+`typing.Callable` is a deprecated alias for `collections.abc.Callable`. Both should narrow
+identically when used as the second argument to `isinstance()`.
+
+```py
+import typing
+import collections.abc
+
+def f(x: object):
+    if isinstance(x, typing.Callable):
+        reveal_type(x)  # revealed: Top[(...) -> object]
+    if isinstance(x, collections.abc.Callable):
+        reveal_type(x)  # revealed: Top[(...) -> object]
+```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
@@ -131,3 +131,59 @@ def f(x: object):
     if isinstance(x, collections.abc.Callable):
         reveal_type(x)  # revealed: Top[(...) -> object]
 ```
+
+## Class-pattern diagnostics distinguish `typing.Callable` from `collections.abc.Callable`
+
+`Callable` is a special form, not a class, so it cannot be used as the class in a class pattern. The
+resulting `invalid-match-pattern` diagnostic should name the symbol by the module it was imported
+from, not the module its definition site happens to live in.
+
+### `from collections.abc import Callable`
+
+```py
+from collections.abc import Callable
+
+def _(subj: int | Callable[..., str]) -> None:
+    match subj:
+        # TODO: Should be valid.
+        # error: [invalid-match-pattern] "`<special-form 'collections.abc.Callable'>` cannot be used in a class pattern because it is not a type"
+        case Callable(): ...
+        case _: ...
+```
+
+### `import collections.abc; collections.abc.Callable()`
+
+```py
+import collections.abc
+
+def _(subj: int | collections.abc.Callable[..., str]) -> None:
+    match subj:
+        # TODO: Should be valid.
+        # error: [invalid-match-pattern] "`<special-form 'collections.abc.Callable'>` cannot be used in a class pattern because it is not a type"
+        case collections.abc.Callable(): ...
+        case _: ...
+```
+
+### `from typing import Callable`
+
+```py
+from typing import Callable
+
+def _(subj: int | Callable[..., str]) -> None:
+    match subj:
+        # error: [invalid-match-pattern] "`<special-form 'typing.Callable'>` cannot be used in a class pattern because it is not a type"
+        case Callable(): ...
+        case _: ...
+```
+
+### `import typing; typing.Callable()`
+
+```py
+import typing
+
+def _(subj: int | typing.Callable[..., str]) -> None:
+    match subj:
+        # error: [invalid-match-pattern] "`<special-form 'typing.Callable'>` cannot be used in a class pattern because it is not a type"
+        case typing.Callable(): ...
+        case _: ...
+```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
@@ -146,11 +146,13 @@ import collections.abc
 import typing
 from collections.abc import Callable as CollectionsAbcCallable
 from typing import Callable as TypingCallable
+from _collections_abc import Callable as _CollectionsAbcCallable
 
 reveal_type(TypingCallable)  # revealed: <special-form 'typing.Callable'>
 reveal_type(typing.Callable)  # revealed: <special-form 'typing.Callable'>
 reveal_type(CollectionsAbcCallable)  # revealed: <special-form 'collections.abc.Callable'>
 reveal_type(collections.abc.Callable)  # revealed: <special-form 'collections.abc.Callable'>
+reveal_type(_CollectionsAbcCallable)  # revealed: <special-form 'collections.abc.Callable'>
 ```
 
 ### Imports proxied through another module

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/concatenate.md_-_`typing.Concatenate`_-_Invalid_uses_of_`Con…_-_Last_argument_must_b…_(dc429fc3e8c18eaf).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/concatenate.md_-_`typing.Concatenate`_-_Invalid_uses_of_`Con…_-_Last_argument_must_b…_(dc429fc3e8c18eaf).snap
@@ -67,7 +67,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
    |                                  ^^^^^^^^^^^
    |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -80,7 +80,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
    |                                  ^^^^^^^^^^^^^^^
    |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -93,7 +93,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
    |                                  ^^^^^^^^^^^^^^^^
    |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -106,7 +106,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
    |                                  ^^^^^^^^^^^^^^^^^^^^^
    |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/concatenate.md_-_`typing.Concatenate`_-_Invalid_uses_of_`Con…_-_Nested_`Concatenate`_(86093b62e6e6874c).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/concatenate.md_-_`typing.Concatenate`_-_Invalid_uses_of_`Con…_-_Nested_`Concatenate`_(86093b62e6e6874c).snap
@@ -36,7 +36,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
   |                             ^^^^^^^^^^^^^^^^^^^^^
   |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -49,7 +49,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
   |                             ^^^^^^^^^^^
   |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -62,7 +62,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
   |                                  ^^^^^^^^^^^^^^^^^^^^^
   |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/concatenate.md_-_`typing.Concatenate`_-_Invalid_uses_of_`Con…_-_Standalone_annotatio…_(bb5fe70ded875e4).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/concatenate.md_-_`typing.Concatenate`_-_Invalid_uses_of_`Con…_-_Standalone_annotatio…_(bb5fe70ded875e4).snap
@@ -53,7 +53,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
   |                 ^^^^^^^^^^^
   |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -66,7 +66,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
   |                 ^^^^^^^^^^^^^^^^
   |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -79,7 +79,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
    |                 ^^^^^^^^^^^^^^^^^^^^^
    |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -92,7 +92,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
    |                   ^^^^^^^^^^^^^^^^^^^^^
    |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -105,7 +105,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
    |                   ^^^^^^^^^^^^^^^
    |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -118,7 +118,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
    |    ^^^^^^^^^^^
    |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -131,7 +131,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
    |        ^^^^^^^^^^^^^^^^^^^
    |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/concatenate.md_-_`typing.Concatenate`_-_Invalid_uses_of_`Con…_-_Too_few_arguments_(efcf77cdbde3ff86).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/concatenate.md_-_`typing.Concatenate`_-_Invalid_uses_of_`Con…_-_Too_few_arguments_(efcf77cdbde3ff86).snap
@@ -156,7 +156,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
    |                  ^^^^^^^^^^^
    |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -169,7 +169,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
    |                  ^^^^^^^^^^^
    |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -182,7 +182,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
    |                  ^^^^^^^^^^^^^^^^
    |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -195,7 +195,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
    |                  ^^^^^^^^^^^^^^^^^^^^^
    |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -208,7 +208,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
    |                  ^^^^^^^^^^^^^^^
    |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -241,7 +241,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
    |                  ^^^^^^^^^^^
    |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```
@@ -254,7 +254,7 @@ error[invalid-type-form]: `typing.Concatenate` is not allowed in this context in
    |                                 ^^^^^^^^^^^
    |
 info: `typing.Concatenate` is only valid:
-info:  - as the first argument to `typing.Callable`
+info:  - as the first argument to `Callable`
 info:  - as a type argument for a `ParamSpec` parameter
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/type_of/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/basic.md
@@ -258,7 +258,7 @@ from collections.abc import Callable
 def f(
     x: type[Callable],  # error: [invalid-type-form]
     y: type[Callable[[int], str]],  # error: [invalid-type-form]
-    # error: [invalid-type-form] "Special form `typing.Callable` expected exactly two arguments"
+    # error: [invalid-type-form] "Special form `Callable` expected exactly two arguments"
     # error: [invalid-type-form] "The first argument to `Callable` must be either a list of types, ParamSpec, Concatenate, or `...`"
     z: type[Callable[int]],  # error: [invalid-type-form] "The argument to `type[]` must be a class object type"
 ):

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -920,6 +920,7 @@ A callable type is disjoint from special form types, except for callable special
 from ty_extensions import is_disjoint_from, static_assert, TypeOf
 from typing_extensions import Any, Callable, TypedDict
 from typing import Literal, Union, Optional, Final, Type, ChainMap, Counter, OrderedDict, DefaultDict, Deque
+from collections.abc import Callable as CollectionsAbcCallable
 
 # Most special forms are disjoint from callable types because they are
 # type constructors/annotations that are subscripted, not called.
@@ -940,6 +941,9 @@ static_assert(is_disjoint_from(TypeOf[Final], Callable[..., Any]))
 
 static_assert(is_disjoint_from(Callable[..., Any], TypeOf[Callable]))
 static_assert(is_disjoint_from(TypeOf[Callable], Callable[..., Any]))
+
+static_assert(is_disjoint_from(Callable[..., Any], TypeOf[CollectionsAbcCallable]))
+static_assert(is_disjoint_from(TypeOf[CollectionsAbcCallable], Callable[..., Any]))
 
 # However, some special forms are callable (TypedDict and collection constructors)
 static_assert(not is_disjoint_from(Callable[..., Any], TypeOf[TypedDict]))

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7593,7 +7593,7 @@ impl<'db> InvalidTypeExpression<'db> {
             diagnostic.info(" - or as part of an argument list when specializing a generic class");
         } else if matches!(self, InvalidTypeExpression::Concatenate) {
             diagnostic.info("`typing.Concatenate` is only valid:");
-            diagnostic.info(" - as the first argument to `typing.Callable`");
+            diagnostic.info(" - as the first argument to `Callable`");
             diagnostic.info(" - as a type argument for a `ParamSpec` parameter");
         }
     }
@@ -7868,6 +7868,26 @@ impl<'db> ModuleLiteralType<'db> {
         // If the normal lookup failed, try to call the module's `__getattr__` function
         if place_and_qualifiers.place.is_undefined() {
             return self.try_module_getattr(db, name);
+        }
+
+        // typeshed re-exports some special forms across modules (e.g. `collections.abc.Callable`
+        // is `from typing import Callable as Callable`). The resolved type still carries the
+        // definition-site variant (`SpecialFormType::TypingCallable`), so we recover the
+        // import-path identity here while it's still observable.
+        if let Place::Defined(defined) = place_and_qualifiers.place
+            && let Type::SpecialForm(special) = defined.ty
+            && let Some(import_module) = self.module(db).known(db)
+        {
+            let rewrapped = special.rewrap_for_import_module(name, import_module);
+            if rewrapped != special {
+                return PlaceAndQualifiers {
+                    place: Place::Defined(DefinedPlace {
+                        ty: Type::SpecialForm(rewrapped),
+                        ..defined
+                    }),
+                    qualifiers: place_and_qualifiers.qualifiers,
+                };
+            }
         }
 
         place_and_qualifiers

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -275,11 +275,13 @@ impl<'db> ClassBase<'db> {
                     Self::try_from_type(db, alias.aliased_class().to_class_literal(db), subclass)
                 }
 
-                SpecialFormType::Callable => Self::try_from_type(
-                    db,
-                    todo_type!("Support for Callable as a base class"),
-                    subclass,
-                ),
+                SpecialFormType::TypingCallable | SpecialFormType::CollectionsAbcCallable => {
+                    Self::try_from_type(
+                        db,
+                        todo_type!("Support for Callable as a base class"),
+                        subclass,
+                    )
+                }
             },
         }
     }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4733,7 +4733,7 @@ pub(crate) fn report_invalid_arguments_to_callable(
         return;
     };
     builder.into_diagnostic(format_args!(
-        "Special form `typing.Callable` expected exactly two arguments (parameter types and return type)",
+        "Special form `Callable` expected exactly two arguments (parameter types and return type)",
     ));
 }
 

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -3136,7 +3136,7 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
                 f.set_invalid_type_annotation();
                 f.write_char('<')?;
                 f.with_type(Type::SpecialForm(SpecialFormType::TypingCallable))
-                    .write_str("typing.Callable")?;
+                    .write_str("Callable")?;
                 f.write_str(" special-form '")?;
                 callable.display(self.db).fmt_detailed(f)?;
                 f.write_str("'>")

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -3135,7 +3135,7 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
             KnownInstanceType::Callable(callable) => {
                 f.set_invalid_type_annotation();
                 f.write_char('<')?;
-                f.with_type(Type::SpecialForm(SpecialFormType::Callable))
+                f.with_type(Type::SpecialForm(SpecialFormType::TypingCallable))
                     .write_str("typing.Callable")?;
                 f.write_str(" special-form '")?;
                 callable.display(self.db).fmt_detailed(f)?;

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -3135,6 +3135,10 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
             KnownInstanceType::Callable(callable) => {
                 f.set_invalid_type_annotation();
                 f.write_char('<')?;
+                // Ensure that when we go-to-definition on an inlay hint for a `Callable`,
+                // regardless of whether it's imported from `collections.abc` or `typing`,
+                // we go to `typing.pyi` because in typeshed there is no `Callable` in
+                // `collections.abc`.
                 f.with_type(Type::SpecialForm(SpecialFormType::TypingCallable))
                     .write_str("Callable")?;
                 f.write_str(" special-form '")?;

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -329,7 +329,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         InternedType::new(db, argument_ty),
                     ));
                 }
-                SpecialFormType::Callable => {
+                SpecialFormType::TypingCallable | SpecialFormType::CollectionsAbcCallable => {
                     let callable = self
                         .infer_callable_type(subscript)
                         .as_callable()

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2229,7 +2229,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         self.type_expression_context()
                     ));
                     diag.info("`typing.Concatenate` is only valid:");
-                    diag.info(" - as the first argument to `typing.Callable`");
+                    diag.info(" - as the first argument to `Callable`");
                     diag.info(" - as a type argument for a `ParamSpec` parameter");
                 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1239,7 +1239,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             }
                         }
                     }
-                    Type::SpecialForm(special_form @ SpecialFormType::Callable) => {
+                    Type::SpecialForm(
+                        special_form @ (SpecialFormType::TypingCallable
+                        | SpecialFormType::CollectionsAbcCallable),
+                    ) => {
                         self.infer_parameterized_special_form_type_expression(
                             subscript,
                             special_form,
@@ -1913,7 +1916,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
                 _ => self.infer_type_expression(arguments_slice),
             },
-            SpecialFormType::Callable => self.infer_callable_type(subscript),
+            SpecialFormType::TypingCallable | SpecialFormType::CollectionsAbcCallable => {
+                self.infer_callable_type(subscript)
+            }
 
             // `ty_extensions` special forms
             SpecialFormType::Not => {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -375,7 +375,8 @@ impl ClassInfoConstraintFunction {
 
                 // We don't have a good meta-type for `Callable`s right now,
                 // so only apply `isinstance()` narrowing, not `issubclass()`
-                SpecialFormType::Callable => (self == ClassInfoConstraintFunction::IsInstance)
+                SpecialFormType::TypingCallable | SpecialFormType::CollectionsAbcCallable => (self
+                    == ClassInfoConstraintFunction::IsInstance)
                     .then(|| Type::Callable(CallableType::unknown(db)).top_materialization(db)),
 
                 // `InitVar` is a class at runtime, so can be used in `isinstance()`,

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -516,7 +516,6 @@ impl SpecialFormType {
                 | LegacyStdlibAlias::Deque
                 | LegacyStdlibAlias::OrderedDict
             )
-            | Self::CollectionsAbcCallable
             | Self::NamedTuple => true,
             Self::TypeForm => true,
 
@@ -552,6 +551,7 @@ impl SpecialFormType {
             | Self::CallableTypeOf
             | Self::RegularCallableTypeOf
             | Self::TypingCallable
+            | Self::CollectionsAbcCallable
             | Self::TypingSelf
             | Self::Concatenate
             | Self::Unpack

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -227,6 +227,33 @@ impl SpecialFormType {
         candidate.check_module(module).then_some(candidate)
     }
 
+    /// Given the special form we resolved (`self`) and the module the user actually
+    /// imported the symbol from (`import_module`), return the variant that matches the
+    /// import path — or `self` if there's no better match.
+    ///
+    /// This exists because typeshed defines `collections.abc.Callable` as
+    /// `from typing import Callable as Callable`. Following the alias chain to the
+    /// definition site lands on `SpecialFormType::TypingCallable` for *both*
+    /// `from typing import Callable` and `from collections.abc import Callable`,
+    /// erasing the distinction. This method substitutes `CollectionsAbcCallable` in
+    /// the latter case, restoring it.
+    ///
+    /// Called at module-attribute resolution — the one boundary where the import-path
+    /// module is still observable.
+    pub(super) fn rewrap_for_import_module(self, name: &str, import_module: KnownModule) -> Self {
+        let Some(candidate) = Self::from_name(name, import_module) else {
+            return self;
+        };
+        if candidate != self
+            && candidate.name() == self.name()
+            && candidate.check_module(import_module)
+        {
+            candidate
+        } else {
+            self
+        }
+    }
+
     /// Parse a `SpecialFormType` from its runtime symbol name in the context of `module`.
     ///
     /// The module is needed to disambiguate symbols like `Callable`, which is exported by both

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -52,13 +52,13 @@ pub enum SpecialFormType {
     /// `typing_extensions.TypeForm`).
     TypeForm,
 
-    /// The special form `Callable`.
+    /// The special form `typing.Callable`.
     ///
-    /// While `typing.Callable` aliases `collections.abc.Callable`, we view both objects
-    /// as inhabiting the same special form type internally. Moreover, `Callable` requires
-    /// special handling for both type-expression parsing and `isinstance`/`issubclass`
-    /// narrowing.
-    Callable,
+    /// This is distinct from the `Callable` exported by the `collections.abc` module.
+    TypingCallable,
+
+    /// The symbol `collections.abc.Callable`
+    CollectionsAbcCallable,
 
     Any,
     /// The symbol `typing.Annotated` (which can also be found as `typing_extensions.Annotated`)
@@ -143,7 +143,8 @@ impl SpecialFormType {
             | Self::Type
             | Self::TypeForm
             | Self::TypingSelf
-            | Self::Callable
+            | Self::TypingCallable
+            | Self::CollectionsAbcCallable
             | Self::Concatenate
             | Self::Unpack
             | Self::TypeAlias
@@ -203,7 +204,9 @@ impl SpecialFormType {
             Self::Type => Some(KnownClass::Type.to_instance(db)),
             Self::TypeForm => Some(TypeFormType::from_type_expression(db, Type::any())),
             Self::Tuple => Some(Type::homogeneous_tuple(db, Type::unknown())),
-            Self::Callable => Some(Type::Callable(CallableType::unknown(db))),
+            Self::TypingCallable | Self::CollectionsAbcCallable => {
+                Some(Type::Callable(CallableType::unknown(db)))
+            }
             Self::LegacyStdlibAlias(alias) => Some(alias.aliased_class().to_instance(db)),
             _ => None,
         }
@@ -219,14 +222,16 @@ impl SpecialFormType {
         file: File,
         symbol_name: &str,
     ) -> Option<Self> {
-        let candidate = Self::from_name(symbol_name)?;
-        candidate
-            .check_module(file_to_module(db, file)?.known(db)?)
-            .then_some(candidate)
+        let module = file_to_module(db, file)?.known(db)?;
+        let candidate = Self::from_name(symbol_name, module)?;
+        candidate.check_module(module).then_some(candidate)
     }
 
-    /// Parse a `SpecialFormType` from its runtime symbol name.
-    fn from_name(name: &str) -> Option<Self> {
+    /// Parse a `SpecialFormType` from its runtime symbol name in the context of `module`.
+    ///
+    /// The module is needed to disambiguate symbols like `Callable`, which is exported by both
+    /// `typing` and `collections.abc` and inhabits a different `SpecialFormType` variant in each.
+    fn from_name(name: &str, module: KnownModule) -> Option<Self> {
         /// An enum that maps 1:1 with `SpecialFormType`, but which holds no associated data
         /// (and therefore can have `EnumString` derived on it).
         /// This is much more robust than having a manual `from_string` method that matches
@@ -293,7 +298,8 @@ impl SpecialFormType {
                     SpecialFormType::AlwaysFalsy => Self::AlwaysFalsy,
                     SpecialFormType::AlwaysTruthy => Self::AlwaysTruthy,
                     SpecialFormType::Annotated => Self::Annotated,
-                    SpecialFormType::Callable => Self::Callable,
+                    SpecialFormType::TypingCallable => Self::Callable,
+                    SpecialFormType::CollectionsAbcCallable => Self::Callable,
                     SpecialFormType::CallableTypeOf => Self::CallableTypeOf,
                     SpecialFormType::RegularCallableTypeOf => Self::RegularCallableTypeOf,
                     SpecialFormType::Concatenate => Self::Concatenate,
@@ -351,7 +357,10 @@ impl SpecialFormType {
                 SpecialFormTypeBuilder::AlwaysFalsy => Self::AlwaysFalsy,
                 SpecialFormTypeBuilder::AlwaysTruthy => Self::AlwaysTruthy,
                 SpecialFormTypeBuilder::Annotated => Self::Annotated,
-                SpecialFormTypeBuilder::Callable => Self::Callable,
+                SpecialFormTypeBuilder::Callable => match module {
+                    KnownModule::CollectionsAbc => Self::CollectionsAbcCallable,
+                    _ => Self::TypingCallable,
+                },
                 SpecialFormTypeBuilder::CallableTypeOf => Self::CallableTypeOf,
                 SpecialFormTypeBuilder::RegularCallableTypeOf => Self::RegularCallableTypeOf,
                 SpecialFormTypeBuilder::Concatenate => Self::Concatenate,
@@ -424,7 +433,7 @@ impl SpecialFormType {
             | Self::Tuple
             | Self::Type
             | Self::Generic
-            | Self::Callable => module.is_typing(),
+            | Self::TypingCallable => module.is_typing(),
 
             Self::Annotated
             | Self::Literal
@@ -454,6 +463,8 @@ impl SpecialFormType {
             | Self::TypeOf
             | Self::CallableTypeOf
             | Self::RegularCallableTypeOf => module.is_ty_extensions(),
+
+            Self::CollectionsAbcCallable => module == KnownModule::CollectionsAbc,
         }
     }
 
@@ -478,6 +489,7 @@ impl SpecialFormType {
                 | LegacyStdlibAlias::Deque
                 | LegacyStdlibAlias::OrderedDict
             )
+            | Self::CollectionsAbcCallable
             | Self::NamedTuple => true,
             Self::TypeForm => true,
 
@@ -512,7 +524,7 @@ impl SpecialFormType {
             | Self::TypeOf
             | Self::CallableTypeOf
             | Self::RegularCallableTypeOf
-            | Self::Callable
+            | Self::TypingCallable
             | Self::TypingSelf
             | Self::Concatenate
             | Self::Unpack
@@ -531,7 +543,8 @@ impl SpecialFormType {
         match self {
             Self::TypeQualifier(qualifier) => qualifier.is_valid_isinstance_target(),
 
-            Self::Callable
+            Self::TypingCallable
+            | Self::CollectionsAbcCallable
             | Self::LegacyStdlibAlias(_)
             | Self::Tuple
             | Self::Type
@@ -584,7 +597,7 @@ impl SpecialFormType {
             SpecialFormType::Type => "Type",
             SpecialFormType::TypeForm => "TypeForm",
             SpecialFormType::TypingSelf => "Self",
-            SpecialFormType::Callable => "Callable",
+            SpecialFormType::TypingCallable | SpecialFormType::CollectionsAbcCallable => "Callable",
             SpecialFormType::Concatenate => "Concatenate",
             SpecialFormType::Unpack => "Unpack",
             SpecialFormType::TypeAlias => "TypeAlias",
@@ -631,7 +644,7 @@ impl SpecialFormType {
             | SpecialFormType::Type
             | SpecialFormType::TypeForm
             | SpecialFormType::TypingSelf
-            | SpecialFormType::Callable
+            | SpecialFormType::TypingCallable
             | SpecialFormType::Concatenate
             | SpecialFormType::Unpack
             | SpecialFormType::TypeAlias
@@ -646,6 +659,8 @@ impl SpecialFormType {
             }
 
             SpecialFormType::TypeQualifier(qualifier) => qualifier.definition_modules(),
+
+            SpecialFormType::CollectionsAbcCallable => &[KnownModule::CollectionsAbc],
 
             SpecialFormType::Unknown
             | SpecialFormType::AlwaysTruthy
@@ -792,7 +807,9 @@ impl SpecialFormType {
             SpecialFormType::Type => Ok(KnownClass::Type.to_instance(db)),
             SpecialFormType::TypeForm => Ok(TypeFormType::from_type_expression(db, Type::any())),
             SpecialFormType::Tuple => Ok(Type::homogeneous_tuple(db, Type::unknown())),
-            SpecialFormType::Callable => Ok(Type::Callable(CallableType::unknown(db))),
+            SpecialFormType::TypingCallable | SpecialFormType::CollectionsAbcCallable => {
+                Ok(Type::Callable(CallableType::unknown(db)))
+            }
             SpecialFormType::LegacyStdlibAlias(alias) => Ok(alias.aliased_class().to_instance(db)),
             SpecialFormType::TypeQualifier(qualifier) => {
                 Err(InvalidTypeExpression::TypeQualifier(qualifier))

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -386,6 +386,7 @@ impl SpecialFormType {
                 SpecialFormTypeBuilder::Annotated => Self::Annotated,
                 SpecialFormTypeBuilder::Callable => match module {
                     KnownModule::CollectionsAbc => Self::CollectionsAbcCallable,
+                    KnownModule::CollectionsAbcInternal => Self::CollectionsAbcCallable,
                     _ => Self::TypingCallable,
                 },
                 SpecialFormTypeBuilder::CallableTypeOf => Self::CallableTypeOf,
@@ -491,7 +492,10 @@ impl SpecialFormType {
             | Self::CallableTypeOf
             | Self::RegularCallableTypeOf => module.is_ty_extensions(),
 
-            Self::CollectionsAbcCallable => module == KnownModule::CollectionsAbc,
+            Self::CollectionsAbcCallable => matches!(
+                module,
+                KnownModule::CollectionsAbc | KnownModule::CollectionsAbcInternal
+            ),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -256,7 +256,7 @@ impl SpecialFormType {
 
     /// Parse a `SpecialFormType` from its runtime symbol name in the context of `module`.
     ///
-    /// The module is needed to disambiguate symbols like `Callable`, which is exported by both
+    /// The `module` parameter is needed to disambiguate symbols like `Callable`, which is exported by both
     /// `typing` and `collections.abc` and inhabits a different `SpecialFormType` variant in each.
     fn from_name(name: &str, module: KnownModule) -> Option<Self> {
         /// An enum that maps 1:1 with `SpecialFormType`, but which holds no associated data

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -222,43 +222,36 @@ impl SpecialFormType {
         file: File,
         symbol_name: &str,
     ) -> Option<Self> {
-        let module = file_to_module(db, file)?.known(db)?;
-        let candidate = Self::from_name(symbol_name, module)?;
-        candidate.check_module(module).then_some(candidate)
+        let candidate = Self::from_name(symbol_name)?;
+        candidate
+            .check_module(file_to_module(db, file)?.known(db)?)
+            .then_some(candidate)
     }
 
     /// Given the special form we resolved (`self`) and the module the user actually
     /// imported the symbol from (`import_module`), return the variant that matches the
     /// import path — or `self` if there's no better match.
     ///
-    /// This exists because typeshed defines `collections.abc.Callable` as
-    /// `from typing import Callable as Callable`. Following the alias chain to the
-    /// definition site lands on `SpecialFormType::TypingCallable` for *both*
-    /// `from typing import Callable` and `from collections.abc import Callable`,
-    /// erasing the distinction. This method substitutes `CollectionsAbcCallable` in
-    /// the latter case, restoring it.
+    /// This exists because typeshed defines `_collections_abc.Callable` as
+    /// `from typing import Callable as Callable`, then re-exports it from `collections.abc`.
+    /// Following the alias chain to the definition site lands on `SpecialFormType::TypingCallable`
+    /// for both `from typing import Callable` and `from collections.abc import Callable`, erasing
+    /// the distinction. This method substitutes `CollectionsAbcCallable` at the `_collections_abc`
+    /// module boundary, restoring it before `collections.abc` star-reexports it.
     ///
     /// Called at module-attribute resolution — the one boundary where the import-path
     /// module is still observable.
     pub(super) fn rewrap_for_import_module(self, name: &str, import_module: KnownModule) -> Self {
-        let Some(candidate) = Self::from_name(name, import_module) else {
-            return self;
-        };
-        if candidate != self
-            && candidate.name() == self.name()
-            && candidate.check_module(import_module)
-        {
-            candidate
-        } else {
-            self
+        match (self, name, import_module) {
+            (Self::TypingCallable, "Callable", KnownModule::CollectionsAbcInternal) => {
+                Self::CollectionsAbcCallable
+            }
+            _ => self,
         }
     }
 
-    /// Parse a `SpecialFormType` from its runtime symbol name in the context of `module`.
-    ///
-    /// The `module` parameter is needed to disambiguate symbols like `Callable`, which is exported by both
-    /// `typing` and `collections.abc` and inhabits a different `SpecialFormType` variant in each.
-    fn from_name(name: &str, module: KnownModule) -> Option<Self> {
+    /// Parse a `SpecialFormType` from its runtime symbol name.
+    fn from_name(name: &str) -> Option<Self> {
         /// An enum that maps 1:1 with `SpecialFormType`, but which holds no associated data
         /// (and therefore can have `EnumString` derived on it).
         /// This is much more robust than having a manual `from_string` method that matches
@@ -384,11 +377,7 @@ impl SpecialFormType {
                 SpecialFormTypeBuilder::AlwaysFalsy => Self::AlwaysFalsy,
                 SpecialFormTypeBuilder::AlwaysTruthy => Self::AlwaysTruthy,
                 SpecialFormTypeBuilder::Annotated => Self::Annotated,
-                SpecialFormTypeBuilder::Callable => match module {
-                    KnownModule::CollectionsAbc => Self::CollectionsAbcCallable,
-                    KnownModule::CollectionsAbcInternal => Self::CollectionsAbcCallable,
-                    _ => Self::TypingCallable,
-                },
+                SpecialFormTypeBuilder::Callable => Self::TypingCallable,
                 SpecialFormTypeBuilder::CallableTypeOf => Self::CallableTypeOf,
                 SpecialFormTypeBuilder::RegularCallableTypeOf => Self::RegularCallableTypeOf,
                 SpecialFormTypeBuilder::Concatenate => Self::Concatenate,


### PR DESCRIPTION
## Summary
https://github.com/astral-sh/ty/issues/887

This is a blocker to supporting `Callable()` in class patterns in match statements (discussion [below](https://github.com/astral-sh/ruff/pull/24954#discussion_r3171744197)). `typing.Callable` is a deprecated alias to `collections.abc.Callable` - calling the former raises a `TypeError` at runtime whereas the latter doesn't.

To allow `Callable()` to be used in `match` statements, we need to be able to distinguish between the two.

Complication: typeshed defines `collections.abc.Callable` as a re-export alias from `typing` (`collections/abc.pyi` -> `_collections_abc.pyi` -> `from typing import Callable as Callable`). This required some additional plumbing to pass `collections.abc` through as the known module (the re-exporting module) vs `typing`

## Test Plan
New mdtests