### PR TITLE
[ty] Preserve transparent callable decorators

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -734,6 +734,46 @@ class ParamSpecWithDefault6(Generic[PAnother]):
     attr: Callable[PAnother, None]
 ```
 
+## Transparent decorator passthrough
+
+A decorator typed as `Callable[P, R] -> Callable[P, R]` preserves overloaded functions.
+
+```py
+from typing import Callable, ParamSpec, TypeVar, overload
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def transparent(func: Callable[P, R]) -> Callable[P, R]:
+    return func
+
+@overload
+def test(x: int) -> int: ...
+@overload
+def test(*, y: str) -> str: ...
+@transparent
+def test(x: int | None = None, *, y: str | None = None) -> int | str:
+    raise NotImplementedError
+
+reveal_type(test)  # revealed: Overload[(x: int) -> int, (*, y: str) -> str]
+reveal_type(test(1))  # revealed: int
+reveal_type(test(y="x"))  # revealed: str
+
+# error: [no-matching-overload]
+reveal_type(test(1, y="x"))  # revealed: Unknown
+```
+
+The same decorator preserves non-overloaded functions.
+
+```py
+@transparent
+def increment(value: int) -> int:
+    return value + 1
+
+reveal_type(increment)  # revealed: def increment(value: int) -> int
+reveal_type(increment(1))  # revealed: int
+```
+
 ## Semantics
 
 The semantics of `ParamSpec` are described in

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -734,46 +734,6 @@ class ParamSpecWithDefault6(Generic[PAnother]):
     attr: Callable[PAnother, None]
 ```
 
-## Transparent decorator passthrough
-
-A decorator typed as `Callable[P, R] -> Callable[P, R]` preserves overloaded functions.
-
-```py
-from typing import Callable, ParamSpec, TypeVar, overload
-
-P = ParamSpec("P")
-R = TypeVar("R")
-
-def transparent(func: Callable[P, R]) -> Callable[P, R]:
-    return func
-
-@overload
-def test(x: int) -> int: ...
-@overload
-def test(*, y: str) -> str: ...
-@transparent
-def test(x: int | None = None, *, y: str | None = None) -> int | str:
-    raise NotImplementedError
-
-reveal_type(test)  # revealed: Overload[(x: int) -> int, (*, y: str) -> str]
-reveal_type(test(1))  # revealed: int
-reveal_type(test(y="x"))  # revealed: str
-
-# error: [no-matching-overload]
-reveal_type(test(1, y="x"))  # revealed: Unknown
-```
-
-The same decorator preserves non-overloaded functions.
-
-```py
-@transparent
-def increment(value: int) -> int:
-    return value + 1
-
-reveal_type(increment)  # revealed: def increment(value: int) -> int
-reveal_type(increment(1))  # revealed: int
-```
-
 ## Semantics
 
 The semantics of `ParamSpec` are described in

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -958,6 +958,31 @@ reveal_type(increment)  # revealed: (value: int) -> int
 reveal_type(increment(1))  # revealed: int
 ```
 
+### Transparent decorator type aliases
+
+A type alias for `Callable[P, R]` can also be used to type a transparent decorator.
+
+```py
+from typing import Callable, overload
+
+type Fn[**P, R] = Callable[P, R]
+
+def transparent[**P, R](func: Fn[P, R]) -> Fn[P, R]:
+    return func
+
+@overload
+def alias_decorated(x: int) -> int: ...
+@overload
+def alias_decorated(*, y: str) -> str: ...
+@transparent
+def alias_decorated(x: int | None = None, *, y: str | None = None) -> int | str:
+    raise NotImplementedError
+
+reveal_type(alias_decorated)  # revealed: Overload[(x: int) -> int, (*, y: str) -> str]
+reveal_type(alias_decorated(1))  # revealed: int
+reveal_type(alias_decorated(y="x"))  # revealed: str
+```
+
 ### Transparent decorator factories
 
 A transparent decorator returned by a decorator factory also preserves overload signatures.

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -958,6 +958,32 @@ reveal_type(increment)  # revealed: (value: int) -> int
 reveal_type(increment(1))  # revealed: int
 ```
 
+### Transparent decorator factories
+
+A transparent decorator returned by a decorator factory also preserves overload signatures.
+
+```py
+from typing import Callable, overload
+
+def transparent_factory[**P, R]() -> Callable[[Callable[P, R]], Callable[P, R]]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        return func
+
+    return decorator
+
+@overload
+def decorated_factory(x: int) -> int: ...
+@overload
+def decorated_factory(*, y: str) -> str: ...
+@transparent_factory()
+def decorated_factory(x: int | None = None, *, y: str | None = None) -> int | str:
+    raise NotImplementedError
+
+reveal_type(decorated_factory)  # revealed: Overload[(x: int) -> int, (*, y: str) -> str]
+reveal_type(decorated_factory(1))  # revealed: int
+reveal_type(decorated_factory(y="x"))  # revealed: str
+```
+
 ### Overloads
 
 #### Return type filtering

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -925,6 +925,39 @@ def f(env: dict) -> None:
 reveal_type(f)
 ```
 
+### Transparent decorator passthrough
+
+A decorator typed as `Callable[P, R] -> Callable[P, R]` preserves overloaded functions.
+
+```py
+from typing import Callable, overload
+
+def transparent[**P, R](func: Callable[P, R]) -> Callable[P, R]:
+    return func
+
+@overload
+def test(x: int) -> int: ...
+@overload
+def test(*, y: str) -> str: ...
+@transparent
+def test(x: int | None = None, *, y: str | None = None) -> int | str:
+    raise NotImplementedError
+
+reveal_type(test)  # revealed: Overload[(x: int) -> int, (*, y: str) -> str]
+reveal_type(test(1))  # revealed: int
+reveal_type(test(y="x"))  # revealed: str
+
+# error: [no-matching-overload]
+reveal_type(test(1, y="x"))  # revealed: Unknown
+
+@transparent
+def increment(value: int) -> int:
+    return value + 1
+
+reveal_type(increment)  # revealed: def increment(value: int) -> int
+reveal_type(increment(1))  # revealed: int
+```
+
 ### Overloads
 
 #### Return type filtering

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -921,13 +921,13 @@ def callable_identity[**P, R](func: Callable[P, R]) -> Callable[P, R]:
 def f(env: dict) -> None:
     pass
 
-# revealed: def f(env: dict[Unknown, Unknown]) -> None
+# revealed: (env: dict[Unknown, Unknown]) -> None
 reveal_type(f)
 ```
 
 ### Transparent decorator passthrough
 
-A decorator typed as `Callable[P, R] -> Callable[P, R]` preserves overloaded functions.
+A decorator typed as `Callable[P, R] -> Callable[P, R]` preserves overload signatures.
 
 ```py
 from typing import Callable, overload
@@ -954,7 +954,7 @@ reveal_type(test(1, y="x"))  # revealed: Unknown
 def increment(value: int) -> int:
     return value + 1
 
-reveal_type(increment)  # revealed: def increment(value: int) -> int
+reveal_type(increment)  # revealed: (value: int) -> int
 reveal_type(increment(1))  # revealed: int
 ```
 
@@ -1281,7 +1281,7 @@ c = Container()
 # revealed: ty_extensions.GenericContext[T@generic_method]
 reveal_type(generic_context(c.generic_method))
 
-reveal_type(c.generic_method)  # revealed: bound method Container.generic_method[T](value: T) -> T
+reveal_type(c.generic_method)  # revealed: [T](value: T) -> T
 reveal_type(c.generic_method(100))  # revealed: Literal[100]
 reveal_type(c.generic_method([1, 2, 3]))  # revealed: list[int]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -958,13 +958,9 @@ reveal_type(increment)  # revealed: (value: int) -> int
 reveal_type(increment(1))  # revealed: int
 ```
 
-### Transparent decorator type aliases
-
 A type alias for `Callable[P, R]` can also be used to type a transparent decorator.
 
 ```py
-from typing import Callable, overload
-
 type Fn[**P, R] = Callable[P, R]
 
 def transparent[**P, R](func: Fn[P, R]) -> Fn[P, R]:
@@ -983,13 +979,9 @@ reveal_type(alias_decorated(1))  # revealed: int
 reveal_type(alias_decorated(y="x"))  # revealed: str
 ```
 
-### Transparent decorator factories
-
 A transparent decorator returned by a decorator factory also preserves overload signatures.
 
 ```py
-from typing import Callable, overload
-
 def transparent_factory[**P, R]() -> Callable[[Callable[P, R]], Callable[P, R]]:
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
         return func

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -921,7 +921,7 @@ def callable_identity[**P, R](func: Callable[P, R]) -> Callable[P, R]:
 def f(env: dict) -> None:
     pass
 
-# revealed: (env: dict[Unknown, Unknown]) -> None
+# revealed: def f(env: dict[Unknown, Unknown]) -> None
 reveal_type(f)
 ```
 
@@ -1248,7 +1248,7 @@ c = Container()
 # revealed: ty_extensions.GenericContext[T@generic_method]
 reveal_type(generic_context(c.generic_method))
 
-reveal_type(c.generic_method)  # revealed: [T](value: T) -> T
+reveal_type(c.generic_method)  # revealed: bound method Container.generic_method[T](value: T) -> T
 reveal_type(c.generic_method(100))  # revealed: Literal[100]
 reveal_type(c.generic_method([1, 2, 3]))  # revealed: list[int]
 ```

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5250,6 +5250,62 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
+        fn callable_paramspec_and_return_typevar<'d>(
+            db: &'d dyn Db,
+            ty: Type<'d>,
+        ) -> Option<(BoundTypeVarInstance<'d>, BoundTypeVarInstance<'d>)> {
+            let Type::Callable(callable) = ty else {
+                return None;
+            };
+            if callable.kind(db) != CallableTypeKind::Regular {
+                return None;
+            }
+            let [signature] = callable.signatures(db).overloads.as_slice() else {
+                return None;
+            };
+            let paramspec = signature.parameters().as_paramspec()?;
+            let Type::TypeVar(return_typevar) = signature.return_ty else {
+                return None;
+            };
+            Some((paramspec, return_typevar))
+        }
+
+        fn is_transparent_callable_decorator<'d>(
+            db: &'d dyn Db,
+            decorator_ty: Type<'d>,
+            decorated_ty: Type<'d>,
+        ) -> bool {
+            if !matches!(decorated_ty, Type::FunctionLiteral(_) | Type::Callable(_)) {
+                return false;
+            }
+
+            let Type::FunctionLiteral(decorator_function) = decorator_ty else {
+                return false;
+            };
+
+            let [decorator_signature] = decorator_function.signature(db).overloads.as_slice()
+            else {
+                return false;
+            };
+            let [parameter] = decorator_signature.parameters().as_slice() else {
+                return false;
+            };
+
+            let Some((parameter_paramspec, parameter_return_typevar)) =
+                callable_paramspec_and_return_typevar(db, parameter.annotated_type())
+            else {
+                return false;
+            };
+            let Some((return_paramspec, return_typevar)) =
+                callable_paramspec_and_return_typevar(db, decorator_signature.return_ty)
+            else {
+                return false;
+            };
+
+            parameter_paramspec.is_same_typevar_as(db, return_paramspec)
+                && parameter_return_typevar.is_same_typevar_as(db, return_typevar)
+        }
+
         // For FunctionLiteral, get the kind directly without computing the full signature.
         // This avoids a query cycle when the function has default parameter values, since
         // computing the signature requires evaluating those defaults which may trigger
@@ -5275,13 +5331,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         let call_arguments = CallArguments::positional([decorated_ty]);
+        let mut decorator_call_succeeded = true;
         let return_ty = decorator_ty
             .try_call(self.db(), &call_arguments)
             .map(|bindings| bindings.return_type(self.db()))
             .unwrap_or_else(|CallError(_, bindings)| {
+                decorator_call_succeeded = false;
                 bindings.report_diagnostics(&self.context, decorator_node.into());
                 bindings.return_type(self.db())
             });
+
+        // TODO: Remove this special case once the new constraint solver can preserve
+        // per-overload ParamSpec/return correlations for `Callable[P, R] -> Callable[P, R]`.
+        if decorator_call_succeeded
+            && is_transparent_callable_decorator(self.db(), decorator_ty, decorated_ty)
+        {
+            return decorated_ty;
+        }
 
         // When a method on a class is decorated with a function that returns a
         // `Callable`, assume that the returned callable is also function-like (or

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5273,11 +5273,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if !matches!(decorated_ty, Type::FunctionLiteral(_) | Type::Callable(_)) {
                 return false;
             }
-            let Type::FunctionLiteral(decorator_function) = decorator_ty else {
-                return false;
+            let decorator_signatures = match decorator_ty {
+                Type::FunctionLiteral(decorator_function) => decorator_function.signature(db),
+                Type::Callable(decorator_callable) => decorator_callable.signatures(db),
+                _ => return false,
             };
-            let [decorator_signature] = decorator_function.signature(db).overloads.as_slice()
-            else {
+            let [decorator_signature] = decorator_signatures.overloads.as_slice() else {
                 return false;
             };
             let [parameter] = decorator_signature.parameters().as_slice() else {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5250,13 +5250,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
-        fn callable_paramspec_and_return_typevar<'d>(
-            db: &'d dyn Db,
-            ty: Type<'d>,
-        ) -> Option<(BoundTypeVarInstance<'d>, BoundTypeVarInstance<'d>)> {
-            let Type::Callable(callable) = ty else {
-                return None;
-            };
+        fn callable_paramspec_and_return_typevar<'db>(
+            db: &'db dyn Db,
+            ty: Type<'db>,
+        ) -> Option<(BoundTypeVarInstance<'db>, BoundTypeVarInstance<'db>)> {
+            let callable = ty.as_callable()?;
             if callable.kind(db) != CallableTypeKind::Regular {
                 return None;
             }
@@ -5264,10 +5262,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 return None;
             };
             let paramspec = signature.parameters().as_paramspec()?;
-            let Type::TypeVar(return_typevar) = signature.return_ty else {
-                return None;
-            };
-            Some((paramspec, return_typevar))
+            Some((paramspec, signature.return_ty.as_typevar()?))
         }
 
         fn is_transparent_callable_decorator<'d>(
@@ -5278,11 +5273,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if !matches!(decorated_ty, Type::FunctionLiteral(_) | Type::Callable(_)) {
                 return false;
             }
-
             let Type::FunctionLiteral(decorator_function) = decorator_ty else {
                 return false;
             };
-
             let [decorator_signature] = decorator_function.signature(db).overloads.as_slice()
             else {
                 return false;
@@ -5291,19 +5284,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 return false;
             };
 
-            let Some((parameter_paramspec, parameter_return_typevar)) =
+            let Some((parameter_callable_paramspec, parameter_callable_return_typevar)) =
                 callable_paramspec_and_return_typevar(db, parameter.annotated_type())
             else {
                 return false;
             };
-            let Some((return_paramspec, return_typevar)) =
+            let Some((return_callable_paramspec, return_callable_typevar)) =
                 callable_paramspec_and_return_typevar(db, decorator_signature.return_ty)
             else {
                 return false;
             };
-
-            parameter_paramspec.is_same_typevar_as(db, return_paramspec)
-                && parameter_return_typevar.is_same_typevar_as(db, return_typevar)
+            parameter_callable_paramspec.is_same_typevar_as(db, return_callable_paramspec)
+                && parameter_callable_return_typevar.is_same_typevar_as(db, return_callable_typevar)
         }
 
         // For FunctionLiteral, get the kind directly without computing the full signature.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5254,7 +5254,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             db: &'db dyn Db,
             ty: Type<'db>,
         ) -> Option<(BoundTypeVarInstance<'db>, BoundTypeVarInstance<'db>)> {
-            let callable = ty.as_callable()?;
+            let callable = ty.resolve_type_alias(db).as_callable()?;
             if callable.kind(db) != CallableTypeKind::Regular {
                 return None;
             }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5337,8 +5337,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // per-overload ParamSpec/return correlations for `Callable[P, R] -> Callable[P, R]`.
         if decorator_call_succeeded
             && is_transparent_callable_decorator(self.db(), decorator_ty, decorated_ty)
+            && let Some(callable) = decorated_ty
+                .try_upcast_to_callable(self.db())
+                .and_then(CallableTypes::exactly_one)
         {
-            return decorated_ty;
+            return Type::Callable(callable);
         }
 
         // When a method on a class is decorated with a function that returns a


### PR DESCRIPTION
## Summary

temporary workaround for https://github.com/astral-sh/ty/issues/2278

This is a temporary fix to special case the `(arg: Callable[P, R]) -> Callable[P, R]` callable which takes in a single parameter annotated as a `Callable[P, R]` and returns the same callable with the same type variables.

This special case is ofcourse very limited because it only looks for specific `Callable[P, R]` type (and a type alias that corresponds to that callable) and nothing else.

## Test Plan

Add a couple of test cases both for overloaded and non-overloaded function.
