### PR TITLE
[ty] Project reachability constraints before narrowing

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -313,7 +313,7 @@ def _(x: Literal["foo", b"bar"] | int):
             pass
         case b"bar" if reveal_type(x):  # revealed: Literal[b"bar"] | int
             pass
-        case _ if reveal_type(x):  # revealed: int | Literal["foo", b"bar"]
+        case _ if reveal_type(x):  # revealed: Literal["foo", b"bar"] | int
             pass
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -95,6 +95,29 @@ def _(x: A | B | C | D):
     reveal_type(x)  # revealed: (C & ~A) | (B & ~A & ~C)
 ```
 
+## Opaque branch predicates should not manufacture narrowing
+
+If a boolean flag is set by an opaque branch predicate, checking that flag later should not make an
+unknown value look more precise than it really is just because other branches contained narrowing
+checks.
+
+```py
+def cond(x) -> bool:
+    return bool(x)
+
+def _(x):
+    flag = False
+    if cond(x):
+        flag = True
+    elif isinstance(x, float):
+        return
+    elif isinstance(x, int):
+        return
+
+    if flag:
+        reveal_type(x)  # revealed: Unknown
+```
+
 ## Multiple sequential if-statements don't leak narrowing
 
 After a complete if/else where both branches flow through (no terminal), narrowing should be

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -2,12 +2,13 @@ use itertools::Either;
 use ruff_db::files::File;
 use ruff_index::IndexVec;
 use ruff_python_ast::PythonVersion;
+use rustc_hash::FxHashMap;
 use ty_module_resolver::{
     KnownModule, Module, ModuleName, file_to_module, resolve_module_confident,
 };
 
 use crate::dunder_all::dunder_all_names;
-use crate::reachability::{ReachabilityConstraintsExtension, evaluate_reachability};
+use crate::reachability::ReachabilityConstraintsExtension;
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::{
     DynamicType, KnownClass, MemberLookupPolicy, Type, TypeAndQualifiers, TypeQualifiers,
@@ -18,7 +19,9 @@ use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
 use ty_python_core::narrowing_constraints::ScopedNarrowingConstraint;
 use ty_python_core::place::{PlaceExprRef, ScopedPlaceId};
 use ty_python_core::predicate::{Predicate, ScopedPredicateId};
-use ty_python_core::reachability_constraints::ReachabilityConstraints;
+use ty_python_core::reachability_constraints::{
+    ReachabilityConstraints, ScopedReachabilityConstraintId,
+};
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{
     BindingWithConstraints, BindingWithConstraintsIterator, BoundnessAnalysis,
@@ -596,6 +599,20 @@ pub(super) fn place_from_bindings<'db>(
     bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
 ) -> PlaceWithDefinition<'db> {
     place_from_bindings_impl(db, bindings_with_constraints, RequiresExplicitReExport::No)
+}
+
+fn evaluate_reachability_cached<'db>(
+    db: &'db dyn Db,
+    predicates: &ty_python_core::predicate::Predicates<'db>,
+    reachability_constraints: &ReachabilityConstraints,
+    reachability_constraint: ScopedReachabilityConstraintId,
+    cache: &mut FxHashMap<ScopedReachabilityConstraintId, Truthiness>,
+) -> Truthiness {
+    if let Some(cached) = cache.get(&reachability_constraint) {
+        return *cached;
+    }
+
+    reachability_constraints.evaluate_cached(db, predicates, reachability_constraint, cache)
 }
 
 /// Build a declared type from a [`DeclarationsIterator`].
@@ -1259,12 +1276,19 @@ fn loop_header_reachability_impl<'db>(
 
     let mut deleted_reachability = Truthiness::AlwaysFalse;
     let mut reachable_bindings = FxIndexSet::default();
+    let mut reachability_cache = FxHashMap::default();
 
     for live_binding in loop_header.bindings_for_place(place) {
         let reachability = if is_cycle_initial {
             Truthiness::Ambiguous
         } else {
-            evaluate_reachability(db, use_def, live_binding.reachability_constraint())
+            evaluate_reachability_cached(
+                db,
+                use_def.predicates(),
+                use_def.reachability_constraints(),
+                live_binding.reachability_constraint(),
+                &mut reachability_cache,
+            )
         };
         // Skip unreachable bindings.
         if reachability.is_always_false() {
@@ -1351,6 +1375,7 @@ fn place_from_bindings_impl<'db>(
     let reachability_constraints = bindings_with_constraints.reachability_constraints();
     let boundness_analysis = bindings_with_constraints.boundness_analysis();
     let mut bindings_with_constraints = bindings_with_constraints.peekable();
+    let mut reachability_cache = FxHashMap::default();
 
     let is_non_exported = |binding: Definition<'db>| {
         requires_explicit_reexport.is_yes() && !is_reexported(db, binding)
@@ -1365,15 +1390,6 @@ fn place_from_bindings_impl<'db>(
         _ => None,
     };
     let mut deleted_reachability = Truthiness::AlwaysFalse;
-
-    // Evaluate this lazily because we don't always need it (for example, if there are no visible
-    // bindings at all, we don't need it), and it can cause us to evaluate reachability constraint
-    // expressions, which is extra work and can lead to cycles.
-    let unbound_visibility = || {
-        unbound_reachability_constraint.map(|reachability_constraint| {
-            reachability_constraints.evaluate(db, predicates, reachability_constraint)
-        })
-    };
 
     let mut first_definition = None;
     let mut only_loop_header_bindings = true;
@@ -1390,9 +1406,16 @@ fn place_from_bindings_impl<'db>(
                     return None;
                 }
                 DefinitionState::Deleted => {
-                    deleted_reachability = deleted_reachability.or_else(|| {
-                        reachability_constraints.evaluate(db, predicates, reachability_constraint)
-                    });
+                    if !deleted_reachability.is_always_true() {
+                        let reachability = evaluate_reachability_cached(
+                            db,
+                            predicates,
+                            reachability_constraints,
+                            reachability_constraint,
+                            &mut reachability_cache,
+                        );
+                        deleted_reachability = deleted_reachability.or(reachability);
+                    }
                     return None;
                 }
             };
@@ -1401,8 +1424,13 @@ fn place_from_bindings_impl<'db>(
                 return None;
             }
 
-            let static_reachability =
-                reachability_constraints.evaluate(db, predicates, reachability_constraint);
+            let static_reachability = evaluate_reachability_cached(
+                db,
+                predicates,
+                reachability_constraints,
+                reachability_constraint,
+                &mut reachability_cache,
+            );
 
             if static_reachability.is_always_false() {
                 // If the static reachability evaluates to false, the binding is either not reachable
@@ -1452,7 +1480,18 @@ fn place_from_bindings_impl<'db>(
                 // return `Never` in this case, because we will union the types of all bindings, and
                 // `Never` will be eliminated automatically.
 
-                if unbound_visibility().is_none_or(Truthiness::is_always_false) {
+                let unbound_visibility =
+                    unbound_reachability_constraint.map(|reachability_constraint| {
+                        evaluate_reachability_cached(
+                            db,
+                            predicates,
+                            reachability_constraints,
+                            reachability_constraint,
+                            &mut reachability_cache,
+                        )
+                    });
+
+                if unbound_visibility.is_none_or(Truthiness::is_always_false) {
                     return Some(Type::Never);
                 }
                 return None;
@@ -1487,7 +1526,7 @@ fn place_from_bindings_impl<'db>(
             builder.add(first);
             builder.add(second);
 
-            for ty in types {
+            for ty in types.by_ref() {
                 builder.add(ty);
             }
 
@@ -1495,10 +1534,20 @@ fn place_from_bindings_impl<'db>(
         } else {
             first
         };
+        drop(types);
 
         let boundness = match boundness_analysis {
             BoundnessAnalysis::AssumeBound => Definedness::AlwaysDefined,
-            BoundnessAnalysis::BasedOnUnboundVisibility => match unbound_visibility() {
+            BoundnessAnalysis::BasedOnUnboundVisibility => match unbound_reachability_constraint
+                .map(|reachability_constraint| {
+                    evaluate_reachability_cached(
+                        db,
+                        predicates,
+                        reachability_constraints,
+                        reachability_constraint,
+                        &mut reachability_cache,
+                    )
+                }) {
                 Some(Truthiness::AlwaysTrue) if only_loop_header_bindings => {
                     // Loop header definitions don't shadow prior bindings, so UNBOUND can still be
                     // definitely-visible alongside a loop header binding. See "Use with loop

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1526,7 +1526,7 @@ fn place_from_bindings_impl<'db>(
             builder.add(first);
             builder.add(second);
 
-            for ty in types.by_ref() {
+            for ty in types {
                 builder.add(ty);
             }
 
@@ -1534,8 +1534,6 @@ fn place_from_bindings_impl<'db>(
         } else {
             first
         };
-        drop(types);
-
         let boundness = match boundness_analysis {
             BoundnessAnalysis::AssumeBound => Definedness::AlwaysDefined,
             BoundnessAnalysis::BasedOnUnboundVisibility => match unbound_reachability_constraint

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -2,13 +2,12 @@ use itertools::Either;
 use ruff_db::files::File;
 use ruff_index::IndexVec;
 use ruff_python_ast::PythonVersion;
-use rustc_hash::FxHashMap;
 use ty_module_resolver::{
     KnownModule, Module, ModuleName, file_to_module, resolve_module_confident,
 };
 
 use crate::dunder_all::dunder_all_names;
-use crate::reachability::ReachabilityConstraintsExtension;
+use crate::reachability::{ReachabilityConstraintsExtension, evaluate_reachability};
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::{
     DynamicType, KnownClass, MemberLookupPolicy, Type, TypeAndQualifiers, TypeQualifiers,
@@ -19,9 +18,7 @@ use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
 use ty_python_core::narrowing_constraints::ScopedNarrowingConstraint;
 use ty_python_core::place::{PlaceExprRef, ScopedPlaceId};
 use ty_python_core::predicate::{Predicate, ScopedPredicateId};
-use ty_python_core::reachability_constraints::{
-    ReachabilityConstraints, ScopedReachabilityConstraintId,
-};
+use ty_python_core::reachability_constraints::ReachabilityConstraints;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{
     BindingWithConstraints, BindingWithConstraintsIterator, BoundnessAnalysis,
@@ -599,20 +596,6 @@ pub(super) fn place_from_bindings<'db>(
     bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
 ) -> PlaceWithDefinition<'db> {
     place_from_bindings_impl(db, bindings_with_constraints, RequiresExplicitReExport::No)
-}
-
-fn evaluate_reachability_cached<'db>(
-    db: &'db dyn Db,
-    predicates: &ty_python_core::predicate::Predicates<'db>,
-    reachability_constraints: &ReachabilityConstraints,
-    reachability_constraint: ScopedReachabilityConstraintId,
-    cache: &mut FxHashMap<ScopedReachabilityConstraintId, Truthiness>,
-) -> Truthiness {
-    if let Some(cached) = cache.get(&reachability_constraint) {
-        return *cached;
-    }
-
-    reachability_constraints.evaluate_cached(db, predicates, reachability_constraint, cache)
 }
 
 /// Build a declared type from a [`DeclarationsIterator`].
@@ -1276,19 +1259,12 @@ fn loop_header_reachability_impl<'db>(
 
     let mut deleted_reachability = Truthiness::AlwaysFalse;
     let mut reachable_bindings = FxIndexSet::default();
-    let mut reachability_cache = FxHashMap::default();
 
     for live_binding in loop_header.bindings_for_place(place) {
         let reachability = if is_cycle_initial {
             Truthiness::Ambiguous
         } else {
-            evaluate_reachability_cached(
-                db,
-                use_def.predicates(),
-                use_def.reachability_constraints(),
-                live_binding.reachability_constraint(),
-                &mut reachability_cache,
-            )
+            evaluate_reachability(db, use_def, live_binding.reachability_constraint())
         };
         // Skip unreachable bindings.
         if reachability.is_always_false() {
@@ -1375,7 +1351,6 @@ fn place_from_bindings_impl<'db>(
     let reachability_constraints = bindings_with_constraints.reachability_constraints();
     let boundness_analysis = bindings_with_constraints.boundness_analysis();
     let mut bindings_with_constraints = bindings_with_constraints.peekable();
-    let mut reachability_cache = FxHashMap::default();
 
     let is_non_exported = |binding: Definition<'db>| {
         requires_explicit_reexport.is_yes() && !is_reexported(db, binding)
@@ -1390,6 +1365,15 @@ fn place_from_bindings_impl<'db>(
         _ => None,
     };
     let mut deleted_reachability = Truthiness::AlwaysFalse;
+
+    // Evaluate this lazily because we don't always need it (for example, if there are no visible
+    // bindings at all, we don't need it), and it can cause us to evaluate reachability constraint
+    // expressions, which is extra work and can lead to cycles.
+    let unbound_visibility = || {
+        unbound_reachability_constraint.map(|reachability_constraint| {
+            reachability_constraints.evaluate(db, predicates, reachability_constraint)
+        })
+    };
 
     let mut first_definition = None;
     let mut only_loop_header_bindings = true;
@@ -1406,16 +1390,9 @@ fn place_from_bindings_impl<'db>(
                     return None;
                 }
                 DefinitionState::Deleted => {
-                    if !deleted_reachability.is_always_true() {
-                        let reachability = evaluate_reachability_cached(
-                            db,
-                            predicates,
-                            reachability_constraints,
-                            reachability_constraint,
-                            &mut reachability_cache,
-                        );
-                        deleted_reachability = deleted_reachability.or(reachability);
-                    }
+                    deleted_reachability = deleted_reachability.or_else(|| {
+                        reachability_constraints.evaluate(db, predicates, reachability_constraint)
+                    });
                     return None;
                 }
             };
@@ -1424,13 +1401,8 @@ fn place_from_bindings_impl<'db>(
                 return None;
             }
 
-            let static_reachability = evaluate_reachability_cached(
-                db,
-                predicates,
-                reachability_constraints,
-                reachability_constraint,
-                &mut reachability_cache,
-            );
+            let static_reachability =
+                reachability_constraints.evaluate(db, predicates, reachability_constraint);
 
             if static_reachability.is_always_false() {
                 // If the static reachability evaluates to false, the binding is either not reachable
@@ -1480,18 +1452,7 @@ fn place_from_bindings_impl<'db>(
                 // return `Never` in this case, because we will union the types of all bindings, and
                 // `Never` will be eliminated automatically.
 
-                let unbound_visibility =
-                    unbound_reachability_constraint.map(|reachability_constraint| {
-                        evaluate_reachability_cached(
-                            db,
-                            predicates,
-                            reachability_constraints,
-                            reachability_constraint,
-                            &mut reachability_cache,
-                        )
-                    });
-
-                if unbound_visibility.is_none_or(Truthiness::is_always_false) {
+                if unbound_visibility().is_none_or(Truthiness::is_always_false) {
                     return Some(Type::Never);
                 }
                 return None;
@@ -1534,18 +1495,10 @@ fn place_from_bindings_impl<'db>(
         } else {
             first
         };
+
         let boundness = match boundness_analysis {
             BoundnessAnalysis::AssumeBound => Definedness::AlwaysDefined,
-            BoundnessAnalysis::BasedOnUnboundVisibility => match unbound_reachability_constraint
-                .map(|reachability_constraint| {
-                    evaluate_reachability_cached(
-                        db,
-                        predicates,
-                        reachability_constraints,
-                        reachability_constraint,
-                        &mut reachability_cache,
-                    )
-                }) {
+            BoundnessAnalysis::BasedOnUnboundVisibility => match unbound_visibility() {
                 Some(Truthiness::AlwaysTrue) if only_loop_header_bindings => {
                     // Loop header definitions don't shadow prior bindings, so UNBOUND can still be
                     // definitely-visible alongside a loop header binding. See "Use with loop

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -203,6 +203,7 @@ use crate::{
     },
 };
 use ruff_text_size::TextRange;
+use rustc_hash::FxHashMap;
 use ty_python_core::{
     BindingWithConstraints, DeclarationWithConstraint, DeclarationsIterator, FileScopeId,
     SemanticIndex, Truthiness, UseDefMap,
@@ -387,6 +388,15 @@ pub(crate) trait ReachabilityConstraintsExtension<'db> {
         predicates: &Predicates<'db>,
         id: ScopedReachabilityConstraintId,
     ) -> Truthiness;
+
+    /// Analyze reachability for a constraint, memoizing intermediate results.
+    fn evaluate_cached(
+        &self,
+        db: &'db dyn Db,
+        predicates: &Predicates<'db>,
+        id: ScopedReachabilityConstraintId,
+        cache: &mut FxHashMap<ScopedReachabilityConstraintId, Truthiness>,
+    ) -> Truthiness;
 }
 
 impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
@@ -419,7 +429,16 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
         base_ty: Type<'db>,
         place: ScopedPlaceId,
     ) -> Type<'db> {
-        narrow_by_constraint_inner(db, self, predicates, id, base_ty, place, None)
+        let mut cache = FxHashMap::default();
+        NarrowingContext {
+            db,
+            constraints: self,
+            predicates,
+            base_ty,
+            place,
+            cache: &mut cache,
+        }
+        .narrow(id, None)
     }
 
     /// Analyze the statically known reachability for a given constraint.
@@ -427,166 +446,158 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
         &self,
         db: &'db dyn Db,
         predicates: &Predicates<'db>,
-        mut id: ScopedReachabilityConstraintId,
+        id: ScopedReachabilityConstraintId,
+    ) -> Truthiness {
+        let mut cache = FxHashMap::default();
+        self.evaluate_cached(db, predicates, id, &mut cache)
+    }
+
+    /// Analyze reachability for a constraint, memoizing intermediate results.
+    fn evaluate_cached(
+        &self,
+        db: &'db dyn Db,
+        predicates: &Predicates<'db>,
+        id: ScopedReachabilityConstraintId,
+        cache: &mut FxHashMap<ScopedReachabilityConstraintId, Truthiness>,
     ) -> Truthiness {
         type Id = ScopedReachabilityConstraintId;
 
-        loop {
-            let node = match id {
-                Id::ALWAYS_TRUE => return Truthiness::AlwaysTrue,
-                Id::AMBIGUOUS => return Truthiness::Ambiguous,
-                Id::ALWAYS_FALSE => return Truthiness::AlwaysFalse,
-                _ => {
-                    // `id` gives us the index of this node in the IndexVec that we used when
-                    // constructing this BDD. When finalizing the builder, we threw away any
-                    // interior nodes that weren't marked as used. The `used_indices` bit vector
-                    // lets us verify that this node was marked as used, and the rank of that bit
-                    // in the bit vector tells us where this node lives in the "condensed"
-                    // `used_interiors` vector.
-                    let raw_index = id.as_u32() as usize;
-                    debug_assert!(
-                        self.used_indices().get_bit(raw_index).unwrap_or(false),
-                        "all used reachability constraints should have been marked as used",
-                    );
-                    let index = self.used_indices().rank(raw_index) as usize;
-                    self.used_interiors()[index]
-                }
-            };
-            let predicate = &predicates[node.atom()];
-            match analyze_single(db, predicate) {
-                Truthiness::AlwaysTrue => id = node.if_true(),
-                Truthiness::Ambiguous => id = node.if_ambiguous(),
-                Truthiness::AlwaysFalse => id = node.if_false(),
-            }
+        if let Some(cached) = cache.get(&id) {
+            return *cached;
         }
+
+        let result = match id {
+            Id::ALWAYS_TRUE => Truthiness::AlwaysTrue,
+            Id::AMBIGUOUS => Truthiness::Ambiguous,
+            Id::ALWAYS_FALSE => Truthiness::AlwaysFalse,
+            _ => {
+                let node = self.get_interior_node(id);
+                let predicate = &predicates[node.atom()];
+                let branch = match analyze_single(db, predicate) {
+                    Truthiness::AlwaysTrue => node.if_true(),
+                    Truthiness::Ambiguous => node.if_ambiguous(),
+                    Truthiness::AlwaysFalse => node.if_false(),
+                };
+                self.evaluate_cached(db, predicates, branch, cache)
+            }
+        };
+
+        cache.insert(id, result);
+        result
     }
 }
 
-/// Inner recursive helper that accumulates narrowing constraints along each TDD path.
-fn narrow_by_constraint_inner<'db>(
+type NarrowingCacheKey<'db> = (
+    ScopedReachabilityConstraintId,
+    Option<NarrowingConstraint<'db>>,
+);
+
+const MAX_NARROWING_STATES: usize = 256;
+
+fn apply_accumulated_narrowing<'db>(
     db: &'db dyn Db,
-    constraints: &ReachabilityConstraints,
-    predicates: &Predicates<'db>,
-    id: ScopedReachabilityConstraintId,
     base_ty: Type<'db>,
-    place: ScopedPlaceId,
     accumulated: Option<NarrowingConstraint<'db>>,
 ) -> Type<'db> {
-    type Id = ScopedReachabilityConstraintId;
+    match accumulated {
+        Some(constraint) => NarrowingConstraint::intersection(base_ty)
+            .merge_constraint_and(constraint)
+            .evaluate_constraint_type(db),
+        None => base_ty,
+    }
+}
 
-    match id {
-        Id::ALWAYS_TRUE | Id::AMBIGUOUS => {
-            // Apply all accumulated narrowing constraints to the base type
-            match accumulated {
-                Some(constraint) => NarrowingConstraint::intersection(base_ty)
-                    .merge_constraint_and(constraint)
-                    .evaluate_constraint_type(db),
-                None => base_ty,
-            }
+struct NarrowingContext<'a, 'db> {
+    db: &'db dyn Db,
+    constraints: &'a ReachabilityConstraints,
+    predicates: &'a Predicates<'db>,
+    base_ty: Type<'db>,
+    place: ScopedPlaceId,
+    cache: &'a mut FxHashMap<NarrowingCacheKey<'db>, Type<'db>>,
+}
+
+impl<'db> NarrowingContext<'_, 'db> {
+    /// Inner recursive helper that accumulates narrowing constraints along each TDD path.
+    fn narrow(
+        &mut self,
+        id: ScopedReachabilityConstraintId,
+        accumulated: Option<NarrowingConstraint<'db>>,
+    ) -> Type<'db> {
+        type Id = ScopedReachabilityConstraintId;
+
+        let key = (id, accumulated.clone());
+        if let Some(cached) = self.cache.get(&key) {
+            return *cached;
         }
-        Id::ALWAYS_FALSE => Type::Never,
-        _ => {
-            let node = constraints.get_interior_node(id);
-            let predicate = predicates[node.atom()];
+        if self.cache.len() >= MAX_NARROWING_STATES {
+            return apply_accumulated_narrowing(self.db, self.base_ty, accumulated);
+        }
 
-            // `IsNonTerminalCall` predicates don't narrow any variable; they only
-            // affect reachability. Evaluate the predicate to determine which
-            // path(s) are reachable, rather than walking both branches.
-            // `IsNonTerminalCall` always evaluates to `AlwaysTrue` or `AlwaysFalse`,
-            // never `Ambiguous`.
-            if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
-                return match analyze_single(db, &predicate) {
-                    Truthiness::AlwaysTrue => narrow_by_constraint_inner(
-                        db,
-                        constraints,
-                        predicates,
-                        node.if_true(),
-                        base_ty,
-                        place,
-                        accumulated,
-                    ),
-                    Truthiness::AlwaysFalse => narrow_by_constraint_inner(
-                        db,
-                        constraints,
-                        predicates,
-                        node.if_false(),
-                        base_ty,
-                        place,
-                        accumulated,
-                    ),
-                    Truthiness::Ambiguous => {
-                        unreachable!("`IsNonTerminalCall` predicates should never be Ambiguous")
+        let result = match id {
+            Id::ALWAYS_TRUE | Id::AMBIGUOUS => {
+                // Apply all accumulated narrowing constraints to the base type
+                apply_accumulated_narrowing(self.db, self.base_ty, accumulated)
+            }
+            Id::ALWAYS_FALSE => Type::Never,
+            _ => {
+                let node = self.constraints.get_interior_node(id);
+                let predicate = self.predicates[node.atom()];
+
+                // `IsNonTerminalCall` predicates don't narrow any variable; they only
+                // affect reachability. Evaluate the predicate to determine which
+                // path(s) are reachable, rather than walking both branches.
+                // `IsNonTerminalCall` always evaluates to `AlwaysTrue` or `AlwaysFalse`,
+                // never `Ambiguous`.
+                if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
+                    match analyze_single(self.db, &predicate) {
+                        Truthiness::AlwaysTrue => self.narrow(node.if_true(), accumulated),
+                        Truthiness::AlwaysFalse => self.narrow(node.if_false(), accumulated),
+                        Truthiness::Ambiguous => {
+                            unreachable!("`IsNonTerminalCall` predicates should never be Ambiguous")
+                        }
                     }
-                };
+                } else {
+                    // Check if this predicate narrows the variable we're interested in.
+                    let pos_constraint = infer_narrowing_constraint(self.db, predicate, self.place);
+
+                    // If the true branch is statically unreachable, skip it entirely.
+                    if node.if_true() == Id::ALWAYS_FALSE {
+                        let neg_predicate = Predicate {
+                            node: predicate.node,
+                            is_positive: !predicate.is_positive,
+                        };
+                        let neg_constraint =
+                            infer_narrowing_constraint(self.db, neg_predicate, self.place);
+                        let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
+                        self.narrow(node.if_false(), false_accumulated)
+                    } else if node.if_false() == Id::ALWAYS_FALSE {
+                        // If the false branch is statically unreachable, skip it entirely.
+                        let true_accumulated = accumulate_constraint(accumulated, pos_constraint);
+                        self.narrow(node.if_true(), true_accumulated)
+                    } else {
+                        // True branch: predicate holds, so accumulate positive narrowing.
+                        let true_accumulated =
+                            accumulate_constraint(accumulated.clone(), pos_constraint);
+                        let true_ty = self.narrow(node.if_true(), true_accumulated);
+
+                        // False branch: predicate doesn't hold, so accumulate negative narrowing.
+                        let neg_predicate = Predicate {
+                            node: predicate.node,
+                            is_positive: !predicate.is_positive,
+                        };
+                        let neg_constraint =
+                            infer_narrowing_constraint(self.db, neg_predicate, self.place);
+                        let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
+                        let false_ty = self.narrow(node.if_false(), false_accumulated);
+
+                        UnionType::from_two_elements(self.db, true_ty, false_ty)
+                    }
+                }
             }
+        };
 
-            // Check if this predicate narrows the variable we're interested in.
-            let pos_constraint = infer_narrowing_constraint(db, predicate, place);
-
-            // If the true branch is statically unreachable, skip it entirely.
-            if node.if_true() == Id::ALWAYS_FALSE {
-                let neg_predicate = Predicate {
-                    node: predicate.node,
-                    is_positive: !predicate.is_positive,
-                };
-                let neg_constraint = infer_narrowing_constraint(db, neg_predicate, place);
-                let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
-                return narrow_by_constraint_inner(
-                    db,
-                    constraints,
-                    predicates,
-                    node.if_false(),
-                    base_ty,
-                    place,
-                    false_accumulated,
-                );
-            }
-
-            // If the false branch is statically unreachable, skip it entirely.
-            if node.if_false() == Id::ALWAYS_FALSE {
-                let true_accumulated = accumulate_constraint(accumulated, pos_constraint);
-                return narrow_by_constraint_inner(
-                    db,
-                    constraints,
-                    predicates,
-                    node.if_true(),
-                    base_ty,
-                    place,
-                    true_accumulated,
-                );
-            }
-
-            // True branch: predicate holds → accumulate positive narrowing
-            let true_accumulated = accumulate_constraint(accumulated.clone(), pos_constraint);
-            let true_ty = narrow_by_constraint_inner(
-                db,
-                constraints,
-                predicates,
-                node.if_true(),
-                base_ty,
-                place,
-                true_accumulated,
-            );
-
-            // False branch: predicate doesn't hold → accumulate negative narrowing
-            let neg_predicate = Predicate {
-                node: predicate.node,
-                is_positive: !predicate.is_positive,
-            };
-            let neg_constraint = infer_narrowing_constraint(db, neg_predicate, place);
-            let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
-            let false_ty = narrow_by_constraint_inner(
-                db,
-                constraints,
-                predicates,
-                node.if_false(),
-                base_ty,
-                place,
-                false_accumulated,
-            );
-
-            UnionType::from_two_elements(db, true_ty, false_ty)
-        }
+        self.cache.insert(key, result);
+        result
     }
 }
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -212,7 +212,7 @@ use ty_python_core::{
     place_table,
     predicate::{
         CallableAndCallExpr, PatternPredicate, PatternPredicateKind, Predicate, PredicateNode,
-        Predicates,
+        Predicates, ScopedPredicateId,
     },
     reachability_constraints::{ReachabilityConstraints, ScopedReachabilityConstraintId},
 };
@@ -388,15 +388,6 @@ pub(crate) trait ReachabilityConstraintsExtension<'db> {
         predicates: &Predicates<'db>,
         id: ScopedReachabilityConstraintId,
     ) -> Truthiness;
-
-    /// Analyze reachability for a constraint, memoizing intermediate results.
-    fn evaluate_cached(
-        &self,
-        db: &'db dyn Db,
-        predicates: &Predicates<'db>,
-        id: ScopedReachabilityConstraintId,
-        cache: &mut FxHashMap<ScopedReachabilityConstraintId, Truthiness>,
-    ) -> Truthiness;
 }
 
 impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
@@ -429,16 +420,14 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
         base_ty: Type<'db>,
         place: ScopedPlaceId,
     ) -> Type<'db> {
-        let mut cache = FxHashMap::default();
-        NarrowingContext {
+        let mut projector = NarrowingProjector::new(db, self, predicates, place);
+        let projected_root = projector.project(id);
+        ProjectedNarrowingContext {
             db,
-            constraints: self,
-            predicates,
             base_ty,
-            place,
-            cache: &mut cache,
+            graph: &projector.graph,
         }
-        .narrow(id, None)
+        .narrow(projected_root, None)
     }
 
     /// Analyze the statically known reachability for a given constraint.
@@ -446,53 +435,40 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
         &self,
         db: &'db dyn Db,
         predicates: &Predicates<'db>,
-        id: ScopedReachabilityConstraintId,
-    ) -> Truthiness {
-        let mut cache = FxHashMap::default();
-        self.evaluate_cached(db, predicates, id, &mut cache)
-    }
-
-    /// Analyze reachability for a constraint, memoizing intermediate results.
-    fn evaluate_cached(
-        &self,
-        db: &'db dyn Db,
-        predicates: &Predicates<'db>,
-        id: ScopedReachabilityConstraintId,
-        cache: &mut FxHashMap<ScopedReachabilityConstraintId, Truthiness>,
+        mut id: ScopedReachabilityConstraintId,
     ) -> Truthiness {
         type Id = ScopedReachabilityConstraintId;
 
-        if let Some(cached) = cache.get(&id) {
-            return *cached;
-        }
-
-        let result = match id {
-            Id::ALWAYS_TRUE => Truthiness::AlwaysTrue,
-            Id::AMBIGUOUS => Truthiness::Ambiguous,
-            Id::ALWAYS_FALSE => Truthiness::AlwaysFalse,
-            _ => {
-                let node = self.get_interior_node(id);
-                let predicate = &predicates[node.atom()];
-                let branch = match analyze_single(db, predicate) {
-                    Truthiness::AlwaysTrue => node.if_true(),
-                    Truthiness::Ambiguous => node.if_ambiguous(),
-                    Truthiness::AlwaysFalse => node.if_false(),
-                };
-                self.evaluate_cached(db, predicates, branch, cache)
+        loop {
+            let node = match id {
+                Id::ALWAYS_TRUE => return Truthiness::AlwaysTrue,
+                Id::AMBIGUOUS => return Truthiness::Ambiguous,
+                Id::ALWAYS_FALSE => return Truthiness::AlwaysFalse,
+                _ => {
+                    // `id` gives us the index of this node in the IndexVec that we used when
+                    // constructing this BDD. When finalizing the builder, we threw away any
+                    // interior nodes that weren't marked as used. The `used_indices` bit vector
+                    // lets us verify that this node was marked as used, and the rank of that bit
+                    // in the bit vector tells us where this node lives in the "condensed"
+                    // `used_interiors` vector.
+                    let raw_index = id.as_u32() as usize;
+                    debug_assert!(
+                        self.used_indices().get_bit(raw_index).unwrap_or(false),
+                        "all used reachability constraints should have been marked as used",
+                    );
+                    let index = self.used_indices().rank(raw_index) as usize;
+                    self.used_interiors()[index]
+                }
+            };
+            let predicate = &predicates[node.atom()];
+            match analyze_single(db, predicate) {
+                Truthiness::AlwaysTrue => id = node.if_true(),
+                Truthiness::Ambiguous => id = node.if_ambiguous(),
+                Truthiness::AlwaysFalse => id = node.if_false(),
             }
-        };
-
-        cache.insert(id, result);
-        result
+        }
     }
 }
-
-type NarrowingCacheKey<'db> = (
-    ScopedReachabilityConstraintId,
-    Option<NarrowingConstraint<'db>>,
-);
-
-const MAX_NARROWING_STATES: usize = 256;
 
 fn apply_accumulated_narrowing<'db>(
     db: &'db dyn Db,
@@ -507,101 +483,269 @@ fn apply_accumulated_narrowing<'db>(
     }
 }
 
-struct NarrowingContext<'a, 'db> {
+/// Identifier for a node in a projected narrowing graph.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct ProjectedNarrowingNodeId(usize);
+
+impl ProjectedNarrowingNodeId {
+    /// Terminal node for paths that remain reachable.
+    const ALWAYS_TRUE: Self = Self(usize::MAX);
+    /// Terminal node for paths that are statically unreachable.
+    const ALWAYS_FALSE: Self = Self(usize::MAX - 1);
+}
+
+/// Interior node in a projected narrowing graph.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct ProjectedNarrowingNode {
+    atom: ScopedPredicateId,
+    if_true: ProjectedNarrowingNodeId,
+    if_false: ProjectedNarrowingNodeId,
+}
+
+/// Reduced reachability graph containing only predicates relevant to one place.
+#[derive(Default)]
+struct ProjectedNarrowingGraph<'db> {
+    nodes: Vec<ProjectedNarrowingNode>,
+    node_cache: FxHashMap<ProjectedNarrowingNode, ProjectedNarrowingNodeId>,
+    or_cache:
+        FxHashMap<(ProjectedNarrowingNodeId, ProjectedNarrowingNodeId), ProjectedNarrowingNodeId>,
+    predicate_constraints_cache: FxHashMap<
+        ScopedPredicateId,
+        (
+            Option<NarrowingConstraint<'db>>,
+            Option<NarrowingConstraint<'db>>,
+        ),
+    >,
+}
+
+impl ProjectedNarrowingGraph<'_> {
+    /// Returns an interior projected node by ID.
+    fn node(&self, id: ProjectedNarrowingNodeId) -> ProjectedNarrowingNode {
+        self.nodes[id.0]
+    }
+
+    /// Interns a projected node, collapsing nodes with identical branches.
+    fn add_node(&mut self, node: ProjectedNarrowingNode) -> ProjectedNarrowingNodeId {
+        if node.if_true == node.if_false {
+            return node.if_true;
+        }
+
+        if let Some(cached) = self.node_cache.get(&node) {
+            return *cached;
+        }
+
+        let id = ProjectedNarrowingNodeId(self.nodes.len());
+        self.nodes.push(node);
+        self.node_cache.insert(node, id);
+        id
+    }
+
+    /// Constructs the canonical disjunction of two projected subgraphs.
+    fn or(
+        &mut self,
+        left: ProjectedNarrowingNodeId,
+        right: ProjectedNarrowingNodeId,
+    ) -> ProjectedNarrowingNodeId {
+        if left == right || left == ProjectedNarrowingNodeId::ALWAYS_TRUE {
+            return left;
+        }
+        if right == ProjectedNarrowingNodeId::ALWAYS_TRUE {
+            return right;
+        }
+        if left == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+            return right;
+        }
+        if right == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+            return left;
+        }
+
+        let key = if left.0 <= right.0 {
+            (left, right)
+        } else {
+            (right, left)
+        };
+        if let Some(cached) = self.or_cache.get(&key) {
+            return *cached;
+        }
+
+        let left_node = self.node(left);
+        let right_node = self.node(right);
+        let result = match left_node.atom.cmp(&right_node.atom).reverse() {
+            std::cmp::Ordering::Equal => {
+                let if_true = self.or(left_node.if_true, right_node.if_true);
+                let if_false = self.or(left_node.if_false, right_node.if_false);
+                self.add_node(ProjectedNarrowingNode {
+                    atom: left_node.atom,
+                    if_true,
+                    if_false,
+                })
+            }
+            std::cmp::Ordering::Less => {
+                let if_true = self.or(left_node.if_true, right);
+                let if_false = self.or(left_node.if_false, right);
+                self.add_node(ProjectedNarrowingNode {
+                    atom: left_node.atom,
+                    if_true,
+                    if_false,
+                })
+            }
+            std::cmp::Ordering::Greater => {
+                let if_true = self.or(left, right_node.if_true);
+                let if_false = self.or(left, right_node.if_false);
+                self.add_node(ProjectedNarrowingNode {
+                    atom: right_node.atom,
+                    if_true,
+                    if_false,
+                })
+            }
+        };
+
+        self.or_cache.insert(key, result);
+        result
+    }
+}
+
+/// Projects reachability constraints onto the predicates that can narrow one place.
+struct NarrowingProjector<'a, 'db> {
     db: &'db dyn Db,
     constraints: &'a ReachabilityConstraints,
     predicates: &'a Predicates<'db>,
-    base_ty: Type<'db>,
     place: ScopedPlaceId,
-    cache: &'a mut FxHashMap<NarrowingCacheKey<'db>, Type<'db>>,
+    project_cache: FxHashMap<ScopedReachabilityConstraintId, ProjectedNarrowingNodeId>,
+    graph: ProjectedNarrowingGraph<'db>,
 }
 
-impl<'db> NarrowingContext<'_, 'db> {
-    /// Inner recursive helper that accumulates narrowing constraints along each TDD path.
-    fn narrow(
+impl<'a, 'db> NarrowingProjector<'a, 'db> {
+    /// Creates a projector for narrowing `place`.
+    fn new(
+        db: &'db dyn Db,
+        constraints: &'a ReachabilityConstraints,
+        predicates: &'a Predicates<'db>,
+        place: ScopedPlaceId,
+    ) -> Self {
+        Self {
+            db,
+            constraints,
+            predicates,
+            place,
+            project_cache: FxHashMap::default(),
+            graph: ProjectedNarrowingGraph::default(),
+        }
+    }
+
+    /// Returns the cached positive and negative narrowing constraints for a predicate.
+    fn predicate_constraints(
         &mut self,
-        id: ScopedReachabilityConstraintId,
-        accumulated: Option<NarrowingConstraint<'db>>,
-    ) -> Type<'db> {
+        predicate_id: ScopedPredicateId,
+    ) -> (
+        Option<NarrowingConstraint<'db>>,
+        Option<NarrowingConstraint<'db>>,
+    ) {
+        if let Some(cached) = self.graph.predicate_constraints_cache.get(&predicate_id) {
+            return cached.clone();
+        }
+
+        let predicate = self.predicates[predicate_id];
+        let pos_constraint = infer_narrowing_constraint(self.db, predicate, self.place);
+        let neg_predicate = Predicate {
+            node: predicate.node,
+            is_positive: !predicate.is_positive,
+        };
+        let neg_constraint = infer_narrowing_constraint(self.db, neg_predicate, self.place);
+        let constraints = (pos_constraint, neg_constraint);
+        self.graph
+            .predicate_constraints_cache
+            .insert(predicate_id, constraints.clone());
+        constraints
+    }
+
+    /// Projects a reachability node into the reduced narrowing graph.
+    fn project(&mut self, id: ScopedReachabilityConstraintId) -> ProjectedNarrowingNodeId {
         type Id = ScopedReachabilityConstraintId;
 
-        if id == Id::ALWAYS_FALSE {
-            return Type::Never;
-        }
-
-        let key = (id, accumulated.clone());
-        if let Some(cached) = self.cache.get(&key) {
+        if let Some(cached) = self.project_cache.get(&id) {
             return *cached;
         }
-        if self.cache.len() >= MAX_NARROWING_STATES {
-            return apply_accumulated_narrowing(self.db, self.base_ty, accumulated);
-        }
 
-        let result = match id {
-            Id::ALWAYS_TRUE | Id::AMBIGUOUS => {
-                // Apply all accumulated narrowing constraints to the base type
-                apply_accumulated_narrowing(self.db, self.base_ty, accumulated)
-            }
-            Id::ALWAYS_FALSE => Type::Never,
+        let projected = match id {
+            Id::ALWAYS_TRUE | Id::AMBIGUOUS => ProjectedNarrowingNodeId::ALWAYS_TRUE,
+            Id::ALWAYS_FALSE => ProjectedNarrowingNodeId::ALWAYS_FALSE,
             _ => {
                 let node = self.constraints.get_interior_node(id);
                 let predicate = self.predicates[node.atom()];
 
-                // `IsNonTerminalCall` predicates don't narrow any variable; they only
-                // affect reachability. Evaluate the predicate to determine which
-                // path(s) are reachable, rather than walking both branches.
-                // `IsNonTerminalCall` always evaluates to `AlwaysTrue` or `AlwaysFalse`,
-                // never `Ambiguous`.
                 if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
                     match analyze_single(self.db, &predicate) {
-                        Truthiness::AlwaysTrue => self.narrow(node.if_true(), accumulated),
-                        Truthiness::AlwaysFalse => self.narrow(node.if_false(), accumulated),
+                        Truthiness::AlwaysTrue => self.project(node.if_true()),
+                        Truthiness::AlwaysFalse => self.project(node.if_false()),
                         Truthiness::Ambiguous => {
                             unreachable!("`IsNonTerminalCall` predicates should never be Ambiguous")
                         }
                     }
                 } else {
-                    // Check if this predicate narrows the variable we're interested in.
-                    let pos_constraint = infer_narrowing_constraint(self.db, predicate, self.place);
+                    let if_true = self.project(node.if_true());
+                    let if_false = self.project(node.if_false());
+                    let (pos_constraint, neg_constraint) = self.predicate_constraints(node.atom());
 
-                    // If the true branch is statically unreachable, skip it entirely.
-                    if node.if_true() == Id::ALWAYS_FALSE {
-                        let neg_predicate = Predicate {
-                            node: predicate.node,
-                            is_positive: !predicate.is_positive,
-                        };
-                        let neg_constraint =
-                            infer_narrowing_constraint(self.db, neg_predicate, self.place);
-                        let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
-                        self.narrow(node.if_false(), false_accumulated)
-                    } else if node.if_false() == Id::ALWAYS_FALSE {
-                        // If the false branch is statically unreachable, skip it entirely.
-                        let true_accumulated = accumulate_constraint(accumulated, pos_constraint);
-                        self.narrow(node.if_true(), true_accumulated)
+                    if pos_constraint.is_none() && neg_constraint.is_none() {
+                        self.graph.or(if_true, if_false)
                     } else {
-                        // True branch: predicate holds, so accumulate positive narrowing.
-                        let true_accumulated =
-                            accumulate_constraint(accumulated.clone(), pos_constraint);
-                        let true_ty = self.narrow(node.if_true(), true_accumulated);
-
-                        // False branch: predicate doesn't hold, so accumulate negative narrowing.
-                        let neg_predicate = Predicate {
-                            node: predicate.node,
-                            is_positive: !predicate.is_positive,
-                        };
-                        let neg_constraint =
-                            infer_narrowing_constraint(self.db, neg_predicate, self.place);
-                        let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
-                        let false_ty = self.narrow(node.if_false(), false_accumulated);
-
-                        UnionType::from_two_elements(self.db, true_ty, false_ty)
+                        self.graph.add_node(ProjectedNarrowingNode {
+                            atom: node.atom(),
+                            if_true,
+                            if_false,
+                        })
                     }
                 }
             }
         };
 
-        self.cache.insert(key, result);
-        result
+        self.project_cache.insert(id, projected);
+        projected
+    }
+}
+
+/// Evaluates narrowed types over a projected narrowing graph.
+struct ProjectedNarrowingContext<'a, 'db> {
+    db: &'db dyn Db,
+    base_ty: Type<'db>,
+    graph: &'a ProjectedNarrowingGraph<'db>,
+}
+
+impl<'db> ProjectedNarrowingContext<'_, 'db> {
+    /// Recursively evaluates a projected path while accumulating narrowing constraints.
+    fn narrow(
+        &mut self,
+        id: ProjectedNarrowingNodeId,
+        accumulated: Option<NarrowingConstraint<'db>>,
+    ) -> Type<'db> {
+        if id == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+            return Type::Never;
+        }
+
+        if id == ProjectedNarrowingNodeId::ALWAYS_TRUE {
+            apply_accumulated_narrowing(self.db, self.base_ty, accumulated)
+        } else {
+            let node = self.graph.node(id);
+            let (pos_constraint, neg_constraint) =
+                self.graph.predicate_constraints_cache[&node.atom].clone();
+
+            if node.if_true == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+                let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
+                self.narrow(node.if_false, false_accumulated)
+            } else if node.if_false == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+                let true_accumulated = accumulate_constraint(accumulated, pos_constraint);
+                self.narrow(node.if_true, true_accumulated)
+            } else {
+                let true_accumulated = accumulate_constraint(accumulated.clone(), pos_constraint);
+                let true_ty = self.narrow(node.if_true, true_accumulated);
+
+                let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
+                let false_ty = self.narrow(node.if_false, false_accumulated);
+
+                UnionType::from_two_elements(self.db, true_ty, false_ty)
+            }
+        }
     }
 }
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -525,6 +525,10 @@ impl<'db> NarrowingContext<'_, 'db> {
     ) -> Type<'db> {
         type Id = ScopedReachabilityConstraintId;
 
+        if id == Id::ALWAYS_FALSE {
+            return Type::Never;
+        }
+
         let key = (id, accumulated.clone());
         if let Some(cached) = self.cache.get(&key) {
             return *cached;


### PR DESCRIPTION
## Summary

The intent of this change is to fix the regression we've seen on PyTorch since the Beta (see: https://github.com/astral-sh/ty/issues/3023). (isort, the other project listed in the relevant issue, is largely unchanged.)

| Project | main | This branch | Beta |
| --- | ---: | ---: | ---: |
| isort | 400.1ms +/- 3.8ms | 387.9ms +/- 4.0ms | 46.6ms +/- 1.1ms |
| PyTorch | 15.324s +/- 0.275s | 1.182s +/- 0.026s | 1.163s +/- 0.094s |

The PyTorch shape has been hard to summarize succinctly and was very hard for Codex to minimize, but the benchmark here... _attempts_ to do so: https://github.com/astral-sh/ruff/pull/24984/changes#diff-2d75cc3cf32fb90e45c717c57dcafeb2bd0aeb0606811054bc470240da8e264cR1003-R1041. The key seems to be assigning to the same `out` from many paths. Then when we ask whether the final `return out` is bound, many definitions share almost the same reachability prefix.

To address it, this PR changes narrowing to first project a reachability graph onto the predicates that can actually narrow the place being queried, and then evaluates that reduced graph.

For example, when narrowing `x`, predicates about unrelated places no longer create distinct paths through the narrowing walk. The projected graph interns equivalent nodes and merges irrelevant branches, which avoids repeatedly exploring states that cannot affect the final type while preserving the paths that do matter.
