### PR TITLE
[ty] Allow reference finding in stringified annotations

### DIFF
--- a/crates/ty_ide/src/find_references.rs
+++ b/crates/ty_ide/src/find_references.rs
@@ -38,9 +38,20 @@ mod tests {
 
     impl CursorTest {
         fn references(&self) -> String {
-            let Some(mut reference_results) =
-                find_references(&self.db, self.cursor.file, self.cursor.offset, true)
-            else {
+            self.references_with_include_declaration(true)
+        }
+
+        fn references_without_declaration(&self) -> String {
+            self.references_with_include_declaration(false)
+        }
+
+        fn references_with_include_declaration(&self, include_declaration: bool) -> String {
+            let Some(mut reference_results) = find_references(
+                &self.db,
+                self.cursor.file,
+                self.cursor.offset,
+                include_declaration,
+            ) else {
                 return "No references found".to_string();
             };
 
@@ -493,6 +504,27 @@ cls = MyClass
         3 |
         4 | class MyClass:
           |       -------
+          |
+        "#);
+    }
+
+    #[test]
+    fn references_string_annotation_without_declaration() {
+        let test = cursor_test(
+            r#"
+        a: "MyCla<CURSOR>ss" = 1
+
+        class MyClass:
+            """some docs"""
+        "#,
+        );
+
+        assert_snapshot!(test.references_without_declaration(), @r#"
+        info[references]: Found 1 references
+         --> main.py:2:5
+          |
+        2 | a: "MyClass" = 1
+          |     -------
           |
         "#);
     }

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -480,7 +480,7 @@ impl<'a> SourceOrderVisitor<'a> for LocalReferencesFinder<'a> {
             AnyNodeRef::TypeParamTypeVar(param_var) if self.should_include_declaration() => {
                 self.check_identifier_reference(&param_var.name);
             }
-            AnyNodeRef::ExprStringLiteral(string_expr) if self.should_include_declaration() => {
+            AnyNodeRef::ExprStringLiteral(string_expr) => {
                 // Highlight the sub-AST of a string annotation
                 if let Some((sub_ast, sub_model)) = self.model.enter_string_annotation(string_expr)
                 {


### PR DESCRIPTION
## Summary

Stringified annotations were being guarded by the `includeDeclaration` flag, so `MyClass` inside `"MyClass"` wasn't being treated as a reference, which seems unintentional.

Closes https://github.com/astral-sh/ty/issues/3386.
