### PR TITLE
[ty] Respect `includeDeclaration` request param

### DIFF
--- a/crates/ty_ide/src/doc_highlights.rs
+++ b/crates/ty_ide/src/doc_highlights.rs
@@ -67,7 +67,7 @@ mod tests {
             .build();
 
         assert_snapshot!(test.document_highlights(), @"
-        info[document_highlights]: Highlight 1 (Read)
+        info[document_highlights]: Highlight 1 (Other)
          --> mypackage/__init__.py:1:15
           |
         1 | from . import module_a

--- a/crates/ty_ide/src/find_references.rs
+++ b/crates/ty_ide/src/find_references.rs
@@ -1972,4 +1972,224 @@ func<CURSOR>_alias()
           |
         "#);
     }
+
+    #[test]
+    fn without_declaration_excludes_initial_assignment() {
+        let test = cursor_test(
+            "
+x<CURSOR> = 1
+print(x)
+",
+        );
+
+        assert_snapshot!(test.references_without_declaration(), @"
+        info[references]: Found 1 references
+         --> main.py:3:7
+          |
+        3 | print(x)
+          |       -
+          |
+        ");
+    }
+
+    #[test]
+    fn without_declaration_keeps_reassignment_without_declaration() {
+        let test = cursor_test(
+            "
+x = 1
+x = 2
+print(x<CURSOR>)
+",
+        );
+
+        assert_snapshot!(test.references_without_declaration(), @"
+        info[references]: Found 2 references
+         --> main.py:3:1
+          |
+        3 | x = 2
+          | -
+        4 | print(x)
+          |       -
+          |
+        ");
+    }
+
+    #[test]
+    fn without_declaration_keeps_assignment_after_annotation() {
+        let test = cursor_test(
+            "
+x<CURSOR>: int
+x = 1
+print(x)
+",
+        );
+
+        assert_snapshot!(test.references_without_declaration(), @"
+        info[references]: Found 2 references
+         --> main.py:3:1
+          |
+        3 | x = 1
+          | -
+        4 | print(x)
+          |       -
+          |
+        ");
+    }
+
+    #[test]
+    fn without_declaration_excludes_repeated_annotation() {
+        let test = cursor_test(
+            "
+x<CURSOR>: int
+x: str
+print(x)
+",
+        );
+
+        assert_snapshot!(test.references_without_declaration(), @"
+        info[references]: Found 1 references
+         --> main.py:4:7
+          |
+        4 | print(x)
+          |       -
+          |
+        ");
+    }
+
+    #[test]
+    fn without_declaration_excludes_type_alias_name() {
+        let test = cursor_test(
+            "
+type Box<CURSOR> = int | None
+value: Box
+",
+        );
+
+        assert_snapshot!(test.references_without_declaration(), @"
+        info[references]: Found 1 references
+         --> main.py:3:8
+          |
+        3 | value: Box
+          |        ---
+          |
+        ");
+    }
+
+    #[test]
+    fn without_declaration_control_flow() {
+        let test = cursor_test(
+            "
+def test(flag: bool):
+    if flag:
+        x: int = 1
+        return
+
+    x = 2
+    print(x<CURSOR>)
+",
+        );
+
+        assert_snapshot!(test.references_without_declaration(), @"
+        info[references]: Found 1 references
+         --> main.py:8:11
+          |
+        8 |     print(x)
+          |           -
+          |
+        ");
+    }
+
+    #[test]
+    fn without_declaration_keeps_binding_when_declaration_is_partial() {
+        let test = cursor_test(
+            "
+def f(flag: bool):
+    if flag:
+        x: int
+    x = 1
+    print(x<CURSOR>)
+",
+        );
+
+        assert_snapshot!(test.references_without_declaration(), @"
+        info[references]: Found 2 references
+         --> main.py:5:5
+          |
+        5 |     x = 1
+          |     -
+        6 |     print(x)
+          |           -
+          |
+        ");
+    }
+
+    #[test]
+    fn without_declaration_excludes_live_conditional_assignments() {
+        let test = cursor_test(
+            "
+if flag:
+    x = 1
+else:
+    x = 2
+print(x<CURSOR>)
+",
+        );
+
+        assert_snapshot!(test.references_without_declaration(), @"
+        info[references]: Found 1 references
+         --> main.py:6:7
+          |
+        6 | print(x)
+          |       -
+          |
+        ");
+    }
+
+    #[test]
+    fn without_declaration_excludes_initial_attribute_assignment() {
+        let test = cursor_test(
+            "
+class C:
+    def __init__(self):
+        self.x<CURSOR> = 1
+
+    def f(self):
+        print(self.x)
+",
+        );
+
+        assert_snapshot!(test.references_without_declaration(), @"
+        info[references]: Found 1 references
+         --> main.py:7:20
+          |
+        7 |         print(self.x)
+          |                    -
+          |
+        ");
+    }
+
+    #[test]
+    fn without_declaration_excludes_attribute_assignment_after_base_rebind() {
+        let test = cursor_test(
+            "
+class C:
+    def f(self, flag: bool):
+        if flag:
+            self.x = 1
+        else:
+            self = C()
+        self.x<CURSOR> = 2
+        print(self.x)
+",
+        );
+
+        assert_snapshot!(test.references_without_declaration(), @"
+        info[references]: Found 1 references
+         --> main.py:9:20
+          |
+        9 |         print(self.x)
+          |                    -
+          |
+        ");
+    }
 }

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -5,6 +5,7 @@ pub use crate::goto_type_definition::goto_type_definition;
 
 use std::borrow::Cow;
 
+use crate::NavigationTarget;
 use crate::stub_mapping::StubMapper;
 use ruff_db::parsed::ParsedModuleRef;
 use ruff_python_ast::find_node::{CoveringNode, covering_node};
@@ -241,10 +242,14 @@ pub(crate) enum GotoTarget<'a> {
 }
 
 /// The resolved definitions for a `GotoTarget`
-#[derive(Debug, Clone)]
-pub(crate) struct Definitions<'db>(pub Vec<ResolvedDefinition<'db>>);
+#[derive(Debug)]
+pub(crate) struct Definitions<'db>(Vec<ResolvedDefinition<'db>>);
 
 impl<'db> Definitions<'db> {
+    fn new(resolved: Vec<ResolvedDefinition<'db>>) -> Self {
+        Self(resolved)
+    }
+
     pub(crate) fn from_ty(db: &'db dyn crate::Db, ty: Type<'db>) -> Option<Self> {
         let ty_def = ty.definition(db)?;
         let resolved = match ty_def {
@@ -262,35 +267,103 @@ impl<'db> Definitions<'db> {
                 ResolvedDefinition::Definition(definition)
             }
         };
-        Some(Definitions(vec![resolved]))
+        Some(Self::new(vec![resolved]))
     }
 
-    /// Get the "goto-declaration" interpretation of this definition
-    ///
-    /// In this case it basically returns exactly what was found.
-    pub(crate) fn declaration_targets(
+    /// Apply the "goto declaration" interpretation to these definitions.
+    pub(crate) fn goto_declaration(
         self,
         model: &SemanticModel<'db>,
         goto_target: &GotoTarget<'_>,
-    ) -> Option<crate::NavigationTargets> {
-        definitions_to_navigation_targets(model, None, goto_target, self.0)
+    ) -> Option<Definitions<'db>> {
+        let mut definitions = self.0;
+
+        // When our target is a class constructor, we want to exclude
+        // navigation targets to its `__init__` or `__new__` methods.
+        //
+        // ... unless the cursor is on the parenthesis of the call,
+        // in which case we want to prefer the constructor methods
+        // if available.
+        //
+        // See: https://github.com/astral-sh/ty/issues/2218
+        if let GotoTarget::Call { on_parenthesis, .. } = *goto_target
+            && goto_target
+                .inferred_type(model)
+                .is_some_and(|ty| ty.is_class_literal())
+        {
+            let is_constructor_method =
+                |resolved_def: &ty_python_semantic::ResolvedDefinition<'_>| {
+                    let Some(def) = resolved_def.definition() else {
+                        return false;
+                    };
+                    if !matches!(*def.kind(model.db()), DefinitionKind::Function(_)) {
+                        return false;
+                    }
+                    def.name(model.db())
+                        .is_some_and(|name| name == "__init__" || name == "__new__")
+                };
+
+            if on_parenthesis {
+                // Only limit to constructor methods if we have at least one.
+                // Otherwise we could end up removing all navigation targets.
+                // e.g., See `goto_definition_dynamic_namedtuple_literal_parenthesis`
+                // test.
+                if definitions.iter().any(is_constructor_method) {
+                    definitions.retain(|resolved_def| is_constructor_method(resolved_def));
+                }
+            } else {
+                definitions.retain(|resolved_def| !is_constructor_method(resolved_def));
+            }
+        }
+
+        if definitions.is_empty() {
+            None
+        } else {
+            Some(Self::new(definitions))
+        }
     }
 
     /// Get the "goto-definition" interpretation of this definition
     ///
     /// In this case we apply stub-mapping to try to find the "real" implementation
     /// if the definition we have is found in a stub file.
-    pub(crate) fn definition_targets(
+    pub(crate) fn goto_definition(
         self,
         model: &SemanticModel<'db>,
         goto_target: &GotoTarget<'_>,
-    ) -> Option<crate::NavigationTargets> {
-        definitions_to_navigation_targets(
-            model,
-            Some(&StubMapper::new(model.db())),
-            goto_target,
-            self.0,
-        )
+    ) -> Option<Definitions<'db>> {
+        let definitions = self.goto_declaration(model, goto_target)?;
+        let resolved = StubMapper::new(model.db()).map_definitions(definitions.0);
+        Some(Self::new(resolved))
+    }
+
+    /// Convert these semantic definitions to editor-facing navigation targets.
+    pub(crate) fn into_navigation_targets(
+        self,
+        db: &'db dyn ty_python_semantic::Db,
+    ) -> crate::NavigationTargets {
+        self.0
+            .into_iter()
+            .map(|definition| match definition {
+                ResolvedDefinition::Definition(definition) => {
+                    let file = definition.file(db);
+                    let module = ruff_db::parsed::parsed_module(db, file).load(db);
+
+                    let focus_range = definition.focus_range(db, &module);
+                    let full_range = definition.full_range(db, &module);
+
+                    NavigationTarget {
+                        file: focus_range.file(),
+                        focus_range: focus_range.range(),
+                        full_range: full_range.range(),
+                    }
+                }
+                ResolvedDefinition::Module(file) => {
+                    NavigationTarget::new(file, TextRange::default())
+                }
+                ResolvedDefinition::FileWithRange(file_range) => NavigationTarget::from(file_range),
+            })
+            .collect()
     }
 
     /// Get the docstring for this definition
@@ -299,7 +372,7 @@ impl<'db> Definitions<'db> {
     /// so this will check both the goto-declarations and goto-definitions (in that order)
     /// and return the first one found.
     pub(crate) fn docstring(self, db: &'db dyn crate::Db) -> Option<Docstring> {
-        for definition in &self.0 {
+        for definition in &self {
             // If we got a docstring from the original definition, use it
             if let Some(docstring) = definition.docstring(db) {
                 return Some(Docstring::new(docstring));
@@ -320,6 +393,30 @@ impl<'db> Definitions<'db> {
 
         None
     }
+
+    /// Return true if `self` and `other` contain at least one shared `definition`.
+    ///
+    /// A symbol can resolve to multiple definitions (for example, overload groups,
+    /// property getter/setter co-definitions, or an import binding plus its
+    /// underlying definition). Intersection semantics avoid missing valid
+    /// references/renames when target ordering differs or when one occurrence
+    /// exposes only part of the co-definition set.
+    pub(crate) fn intersects(&self, other: &Self) -> bool {
+        self.iter().any(|definition| other.0.contains(definition))
+    }
+
+    pub(crate) fn iter(&self) -> std::slice::Iter<'_, ResolvedDefinition<'db>> {
+        self.0.iter()
+    }
+}
+
+impl<'a, 'db> IntoIterator for &'a Definitions<'db> {
+    type Item = &'a ResolvedDefinition<'db>;
+    type IntoIter = std::slice::Iter<'a, ResolvedDefinition<'db>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
 }
 
 /// Resolve the docstring for a call-signature's resolved definition.
@@ -336,7 +433,7 @@ pub(crate) fn docstring_for_call_definition<'db>(
     definition: Definition<'db>,
 ) -> Option<Docstring> {
     let resolved = ResolvedDefinition::Definition(definition);
-    Definitions(vec![resolved.clone()])
+    Definitions::new(vec![resolved.clone()])
         .docstring(db)
         .or_else(|| resolved.implementation_docstring(db).map(Docstring::new))
 }
@@ -449,13 +546,7 @@ impl GotoTarget<'_> {
     /// (i.e. "x" in "from a import b as x") are resolved or returned as is.
     /// We want to resolve them in some cases (like "goto declaration") but not in others
     /// (like find references or rename).
-    ///
-    ///
-    /// Ideally this would always return `DefinitionsOrTargets::Definitions`
-    /// as this is more useful for doing stub mapping (goto-definition) and
-    /// retrieving docstrings. However for now some cases are stubbed out
-    /// as just returning a raw `NavigationTarget`.
-    pub(crate) fn get_definition_targets<'db>(
+    pub(crate) fn definitions<'db>(
         &self,
         model: &SemanticModel<'db>,
         alias_resolution: ImportAliasResolution,
@@ -704,7 +795,7 @@ impl GotoTarget<'_> {
             } => typed_dict_key_definition(model, subscript, literal_key)
                 .map(|definition| vec![definition]),
         };
-        definitions.map(Definitions)
+        definitions.map(Definitions::new)
     }
 
     /// Returns the text representation of this goto target.
@@ -1177,41 +1268,6 @@ impl Ranged for GotoTarget<'_> {
     }
 }
 
-/// Converts a collection of `ResolvedDefinition` items into `NavigationTarget` items.
-fn convert_resolved_definitions_to_targets<'db>(
-    db: &'db dyn ty_python_semantic::Db,
-    definitions: Vec<ty_python_semantic::ResolvedDefinition<'db>>,
-) -> Vec<crate::NavigationTarget> {
-    definitions
-        .into_iter()
-        .map(|resolved_definition| match resolved_definition {
-            ty_python_semantic::ResolvedDefinition::Definition(definition) => {
-                // Get the parsed module for range calculation
-                let definition_file = definition.file(db);
-                let module = ruff_db::parsed::parsed_module(db, definition_file).load(db);
-
-                // Get the ranges for this definition
-                let focus_range = definition.focus_range(db, &module);
-                let full_range = definition.full_range(db, &module);
-
-                crate::NavigationTarget {
-                    file: focus_range.file(),
-                    focus_range: focus_range.range(),
-                    full_range: full_range.range(),
-                }
-            }
-            ty_python_semantic::ResolvedDefinition::Module(file) => {
-                // For modules, navigate to the start of the file
-                crate::NavigationTarget::new(file, TextRange::default())
-            }
-            ty_python_semantic::ResolvedDefinition::FileWithRange(file_range) => {
-                // For file ranges, navigate to the specific range within the file
-                crate::NavigationTarget::from(file_range)
-            }
-        })
-        .collect()
-}
-
 /// If a function is a property setter or deleter (e.g., decorated with
 /// `@my_property.setter`), return the definitions for the property getter.
 /// This ensures that the setter/deleter function name is recognized as a
@@ -1265,65 +1321,6 @@ fn definitions_for_callable<'db>(
         .into_iter()
         .filter_map(|signature| signature.definition.map(ResolvedDefinition::Definition))
         .collect()
-}
-
-/// Shared helper to map and convert resolved definitions into navigation targets.
-///
-/// The `goto_target` corresponds to the original target that definitions were
-/// requested for. In some cases, this can influence the targets returned. For
-/// example, when the target is a constructor for a class, definitions other
-/// than the class definition are filtered out.
-fn definitions_to_navigation_targets<'db>(
-    model: &SemanticModel<'db>,
-    stub_mapper: Option<&StubMapper<'db>>,
-    goto_target: &GotoTarget<'_>,
-    mut definitions: Vec<ty_python_semantic::ResolvedDefinition<'db>>,
-) -> Option<crate::NavigationTargets> {
-    // When our target is a class constructor, we want to exclude
-    // navigation targets to its `__init__` or `__new__` methods.
-    //
-    // ... unless the cursor is on the parenthesis of the call,
-    // in which case we want to prefer the constructor methods
-    // if available.
-    //
-    // See: https://github.com/astral-sh/ty/issues/2218
-    if let GotoTarget::Call { on_parenthesis, .. } = *goto_target
-        && goto_target
-            .inferred_type(model)
-            .is_some_and(|ty| ty.is_class_literal())
-    {
-        let is_constructor_method = |resolved_def: &ty_python_semantic::ResolvedDefinition<'_>| {
-            let Some(def) = resolved_def.definition() else {
-                return false;
-            };
-            if !matches!(*def.kind(model.db()), DefinitionKind::Function(_)) {
-                return false;
-            }
-            def.name(model.db())
-                .is_some_and(|name| name == "__init__" || name == "__new__")
-        };
-
-        if on_parenthesis {
-            // Only limit to constructor methods if we have at least one.
-            // Otherwise we could end up removing all navigation targets.
-            // e.g., See `goto_definition_dynamic_namedtuple_literal_parenthesis`
-            // test.
-            if definitions.iter().any(is_constructor_method) {
-                definitions.retain(|resolved_def| is_constructor_method(resolved_def));
-            }
-        } else {
-            definitions.retain(|resolved_def| !is_constructor_method(resolved_def));
-        }
-    }
-    if let Some(mapper) = stub_mapper {
-        definitions = mapper.map_definitions(definitions);
-    }
-    if definitions.is_empty() {
-        None
-    } else {
-        let targets = convert_resolved_definitions_to_targets(model.db(), definitions);
-        Some(crate::NavigationTargets::unique(targets))
-    }
 }
 
 pub(crate) fn find_goto_target<'a>(

--- a/crates/ty_ide/src/goto_declaration.rs
+++ b/crates/ty_ide/src/goto_declaration.rs
@@ -20,8 +20,9 @@ pub fn goto_declaration(
     let goto_target = find_goto_target(&model, &module, offset)?;
 
     let declaration_targets = goto_target
-        .get_definition_targets(&model, ImportAliasResolution::ResolveAliases)?
-        .declaration_targets(&model, &goto_target)?;
+        .definitions(&model, ImportAliasResolution::ResolveAliases)?
+        .goto_declaration(&model, &goto_target)?
+        .into_navigation_targets(model.db());
 
     Some(RangedValue {
         range: FileRange::new(file, goto_target.range()),

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -20,8 +20,9 @@ pub fn goto_definition(
     let model = SemanticModel::new(db, file);
     let goto_target = find_goto_target(&model, &module, offset)?;
     let definition_targets = goto_target
-        .get_definition_targets(&model, ImportAliasResolution::ResolveAliases)?
-        .definition_targets(&model, &goto_target)?;
+        .definitions(&model, ImportAliasResolution::ResolveAliases)?
+        .goto_definition(&model, &goto_target)?
+        .into_navigation_targets(model.db());
 
     Some(RangedValue {
         range: FileRange::new(file, goto_target.range()),

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -41,7 +41,7 @@ pub fn hover(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<Ho
                 // `Foo()`, where the resolved definition is `__init__` and
                 // usually carries no docstring of its own.
                 goto_target
-                    .get_definition_targets(
+                    .definitions(
                         &model,
                         ty_python_semantic::ImportAliasResolution::ResolveAliases,
                     )
@@ -50,7 +50,7 @@ pub fn hover(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<Ho
             .map(HoverContent::Docstring)
     } else {
         goto_target
-            .get_definition_targets(
+            .definitions(
                 &model,
                 ty_python_semantic::ImportAliasResolution::ResolveAliases,
             )

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -19,7 +19,7 @@ use ruff_python_ast::{
     self as ast, AnyNodeRef,
     visitor::source_order::{SourceOrderVisitor, TraversalSignal},
 };
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::Ranged;
 use ty_python_core::scope::ScopeKind;
 use ty_python_semantic::{ImportAliasResolution, ResolvedDefinition, SemanticModel};
 
@@ -335,6 +335,35 @@ fn parameter_owner_is_externally_visible_for_target(
     matches!(owner, Some(AnyNodeRef::StmtFunctionDef(_)))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OccurrenceKind {
+    /// An identifier that references a symbol.
+    Reference,
+    /// An identifier that declares a new symbol.
+    Declaration,
+    /// An identifier that binds a new value to a symbol.
+    Binding,
+}
+
+impl OccurrenceKind {
+    fn to_reference_kind(self) -> ReferenceKind {
+        match self {
+            Self::Reference => ReferenceKind::Read,
+            Self::Declaration => ReferenceKind::Other,
+            Self::Binding => ReferenceKind::Write,
+        }
+    }
+}
+
+impl From<ast::ExprContext> for OccurrenceKind {
+    fn from(value: ast::ExprContext) -> Self {
+        match value {
+            ast::ExprContext::Load | ast::ExprContext::Invalid => Self::Reference,
+            ast::ExprContext::Store | ast::ExprContext::Del => OccurrenceKind::Binding,
+        }
+    }
+}
+
 /// AST visitor to find all references to a specific symbol by comparing semantic definitions
 struct LocalReferencesFinder<'a> {
     model: &'a SemanticModel<'a>,
@@ -357,68 +386,70 @@ impl<'a> SourceOrderVisitor<'a> for LocalReferencesFinder<'a> {
                     return TraversalSignal::Traverse;
                 }
 
+                let kind = OccurrenceKind::from(name_expr.ctx);
                 let covering_node = CoveringNode::from_ancestors(self.ancestors.clone());
-                self.check_reference_from_covering_node(&covering_node);
+                self.check_covering_node(&covering_node, kind);
             }
             AnyNodeRef::ExprAttribute(attr_expr) => {
-                self.check_identifier_reference(&attr_expr.attr);
+                let kind = OccurrenceKind::from(attr_expr.ctx);
+                self.check_identifier(&attr_expr.attr, kind);
             }
             AnyNodeRef::StmtFunctionDef(func) if self.should_include_declaration() => {
-                self.check_identifier_reference(&func.name);
+                self.check_declaration_identifier(&func.name);
             }
             AnyNodeRef::StmtClassDef(class) if self.should_include_declaration() => {
-                self.check_identifier_reference(&class.name);
+                self.check_declaration_identifier(&class.name);
             }
             AnyNodeRef::Parameter(parameter) if self.should_include_declaration() => {
-                self.check_identifier_reference(&parameter.name);
+                self.check_declaration_identifier(&parameter.name);
             }
             AnyNodeRef::Keyword(keyword) => {
                 if let Some(arg) = &keyword.arg {
-                    self.check_identifier_reference(arg);
+                    self.check_reference_identifier(arg);
                 }
             }
             AnyNodeRef::StmtGlobal(global_stmt) if self.should_include_declaration() => {
                 for name in &global_stmt.names {
-                    self.check_identifier_reference(name);
+                    self.check_declaration_identifier(name);
                 }
             }
             AnyNodeRef::StmtNonlocal(nonlocal_stmt) if self.should_include_declaration() => {
                 for name in &nonlocal_stmt.names {
-                    self.check_identifier_reference(name);
+                    self.check_declaration_identifier(name);
                 }
             }
             AnyNodeRef::ExceptHandlerExceptHandler(handler)
                 if self.should_include_declaration() =>
             {
                 if let Some(name) = &handler.name {
-                    self.check_identifier_reference(name);
+                    self.check_binding_identifier(name);
                 }
             }
             AnyNodeRef::PatternMatchAs(pattern_as) if self.should_include_declaration() => {
                 if let Some(name) = &pattern_as.name {
-                    self.check_identifier_reference(name);
+                    self.check_binding_identifier(name);
                 }
             }
             AnyNodeRef::PatternMatchStar(pattern_star) if self.should_include_declaration() => {
                 if let Some(name) = &pattern_star.name {
-                    self.check_identifier_reference(name);
+                    self.check_binding_identifier(name);
                 }
             }
             AnyNodeRef::PatternMatchMapping(pattern_mapping)
                 if self.should_include_declaration() =>
             {
                 if let Some(rest_name) = &pattern_mapping.rest {
-                    self.check_identifier_reference(rest_name);
+                    self.check_binding_identifier(rest_name);
                 }
             }
             AnyNodeRef::TypeParamParamSpec(param_spec) if self.should_include_declaration() => {
-                self.check_identifier_reference(&param_spec.name);
+                self.check_declaration_identifier(&param_spec.name);
             }
             AnyNodeRef::TypeParamTypeVarTuple(param_tuple) if self.should_include_declaration() => {
-                self.check_identifier_reference(&param_tuple.name);
+                self.check_declaration_identifier(&param_tuple.name);
             }
             AnyNodeRef::TypeParamTypeVar(param_var) if self.should_include_declaration() => {
-                self.check_identifier_reference(&param_var.name);
+                self.check_declaration_identifier(&param_var.name);
             }
             AnyNodeRef::ExprStringLiteral(string_expr) => {
                 // Highlight the sub-AST of a string annotation
@@ -439,12 +470,12 @@ impl<'a> SourceOrderVisitor<'a> for LocalReferencesFinder<'a> {
             AnyNodeRef::Alias(alias) if self.should_include_declaration() => {
                 // Handle import alias declarations
                 if let Some(asname) = &alias.asname {
-                    self.check_identifier_reference(asname);
+                    self.check_declaration_identifier(asname);
                 }
                 // Only check the original name if it matches our target text
                 // This is for cases where we're renaming the imported symbol name itself
                 if alias.name.id == self.target_text {
-                    self.check_identifier_reference(&alias.name);
+                    self.check_declaration_identifier(&alias.name);
                 }
             }
             _ => {}
@@ -468,7 +499,7 @@ impl<'a> SourceOrderVisitor<'a> for KeywordArgumentReferencesFinder<'a> {
 
         if let AnyNodeRef::Keyword(keyword) = node {
             if let Some(arg) = &keyword.arg {
-                self.0.check_identifier_reference(arg);
+                self.0.check_reference_identifier(arg);
             }
         }
 
@@ -493,8 +524,22 @@ impl<'a> LocalReferencesFinder<'a> {
         )
     }
 
-    /// Helper method to check identifier references.
-    fn check_identifier_reference(&mut self, identifier: &ast::Identifier) {
+    /// Checks an identifier of a binding (e.g. `x = 10`).
+    fn check_binding_identifier(&mut self, identifier: &ast::Identifier) {
+        self.check_identifier(identifier, OccurrenceKind::Binding);
+    }
+
+    /// Checks an identifier that references a variable (a use).
+    fn check_reference_identifier(&mut self, identifier: &ast::Identifier) {
+        self.check_identifier(identifier, OccurrenceKind::Reference);
+    }
+
+    /// Checks an identifier that's part of a declaration, e.g. the name of the class.
+    fn check_declaration_identifier(&mut self, identifier: &ast::Identifier) {
+        self.check_identifier(identifier, OccurrenceKind::Declaration);
+    }
+
+    fn check_identifier(&mut self, identifier: &ast::Identifier, kind: OccurrenceKind) {
         // Quick text-based check first
         if identifier.id != self.target_text {
             return;
@@ -503,7 +548,7 @@ impl<'a> LocalReferencesFinder<'a> {
         let mut ancestors_with_identifier = self.ancestors.clone();
         ancestors_with_identifier.push(AnyNodeRef::from(identifier));
         let covering_node = CoveringNode::from_ancestors(ancestors_with_identifier);
-        self.check_reference_from_covering_node(&covering_node);
+        self.check_covering_node(&covering_node, kind);
     }
 
     /// Returns the covering node's resolved definitions.
@@ -525,8 +570,8 @@ impl<'a> LocalReferencesFinder<'a> {
         Some(definitions)
     }
 
-    /// Pushes a reference target when the covering node resolves to any target definition
-    fn check_reference_from_covering_node(&mut self, covering_node: &CoveringNode<'_>) {
+    /// Pushes a reference target when the covering node resolves to any target definition.
+    fn check_covering_node(&mut self, covering_node: &CoveringNode<'_>, kind: OccurrenceKind) {
         let Some(current_definitions) = self.definitions_for_covering_node(covering_node) else {
             return;
         };
@@ -536,104 +581,12 @@ impl<'a> LocalReferencesFinder<'a> {
             return;
         }
 
-        let kind = self.determine_reference_kind(covering_node);
-        let target = ReferenceTarget::new(self.model.file(), covering_node.node().range(), kind);
+        let target = ReferenceTarget::new(
+            self.model.file(),
+            covering_node.node().range(),
+            kind.to_reference_kind(),
+        );
         self.references.push(target);
-    }
-
-    /// Determine whether a reference is a read or write operation based on its context
-    fn determine_reference_kind(&self, covering_node: &CoveringNode<'_>) -> ReferenceKind {
-        // Reference kind is only meaningful for DocumentHighlights mode
-        if !matches!(self.mode, ReferencesMode::DocumentHighlights) {
-            return ReferenceKind::Other;
-        }
-
-        // Walk up the ancestors to find the context
-        for ancestor in self.ancestors.iter().rev() {
-            match ancestor {
-                // Assignment targets are writes
-                AnyNodeRef::StmtAssign(assign) => {
-                    // Check if our node is in the targets (left side) of assignment
-                    for target in &assign.targets {
-                        if Self::expr_contains_range(target, covering_node.node().range()) {
-                            return ReferenceKind::Write;
-                        }
-                    }
-                }
-                AnyNodeRef::StmtAnnAssign(ann_assign)
-                    // Check if our node is the target (left side) of annotated assignment
-                    if Self::expr_contains_range(&ann_assign.target, covering_node.node().range()) => {
-                        return ReferenceKind::Write;
-                    }
-                AnyNodeRef::StmtAugAssign(aug_assign)
-                    // Check if our node is the target (left side) of augmented assignment
-                    if Self::expr_contains_range(&aug_assign.target, covering_node.node().range()) => {
-                        return ReferenceKind::Write;
-                    }
-                // For loop targets are writes
-                AnyNodeRef::StmtFor(for_stmt)
-                    if Self::expr_contains_range(&for_stmt.target, covering_node.node().range()) => {
-                        return ReferenceKind::Write;
-                    }
-                // With statement targets are writes
-                AnyNodeRef::WithItem(with_item) => {
-                    if let Some(optional_vars) = &with_item.optional_vars {
-                        if Self::expr_contains_range(optional_vars, covering_node.node().range()) {
-                            return ReferenceKind::Write;
-                        }
-                    }
-                }
-                // Exception handler names are writes
-                AnyNodeRef::ExceptHandlerExceptHandler(handler) => {
-                    if let Some(name) = &handler.name {
-                        if Self::node_contains_range(
-                            AnyNodeRef::from(name),
-                            covering_node.node().range(),
-                        ) {
-                            return ReferenceKind::Write;
-                        }
-                    }
-                }
-                AnyNodeRef::StmtFunctionDef(func)
-                    if Self::node_contains_range(
-                        AnyNodeRef::from(&func.name),
-                        covering_node.node().range(),
-                    ) => {
-                        return ReferenceKind::Other;
-                    }
-                AnyNodeRef::StmtClassDef(class)
-                    if Self::node_contains_range(
-                        AnyNodeRef::from(&class.name),
-                        covering_node.node().range(),
-                    ) => {
-                        return ReferenceKind::Other;
-                    }
-                AnyNodeRef::Parameter(param)
-                    if Self::node_contains_range(
-                        AnyNodeRef::from(&param.name),
-                        covering_node.node().range(),
-                    ) => {
-                        return ReferenceKind::Other;
-                    }
-                AnyNodeRef::StmtGlobal(_) | AnyNodeRef::StmtNonlocal(_) => {
-                    return ReferenceKind::Other;
-                }
-                _ => {}
-            }
-        }
-
-        // Default to read
-        ReferenceKind::Read
-    }
-
-    /// Helper to check if a node contains a given range
-    fn node_contains_range(node: AnyNodeRef<'_>, range: TextRange) -> bool {
-        node.range().contains_range(range)
-    }
-
-    /// Helper to check if an expression contains a given range
-    fn expr_contains_range(expr: &ast::Expr, range: TextRange) -> bool {
-        expr.range().contains_range(range)
     }
 }
 

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -20,6 +20,7 @@ use ruff_python_ast::{
     visitor::source_order::{SourceOrderVisitor, TraversalSignal},
 };
 use ruff_text_size::Ranged;
+use ty_python_core::definition::{Definition, DefinitionState};
 use ty_python_core::scope::ScopeKind;
 use ty_python_semantic::{ImportAliasResolution, ResolvedDefinition, SemanticModel};
 
@@ -394,13 +395,13 @@ impl<'a> SourceOrderVisitor<'a> for LocalReferencesFinder<'a> {
                 let kind = OccurrenceKind::from(attr_expr.ctx);
                 self.check_identifier(&attr_expr.attr, kind);
             }
-            AnyNodeRef::StmtFunctionDef(func) if self.should_include_declaration() => {
+            AnyNodeRef::StmtFunctionDef(func) => {
                 self.check_declaration_identifier(&func.name);
             }
-            AnyNodeRef::StmtClassDef(class) if self.should_include_declaration() => {
+            AnyNodeRef::StmtClassDef(class) => {
                 self.check_declaration_identifier(&class.name);
             }
-            AnyNodeRef::Parameter(parameter) if self.should_include_declaration() => {
+            AnyNodeRef::Parameter(parameter) => {
                 self.check_declaration_identifier(&parameter.name);
             }
             AnyNodeRef::Keyword(keyword) => {
@@ -408,47 +409,43 @@ impl<'a> SourceOrderVisitor<'a> for LocalReferencesFinder<'a> {
                     self.check_reference_identifier(arg);
                 }
             }
-            AnyNodeRef::StmtGlobal(global_stmt) if self.should_include_declaration() => {
+            AnyNodeRef::StmtGlobal(global_stmt) => {
                 for name in &global_stmt.names {
                     self.check_declaration_identifier(name);
                 }
             }
-            AnyNodeRef::StmtNonlocal(nonlocal_stmt) if self.should_include_declaration() => {
+            AnyNodeRef::StmtNonlocal(nonlocal_stmt) => {
                 for name in &nonlocal_stmt.names {
                     self.check_declaration_identifier(name);
                 }
             }
-            AnyNodeRef::ExceptHandlerExceptHandler(handler)
-                if self.should_include_declaration() =>
-            {
+            AnyNodeRef::ExceptHandlerExceptHandler(handler) => {
                 if let Some(name) = &handler.name {
                     self.check_binding_identifier(name);
                 }
             }
-            AnyNodeRef::PatternMatchAs(pattern_as) if self.should_include_declaration() => {
+            AnyNodeRef::PatternMatchAs(pattern_as) => {
                 if let Some(name) = &pattern_as.name {
                     self.check_binding_identifier(name);
                 }
             }
-            AnyNodeRef::PatternMatchStar(pattern_star) if self.should_include_declaration() => {
+            AnyNodeRef::PatternMatchStar(pattern_star) => {
                 if let Some(name) = &pattern_star.name {
                     self.check_binding_identifier(name);
                 }
             }
-            AnyNodeRef::PatternMatchMapping(pattern_mapping)
-                if self.should_include_declaration() =>
-            {
+            AnyNodeRef::PatternMatchMapping(pattern_mapping) => {
                 if let Some(rest_name) = &pattern_mapping.rest {
                     self.check_binding_identifier(rest_name);
                 }
             }
-            AnyNodeRef::TypeParamParamSpec(param_spec) if self.should_include_declaration() => {
+            AnyNodeRef::TypeParamParamSpec(param_spec) => {
                 self.check_declaration_identifier(&param_spec.name);
             }
-            AnyNodeRef::TypeParamTypeVarTuple(param_tuple) if self.should_include_declaration() => {
+            AnyNodeRef::TypeParamTypeVarTuple(param_tuple) => {
                 self.check_declaration_identifier(&param_tuple.name);
             }
-            AnyNodeRef::TypeParamTypeVar(param_var) if self.should_include_declaration() => {
+            AnyNodeRef::TypeParamTypeVar(param_var) => {
                 self.check_declaration_identifier(&param_var.name);
             }
             AnyNodeRef::ExprStringLiteral(string_expr) => {
@@ -467,7 +464,7 @@ impl<'a> SourceOrderVisitor<'a> for LocalReferencesFinder<'a> {
                     sub_finder.visit_expr(sub_ast.expr());
                 }
             }
-            AnyNodeRef::Alias(alias) if self.should_include_declaration() => {
+            AnyNodeRef::Alias(alias) => {
                 // Handle import alias declarations
                 if let Some(asname) = &alias.asname {
                     self.check_declaration_identifier(asname);
@@ -513,18 +510,7 @@ impl<'a> SourceOrderVisitor<'a> for KeywordArgumentReferencesFinder<'a> {
 }
 
 impl<'a> LocalReferencesFinder<'a> {
-    /// Check if we should include declarations based on the current mode
-    fn should_include_declaration(&self) -> bool {
-        matches!(
-            self.mode,
-            ReferencesMode::References
-                | ReferencesMode::DocumentHighlights
-                | ReferencesMode::Rename
-                | ReferencesMode::RenameMultiFile
-        )
-    }
-
-    /// Checks an identifier of a binding (e.g. `x = 10`).
+    /// Checks an identifier of a binding (e.g. `x = 10`)
     fn check_binding_identifier(&mut self, identifier: &ast::Identifier) {
         self.check_identifier(identifier, OccurrenceKind::Binding);
     }
@@ -570,7 +556,6 @@ impl<'a> LocalReferencesFinder<'a> {
         Some(definitions)
     }
 
-    /// Pushes a reference target when the covering node resolves to any target definition.
     fn check_covering_node(&mut self, covering_node: &CoveringNode<'_>, kind: OccurrenceKind) {
         let Some(current_definitions) = self.definitions_for_covering_node(covering_node) else {
             return;
@@ -581,12 +566,68 @@ impl<'a> LocalReferencesFinder<'a> {
             return;
         }
 
+        if matches!(self.mode, ReferencesMode::ReferencesSkipDeclaration) {
+            let is_declaration = match kind {
+                OccurrenceKind::Declaration => true,
+                OccurrenceKind::Reference => false,
+                OccurrenceKind::Binding => self.is_declaration(covering_node),
+            };
+
+            if is_declaration {
+                return;
+            }
+        }
+
         let target = ReferenceTarget::new(
             self.model.file(),
             covering_node.node().range(),
             kind.to_reference_kind(),
         );
         self.references.push(target);
+    }
+
+    fn is_declaration(&self, covering_node: &CoveringNode<'_>) -> bool {
+        let db = self.model.db();
+
+        let Some(local_definition) = self.model.first_local_definition(covering_node) else {
+            return false;
+        };
+
+        let file = local_definition.file(db);
+        let module = ruff_db::parsed::parsed_module(db, file).load(db);
+        let kind = local_definition.kind(db);
+        let category = kind.category(file.is_stub(db), &module);
+
+        if category.is_declaration() {
+            return true;
+        }
+
+        if self.binding_has_reachable_explicit_declaration(local_definition) {
+            return false;
+        }
+
+        self.binding_is_first_assignment_on_some_path(local_definition)
+    }
+
+    fn binding_has_reachable_explicit_declaration(&self, binding: Definition<'a>) -> bool {
+        let db = self.model.db();
+        let use_def = ty_python_core::use_def_map(db, binding.scope(db));
+        use_def
+            .declarations_at_binding(binding)
+            .any(|declaration| declaration.declaration.definition().is_some())
+    }
+
+    fn binding_is_first_assignment_on_some_path(&self, binding: Definition<'a>) -> bool {
+        let db = self.model.db();
+        let use_def = ty_python_core::use_def_map(db, binding.scope(db));
+        use_def
+            .bindings_at_definition(binding)
+            .any(|prior_binding| {
+                matches!(
+                    prior_binding.binding,
+                    DefinitionState::Deleted | DefinitionState::Undefined
+                )
+            })
     }
 }
 

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -11,7 +11,7 @@
 //! an expensive search of all source files in the workspace.
 
 use crate::goto::{Definitions, GotoTarget};
-use crate::{Db, NavigationTarget, NavigationTargets, ReferenceKind, ReferenceTarget};
+use crate::{Db, ReferenceKind, ReferenceTarget};
 use ruff_db::files::File;
 use ruff_python_ast::find_node::{CoveringNode, covering_node};
 use ruff_python_ast::token::Tokens;
@@ -79,11 +79,10 @@ pub(crate) fn references(
     mode: ReferencesMode,
 ) -> Option<Vec<ReferenceTarget>> {
     let model = SemanticModel::new(db, file);
-    let target_definitions =
-        goto_target.get_definition_targets(&model, mode.to_import_alias_resolution())?;
+    let target_definitions = goto_target.definitions(&model, mode.to_import_alias_resolution())?;
     let is_externally_visible_symbol =
         has_any_external_visible_definitions(db, &target_definitions);
-    let target_definitions = target_definitions.declaration_targets(&model, goto_target)?;
+    let target_definitions = target_definitions.goto_declaration(&model, goto_target)?;
 
     // Extract the target text from the goto target for fast comparison
     let target_text = goto_target.to_string()?;
@@ -164,7 +163,7 @@ pub(crate) fn references(
 fn references_for_keyword_arguments_in_file(
     db: &dyn Db,
     file: File,
-    target_definitions: &NavigationTargets,
+    target_definitions: &Definitions<'_>,
     target_text: &str,
     mode: ReferencesMode,
 ) -> Vec<ReferenceTarget> {
@@ -225,29 +224,12 @@ fn is_ascii_identifier_continue(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
-/// Return true if the declaration-target sets intersect.
-///
-/// A symbol can resolve to multiple declaration targets (for example, overload groups or an
-/// import binding plus its underlying definition). Intersection semantics avoid missing valid
-/// references/renames when target ordering differs.
-fn navigation_targets_intersect(
-    target_definitions: &NavigationTargets,
-    current_targets: &NavigationTargets,
-) -> bool {
-    target_definitions.iter().any(|target_definition| {
-        current_targets.iter().any(|current_target| {
-            current_target.file == target_definition.file
-                && current_target.focus_range == target_definition.focus_range
-        })
-    })
-}
-
 /// Find all references to a local symbol within the current file.
 /// The behavior depends on the provided mode.
 fn references_for_file(
     db: &dyn Db,
     file: File,
-    target_definitions: &NavigationTargets,
+    target_definitions: &Definitions<'_>,
     target_text: &str,
     mode: ReferencesMode,
 ) -> Vec<ReferenceTarget> {
@@ -273,7 +255,7 @@ fn references_for_file(
 
 /// Determines whether the resolved definitions can have references outside their file.
 fn has_any_external_visible_definitions(db: &dyn Db, definitions: &Definitions<'_>) -> bool {
-    definitions.0.iter().any(|definition| match definition {
+    definitions.iter().any(|definition| match definition {
         ResolvedDefinition::Definition(definition) => match definition.scope(db).scope(db).kind() {
             ScopeKind::Module | ScopeKind::Class => true,
             ScopeKind::TypeParams
@@ -292,7 +274,7 @@ fn has_any_external_visible_definitions(db: &dyn Db, definitions: &Definitions<'
 /// when the owning callable is visible outside of the current module.
 fn parameter_owner_is_externally_visible(
     db: &dyn Db,
-    target_definitions: &NavigationTargets,
+    target_definitions: &Definitions<'_>,
 ) -> bool {
     target_definitions
         .iter()
@@ -301,13 +283,14 @@ fn parameter_owner_is_externally_visible(
 
 fn parameter_owner_is_externally_visible_for_target(
     db: &dyn Db,
-    target: &NavigationTarget,
+    definition: &ResolvedDefinition,
 ) -> bool {
+    let target = definition.focus_range(db);
     let file = target.file();
     let parsed = ruff_db::parsed::parsed_module(db, file);
     let module = parsed.load(db);
 
-    let covering = covering_node(module.syntax().into(), target.focus_range());
+    let covering = covering_node(module.syntax().into(), target.range());
     let Ok(parameter_covering) =
         covering.find_last(|node| matches!(node, AnyNodeRef::Parameter(_)))
     else {
@@ -356,7 +339,7 @@ fn parameter_owner_is_externally_visible_for_target(
 struct LocalReferencesFinder<'a> {
     model: &'a SemanticModel<'a>,
     tokens: &'a Tokens,
-    target_definitions: &'a NavigationTargets,
+    target_definitions: &'a Definitions<'a>,
     references: &'a mut Vec<ReferenceTarget>,
     mode: ReferencesMode,
     target_text: &'a str,
@@ -498,7 +481,7 @@ impl<'a> SourceOrderVisitor<'a> for KeywordArgumentReferencesFinder<'a> {
     }
 }
 
-impl LocalReferencesFinder<'_> {
+impl<'a> LocalReferencesFinder<'a> {
     /// Check if we should include declarations based on the current mode
     fn should_include_declaration(&self) -> bool {
         matches!(
@@ -510,7 +493,7 @@ impl LocalReferencesFinder<'_> {
         )
     }
 
-    /// Helper method to check identifier references for declarations
+    /// Helper method to check identifier references.
     fn check_identifier_reference(&mut self, identifier: &ast::Identifier) {
         // Quick text-based check first
         if identifier.id != self.target_text {
@@ -523,39 +506,39 @@ impl LocalReferencesFinder<'_> {
         self.check_reference_from_covering_node(&covering_node);
     }
 
-    /// Returns true if the covering node's resolved definitions intersect `target_definitions`.
-    fn matches_target_definitions(&self, covering_node: &CoveringNode<'_>) -> bool {
+    /// Returns the covering node's resolved definitions.
+    fn definitions_for_covering_node(
+        &self,
+        covering_node: &CoveringNode<'_>,
+    ) -> Option<Definitions<'a>> {
         // Use the start of the covering node as the offset. Any offset within
         // the node is fine here. Offsets matter only for import statements
         // where the identifier might be a multi-part module name.
         let offset = covering_node.node().start();
-        let Some(goto_target) =
-            GotoTarget::from_covering_node(self.model, covering_node, offset, self.tokens)
-        else {
-            return false;
-        };
+        let goto_target =
+            GotoTarget::from_covering_node(self.model, covering_node, offset, self.tokens)?;
 
-        // Get the definitions for this goto target
-        let Some(current_definitions) = goto_target
-            .get_definition_targets(self.model, self.mode.to_import_alias_resolution())
-            .and_then(|definitions| definitions.declaration_targets(self.model, &goto_target))
-        else {
-            return false;
-        };
+        let definitions = goto_target
+            .definitions(self.model, self.mode.to_import_alias_resolution())?
+            .goto_declaration(self.model, &goto_target)?;
 
-        // Check if any of the current definitions match our target definitions
-        navigation_targets_intersect(self.target_definitions, &current_definitions)
+        Some(definitions)
     }
 
     /// Pushes a reference target when the covering node resolves to any target definition
     fn check_reference_from_covering_node(&mut self, covering_node: &CoveringNode<'_>) {
-        if self.matches_target_definitions(covering_node) {
-            // Determine if this is a read or write reference
-            let kind = self.determine_reference_kind(covering_node);
-            let target =
-                ReferenceTarget::new(self.model.file(), covering_node.node().range(), kind);
-            self.references.push(target);
+        let Some(current_definitions) = self.definitions_for_covering_node(covering_node) else {
+            return;
+        };
+
+        // Check if any of the current definitions match our target definitions
+        if !self.target_definitions.intersects(&current_definitions) {
+            return;
         }
+
+        let kind = self.determine_reference_kind(covering_node);
+        let target = ReferenceTarget::new(self.model.file(), covering_node.node().range(), kind);
+        self.references.push(target);
     }
 
     /// Determine whether a reference is a read or write operation based on its context
@@ -665,7 +648,7 @@ mod tests {
         let goto_target =
             find_goto_target(&model, &test.cursor.parsed, test.cursor.offset).unwrap();
         let definitions = goto_target
-            .get_definition_targets(
+            .definitions(
                 &model,
                 ReferencesMode::References.to_import_alias_resolution(),
             )

--- a/crates/ty_ide/src/rename.rs
+++ b/crates/ty_ide/src/rename.rs
@@ -24,11 +24,12 @@ pub fn can_rename(db: &dyn Db, file: File, offset: TextSize) -> Option<ruff_text
 
     let current_file_in_project = is_file_in_project(db, file);
 
-    let definition_targets = goto_target
-        .get_definition_targets(&model, ReferencesMode::Rename.to_import_alias_resolution())?
-        .declaration_targets(&model, &goto_target)?;
+    let declaration_targets = goto_target
+        .definitions(&model, ReferencesMode::Rename.to_import_alias_resolution())?
+        .goto_declaration(&model, &goto_target)?
+        .into_navigation_targets(model.db());
 
-    for target in &definition_targets {
+    for target in &declaration_targets {
         let target_file = target.file();
 
         // If definition is outside the project, refuse rename

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -1491,6 +1491,12 @@ impl<'db> LoopHeaderDefinitionKind<'db> {
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, salsa::Update, get_size2::GetSize)]
 pub struct DefinitionNodeKey(NodeKey);
 
+impl DefinitionNodeKey {
+    pub(crate) fn from_node_ref(node: ast::AnyNodeRef<'_>) -> Self {
+        Self(NodeKey::from_node(node))
+    }
+}
+
 impl From<&ast::Alias> for DefinitionNodeKey {
     fn from(node: &ast::Alias) -> Self {
         Self(NodeKey::from_node(node))

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -502,6 +502,15 @@ impl<'db> SemanticIndex<'db> {
         &self.definitions_by_node[&definition_key.into()]
     }
 
+    /// Returns the [`definition::Definition`] salsa ingredient(s) for `definition_node`, if any.
+    pub fn try_definitions(
+        &self,
+        definition_node: ast::AnyNodeRef<'_>,
+    ) -> Option<&Definitions<'db>> {
+        let definition_key = DefinitionNodeKey::from_node_ref(definition_node);
+        self.definitions_by_node.get(&definition_key)
+    }
+
     /// Returns the [`definition::Definition`] salsa ingredient for `definition_key`.
     ///
     /// ## Panics

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -1,10 +1,12 @@
 use ruff_db::files::{File, FilePath};
 use ruff_db::parsed::{parsed_module, parsed_string_annotation};
 use ruff_db::source::{line_index, source_text};
+use ruff_python_ast::find_node::CoveringNode;
 use ruff_python_ast::{self as ast, ExprStringLiteral, ModExpression};
 use ruff_python_ast::{Expr, ExprRef, name::Name};
 use ruff_python_parser::Parsed;
 use ruff_source_file::LineIndex;
+use ruff_text_size::Ranged;
 use rustc_hash::FxHashMap;
 use ty_module_resolver::{
     KnownModule, Module, ModuleName, list_modules, resolve_module, resolve_real_shadowable_module,
@@ -322,6 +324,42 @@ impl<'db> SemanticModel<'db> {
                 Some(expr) => index.try_expression_scope_id(&expr),
             },
         }
+    }
+
+    /// Returns the first local definition created by `covering_node`, if any.
+    ///
+    /// A local definition is a user-visible definition associated with `covering_node` itself, or
+    /// one of its ancestors, whose focus range covers the queried node. This returns only the first
+    /// match because one syntax node can represent multiple semantic definitions, for example
+    /// `from module import *`. This helper is intended for classifying the local occurrence, such as
+    /// deciding whether it is a binding or declaration, not for enumerating every symbol introduced
+    /// by the syntax.
+    pub fn first_local_definition(
+        &self,
+        covering_node: &CoveringNode<'_>,
+    ) -> Option<Definition<'db>> {
+        let index = semantic_index(self.db, self.file);
+        let parsed = parsed_module(self.db, self.file).load(self.db);
+        let target_range = covering_node.node().range();
+
+        for node in covering_node.ancestors() {
+            let Some(definitions) = index.try_definitions(node) else {
+                continue;
+            };
+
+            if let Some(definition) = definitions.iter().copied().find(|definition| {
+                let kind = definition.kind(self.db);
+                kind.is_user_visible()
+                    && definition
+                        .focus_range(self.db, &parsed)
+                        .range()
+                        .contains_range(target_range)
+            }) {
+                return Some(definition);
+            }
+        }
+
+        None
     }
 
     /// Get a "safe" [`ast::AnyNodeRef`] to use for referring to the given (sub-)AST node.
@@ -726,6 +764,9 @@ impl_binding_has_ty_def!(ast::StmtClassDef);
 impl_binding_has_ty_def!(ast::Parameter);
 impl_binding_has_ty_def!(ast::ParameterWithDefault);
 impl_binding_has_ty_def!(ast::TypeParamTypeVar);
+impl_binding_has_ty_def!(ast::TypeParamParamSpec);
+impl_binding_has_ty_def!(ast::TypeParamTypeVarTuple);
+impl_binding_has_ty_def!(ast::StmtTypeAlias);
 
 impl HasType for ast::Alias {
     fn inferred_type<'db>(&self, model: &SemanticModel<'db>) -> Option<Type<'db>> {
@@ -740,6 +781,7 @@ impl HasType for ast::Alias {
 impl HasOptionalDefinition for ast::ExceptHandlerExceptHandler {
     fn optional_definition<'db>(&self, model: &SemanticModel<'db>) -> Option<Definition<'db>> {
         self.name.as_ref()?;
+
         let index = semantic_index(model.db, model.file);
         Some(index.expect_single_definition(self))
     }
@@ -754,11 +796,10 @@ impl HasType for ast::ExceptHandlerExceptHandler {
 
 #[cfg(test)]
 mod tests {
-    use ruff_db::files::system_path_to_file;
-    use ruff_db::parsed::parsed_module;
-
     use crate::db::tests::TestDbBuilder;
     use crate::{HasType, SemanticModel};
+    use ruff_db::files::system_path_to_file;
+    use ruff_db::parsed::parsed_module;
 
     #[test]
     fn function_type() -> anyhow::Result<()> {

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1268,6 +1268,7 @@ mod resolve_definition {
     use ruff_db::vendored::VendoredPathBuf;
     use ruff_python_ast as ast;
     use ruff_python_stdlib::sys::is_builtin_module;
+    use ruff_text_size::TextRange;
     use rustc_hash::FxHashSet;
     use tracing::trace;
     use ty_module_resolver::{ModuleName, file_to_module, resolve_module, resolve_real_module};
@@ -1295,6 +1296,18 @@ mod resolve_definition {
     }
 
     impl<'db> ResolvedDefinition<'db> {
+        pub fn focus_range(&self, db: &dyn Db) -> FileRange {
+            match self {
+                ResolvedDefinition::Definition(definition) => {
+                    let parsed = parsed_module(db, definition.file(db)).load(db);
+                    definition.focus_range(db, &parsed)
+                }
+                // For modules, navigate to the start of the file
+                ResolvedDefinition::Module(module) => FileRange::new(*module, TextRange::default()),
+                ResolvedDefinition::FileWithRange(file_range) => *file_range,
+            }
+        }
+
         pub fn definition(&self) -> Option<Definition<'db>> {
             match self {
                 ResolvedDefinition::Definition(definition) => Some(*definition),

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1276,7 +1276,7 @@ mod resolve_definition {
     use crate::Db;
     use crate::module_docstring;
     use crate::types::binding_type;
-    use ty_python_core::definition::{Definition, DefinitionKind};
+    use ty_python_core::definition::{Definition, DefinitionCategory, DefinitionKind};
     use ty_python_core::scope::{NodeWithScopeKind, ScopeId};
     use ty_python_core::{global_scope, place_table, semantic_index, use_def_map};
 
@@ -1305,6 +1305,19 @@ mod resolve_definition {
                 // For modules, navigate to the start of the file
                 ResolvedDefinition::Module(module) => FileRange::new(*module, TextRange::default()),
                 ResolvedDefinition::FileWithRange(file_range) => *file_range,
+            }
+        }
+
+        pub fn category(&self, db: &dyn Db) -> DefinitionCategory {
+            match self {
+                ResolvedDefinition::Definition(definition) => {
+                    let file = definition.file(db);
+                    let parsed = parsed_module(db, file).load(db);
+                    definition.kind(db).category(file.is_stub(db), &parsed)
+                }
+                ResolvedDefinition::Module(_) | ResolvedDefinition::FileWithRange(_) => {
+                    DefinitionCategory::DeclarationAndBinding
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

This PR extends our support for `includeDeclaration` by making it depend on the semantic model's classification instead of only excluding a fixed set of nodes, which didn't cover `ExprName`, which is rather important. 

I first assumed that this would be an easy single line fix. Well, I was very wrong :). There were two main issues that I ran into:

1. Our reference machinary almost immediately went from operating on `ResolvedDefinition` to the generic `NavigationTargets`, which only stores ranges. This now became an issue because `NavigationTarget` doesn't support any semantic operations. 
2. `GotoTarget::definitions` answers the question: to which definitions can the node possibly resolve to. For example, if you have `x = 10;x=20; print(x)`, the definitions for all thre statements are the same: `x = 10` and `x = 20`. However, we had no API that answers the queestion: What definition does `x = 10` resolve to (which is `x = 10`, but not `x = 20`). 

The first commit in this PR is a pure refactor that addresses 1. by deferring the `Vec<ResolvedDefinition>` -> `NavigationTargets` conversation until we have to send the LSP response .


The third commit introduces a new `first_local_definition` method that returns the definition a specific node introduces.

The second commit is somewhat unrelated but something I stumbled over when implementing this feature. Instead of traversing the `CoveringNode` to determine the `ReferenceKind` of a statement, pass that information down when calling `check_identifier`. Not only reduces this a bunch of code, but we can use the same information to skip the `first_local_declaration` call when it is known that this node is _alway_ a declaration.


Besides these technical challenges, it's also not well defined what `includeDeclaration: false` should exclude. The behavior I landed on is:

Always exclude explicit declarations (category = `Declaration` and `DeclarationAndBinding`). E.g. exclude function declarations, annotated assignments, class declarations, etc. 

For plain bindings (`x = 10`, `fox x in ...`), the logic is a bit more involved

* Keep the binding if the symbol has an explicit declaration (e.g. an annotated assignment), because it is a write to the same symbol. 
* Otherwise, only exclude it if it is the first reachable binding, but keep later assignments

A few examples:

```py
x = 1
x = 2
print(x)
```

We now exclude `x = 1` but keep `x = 2` and `print(x)`.

```py
if flag:
    x = 1
else:
    x = 2
print(x)
```

We exclude both `x = 1` and `x = 2` because both are their first definition in their control flow.

```py
def test(flag: bool):
    if flag:
        x: int = 1
        return

    x = 2
    print(x)
```

Filter out both `x: int = 1` and `x = 2`, because they're both the first reachable declarations 

Closes https://github.com/astral-sh/ty/issues/1950

## Test Plan

Added integration tests.

It's a bit funny. I tried to test this in an IDE but neither VS Code nor Zed support `includeDeclaration = false`... I'd deprioritized this task if I knew earlier, but now is a bit too late :)