### PR TITLE
[ty] Fix missing visitor guard in `Callable` branch

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5768,9 +5768,9 @@ impl<'db> Type<'db> {
                 ))
             }
 
-            Type::Callable(callable) => {
+            Type::Callable(callable) => visitor.visit(self, type_mapping, || {
                 Type::Callable(callable.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
-            }
+            }),
 
             Type::GenericAlias(generic) => {
                 Type::GenericAlias(generic.apply_type_mapping_impl(db, type_mapping, tcx, visitor))


### PR DESCRIPTION
## Summary

This came up in a subsequent PR, but I think it's just missing here.