### PR TITLE
[ty] Block user-supplied typing.py from shadowing typeshed

### DIFF
--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -187,6 +187,15 @@ impl ModuleResolveMode {
         if module_name == "types" {
             return true;
         }
+        // Same for `typing`: ty hard-codes recognition of its special forms
+        // (`Any`, `Literal`, `Protocol`, etc.) and assumes they come from
+        // typeshed. If a user-supplied `typing.py` were allowed to shadow
+        // typeshed (as can happen when `--extra-search-path` points at a
+        // CPython runtime stdlib directory), `Any` becomes a regular class
+        // and assignability checks against it stop behaving correctly.
+        if module_name == "typing" {
+            return true;
+        }
 
         // Otherwise, some modules should only be conditionally allowed
         // to be shadowed, depending on the module resolution mode.

--- a/crates/ty_python_semantic/resources/mdtest/regression/extra_paths_shadow_typing_module.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/extra_paths_shadow_typing_module.md
@@ -1,0 +1,49 @@
+# `extra-paths` must not let user-supplied `typing.py` shadow typeshed
+
+Regression test for ty issue #3169. When `--extra-search-path` points at a directory containing a
+CPython runtime `typing.py` (which happens whenever the runtime stdlib is reachable via `PYTHONPATH`
+or similar), ty resolved `from typing import Any` to that file rather than the bundled typeshed
+`typing.pyi`. The runtime declares `class Any(metaclass=_AnyMeta): ...`, a regular class, so `Any`
+annotations stopped acting as the dynamic type and `Literal[X]` arguments were rejected as not
+assignable.
+
+Root cause: `extra_paths` enter `SearchPaths::static_paths`, which `SearchPathIterator::next` (in
+`crates/ty_module_resolver/src/resolve.rs`) iterates before `stdlib_path`. Fix: treat `typing` as
+non-shadowable in `ModuleResolveMode::is_non_shadowable`, alongside the existing `types` and
+`typing_extensions` exceptions.
+
+```toml
+[environment]
+extra-paths = ["/runtime_lib"]
+```
+
+`/runtime_lib/typing.py`:
+
+```py
+class _AnyMeta(type): ...
+
+class Any(metaclass=_AnyMeta):
+    """Special type indicating an unconstrained type."""
+```
+
+`main.py`:
+
+```py
+from typing import Any
+
+# Must resolve to the typeshed special form, not the user class above.
+reveal_type(Any)  # revealed: <special-form 'typing.Any'>
+
+def takes_any(**kwargs: Any) -> None: ...
+
+# `Literal["openai/gpt-4o"]` is assignable to `Any`. No error.
+takes_any(model="openai/gpt-4o")
+
+def boom() -> None:
+    # `BaseException.__new__` takes `*args: Any` per typeshed. No error.
+    raise ValueError("oops")
+
+def newline() -> str:
+    # `chr` takes `SupportsIndex`; `int` (and `Literal[10]`) implements it. No error.
+    return chr(10)
+```


### PR DESCRIPTION
## Summary

Yo! I had an issue with my python sandbox where I use ty to check the code AI generates. Turned out that there seems to be a problem in ty that I could resolve. I'm not an expert in typing or in rust.. but I got some help from Claude to explain it and fix it. Validated the fix within my sandbox. 

## Problem / Solution:

I hit this running ty inside a Docker sandbox that typechecks AI-generated Python.
Same ty 0.0.32 binary, same source files: clean on the host, some
`invalid-argument-type` diagnostics in the container. The errors all had the same
shape:

```
Argument to `ChatModel.__init__` is incorrect: Expected `Any`, found `Literal["some-model"]`
Argument to constructor `BaseException.__new__` is incorrect: Expected `Any`, found `Literal["hello"]`
Argument to function `chr` is incorrect: Expected `SupportsIndex`, found `Literal[10]`
```

`Literal[X]` is always assignable to `Any`. `Literal[10]` is always `SupportsIndex`.
The diagnostics are wrong by definition.

The container ran a Chainguard distroless image with site-packages detached at
`/app/site-packages`. The wrapper script invoked ty with `--extra-search-path`
for every `sys.path` entry, which on that interpreter included the runtime CPython
`lib/python3.14/` directory. That directory contains a real `typing.py`. ty resolved
`from typing import Any` to that file instead of the bundled typeshed `typing.pyi`.
CPython's runtime declares `class Any(metaclass=_AnyMeta): ...`, a regular class.
With `Any` as a class rather than the special form, every `**kwargs: Any`
annotation became "instance of class Any", and `Literal[X]` correctly fails that
nominal check. The same effect cascaded to anything else that ran through `typing`,
including `SupportsIndex`.

`extra_paths` enter `SearchPaths::static_paths`, which `SearchPathIterator::next`
iterates before `stdlib_path`, so a user-supplied `typing.py` always wins.
`ModuleResolveMode::is_non_shadowable` already filters non-stdlib paths for `types`
and `typing_extensions` for the same kind of reason (the existing comment cites
mypy's identical guard). I added `typing` to the list. Two lines of logic, plus the
comment.

I think this also matches @carljm's `PYTHONPATH` question on #3169. Whenever the
runtime stdlib is reachable through any non-stdlib search path, `typing.py` from
the runtime shadows typeshed and the bug fires.

## Test Plan

Added a regression mdtest at
`crates/ty_python_semantic/resources/mdtest/regression/extra_paths_shadow_typing_module.md`.
It plants a CPython-shaped `typing.py` (with `class Any(metaclass=_AnyMeta)`) on
`extra-paths`, asserts `reveal_type(Any)` is the special form, and asserts that
`Literal[X]` arguments to `Any` and `SupportsIndex` parameters do not error. Fails
on `main`, passes with the fix.

Other validation:

- `cargo test -p ty_python_semantic --test mdtest`: 337 passed, 0 failed.
- `cargo test -p ty_module_resolver`: 13 passed, 0 failed.
- `cargo clippy -p ty_module_resolver -p ty_python_semantic --all-targets --all-features -- -D warnings`: clean.
- `uvx prek run --files <touched files>`: clean.
- Rebuilt my sandbox Docker image with the fix and replayed the original case, fixed my issues.


