### PR TITLE
[ty] Fix method calls on TypeVars with union upper bounds

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -588,6 +588,25 @@ def f(
     reveal_type(close_and_return(g))  # revealed: Unknown
 ```
 
+## Union upper bounds and method calls
+
+When a TypeVar has a union as its upper bound, we can call methods that exist on all elements of the
+union. The return type is the union of the return types from each element.
+
+```py
+class C:
+    def method(self) -> int:
+        return 1
+
+class D:
+    def method(self) -> str:
+        return "foo"
+
+def f[T: C | D](x: T) -> T:
+    reveal_type(x.method())  # revealed: int | str
+    return x
+```
+
 ## Opaque decorators don't affect typevar binding
 
 Inside the body of a generic function, we should be able to see that the typevars bound by that

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3310,6 +3310,27 @@ impl<'db> Type<'db> {
                 .into()
             }
 
+            // For a TypeVar with a union upper bound, we need to map over the union elements
+            // and do the full member lookup on each element. This ensures that when we access
+            // a method on `T: A | B`, the method binding is done with the correct instance type
+            // for each union element, rather than trying to bind the method with the TypeVar
+            // itself (which would fail because T is not assignable to A or B individually).
+            Type::TypeVar(typevar)
+                if matches!(
+                    typevar.typevar(db).bound_or_constraints(db),
+                    Some(TypeVarBoundOrConstraints::UpperBound(Type::Union(_)))
+                ) =>
+            {
+                let Some(TypeVarBoundOrConstraints::UpperBound(Type::Union(union))) =
+                    typevar.typevar(db).bound_or_constraints(db)
+                else {
+                    unreachable!("We just checked this is a union bound")
+                };
+                union.map_with_boundness_and_qualifiers(db, |elem| {
+                    elem.member_lookup_with_policy(db, name_str.into(), policy)
+                })
+            }
+
             Type::NominalInstance(instance)
                 if matches!(name_str, "value" | "_value_")
                     && is_single_member_enum(db, instance.class_literal(db)) =>


### PR DESCRIPTION
Fixes https://github.com/astral-sh/ty/issues/2585

When a TypeVar has a union as its upper bound (e.g., `T: A | B`), method lookups need to map over the union elements and do the full member lookup on each element separately. This ensures that method binding is done with the correct instance type for each union element.

Previously, we would look up the method on the union bound, getting a union of methods, then try to call each method with the TypeVar as the `self` argument. This failed because the TypeVar is not assignable to individual union elements (e.g., `T` is not assignable to `A` or `B` individually, only to `A | B`).

The fix adds a special case in `member_lookup_with_policy` that detects TypeVars with union upper bounds and maps over the union elements, performing the full member lookup on each element before combining the results.
