### PR TITLE
[ty] Expand support for narrowing within walruses

### DIFF
--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -84,6 +84,17 @@ impl Expr {
         }
     }
 
+    /// Return the value expression after peeling off any nested named expressions.
+    ///
+    /// For example, this returns the `x` expression for both `x` and `(y := x)`.
+    pub fn expression_value(&self) -> &Self {
+        let mut expr = self;
+        while let Expr::Named(named) = expr {
+            expr = &named.value;
+        }
+        expr
+    }
+
     /// Return the [`OperatorPrecedence`] of this expression
     pub fn precedence(&self) -> OperatorPrecedence {
         OperatorPrecedence::from(self)

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -653,7 +653,7 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
         // For subscript expressions on either side, the subscript base can also be narrowed.
         // (TypedDict and tuple discriminated union narrowing.)
         for expr in std::iter::once(&*expr_compare.left).chain(&expr_compare.comparators) {
-            if let ast::Expr::Subscript(subscript) = expr
+            if let ast::Expr::Subscript(subscript) = expr.expression_value()
                 && let Some(place_expr) = PlaceExpr::try_from_expr(&subscript.value)
                 && let Some(place) = self.places.place_id((&place_expr).into())
             {
@@ -710,17 +710,13 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
 
     /// Helper to add a potential narrowing target expression to the set.
     fn add_narrowing_target(&self, expr: &ast::Expr, places: &mut PossiblyNarrowedPlaces) {
-        match expr {
-            ast::Expr::Name(_)
-            | ast::Expr::Attribute(_)
-            | ast::Expr::Subscript(_)
-            | ast::Expr::Named(_) => {
-                if let Some(place_expr) = PlaceExpr::try_from_expr(expr) {
-                    if let Some(place) = self.places.place_id((&place_expr).into()) {
-                        places.insert(place);
-                    }
-                }
+        if let Some(place_expr) = PlaceExpr::try_from_expr(expr) {
+            if let Some(place) = self.places.place_id((&place_expr).into()) {
+                places.insert(place);
             }
+        }
+
+        match expr.expression_value() {
             // type(x) is Y can narrow x
             ast::Expr::Call(call) if call.arguments.args.len() == 1 => {
                 if let Some(first_arg) = call.arguments.args.first() {

--- a/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
@@ -220,6 +220,13 @@ def _(t1: tuple[int | None, int | None], t2: tuple[int, int] | tuple[None, None]
     else:
         reveal_type(t2)  # revealed: tuple[int, int]
 
+    if (first := t2[0]) is not None:
+        reveal_type(first)  # revealed: int
+        reveal_type(t2)  # revealed: tuple[int, int]
+    else:
+        reveal_type(first)  # revealed: None
+        reveal_type(t2)  # revealed: tuple[None, None]
+
 def _(t3: tuple[int, str] | tuple[None, None] | tuple[bool, bytes]):
     # Narrow to tuples where first element is not None
     if t3[0] is not None:
@@ -304,6 +311,14 @@ def _(x: tuple[Literal["tag1"], A] | tuple[Literal["tag2"], B, C]):
         reveal_type(x)  # revealed: tuple[Literal["tag2"], B, C]
     else:
         reveal_type(x)  # revealed: tuple[Literal["tag1"], A]
+
+def _(x: tuple[Literal["tag1"], A] | tuple[Literal["tag2"], B, C]):
+    if (tag := x[0]) == "tag1":
+        reveal_type(tag)  # revealed: Literal["tag1"]
+        reveal_type(x)  # revealed: tuple[Literal["tag1"], A]
+    else:
+        reveal_type(tag)  # revealed: Literal["tag2"]
+        reveal_type(x)  # revealed: tuple[Literal["tag2"], B, C]
 
 # With int literals
 def _(x: tuple[Literal[1], A] | tuple[Literal[2], B]):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type.md
@@ -331,6 +331,7 @@ def _(x: Base):
 def _(x: object):
     if (y := type(x)) is bool:
         reveal_type(y)  # revealed: <class 'bool'>
+        reveal_type(x)  # revealed: bool
     if (type(y := x)) is bool:
         reveal_type(y)  # revealed: bool
 ```

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -4250,6 +4250,14 @@ def _(u: Foo | Bar | Baz | Bing):
         reveal_type(u)  # revealed: Baz
     else:
         reveal_type(u)  # revealed: Bing
+
+def _(u: Foo | Bar):
+    if (tag := u["tag"]) == "foo":
+        reveal_type(tag)  # revealed: Literal["foo"]
+        reveal_type(u)  # revealed: Foo
+    else:
+        reveal_type(tag)  # revealed: Literal[42]
+        reveal_type(u)  # revealed: Bar
 ```
 
 We can descend into intersections to discover `TypedDict` types that need narrowing:
@@ -4432,6 +4440,11 @@ def _(t: Bar, u: Foo | Intersection[Bar, Any], v: Intersection[Bar, Any], w: Lit
         reveal_type(u)  # revealed: Foo
     else:
         reveal_type(u)  # revealed: Foo | (Bar & Any)
+
+    if "bar" not in (u2 := u):
+        reveal_type(u2)  # revealed: Foo
+    else:
+        reveal_type(u2)  # revealed: Foo | (Bar & Any)
 ```
 
 With `closed=True`, the narrowing that we couldn't do above becomes possible, because a [closed]

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1254,7 +1254,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         //         if t[0] is not None:
         //             reveal_type(t)  # tuple[int, int]
         if matches!(&**ops, [ast::CmpOp::Is | ast::CmpOp::IsNot])
-            && let ast::Expr::Subscript(subscript) = &**left
+            && let ast::Expr::Subscript(subscript) = left.expression_value()
             && let Type::Union(union) = inference
                 .expression_type(&*subscript.value)
                 .resolve_type_alias(self.db)
@@ -1337,11 +1337,11 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 }
             };
 
-            if let ast::Expr::Subscript(subscript) = &**left {
+            if let ast::Expr::Subscript(subscript) = left.expression_value() {
                 narrow_subscript(subscript, inference.expression_type(&comparators[0]));
             }
 
-            if let ast::Expr::Subscript(subscript) = &comparators[0] {
+            if let ast::Expr::Subscript(subscript) = comparators[0].expression_value() {
                 narrow_subscript(subscript, inference.expression_type(&**left));
             }
         }
@@ -1359,7 +1359,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         //         reveal_type(u)  # revealed: Bar
         if matches!(&**ops, [ast::CmpOp::In | ast::CmpOp::NotIn])
             && let Some(key) = inference.expression_type(&**left).as_string_literal()
-            && let Some(rhs_place_expr) = PlaceExpr::try_from_expr(&comparators[0])
+            && let rhs_expr = comparators[0].expression_value()
             && let rhs_type = inference.expression_type(&comparators[0])
             && is_or_contains_typeddict(self.db, rhs_type)
         {
@@ -1411,8 +1411,21 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 };
 
                 if narrowed != resolved_rhs_type {
-                    let place = self.expect_place(&rhs_place_expr);
-                    constraints.insert(place, NarrowingConstraint::replacement(narrowed));
+                    let constraint = NarrowingConstraint::replacement(narrowed);
+
+                    let comparator_place = PlaceExpr::try_from_expr(&comparators[0])
+                        .and_then(|place_expr| self.places().place_id(&place_expr));
+                    if let Some(place) = comparator_place {
+                        constraints.insert(place, constraint.clone());
+                    }
+
+                    let value_place = PlaceExpr::try_from_expr(rhs_expr)
+                        .and_then(|place_expr| self.places().place_id(&place_expr));
+                    if value_place != comparator_place
+                        && let Some(place) = value_place
+                    {
+                        constraints.insert(place, constraint);
+                    }
                 }
             }
         }
@@ -1428,9 +1441,12 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             // - `if type(x) is not Y`
             // - `if Y is type(x)`
             // - `if Y is not type(x)`
-            if let (ast::Expr::Call(call), _, _, other) | (_, other, ast::Expr::Call(call), _) =
-                (left, lhs_ty, right, rhs_ty)
-            {
+            if let (ast::Expr::Call(call), _, _, other) | (_, other, ast::Expr::Call(call), _) = (
+                left.expression_value(),
+                lhs_ty,
+                right.expression_value(),
+                rhs_ty,
+            ) {
                 let ast::ExprCall {
                     range: _,
                     node_index: _,
@@ -1472,8 +1488,6 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                                 .negate_if(self.db, !is_positive),
                         ),
                     );
-                    last_rhs_ty = Some(rhs_ty);
-                    continue;
                 }
             }
 


### PR DESCRIPTION
## Summary

Support narrowing for a few more already-supported sites, but in the context of a walrus, as in:

```python
def f(t: tuple[int, int] | tuple[None, None]):
    if (first := t[0]) is not None:
        reveal_type(first)  # int
        reveal_type(t)      # tuple[int, int]
    else:
        reveal_type(first)  # None
        reveal_type(t)      # tuple[None, None]
```
