### PR TITLE
[ty] Bound loop-header analysis for large loops

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -1554,6 +1554,139 @@ for _ in range(1_000_000):
         x = 2
 ```
 
+### Large reachability constraint graphs fall back to `Unknown`
+
+```py
+def f(items, flags):
+    x = 1
+    for item in items:
+        # This example is just over the exact loop-header reachability cutoff. If it falls
+        # below the cutoff, this line reveals `Literal[1, 2]`.
+        reveal_type(x)  # revealed: Literal[1] | Unknown
+        if flags[200]:
+            x = 2
+    for item0 in items:
+        if flags[0]:
+            x = item0
+        for item1 in items:
+            if flags[1]:
+                x = item1
+            for item2 in items:
+                if flags[2]:
+                    x = item2
+                for item3 in items:
+                    if flags[3]:
+                        x = item3
+                    for item4 in items:
+                        if flags[4]:
+                            x = item4
+                        for item5 in items:
+                            if flags[5]:
+                                x = item5
+        for item6 in items:
+            if flags[6]:
+                x = item6
+            for item7 in items:
+                if flags[7]:
+                    x = item7
+                for item8 in items:
+                    if flags[8]:
+                        x = item8
+                    for item9 in items:
+                        if flags[9]:
+                            x = item9
+                        for item10 in items:
+                            if flags[10]:
+                                x = item10
+    for item11 in items:
+        if flags[11]:
+            x = item11
+        for item12 in items:
+            if flags[12]:
+                x = item12
+            for item13 in items:
+                if flags[13]:
+                    x = item13
+                for item14 in items:
+                    if flags[14]:
+                        x = item14
+                    for item15 in items:
+                        if flags[15]:
+                            x = item15
+                        for item16 in items:
+                            if flags[16]:
+                                x = item16
+        for item17 in items:
+            if flags[17]:
+                x = item17
+            for item18 in items:
+                if flags[18]:
+                    x = item18
+                for item19 in items:
+                    if flags[19]:
+                        x = item19
+                    for item20 in items:
+                        if flags[20]:
+                            x = item20
+                        for item21 in items:
+                            if flags[21]:
+                                x = item21
+    if flags[100]:
+        x = 0
+    if flags[101]:
+        x = 1
+    if flags[102]:
+        x = 2
+    if flags[103]:
+        x = 3
+    if flags[104]:
+        x = 4
+    if flags[105]:
+        x = 5
+    if flags[106]:
+        x = 6
+    if flags[107]:
+        x = 7
+    if flags[108]:
+        x = 8
+    if flags[109]:
+        x = 9
+    if flags[110]:
+        x = 10
+    if flags[111]:
+        x = 11
+    if flags[112]:
+        x = 12
+    if flags[113]:
+        x = 13
+    if flags[114]:
+        x = 14
+    if flags[115]:
+        x = 15
+    if flags[116]:
+        x = 16
+    if flags[117]:
+        x = 17
+    if flags[118]:
+        x = 18
+    if flags[119]:
+        x = 19
+    if flags[120]:
+        x = 20
+    if flags[121]:
+        x = 21
+    if flags[122]:
+        x = 22
+    if flags[123]:
+        x = 23
+    if flags[124]:
+        x = 24
+    if flags[125]:
+        x = 25
+    if flags[126]:
+        x = 26
+```
+
 ### `Divergent` in narrowing conditions doesn't run afoul of "monotonic widening" in cycle recovery
 
 This test looks for a complicated inference failure case that came up during implementation. See the

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1250,8 +1250,8 @@ fn loop_header_reachability_impl<'db>(
     definition: Definition<'db>,
     is_cycle_initial: bool,
 ) -> LoopHeaderReachability<'db> {
-    const MAX_EXACT_LOOP_HEADER_REACHABILITY_BINDINGS: usize = 32;
-    const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 2048;
+    const MAX_EXACT_LOOP_HEADER_REACHABILITY_BINDINGS: usize = 128;
+    const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 2688;
 
     let DefinitionKind::LoopHeader(loop_header_definition) = definition.kind(db) else {
         unreachable!("`loop_header_reachability` called with non-loop-header definition");

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1250,8 +1250,10 @@ fn loop_header_reachability_impl<'db>(
     definition: Definition<'db>,
     is_cycle_initial: bool,
 ) -> LoopHeaderReachability<'db> {
+    // These cutoffs were chosen by benchmarking real isort to keep loop analysis
+    // overhead minimal while preserving diagnostics.
     const MAX_EXACT_LOOP_HEADER_REACHABILITY_BINDINGS: usize = 128;
-    const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 2688;
+    const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 2048;
 
     let DefinitionKind::LoopHeader(loop_header_definition) = definition.kind(db) else {
         unreachable!("`loop_header_reachability` called with non-loop-header definition");
@@ -1390,6 +1392,7 @@ fn place_from_bindings_impl<'db>(
             reachability_constraints.evaluate(db, predicates, reachability_constraint)
         })
     };
+
     let mut first_definition = None;
     let mut only_loop_header_bindings = true;
 

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -18,7 +18,9 @@ use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
 use ty_python_core::narrowing_constraints::ScopedNarrowingConstraint;
 use ty_python_core::place::{PlaceExprRef, ScopedPlaceId};
 use ty_python_core::predicate::{Predicate, ScopedPredicateId};
-use ty_python_core::reachability_constraints::ReachabilityConstraints;
+use ty_python_core::reachability_constraints::{
+    ReachabilityConstraints, ScopedReachabilityConstraintId,
+};
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{
     BindingWithConstraints, BindingWithConstraintsIterator, BoundnessAnalysis,
@@ -1259,12 +1261,22 @@ fn loop_header_reachability_impl<'db>(
 
     let mut deleted_reachability = Truthiness::AlwaysFalse;
     let mut reachable_bindings = FxIndexSet::default();
+    let live_bindings: Vec<_> = loop_header.bindings_for_place(place).collect();
+    let live_binding_count = live_bindings.len();
+    let use_exact_reachability = live_binding_count <= 16
+        && use_def.reachability_constraints().used_interiors().len() <= 256;
 
-    for live_binding in loop_header.bindings_for_place(place) {
+    for live_binding in live_bindings {
         let reachability = if is_cycle_initial {
             Truthiness::Ambiguous
-        } else {
+        } else if use_exact_reachability {
             evaluate_reachability(db, use_def, live_binding.reachability_constraint())
+        } else if live_binding.reachability_constraint()
+            == ScopedReachabilityConstraintId::ALWAYS_FALSE
+        {
+            Truthiness::AlwaysFalse
+        } else {
+            Truthiness::Ambiguous
         };
         // Skip unreachable bindings.
         if reachability.is_always_false() {
@@ -1374,7 +1386,6 @@ fn place_from_bindings_impl<'db>(
             reachability_constraints.evaluate(db, predicates, reachability_constraint)
         })
     };
-
     let mut first_definition = None;
     let mut only_loop_header_bindings = true;
 

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1250,6 +1250,9 @@ fn loop_header_reachability_impl<'db>(
     definition: Definition<'db>,
     is_cycle_initial: bool,
 ) -> LoopHeaderReachability<'db> {
+    const MAX_EXACT_LOOP_HEADER_REACHABILITY_BINDINGS: usize = 32;
+    const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 2048;
+
     let DefinitionKind::LoopHeader(loop_header_definition) = definition.kind(db) else {
         unreachable!("`loop_header_reachability` called with non-loop-header definition");
     };
@@ -1263,8 +1266,9 @@ fn loop_header_reachability_impl<'db>(
     let mut reachable_bindings = FxIndexSet::default();
     let live_bindings: Vec<_> = loop_header.bindings_for_place(place).collect();
     let live_binding_count = live_bindings.len();
-    let use_exact_reachability = live_binding_count <= 16
-        && use_def.reachability_constraints().used_interiors().len() <= 256;
+    let use_exact_reachability = live_binding_count <= MAX_EXACT_LOOP_HEADER_REACHABILITY_BINDINGS
+        && use_def.reachability_constraints().used_interiors().len()
+            <= MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES;
 
     for live_binding in live_bindings {
         let reachability = if is_cycle_initial {

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1250,9 +1250,8 @@ fn loop_header_reachability_impl<'db>(
     definition: Definition<'db>,
     is_cycle_initial: bool,
 ) -> LoopHeaderReachability<'db> {
-    // These cutoffs were chosen by benchmarking real isort to keep loop analysis
+    // This cutoff was chosen by benchmarking real isort to keep loop analysis
     // overhead minimal while preserving diagnostics.
-    const MAX_EXACT_LOOP_HEADER_REACHABILITY_BINDINGS: usize = 128;
     const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 2048;
 
     let DefinitionKind::LoopHeader(loop_header_definition) = definition.kind(db) else {
@@ -1267,10 +1266,8 @@ fn loop_header_reachability_impl<'db>(
     let mut deleted_reachability = Truthiness::AlwaysFalse;
     let mut reachable_bindings = FxIndexSet::default();
     let live_bindings: Vec<_> = loop_header.bindings_for_place(place).collect();
-    let live_binding_count = live_bindings.len();
-    let use_exact_reachability = live_binding_count <= MAX_EXACT_LOOP_HEADER_REACHABILITY_BINDINGS
-        && use_def.reachability_constraints().used_interiors().len()
-            <= MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES;
+    let use_exact_reachability = use_def.reachability_constraints().used_interiors().len()
+        <= MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES;
 
     for live_binding in live_bindings {
         let reachability = if is_cycle_initial {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2018,7 +2018,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // These cutoffs were chosen by benchmarking real isort to keep loop analysis
         // overhead minimal while preserving diagnostics.
         const MAX_EXACT_LOOP_HEADER_BINDINGS: usize = 128;
-        const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 2048;
+        const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 4096;
 
         let db = self.db();
         let loop_header = loop_header_reachability(db, definition);

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2015,8 +2015,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         loop_header_kind: &LoopHeaderDefinitionKind<'db>,
         definition: Definition<'db>,
     ) {
-        const MAX_EXACT_LOOP_HEADER_BINDINGS: usize = 16;
-        const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 1024;
+        const MAX_EXACT_LOOP_HEADER_BINDINGS: usize = 32;
+        const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 2048;
 
         let db = self.db();
         let loop_header = loop_header_reachability(db, definition);

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2015,9 +2015,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         loop_header_kind: &LoopHeaderDefinitionKind<'db>,
         definition: Definition<'db>,
     ) {
-        // These cutoffs were chosen by benchmarking real isort to keep loop analysis
+        // This cutoff was chosen by benchmarking real isort to keep loop analysis
         // overhead minimal while preserving diagnostics.
-        const MAX_EXACT_LOOP_HEADER_BINDINGS: usize = 128;
         const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 4096;
 
         let db = self.db();
@@ -2029,9 +2028,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Loop-header types are an approximation point for loop fixpoint analysis. Inferring the
         // exact union of every visible loop-back binding can recursively force inference of large
         // boolean expressions and explode on real-world loops.
-        if loop_header.reachable_bindings.len() > MAX_EXACT_LOOP_HEADER_BINDINGS
-            || use_def.reachability_constraints().used_interiors().len()
-                > MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES
+        if use_def.reachability_constraints().used_interiors().len()
+            > MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES
         {
             self.bindings.insert(definition, Type::unknown());
             return;

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2015,12 +2015,27 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         loop_header_kind: &LoopHeaderDefinitionKind<'db>,
         definition: Definition<'db>,
     ) {
+        const MAX_EXACT_LOOP_HEADER_BINDINGS: usize = 16;
+        const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 1024;
+
         let db = self.db();
-        let place = loop_header_kind.place();
+        let loop_header = loop_header_reachability(db, definition);
         let use_def = self
             .index
             .use_def_map(self.scope().file_scope_id(self.db()));
-        let loop_header = loop_header_reachability(db, definition);
+
+        // Loop-header types are an approximation point for loop fixpoint analysis. Inferring the
+        // exact union of every visible loop-back binding can recursively force inference of large
+        // boolean expressions and explode on real-world loops.
+        if loop_header.reachable_bindings.len() > MAX_EXACT_LOOP_HEADER_BINDINGS
+            || use_def.reachability_constraints().used_interiors().len()
+                > MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES
+        {
+            self.bindings.insert(definition, Type::unknown());
+            return;
+        }
+
+        let place = loop_header_kind.place();
 
         let mut union = UnionBuilder::new(db).recursively_defined(RecursivelyDefined::Yes);
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2015,8 +2015,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         loop_header_kind: &LoopHeaderDefinitionKind<'db>,
         definition: Definition<'db>,
     ) {
+        // These cutoffs were chosen by benchmarking real isort to keep loop analysis
+        // overhead minimal while preserving diagnostics.
         const MAX_EXACT_LOOP_HEADER_BINDINGS: usize = 128;
-        const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 2688;
+        const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 2048;
 
         let db = self.db();
         let loop_header = loop_header_reachability(db, definition);

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2015,8 +2015,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         loop_header_kind: &LoopHeaderDefinitionKind<'db>,
         definition: Definition<'db>,
     ) {
-        const MAX_EXACT_LOOP_HEADER_BINDINGS: usize = 32;
-        const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 2048;
+        const MAX_EXACT_LOOP_HEADER_BINDINGS: usize = 128;
+        const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 2688;
 
         let db = self.db();
         let loop_header = loop_header_reachability(db, definition);


### PR DESCRIPTION
## Summary

The intent of this change is to fix the regression we've seen isort since the Beta (see: https://github.com/astral-sh/ty/issues/3023):

The loop control-flow work made exact loop-header reachability and type inference too expensive on very large real-world loops, as in isort’s `isort/parse.py` and `isort/core.py`. The problematic shape is not super interesting -- roughly:

```python
def parse(items, opt0, opt1, opt2, ...):
    index = 0
    state = ""

    while index < len(items):
        line = items[index]
        index += 1

        if opt0:
            state = line
            continue

        if opt1:
            state = state.strip()

        if opt2:
            while ...:
                state = ...

    return state
```

So there's a large graph, with many loop-header places, but caching doesn't seem to help much because the work is spread across many places.

This PR keeps exact loop-header analysis for smaller loops, but bounds it for large loop headers. If a loop exceeds the limit, we fall back to an ambiguous reachability/type result instead of expanding every loop-back binding/state.

Compared to main, this gets isort back to beta-era performance:

| Project | Beta | charlie/reachability-cache | This branch |
| --- | ---: | ---: | ---: |
| isort | 47.7ms +/- 3.7ms | 405.4ms +/- 10.5ms | 52.9ms +/- 1.8ms |
| PyTorch | 1.183s +/- 0.114s | 1.218s +/- 0.037s | 1.192s +/- 0.034s |

Closes https://github.com/astral-sh/ty/issues/3023.
