### PR TITLE
[ty] Allow equality narrowing for unions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -212,6 +212,30 @@ def _(flag1: bool, flag2: bool, a: int):
         reveal_type(x)  # revealed: Literal[1, 2]
 ```
 
+## `==` against non-single-valued types
+
+```py
+def _(p: str | None, q: str) -> None:
+    if p == q:
+        reveal_type(p)  # revealed: str
+    else:
+        reveal_type(p)  # revealed: str | None
+
+    if q == p:
+        reveal_type(p)  # revealed: str
+
+    if p != q:
+        reveal_type(p)  # revealed: str | None
+    else:
+        reveal_type(p)  # revealed: str
+
+def _(x: str | int | None, y: str) -> None:
+    if x == y:
+        # `int` is not eliminated here because there could be subclasses of `int`
+        # with custom `__eq__`/`__ne__` methods
+        reveal_type(x)  # revealed: str | int
+```
+
 ## `==` / `!=` with two narrowable operands
 
 Both operands should be narrowed when both are narrowable expressions.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -228,23 +228,17 @@ def _(x: str | None, y: Mock) -> None:
 
 def _(p: str | None, q: str) -> None:
     if p == q:
-        reveal_type(p)  # revealed: str
+        reveal_type(p)  # revealed: str | None
     else:
         reveal_type(p)  # revealed: str | None
 
     if q == p:
-        reveal_type(p)  # revealed: str
+        reveal_type(p)  # revealed: str | None
 
     if p != q:
         reveal_type(p)  # revealed: str | None
     else:
-        reveal_type(p)  # revealed: str
-
-def _(x: str | int | None, y: str) -> None:
-    if x == y:
-        # `int` is not eliminated here because there could be subclasses of `int`
-        # with custom `__eq__`/`__ne__` methods
-        reveal_type(x)  # revealed: str | int
+        reveal_type(p)  # revealed: str | None
 ```
 
 ## `==` / `!=` with two narrowable operands

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -215,25 +215,30 @@ def _(flag1: bool, flag2: bool, a: int):
 ## `==` against non-single-valued types
 
 ```py
+class Mock:
+    def __eq__(self, other) -> bool:
+        return True
+
+def _(x: str | None, y: Mock) -> None:
+    if x == y:
+        reveal_type(x)  # revealed: str | None
+
+    if y == x:
+        reveal_type(x)  # revealed: str | None
+
 def _(p: str | None, q: str) -> None:
     if p == q:
-        reveal_type(p)  # revealed: str
+        reveal_type(p)  # revealed: str | None
     else:
         reveal_type(p)  # revealed: str | None
 
     if q == p:
-        reveal_type(p)  # revealed: str
+        reveal_type(p)  # revealed: str | None
 
     if p != q:
         reveal_type(p)  # revealed: str | None
     else:
-        reveal_type(p)  # revealed: str
-
-def _(x: str | int | None, y: str) -> None:
-    if x == y:
-        # `int` is not eliminated here because there could be subclasses of `int`
-        # with custom `__eq__`/`__ne__` methods
-        reveal_type(x)  # revealed: str | int
+        reveal_type(p)  # revealed: str | None
 ```
 
 ## `==` / `!=` with two narrowable operands

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -228,17 +228,23 @@ def _(x: str | None, y: Mock) -> None:
 
 def _(p: str | None, q: str) -> None:
     if p == q:
-        reveal_type(p)  # revealed: str | None
+        reveal_type(p)  # revealed: str
     else:
         reveal_type(p)  # revealed: str | None
 
     if q == p:
-        reveal_type(p)  # revealed: str | None
+        reveal_type(p)  # revealed: str
 
     if p != q:
         reveal_type(p)  # revealed: str | None
     else:
-        reveal_type(p)  # revealed: str | None
+        reveal_type(p)  # revealed: str
+
+def _(x: str | int | None, y: str) -> None:
+    if x == y:
+        # `int` is not eliminated here because there could be subclasses of `int`
+        # with custom `__eq__`/`__ne__` methods
+        reveal_type(x)  # revealed: str | int
 ```
 
 ## `==` / `!=` with two narrowable operands

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -177,14 +177,14 @@ def _(x: str | None, y: Mock):
 
 def _(x: str | None, y: str):
     if x in [y]:
-        reveal_type(x)  # revealed: str | None
+        reveal_type(x)  # revealed: str
     else:
         reveal_type(x)  # revealed: str | None
 
     if x not in [y]:
         reveal_type(x)  # revealed: str | None
     else:
-        reveal_type(x)  # revealed: str | None
+        reveal_type(x)  # revealed: str
 ```
 
 ## Direct `not in` conditional

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -162,6 +162,31 @@ def test(x: Literal["a", "b", "c"] | None | int = None):
         reveal_type(x)  # revealed: Literal["c"] | None | int
 ```
 
+## No narrowing against non-single-valued elements
+
+```py
+class Mock:
+    def __eq__(self, other) -> bool:
+        return True
+
+def _(x: str | None, y: Mock):
+    if x in [y]:
+        reveal_type(x)  # revealed: str | None
+    else:
+        reveal_type(x)  # revealed: str | None
+
+def _(x: str | None, y: str):
+    if x in [y]:
+        reveal_type(x)  # revealed: str | None
+    else:
+        reveal_type(x)  # revealed: str | None
+
+    if x not in [y]:
+        reveal_type(x)  # revealed: str | None
+    else:
+        reveal_type(x)  # revealed: str | None
+```
+
 ## Direct `not in` conditional
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -177,14 +177,14 @@ def _(x: str | None, y: Mock):
 
 def _(x: str | None, y: str):
     if x in [y]:
-        reveal_type(x)  # revealed: str
+        reveal_type(x)  # revealed: str | None
     else:
         reveal_type(x)  # revealed: str | None
 
     if x not in [y]:
         reveal_type(x)  # revealed: str | None
     else:
-        reveal_type(x)  # revealed: str
+        reveal_type(x)  # revealed: str | None
 ```
 
 ## Direct `not in` conditional

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -219,9 +219,9 @@ def _(x: Literal["foo", "bar", 42, b"foo"] | bool | complex):
         case 42:
             reveal_type(x)  # revealed: int | float | complex
         case 6.0:
-            reveal_type(x)  # revealed: Literal["bar", b"foo"] | (int & ~Literal[42]) | float | complex
+            reveal_type(x)  # revealed: float | (int & ~Literal[42]) | complex
         case 1j:
-            reveal_type(x)  # revealed: Literal["bar", b"foo"] | (int & ~Literal[42]) | float | complex
+            reveal_type(x)  # revealed: complex | (int & ~Literal[42]) | float
         case b"foo":
             reveal_type(x)  # revealed: (int & ~Literal[42]) | Literal[b"foo"] | float | complex
         case _:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -219,9 +219,9 @@ def _(x: Literal["foo", "bar", 42, b"foo"] | bool | complex):
         case 42:
             reveal_type(x)  # revealed: int | float | complex
         case 6.0:
-            reveal_type(x)  # revealed: float | (int & ~Literal[42]) | complex
+            reveal_type(x)  # revealed: Literal["bar", b"foo"] | (int & ~Literal[42]) | float | complex
         case 1j:
-            reveal_type(x)  # revealed: complex | (int & ~Literal[42]) | float
+            reveal_type(x)  # revealed: Literal["bar", b"foo"] | (int & ~Literal[42]) | float | complex
         case b"foo":
             reveal_type(x)  # revealed: (int & ~Literal[42]) | Literal[b"foo"] | float | complex
         case _:

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -572,6 +572,14 @@ fn could_compare_equal<'db>(db: &'db dyn Db, left_ty: Type<'db>, right_ty: Type<
     }
 }
 
+/// Return `true` for types that we can model as a known value-domain for equality narrowing.
+fn is_single_valued_equality_domain<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    ty.is_single_valued(db)
+        || ty.is_subtype_of(db, Type::literal_string())
+        || ty.is_bool(db)
+        || (ty.is_enum(db) && !ty.overrides_equality(db))
+}
+
 struct NarrowingConstraintsBuilder<'db, 'ast> {
     db: &'db dyn Db,
     module: &'ast ParsedModuleRef,
@@ -929,9 +937,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     }
 
     fn evaluate_expr_eq(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
+        let lhs_ty = lhs_ty.resolve_type_alias(self.db);
         let rhs_ty = rhs_ty.resolve_type_alias(self.db);
 
-        // We can only narrow on equality checks against single-valued types.
+        // Equality narrowing is most precise when comparing against single-valued types.
         if rhs_ty.is_single_valued(self.db) || rhs_ty.is_union_of_single_valued(self.db) {
             // The fully-general (and more efficient) approach here would be to introduce a
             // `NeverEqualTo` type that can wrap a single-valued type, and then simply return
@@ -1011,6 +1020,31 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             } else {
                 filter_to_cannot_be_equal(self.db, lhs_ty, rhs_ty).negate(self.db)
             })
+        } else if let Type::Union(union) = lhs_ty {
+            // Match `in` narrowing for unions that mix known value-domains with broader
+            // arms: the RHS can rule out the value-domain arms, but broader arms stay
+            // if custom equality could make them compare equal.
+            if !union
+                .elements(self.db)
+                .iter()
+                .any(|element| is_single_valued_equality_domain(self.db, *element))
+            {
+                return None;
+            }
+
+            let mut builder = UnionBuilder::new(self.db).add(rhs_ty);
+
+            for element in union.elements(self.db) {
+                if is_single_valued_equality_domain(self.db, *element) {
+                    continue;
+                }
+
+                if could_compare_equal(self.db, *element, rhs_ty) {
+                    builder = builder.add(*element);
+                }
+            }
+
+            Some(builder.build())
         } else {
             None
         }
@@ -1061,15 +1095,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
             if let Some(lhs_union) = lhs_ty.as_union() {
                 for element in lhs_union.elements(self.db) {
-                    // Skip single-valued types (handled via RHS matching).
-                    if element.is_single_valued(self.db) {
-                        continue;
-                    }
-                    // Skip types that are handled specially (LiteralString, bool, enum).
-                    if element.is_subtype_of(self.db, Type::literal_string())
-                        || element.is_bool(self.db)
-                        || (element.is_enum(self.db) && !element.overrides_equality(self.db))
-                    {
+                    // Skip single-valued equality domains (handled via RHS matching).
+                    if is_single_valued_equality_domain(self.db, *element) {
                         continue;
                     }
                     // Skip types that cannot compare equal to any RHS value.
@@ -1108,11 +1135,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
             if let Some(lhs_union) = lhs_ty.as_union() {
                 for element in lhs_union.elements(self.db) {
-                    if element.is_single_valued(self.db)
-                        || element.is_subtype_of(self.db, Type::literal_string())
-                        || element.is_bool(self.db)
-                        || (element.is_enum(self.db) && !element.overrides_equality(self.db))
-                    {
+                    if is_single_valued_equality_domain(self.db, *element) {
                         single_builder = single_builder.add(*element);
                     } else {
                         rest_builder = rest_builder.add(*element);

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -586,28 +586,6 @@ fn is_equality_domain<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     ty.is_single_valued(db) || ty.is_union_of_single_valued(db)
 }
 
-/// Return the broad portion of `ty` that is not modeled as a known equality domain.
-fn broad_equality_domain_part<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
-    match ty {
-        Type::Union(union) => UnionType::from_elements(
-            db,
-            union
-                .elements(db)
-                .iter()
-                .copied()
-                .filter(|element| !is_single_valued_equality_domain(db, *element)),
-        ),
-        _ if is_single_valued_equality_domain(db, ty) => Type::Never,
-        _ => ty,
-    }
-}
-
-/// Return `true` if every possible RHS value is already covered by a broad LHS arm.
-fn rhs_is_covered_by_broad_lhs<'db>(db: &'db dyn Db, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> bool {
-    let broad_lhs = broad_equality_domain_part(db, lhs_ty);
-    !broad_lhs.is_never() && rhs_ty.is_subtype_of(db, broad_lhs)
-}
-
 struct NarrowingConstraintsBuilder<'db, 'ast> {
     db: &'db dyn Db,
     module: &'ast ParsedModuleRef,
@@ -968,7 +946,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         let lhs_ty = lhs_ty.resolve_type_alias(self.db);
         let rhs_ty = rhs_ty.resolve_type_alias(self.db);
 
-        // Equality narrowing is most precise when comparing against known equality domains.
+        // A broad RHS can make arbitrary LHS values compare equal through reflected `__eq__`, so
+        // equality only gives us useful information when the RHS is a known equality domain.
         if is_equality_domain(self.db, rhs_ty) {
             // The fully-general (and more efficient) approach here would be to introduce a
             // `NeverEqualTo` type that can wrap a single-valued type, and then simply return
@@ -1048,28 +1027,6 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             } else {
                 filter_to_cannot_be_equal(self.db, lhs_ty, rhs_ty).negate(self.db)
             })
-        } else if let Type::Union(union) = lhs_ty {
-            // Preserve the ergonomic mixed-union narrowing used for cases like
-            // `str | None == str`, but only when the broad RHS is already covered by one of the
-            // broad LHS arms. An unrelated broad RHS can only erase known value-domain arms via
-            // reflected `__eq__`, as in `str | None == Mock`, so we leave those cases unchanged.
-            if !rhs_is_covered_by_broad_lhs(self.db, lhs_ty, rhs_ty) {
-                return None;
-            }
-
-            let mut builder = UnionBuilder::new(self.db).add(rhs_ty);
-
-            for element in union.elements(self.db) {
-                if is_single_valued_equality_domain(self.db, *element) {
-                    continue;
-                }
-
-                if could_compare_equal(self.db, *element, rhs_ty) {
-                    builder = builder.add(*element);
-                }
-            }
-
-            Some(builder.build())
         } else {
             None
         }
@@ -1106,19 +1063,16 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             .ok()?
             .homogeneous_element_type(self.db);
 
-        if lhs_ty.is_single_valued(self.db) || lhs_ty.is_union_of_single_valued(self.db) {
-            is_equality_domain(self.db, rhs_values).then_some(rhs_values)
-        } else if lhs_ty.is_union_with_single_valued(self.db) {
-            // Match the `==` policy: broad RHS values are only useful when they are already
-            // covered by retained broad LHS arms. This keeps `str | None in list[str]`
-            // narrowing, without letting unrelated element types erase `None` via reflected
-            // equality.
-            if !is_equality_domain(self.db, rhs_values)
-                && !rhs_is_covered_by_broad_lhs(self.db, lhs_ty, rhs_values)
-            {
-                return None;
-            }
+        // Membership compares the LHS against the RHS elements. If those elements are broad,
+        // reflected `__eq__` can make any LHS value compare equal, so a successful membership
+        // check tells us nothing useful about the LHS.
+        if !is_equality_domain(self.db, rhs_values) {
+            return None;
+        }
 
+        if lhs_ty.is_single_valued(self.db) || lhs_ty.is_union_of_single_valued(self.db) {
+            Some(rhs_values)
+        } else if lhs_ty.is_union_with_single_valued(self.db) {
             let mut builder = UnionBuilder::new(self.db);
 
             // Add the narrowed values from the RHS first, to keep literals before broader types.

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -586,6 +586,28 @@ fn is_equality_domain<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     ty.is_single_valued(db) || ty.is_union_of_single_valued(db)
 }
 
+/// Return the broad portion of `ty` that is not modeled as a known equality domain.
+fn broad_equality_domain_part<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+    match ty {
+        Type::Union(union) => UnionType::from_elements(
+            db,
+            union
+                .elements(db)
+                .iter()
+                .copied()
+                .filter(|element| !is_single_valued_equality_domain(db, *element)),
+        ),
+        _ if is_single_valued_equality_domain(db, ty) => Type::Never,
+        _ => ty,
+    }
+}
+
+/// Return `true` if every possible RHS value is already covered by a broad LHS arm.
+fn rhs_is_covered_by_broad_lhs<'db>(db: &'db dyn Db, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> bool {
+    let broad_lhs = broad_equality_domain_part(db, lhs_ty);
+    !broad_lhs.is_never() && rhs_ty.is_subtype_of(db, broad_lhs)
+}
+
 struct NarrowingConstraintsBuilder<'db, 'ast> {
     db: &'db dyn Db,
     module: &'ast ParsedModuleRef,
@@ -946,8 +968,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         let lhs_ty = lhs_ty.resolve_type_alias(self.db);
         let rhs_ty = rhs_ty.resolve_type_alias(self.db);
 
-        // A broad RHS can make arbitrary LHS values compare equal through reflected `__eq__`, so
-        // equality only gives us useful information when the RHS is a known equality domain.
+        // Equality narrowing is most precise when comparing against known equality domains.
         if is_equality_domain(self.db, rhs_ty) {
             // The fully-general (and more efficient) approach here would be to introduce a
             // `NeverEqualTo` type that can wrap a single-valued type, and then simply return
@@ -1027,6 +1048,28 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             } else {
                 filter_to_cannot_be_equal(self.db, lhs_ty, rhs_ty).negate(self.db)
             })
+        } else if let Type::Union(union) = lhs_ty {
+            // Preserve the ergonomic mixed-union narrowing used for cases like
+            // `str | None == str`, but only when the broad RHS is already covered by one of the
+            // broad LHS arms. An unrelated broad RHS can only erase known value-domain arms via
+            // reflected `__eq__`, as in `str | None == Mock`, so we leave those cases unchanged.
+            if !rhs_is_covered_by_broad_lhs(self.db, lhs_ty, rhs_ty) {
+                return None;
+            }
+
+            let mut builder = UnionBuilder::new(self.db).add(rhs_ty);
+
+            for element in union.elements(self.db) {
+                if is_single_valued_equality_domain(self.db, *element) {
+                    continue;
+                }
+
+                if could_compare_equal(self.db, *element, rhs_ty) {
+                    builder = builder.add(*element);
+                }
+            }
+
+            Some(builder.build())
         } else {
             None
         }
@@ -1063,16 +1106,19 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             .ok()?
             .homogeneous_element_type(self.db);
 
-        // Membership compares the LHS against the RHS elements. If those elements are broad,
-        // reflected `__eq__` can make any LHS value compare equal, so a successful membership
-        // check tells us nothing useful about the LHS.
-        if !is_equality_domain(self.db, rhs_values) {
-            return None;
-        }
-
         if lhs_ty.is_single_valued(self.db) || lhs_ty.is_union_of_single_valued(self.db) {
-            Some(rhs_values)
+            is_equality_domain(self.db, rhs_values).then_some(rhs_values)
         } else if lhs_ty.is_union_with_single_valued(self.db) {
+            // Match the `==` policy: broad RHS values are only useful when they are already
+            // covered by retained broad LHS arms. This keeps `str | None in list[str]`
+            // narrowing, without letting unrelated element types erase `None` via reflected
+            // equality.
+            if !is_equality_domain(self.db, rhs_values)
+                && !rhs_is_covered_by_broad_lhs(self.db, lhs_ty, rhs_values)
+            {
+                return None;
+            }
+
             let mut builder = UnionBuilder::new(self.db);
 
             // Add the narrowed values from the RHS first, to keep literals before broader types.

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -580,6 +580,12 @@ fn is_single_valued_equality_domain<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool
         || (ty.is_enum(db) && !ty.overrides_equality(db))
 }
 
+/// Return `true` if every inhabitant of `ty` comes from a known value-domain for equality
+/// narrowing.
+fn is_equality_domain<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    ty.is_single_valued(db) || ty.is_union_of_single_valued(db)
+}
+
 struct NarrowingConstraintsBuilder<'db, 'ast> {
     db: &'db dyn Db,
     module: &'ast ParsedModuleRef,
@@ -940,8 +946,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         let lhs_ty = lhs_ty.resolve_type_alias(self.db);
         let rhs_ty = rhs_ty.resolve_type_alias(self.db);
 
-        // Equality narrowing is most precise when comparing against single-valued types.
-        if rhs_ty.is_single_valued(self.db) || rhs_ty.is_union_of_single_valued(self.db) {
+        // A broad RHS can make arbitrary LHS values compare equal through reflected `__eq__`, so
+        // equality only gives us useful information when the RHS is a known equality domain.
+        if is_equality_domain(self.db, rhs_ty) {
             // The fully-general (and more efficient) approach here would be to introduce a
             // `NeverEqualTo` type that can wrap a single-valued type, and then simply return
             // `~NeverEqualTo(rhs_ty)` here and let union/intersection builder sort it out. This is
@@ -1020,31 +1027,6 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             } else {
                 filter_to_cannot_be_equal(self.db, lhs_ty, rhs_ty).negate(self.db)
             })
-        } else if let Type::Union(union) = lhs_ty {
-            // Match `in` narrowing for unions that mix known value-domains with broader
-            // arms: the RHS can rule out the value-domain arms, but broader arms stay
-            // if custom equality could make them compare equal.
-            if !union
-                .elements(self.db)
-                .iter()
-                .any(|element| is_single_valued_equality_domain(self.db, *element))
-            {
-                return None;
-            }
-
-            let mut builder = UnionBuilder::new(self.db).add(rhs_ty);
-
-            for element in union.elements(self.db) {
-                if is_single_valued_equality_domain(self.db, *element) {
-                    continue;
-                }
-
-                if could_compare_equal(self.db, *element, rhs_ty) {
-                    builder = builder.add(*element);
-                }
-            }
-
-            Some(builder.build())
         } else {
             None
         }
@@ -1076,18 +1058,21 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     // since `eq` and `ne` are equivalent to `in` and `not in` with only one element in the RHS.
     fn evaluate_expr_in(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
         let lhs_ty = lhs_ty.resolve_type_alias(self.db);
+        let rhs_values = rhs_ty
+            .try_iterate(self.db)
+            .ok()?
+            .homogeneous_element_type(self.db);
+
+        // Membership compares the LHS against the RHS elements. If those elements are broad,
+        // reflected `__eq__` can make any LHS value compare equal, so a successful membership
+        // check tells us nothing useful about the LHS.
+        if !is_equality_domain(self.db, rhs_values) {
+            return None;
+        }
 
         if lhs_ty.is_single_valued(self.db) || lhs_ty.is_union_of_single_valued(self.db) {
-            rhs_ty
-                .try_iterate(self.db)
-                .ok()
-                .map(|iterable| iterable.homogeneous_element_type(self.db))
+            Some(rhs_values)
         } else if lhs_ty.is_union_with_single_valued(self.db) {
-            let rhs_values = rhs_ty
-                .try_iterate(self.db)
-                .ok()?
-                .homogeneous_element_type(self.db);
-
             let mut builder = UnionBuilder::new(self.db);
 
             // Add the narrowed values from the RHS first, to keep literals before broader types.
@@ -1119,6 +1104,12 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             .try_iterate(self.db)
             .ok()?
             .homogeneous_element_type(self.db);
+
+        // See `evaluate_expr_in`: broad RHS elements can define arbitrary reflected equality, so
+        // failed membership only gives us useful information for known equality domains.
+        if !is_equality_domain(self.db, rhs_values) {
+            return None;
+        }
 
         if lhs_ty.is_single_valued(self.db) || lhs_ty.is_union_of_single_valued(self.db) {
             // Exclude the RHS values from the entire (single-valued) LHS domain.


### PR DESCRIPTION
## Summary

We already support equality narrowing when comparing against single-valued types, but we didn't handle the mixed-union case where the right-hand side is not single-valued.

This extends equality narrowing to cases like:

```python
def g(p: str | None, q: str) -> None:
    if p == q:
        reveal_type(p)  # str
```

Closes https://github.com/astral-sh/ty/issues/3419.
