### PR TITLE
[ty] Include TypedDict type context when inferring string keys

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -7000,6 +7000,33 @@ td["<CURSOR>"]
     }
 
     #[test]
+    fn string_literal_completions_typed_dict_literal_keys() {
+        let builder = completion_test_builder(
+            r#"
+from typing import TypedDict
+
+class Box(TypedDict):
+    x: float
+    y: float
+    z: float
+
+def take(box: Box): ...
+
+take({"<CURSOR>": 1})
+"#,
+        );
+
+        assert_snapshot!(
+            builder.skip_keywords().skip_builtins().skip_auto_import().type_signatures().build().snapshot(),
+            @r#"
+        x :: Literal["x"]
+        y :: Literal["y"]
+        z :: Literal["z"]
+        "#,
+        );
+    }
+
+    #[test]
     fn string_literal_completions_typed_dict_keys_assignment() {
         let builder = completion_test_builder(
             r#"

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -38,7 +38,7 @@ use ty_python_core::place::{PlaceExpr, PlaceExprRef};
 use ty_python_core::scope::FileScopeId;
 
 impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
-    fn typed_dict_key_expected_type(&self, ty: Type<'db>) -> Option<Type<'db>> {
+    pub(super) fn typed_dict_key_expected_type(&self, ty: Type<'db>) -> Option<Type<'db>> {
         struct TypedDictKeyExpectedType;
         type TypedDictKeyExpectedTypeVisitor<'db> =
             CycleDetector<TypedDictKeyExpectedType, Type<'db>, Option<Type<'db>>>;

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -307,9 +307,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         } = dict;
 
         let typed_dict_items = typed_dict.items(self.db());
+        let key_tcx =
+            TypeContext::new(self.typed_dict_key_expected_type(Type::TypedDict(typed_dict)));
 
         for item in items {
-            let key_ty = self.infer_optional_expression(item.key.as_ref(), TypeContext::default());
+            let key_ty = self.infer_optional_expression(item.key.as_ref(), key_tcx);
             if let Some((key, key_ty)) = item.key.as_ref().zip(key_ty) {
                 item_types.insert(key.node_index().load(), key_ty);
             }


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ty/issues/3425.
