### PR TITLE
[`pylint`] Standardize diagnostic message (`PLR0914`, `PLR0917`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/too_many_positional_arguments.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/too_many_positional_arguments.py
@@ -1,4 +1,4 @@
-def f(x, y, z, t, u, v, w, r):  # Too many positional arguments (8/5)
+def f(x, y, z, t, u, v, w, r):  # Too many positional arguments (8 > 5)
     pass
 
 
@@ -18,7 +18,7 @@ def f(x=1, y=1, z=1):  # OK
     pass
 
 
-def f(x, y, z, /, u, v, w):  # Too many positional arguments (6/5)
+def f(x, y, z, /, u, v, w):  # Too many positional arguments (6 > 5)
     pass
 
 
@@ -26,7 +26,7 @@ def f(x, y, z, *, u, v, w):  # OK
     pass
 
 
-def f(x, y, z, a, b, c, *, u, v, w):  # Too many positional arguments (6/5)
+def f(x, y, z, a, b, c, *, u, v, w):  # Too many positional arguments (6 > 5)
     pass
 
 
@@ -40,11 +40,11 @@ class C:
     def f(weird_self_name, a, b, c, d, e):  # OK
         pass
 
-    def f(self, a, b, c, d, e, g):  # Too many positional arguments (6/5)
+    def f(self, a, b, c, d, e, g):  # Too many positional arguments (6 > 5)
         pass
 
     @staticmethod
-    def f(self, a, b, c, d, e):  # Too many positional arguments (6/5)
+    def f(self, a, b, c, d, e):  # Too many positional arguments (6 > 5)
         pass
 
     @classmethod

--- a/crates/ruff_linter/resources/test/fixtures/pylint/too_many_positional_params.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/too_many_positional_params.py
@@ -1,10 +1,10 @@
-# Too many positional arguments (7/4) for max_positional=4
+# Too many positional arguments (7 > 4) for max_positional=4
 # OK for dummy_variable_rgx ~ "skip_.*"
 def f(w, x, y, z, skip_t, skip_u, skip_v):
     pass
 
 
-# Too many positional arguments (7/4) for max_args=4
-# Too many positional arguments (7/3) for dummy_variable_rgx ~ "skip_.*"
+# Too many positional arguments (7 > 4) for max_args=4
+# Too many positional arguments (7 > 3) for dummy_variable_rgx ~ "skip_.*"
 def f(w, x, y, z, t, u, v):
     pass

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_locals.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_locals.rs
@@ -33,7 +33,7 @@ impl Violation for TooManyLocals {
             current_amount,
             max_amount,
         } = self;
-        format!("Too many local variables ({current_amount}/{max_amount})")
+        format!("Too many local variables ({current_amount} > {max_amount})")
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_positional_arguments.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_positional_arguments.rs
@@ -65,7 +65,7 @@ impl Violation for TooManyPositionalArguments {
     #[derive_message_formats]
     fn message(&self) -> String {
         let TooManyPositionalArguments { c_pos, max_pos } = self;
-        format!("Too many positional arguments ({c_pos}/{max_pos})")
+        format!("Too many positional arguments ({c_pos} > {max_pos})")
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR0917_too_many_positional_arguments.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR0917_too_many_positional_arguments.py.snap
@@ -1,46 +1,46 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
-PLR0917 Too many positional arguments (8/5)
+PLR0917 Too many positional arguments (8 > 5)
  --> too_many_positional_arguments.py:1:5
   |
-1 | def f(x, y, z, t, u, v, w, r):  # Too many positional arguments (8/5)
+1 | def f(x, y, z, t, u, v, w, r):  # Too many positional arguments (8 > 5)
   |     ^
 2 |     pass
   |
 
-PLR0917 Too many positional arguments (6/5)
+PLR0917 Too many positional arguments (6 > 5)
   --> too_many_positional_arguments.py:21:5
    |
-21 | def f(x, y, z, /, u, v, w):  # Too many positional arguments (6/5)
+21 | def f(x, y, z, /, u, v, w):  # Too many positional arguments (6 > 5)
    |     ^
 22 |     pass
    |
 
-PLR0917 Too many positional arguments (6/5)
+PLR0917 Too many positional arguments (6 > 5)
   --> too_many_positional_arguments.py:29:5
    |
-29 | def f(x, y, z, a, b, c, *, u, v, w):  # Too many positional arguments (6/5)
+29 | def f(x, y, z, a, b, c, *, u, v, w):  # Too many positional arguments (6 > 5)
    |     ^
 30 |     pass
    |
 
-PLR0917 Too many positional arguments (6/5)
+PLR0917 Too many positional arguments (6 > 5)
   --> too_many_positional_arguments.py:43:9
    |
 41 |         pass
 42 |
-43 |     def f(self, a, b, c, d, e, g):  # Too many positional arguments (6/5)
+43 |     def f(self, a, b, c, d, e, g):  # Too many positional arguments (6 > 5)
    |         ^
 44 |         pass
    |
 help: Consider adding `@typing.override` if changing the function signature would violate the Liskov Substitution Principle
 
-PLR0917 Too many positional arguments (6/5)
+PLR0917 Too many positional arguments (6 > 5)
   --> too_many_positional_arguments.py:47:9
    |
 46 |     @staticmethod
-47 |     def f(self, a, b, c, d, e):  # Too many positional arguments (6/5)
+47 |     def f(self, a, b, c, d, e):  # Too many positional arguments (6 > 5)
    |         ^
 48 |         pass
    |

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__max_positional_args.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__max_positional_args.snap
@@ -1,21 +1,21 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
-PLR0917 Too many positional arguments (7/4)
+PLR0917 Too many positional arguments (7 > 4)
  --> too_many_positional_params.py:3:5
   |
-1 | # Too many positional arguments (7/4) for max_positional=4
+1 | # Too many positional arguments (7 > 4) for max_positional=4
 2 | # OK for dummy_variable_rgx ~ "skip_.*"
 3 | def f(w, x, y, z, skip_t, skip_u, skip_v):
   |     ^
 4 |     pass
   |
 
-PLR0917 Too many positional arguments (7/4)
+PLR0917 Too many positional arguments (7 > 4)
   --> too_many_positional_params.py:9:5
    |
- 7 | # Too many positional arguments (7/4) for max_args=4
- 8 | # Too many positional arguments (7/3) for dummy_variable_rgx ~ "skip_.*"
+ 7 | # Too many positional arguments (7 > 4) for max_args=4
+ 8 | # Too many positional arguments (7 > 3) for dummy_variable_rgx ~ "skip_.*"
  9 | def f(w, x, y, z, t, u, v):
    |     ^
 10 |     pass

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__too_many_locals.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__too_many_locals.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
-PLR0914 Too many local variables (16/15)
+PLR0914 Too many local variables (16 > 15)
   --> too_many_locals.py:20:5
    |
 20 | def func() -> None:  # PLR0914


### PR DESCRIPTION
## Summary

`PLR0914` (`too-many-locals`) and `PLR0917` (`too-many-positional-arguments`) used `/` as the delimiter between the current and maximum values in their diagnostic messages, while all other comparable pylint rules use ` > `.

Before:
```
PLR0914 Too many local variables (16/15)
PLR0917 Too many positional arguments (8/5)
```

After:
```
PLR0914 Too many local variables (16 > 15)
PLR0917 Too many positional arguments (8 > 5)
```

This matches the format used by `PLR0904`, `PLR0911`, `PLR0912`, `PLR0913`, `PLR0915`, `PLR0916`, and `PLR1702`.

Closes #24985

## Test plan

- [x] Updated snapshots for `PLR0914` and `PLR0917`
- [x] All affected tests pass (`too_many_locals`, `max_positional_args`, `rule_toomanypositionalarguments_...`)