### PR TITLE
[ty] Support narrowing on `__class__` checks

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -231,7 +231,7 @@ static STATIC_FRAME: Benchmark = Benchmark::new(
         max_dep_date: "2025-08-09",
         python_version: SupportedPythonVersion::Py311,
     },
-    1800,
+    1810,
 );
 
 #[track_caller]

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -727,6 +727,14 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
                     }
                 }
             }
+            // x.__class__ is Y can narrow x
+            ast::Expr::Attribute(attribute) if attribute.attr.as_str() == "__class__" => {
+                if let Some(place_expr) = PlaceExpr::try_from_expr(&attribute.value) {
+                    if let Some(place) = self.places.place_id((&place_expr).into()) {
+                        places.insert(place);
+                    }
+                }
+            }
             _ => {}
         }
     }

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -710,29 +710,28 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
 
     /// Helper to add a potential narrowing target expression to the set.
     fn add_narrowing_target(&self, expr: &ast::Expr, places: &mut PossiblyNarrowedPlaces) {
-        if let Some(place_expr) = PlaceExpr::try_from_expr(expr) {
-            if let Some(place) = self.places.place_id((&place_expr).into()) {
-                places.insert(place);
-            }
+        if let Some(place_expr) = PlaceExpr::try_from_expr(expr)
+            && let Some(place) = self.places.place_id((&place_expr).into())
+        {
+            places.insert(place);
         }
 
         match expr.expression_value() {
             // type(x) is Y can narrow x
             ast::Expr::Call(call) if call.arguments.args.len() == 1 => {
-                if let Some(first_arg) = call.arguments.args.first() {
-                    if let Some(place_expr) = PlaceExpr::try_from_expr(first_arg) {
-                        if let Some(place) = self.places.place_id((&place_expr).into()) {
-                            places.insert(place);
-                        }
-                    }
+                if let Some(first_arg) = call.arguments.args.first()
+                    && let Some(place_expr) = PlaceExpr::try_from_expr(first_arg)
+                    && let Some(place) = self.places.place_id((&place_expr).into())
+                {
+                    places.insert(place);
                 }
             }
             // x.__class__ is Y can narrow x
             ast::Expr::Attribute(attribute) if attribute.attr.as_str() == "__class__" => {
-                if let Some(place_expr) = PlaceExpr::try_from_expr(&attribute.value) {
-                    if let Some(place) = self.places.place_id((&place_expr).into()) {
-                        places.insert(place);
-                    }
+                if let Some(place_expr) = PlaceExpr::try_from_expr(&attribute.value)
+                    && let Some(place) = self.places.place_id((&place_expr).into())
+                {
+                    places.insert(place);
                 }
             }
             _ => {}

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type.md
@@ -69,6 +69,21 @@ def _(x: A | B, y: Literal[1, 2]):
         reveal_type(y)  # revealed: Literal[1]
 ```
 
+## `type(x) is type(self)`
+
+```py
+class Pattern: ...
+
+class InstanceOf(Pattern):
+    def matches(self, other: Pattern) -> bool:
+        if type(other) is type(self):
+            reveal_type(other)  # revealed: InstanceOf
+            return True
+
+        reveal_type(other)  # revealed: Pattern
+        return False
+```
+
 ## `type(x) is not C`
 
 ```py
@@ -99,6 +114,39 @@ def _(x: A | B, y: A | C):
         reveal_type(y)  # revealed: A | C
     else:
         reveal_type(y)  # revealed: A
+```
+
+## `x.__class__ is C`
+
+```py
+from typing import final
+
+class A: ...
+class B: ...
+
+@final
+class C: ...
+
+def _(x: A | B, y: A | C):
+    if x.__class__ is A:
+        reveal_type(x)  # revealed: A
+    else:
+        reveal_type(x)  # revealed: A | B
+
+    if C is y.__class__:
+        reveal_type(y)  # revealed: C
+    else:
+        reveal_type(y)  # revealed: A
+
+    if x.__class__ is not A:
+        reveal_type(x)  # revealed: A | B
+    else:
+        reveal_type(x)  # revealed: A
+
+    if y.__class__ is not C:
+        reveal_type(y)  # revealed: A
+    else:
+        reveal_type(y)  # revealed: C
 ```
 
 ## The top materialization is used for generic classes

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1216,6 +1216,40 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             }
         }
 
+        /// Return the expression being tested by an exact runtime-class check.
+        ///
+        /// `x.__class__` is modeled as equivalent to `type(x)` by [`Type::dunder_class`], so class
+        /// identity checks against either expression can narrow `x`.
+        fn exact_class_narrowing_target<'a, 'db>(
+            db: &'db dyn Db,
+            inference: &ExpressionInference<'db>,
+            expr: &'a ast::Expr,
+        ) -> Option<&'a ast::Expr> {
+            match expr.expression_value() {
+                ast::Expr::Call(ast::ExprCall {
+                    func,
+                    arguments: ast::Arguments { args, keywords, .. },
+                    ..
+                }) => {
+                    if keywords.is_empty()
+                        && let [single_argument] = &**args
+                        && let Type::ClassLiteral(called_class) = inference.expression_type(func)
+                        && called_class.is_known(db, KnownClass::Type)
+                    {
+                        Some(single_argument)
+                    } else {
+                        None
+                    }
+                }
+                ast::Expr::Attribute(ast::ExprAttribute { value, attr, .. })
+                    if attr.as_str() == "__class__" =>
+                {
+                    Some(value)
+                }
+                _ => None,
+            }
+        }
+
         let ast::ExprCompare {
             range: _,
             node_index: _,
@@ -1441,25 +1475,22 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             // - `if type(x) is not Y`
             // - `if Y is type(x)`
             // - `if Y is not type(x)`
-            if let (ast::Expr::Call(call), _, _, other) | (_, other, ast::Expr::Call(call), _) = (
-                left.expression_value(),
-                lhs_ty,
-                right.expression_value(),
-                rhs_ty,
+            // - `if x.__class__ is Y`
+            // - `if x.__class__ is not Y`
+            // - `if Y is x.__class__`
+            // - `if Y is not x.__class__`
+            let exact_class_checks = match (
+                exact_class_narrowing_target(self.db, inference, left),
+                exact_class_narrowing_target(self.db, inference, right),
             ) {
-                let ast::ExprCall {
-                    range: _,
-                    node_index: _,
-                    func,
-                    arguments:
-                        ast::Arguments {
-                            args,
-                            keywords,
-                            range: _,
-                            node_index: _,
-                        },
-                } = call;
-
+                (Some(left_target), Some(right_target)) => {
+                    [Some((left_target, rhs_ty)), Some((right_target, lhs_ty))]
+                }
+                (Some(target), None) => [Some((target, rhs_ty)), None],
+                (None, Some(target)) => [Some((target, lhs_ty)), None],
+                (None, None) => [None, None],
+            };
+            for (target_expr, other) in exact_class_checks.into_iter().flatten() {
                 // If this is `None`, it indicates that we cannot do `if type(x) is Y`
                 // narrowing: we can only do narrowing for `if type(x) is Y` and
                 // `if type(x) is not Y`, not for `if type(x) == Y` or `if type(x) != Y`.
@@ -1470,11 +1501,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 };
 
                 if let Some(is_positive) = is_positive
-                    && keywords.is_empty()
-                    && let [single_argument] = &**args
-                    && let Some(target) = PlaceExpr::try_from_expr(single_argument)
-                    && let Type::ClassLiteral(called_class) = inference.expression_type(func)
-                    && called_class.is_known(self.db, KnownClass::Type)
+                    && let Some(target) = PlaceExpr::try_from_expr(target_expr)
                     && let Some(other_class) = find_underlying_class(self.db, other)
                     // `else`-branch narrowing for `if type(x) is Y` can only be done
                     // if `Y` is a final class

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1475,10 +1475,14 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             // - `if type(x) is not Y`
             // - `if Y is type(x)`
             // - `if Y is not type(x)`
+            // - `if type(x) is type(y)`
+            // - `if type(x) is not type(y)`
             // - `if x.__class__ is Y`
             // - `if x.__class__ is not Y`
             // - `if Y is x.__class__`
             // - `if Y is not x.__class__`
+            // - `if x.__class__ is y.__class__`
+            // - `if x.__class__ is not y.__class__`
             let exact_class_checks = match (
                 exact_class_narrowing_target(self.db, inference, left),
                 exact_class_narrowing_target(self.db, inference, right),


### PR DESCRIPTION
## Summary

This adds support for narrowing based on `__class__` identity checks, treating them the same way we already treat `type(...)` checks. Although these _can_ differ at runtime, AFAICT we already treat these as the same internally (i.e., `infer_builtins_type_call` calls `arg_type.dunder_class(db)`).

For example:

```python
from typing import final, reveal_type

class A: ...
class B: ...

@final
class C: ...

def f(x: A | B, y: A | C):
    if x.__class__ is A:
        reveal_type(x)  # revealed: A

    if C is y.__class__:
        reveal_type(y)  # revealed: C
    else:
        reveal_type(y)  # revealed: A
```

This supports both operand orders, and both `is` and `is not`. As with `type(x) is C`, negative-branch narrowing is only applied when the tested class is final.
