### PR TITLE
[ty] Support narrowing on `dict.get` calls

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3601,6 +3601,13 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                     }
                 }
             }
+            ast::Expr::Call(call) => {
+                walk_expr(self, expr);
+
+                if let Some(place_expr) = PlaceExpr::try_from_get_method_call(call) {
+                    self.add_place(place_expr);
+                }
+            }
             ast::Expr::Named(node) => {
                 // TODO walrus in comprehensions is implicitly nonlocal
                 self.visit_expr(&node.value);

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -56,6 +56,32 @@ impl PlaceExpr {
         MemberExprBuilder::visit_expr(expr).and_then(Self::try_from_member_expr)
     }
 
+    /// Tries to create the equivalent subscript place for a call like `x.get("key")`.
+    ///
+    /// This is intentionally syntactic. Callers that use the returned place for narrowing must
+    /// still verify that the receiver type has `dict.get` semantics.
+    pub fn try_from_get_method_call(expr_call: &ast::ExprCall) -> Option<Self> {
+        if !expr_call.arguments.keywords.is_empty() {
+            return None;
+        }
+
+        let [key] = &*expr_call.arguments.args else {
+            return None;
+        };
+
+        let ast::Expr::Attribute(attribute) = expr_call.func.as_ref() else {
+            return None;
+        };
+
+        if attribute.attr.id != "get" {
+            return None;
+        }
+
+        let value = MemberExprBuilder::visit_expr(ast::ExprRef::from(attribute.value.as_ref()))?;
+        let subscript = MemberExprBuilder::visit_subscript_expr(value, key)?;
+        Self::try_from_member_expr(subscript)
+    }
+
     /// Tries to create a `PlaceExpr` from a member expression.
     ///
     /// Returns `None` if the expression is not a valid place expression and `Some` otherwise.
@@ -669,6 +695,14 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
     fn expr_call(&self, expr_call: &ast::ExprCall) -> PossiblyNarrowedPlaces {
         let mut places = PossiblyNarrowedPlaces::default();
 
+        // Include the synthetic subscript place that `.get()` may narrow; semantic checks decide
+        // whether the call actually has `dict.get` semantics.
+        if let Some(place_expr) = PlaceExpr::try_from_get_method_call(expr_call)
+            && let Some(place) = self.places.place_id((&place_expr).into())
+        {
+            places.insert(place);
+        }
+
         // Under the current narrowing semantics, we only ever use the first two positional
         // arguments: argument 0 for most narrowing calls, and argument 1 for unbound
         // TypeGuard/TypeIs methods (e.g. `C.f(C(), x)`).
@@ -717,9 +751,19 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
         }
 
         match expr.expression_value() {
-            // type(x) is Y can narrow x
-            ast::Expr::Call(call) if call.arguments.args.len() == 1 => {
-                if let Some(first_arg) = call.arguments.args.first() {
+            ast::Expr::Call(call) => {
+                // Include the synthetic subscript place that `.get()` may narrow; semantic checks
+                // decide whether the call actually has `dict.get` semantics.
+                if let Some(place_expr) = PlaceExpr::try_from_get_method_call(call)
+                    && let Some(place) = self.places.place_id((&place_expr).into())
+                {
+                    places.insert(place);
+                }
+
+                // type(x) is Y can narrow x
+                if call.arguments.args.len() == 1
+                    && let Some(first_arg) = call.arguments.args.first()
+                {
                     if let Some(place_expr) = PlaceExpr::try_from_expr(first_arg) {
                         if let Some(place) = self.places.place_id((&place_expr).into()) {
                             places.insert(place);

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -744,13 +744,18 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
 
     /// Helper to add a potential narrowing target expression to the set.
     fn add_narrowing_target(&self, expr: &ast::Expr, places: &mut PossiblyNarrowedPlaces) {
-        if let Some(place_expr) = PlaceExpr::try_from_expr(expr) {
-            if let Some(place) = self.places.place_id((&place_expr).into()) {
-                places.insert(place);
+        match expr {
+            ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::Subscript(_) => {
+                if let Some(place_expr) = PlaceExpr::try_from_expr(expr) {
+                    if let Some(place) = self.places.place_id((&place_expr).into()) {
+                        places.insert(place);
+                    }
+                }
             }
-        }
-
-        match expr.expression_value() {
+            ast::Expr::Named(expr_named) => {
+                places.extend(self.simple_expr(&expr_named.target));
+                places.extend(self.expression_node(&expr_named.value));
+            }
             ast::Expr::Call(call) => {
                 // Include the synthetic subscript place that `.get()` may narrow; semantic checks
                 // decide whether the call actually has `dict.get` semantics.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
@@ -467,12 +467,20 @@ def dict_get(d: dict[str, str | None]):
         reveal_type(d["a"])  # revealed: str
         reveal_type(d["b"])  # revealed: str | None
     else:
-        reveal_type(d["a"])  # revealed: str | None
+        reveal_type(d["a"])  # revealed: None
 
     if d.get("a") is None:
         return
 
     reveal_type(d["a"])  # revealed: str
+
+def dict_get_walrus(d: dict[str, str | None]):
+    if (value := d.get("a")) is None:
+        reveal_type(value)  # revealed: None
+        reveal_type(d["a"])  # revealed: None
+    else:
+        reveal_type(value)  # revealed: str
+        reveal_type(d["a"])  # revealed: str
 
 from typing_extensions import NotRequired, TypedDict
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
@@ -461,6 +461,18 @@ def _(d: dict[str, str | None]):
     if d["a"] is not None:
         reveal_type(d["a"])  # revealed: str
         reveal_type(d["b"])  # revealed: str | None
+
+def dict_get(d: dict[str, str | None]):
+    if d.get("a") is not None:
+        reveal_type(d["a"])  # revealed: str
+        reveal_type(d["b"])  # revealed: str | None
+    else:
+        reveal_type(d["a"])  # revealed: str | None
+
+    if d.get("a") is None:
+        return
+
+    reveal_type(d["a"])  # revealed: str
 ```
 
 ## Combined attribute and subscript narrowing

--- a/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
@@ -473,6 +473,19 @@ def dict_get(d: dict[str, str | None]):
         return
 
     reveal_type(d["a"])  # revealed: str
+
+from typing_extensions import NotRequired, TypedDict
+
+class TD(TypedDict):
+    required: str | None
+    optional: NotRequired[str | None]
+
+def typed_dict_get(td: TD):
+    if td.get("required") is not None:
+        reveal_type(td["required"])  # revealed: str
+
+    if td.get("optional") is not None:
+        reveal_type(td["optional"])  # revealed: str
 ```
 
 ## Combined attribute and subscript narrowing

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1190,6 +1190,14 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             )
         }
 
+        fn expression_value(expr: &ast::Expr) -> &ast::Expr {
+            let mut expr = expr;
+            while let ast::Expr::Named(named) = expr {
+                expr = &named.value;
+            }
+            expr
+        }
+
         /// Attempt to find an underlying class literal for purposes of `if type(x) is Y` narrowing.
         ///
         /// We deliberately return `None` for generic-alias types, since narrowing based
@@ -1441,7 +1449,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             // - `if d.get("key") is None`
             // - `if None is not d.get("key")`
             // - `if None is d.get("key")`
-            if let ast::Expr::Call(call) = left
+            if let ast::Expr::Call(call) = expression_value(left)
                 && let Some((place, constraint)) =
                     self.narrow_dict_get_call(inference, call, rhs_ty, *op, is_positive)
             {
@@ -1453,7 +1461,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     .or_insert(constraint);
             }
 
-            if let ast::Expr::Call(call) = right
+            if let ast::Expr::Call(call) = expression_value(right)
                 && let Some((place, constraint)) =
                     self.narrow_dict_get_call(inference, call, lhs_ty, *op, is_positive)
             {
@@ -2091,8 +2099,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         }
     }
 
-    /// Narrow the matching subscript place for a `dict.get` or `TypedDict.get` call proven to
-    /// return a non-`None` value.
+    /// Narrow the matching subscript place for a `dict.get` or `TypedDict.get` call compared
+    /// against `None`.
     ///
     /// For example, given `d: dict[str, int | None]`, `d.get("key") is not None` proves that
     /// `d["key"]` exists and has type `int`:
@@ -2101,9 +2109,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     ///     reveal_type(d["key"])  # int
     /// ```
     ///
-    /// The inverse branch is intentionally not narrowed. `d.get("key") is None` can mean either
-    /// that the key is missing or that the stored value is `None`, so a later `d["key"]` access
-    /// still has the declared value type and may raise `KeyError`.
+    /// In the inverse branch, a successful `d["key"]` access can only produce `None`; if the key
+    /// is missing, the access raises and produces no value.
     fn narrow_dict_get_call(
         &self,
         inference: &ExpressionInference<'db>,
@@ -2113,9 +2120,14 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         is_positive: bool,
     ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
         let effective_op = if is_positive { op } else { op.negate() };
-        if effective_op != ast::CmpOp::IsNot || !other_type.is_none(self.db) {
+        if !other_type.is_none(self.db) {
             return None;
         }
+        let constraint_ty = match effective_op {
+            ast::CmpOp::Is => Type::none(self.db),
+            ast::CmpOp::IsNot => Type::none(self.db).negate(self.db),
+            _ => return None,
+        };
 
         let ast::Expr::Attribute(attribute) = call.func.as_ref() else {
             return None;
@@ -2130,10 +2142,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
         let place_expr = PlaceExpr::try_from_get_method_call(call)?;
         let place = self.places().place_id(&place_expr)?;
-        Some((
-            place,
-            NarrowingConstraint::intersection(Type::none(self.db).negate(self.db)),
-        ))
+        Some((place, NarrowingConstraint::intersection(constraint_ty)))
     }
 }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1437,6 +1437,35 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             let rhs_ty = inference.expression_type(right);
 
             // Narrowing for:
+            // - `if d.get("key") is not None`
+            // - `if d.get("key") is None`
+            // - `if None is not d.get("key")`
+            // - `if None is d.get("key")`
+            if let ast::Expr::Call(call) = left
+                && let Some((place, constraint)) =
+                    self.narrow_dict_get_call(inference, call, rhs_ty, *op, is_positive)
+            {
+                constraints
+                    .entry(place)
+                    .and_modify(|existing| {
+                        *existing = existing.merge_constraint_and(constraint.clone());
+                    })
+                    .or_insert(constraint);
+            }
+
+            if let ast::Expr::Call(call) = right
+                && let Some((place, constraint)) =
+                    self.narrow_dict_get_call(inference, call, lhs_ty, *op, is_positive)
+            {
+                constraints
+                    .entry(place)
+                    .and_modify(|existing| {
+                        *existing = existing.merge_constraint_and(constraint.clone());
+                    })
+                    .or_insert(constraint);
+            }
+
+            // Narrowing for:
             // - `if type(x) is Y`
             // - `if type(x) is not Y`
             // - `if Y is type(x)`
@@ -2060,6 +2089,63 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         } else {
             None
         }
+    }
+
+    /// Narrow the matching subscript place for a `dict.get` call proven to return a non-`None`
+    /// value.
+    ///
+    /// For example, given `d: dict[str, int | None]`, `d.get("key") is not None` proves that
+    /// `d["key"]` exists and has type `int`:
+    /// ```python
+    /// if d.get("key") is not None:
+    ///     reveal_type(d["key"])  # int
+    /// ```
+    ///
+    /// The inverse branch is intentionally not narrowed. `d.get("key") is None` can mean either
+    /// that the key is missing or that the stored value is `None`, so a later `d["key"]` access
+    /// still has the declared value type and may raise `KeyError`.
+    fn narrow_dict_get_call(
+        &self,
+        inference: &ExpressionInference<'db>,
+        call: &ast::ExprCall,
+        other_type: Type<'db>,
+        op: ast::CmpOp,
+        is_positive: bool,
+    ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
+        let effective_op = if is_positive { op } else { op.negate() };
+        if effective_op != ast::CmpOp::IsNot || !other_type.is_none(self.db) {
+            return None;
+        }
+
+        let ast::Expr::Attribute(attribute) = call.func.as_ref() else {
+            return None;
+        };
+
+        if !is_dict_instance(self.db, inference.expression_type(attribute.value.as_ref())) {
+            return None;
+        }
+
+        let place_expr = PlaceExpr::try_from_get_method_call(call)?;
+        let place = self.places().place_id(&place_expr)?;
+        Some((
+            place,
+            NarrowingConstraint::intersection(Type::none(self.db).negate(self.db)),
+        ))
+    }
+}
+
+fn is_dict_instance<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    match ty.resolve_type_alias(db) {
+        Type::NominalInstance(instance) => instance.has_known_class(db, KnownClass::Dict),
+        Type::Intersection(intersection) => intersection
+            .positive(db)
+            .iter()
+            .any(|element| is_dict_instance(db, *element)),
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| is_dict_instance(db, *element)),
+        _ => false,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2091,8 +2091,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         }
     }
 
-    /// Narrow the matching subscript place for a `dict.get` call proven to return a non-`None`
-    /// value.
+    /// Narrow the matching subscript place for a `dict.get` or `TypedDict.get` call proven to
+    /// return a non-`None` value.
     ///
     /// For example, given `d: dict[str, int | None]`, `d.get("key") is not None` proves that
     /// `d["key"]` exists and has type `int`:
@@ -2121,7 +2121,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             return None;
         };
 
-        if !is_dict_instance(self.db, inference.expression_type(attribute.value.as_ref())) {
+        if !has_known_dict_get_semantics(
+            self.db,
+            inference.expression_type(attribute.value.as_ref()),
+        ) {
             return None;
         }
 
@@ -2134,17 +2137,20 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     }
 }
 
-fn is_dict_instance<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+// We only apply `dict.get`-to-subscript narrowing for types whose `get` and `__getitem__`
+// relationship is known. Arbitrary `Mapping` implementations can override `get` independently.
+fn has_known_dict_get_semantics<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     match ty.resolve_type_alias(db) {
         Type::NominalInstance(instance) => instance.has_known_class(db, KnownClass::Dict),
+        Type::TypedDict(_) => true,
         Type::Intersection(intersection) => intersection
             .positive(db)
             .iter()
-            .any(|element| is_dict_instance(db, *element)),
+            .any(|element| has_known_dict_get_semantics(db, *element)),
         Type::Union(union) => union
             .elements(db)
             .iter()
-            .all(|element| is_dict_instance(db, *element)),
+            .all(|element| has_known_dict_get_semantics(db, *element)),
         _ => false,
     }
 }


### PR DESCRIPTION
## Summary

These now narrow equivalently:

```python
from typing import reveal_type

def bar(data: dict[str, int | None]):
    if data["value"] is not None:
        reveal_type(data["value"])  # Revealed type: `int` 

    if data.get("value") is not None:
        reveal_type(data["value"])  # Revealed type: `int`
```

The narrowing here is a little different than prior call narrowing in that the call narrows the subscript (i.e., `data.get("value") is not None` narrows `data["value"]`), so there's some additional logic to ensure we create the place.

Closes https://github.com/astral-sh/ty/issues/3394.
