### PR TITLE
Increase max allowed value of `line-length` setting

### DIFF
--- a/crates/ruff_linter/src/line_width.rs
+++ b/crates/ruff_linter/src/line_width.rs
@@ -17,12 +17,12 @@ use ruff_text_size::TextSize;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct LineLength(
-    #[cfg_attr(feature = "schemars", schemars(range(min = 1, max = 320)))] NonZeroU16,
+    #[cfg_attr(feature = "schemars", schemars(range(min = 1, max = 65536)))] NonZeroU16,
 );
 
 impl LineLength {
     /// Maximum allowed value for a valid [`LineLength`]
-    pub const MAX: u16 = 320;
+    pub const MAX: u16 = 65535;
 
     /// Return the numeric value for this [`LineLength`]
     pub fn value(&self) -> u16 {

--- a/crates/ruff_linter/src/line_width.rs
+++ b/crates/ruff_linter/src/line_width.rs
@@ -17,7 +17,7 @@ use ruff_text_size::TextSize;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct LineLength(
-    #[cfg_attr(feature = "schemars", schemars(range(min = 1, max = 65536)))] NonZeroU16,
+    #[cfg_attr(feature = "schemars", schemars(range(min = 1, max = 65535)))] NonZeroU16,
 );
 
 impl LineLength {
@@ -115,8 +115,8 @@ impl TryFrom<u16> for LineLength {
 
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         match NonZeroU16::try_from(value) {
-            Ok(value) if value.get() <= Self::MAX => Ok(LineLength(value)),
-            Ok(_) | Err(_) => Err(LineLengthFromIntError(value)),
+            Ok(value) => Ok(LineLength(value)),
+            Err(_) => Err(LineLengthFromIntError(value)),
         }
     }
 }

--- a/crates/ruff_linter/src/line_width.rs
+++ b/crates/ruff_linter/src/line_width.rs
@@ -13,7 +13,7 @@ use ruff_text_size::TextSize;
 
 /// The length of a line of text that is considered too long.
 ///
-/// The allowed range of values is 1..=320
+/// The allowed range of values is 1..=65535
 #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct LineLength(

--- a/crates/ruff_linter/src/line_width.rs
+++ b/crates/ruff_linter/src/line_width.rs
@@ -22,7 +22,7 @@ pub struct LineLength(
 
 impl LineLength {
     /// Maximum allowed value for a valid [`LineLength`]
-    pub const MAX: u16 = 65535;
+    pub const MAX: u16 = u16::MAX;
 
     /// Return the numeric value for this [`LineLength`]
     pub fn value(&self) -> u16 {

--- a/crates/ruff_linter/src/line_width.rs
+++ b/crates/ruff_linter/src/line_width.rs
@@ -16,9 +16,7 @@ use ruff_text_size::TextSize;
 /// The allowed range of values is 1..=65535
 #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub struct LineLength(
-    NonZeroU16,
-);
+pub struct LineLength(NonZeroU16);
 
 impl LineLength {
     /// Maximum allowed value for a valid [`LineLength`]

--- a/crates/ruff_linter/src/line_width.rs
+++ b/crates/ruff_linter/src/line_width.rs
@@ -17,7 +17,7 @@ use ruff_text_size::TextSize;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct LineLength(
-    #[cfg_attr(feature = "schemars", schemars(range(min = 1, max = 65535)))] NonZeroU16,
+    NonZeroU16,
 );
 
 impl LineLength {

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -439,7 +439,7 @@ pub struct Options {
     /// The length is determined by the number of characters per line, except for lines containing East Asian characters or emojis.
     /// For these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.
     ///
-    /// The value must be greater than `0` and less than or equal to `65535`.
+    /// The value must be greater than `0`.
     ///
     /// Note: While the formatter will attempt to format lines such that they remain
     /// within the `line-length`, it isn't a hard upper bound, and formatted lines may

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -439,7 +439,7 @@ pub struct Options {
     /// The length is determined by the number of characters per line, except for lines containing East Asian characters or emojis.
     /// For these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.
     ///
-    /// The value must be greater than `0` and less than or equal to `320`.
+    /// The value must be greater than `0` and less than or equal to `65535`.
     ///
     /// Note: While the formatter will attempt to format lines such that they remain
     /// within the `line-length`, it isn't a hard upper bound, and formatted lines may

--- a/crates/ruff_workspace/src/pyproject.rs
+++ b/crates/ruff_workspace/src/pyproject.rs
@@ -473,33 +473,6 @@ other-attribute = 1
             .is_err()
         );
 
-        let invalid_line_length = toml::from_str::<Pyproject>(
-            r"
-[tool.ruff]
-line-length = 500
-",
-        )
-        .expect_err("Deserialization should have failed for a too large line-length");
-
-        assert_eq!(
-            invalid_line_length.message(),
-            "line-length must be between 1 and 320 (got 500)"
-        );
-
-        // Test value at u16::MAX boundary (65535) - should show range error
-        let invalid_line_length_65535 = toml::from_str::<Pyproject>(
-            r"
-[tool.ruff]
-line-length = 65535
-",
-        )
-        .expect_err("Deserialization should have failed for line-length at u16::MAX");
-
-        assert_eq!(
-            invalid_line_length_65535.message(),
-            "line-length must be between 1 and 320 (got 65535)"
-        );
-
         // Test value exceeding u16::MAX (65536) - should show clear error
         let invalid_line_length_65536 = toml::from_str::<Pyproject>(
             r"
@@ -511,7 +484,7 @@ line-length = 65536
 
         assert_eq!(
             invalid_line_length_65536.message(),
-            "line-length must be between 1 and 320 (got 65536)"
+            "line-length must be between 1 and 65535 (got 65536)"
         );
 
         // Test value far exceeding u16::MAX (99_999) - should show clear error
@@ -525,7 +498,7 @@ line-length = 99_999
 
         assert_eq!(
             invalid_line_length_99999.message(),
-            "line-length must be between 1 and 320 (got 99999)"
+            "line-length must be between 1 and 65535 (got 99999)"
         );
 
         // Test negative value - should show clear error
@@ -539,7 +512,7 @@ line-length = -5
 
         assert_eq!(
             invalid_line_length_negative.message(),
-            "line-length must be between 1 and 320 (got -5)"
+            "line-length must be between 1 and 65535 (got -5)"
         );
 
         Ok(())

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -498,7 +498,7 @@
       "deprecated": true
     },
     "line-length": {
-      "description": "The line length to use when enforcing long-lines violations (like `E501`)\nand at which `isort` and the formatter prefers to wrap lines.\n\nThe length is determined by the number of characters per line, except for lines containing East Asian characters or emojis.\nFor these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.\n\nThe value must be greater than `0` and less than or equal to `320`.\n\nNote: While the formatter will attempt to format lines such that they remain\nwithin the `line-length`, it isn't a hard upper bound, and formatted lines may\nexceed the `line-length`.\n\nSee [`pycodestyle.max-line-length`](#lint_pycodestyle_max-line-length) to configure different lengths for `E501` and the formatter.",
+      "description": "The line length to use when enforcing long-lines violations (like `E501`)\nand at which `isort` and the formatter prefers to wrap lines.\n\nThe length is determined by the number of characters per line, except for lines containing East Asian characters or emojis.\nFor these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.\n\nThe value must be greater than `0` and less than or equal to `65535`.\n\nNote: While the formatter will attempt to format lines such that they remain\nwithin the `line-length`, it isn't a hard upper bound, and formatted lines may\nexceed the `line-length`.\n\nSee [`pycodestyle.max-line-length`](#lint_pycodestyle_max-line-length) to configure different lengths for `E501` and the formatter.",
       "anyOf": [
         {
           "$ref": "#/definitions/LineLength"
@@ -2101,10 +2101,10 @@
       ]
     },
     "LineLength": {
-      "description": "The length of a line of text that is considered too long.\n\nThe allowed range of values is 1..=320",
+      "description": "The length of a line of text that is considered too long.\n\nThe allowed range of values is 1..=65535",
       "type": "integer",
       "format": "uint16",
-      "maximum": 320,
+      "maximum": 65535,
       "minimum": 1
     },
     "LineWidth": {

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -498,7 +498,7 @@
       "deprecated": true
     },
     "line-length": {
-      "description": "The line length to use when enforcing long-lines violations (like `E501`)\nand at which `isort` and the formatter prefers to wrap lines.\n\nThe length is determined by the number of characters per line, except for lines containing East Asian characters or emojis.\nFor these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.\n\nThe value must be greater than `0` and less than or equal to `65535`.\n\nNote: While the formatter will attempt to format lines such that they remain\nwithin the `line-length`, it isn't a hard upper bound, and formatted lines may\nexceed the `line-length`.\n\nSee [`pycodestyle.max-line-length`](#lint_pycodestyle_max-line-length) to configure different lengths for `E501` and the formatter.",
+      "description": "The line length to use when enforcing long-lines violations (like `E501`)\nand at which `isort` and the formatter prefers to wrap lines.\n\nThe length is determined by the number of characters per line, except for lines containing East Asian characters or emojis.\nFor these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.\n\nThe value must be greater than `0`.\n\nNote: While the formatter will attempt to format lines such that they remain\nwithin the `line-length`, it isn't a hard upper bound, and formatted lines may\nexceed the `line-length`.\n\nSee [`pycodestyle.max-line-length`](#lint_pycodestyle_max-line-length) to configure different lengths for `E501` and the formatter.",
       "anyOf": [
         {
           "$ref": "#/definitions/LineLength"


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

This moves the arbitrary line-length upper limit of 320 to the declared u16 type max of 65535, better allowing coders who have editors capable of line-wrapping to denote when they want lines to be forcibly broken up with trailing commas where applicable.

## Test Plan

Compiled, and run against scripts reformatted by the 320 limit.  It correctly flattened the previously exploded lists and functions when the trailing comma was removed.

Applicable issues:
Closes https://github.com/astral-sh/ruff/issues/24547
#8106