### PR TITLE
[`flake8-type-checking`] Avoid `strict` behavior when `future-annotations` are enabled (`TC001`, `TC002`, `TC003`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC001-3_future_strict.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC001-3_future_strict.py
@@ -2,14 +2,11 @@
 #
 # With `future-annotations = true` and `strict = false`, a typing-only import
 # that is implicitly loaded by a valid runtime-used sibling import from the
-# same module should NOT be flagged as TC001/TC002/TC003. Previously, enabling
-# `future_annotations` silently flipped these rules into strict-mode behaviour.
+# same module should NOT be flagged as TC001/TC002/TC003.
 
 
 def from_collections_abc():
     # `Set` is used at runtime, so `Iterable` is implicitly available at runtime.
-    # In un-strict mode (even with `future_annotations=true`), this should not
-    # be flagged.
     from collections.abc import Iterable, Set
 
     def f(x: Iterable[int]) -> Set[int]:
@@ -18,7 +15,7 @@ def from_collections_abc():
 
 def from_pkg():
     # `pkg` is used at runtime, `A` is typing-only but implicitly runtime-available
-    # via `pkg`. Should not be flagged in un-strict mode.
+    # via `pkg`.
     import pkg
     from pkg import A
 
@@ -28,7 +25,6 @@ def from_pkg():
 
 def submodule_implicit():
     # `pkg.bar` is used at runtime, which implicitly makes `pkg` available.
-    # Should not be flagged in un-strict mode.
     import pkg
     import pkg.bar
 

--- a/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC001-3_future_strict.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC001-3_future_strict.py
@@ -1,0 +1,36 @@
+# Regression test for https://github.com/astral-sh/ruff/issues/23185.
+#
+# With `future-annotations = true` and `strict = false`, a typing-only import
+# that is implicitly loaded by a valid runtime-used sibling import from the
+# same module should NOT be flagged as TC001/TC002/TC003. Previously, enabling
+# `future_annotations` silently flipped these rules into strict-mode behaviour.
+
+
+def from_collections_abc():
+    # `Set` is used at runtime, so `Iterable` is implicitly available at runtime.
+    # In un-strict mode (even with `future_annotations=true`), this should not
+    # be flagged.
+    from collections.abc import Iterable, Set
+
+    def f(x: Iterable[int]) -> Set[int]:
+        return Set(x)
+
+
+def from_pkg():
+    # `pkg` is used at runtime, `A` is typing-only but implicitly runtime-available
+    # via `pkg`. Should not be flagged in un-strict mode.
+    import pkg
+    from pkg import A
+
+    def test(value: A):
+        return pkg.B()
+
+
+def submodule_implicit():
+    # `pkg.bar` is used at runtime, which implicitly makes `pkg` available.
+    # Should not be flagged in un-strict mode.
+    import pkg
+    import pkg.bar
+
+    def test(value: pkg.A):
+        return pkg.bar.B()

--- a/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
@@ -118,11 +118,6 @@ mod tests {
         Ok(())
     }
 
-    /// Regression test for <https://github.com/astral-sh/ruff/issues/23185>:
-    /// enabling `future_annotations=true` must not silently flip TC001/TC002/TC003
-    /// into strict-mode behaviour when `strict=false`. A typing-only import whose
-    /// module is already available at runtime (through a sibling import or a
-    /// parent/submodule import) should not be flagged.
     #[test]
     fn future_annotations_respects_non_strict_mode() -> Result<()> {
         let diagnostics = test_path(
@@ -142,10 +137,7 @@ mod tests {
                 ])
             },
         )?;
-        assert!(
-            diagnostics.is_empty(),
-            "expected no TC001/TC002/TC003 diagnostics with future_annotations=true and strict=false, got: {diagnostics:#?}"
-        );
+        assert_diagnostics!(diagnostics);
         Ok(())
     }
 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
@@ -118,6 +118,37 @@ mod tests {
         Ok(())
     }
 
+    /// Regression test for <https://github.com/astral-sh/ruff/issues/23185>:
+    /// enabling `future_annotations=true` must not silently flip TC001/TC002/TC003
+    /// into strict-mode behaviour when `strict=false`. A typing-only import whose
+    /// module is already available at runtime (through a sibling import or a
+    /// parent/submodule import) should not be flagged.
+    #[test]
+    fn future_annotations_respects_non_strict_mode() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("flake8_type_checking")
+                .join("TC001-3_future_strict.py")
+                .as_path(),
+            &settings::LinterSettings {
+                future_annotations: true,
+                flake8_type_checking: super::settings::Settings {
+                    strict: false,
+                    ..Default::default()
+                },
+                ..settings::LinterSettings::for_rules([
+                    Rule::TypingOnlyFirstPartyImport,
+                    Rule::TypingOnlyThirdPartyImport,
+                    Rule::TypingOnlyStandardLibraryImport,
+                ])
+            },
+        )?;
+        assert!(
+            diagnostics.is_empty(),
+            "expected no TC001/TC002/TC003 diagnostics with future_annotations=true and strict=false, got: {diagnostics:#?}"
+        );
+        Ok(())
+    }
+
     // we test these rules as a pair, since they're opposites of one another
     // so we want to make sure their fixes are not going around in circles.
     #[test_case(Rule::UnquotedTypeAlias, Path::new("TC007.py"))]

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -284,11 +284,8 @@ pub(crate) fn typing_only_runtime_import(
     for binding_id in scope.binding_ids() {
         let binding = checker.semantic().binding(binding_id);
 
-        // In un-strict mode, don't flag typing-only imports that are implicitly loaded by way
-        // of a valid runtime import. The `future_annotations` setting only controls whether a
-        // `from __future__ import annotations` import is auto-inserted as part of the fix; it
-        // is an orthogonal concern from strict mode and should not flip the flagging behaviour
-        // (see https://github.com/astral-sh/ruff/issues/23185).
+        // If we're in un-strict mode, don't flag typing-only imports that are
+        // implicitly loaded by way of a valid runtime import.
         if !checker.settings().flake8_type_checking.strict
             && runtime_imports
                 .iter()

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -284,10 +284,12 @@ pub(crate) fn typing_only_runtime_import(
     for binding_id in scope.binding_ids() {
         let binding = checker.semantic().binding(binding_id);
 
-        // If we can't add a `__future__` import and in un-strict mode, don't flag typing-only
-        // imports that are implicitly loaded by way of a valid runtime import.
-        if !checker.settings().future_annotations
-            && !checker.settings().flake8_type_checking.strict
+        // In un-strict mode, don't flag typing-only imports that are implicitly loaded by way
+        // of a valid runtime import. The `future_annotations` setting only controls whether a
+        // `from __future__ import annotations` import is auto-inserted as part of the fix; it
+        // is an orthogonal concern from strict mode and should not flip the flagging behaviour
+        // (see https://github.com/astral-sh/ruff/issues/23185).
+        if !checker.settings().flake8_type_checking.strict
             && runtime_imports
                 .iter()
                 .any(|import| is_implicit_import(binding, import))

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__future_annotations_respects_non_strict_mode.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__future_annotations_respects_non_strict_mode.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
+---
+


### PR DESCRIPTION
## Summary

Fixes #23185.

Enabling `lint.future-annotations = true` was silently flipping `TC001`/`TC002`/`TC003` into strict-mode behaviour, even when `lint.flake8-type-checking.strict = false`. The two settings are orthogonal — the former controls whether `from __future__ import annotations` is auto-inserted as a fix; the latter controls whether typing-only imports whose module is already imported at runtime should be flagged.

## Root cause

In [`crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs`](https://github.com/astral-sh/ruff/blob/main/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs), the skip condition for implicit runtime imports read:

```rust
if !checker.settings().future_annotations
    && !checker.settings().flake8_type_checking.strict
    && runtime_imports.iter().any(|import| is_implicit_import(binding, import))
{
    continue;
}
```

This required **both** `!future_annotations` **and** `!strict` to be true. The moment a user opted into `future_annotations = true`, the first clause became false and the entire skip was bypassed — making the rules behave as if `strict = true`, regardless of the user's explicit `strict = false` setting.

This also matches the direction @ntBre suggested on the issue:

> This does sound like a bug to me. I think I may have gotten this logic wrong, and it should be an `or` instead of `and`…

## Solution

Drop the `!future_annotations` clause. Only `!strict` should gate whether implicit runtime imports are skipped. The `future_annotations` setting is handled elsewhere (as part of the fix-generation path for adding the `__future__` import); it has no bearing on which imports are flagged.

## Testing

- **New regression test** in `crates/ruff_linter/src/rules/flake8_type_checking/mod.rs`: `future_annotations_respects_non_strict_mode`, backed by a new fixture `crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC001-3_future_strict.py`. The test pins the exact scenario from the issue (`future_annotations=true`, `strict=false`, typing-only import whose module has a runtime-used sibling) and asserts zero `TC001`/`TC002`/`TC003` diagnostics are produced — a result that would have been non-zero prior to this patch.
- All 92 pre-existing `flake8_type_checking` lib tests still pass locally; the `add_future_import` snapshot tests (which exercise the `future_annotations = true` path) also pass unchanged, confirming the fix does not regress the auto-insert-`__future__`-import behaviour.
  - `cargo test --lib flake8_type_checking` → 92 passed, 0 failed
  - `cargo test --lib add_future_import` → 12 passed, 0 failed

## Checklist

- [x] Fixes the root cause (not just the symptom)
- [x] New test covers the exact failing scenario from the issue
- [x] All existing tests pass
- [x] No unrelated changes
- [x] Code style matches project conventions
- [x] Followed CONTRIBUTING.md
