### PR TITLE
[ty] Preserve delimiters when folding expressions.

### DIFF
--- a/crates/ty_ide/src/folding_range.rs
+++ b/crates/ty_ide/src/folding_range.rs
@@ -1,16 +1,22 @@
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
-use ruff_python_ast::token::{TokenKind, Tokens};
+use ruff_python_ast::token::{TokenKind, Tokens, parenthesized_range};
 use ruff_python_ast::visitor::source_order::{
     SourceOrderVisitor, TraversalSignal, walk_body, walk_node,
 };
-use ruff_python_ast::{AnyNodeRef, Stmt};
+use ruff_python_ast::{
+    AnyNodeRef, ExprAttribute, ExprCall, ExprGenerator, ExprRef, ExprSubscript, Stmt,
+};
 use ruff_python_trivia::{CommentLinePosition, is_python_whitespace};
 use ruff_source_file::{LineRanges, UniversalNewlines};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::Db;
+
+const PARENTHESES: (TokenKind, TokenKind) = (TokenKind::Lpar, TokenKind::Rpar);
+const BRACKETS: (TokenKind, TokenKind) = (TokenKind::Lsqb, TokenKind::Rsqb);
+const BRACES: (TokenKind, TokenKind) = (TokenKind::Lbrace, TokenKind::Rbrace);
 
 /// The kind of a folding range.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -142,7 +148,7 @@ impl<'a> FoldingRangeVisitor<'a> {
     }
 
     /// Adds a folding range for an expression.
-    fn add_expression_range(&mut self, range: TextRange) {
+    fn add_expression_range(&mut self, range: TextRange) -> bool {
         // Block folds preserve statement headers, so they take precedence over expression folds
         // when both would render a folding trigger on the same line.
         let line_start = self.source.line_start(range.start());
@@ -151,10 +157,96 @@ impl<'a> FoldingRangeVisitor<'a> {
             .iter()
             .any(|block_fold| block_fold.line_start == line_start)
         {
+            return false;
+        }
+
+        self.add_range(range)
+    }
+
+    /// Add a folding range for an expression that excludes enclosing delimiters like parentheses
+    /// or square braces.
+    fn add_delimited_expression_range(
+        &mut self,
+        range: TextRange,
+        delimiters: (TokenKind, TokenKind),
+    ) -> bool {
+        if !self.is_multiline(range) {
+            return false;
+        }
+
+        let Some(range) = self.delimited_range(range, delimiters) else {
+            return false;
+        };
+
+        self.add_expression_range(range)
+    }
+
+    /// Adds a folding range for an expression if it is enclosed in parentheses.
+    fn add_parenthesized_expression_range(
+        &mut self,
+        expr: ExprRef<'a>,
+        parent: AnyNodeRef<'a>,
+    ) -> bool {
+        let Some(range) = parenthesized_range(expr, parent, self.tokens) else {
+            return false;
+        };
+
+        self.add_delimited_expression_range(range, PARENTHESES)
+    }
+
+    fn add_call_expression_ranges(&mut self, call: &'a ExprCall, node: AnyNodeRef<'a>) {
+        if !self.is_multiline(node.range()) {
             return;
         }
 
-        self.add_range(range);
+        let arguments_range = call.arguments.range();
+
+        self.add_parenthesized_expression_range(call.func.as_ref().into(), node);
+        self.add_delimited_expression_range(arguments_range, PARENTHESES);
+    }
+
+    fn add_attribute_expression_range(
+        &mut self,
+        attribute: &'a ExprAttribute,
+        node: AnyNodeRef<'a>,
+    ) {
+        if !self.is_multiline(node.range()) {
+            return;
+        }
+
+        self.add_parenthesized_expression_range(attribute.value.as_ref().into(), node);
+    }
+
+    fn add_subscript_expression_ranges(
+        &mut self,
+        subscript: &'a ExprSubscript,
+        node: AnyNodeRef<'a>,
+    ) {
+        if !self.is_multiline(node.range()) {
+            return;
+        }
+
+        let search_range = TextRange::new(subscript.value.end(), node.end());
+        let Some(opening) = self.find_token_start(TokenKind::Lsqb, search_range) else {
+            return;
+        };
+
+        self.add_parenthesized_expression_range(subscript.value.as_ref().into(), node);
+
+        let subscript_range = TextRange::new(opening, node.end());
+        self.add_delimited_expression_range(subscript_range, BRACKETS);
+    }
+
+    fn add_generator_expression_range(
+        &mut self,
+        generator: &'a ExprGenerator,
+        node: AnyNodeRef<'a>,
+    ) {
+        if generator.parenthesized {
+            self.add_delimited_expression_range(node.range(), PARENTHESES);
+        } else {
+            self.add_expression_range(node.range());
+        }
     }
 
     fn is_multiline(&self, range: TextRange) -> bool {
@@ -443,6 +535,28 @@ impl<'a> FoldingRangeVisitor<'a> {
         Some(TextRange::new(block_fold_start, last_block_statement.end()))
     }
 
+    /// Returns the range inside a delimiter pair that bounds the given range.
+    fn delimited_range(
+        &self,
+        range: TextRange,
+        (opening, closing): (TokenKind, TokenKind),
+    ) -> Option<TextRange> {
+        let mut tokens = self
+            .tokens
+            .in_range(range)
+            .iter()
+            .filter(|token| !token.kind().is_trivia());
+
+        let opening_token = tokens.next()?;
+        let closing_token = tokens.next_back()?;
+
+        if opening_token.kind() != opening || closing_token.kind() != closing {
+            return None;
+        }
+
+        Some(TextRange::new(opening_token.end(), closing_token.start()))
+    }
+
     /// Searches for a given keyword and, if present, adds folds for the block it defines.
     fn add_block_ranges_after_keyword<T: Ranged>(
         &mut self,
@@ -582,55 +696,41 @@ impl<'a> SourceOrderVisitor<'a> for FoldingRangeVisitor<'a> {
             }
 
             // Multiline expressions
-            AnyNodeRef::ExprList(list) => {
-                self.add_expression_range(list.range());
+            AnyNodeRef::ExprList(_) | AnyNodeRef::ExprListComp(_) | AnyNodeRef::TypeParams(_) => {
+                self.add_delimited_expression_range(node.range(), BRACKETS);
             }
             AnyNodeRef::ExprTuple(tuple)
                 // Only fold parenthesized tuples.
                 if tuple.parenthesized => {
-                    self.add_expression_range(tuple.range());
+                    self.add_delimited_expression_range(node.range(), PARENTHESES);
                 }
-            AnyNodeRef::ExprDict(dict) => {
-                self.add_expression_range(dict.range());
-            }
-            AnyNodeRef::ExprSet(set) => {
-                self.add_expression_range(set.range());
-            }
-            AnyNodeRef::ExprListComp(listcomp) => {
-                self.add_expression_range(listcomp.range());
-            }
-            AnyNodeRef::ExprSetComp(setcomp) => {
-                self.add_expression_range(setcomp.range());
-            }
-            AnyNodeRef::ExprDictComp(dictcomp) => {
-                self.add_expression_range(dictcomp.range());
+            AnyNodeRef::ExprDict(_)
+            | AnyNodeRef::ExprSet(_)
+            | AnyNodeRef::ExprSetComp(_)
+            | AnyNodeRef::ExprDictComp(_) => {
+                self.add_delimited_expression_range(node.range(), BRACES);
             }
             AnyNodeRef::ExprGenerator(generator) => {
-                self.add_expression_range(generator.range());
+                self.add_generator_expression_range(generator, node);
+            }
+            AnyNodeRef::ExprAttribute(attribute) => {
+                self.add_attribute_expression_range(attribute, node);
+            }
+            AnyNodeRef::ExprSubscript(subscript) => {
+                self.add_subscript_expression_ranges(subscript, node);
             }
 
-            // Function calls with arguments spanning multiple lines
+            // Function calls with foldable callables or arguments.
             AnyNodeRef::ExprCall(call) => {
-                self.add_expression_range(call.range());
+                self.add_call_expression_ranges(call, node);
             }
 
             // String and bytes literals
-            AnyNodeRef::ExprStringLiteral(string) => {
-                self.add_expression_range(string.range());
-            }
-            AnyNodeRef::ExprBytesLiteral(bytes) => {
-                self.add_expression_range(bytes.range());
-            }
-            AnyNodeRef::ExprFString(fstring) => {
-                self.add_expression_range(fstring.range());
-            }
-            AnyNodeRef::ExprTString(tstring) => {
-                self.add_expression_range(tstring.range());
-            }
-
-            // Type parameter lists
-            AnyNodeRef::TypeParams(params) => {
-                self.add_expression_range(params.range());
+            AnyNodeRef::ExprStringLiteral(_)
+            | AnyNodeRef::ExprBytesLiteral(_)
+            | AnyNodeRef::ExprFString(_)
+            | AnyNodeRef::ExprTString(_) => {
+                self.add_expression_range(node.range());
             }
 
             _ => {}

--- a/crates/ty_ide/src/folding_range.rs
+++ b/crates/ty_ide/src/folding_range.rs
@@ -1200,12 +1200,13 @@ match value:
            |
 
         info[folding-range]: Folding Range
-         --> main.py:7:9
+         --> main.py:7:10
           |
-        7 | /         [
+        7 |           [
+          |  __________^
         8 | |             value,
         9 | |         ]
-          | |_________^
+          | |________^
           |
 
         info[folding-range]: Folding Range
@@ -1605,6 +1606,19 @@ my_dict = {
     "a": 1,
     "b": 2,
 }
+
+my_list_with_trailing_element_comment = [
+    1,
+    2,
+    3,  # reason
+]
+
+my_list_with_trailing_own_line_comment = [
+    1,
+    2,
+    3,
+    # comment
+]
 <CURSOR>
 "#,
             )
@@ -1612,28 +1626,307 @@ my_dict = {
 
         assert_snapshot!(test.folding_ranges(), @r#"
         info[folding-range]: Folding Range
-         --> main.py:2:11
+         --> main.py:2:12
           |
         2 |   my_list = [
-          |  ___________^
+          |  ____________^
         3 | |     1,
         4 | |     2,
         5 | |     3,
-        6 | | ]
-          | |_^
+          | |_______^
           |
 
         info[folding-range]: Folding Range
-          --> main.py:8:11
+          --> main.py:8:12
            |
          8 |   my_dict = {
-           |  ___________^
+           |  ____________^
          9 | |     "a": 1,
         10 | |     "b": 2,
-        11 | | }
-           | |_^
+           | |____________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:13:42
+           |
+        13 |   my_list_with_trailing_element_comment = [
+           |  __________________________________________^
+        14 | |     1,
+        15 | |     2,
+        16 | |     3,  # reason
+           | |_________________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:19:43
+           |
+        19 |   my_list_with_trailing_own_line_comment = [
+           |  ___________________________________________^
+        20 | |     1,
+        21 | |     2,
+        22 | |     3,
+        23 | |     # comment
+           | |______________^
            |
         "#);
+    }
+
+    #[test]
+    fn test_folding_range_expression_delimiters() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+result = call(
+    first,
+    second,
+)
+
+my_set = {
+    "a",
+    "b",
+}
+
+my_tuple = (
+    first,
+    second,
+)
+
+my_generator = (
+    item
+    for item in items
+)
+
+my_list_comp = [
+    item
+    for item in items
+]
+
+my_set_comp = {
+    item
+    for item in items
+}
+
+my_dict_comp = {
+    key: value
+    for key, value in items
+}
+
+type Alias[
+    T,
+    U,
+] = tuple[T, U]
+<CURSOR>
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.folding_ranges(), @r#"
+        info[folding-range]: Folding Range
+         --> main.py:2:15
+          |
+        2 |   result = call(
+          |  _______________^
+        3 | |     first,
+        4 | |     second,
+          | |____________^
+          |
+
+        info[folding-range]: Folding Range
+         --> main.py:7:11
+          |
+        7 |   my_set = {
+          |  ___________^
+        8 | |     "a",
+        9 | |     "b",
+          | |_________^
+          |
+
+        info[folding-range]: Folding Range
+          --> main.py:12:13
+           |
+        12 |   my_tuple = (
+           |  _____________^
+        13 | |     first,
+        14 | |     second,
+           | |____________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:17:17
+           |
+        17 |   my_generator = (
+           |  _________________^
+        18 | |     item
+        19 | |     for item in items
+           | |______________________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:22:17
+           |
+        22 |   my_list_comp = [
+           |  _________________^
+        23 | |     item
+        24 | |     for item in items
+           | |______________________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:27:16
+           |
+        27 |   my_set_comp = {
+           |  ________________^
+        28 | |     item
+        29 | |     for item in items
+           | |______________________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:32:17
+           |
+        32 |   my_dict_comp = {
+           |  _________________^
+        33 | |     key: value
+        34 | |     for key, value in items
+           | |____________________________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:37:12
+           |
+        37 |   type Alias[
+           |  ____________^
+        38 | |     T,
+        39 | |     U,
+           | |_______^
+           |
+        "#);
+    }
+
+    #[test]
+    fn test_folding_range_multiline_call_callables() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+callable_and_arguments = (
+    factory
+)(
+    arg,
+)
+
+parenthesized_method_callable = (
+    factory
+).method(arg)
+
+chained_call = (
+    factory
+)(
+    first,
+)(
+    second,
+)
+<CURSOR>
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.folding_ranges(), @"
+        info[folding-range]: Folding Range
+         --> main.py:2:27
+          |
+        2 |   callable_and_arguments = (
+          |  ___________________________^
+        3 | |     factory
+          | |____________^
+          |
+
+        info[folding-range]: Folding Range
+         --> main.py:4:3
+          |
+        4 |   )(
+          |  ___^
+        5 | |     arg,
+          | |_________^
+          |
+
+        info[folding-range]: Folding Range
+         --> main.py:8:34
+          |
+        8 |   parenthesized_method_callable = (
+          |  __________________________________^
+        9 | |     factory
+          | |____________^
+          |
+
+        info[folding-range]: Folding Range
+          --> main.py:16:3
+           |
+        16 |   )(
+           |  ___^
+        17 | |     second,
+           | |____________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:12:17
+           |
+        12 |   chained_call = (
+           |  _________________^
+        13 | |     factory
+           | |____________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:14:3
+           |
+        14 |   )(
+           |  ___^
+        15 | |     first,
+           | |___________^
+           |
+        ");
+    }
+
+    #[test]
+    fn test_folding_range_multiline_subscripts() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+grouped_subscript = (data)[
+    key
+]
+
+parenthesized_subscript_value = (
+    data
+)[key]
+<CURSOR>
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.folding_ranges(), @"
+        info[folding-range]: Folding Range
+         --> main.py:2:28
+          |
+        2 |   grouped_subscript = (data)[
+          |  ____________________________^
+        3 | |     key
+          | |________^
+          |
+
+        info[folding-range]: Folding Range
+         --> main.py:6:34
+          |
+        6 |   parenthesized_subscript_value = (
+          |  __________________________________^
+        7 | |     data
+          | |_________^
+          |
+
+        ");
     }
 
     #[test]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__folding_range__folding_range_notebook_cells_are_filtered_to_the_requested_cell.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__folding_range__folding_range_notebook_cells_are_filtered_to_the_requested_cell.snap
@@ -45,15 +45,15 @@ expression: "[first_cell_ranges, second_cell_ranges]"
   [
     {
       "startLine": 0,
-      "startCharacter": 5,
+      "startCharacter": 7,
       "endLine": 2,
-      "endCharacter": 1
+      "endCharacter": 0
     },
     {
       "startLine": 4,
-      "startCharacter": 5,
+      "startCharacter": 7,
       "endLine": 12,
-      "endCharacter": 1
+      "endCharacter": 0
     }
   ]
 ]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This makes it so that we preserve outer delimiters when folding expressions. For instance:

```py
x = [
    1,
    2,
    3,
]
```

now folds like so in a character-precise LSP client:

```py
x = [...]
```

rather than like so:

```py
x = ...
```

The same behavior applies to parethesized callables, call args, sets, tuples, comprehensions, type parameter lists, and subscripts.

**I recommend reviewing this diff commit-by-commit.**

Closes https://github.com/astral-sh/ty/issues/3427.

## Test Plan

Please see updated tests.
<!-- How was it tested? -->
