### PR TITLE
[ty] Re-infer binary operator arguments with type context

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2774,7 +2774,7 @@ class ManyCycles2:
         self.x3 = [1]
 
     def f1(self: "ManyCycles2"):
-        reveal_type(self.x3)  # revealed: list[int] | list[Divergent] | Unknown | list[Unknown]
+        reveal_type(self.x3)  # revealed: list[int] | list[Divergent] | Unknown
 
         self.x1 = [self.x2] + [self.x3]
         self.x2 = [self.x1] + [self.x3]

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -47,51 +47,6 @@ reveal_type(x)  # revealed: list[int]
 
 x: list[list[int]] = [[1], [2], *([3], [4])]
 reveal_type(x)  # revealed: list[list[int]]
-
-x: list[list[int | str]] = [[1], [2]] * 3
-reveal_type(x)  # revealed: list[list[int | str]]
-
-x: list[list[int | str]] = 3 * ([[1]] + [[2]])
-reveal_type(x)  # revealed: list[list[int | str]]
-
-x: list[int | str] = 3 * ["x" for _ in range(3)]
-reveal_type(x)  # revealed: list[int | str]
-
-# Tuple elements are inferred individually, but type context can prevent e.g. `int` widening.
-x: tuple[list[Literal[1]]] = (list1(1),)
-reveal_type(x)  # revealed: tuple[list[Literal[1]]]
-
-x: tuple[list[Literal[1]], ...] = (list1(1),) * 3
-reveal_type(x)  # revealed: tuple[list[Literal[1]], ...]
-
-x: tuple[list[Literal[1]], ...] = 3 * ((list1(1),) + (list1(1),))
-reveal_type(x)  # revealed: tuple[list[Literal[1]], ...]
-
-x: set[int | str] = {1, 2} | {3, 4}
-reveal_type(x)  # revealed: set[int | str]
-
-x: set[int | str] = {42 for _ in range(3)}
-reveal_type(x)  # revealed: set[int | str]
-
-x: dict[int | str, int | str] = {1: 2} | {3: 4}
-reveal_type(x)  # revealed: dict[int | str, int | str]
-
-x: dict[int | str, int | str] = {str(i): i for i in range(3)}
-reveal_type(x)  # revealed: dict[int | str, int | str]
-
-# TODO: We currently eagerly pass type context to collection literals on either side of a binary
-# operator. That makes the cases above work, but it's not generally sound. For example, it gives the
-# wrong result in this case.
-class X:
-    def __add__(self, _: list[int]) -> list[int | str]:
-        return []
-
-# error: [unsupported-operator] "Operator `+` is not supported between objects of type `X` and `list[int | str]`"
-x: list[int | str] = X() + [1]
-
-# TODO: We also don't yet support generic function calls like this.
-# error: [invalid-assignment] "Object of type `list[int]` is not assignable to `list[int | str]`"
-x: list[int | str] = list1(42) * 3
 ```
 
 `typed_dict.py`:
@@ -162,6 +117,8 @@ def keep_keyword_diagnostics(kwargs: Mapping[str, object]) -> None:
 d5_literal: dict[Hashable, Callable[..., object]] = {"x": lambda: 1}
 d5_dict: dict[Hashable, Callable[..., object]] = dict(x=lambda: 1)
 
+# TODO: We could support this.
+# error: [invalid-assignment]
 d6_dict: TD = {"x": 1} | {"x": 2}
 
 def return_literal() -> TD:
@@ -680,6 +637,80 @@ def _(x: Intersection[X, Y]):
     # TODO: Reveal `Bar` and `Baz` here.
     x |= reveal_type({"bar": [1, "2"]})  # revealed: dict[str, list[int | str]]
     x |= reveal_type({"bar": [1, None]})  # revealed: dict[str, list[int | None]]
+```
+
+## Binary Operators
+
+The signature of binary operator dunder calls is used as type context for both sides of the binary
+operation:
+
+```py
+from typing import Literal
+
+def lst[T](x: T) -> list[T]:
+    return [x]
+
+# TODO: This should reveal `list[list[int | str]]`.
+x1: list[list[int | str]] = reveal_type([[1], [2]]) * 3  # revealed: list[list[int]]
+reveal_type(x1)  # revealed: list[list[int | str]]
+
+# TODO: This should also reveal `list[list[int | str]]`.
+x2: list[list[int | str]] = 3 * reveal_type([[1]] + [[2]])  # revealed: list[list[int]]
+reveal_type(x2)  # revealed: list[list[int | str]]
+
+x3: list[int | str] = 3 * ["x" for _ in range(3)]
+reveal_type(x3)  # revealed: list[int | str]
+
+x4: tuple[list[Literal[1]]] = (lst(1),)
+reveal_type(x4)  # revealed: tuple[list[Literal[1]]]
+
+x5: tuple[list[Literal[1]], ...] = (lst(1),) * 3
+reveal_type(x5)  # revealed: tuple[list[Literal[1]], ...]
+
+x6: tuple[list[Literal[1]], ...] = 3 * ((lst(1),) + (lst(1),))
+reveal_type(x6)  # revealed: tuple[list[Literal[1]], ...]
+
+x7: set[int | str] = {1, 2} | {3, 4}
+reveal_type(x7)  # revealed: set[int | str]
+
+x8: set[int | str] = {42 for _ in range(3)}
+reveal_type(x8)  # revealed: set[int | str]
+
+x9: dict[int | str, int | str] = {1: 2} | {3: 4}
+reveal_type(x9)  # revealed: dict[int | str, int | str]
+
+x10: dict[int | str, int | str] = {str(i): i for i in range(3)}
+reveal_type(x10)  # revealed: dict[int | str, int | str]
+
+class X:
+    def __add__(self, _: list[int]) -> list[int | str]:
+        return []
+
+x11: list[int | str] = X() + [1]
+reveal_type(x11)  # revealed: list[int | str]
+
+class Y:
+    def __add__(self, _: list[int | str]) -> list[int]:
+        return []
+
+x12: list[int] = Y() + [1]
+reveal_type(x12)  # revealed: list[int]
+
+x13: list[int | str] = lst(42) * 3
+reveal_type(x13)  # revealed: list[int | str]
+
+x14: list[list[int | str]] = lst(lst(42)) * 3
+reveal_type(x14)  # revealed: list[list[int | str]]
+
+class Y[T]:
+    x: T
+
+    def __init__(self, x: T): ...
+    def __add__[U](self, _: Y[U]) -> Y[T | U]:
+        raise NotImplementedError
+
+x15: Y[int | str] = Y(1) + Y(2)
+reveal_type(x15)  # revealed: Y[int | str]
 ```
 
 ## `await` expressions

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4856,15 +4856,27 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         name: &str,
         argument_types: &mut CallArguments<'_, 'db>,
-        tcx: TypeContext<'db>,
+        call_expression_tcx: TypeContext<'db>,
         policy: MemberLookupPolicy,
     ) -> Result<Bindings<'db>, CallDunderError<'db>> {
         if let Type::Intersection(intersection) = self {
-            return intersection.try_call_dunder_with_policy(db, name, argument_types, tcx, policy);
+            return intersection.try_call_dunder_with_policy(
+                db,
+                name,
+                argument_types,
+                call_expression_tcx,
+                policy,
+            );
         }
 
         if let Type::Union(union) = self {
-            return union.try_call_dunder_with_policy(db, name, argument_types, tcx, policy);
+            return union.try_call_dunder_with_policy(
+                db,
+                name,
+                argument_types,
+                call_expression_tcx,
+                policy,
+            );
         }
 
         // Implicit calls to dunder methods never access instance members, so we pass
@@ -4886,7 +4898,7 @@ impl<'db> Type<'db> {
                 let bindings = dunder_callable
                     .bindings(db)
                     .match_parameters(db, argument_types)
-                    .check_types(db, &constraints, argument_types, tcx, &[])?;
+                    .check_types(db, &constraints, argument_types, call_expression_tcx, &[])?;
 
                 if boundness == Definedness::PossiblyUndefined {
                     return Err(CallDunderError::PossiblyUnbound {

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -18,6 +18,7 @@ impl<'db> Type<'db> {
         left_ty: Type<'db>,
         op: ast::Operator,
         right_ty: Type<'db>,
+        tcx: TypeContext<'db>,
     ) -> Option<Type<'db>> {
         #[salsa::tracked]
         fn try_call_bin_op_return_type_impl<'db>(
@@ -25,13 +26,14 @@ impl<'db> Type<'db> {
             left_ty: Type<'db>,
             op: ast::Operator,
             right_ty: Type<'db>,
+            tcx: TypeContext<'db>,
         ) -> Option<Type<'db>> {
-            Type::try_call_bin_op(db, left_ty, op, right_ty)
+            Type::try_call_bin_op(db, left_ty, op, right_ty, tcx)
                 .ok()
                 .map(|bindings| bindings.return_type(db))
         }
 
-        try_call_bin_op_return_type_impl(db, left_ty, op, right_ty)
+        try_call_bin_op_return_type_impl(db, left_ty, op, right_ty, tcx)
     }
 
     pub(crate) fn try_call_bin_op(
@@ -39,8 +41,16 @@ impl<'db> Type<'db> {
         left_ty: Type<'db>,
         op: ast::Operator,
         right_ty: Type<'db>,
+        tcx: TypeContext<'db>,
     ) -> Result<Bindings<'db>, CallBinOpError> {
-        Self::try_call_bin_op_with_policy(db, left_ty, op, right_ty, MemberLookupPolicy::default())
+        Self::try_call_bin_op_with_policy(
+            db,
+            left_ty,
+            op,
+            right_ty,
+            tcx,
+            MemberLookupPolicy::default(),
+        )
     }
 
     pub(crate) fn try_call_bin_op_with_policy(
@@ -48,6 +58,7 @@ impl<'db> Type<'db> {
         left_ty: Type<'db>,
         op: ast::Operator,
         right_ty: Type<'db>,
+        tcx: TypeContext<'db>,
         policy: MemberLookupPolicy,
     ) -> Result<Bindings<'db>, CallBinOpError> {
         // We either want to call lhs.__op__ or rhs.__rop__. The full decision tree from
@@ -80,7 +91,7 @@ impl<'db> Type<'db> {
                         db,
                         reflected_dunder,
                         &mut CallArguments::positional([left_ty]),
-                        TypeContext::default(),
+                        tcx,
                         policy,
                     )
                     .or_else(|_| {
@@ -88,7 +99,7 @@ impl<'db> Type<'db> {
                             db,
                             op.dunder(),
                             &mut CallArguments::positional([right_ty]),
-                            TypeContext::default(),
+                            tcx,
                             policy,
                         )
                     })?);
@@ -99,7 +110,7 @@ impl<'db> Type<'db> {
             db,
             op.dunder(),
             &mut CallArguments::positional([right_ty]),
-            TypeContext::default(),
+            tcx,
             policy,
         );
 
@@ -111,7 +122,7 @@ impl<'db> Type<'db> {
                     db,
                     op.reflected_dunder(),
                     &mut CallArguments::positional([left_ty]),
-                    TypeContext::default(),
+                    tcx,
                     policy,
                 )?)
             }

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -997,7 +997,13 @@ pub fn definitions_for_bin_op<'db>(
     let left_ty = binary_op.left.inferred_type(model)?;
     let right_ty = binary_op.right.inferred_type(model)?;
 
-    let Ok(bindings) = Type::try_call_bin_op(model.db(), left_ty, binary_op.op, right_ty) else {
+    let Ok(bindings) = Type::try_call_bin_op(
+        model.db(),
+        left_ty,
+        binary_op.op,
+        right_ty,
+        TypeContext::default(),
+    ) else {
         return None;
     };
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4312,7 +4312,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Fall back to non-augmented binary operator inference.
         let binary_return_ty = |builder: &mut Self, value_ty| {
             builder
-                .infer_binary_expression_type(assignment.into(), false, target_type, value_ty, op)
+                .infer_binary_expression_type(
+                    assignment.into(),
+                    false,
+                    None,
+                    target_type,
+                    None,
+                    value_ty,
+                    op,
+                    TypeContext::default(),
+                )
                 .unwrap_or_else(|| {
                     report_unsupported_augmented_assignment(
                         &builder.context,
@@ -4354,12 +4363,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     return typed_dict_update_ty;
                 }
 
-                let ast_arguments = [ArgOrKeyword::Arg(value_expr)];
+                let ast_arguments = [Some(value_expr)];
                 let mut call_arguments = CallArguments::positional([Type::unknown()]);
 
                 let call = self.infer_and_try_call_dunder(
-                    db,
                     target_type,
+                    None,
                     op.in_place_dunder(),
                     ArgumentsIter::synthesized(&ast_arguments),
                     &mut call_arguments,
@@ -4920,16 +4929,111 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     #[expect(clippy::too_many_arguments)]
     fn infer_and_try_call_dunder(
         &mut self,
-        db: &'db dyn Db,
-        object: Type<'db>,
+        object_ty: Type<'db>,
+        object_expr: Option<&ast::Expr>,
         name: &str,
         ast_arguments: ArgumentsIter<'_>,
         argument_types: &mut CallArguments<'_, 'db>,
         infer_argument_ty: &mut dyn FnMut(&mut Self, ArgExpr<'db, '_>) -> Type<'db>,
         call_expression_tcx: TypeContext<'db>,
     ) -> Result<Bindings<'db>, CallDunderError<'db>> {
-        match object
-            .member_lookup_with_policy(db, name.into(), MemberLookupPolicy::NO_INSTANCE_FALLBACK)
+        self.infer_and_try_call_dunder_with_policy(
+            object_ty,
+            object_expr,
+            name,
+            ast_arguments,
+            argument_types,
+            infer_argument_ty,
+            call_expression_tcx,
+            MemberLookupPolicy::default(),
+        )
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    fn infer_and_try_call_dunder_with_policy(
+        &mut self,
+        mut object_ty: Type<'db>,
+        object_expr: Option<&ast::Expr>,
+        name: &str,
+        ast_arguments: ArgumentsIter<'_>,
+        argument_types: &mut CallArguments<'_, 'db>,
+        infer_argument_ty: &mut dyn FnMut(&mut Self, ArgExpr<'db, '_>) -> Type<'db>,
+        call_expression_tcx: TypeContext<'db>,
+        policy: MemberLookupPolicy,
+    ) -> Result<Bindings<'db>, CallDunderError<'db>> {
+        let db = self.db();
+
+        if let Some(object_expr) = object_expr
+            && let Some(class_type) = object_ty.nominal_class(db)
+            && let Some(generic_alias) = class_type.into_generic_alias()
+            && let Some(generic_context) = generic_alias.origin(db).generic_context(db)
+            && let Some(call_expression_tcx) = call_expression_tcx.annotation
+            && let Place::Defined(DefinedPlace {
+                ty: dunder_callable,
+                ..
+            }) = Type::instance(db, generic_alias.origin(db).identity_specialization(db))
+                .member_lookup_with_policy(
+                    db,
+                    name.into(),
+                    policy | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                )
+                .place
+        {
+            let bindings = dunder_callable
+                .bindings(db)
+                .match_parameters(db, argument_types);
+
+            let constraints = ConstraintSetBuilder::new();
+            let mut builder = SpecializationBuilder::new(
+                db,
+                &constraints,
+                generic_context.inferable_typevars(db),
+            );
+
+            // Collect the constraints on the callable type's generic context
+            // enforced by the type context of the call expression. Note that
+            // the callable expression of a bound method is initially inferred
+            // without type context, and so the bindings we collect may not be
+            // specialized with the correct types.
+            if let Some(callable) = bindings.single_element() {
+                for (_, binding) in callable.matching_overloads() {
+                    let _ = builder.infer(binding.signature.return_ty, call_expression_tcx);
+                }
+            }
+
+            // Re-infer the callable type with the new type context.
+            let generic_alias =
+                generic_alias
+                    .origin(db)
+                    .apply_specialization(db, |generic_context| {
+                        builder.build_with(generic_context, |_, bounds| {
+                            // Default specialize any type variables to a marker type, which will be
+                            // ignored during argument inference, allowing the concrete subset of the
+                            // parameter type to still affect argument inference.
+                            if bounds.is_none() {
+                                Some(Type::Dynamic(DynamicType::UnspecializedTypeVar))
+                            } else {
+                                None
+                            }
+                        })
+                    });
+
+            let object_tcx = TypeContext::new(Some(Type::instance(db, generic_alias)));
+
+            // TODO: This is the correct inferred type for `right_expr`, as the
+            // original inference did not provide type context. In principle, the
+            // original inference should have been speculated, and this inference
+            // should be persisted, but we acquire the type context much after the
+            // original inference, which makes this difficult.
+            object_ty = self.speculate().infer_expression(object_expr, object_tcx);
+        }
+
+        match object_ty
+            .member_lookup_with_policy(
+                db,
+                name.into(),
+                policy | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+            )
             .place
         {
             Place::Defined(DefinedPlace {
@@ -5160,11 +5264,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // determine their length.
                 //
                 // TODO: Re-infer splatted arguments with their type context.
-                ast::ArgOrKeyword::Arg(ast::Expr::Starred(_))
-                | ast::ArgOrKeyword::Keyword(ast::Keyword { arg: None, .. }) => continue,
+                Some(
+                    ast::ArgOrKeyword::Arg(ast::Expr::Starred(_))
+                    | ast::ArgOrKeyword::Keyword(ast::Keyword { arg: None, .. }),
+                ) => continue,
 
-                ast::ArgOrKeyword::Arg(arg) => arg,
-                ast::ArgOrKeyword::Keyword(ast::Keyword { value, .. }) => value,
+                Some(ast::ArgOrKeyword::Arg(arg)) => arg,
+                Some(ast::ArgOrKeyword::Keyword(ast::Keyword { value, .. })) => value,
+
+                None => {
+                    assert!(
+                        argument_types.get_default().is_some(),
+                        "synthesized argument must provide type"
+                    );
+                    continue;
+                }
             };
 
             // Type-form arguments are inferred without type context, so we can infer the argument type directly.
@@ -9510,6 +9624,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     /// Extend the current region with the results of a speculative [`TypeInferenceBuilder`].
+    ///
+    /// Note that this overrides the inferred types of any expressions or bindings.
     fn extend(&mut self, other: Self) {
         let Self {
             context,
@@ -9640,7 +9756,7 @@ type ArgExpr<'db, 'ast> = (usize, &'ast ast::Expr, TypeContext<'db>);
 #[derive(Clone)]
 enum ArgumentsIter<'a> {
     FromAst(ArgumentsSourceOrder<'a>),
-    Synthesized(std::slice::Iter<'a, ArgOrKeyword<'a>>),
+    Synthesized(std::slice::Iter<'a, Option<&'a ast::Expr>>),
 }
 
 impl<'a> ArgumentsIter<'a> {
@@ -9648,18 +9764,18 @@ impl<'a> ArgumentsIter<'a> {
         Self::FromAst(arguments.iter_source_order())
     }
 
-    fn synthesized(arguments: &'a [ArgOrKeyword<'a>]) -> Self {
+    fn synthesized(arguments: &'a [Option<&'a ast::Expr>]) -> Self {
         Self::Synthesized(arguments.iter())
     }
 }
 
 impl<'a> Iterator for ArgumentsIter<'a> {
-    type Item = ArgOrKeyword<'a>;
+    type Item = Option<ArgOrKeyword<'a>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
-            ArgumentsIter::FromAst(args) => args.next(),
-            ArgumentsIter::Synthesized(args) => args.next().copied(),
+            ArgumentsIter::FromAst(args) => Some(args.next()),
+            ArgumentsIter::Synthesized(args) => Some(args.next()?.map(ArgOrKeyword::Arg)),
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -8,6 +8,7 @@ use crate::types::cyclic::CycleDetector;
 use crate::types::diagnostic::{
     DIVISION_BY_ZERO, report_unsupported_augmented_assignment, report_unsupported_binary_operation,
 };
+use crate::types::infer::builder::ArgumentsIter;
 use crate::types::typevar::TypeVarConstraints;
 use crate::types::{
     DynamicType, InternedConstraintSet, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -44,24 +45,33 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             node_index: _,
         } = binary;
 
-        let (left_ty, right_ty) =
-            match self.infer_binary_expression_operand_types(left, *op, right, tcx) {
-                BinaryExpressionOperandTypes::TypedDictResult(ty) => return ty,
-                BinaryExpressionOperandTypes::Inferred(left_ty, right_ty) => (left_ty, right_ty),
-            };
+        let (left_ty, right_ty) = match self.infer_binary_expression_operand_types(left, *op, right)
+        {
+            BinaryExpressionOperandTypes::TypedDictResult(ty) => return ty,
+            BinaryExpressionOperandTypes::Inferred(left_ty, right_ty) => (left_ty, right_ty),
+        };
 
-        self.infer_binary_expression_type(binary.into(), false, left_ty, right_ty, *op)
-            .unwrap_or_else(|| {
-                report_unsupported_binary_operation(
-                    &self.context,
-                    self.index,
-                    binary,
-                    left_ty,
-                    right_ty,
-                    *op,
-                );
-                Type::unknown()
-            })
+        self.infer_binary_expression_type(
+            binary.into(),
+            false,
+            Some(left),
+            left_ty,
+            Some(right),
+            right_ty,
+            *op,
+            tcx,
+        )
+        .unwrap_or_else(|| {
+            report_unsupported_binary_operation(
+                &self.context,
+                self.index,
+                binary,
+                left_ty,
+                right_ty,
+                *op,
+            );
+            Type::unknown()
+        })
     }
 
     fn infer_pep_604_union_type_alias(
@@ -112,37 +122,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         left: &ast::Expr,
         op: ast::Operator,
         right: &ast::Expr,
-        tcx: TypeContext<'db>,
     ) -> BinaryExpressionOperandTypes<'db> {
-        // As a special case, pass `tcx` to binary operands that are collection literals/displays.
-        // Note that it's not correct to pass it to all binary operands, for example:
-        // ```
-        // x: list[str] = ["x"] * 3
-        // ```
-        // It doesn't make sense to pass the list type context to the `3` expression. It wouldn't
-        // have any effect in this case, but it could in more complicated cases.
-        // TODO: When we support passing `tcx` through generic method calls, we can remove this
-        // special case and handle the relevant dunder method instead.
-        let operand_tcx = |expr: &ast::Expr| -> TypeContext<'db> {
-            match expr {
-                ast::Expr::List(_)
-                | ast::Expr::Tuple(_)
-                | ast::Expr::Set(_)
-                | ast::Expr::Dict(_)
-                | ast::Expr::ListComp(_)
-                | ast::Expr::SetComp(_)
-                | ast::Expr::DictComp(_) => tcx,
-                // Also pass `tcx` to nested binary expressions.
-                ast::Expr::BinOp(_) => tcx,
-                _ => TypeContext::default(),
-            }
-        };
-
         // When a dict literal is `|`'d with a TypedDict, infer the non-literal side first
         // so we can use bidirectional inference on the literal before calling the synthesized
         // `__or__`/`__ror__` method on the TypedDict side.
         if op == ast::Operator::BitOr && matches!(left, ast::Expr::Dict(_)) {
-            let right_ty = self.infer_expression(right, operand_tcx(right));
+            let right_ty = self.infer_expression(right, TypeContext::default());
             if let Type::TypedDict(typed_dict) = right_ty
                 && let Some(ty) = self.try_typed_dict_pep_584_dunder(
                     left,
@@ -157,12 +142,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             // If the TypedDict update path rejects the literal, fall back to ordinary inference
             // even though that means re-inferring the literal without TypedDict context.
             return BinaryExpressionOperandTypes::Inferred(
-                self.infer_expression(left, operand_tcx(left)),
+                self.infer_expression(left, TypeContext::default()),
                 right_ty,
             );
         }
 
-        let left_ty = self.infer_expression(left, operand_tcx(left));
+        let left_ty = self.infer_expression(left, TypeContext::default());
         if op == ast::Operator::BitOr
             && let Type::TypedDict(typed_dict) = left_ty
             && matches!(right, ast::Expr::Dict(_))
@@ -178,7 +163,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         BinaryExpressionOperandTypes::Inferred(
             left_ty,
-            self.infer_expression(right, operand_tcx(right)),
+            self.infer_expression(right, TypeContext::default()),
         )
     }
 
@@ -291,31 +276,42 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         })
     }
 
+    #[expect(clippy::too_many_arguments)]
     pub(super) fn infer_binary_expression_type(
         &mut self,
         node: AnyNodeRef<'_>,
         emitted_division_by_zero_diagnostic: bool,
+        left_expr: Option<&ast::Expr>,
         left_ty: Type<'db>,
+        right_expr: Option<&ast::Expr>,
         right_ty: Type<'db>,
         op: ast::Operator,
+        tcx: TypeContext<'db>,
     ) -> Option<Type<'db>> {
         self.infer_binary_expression_type_impl(
             node,
             emitted_division_by_zero_diagnostic,
+            left_expr,
             left_ty,
+            right_expr,
             right_ty,
             op,
+            tcx,
             &BinaryExpressionVisitor::new(Some(Type::Never)),
         )
     }
 
+    #[expect(clippy::too_many_arguments)]
     fn infer_binary_expression_type_impl(
         &mut self,
         node: AnyNodeRef<'_>,
         mut emitted_division_by_zero_diagnostic: bool,
+        left_expr: Option<&ast::Expr>,
         left_ty: Type<'db>,
+        right_expr: Option<&ast::Expr>,
         right_ty: Type<'db>,
         op: ast::Operator,
+        tcx: TypeContext<'db>,
         visitor: &BinaryExpressionVisitor<'db>,
     ) -> Option<Type<'db>> {
         let db = self.db();
@@ -345,9 +341,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 self.infer_binary_expression_type_impl(
                     node,
                     emitted_division_by_zero_diagnostic,
+                    None,
                     *lhs_element,
+                    right_expr,
                     rhs,
                     op,
+                    tcx,
                     visitor,
                 )
             }),
@@ -355,9 +354,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 self.infer_binary_expression_type_impl(
                     node,
                     emitted_division_by_zero_diagnostic,
+                    left_expr,
                     lhs,
+                    None,
                     *rhs_element,
                     op,
+                    tcx,
                     visitor,
                 )
             }),
@@ -366,9 +368,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 self.infer_binary_expression_type_impl(
                     node,
                     emitted_division_by_zero_diagnostic,
+                    left_expr,
                     alias.value_type(db),
+                    right_expr,
                     rhs,
                     op,
+                    tcx,
                     visitor,
                 )
             }),
@@ -377,9 +382,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 self.infer_binary_expression_type_impl(
                     node,
                     emitted_division_by_zero_diagnostic,
+                    left_expr,
                     lhs,
+                    right_expr,
                     alias.value_type(db),
                     op,
+                    tcx,
                     visitor,
                 )
             }),
@@ -442,15 +450,18 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 self.infer_binary_expression_type(
                                     node,
                                     emitted_division_by_zero_diagnostic,
+                                    None,
                                     constraint,
+                                    None,
                                     constraint,
                                     op,
+                                    tcx,
                                 )
                             },
                         )
                     }
                     // For bounded TypeVars or unconstrained TypeVars, fall through to the default handling.
-                    _ => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty),
+                    _ => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty, tcx),
                 }
             }
 
@@ -472,16 +483,19 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 self.infer_binary_expression_type_impl(
                                     node,
                                     emitted_division_by_zero_diagnostic,
+                                    None,
                                     constraint,
+                                    right_expr,
                                     rhs,
                                     op,
+                                    tcx,
                                     visitor,
                                 )
                             },
                         )
                     }
                     // For bounded TypeVars or unconstrained TypeVars, fall through to the default handling.
-                    _ => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty),
+                    _ => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty, tcx),
                 }
             }
 
@@ -498,16 +512,19 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 self.infer_binary_expression_type_impl(
                                     node,
                                     emitted_division_by_zero_diagnostic,
+                                    left_expr,
                                     lhs,
+                                    None,
                                     constraint,
                                     op,
+                                    tcx,
                                     visitor,
                                 )
                             },
                         )
                     }
                     // For bounded TypeVars or unconstrained TypeVars, fall through to the default handling.
-                    _ => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty),
+                    _ => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty, tcx),
                 }
             }
 
@@ -518,25 +535,31 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             // positional arguments get. In those cases we need to explicitly delegate to the base
             // type, so that it hits the `Type::Union` branches above.
             (Type::NewTypeInstance(newtype), rhs, _) => {
-                Type::try_call_bin_op_return_type(db, left_ty, op, right_ty).or_else(|| {
+                Type::try_call_bin_op_return_type(db, left_ty, op, right_ty, tcx).or_else(|| {
                     self.infer_binary_expression_type_impl(
                         node,
                         emitted_division_by_zero_diagnostic,
+                        left_expr,
                         newtype.concrete_base_type(db),
+                        right_expr,
                         rhs,
                         op,
+                        tcx,
                         visitor,
                     )
                 })
             }
             (lhs, Type::NewTypeInstance(newtype), _) => {
-                Type::try_call_bin_op_return_type(db, left_ty, op, right_ty).or_else(|| {
+                Type::try_call_bin_op_return_type(db, left_ty, op, right_ty, tcx).or_else(|| {
                     self.infer_binary_expression_type_impl(
                         node,
                         emitted_division_by_zero_diagnostic,
+                        left_expr,
                         lhs,
+                        right_expr,
                         newtype.concrete_base_type(db),
                         op,
+                        tcx,
                         visitor,
                     )
                 })
@@ -775,18 +798,24 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     ) => self.infer_binary_expression_type(
                         node,
                         emitted_division_by_zero_diagnostic,
+                        None,
                         Type::int_literal(i64::from(b1)),
+                        None,
                         right_ty,
                         op,
+                        tcx,
                     ),
 
                     (LiteralValueTypeKind::Int(_), LiteralValueTypeKind::Bool(b2), op) => self
                         .infer_binary_expression_type(
                             node,
                             emitted_division_by_zero_diagnostic,
+                            None,
                             left_ty,
+                            None,
                             Type::int_literal(i64::from(b2)),
                             op,
+                            tcx,
                         ),
 
                     (
@@ -842,7 +871,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         Some(result)
                     }
 
-                    _ => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty),
+                    _ => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty, tcx),
                 }
             }
 
@@ -961,15 +990,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 _,
                 Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..),
                 ast::Operator::BitOr,
-            ) if pep_604_unions_allowed() => Type::try_call_bin_op_with_policy(
-                db,
+            ) if pep_604_unions_allowed() => self.infer_and_try_call_bin_op_with_policy(
+                left_expr,
                 left_ty,
                 ast::Operator::BitOr,
+                right_expr,
                 right_ty,
+                tcx,
                 MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
-            )
-            .ok()
-            .map(|binding| binding.return_type(db)),
+            ),
 
             // We've handled all of the special cases that we support for literals, so we need to
             // fall back on looking for dunder methods on one of the operand types.
@@ -1025,8 +1054,105 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 | Type::TypeGuard(_)
                 | Type::TypedDict(_),
                 op,
-            ) => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty),
+            ) => self.infer_and_try_call_bin_op(left_expr, left_ty, op, right_expr, right_ty, tcx),
         }
+    }
+
+    pub(crate) fn infer_and_try_call_bin_op(
+        &mut self,
+        left_expr: Option<&ast::Expr>,
+        left_ty: Type<'db>,
+        op: ast::Operator,
+        right_expr: Option<&ast::Expr>,
+        right_ty: Type<'db>,
+        tcx: TypeContext<'db>,
+    ) -> Option<Type<'db>> {
+        self.infer_and_try_call_bin_op_with_policy(
+            left_expr,
+            left_ty,
+            op,
+            right_expr,
+            right_ty,
+            tcx,
+            MemberLookupPolicy::default(),
+        )
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    pub(crate) fn infer_and_try_call_bin_op_with_policy(
+        &mut self,
+        left_expr: Option<&ast::Expr>,
+        left_ty: Type<'db>,
+        op: ast::Operator,
+        right_expr: Option<&ast::Expr>,
+        right_ty: Type<'db>,
+        tcx: TypeContext<'db>,
+        policy: MemberLookupPolicy,
+    ) -> Option<Type<'db>> {
+        let db = self.db();
+        let left_instance = (left_expr, left_ty);
+        let right_instance = (right_expr, right_ty);
+
+        let mut call_on_instance =
+            |(left_expr, left_ty), op, (right_expr, right_ty): (Option<_>, _)| {
+                self.infer_and_try_call_dunder_with_policy(
+                    left_ty,
+                    left_expr,
+                    op,
+                    ArgumentsIter::synthesized(&[right_expr]),
+                    &mut CallArguments::positional([right_ty]),
+                    &mut |builder: &mut Self, (_, right_expr, tcx)| {
+                        // TODO: This is the correct inferred type for `right_expr`, as the
+                        // original inference did not provide type context. In principle,
+                        // the original inference should have been speculated, and this
+                        // inference should be persisted, but we acquire the type context
+                        // much after the original inference, which makes this difficult.
+                        builder.speculate().infer_expression(right_expr, tcx)
+                    },
+                    tcx,
+                    policy,
+                )
+                .ok()
+                .map(|bindings| bindings.return_type(db))
+            };
+
+        // We either want to call lhs.__op__ or rhs.__rop__. The full decision tree from
+        // the Python spec [1] is:
+        //
+        //   - If rhs is a (proper) subclass of lhs, and it provides a different
+        //     implementation of __rop__, use that.
+        //   - Otherwise, if lhs implements __op__, use that.
+        //   - Otherwise, if lhs and rhs are different types, and rhs implements __rop__,
+        //     use that.
+        //
+        // [1] https://docs.python.org/3/reference/datamodel.html#object.__radd__
+
+        // Technically we don't have to check left_ty != right_ty here, since if the types
+        // are the same, they will trivially have the same implementation of the reflected
+        // dunder, and so we'll fail the inner check. But the type equality check will be
+        // faster for the common case, and allow us to skip the (two) class member lookups.
+        let left_class = left_ty.to_meta_type(db);
+        let right_class = right_ty.to_meta_type(db);
+        if left_ty != right_ty && right_ty.is_subtype_of(db, left_ty) {
+            let reflected_dunder = op.reflected_dunder();
+            let rhs_reflected = right_class.member(db, reflected_dunder).place;
+            // TODO: if `rhs_reflected` is possibly unbound, we should union the two possible
+            // Bindings together
+            if !rhs_reflected.is_undefined()
+                && rhs_reflected != left_class.member(db, reflected_dunder).place
+            {
+                return call_on_instance(right_instance, reflected_dunder, left_instance)
+                    .or_else(|| call_on_instance(left_instance, op.dunder(), right_instance));
+            }
+        }
+
+        call_on_instance(left_instance, op.dunder(), right_instance).or_else(|| {
+            if left_ty == right_ty {
+                None
+            } else {
+                call_on_instance(right_instance, op.reflected_dunder(), left_instance)
+            }
+        })
     }
 
     /// Raise a diagnostic if the given type cannot be divided by zero.

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -1,7 +1,7 @@
 use itertools::{Either, EitherOrBoth, Itertools};
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span};
 use ruff_db::parsed::parsed_module;
-use ruff_python_ast::{self as ast, ArgOrKeyword, ExprContext};
+use ruff_python_ast::{self as ast, ExprContext};
 use ruff_text_size::Ranged;
 use ty_module_resolver::file_to_module;
 
@@ -1462,10 +1462,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             _ => {
-                let ast_arguments = [
-                    ArgOrKeyword::Arg(&target.slice),
-                    ArgOrKeyword::Arg(rhs_value_node),
-                ];
+                let ast_arguments = [Some(&*target.slice), Some(rhs_value_node)];
 
                 let mut call_arguments =
                     CallArguments::positional([Type::unknown(), Type::unknown()]);
@@ -1480,8 +1477,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     };
 
                 let Err(call_dunder_err) = self.infer_and_try_call_dunder(
-                    db,
                     object_ty,
+                    None,
                     "__setitem__",
                     ArgumentsIter::synthesized(&ast_arguments),
                     &mut call_arguments,

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -232,6 +232,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 left_type_value,
                                 ast::Operator::BitOr,
                                 right_type_value,
+                                TypeContext::default(),
                             )
                             .is_err();
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::marker::PhantomData;
 
+use itertools::Itertools;
 use ruff_python_ast::PythonVersion;
 use ruff_python_ast::name::Name;
 use ty_module_resolver::{ModuleName, file_to_module};
@@ -63,13 +64,35 @@ impl<'db> Type<'db> {
             ClassLiteral::Static(class_literal) => {
                 let specialization = class.into_generic_alias().map(|g| g.specialization(db));
                 match class_literal.known(db) {
-                    Some(KnownClass::Tuple) => Type::tuple(TupleType::new(
-                        db,
-                        specialization
-                            .and_then(|spec| Some(Cow::Borrowed(spec.tuple(db)?)))
-                            .unwrap_or_else(|| Cow::Owned(TupleSpec::homogeneous(Type::unknown())))
-                            .as_ref(),
-                    )),
+                    Some(KnownClass::Tuple) => {
+                        let Some(specialization) = specialization else {
+                            return Type::homogeneous_tuple(db, Type::unknown());
+                        };
+
+                        let Some(tuple_spec) = specialization.tuple(db) else {
+                            let tuple_typevar = class_literal
+                                .generic_context(db)
+                                .and_then(|generic_context| {
+                                    generic_context.variables(db).exactly_one().ok()
+                                })
+                                .expect("`tuple` should have exactly one type variable");
+
+                            // We sometimes internally specialize `_T_co@tuple` directly.
+                            if let Ok((typevar, ty)) = specialization
+                                .generic_context(db)
+                                .variables(db)
+                                .zip(specialization.types(db))
+                                .exactly_one()
+                                && typevar == tuple_typevar
+                            {
+                                return Type::homogeneous_tuple(db, *ty);
+                            }
+
+                            return Type::homogeneous_tuple(db, Type::unknown());
+                        };
+
+                        Type::tuple(TupleType::new(db, tuple_spec))
+                    }
                     Some(KnownClass::Object) => Type::object(),
                     _ => class_literal
                         .is_typed_dict(db)


### PR DESCRIPTION
Part of https://github.com/astral-sh/ty/issues/3420. This improves our support for binary operator expressions, but does not generally support bound method calls.