### PR TITLE
[ty] Use `as_i64` when comparing `IntLiteralType` instances

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/comparison/integers.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/integers.md
@@ -14,6 +14,7 @@ reveal_type(1 is 2)  # revealed: Literal[False]
 reveal_type(1 is not 7)  # revealed: Literal[True]
 # error: [unsupported-operator] "Operator `<=` is not supported between objects of type `Literal[1]` and `Literal[""]`"
 reveal_type(1 <= "" and 0 < 1)  # revealed: (Unknown & ~AlwaysTruthy) | Literal[True]
+reveal_type(-1 < 0)  # revealed: Literal[True]
 ```
 
 ## Integer instance

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -379,8 +379,6 @@ pub(super) fn infer_binary_type_comparison<'db>(
         (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal)) => {
             match (left_literal.kind(), right_literal.kind()) {
                 (LiteralValueTypeKind::Int(n), LiteralValueTypeKind::Int(m)) => {
-                    let n = n.as_i64();
-                    let m = m.as_i64();
                     Some(match op {
                         ast::CmpOp::Eq => Ok(Type::bool_literal(n == m)),
                         ast::CmpOp::NotEq => Ok(Type::bool_literal(n != m)),

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -379,6 +379,8 @@ pub(super) fn infer_binary_type_comparison<'db>(
         (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal)) => {
             match (left_literal.kind(), right_literal.kind()) {
                 (LiteralValueTypeKind::Int(n), LiteralValueTypeKind::Int(m)) => {
+                    let n = n.as_i64();
+                    let m = m.as_i64();
                     Some(match op {
                         ast::CmpOp::Eq => Ok(Type::bool_literal(n == m)),
                         ast::CmpOp::NotEq => Ok(Type::bool_literal(n != m)),

--- a/crates/ty_python_semantic/src/types/literal.rs
+++ b/crates/ty_python_semantic/src/types/literal.rs
@@ -297,7 +297,7 @@ impl<'db> From<LiteralValueType<'db>> for Type<'db> {
 
 // This type has the same alignment as `salsa::Id`, allowing `LiteralValueType` to use a smaller
 // discriminant.
-#[derive(PartialOrd, Ord, Copy, Clone, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
 pub(crate) struct IntLiteralType {
     high: u32,
     low: u32,

--- a/crates/ty_python_semantic/src/types/literal.rs
+++ b/crates/ty_python_semantic/src/types/literal.rs
@@ -331,6 +331,18 @@ impl std::fmt::Debug for IntLiteralType {
     }
 }
 
+impl std::cmp::Ord for IntLiteralType {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_i64().cmp(&other.as_i64())
+    }
+}
+
+impl std::cmp::PartialOrd for IntLiteralType {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct StringLiteralType<'db> {
     #[returns(deref)]


### PR DESCRIPTION
Previously we had:

```
reveal_type(-1 < 0) # Literal[False]
```

which doesn't seem great.

Turns out that we encode integers as a pair of `u32`s and had derived `Ord` on that implementation detail. This PR removes that derivation and replaces the misuse of that ordering with a comparison between integers.

Happy to implement `Ord` directly on `IntLiteralType` if you would prefer, but using `as_i64` seems to match what is done in nearby code.
