### PR TITLE
Bump release maturin for wheel RECORD paths

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -51,7 +51,7 @@ jobs:
       - name: "Build sdist"
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
-          maturin-version: v1.11.5
+          maturin-version: v1.12.0
           command: sdist
           args: --out dist
       - name: "Test sdist"
@@ -82,7 +82,7 @@ jobs:
       - name: "Build wheels - x86_64"
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
-          maturin-version: v1.11.5
+          maturin-version: v1.12.0
           target: x86_64
           args: --release --locked --out dist --compatibility pypi
       - name: "Upload wheels"
@@ -125,7 +125,7 @@ jobs:
       - name: "Build wheels - aarch64"
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
-          maturin-version: v1.11.5
+          maturin-version: v1.12.0
           target: aarch64
           args: --release --locked --out dist --compatibility pypi
       - name: "Test wheel - aarch64"
@@ -182,7 +182,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
-          maturin-version: v1.11.5
+          maturin-version: v1.12.0
           target: ${{ matrix.platform.target }}
           args: --release --locked --out dist --compatibility pypi
         env:
@@ -236,7 +236,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
-          maturin-version: v1.11.5
+          maturin-version: v1.12.0
           target: ${{ matrix.target }}
           manylinux: 2_17
           args: --release --locked --out dist --compatibility pypi
@@ -317,7 +317,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
-          maturin-version: v1.11.5
+          maturin-version: v1.12.0
           target: ${{ matrix.platform.target }}
           manylinux: ${{ matrix.platform.manylinux }}
           docker-options: ${{ matrix.platform.maturin_docker_options }}
@@ -384,7 +384,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
-          maturin-version: v1.11.5
+          maturin-version: v1.12.0
           target: ${{ matrix.target }}
           manylinux: musllinux_1_2
           args: --release --locked --out dist --compatibility pypi
@@ -448,7 +448,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
-          maturin-version: v1.11.5
+          maturin-version: v1.12.0
           target: ${{ matrix.platform.target }}
           manylinux: musllinux_1_2
           args: --release --locked --out dist --compatibility pypi


### PR DESCRIPTION
Fixes #24940.

Ruff's release wheel jobs are pinned to maturin v1.11.5, which includes the Windows RECORD path separator regression mentioned in the issue. This bumps those jobs to maturin v1.12.0, where the upstream path handling fix is available.

Tested:
- `git diff --check -- .github/workflows/build-binaries.yml`
- Parsed `.github/workflows/build-binaries.yml` with PyYAML
- Verified the PyO3/maturin v1.12.0 release exists