### PR TITLE
[ty] Narrow generic type classinfo in `isinstance` and `issubclass`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -444,6 +444,74 @@ def _(x: object, y: type[int]):
         reveal_type(x)  # revealed: int
 ```
 
+Generic `type[]` classinfo arguments are supported for non-final classes whose generic contexts
+contain only ordinary, unbounded type parameters. The runtime class object does not retain the
+specialization from its annotation, so narrowing uses the top materialization of the class:
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from ty_extensions import Unknown
+
+class Invariant[T]:
+    value: T
+
+def _(
+    x: object,
+    cls: type[Invariant[int]],
+    y: Invariant[str],
+    unknown_cls: type[Invariant[Unknown]],
+):
+    if isinstance(x, cls):
+        reveal_type(x)  # revealed: Top[Invariant[Unknown]]
+        reveal_type(x.value)  # revealed: object
+
+    if isinstance(x, type(y)):
+        reveal_type(x)  # revealed: Top[Invariant[Unknown]]
+        reveal_type(x.value)  # revealed: object
+
+    if isinstance(x, unknown_cls):
+        reveal_type(x)  # revealed: Top[Invariant[Unknown]]
+        reveal_type(x.value)  # revealed: object
+```
+
+For now, narrowing is declined for generic classes that are final or have defaults, bounds,
+constraints, or `ParamSpec` parameters:
+
+```py
+from typing import final
+
+class Bounded[T: int]: ...
+class Constrained[T: (int, str)]: ...
+class Defaulted[T = int]: ...
+class WithParamSpec[**P]: ...
+
+@final
+class Final[T]: ...
+
+def _(
+    x: object,
+    bounded: type[Bounded[int]],
+    constrained: type[Constrained[int]],
+    defaulted: type[Defaulted[int]],
+    paramspec: type[WithParamSpec[[int]]],
+    final: type[Final[int]],
+):
+    if isinstance(x, bounded):
+        reveal_type(x)  # revealed: object
+    if isinstance(x, constrained):
+        reveal_type(x)  # revealed: object
+    if isinstance(x, defaulted):
+        reveal_type(x)  # revealed: object
+    if isinstance(x, paramspec):
+        reveal_type(x)  # revealed: object
+    if isinstance(x, final):
+        reveal_type(x)  # revealed: object
+```
+
 Negative narrowing is not sound in this case, because `type[A]` includes subclasses of `A`:
 
 ```py
@@ -591,18 +659,17 @@ def i[T: Intersection[type[Bar], type[Baz | Spam]], U: (type[Eggs], type[Ham])](
     return (y, z)
 ```
 
-If some (but not all) positive members of the intersection are not valid `isinstance()` targets --
-for example a parametrized generic alias such as `type[list[int]]`, which raises `TypeError` at
-runtime -- we skip those members and narrow using the remaining valid ones, rather than declining to
-narrow at all:
+If some (but not all) positive members of the intersection do not provide an `isinstance()`
+constraint, we skip those members and narrow using the remaining valid ones, rather than declining
+to narrow at all:
 
 ```py
+from typing import Callable
 from ty_extensions import Intersection
 
-def f(x: Foo, y: Intersection[type[Bar], type[list[int]]]):
+def f(x: Foo, y: Intersection[type[Bar], Callable[[], object]]):
     if isinstance(x, y):
-        # `type[list[int]]` is not a valid `isinstance()` target and contributes no
-        # constraint, but `type[Bar]` still narrows.
+        # The callable component contributes no constraint, but `type[Bar]` still narrows.
         reveal_type(x)  # revealed: Foo & Bar
         reveal_type(x.attribute)  # revealed: int
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/issubclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/issubclass.md
@@ -445,6 +445,27 @@ def _(x: type, y: type[int]):
         reveal_type(x)  # revealed: type[int]
 ```
 
+Generic `type[]` classinfo arguments with ordinary, unbounded type parameters use the top
+materialization of the instance type. This also applies when the runtime class object comes from
+`type(y)`:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+class Invariant[T]:
+    value: T
+
+def _(x: type[object], cls: type[Invariant[int]], y: Invariant[str]):
+    if issubclass(x, cls):
+        reveal_type(x)  # revealed: type[Top[Invariant[Unknown]]]
+
+    if issubclass(x, type(y)):
+        reveal_type(x)  # revealed: type[Top[Invariant[Unknown]]]
+```
+
 ### Disjoint `type[]` types are narrowed to `Never`
 
 Here, `type[UsesMeta1]` and `type[UsesMeta2]` are disjoint because a common subclass of `UsesMeta1`

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -445,6 +445,30 @@ impl ClassInfoConstraintFunction {
             }
         };
 
+        let constraint_from_class_type = |class: ClassType<'db>| match class {
+            ClassType::NonGeneric(class) => Some(constraint_from_class_literal(class)),
+            ClassType::Generic(generic) => {
+                // A generic `ClassType` here is the type of a runtime class object, e.g.
+                // `cls: type[list[int]]`, not the generic alias expression `list[int]`
+                // itself. Direct generic aliases are rejected by the `Type::GenericAlias`
+                // case below.
+                let origin = generic.origin(db);
+                let generic_context = origin.generic_context(db)?;
+
+                // For now, only handle non-final generics with ordinary, unbounded type
+                // parameters. Defaults, bounds, constraints, and ParamSpecs require a dedicated
+                // runtime-class materialization that does not affect ordinary materialization.
+                (!origin.is_final(db)
+                    && generic_context.variables(db).all(|typevar| {
+                        let typevar = typevar.typevar(db);
+                        !typevar.is_paramspec(db)
+                            && typevar.bound_or_constraints(db).is_none()
+                            && typevar.default_type(db).is_none()
+                    }))
+                .then(|| constraint_from_class_literal(ClassLiteral::Static(origin)))
+            }
+        };
+
         match classinfo {
             Type::TypeAlias(alias) => {
                 self.generate_constraint(db, alias.value_type(db), is_positive)
@@ -459,12 +483,7 @@ impl ClassInfoConstraintFunction {
                 }
 
                 match subclass_of_ty.subclass_of() {
-                    SubclassOfInner::Class(ClassType::NonGeneric(class_literal)) => {
-                        Some(constraint_from_class_literal(class_literal))
-                    }
-                    // It's not valid to use a generic alias as the second argument to `isinstance()` or `issubclass()`,
-                    // e.g. `isinstance(x, list[int])` fails at runtime.
-                    SubclassOfInner::Class(ClassType::Generic(_)) => None,
+                    SubclassOfInner::Class(class) => constraint_from_class_type(class),
                     SubclassOfInner::Dynamic(dynamic) => Some(Type::Dynamic(dynamic)),
                     SubclassOfInner::TypeVar(bound_typevar) => match self {
                         ClassInfoConstraintFunction::IsSubclass => Some(classinfo),


### PR DESCRIPTION
## Summary

This PR adds support for generic `type[]` classinfo arguments to `isinstance` and `issubclass`, as in:

```python
class Invariant[T]: ...

def f(x: object, cls: type[Invariant[int]]):
    if isinstance(x, cls):
        reveal_type(x)  # Top[Invariant[Unknown]]
```

Note that `isinstance(x, type[Invariant[int]])` remains unsupported.
