### PR TITLE
Add TOML examples to `--config` help text

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -43,10 +43,12 @@ pub struct GlobalConfigArgs {
     /// Either a path to a TOML configuration file (`pyproject.toml` or `ruff.toml`),
     /// or a TOML `<KEY> = <VALUE>` pair
     /// (such as you might find in a `ruff.toml` configuration file)
-    /// overriding a specific configuration option.
+    /// overriding a specific configuration option
+    /// (e.g., `--config "lint.line-length = 100"` or `--config "format.quote-style = 'single'"`).
     /// Overrides of individual settings using this option always take precedence
     /// over all configuration files, including configuration files that were also
     /// specified using `--config`.
+
     #[arg(
         long,
         action = clap::ArgAction::Append,

--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -48,7 +48,6 @@ pub struct GlobalConfigArgs {
     /// Overrides of individual settings using this option always take precedence
     /// over all configuration files, including configuration files that were also
     /// specified using `--config`.
-
     #[arg(
         long,
         action = clap::ArgAction::Append,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -554,9 +554,11 @@ Global options:
           Either a path to a TOML configuration file (`pyproject.toml` or
           `ruff.toml`), or a TOML `<KEY> = <VALUE>` pair (such as you might
           find in a `ruff.toml` configuration file) overriding a specific
-          configuration option. Overrides of individual settings using this
-          option always take precedence over all configuration files, including
-          configuration files that were also specified using `--config`
+          configuration option (e.g., `--config "lint.line-length = 100"` or
+          `--config "format.quote-style = 'single'"`). Overrides of individual
+          settings using this option always take precedence over all
+          configuration files, including configuration files that were also
+          specified using `--config`
       --isolated
           Ignore all configuration files
       --color <WHEN>
@@ -695,9 +697,11 @@ Global options:
           Either a path to a TOML configuration file (`pyproject.toml` or
           `ruff.toml`), or a TOML `<KEY> = <VALUE>` pair (such as you might
           find in a `ruff.toml` configuration file) overriding a specific
-          configuration option. Overrides of individual settings using this
-          option always take precedence over all configuration files, including
-          configuration files that were also specified using `--config`
+          configuration option (e.g., `--config "lint.line-length = 100"` or
+          `--config "format.quote-style = 'single'"`). Overrides of individual
+          settings using this option always take precedence over all
+          configuration files, including configuration files that were also
+          specified using `--config`
       --isolated
           Ignore all configuration files
       --color <WHEN>
@@ -789,9 +793,11 @@ Global options:
           Either a path to a TOML configuration file (`pyproject.toml` or
           `ruff.toml`), or a TOML `<KEY> = <VALUE>` pair (such as you might
           find in a `ruff.toml` configuration file) overriding a specific
-          configuration option. Overrides of individual settings using this
-          option always take precedence over all configuration files, including
-          configuration files that were also specified using `--config`
+          configuration option (e.g., `--config "lint.line-length = 100"` or
+          `--config "format.quote-style = 'single'"`). Overrides of individual
+          settings using this option always take precedence over all
+          configuration files, including configuration files that were also
+          specified using `--config`
       --isolated
           Ignore all configuration files
       --color <WHEN>


### PR DESCRIPTION
This PR adds TOML examples to the `--config` help text to clarify that it accepts both file paths and inline key-value pairs. 

